### PR TITLE
Suppress log output when --quiet flag is on

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -85,6 +85,10 @@ OPTIONS:
 		},
 		cli.BoolFlag{
 			Name:  "quiet, q",
+			Usage: "suppress progress bar and log output",
+		},
+		cli.BoolFlag{
+			Name:  "no-progress",
 			Usage: "suppress progress bar",
 		},
 		cli.BoolFlag{

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"os"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/xerrors"
@@ -11,9 +13,9 @@ var (
 	debugOption bool
 )
 
-func InitLogger(debug bool) (err error) {
+func InitLogger(debug, disable bool) (err error) {
 	debugOption = debug
-	Logger, err = newLogger(debug)
+	Logger, err = newLogger(debug, disable)
 	if err != nil {
 		return xerrors.Errorf("error in new logger: %w", err)
 	}
@@ -21,7 +23,7 @@ func InitLogger(debug bool) (err error) {
 
 }
 
-func newLogger(debug bool) (*zap.SugaredLogger, error) {
+func newLogger(debug, disable bool) (*zap.SugaredLogger, error) {
 	level := zap.NewAtomicLevel()
 	if debug {
 		level.SetLevel(zapcore.DebugLevel)
@@ -49,6 +51,10 @@ func newLogger(debug bool) (*zap.SugaredLogger, error) {
 		},
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
+	}
+	if disable {
+		myConfig.OutputPaths = []string{os.DevNull}
+		myConfig.ErrorOutputPaths = []string{os.DevNull}
 	}
 	logger, err := myConfig.Build()
 	if err != nil {

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/genuinetools/reg/registry"
 	"github.com/aquasecurity/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -15,6 +14,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/utils"
 	"github.com/aquasecurity/trivy/pkg/vulnsrc"
 	"github.com/aquasecurity/trivy/pkg/vulnsrc/vulnerability"
+	"github.com/genuinetools/reg/registry"
 	"github.com/urfave/cli"
 	"golang.org/x/xerrors"
 )
@@ -22,7 +22,9 @@ import (
 func Run(c *cli.Context) (err error) {
 	cliVersion := c.App.Version
 
-	utils.Quiet = c.Bool("quiet")
+	if c.Bool("quiet") || c.Bool("no-progress") {
+		utils.Quiet = true
+	}
 	debug := c.Bool("debug")
 	if err = log.InitLogger(debug); err != nil {
 		l.Fatal(err)

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -26,7 +26,7 @@ func Run(c *cli.Context) (err error) {
 		utils.Quiet = true
 	}
 	debug := c.Bool("debug")
-	if err = log.InitLogger(debug); err != nil {
+	if err = log.InitLogger(debug, c.Bool("quiet")); err != nil {
 		l.Fatal(err)
 	}
 

--- a/pkg/scanner/ospkg/alpine/alpine_test.go
+++ b/pkg/scanner/ospkg/alpine/alpine_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false)
+	log.InitLogger(false, false)
 	os.Exit(m.Run())
 }
 

--- a/pkg/scanner/ospkg/debian/debian_test.go
+++ b/pkg/scanner/ospkg/debian/debian_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false)
+	log.InitLogger(false, false)
 	os.Exit(m.Run())
 }
 

--- a/pkg/scanner/ospkg/redhat/redhat_test.go
+++ b/pkg/scanner/ospkg/redhat/redhat_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false)
+	log.InitLogger(false, false)
 	os.Exit(m.Run())
 }
 

--- a/pkg/scanner/ospkg/ubuntu/ubnutu_test.go
+++ b/pkg/scanner/ospkg/ubuntu/ubnutu_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false)
+	log.InitLogger(false, false)
 	os.Exit(m.Run())
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -31,7 +31,7 @@ func write(t *testing.T, name string, content string) {
 }
 
 func TestFileWalk(t *testing.T) {
-	if err := log.InitLogger(false); err != nil {
+	if err := log.InitLogger(false, false); err != nil {
 		t.Fatal(err)
 	}
 	td, err := ioutil.TempDir("", "walktest")


### PR DESCRIPTION
ref.) https://github.com/aquasecurity/trivy/issues/106

Disable log output when `--quiet` flag is on.
Also, add new flag `--no-progress` to disable only progress bar (same feature implemented as `--quiet` previously).