### PR TITLE
Fix bug. always application vulnerabilities list make in current directory.

### DIFF
--- a/pkg/scanner/library/bundler/advisory.go
+++ b/pkg/scanner/library/bundler/advisory.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	repoPath = filepath.Join(utils.CacheDir(), "ruby-advisory-db")
+	repoPath string
 )
 
 type AdvisoryDB map[string][]Advisory
@@ -49,6 +49,7 @@ type Related struct {
 }
 
 func (s *Scanner) UpdateDB() (err error) {
+	repoPath = filepath.Join(utils.CacheDir(), "ruby-advisory-db")
 	if _, err := git.CloneOrPull(dbURL, repoPath); err != nil {
 		return xerrors.Errorf("error in %s security DB update: %w", s.Type(), err)
 	}

--- a/pkg/scanner/library/cargo/advisory.go
+++ b/pkg/scanner/library/cargo/advisory.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	repoPath = filepath.Join(utils.CacheDir(), "rust-advisory-db")
+	repoPath string
 )
 
 type AdvisoryDB map[string][]Lockfile
@@ -45,6 +45,7 @@ type Advisory struct {
 }
 
 func (s *Scanner) UpdateDB() (err error) {
+	repoPath = filepath.Join(utils.CacheDir(), "rust-advisory-db")
 	if _, err := git.CloneOrPull(dbURL, repoPath); err != nil {
 		return xerrors.Errorf("error in %s security DB update: %w", s.Type(), err)
 	}

--- a/pkg/scanner/library/composer/advisory.go
+++ b/pkg/scanner/library/composer/advisory.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/etcd-io/bbolt"
 	"github.com/aquasecurity/trivy/pkg/db"
+	"github.com/etcd-io/bbolt"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/utils"
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	repoPath = filepath.Join(utils.CacheDir(), "php-security-advisories")
+	repoPath string
 )
 
 type AdvisoryDB map[string][]Advisory
@@ -40,6 +40,7 @@ type Branch struct {
 }
 
 func (s *Scanner) UpdateDB() (err error) {
+	repoPath = filepath.Join(utils.CacheDir(), "php-security-advisories")
 	if _, err := git.CloneOrPull(dbURL, repoPath); err != nil {
 		return err
 	}

--- a/pkg/scanner/library/node/advisory.go
+++ b/pkg/scanner/library/node/advisory.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	repoPath = filepath.Join(utils.CacheDir(), "nodejs-security-wg")
+	repoPath string
 )
 
 type AdvisoryDB map[string][]Advisory
@@ -44,6 +44,7 @@ type Advisory struct {
 }
 
 func (s *Scanner) UpdateDB() (err error) {
+	repoPath = filepath.Join(utils.CacheDir(), "nodejs-security-wg")
 	if _, err := git.CloneOrPull(dbURL, repoPath); err != nil {
 		return err
 	}

--- a/pkg/scanner/library/python/advisory.go
+++ b/pkg/scanner/library/python/advisory.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	repoPath = filepath.Join(utils.CacheDir(), "python-safety-db")
+	repoPath string
 )
 
 type AdvisoryDB map[string][]Advisory
@@ -36,6 +36,7 @@ type Advisory struct {
 }
 
 func (s *Scanner) UpdateDB() (err error) {
+	repoPath = filepath.Join(utils.CacheDir(), "python-safety-db")
 	if _, err := git.CloneOrPull(dbURL, repoPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
The path of the cache directory used when detecting application vulnerabilities is the always current directory.

```
$ ls 


$ trivy -debug trivy-ci-test:1.0       
2019-08-23T16:37:14.705+0900	DEBUG	cache dir:  /Users/masahiro331/Library/Caches/trivy
2019-08-23T16:37:14.706+0900	DEBUG	db path: /Users/01025026/Library/Caches/trivy/db/trivy.db
2019-08-23T16:37:14.709+0900	INFO	Updating vulnerability database...
2019-08-23T16:37:14.709+0900	DEBUG	git pull
2019-08-23T16:37:15.758+0900	DEBUG	total updated files: 1
2019-08-23T16:37:15.951+0900	DEBUG	Vulnerability type:  [os library]
2019-08-23T16:37:16.061+0900	DEBUG	OS family: alpine, OS version: 3.7.1
2019-08-23T16:37:16.062+0900	DEBUG	the number of packages: 65
2019-08-23T16:37:16.659+0900	DEBUG	the number of packages from commands: 83
2019-08-23T16:37:16.659+0900	DEBUG	the number of packages: 111
2019-08-23T16:37:16.659+0900	INFO	Detecting Alpine vulnerabilities...
2019-08-23T16:37:16.659+0900	DEBUG	alpine: os version: 3.7
2019-08-23T16:37:16.659+0900	DEBUG	alpine: the number of packages: 111
2019-08-23T16:37:16.662+0900	DEBUG	Detecting library vulnerabilities, path: python-app/Pipfile.lock
2019-08-23T16:37:16.662+0900	INFO	Updating pipenv Security DB...
2019-08-23T16:37:16.672+0900	DEBUG	remove an existed directory
[========>           ] It will take a while for the first time...

$ ls 
nodejs-security-wg      php-security-advisories python-safety-db        ruby-advisory-db        rust-advisory-db
```
