### PR TITLE
Add the RHEL8 support to rpm repository

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -2,14 +2,15 @@
 
 function create_rpm_repo () {
         version=$1
+        rpm_path=rpm/releases/${version}/x86_64
 
         RPM_EL=$(find ../dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -e "s/_/-/g" -e "s/-Linux/.el$version/" -e "s/-64bit/.x86_64/")
         echo $RPM_EL
 
-        mkdir -p rpm/releases/${version}/x86_64
-        cp ../dist/*64bit.rpm rpm/releases/${version}/x86_64/${RPM_EL}
+        mkdir -p $rpm_path
+        cp ../dist/*64bit.rpm ${rpm_path}/${RPM_EL}
 
-        createrepo --update rpm/releases/${version}/x86_64/
+        createrepo --update $rpm_path
 }
 
 cd trivy-repo

--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -1,18 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
-RPM_EL6=$(find dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -e 's/_/-/g' -e 's/-Linux/.el6/' -e 's/-64bit/.x86_64/')
-RPM_EL7=$(find dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -e 's/_/-/g' -e 's/-Linux/.el7/' -e 's/-64bit/.x86_64/')
+function create_rpm_repo () {
+        version=$1
+
+        RPM_EL=$(find ../dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -e "s/_/-/g" -e "s/-Linux/.el$version/" -e "s/-64bit/.x86_64/")
+        echo $RPM_EL
+
+        mkdir -p rpm/releases/${version}/x86_64
+        cp ../dist/*64bit.rpm rpm/releases/${version}/x86_64/${RPM_EL}
+
+        createrepo --update rpm/releases/${version}/x86_64/
+}
 
 cd trivy-repo
-mkdir -p rpm/releases/6/x86_64
-mkdir -p rpm/releases/7/x86_64
 
-cd rpm
-cp ../../dist/*64bit.rpm releases/6/x86_64/${RPM_EL6}
-cp ../../dist/*64bit.rpm releases/7/x86_64/${RPM_EL7}
-
-createrepo --update releases/6/x86_64/
-createrepo --update releases/7/x86_64/
+VERSIONS=(5 6 7 8)
+for version in ${VERSIONS[@]}; do
+        echo "Processing RHEL/CentOS $version..."
+        create_rpm_repo $version
+done
 
 git add .
 git commit -m "Update rpm packages"


### PR DESCRIPTION
Close https://github.com/aquasecurity/trivy/issues/137

[trivy-repo](https://github.com/aquasecurity/trivy-repo) which provides rpm repository supports only RHEL/CentOS 6/7. This PR adds RHEL8 support to rpm repository.