### PR TITLE
Add template writer

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -44,9 +44,14 @@ OPTIONS:
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "template, t",
+			Value: "",
+			Usage: "output template",
+		},
+		cli.StringFlag{
 			Name:  "format, f",
 			Value: "table",
-			Usage: "format (table, json)",
+			Usage: "format (table, json, template)",
 		},
 		cli.StringFlag{
 			Name:  "input, i",

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"text/template"
 
 	"golang.org/x/xerrors"
 
@@ -91,6 +92,19 @@ func (jw JsonWriter) Write(results Results) error {
 
 	if _, err = fmt.Fprint(jw.Output, string(output)); err != nil {
 		return xerrors.Errorf("failed to write json: %w", err)
+	}
+	return nil
+}
+
+type TemplateWriter struct {
+	Output   io.Writer
+	Template *template.Template
+}
+
+func (tw TemplateWriter) Write(results Results) error {
+	err := tw.Template.Execute(tw.Output, results)
+	if err != nil {
+		return xerrors.Errorf("failed to write with template: %w", err)
 	}
 	return nil
 }

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -4,6 +4,7 @@ import (
 	l "log"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/aquasecurity/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/db"
@@ -179,6 +180,13 @@ func Run(c *cli.Context) (err error) {
 		writer = &report.TableWriter{Output: output}
 	case "json":
 		writer = &report.JsonWriter{Output: output}
+	case "template":
+		outputTemplate := c.String("template")
+		tmpl, err := template.New("output template").Parse(outputTemplate)
+		if err != nil {
+			return xerrors.Errorf("error parsing template: %w", err)
+		}
+		writer = &report.TemplateWriter{Output: output, Template: tmpl}
 	default:
 		return xerrors.Errorf("unknown format: %v", format)
 	}


### PR DESCRIPTION
Adds a new output format "template" with a new command line argument to specify a template for the report.

    trivy -t "{{ range . }}{{ range .Vulnerabilities}}{{ println .Severity }}{{ end }}{{ end }}" -f json -q rabbitmq:3-management