### PR TITLE
Modify cache-dir usage comment

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -115,7 +115,7 @@ OPTIONS:
 		cli.StringFlag{
 			Name:  "cache-dir",
 			Value: utils.DefaultCacheDir(),
-			Usage: "cache directory",
+			Usage: "use as cache directory, but image cache is stored in /path/to/cache/fanal",
 		},
 	}
 


### PR DESCRIPTION
Hi.

Trivy cache dir is changed by `--cache-dir` option.
But image cache is not changed and stored in /path/to/cache/fanal ( /path/to/cache/ = os.UserCacheDir() ).
So, I changed `--cache-dir` option usage comment.

If we want to change image cache dir too, we need to fix [aquasecurity/fanal/utils/utils.go - CacheDir](https://github.com/aquasecurity/fanal/blob/master/utils/utils.go#L14).