### PR TITLE
Add option to only download vulnerability database

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,15 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
 
 </details>
 
+### Only download vulnerability database
+
+You can also ask `Trivy` to simply retrieve the vulnerability database. This is useful to initialize workers in Continuous Integration systems. In the first run, the `--only-update` option is silently ignored.
+
+```
+$ trivy --download-db-only
+$ trivy --download-db-only --only-update alpine
+```
+
 ### Ignore unfixed vulnerabilities
 
 By default, `Trivy` also detects unpatched/unfixed vulnerabilities. This means you can't fix these vulnerabilities even if you update all packages.

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -71,6 +71,10 @@ OPTIONS:
 			Usage: "update db only specified distribution (comma separated)",
 		},
 		cli.BoolFlag{
+			Name:  "download-db-only",
+			Usage: "download/update vulnerability database but don't run a scan",
+		},
+		cli.BoolFlag{
 			Name:  "reset",
 			Usage: "remove all caches and database",
 		},


### PR DESCRIPTION
Many Continuous Integration systems in companies use ephemeral workers
that may run more than one Trivy job. In those cases, downloading the
vulnerability database from the beginning time and again is a waste of
resources.

With this flag, we can download the database on worker creation
offsetting most of the download time on each job. execution

References: #109

---

# Add flag to download vulnerability database

When the `--download-db-only` flag is supplied, we will just download
the vulnerability database and exit without performing any scans.

If a database had been downloaded before the present run, and
`--only-update` option has been specified, we will only update the
database for the selected distribution and exit.

# Add documentation for `--download-db-only` flag

Add section to README on usage limitations of the new flag.