### PR TITLE
Check errors passed through by filepath.Walk

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -59,6 +59,9 @@ func CloneOrPull(url, repoPath string) (map[string]struct{}, error) {
 	// Need to refresh all vulnerabilities
 	if db.GetVersion() == "" {
 		err = filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}

--- a/pkg/scanner/library/bundler/advisory.go
+++ b/pkg/scanner/library/bundler/advisory.go
@@ -63,6 +63,9 @@ func (s *Scanner) walk() (AdvisoryDB, error) {
 
 	var vulns []vulnerability.Vulnerability
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/scanner/library/cargo/advisory.go
+++ b/pkg/scanner/library/cargo/advisory.go
@@ -59,6 +59,9 @@ func (s *Scanner) walk() (AdvisoryDB, error) {
 
 	var vulns []vulnerability.Vulnerability
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}

--- a/pkg/scanner/library/composer/advisory.go
+++ b/pkg/scanner/library/composer/advisory.go
@@ -52,6 +52,9 @@ func (s *Scanner) walk() (AdvisoryDB, error) {
 	advisoryDB := AdvisoryDB{}
 	var vulns []vulnerability.Vulnerability
 	err := filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() || !strings.HasPrefix(info.Name(), "CVE-") {
 			return nil
 		}

--- a/pkg/scanner/library/node/advisory.go
+++ b/pkg/scanner/library/node/advisory.go
@@ -56,6 +56,9 @@ func (s *Scanner) walk() (AdvisoryDB, error) {
 	advisoryDB := AdvisoryDB{}
 	var vulns []vulnerability.Vulnerability
 	err := filepath.Walk(filepath.Join(repoPath, "vuln"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
 			return nil
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,6 +32,9 @@ func SetCacheDir(dir string) {
 
 func FileWalk(root string, targetFiles map[string]struct{}, walkFn func(r io.Reader, path string) error) error {
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
In several files, the error passed from `filepath.Walk` to `WalkFunc` is not checked (see issue #207). As the `info` argument to WalkFn is `nil` in case of an error, accessing `info` can cause a runtime panic.
This commit adds checks for errors passed to WalkFunc.
Other solutions, like checking `info` for `nil` might be possible, too, but `err` should be handled in some way.