### PR TITLE
fix(db): introduce db schema version

### DIFF
--- a/pkg/db/db_mock.go
+++ b/pkg/db/db_mock.go
@@ -9,7 +9,7 @@ type MockDBConfig struct {
 	mock.Mock
 }
 
-func (_m *MockDBConfig) SetVersion(version string) error {
+func (_m *MockDBConfig) SetVersion(version int) error {
 	ret := _m.Called(version)
 	return ret.Error(0)
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -57,7 +57,7 @@ func CloneOrPull(url, repoPath string) (map[string]struct{}, error) {
 	}
 
 	// Need to refresh all vulnerabilities
-	if db.GetVersion() == "" {
+	if db.GetVersion() == 0 {
 		err = filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -21,8 +21,6 @@ import (
 )
 
 func Run(c *cli.Context) (err error) {
-	cliVersion := c.App.Version
-
 	if c.Bool("quiet") || c.Bool("no-progress") {
 		utils.Quiet = true
 	}
@@ -87,7 +85,7 @@ func Run(c *cli.Context) (err error) {
 
 	needRefresh := false
 	dbVersion := db.GetVersion()
-	if dbVersion != "" && dbVersion != cliVersion {
+	if 0 < dbVersion && dbVersion < db.SchemaVersion {
 		if !refresh && !autoRefresh {
 			return xerrors.New("Detected version update of trivy. Please try again with --refresh or --auto-refresh option")
 		}
@@ -114,7 +112,7 @@ func Run(c *cli.Context) (err error) {
 	}
 
 	dbc := db.Config{}
-	if err = dbc.SetVersion(cliVersion); err != nil {
+	if err = dbc.SetVersion(db.SchemaVersion); err != nil {
 		return xerrors.Errorf("unexpected error: %w", err)
 	}
 

--- a/pkg/vulnsrc/vulnsrc_test.go
+++ b/pkg/vulnsrc/vulnsrc_test.go
@@ -28,7 +28,7 @@ func BenchmarkUpdate(b *testing.B) {
 	b.Run("NVD", func(b *testing.B) {
 		dbc := db.Config{}
 		for i := 0; i < b.N; i++ {
-			if err := dbc.SetVersion(""); err != nil {
+			if err := dbc.SetVersion(db.SchemaVersion); err != nil {
 				b.Fatal(err)
 			}
 			if err := Update([]string{vulnerability.Nvd}); err != nil {


### PR DESCRIPTION
Trivy uses the app version as the database schema version. When the app version is updated, an entire update of the database is forced. This is for DB migration, but the DB schema hardly changes.

This PR separates the app version and the DB version. It makes it possible to update the app version without forcing the entire update of the database.

Before:

|     | version |
|-----|---------|
| app | v0.1.6  |
| db  | v0.1.6  |

After:

|     | version |
|-----|---------|
| app | v0.1.6  |
| db  | v1  |