### PR TITLE
add echo to CI gofmt step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             if test -z "$(gofmt -l .)"; then
               echo "Congrats! There is nothing to fix."
             else
-              "The following lines should be fixed."
+              echo "The following lines should be fixed."
               gofmt -s -d .
               exit 1
             fi


### PR DESCRIPTION
the CI step that runs gofmt doesn't echo out a string
so it causes the step to fail before emitting the "gofmt"
errors that need to be fixed