### PR TITLE
pass SkipUpdate in ScanOptions to stop app updates

### DIFF
--- a/pkg/run.go
+++ b/pkg/run.go
@@ -157,8 +157,9 @@ func Run(c *cli.Context) (err error) {
 
 	timeout := c.Duration("timeout")
 	scanOptions := types.ScanOptions{
-		VulnType: strings.Split(c.String("vuln-type"), ","),
-		Timeout:  timeout,
+		VulnType:   strings.Split(c.String("vuln-type"), ","),
+		SkipUpdate: skipUpdate,
+		Timeout:    timeout,
 	}
 
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -88,8 +88,8 @@ func ScanImage(imageName, filePath string, scanOptions types.ScanOptions) (repor
 	return results, nil
 }
 
-func ScanFile(f *os.File) (report.Results, error) {
-	vulns, err := library.ScanFile(f)
+func ScanFile(f *os.File, scanOptions types.ScanOptions) (report.Results, error) {
+	vulns, err := library.ScanFile(f, scanOptions)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to scan libraries in file: %w", err)
 	}

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -3,6 +3,7 @@ package types
 import "time"
 
 type ScanOptions struct {
-	VulnType []string
-	Timeout  time.Duration
+	VulnType   []string
+	SkipUpdate bool
+	Timeout    time.Duration
 }


### PR DESCRIPTION
the `--skip-update` option didn't prevent application scan
updates as those happend a bit later in the whole process.

we've passed those settings through the "scanoptions"
to get that handled later in the system so we can prevent
the UpdateDB call from happening during the scan.

this also updates ScanFile to also accept "ScanOptions"

Closes #192 