### PR TITLE
fix(skip-update): prohibit --skip-update in some situations

### DIFF
--- a/pkg/run.go
+++ b/pkg/run.go
@@ -49,12 +49,10 @@ func Run(c *cli.Context) (err error) {
 	}
 
 	light := c.Bool("light")
-	if !skipUpdate {
-		client := dbFile.NewClient()
-		ctx := context.Background()
-		if err = client.Download(ctx, c.App.Version, cacheDir, light); err != nil {
-			return xerrors.Errorf("failed to download vulnerability DB: %w", err)
-		}
+	client := dbFile.NewClient()
+	ctx := context.Background()
+	if err = client.Download(ctx, c.App.Version, cacheDir, light, skipUpdate); err != nil {
+		return xerrors.Errorf("failed to download vulnerability DB: %w", err)
 	}
 
 	if downloadDBOnly {


### PR DESCRIPTION
`--skip-update` cannot be specified:
- First run
- Old DB version
- Different DB type (full vs light)