### PR TITLE
Fix DonwloadDBOnly conduct strategy.

### DIFF
--- a/internal/standalone/config/config.go
+++ b/internal/standalone/config/config.go
@@ -113,8 +113,8 @@ func (c *Config) Init() (err error) {
 		utils.Quiet = true
 	}
 
-	// --clear-cache and --reset don't conduct the scan
-	if c.ClearCache || c.Reset {
+	// --clear-cache, --download-db-only and --reset don't conduct the scan
+	if c.ClearCache || c.DownloadDBOnly || c.Reset {
 		return nil
 	}
 


### PR DESCRIPTION
```
$ ./trivy　--download-db-only               
2019-12-09T14:10:05.246+0900    ERROR   trivy requires at least 1 argument or --input option
```