### PR TITLE
fix(writer): Refactor results struct

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -19,7 +19,7 @@ import (
 type Results []Result
 
 type Result struct {
-	FileName        string                        `json:"Target"`
+	Target          string                        `json:"Target"`
 	Vulnerabilities []types.DetectedVulnerability `json:"Vulnerabilities"`
 }
 
@@ -101,8 +101,8 @@ func (tw TableWriter) write(result Result) {
 		results = append(results, r)
 	}
 
-	fmt.Printf("\n%s\n", result.FileName)
-	fmt.Println(strings.Repeat("=", len(result.FileName)))
+	fmt.Printf("\n%s\n", result.Target)
+	fmt.Println(strings.Repeat("=", len(result.Target)))
 	fmt.Printf("Total: %d (%s)\n\n", len(result.Vulnerabilities), strings.Join(results, ", "))
 
 	if len(result.Vulnerabilities) == 0 {

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -117,7 +117,7 @@ func TestReportWriter_Table(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			inputResults := report.Results{
 				{
-					FileName:        "foo",
+					Target:          "foo",
 					Vulnerabilities: tc.detectedVulns,
 				},
 			}
@@ -151,7 +151,7 @@ func TestReportWriter_JSON(t *testing.T) {
 			},
 			expectedJSON: report.Results{
 				report.Result{
-					FileName: "foojson",
+					Target: "foojson",
 					Vulnerabilities: []types.DetectedVulnerability{
 						{
 							VulnerabilityID:  "123",
@@ -179,7 +179,7 @@ func TestReportWriter_JSON(t *testing.T) {
 
 			inputResults := report.Results{
 				{
-					FileName:        "foojson",
+					Target:          "foojson",
 					Vulnerabilities: tc.detectedVulns,
 				},
 			}
@@ -236,7 +236,7 @@ func TestReportWriter_Template(t *testing.T) {
 			tmplWritten := bytes.Buffer{}
 			inputResults := report.Results{
 				{
-					FileName:        "foojson",
+					Target:          "foojson",
 					Vulnerabilities: tc.detectedVulns,
 				},
 			}

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -103,7 +103,7 @@ func (s Scanner) ScanImage(imageName, filePath string, scanOptions types.ScanOpt
 		if osFamily != "" {
 			imageDetail := fmt.Sprintf("%s (%s %s)", target, osFamily, osVersion)
 			results = append(results, report.Result{
-				FileName:        imageDetail,
+				Target:          imageDetail,
 				Vulnerabilities: osVulns,
 			})
 		}
@@ -118,12 +118,12 @@ func (s Scanner) ScanImage(imageName, filePath string, scanOptions types.ScanOpt
 		var libResults report.Results
 		for path, vulns := range libVulns {
 			libResults = append(libResults, report.Result{
-				FileName:        path,
+				Target:          path,
 				Vulnerabilities: vulns,
 			})
 		}
 		sort.Slice(libResults, func(i, j int) bool {
-			return libResults[i].FileName < libResults[j].FileName
+			return libResults[i].Target < libResults[j].Target
 		})
 		results = append(results, libResults...)
 	}
@@ -137,7 +137,7 @@ func (s Scanner) ScanFile(f *os.File) (report.Results, error) {
 		return nil, xerrors.Errorf("failed to scan libraries in file: %w", err)
 	}
 	results := report.Results{
-		{FileName: f.Name(), Vulnerabilities: vulns},
+		{Target: f.Name(), Vulnerabilities: vulns},
 	}
 	return results, nil
 }


### PR DESCRIPTION
This would result in an empty query:
```./trivy -f template -t "{{ range . }} {{ .Target }} {{ end }}" -q alpine:3.10```

instead of showing

```alpine:3.10 (alpine 3.10.3)```