### PR TITLE
fix(integration-test): use a snapshot database for Docker mode

### DIFF
--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -38,6 +38,10 @@ func TestRun_WithDockerEngine(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Copy DB file
+		cacheDir := gunzipDB()
+		//defer os.RemoveAll(cacheDir)
+
 		ctx := context.Background()
 		defer ctx.Done()
 
@@ -63,18 +67,12 @@ func TestRun_WithDockerEngine(t *testing.T) {
 			require.NoError(t, err, tc.name)
 		}
 
-		// run trivy
-		tmpDir, err := ioutil.TempDir("", "integration-docker-engine-*")
-		require.NoError(t, err)
-		defer func() {
-			os.RemoveAll(tmpDir)
-		}()
-
-		of, err := ioutil.TempFile(tmpDir, "integration-docker-engine-output-file-*")
+		of, err := ioutil.TempFile("", "integration-docker-engine-output-file-*")
 		require.NoError(t, err, tc.name)
-		app := internal.NewApp("dev")
+		defer os.Remove(of.Name())
 
-		trivyArgs := []string{"--skip-update", "--quiet", "--cache-dir", tmpDir, "--format=json"}
+		// run trivy
+		app := internal.NewApp("dev")
 		trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json"}
 		if !tc.invalidImage {
 			trivyArgs = append(trivyArgs, "--output", of.Name())

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -38,69 +38,71 @@ func TestRun_WithDockerEngine(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// Copy DB file
-		cacheDir := gunzipDB()
-		//defer os.RemoveAll(cacheDir)
+		t.Run(tc.name, func(t *testing.T) {
+			// Copy DB file
+			cacheDir := gunzipDB()
+			defer os.RemoveAll(cacheDir)
 
-		ctx := context.Background()
-		defer ctx.Done()
+			ctx := context.Background()
+			defer ctx.Done()
 
-		cli, err := client.NewClientWithOpts(client.FromEnv)
-		require.NoError(t, err, tc.name)
-
-		if !tc.invalidImage {
-			testfile, err := os.Open(tc.testfile)
+			cli, err := client.NewClientWithOpts(client.FromEnv)
 			require.NoError(t, err, tc.name)
 
-			// ensure image doesnt already exists
-			_, _ = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
-				Force:         true,
-				PruneChildren: true,
-			})
+			if !tc.invalidImage {
+				testfile, err := os.Open(tc.testfile)
+				require.NoError(t, err, tc.name)
 
-			// load image into docker engine
-			_, err = cli.ImageLoad(ctx, testfile, true)
+				// ensure image doesnt already exists
+				_, _ = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
+					Force:         true,
+					PruneChildren: true,
+				})
+
+				// load image into docker engine
+				_, err = cli.ImageLoad(ctx, testfile, true)
+				require.NoError(t, err, tc.name)
+
+				// tag our image to something unique
+				err = cli.ImageTag(ctx, "alpine:3.10", tc.testfile)
+				require.NoError(t, err, tc.name)
+			}
+
+			of, err := ioutil.TempFile("", "integration-docker-engine-output-file-*")
 			require.NoError(t, err, tc.name)
+			defer os.Remove(of.Name())
 
-			// tag our image to something unique
-			err = cli.ImageTag(ctx, "alpine:3.10", tc.testfile)
-			require.NoError(t, err, tc.name)
-		}
+			// run trivy
+			app := internal.NewApp("dev")
+			trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json"}
+			if !tc.invalidImage {
+				trivyArgs = append(trivyArgs, "--output", of.Name())
+			}
+			trivyArgs = append(trivyArgs, tc.testfile)
 
-		of, err := ioutil.TempFile("", "integration-docker-engine-output-file-*")
-		require.NoError(t, err, tc.name)
-		defer os.Remove(of.Name())
+			err = app.Run(trivyArgs)
+			switch {
+			case tc.expectedError != "":
+				assert.Equal(t, tc.expectedError, err.Error(), tc.name)
+			default:
+				assert.NoError(t, err, tc.name)
+			}
 
-		// run trivy
-		app := internal.NewApp("dev")
-		trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json"}
-		if !tc.invalidImage {
-			trivyArgs = append(trivyArgs, "--output", of.Name())
-		}
-		trivyArgs = append(trivyArgs, tc.testfile)
+			if !tc.invalidImage {
+				// check for vulnerability output info
+				got, err := ioutil.ReadAll(of)
+				assert.NoError(t, err, tc.name)
+				want, err := ioutil.ReadFile(tc.expectedOutputFile)
+				assert.NoError(t, err, tc.name)
+				assert.JSONEq(t, string(want), string(got), tc.name)
 
-		err = app.Run(trivyArgs)
-		switch {
-		case tc.expectedError != "":
-			assert.Equal(t, tc.expectedError, err.Error(), tc.name)
-		default:
-			assert.NoError(t, err, tc.name)
-		}
-
-		if !tc.invalidImage {
-			// check for vulnerability output info
-			got, err := ioutil.ReadAll(of)
-			assert.NoError(t, err, tc.name)
-			want, err := ioutil.ReadFile(tc.expectedOutputFile)
-			assert.NoError(t, err, tc.name)
-			assert.JSONEq(t, string(want), string(got), tc.name)
-
-			// cleanup
-			_, err = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
-				Force:         true,
-				PruneChildren: true,
-			})
-			assert.NoError(t, err, tc.name)
-		}
+				// cleanup
+				_, err = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
+					Force:         true,
+					PruneChildren: true,
+				})
+				assert.NoError(t, err, tc.name)
+			}
+		})
 	}
 }

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -75,6 +75,7 @@ func TestRun_WithDockerEngine(t *testing.T) {
 		app := internal.NewApp("dev")
 
 		trivyArgs := []string{"--skip-update", "--quiet", "--cache-dir", tmpDir, "--format=json"}
+		trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json"}
 		if !tc.invalidImage {
 			trivyArgs = append(trivyArgs, "--output", of.Name())
 		}


### PR DESCRIPTION
## ToDo
- [x] add a binary name to skip updating DB
- [x] use a snapshot database
- [x] add t.Run()

## Issue
Close https://github.com/aquasecurity/trivy/issues/351