### PR TITLE
chore(goreleaser): change name_template to file_name_template

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -34,7 +34,7 @@ nfpms:
     maintainer: "Teppei Fukuda <knqyf263@gmail.com>"
     description: "A Fast Vulnerability Scanner for Containers"
     license: "AGPL-3.0"
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
     replacements:
       amd64: 64bit
       386: 32bit


### PR DESCRIPTION
According to https://goreleaser.com/deprecations/#nfpms-name-template, the name_template field was deprecated.