### PR TITLE
contrib: Add GitLab CI template to deeply integrated with GitLab Container Scanning

### DIFF
--- a/contrib/Trivy.gitlab-ci.yml
+++ b/contrib/Trivy.gitlab-ci.yml
@@ -1,0 +1,29 @@
+Trivy_container_scanning:
+  stage: test
+  image:
+    name: alpine:3.11
+  variables:
+    # Override the GIT_STRATEGY variable in your `.gitlab-ci.yml` file and set it to `fetch` if you want to provide a `clair-whitelist.yml`
+    # file. See https://docs.gitlab.com/ee/user/application_security/container_scanning/index.html#overriding-the-container-scanning-template
+    # for details
+    GIT_STRATEGY: none
+    IMAGE: "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  allow_failure: true
+  before_script:
+    - export TRIVY_VERSION=${TRIVY_VERSION:-v0.4.3}
+    - apk add --no-cache curl docker-cli
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    - curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin ${TRIVY_VERSION}
+    - curl -sSL -o /tmp/trivy-gitlab.tpl https://github.com/aquasecurity/trivy/raw/${TRIVY_VERSION}/contrib/gitlab.tpl
+  script:
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@/tmp/trivy-gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
+  cache:
+    paths:
+      - .trivycache/
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+  dependencies: []
+  only:
+    refs:
+      - branches


### PR DESCRIPTION
Adds GitLab CI template with deep integration with GitLab Container Scanning (report) (part of GitLab Security Product)

cf. https://gitlab.com/gitlab-org/gitlab/blob/f156adcec4c48d304128f2a4a8987f9ad6408591/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml

## TODO

- [x] Integrated with GitLab Container Scanning and Security Dashboard on GitLab CI at https://gitlab.com
- [x] Initial review by @knqyf263
- [x] Initial review by @mrueg 
- [x] Identify why the results cannot be shown in GitLab Web UI
- [x] Merge #387 
- [x] Pin `alpine` version to `3.11`
- [x] Parameterize GitLab template version (specified by git version)
- [x] TODO(tnir): `- export TRIVY_VERSION_FOR_TEMPLATE=${TRIVY_VERSION_FOR_TEMPLATE:-v0.4.3}`
- [x] TODO(tnir): replace `s!tnir/trivy!aquasecurity/trivy!` after #387 gets merged