### PR TITLE
Modify template for GitLab Container Scanning

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -1,40 +1,40 @@
-{{- /* Template based on https://docs.gitlab.com/ee/user/application_security/container_scanning/#reports-json-format */}}
+{{- /* Template based on https://docs.gitlab.com/ee/user/application_security/container_scanning/#reports-json-format */ -}}
 {
-"version": "2.3",
-{{- range . }}
-{{- $target := .Target }}
-"vulnerabilities": [
-    {{- $first := true}}
+  "version": "2.3",
+  "vulnerabilities": [
+  {{- $first := true }}
+  {{- range . }}
+  {{- $target := .Target }}
     {{- range .Vulnerabilities -}}
     {{- if $first -}}
       {{- $first = false -}}
-    {{else -}}
-,
-    {{- end}}
+    {{ else -}}
+      ,
+    {{- end }}
     {
       "category": "container_scanning",
       "message": {{ .Title | printf "%q" }},
-      "description": {{ .Description | printf "%q"}},
+      "description": {{ .Description | printf "%q" }},
       "cve": "{{ .VulnerabilityID }}",
       "severity": {{ if eq .Severity "UNKNOWN" -}}
                     "Unknown"
-                {{else if eq .Severity "LOW" -}}
+                  {{- else if eq .Severity "LOW" -}}
                     "Low"
-                {{else if eq .Severity "MEDIUM" -}}
+                  {{- else if eq .Severity "MEDIUM" -}}
                     "Medium"
-                {{else if eq .Severity "HIGH" -}}
+                  {{- else if eq .Severity "HIGH" -}}
                     "High"
-                {{else if eq .Severity "CRITICAL" -}}
+                  {{- else if eq .Severity "CRITICAL" -}}
                     "Critical"
-                {{ else -}}
-                "{{ .Severity }}"
-                {{- end }},
+                  {{-  else -}}
+                    "{{ .Severity }}"
+                  {{- end }},
       "confidence": "Unknown",
       "solution": {{ if .FixedVersion -}}
-                  "Upgrade {{ .PkgName }} to {{ .FixedVersion }}",
+                    "Upgrade {{ .PkgName }} to {{ .FixedVersion }}"
                   {{- else -}}
-                  "No solution provided",
-                  {{- end }}
+                    "No solution provided"
+                  {{- end }},
       "scanner": {
         "id": "trivy",
         "name": "trivy"
@@ -43,38 +43,38 @@
         "dependency": {
           "package": {
             "name": "{{ .PkgName }}"
-       },
-            "version": "{{ .InstalledVersion }}"
+          },
+          "version": "{{ .InstalledVersion }}"
         },
-    {{- /* TODO: No mapping available - https://github.com/aquasecurity/trivy/issues/332 */}}
-    "operating_system": "Unknown",
-    "image": "{{ $target }}"
+        {{- /* TODO: No mapping available - https://github.com/aquasecurity/trivy/issues/332 */}}
+        "operating_system": "Unknown",
+        "image": "{{ $target }}"
       },
       "identifiers": [
-          {
+        {
 	  {{- /* TODO: Type not extractable - https://github.com/aquasecurity/trivy-db/pull/24 */}}
           "type": "cve",
           "name": "{{ .VulnerabilityID }}",
           "value": "{{ .VulnerabilityID }}",
           "url": ""
-          }
+        }
       ],
       "links": [
-          {{ $first := true -}}
-          {{- range .References -}}
-          {{- if $first -}}
-          {{- $first = false -}}
-          {{else -}}
- ,
-          {{ end -}}
-      {
+        {{- $first := true -}}
+        {{- range .References -}}
+        {{- if $first -}}
+          {{- $first = false }}
+        {{- else -}}
+          ,
+        {{- end -}}
+        {
           "url": "{{ . }}"
-      }
-      {{- end }}
-    ]
+        }
+        {{- end }}
+      ]
     }
-  {{- end -}}
-{{- end}}
+    {{- end -}}
+  {{- end }}
   ],
   "remediations": []
 }


### PR DESCRIPTION
While a template for [GitLab Container Scanning Report](https://docs.gitlab.com/ee/user/application_security/container_scanning/) was introduced in #367, the template should be modified to comply with GitLab Container Scanning Report as of 2020-01 (GitLab EE 
 12.7).

### for reviewers: Test on your local

```
git checkout fix-template-for-gitlab-integration
trivy --format template --template "@contrib/gitlab.tpl" alpine:3.9
```

### Tests with GitLab CI at gitlab.com

- https://gitlab.com/tnir/trivy-ci-test/-/jobs/414069581

### Screenshot of integrated Container Scanning Report on GitLab Web UI

 🚀 🚀 🚀 

Successfully parsed by GitLab Container Scanning report parser

<img width="1262" alt="gitlab-container-scanning-with-trivy" src="https://user-images.githubusercontent.com/10229505/73082911-a4c94500-3f0d-11ea-860a-54fd18722836.png">

Closes #386 