### PR TITLE
feat(): include GitLab template inside the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.11
 RUN apk --no-cache add ca-certificates git rpm
 COPY trivy /usr/local/bin/trivy
-
+COPY contrib/gitlab.tpl contrib/gitlab.tpl
 ENTRYPOINT ["trivy"]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -94,3 +94,5 @@ dockers:
       - "--label=org.label-schema.build-date={{ .Date }}"
       - "--label=org.label-schema.vcs=https://github.com/aquasecurity/trivy"
       - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"
+    extra_files:
+    - contrib/gitlab.tpl


### PR DESCRIPTION
If we use the docker image in the GitLab CI (and not download/install trivy in a GitLab Job), we have to download the template and integrate it into our repository. 

To simplify this, I modified the project to include the file into the `/@contrib` folder. So, the line from the GitLab example can be used to do a GitLab analysis with Trivy. 

```yaml
🔎 ui:
  stage: 🔎 Security Analysis
  image:
    name: aquasec/trivy
    entrypoint: [""]
  script:
    - trivy --exit-code 0 --no-progress --format template --template "@.ci/gitlab-trivy.tpl" -o gl-container-scanning-report.json podcastserver/ui:${CI_COMMIT_TAG:-$CI_COMMIT_REF_SLUG}
  artifacts:
    reports:
      container_scanning: gl-container-scanning-report.json
```

This PR could be integrated into #376 & #387 

/cc @neonox31