### PR TITLE
cli: append warning when --template option is ignored

### DIFF
--- a/internal/standalone/config/config.go
+++ b/internal/standalone/config/config.go
@@ -104,6 +104,9 @@ func (c *Config) Init() (err error) {
 			c.logger.Warnf("--template is ignored because --format %s is specified. Use --template option with --format template option.", c.Format)
 		}
 	}
+	if c.Format == "template" && c.Template == "" {
+		c.logger.Warn("--format template is ignored because --template not is specified. Specify --template option when you use --format template.")
+	}
 	if c.onlyUpdate != "" || c.refresh || c.autoRefresh {
 		c.logger.Warn("--only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.")
 	}

--- a/internal/standalone/config/config.go
+++ b/internal/standalone/config/config.go
@@ -97,6 +97,13 @@ func New(c *cli.Context) (Config, error) {
 }
 
 func (c *Config) Init() (err error) {
+	if c.Template != "" {
+		if c.Format == "" {
+			c.logger.Warn("--template is ignored because --format template is not specified. Use --template option with --format template option.")
+		} else if c.Format != "template" {
+			c.logger.Warnf("--template is ignored because --format %s is specified. Use --template option with --format template option.", c.Format)
+		}
+	}
 	if c.onlyUpdate != "" || c.refresh || c.autoRefresh {
 		c.logger.Warn("--only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.")
 	}

--- a/internal/standalone/config/config_test.go
+++ b/internal/standalone/config/config_test.go
@@ -211,6 +211,26 @@ func TestConfig_Init(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid option combination: --format template without --template",
+			fields: fields{
+				Format:     "template",
+				severities: "LOW",
+			},
+			args: []string{"gitlab/gitlab-ce:12.7.2-ce.0"},
+			logs: []string{
+				"--format template is ignored because --template not is specified. Specify --template option when you use --format template.",
+			},
+			want: Config{
+				AppVersion: "0.0.0",
+				Format:     "template",
+				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
+				Output:     os.Stdout,
+				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
+				severities: "LOW",
+				VulnType:   []string{""},
+			},
+		},
+		{
 			name: "with latest tag",
 			fields: fields{
 				onlyUpdate: "alpine",

--- a/internal/standalone/config/config_test.go
+++ b/internal/standalone/config/config_test.go
@@ -169,6 +169,48 @@ func TestConfig_Init(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid option combination: --template enabled without --format",
+			fields: fields{
+				Template:   "@contrib/gitlab.tpl",
+				severities: "LOW",
+			},
+			args: []string{"gitlab/gitlab-ce:12.7.2-ce.0"},
+			logs: []string{
+				"--template is ignored because --format template is not specified. Use --template option with --format template option.",
+			},
+			want: Config{
+				AppVersion: "0.0.0",
+				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
+				Output:     os.Stdout,
+				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
+				severities: "LOW",
+				Template:   "@contrib/gitlab.tpl",
+				VulnType:   []string{""},
+			},
+		},
+		{
+			name: "invalid option combination: --template and --format json",
+			fields: fields{
+				Format:     "json",
+				Template:   "@contrib/gitlab.tpl",
+				severities: "LOW",
+			},
+			args: []string{"gitlab/gitlab-ce:12.7.2-ce.0"},
+			logs: []string{
+				"--template is ignored because --format json is specified. Use --template option with --format template option.",
+			},
+			want: Config{
+				AppVersion: "0.0.0",
+				Format:     "json",
+				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
+				Output:     os.Stdout,
+				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
+				severities: "LOW",
+				Template:   "@contrib/gitlab.tpl",
+				VulnType:   []string{""},
+			},
+		},
+		{
 			name: "with latest tag",
 			fields: fields{
 				onlyUpdate: "alpine",


### PR DESCRIPTION
to avoid `--template` is silently ignored when `--format <table|json>` or no `--format` is passed.

Closes #390 #394

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>