### PR TITLE
fix(redhat): use binary package name for OVAL

### DIFF
--- a/integration/testdata/centos-6.json.golden
+++ b/integration/testdata/centos-6.json.golden
@@ -12629,6 +12629,32 @@
         ]
       },
       {
+        "VulnerabilityID": "CVE-2019-12735",
+        "PkgName": "vim-minimal",
+        "InstalledVersion": "2:7.4.629-5.el6_8.1",
+        "FixedVersion": "2:7.4.629-5.el6_10.2",
+        "Title": "vim/neovim: ':source!' command allows arbitrary command execution via modelines",
+        "Description": "getchar.c in Vim before 8.1.1365 and Neovim before 0.3.6 allows remote attackers to execute arbitrary OS commands via the :source! command in a modeline, as demonstrated by execute in Vim, and assert_fails or nvim_input in Neovim.",
+        "Severity": "CRITICAL",
+        "References": [
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00031.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00036.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00037.html",
+          "http://www.securityfocus.com/bid/108724",
+          "https://bugs.debian.org/930020",
+          "https://bugs.debian.org/930024",
+          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12735",
+          "https://github.com/neovim/neovim/pull/10082",
+          "https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md",
+          "https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/2BMDSHTF754TITC6AQJPCS5IRIDMMIM7/",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TRIRBC2YRGKPAWVRMZS4SZTGGCVRVZPR/",
+          "https://usn.ubuntu.com/4016-1/",
+          "https://usn.ubuntu.com/4016-2/",
+          "https://www.debian.org/security/2019/dsa-4467"
+        ]
+      },
+      {
         "VulnerabilityID": "CVE-2017-5953",
         "PkgName": "vim-minimal",
         "InstalledVersion": "2:7.4.629-5.el6_8.1",

--- a/integration/testdata/centos-7-critical.json.golden
+++ b/integration/testdata/centos-7-critical.json.golden
@@ -112,6 +112,32 @@
           "https://usn.ubuntu.com/3816-1/",
           "https://www.exploit-db.com/exploits/45714/"
         ]
+      },
+      {
+        "VulnerabilityID": "CVE-2019-12735",
+        "PkgName": "vim-minimal",
+        "InstalledVersion": "2:7.4.160-5.el7",
+        "FixedVersion": "2:7.4.160-6.el7_6",
+        "Title": "vim/neovim: ':source!' command allows arbitrary command execution via modelines",
+        "Description": "getchar.c in Vim before 8.1.1365 and Neovim before 0.3.6 allows remote attackers to execute arbitrary OS commands via the :source! command in a modeline, as demonstrated by execute in Vim, and assert_fails or nvim_input in Neovim.",
+        "Severity": "CRITICAL",
+        "References": [
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00031.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00036.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00037.html",
+          "http://www.securityfocus.com/bid/108724",
+          "https://bugs.debian.org/930020",
+          "https://bugs.debian.org/930024",
+          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12735",
+          "https://github.com/neovim/neovim/pull/10082",
+          "https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md",
+          "https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/2BMDSHTF754TITC6AQJPCS5IRIDMMIM7/",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TRIRBC2YRGKPAWVRMZS4SZTGGCVRVZPR/",
+          "https://usn.ubuntu.com/4016-1/",
+          "https://usn.ubuntu.com/4016-2/",
+          "https://www.debian.org/security/2019/dsa-4467"
+        ]
       }
     ]
   }

--- a/integration/testdata/centos-7-ignore-unfixed.json.golden
+++ b/integration/testdata/centos-7-ignore-unfixed.json.golden
@@ -1708,6 +1708,32 @@
           "https://lists.apache.org/thread.html/5960a34a524848cd722fd7ab7e2227eac10107b0f90d9d1e9c3caa74@%3Cuser.cassandra.apache.org%3E",
           "https://security.netapp.com/advisory/ntap-20190307-0007/"
         ]
+      },
+      {
+        "VulnerabilityID": "CVE-2019-12735",
+        "PkgName": "vim-minimal",
+        "InstalledVersion": "2:7.4.160-5.el7",
+        "FixedVersion": "2:7.4.160-6.el7_6",
+        "Title": "vim/neovim: ':source!' command allows arbitrary command execution via modelines",
+        "Description": "getchar.c in Vim before 8.1.1365 and Neovim before 0.3.6 allows remote attackers to execute arbitrary OS commands via the :source! command in a modeline, as demonstrated by execute in Vim, and assert_fails or nvim_input in Neovim.",
+        "Severity": "CRITICAL",
+        "References": [
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00031.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00036.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00037.html",
+          "http://www.securityfocus.com/bid/108724",
+          "https://bugs.debian.org/930020",
+          "https://bugs.debian.org/930024",
+          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12735",
+          "https://github.com/neovim/neovim/pull/10082",
+          "https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md",
+          "https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/2BMDSHTF754TITC6AQJPCS5IRIDMMIM7/",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TRIRBC2YRGKPAWVRMZS4SZTGGCVRVZPR/",
+          "https://usn.ubuntu.com/4016-1/",
+          "https://usn.ubuntu.com/4016-2/",
+          "https://www.debian.org/security/2019/dsa-4467"
+        ]
       }
     ]
   }

--- a/integration/testdata/centos-7.json.golden
+++ b/integration/testdata/centos-7.json.golden
@@ -11850,6 +11850,32 @@
         ]
       },
       {
+        "VulnerabilityID": "CVE-2019-12735",
+        "PkgName": "vim-minimal",
+        "InstalledVersion": "2:7.4.160-5.el7",
+        "FixedVersion": "2:7.4.160-6.el7_6",
+        "Title": "vim/neovim: ':source!' command allows arbitrary command execution via modelines",
+        "Description": "getchar.c in Vim before 8.1.1365 and Neovim before 0.3.6 allows remote attackers to execute arbitrary OS commands via the :source! command in a modeline, as demonstrated by execute in Vim, and assert_fails or nvim_input in Neovim.",
+        "Severity": "CRITICAL",
+        "References": [
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00031.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00036.html",
+          "http://lists.opensuse.org/opensuse-security-announce/2019-06/msg00037.html",
+          "http://www.securityfocus.com/bid/108724",
+          "https://bugs.debian.org/930020",
+          "https://bugs.debian.org/930024",
+          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12735",
+          "https://github.com/neovim/neovim/pull/10082",
+          "https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md",
+          "https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/2BMDSHTF754TITC6AQJPCS5IRIDMMIM7/",
+          "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TRIRBC2YRGKPAWVRMZS4SZTGGCVRVZPR/",
+          "https://usn.ubuntu.com/4016-1/",
+          "https://usn.ubuntu.com/4016-2/",
+          "https://www.debian.org/security/2019/dsa-4467"
+        ]
+      },
+      {
         "VulnerabilityID": "CVE-2017-5953",
         "PkgName": "vim-minimal",
         "InstalledVersion": "2:7.4.160-5.el7",

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -5,12 +5,209 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/fanal/analyzer"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 func TestMain(m *testing.M) {
 	log.InitLogger(false, false)
 	os.Exit(m.Run())
+}
+
+func TestScanner_Detect(t *testing.T) {
+	type args struct {
+		osVer string
+		pkgs  []analyzer.Package
+	}
+	tests := []struct {
+		name    string
+		args    args
+		get     []dbTypes.GetExpectation
+		want    []types.DetectedVulnerability
+		wantErr bool
+	}{
+		{
+			name: "happy path: src pkg name is different from bin pkg name",
+			args: args{
+				osVer: "7.6",
+				pkgs: []analyzer.Package{
+					{
+						Name:       "vim-minimal",
+						Version:    "7.4.160",
+						Release:    "5.el7",
+						Epoch:      2,
+						Arch:       "x86_64",
+						SrcName:    "vim",
+						SrcVersion: "7.4.160",
+						SrcRelease: "5.el7",
+						SrcEpoch:   2,
+					},
+				},
+			},
+			get: []dbTypes.GetExpectation{
+				{
+					Args: dbTypes.GetArgs{
+						Release: "7",
+						PkgName: "vim",
+					},
+					Returns: dbTypes.GetReturns{
+						Advisories: []dbTypes.Advisory{
+							{
+								VulnerabilityID: "CVE-2017-5953",
+								FixedVersion:    "",
+							},
+							{
+								VulnerabilityID: "CVE-2017-6350",
+								FixedVersion:    "",
+							},
+						},
+					},
+				},
+				{
+					Args: dbTypes.GetArgs{
+						Release: "7",
+						PkgName: "vim-minimal",
+					},
+					Returns: dbTypes.GetReturns{
+						Advisories: []dbTypes.Advisory{
+							{
+								VulnerabilityID: "CVE-2019-12735",
+								FixedVersion:    "2:7.4.160-6.el7_6",
+							},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2017-5953",
+					PkgName:          "vim-minimal",
+					InstalledVersion: "2:7.4.160-5.el7",
+				},
+				{
+					VulnerabilityID:  "CVE-2017-6350",
+					PkgName:          "vim-minimal",
+					InstalledVersion: "2:7.4.160-5.el7",
+				},
+				{
+					VulnerabilityID:  "CVE-2019-12735",
+					PkgName:          "vim-minimal",
+					InstalledVersion: "2:7.4.160-5.el7",
+					FixedVersion:     "2:7.4.160-6.el7_6",
+				},
+			},
+		},
+		{
+			name: "happy path: src pkg name is the same as bin pkg name",
+			args: args{
+				osVer: "6.5",
+				pkgs: []analyzer.Package{
+					{
+						Name:       "nss",
+						Version:    "3.36.0",
+						Release:    "7.1.el7_6",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "nss",
+						SrcVersion: "3.36.0",
+						SrcRelease: "7.4.160",
+						SrcEpoch:   0,
+					},
+				},
+			},
+			get: []dbTypes.GetExpectation{
+				{
+					Args: dbTypes.GetArgs{
+						Release: "6",
+						PkgName: "nss",
+					},
+					Returns: dbTypes.GetReturns{
+						Advisories: []dbTypes.Advisory{
+							{
+								VulnerabilityID: "CVE-2015-2808",
+								FixedVersion:    "",
+							},
+							{
+								VulnerabilityID: "CVE-2016-2183",
+								FixedVersion:    "",
+							},
+							{
+								VulnerabilityID: "CVE-2018-12404",
+								FixedVersion:    "3.44.0-4.el7",
+							},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2015-2808",
+					PkgName:          "nss",
+					InstalledVersion: "3.36.0-7.1.el7_6",
+				},
+				{
+					VulnerabilityID:  "CVE-2016-2183",
+					PkgName:          "nss",
+					InstalledVersion: "3.36.0-7.1.el7_6",
+				},
+				{
+					VulnerabilityID:  "CVE-2018-12404",
+					PkgName:          "nss",
+					InstalledVersion: "3.36.0-7.1.el7_6",
+					FixedVersion:     "3.44.0-4.el7",
+				},
+			},
+		},
+		{
+			name: "sad path: Get returns an error",
+			args: args{
+				osVer: "5",
+				pkgs: []analyzer.Package{
+					{
+						Name:       "nss",
+						Version:    "3.36.0",
+						Release:    "7.1.el7_6",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "nss",
+						SrcVersion: "3.36.0",
+						SrcRelease: "7.4.160",
+						SrcEpoch:   0,
+					},
+				},
+			},
+			get: []dbTypes.GetExpectation{
+				{
+					Args: dbTypes.GetArgs{
+						Release: "5",
+						PkgName: "nss",
+					},
+					Returns: dbTypes.GetReturns{
+						Err: xerrors.New("error"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockVs := new(dbTypes.MockVulnSrc)
+			mockVs.ApplyGetExpectations(tt.get)
+			s := &Scanner{
+				vs: mockVs,
+			}
+			got, err := s.Detect(tt.args.osVer, tt.args.pkgs)
+			require.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestScanner_IsSupportedVersion(t *testing.T) {


### PR DESCRIPTION
Red Hat OVAL provides only binary package names having vulnerabilities. Trivy uses source package names to detect vulnerabilities. This is because Red Hat Security Data API provides only source package names having vulnerabilities. Now, Trivy uses both data source, so we need to use binary package names for OVAL and source package names for Security Data API. Most source package has the same name in binary packages like this.


- Source Package: openssl
- Binary Packages: 
  - **openssl**
  - openssl-debuginfo
  - openssl-perl
  - etc.

There is no problem in this case. But it sometimes doesn't have the same name.

- Source Package: vim
- Binary Packages: 
  - vim-common
  - vim-enhanced
  - vim-minimal
  - etc.

In this case, Trivy queries `vim` to OVAL DB to get security advisories, but DB doesn't have such a key, `vim` since OVAL has only binary package names such as `vim-common`. It causes false negatives. This case is not so much, but exists.