### PR TITLE
fix(gitlab): fix json template on loop

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -2,12 +2,12 @@
 {
   "version": "2.3",
   "vulnerabilities": [
-  {{- $first := true }}
+  {{- $t_first := true }}
   {{- range . }}
   {{- $target := .Target }}
     {{- range .Vulnerabilities -}}
-    {{- if $first -}}
-      {{- $first = false -}}
+    {{- if $t_first -}}
+      {{- $t_first = false -}}
     {{ else -}}
       ,
     {{- end }}
@@ -60,10 +60,10 @@
         }
       ],
       "links": [
-        {{- $first := true -}}
+        {{- $l_first := true -}}
         {{- range .References -}}
-        {{- if $first -}}
-          {{- $first = false }}
+        {{- if $l_first -}}
+          {{- $l_first = false }}
         {{- else -}}
           ,
         {{- end -}}


### PR DESCRIPTION
https://aquasecurity.gitlab.io/-/trivy-ci-test/-/jobs/440937099/artifacts/gl-container-scanning-report.json is not a valid JSON. This PR fixes the JSON template for GitLab security report.

Address the problem on https://github.com/aquasecurity/trivy-ci-test/pull/7#issuecomment-587354942