### PR TITLE
Document that --input accepts a hyphen to read from STDIN

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -32,7 +32,7 @@ var (
 	inputFlag = cli.StringFlag{
 		Name:   "input, i",
 		Value:  "",
-		Usage:  "input file path instead of image name",
+		Usage:  `input file path instead of image name ("-" for STDIN)`,
 		EnvVar: "TRIVY_INPUT",
 	}
 


### PR DESCRIPTION
Implementation of behaviour has existed since initial commit:
https://github.com/aquasecurity/trivy/blob/7726963e868d490cc2cffac7425c31f9bc0a42ec/pkg/scanner/scan.go#L148-L154