### PR TITLE
chore(goreleaser): drop BSD support temporarily

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,8 +12,6 @@ builds:
     goos:
       - darwin
       - linux
-      - freebsd
-      - openbsd
     goarch:
       - amd64
       - 386


### PR DESCRIPTION
`containers/storage` doesn't support FreeBSD and OpenBSD. It appears to be difficult to fix it shortly. Let me drop BSD support once. We don't have so many BSD users.

The following is binary names and download counts from GitHub Releases.
```
curl https://api.github.com/repos/aquasecurity/trivy/releases | jq -c '.[].assets[] | .name, .download_count' | xargs -n 2 | grep -i bsd
trivy_0.4.4_FreeBSD-32bit.tar.gz 0
trivy_0.4.4_FreeBSD-64bit.tar.gz 0
trivy_0.4.4_FreeBSD-ARM.tar.gz 0
trivy_0.4.4_OpenBSD-32bit.tar.gz 0
trivy_0.4.4_OpenBSD-64bit.tar.gz 0
trivy_0.4.4_OpenBSD-ARM.tar.gz 0
trivy_0.4.3_FreeBSD-32bit.tar.gz 0
trivy_0.4.3_FreeBSD-64bit.tar.gz 0
trivy_0.4.3_FreeBSD-ARM.tar.gz 0
trivy_0.4.3_OpenBSD-32bit.tar.gz 0
trivy_0.4.3_OpenBSD-64bit.tar.gz 1
trivy_0.4.3_OpenBSD-ARM.tar.gz 0
...
```
