### PR TITLE
fix(rpm): make it possible to scan non-RHEL images without rpm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy
 go 1.13
 
 require (
-	github.com/aquasecurity/fanal v0.0.0-20200306093250-5d9dd72b60d3
+	github.com/aquasecurity/fanal v0.0.0-20200306122936-f0a17242a9a0
 	github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b
 	github.com/aquasecurity/trivy-db v0.0.0-20191226181755-d6cabf5bc5d1
 	github.com/caarlos0/env/v6 v6.0.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/aquasecurity/fanal v0.0.0-20190819081512-f04452b627c6/go.mod h1:enEz4FFetw4XAbkffaYgyCVq1556R9Ry+noqT4rq9BE=
-github.com/aquasecurity/fanal v0.0.0-20200306093250-5d9dd72b60d3 h1:1XTIy2e0lWk1qEG4blmdygMDxCPPFo1TReC4AAnp/FM=
-github.com/aquasecurity/fanal v0.0.0-20200306093250-5d9dd72b60d3/go.mod h1:yPZqe/vMN0QDXBIl3kE9s793zU9NSQuEHGWLlL85bG8=
+github.com/aquasecurity/fanal v0.0.0-20200306122936-f0a17242a9a0 h1:ZkK02opCRhNdXBQHVA8cYgMFWfIYKAdje6s7LJQOQ0I=
+github.com/aquasecurity/fanal v0.0.0-20200306122936-f0a17242a9a0/go.mod h1:yPZqe/vMN0QDXBIl3kE9s793zU9NSQuEHGWLlL85bG8=
 github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b h1:55Ulc/gvfWm4ylhVaR7MxOwujRjA6et7KhmUbSgUFf4=
 github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b/go.mod h1:BpNTD9vHfrejKsED9rx04ldM1WIbeyXGYxUrqTVwxVQ=
 github.com/aquasecurity/trivy v0.1.6/go.mod h1:5hobyhxLzDtxruHzPxpND2PUKOssvGUdE9BocpJUwo4=


### PR DESCRIPTION
Close https://github.com/aquasecurity/trivy/issues/426