### PR TITLE
feat(release): fetch all supported versions automatically

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM circleci/golang:1.13-buster 
 
 RUN sudo apt-get -y update \
-    && sudo apt-get -y install rpm reprepro createrepo
+    && sudo apt-get -y install rpm reprepro createrepo distro-info
 
 ARG GORELEASER_VERSION=0.124.1
 ARG GORELEASER_ARTIFACT=goreleaser_Linux_x86_64.tar.gz

--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-RELEASES=(wheezy jessie stretch buster trusty xenial bionic)
+DEBIAN_RELEASES=$(debian-distro-info --supported)
+UBUNTU_RELEASES=$(ubuntu-distro-info --supported)
 
 cd trivy-repo/deb
 
-for release in ${RELEASES[@]}; do
-  echo "Adding deb package to $release"
+for release in $(reprepro ls trivy | awk -F "|" '{print $3}' | sed 's/ //g'); do
+  echo "Removing deb package of $release"
   reprepro -A i386 remove $release trivy
   reprepro -A amd64 remove $release trivy
+done
+
+for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+  echo "Adding deb package to $release"
   reprepro includedeb $release ../../dist/*Linux-64bit.deb
   reprepro includedeb $release ../../dist/*Linux-32bit.deb
 done


### PR DESCRIPTION
# Overview
This PR makes it possible to fetch all supported versions automatically using `debian-distro-info` and `ubuntu-distro-info`

Close https://github.com/aquasecurity/trivy/issues/444
Related: https://github.com/aquasecurity/trivy-repo/pull/3