### PR TITLE
Fix CircleCI example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,9 +1207,10 @@ $ cat .circleci/config.yml
 jobs:
   build:
     docker:
-      - image: docker:18.09-git
+      - image: docker:stable-git
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Build image
           command: docker build -t trivy-ci-test:${CIRCLE_SHA1} .


### PR DESCRIPTION
After trying to run trivy using CircleCI based on the sample configuration and failing, I want to suggest the following updates:

* `docker:18.09-git` no longer exists and causes workflow to fail, replaced with `stable-git` instead.

* added  `setup_remote_docker` or else the docker commands fail in the rest of the execution, as per https://circleci.com/docs/2.0/building-docker-images/#overview