### PR TITLE
improve: using STDIN for docker login command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           version: 18.06.0-ce
       - run:
           name: setup docker
-          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+          command: echo $DOCKER_PASS | docker login --username $DOCKER_USER --password-stdin
       - run:
           name: Release
           command: goreleaser --rm-dist


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy/issues/457

The Docker documentation recommends piping the registry password through STDIN when logging in with `docker login` non-interactively. This is for security reasons:

> To run the docker login command non-interactively, you can set the --password-stdin flag to provide a password through STDIN. Using STDIN prevents the password from ending up in the shell’s history, or log-files.

Source: [Provide a password using STDIN](https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin)

However, the trivy CI doesn't make use of this yet:

https://github.com/aquasecurity/trivy/blob/e5ff5ec89542bda37b744f4cbc24bc267e72fccd/.circleci/config.yml#L45-L47

This PR changes the `docker login` command.