### PR TITLE
chore(ci): move integration tests to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,18 +24,6 @@ jobs:
       - run:
           name: Test
           command: make test
-  integration-test:
-    <<: *defaults
-    parameters:
-      docker_version:
-        type: string
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: << parameters.docker_version >>
-      - run:
-          name: Integration Test
-          command: make test-integration
   release:
     <<: *defaults
     steps:
@@ -71,8 +59,6 @@ workflows:
   release:
     jobs:
       - unit-test
-      - integration-test:
-            docker_version: 18.09.3
       - release:
           filters:
             branches:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,22 @@
 name: Test
 on: pull_request
 jobs:
+  integration:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14.x
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Run integration tests
+      run: make test-integration
+
   build-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
       run: make test-integration
 
   build-test:
+    name: Build Test
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.14
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
         go-version: 1.14.x
@@ -22,10 +22,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up go
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.14.x
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,10 +23,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
         go-version: 1.14.x
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/trivy
 go 1.13
 
 require (
-	github.com/aquasecurity/fanal v0.0.0-20200427221647-c3528846e21c
+	github.com/aquasecurity/fanal v0.0.0-20200504143803-30a561989059
 	github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b
 	github.com/aquasecurity/trivy-db v0.0.0-20200430091154-7c0a6e1ad398
 	github.com/caarlos0/env/v6 v6.0.0

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/aquasecurity/fanal v0.0.0-20200427221647-c3528846e21c h1:Rg4yt5YiL2SfOx2sbJjn3Y3jgYxOSJ+XXj7ogp+FeWk=
-github.com/aquasecurity/fanal v0.0.0-20200427221647-c3528846e21c/go.mod h1:3H3F3x2XtcdFH3o1LQJEzfu2sS/rf+XufPIngMZrKO4=
+github.com/aquasecurity/fanal v0.0.0-20200504143803-30a561989059 h1:FLQkluzBXeQvyNAMNtFpvd0qMbxLeYVdP6B/Pxx/d54=
+github.com/aquasecurity/fanal v0.0.0-20200504143803-30a561989059/go.mod h1:3H3F3x2XtcdFH3o1LQJEzfu2sS/rf+XufPIngMZrKO4=
 github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b h1:55Ulc/gvfWm4ylhVaR7MxOwujRjA6et7KhmUbSgUFf4=
 github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b/go.mod h1:BpNTD9vHfrejKsED9rx04ldM1WIbeyXGYxUrqTVwxVQ=
 github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a h1:hsw7PpiymXP64evn/K7gsj3hWzMqLrdoeE6JkqDocVg=

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -83,12 +83,6 @@ func TestRun_WithDockerEngine(t *testing.T) {
 			testfile:           "testdata/fixtures/centos-6.tar.gz",
 		},
 		{
-			name:               "happy path, valid image path, centos:6",
-			imageTag:           "centos:6",
-			expectedOutputFile: "testdata/centos-6.json.golden",
-			testfile:           "testdata/fixtures/centos-6.tar.gz",
-		},
-		{
 			name:               "happy path, valid image path, centos:7",
 			imageTag:           "centos:7",
 			expectedOutputFile: "testdata/centos-7.json.golden",

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -234,19 +234,19 @@ func TestRun_WithDockerEngine(t *testing.T) {
 		},
 	}
 
+	// Copy DB file
+	cacheDir, err := gunzipDB()
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	ctx := context.Background()
+	defer ctx.Done()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Copy DB file
-			cacheDir, err := gunzipDB()
-			require.NoError(t, err)
-			defer os.RemoveAll(cacheDir)
-
-			ctx := context.Background()
-			defer ctx.Done()
-
-			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-			require.NoError(t, err, tc.name)
-
 			if !tc.invalidImage {
 				testfile, err := os.Open(tc.testfile)
 				require.NoError(t, err, tc.name)
@@ -273,7 +273,7 @@ func TestRun_WithDockerEngine(t *testing.T) {
 
 			// run trivy
 			app := internal.NewApp("dev")
-			trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json"}
+			trivyArgs := []string{"trivy", "--skip-update", "--cache-dir", cacheDir, "--format=json", "--output", of.Name()}
 			if tc.ignoreUnfixed {
 				trivyArgs = append(trivyArgs, "--ignore-unfixed")
 			}
@@ -288,9 +288,6 @@ func TestRun_WithDockerEngine(t *testing.T) {
 				assert.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
-			if !tc.invalidImage {
-				trivyArgs = append(trivyArgs, "--output", of.Name())
-			}
 			trivyArgs = append(trivyArgs, tc.testfile)
 
 			err = app.Run(trivyArgs)
@@ -298,29 +295,28 @@ func TestRun_WithDockerEngine(t *testing.T) {
 			case tc.expectedError != "":
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tc.expectedError, tc.name)
+				return
 			default:
 				assert.NoError(t, err, tc.name)
 			}
 
-			if !tc.invalidImage {
-				// check for vulnerability output info
-				got, err := ioutil.ReadAll(of)
-				assert.NoError(t, err, tc.name)
-				want, err := ioutil.ReadFile(tc.expectedOutputFile)
-				assert.NoError(t, err, tc.name)
-				assert.JSONEq(t, string(want), string(got), tc.name)
+			// check for vulnerability output info
+			got, err := ioutil.ReadAll(of)
+			assert.NoError(t, err, tc.name)
+			want, err := ioutil.ReadFile(tc.expectedOutputFile)
+			assert.NoError(t, err, tc.name)
+			assert.JSONEq(t, string(want), string(got), tc.name)
 
-				// cleanup
-				_, err = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
-					Force:         true,
-					PruneChildren: true,
-				})
-				_, err = cli.ImageRemove(ctx, tc.imageTag, types.ImageRemoveOptions{
-					Force:         true,
-					PruneChildren: true,
-				})
-				assert.NoError(t, err, tc.name)
-			}
+			// cleanup
+			_, err = cli.ImageRemove(ctx, tc.testfile, types.ImageRemoveOptions{
+				Force:         true,
+				PruneChildren: true,
+			})
+			_, err = cli.ImageRemove(ctx, tc.imageTag, types.ImageRemoveOptions{
+				Force:         true,
+				PruneChildren: true,
+			})
+			assert.NoError(t, err, tc.name)
 		})
 	}
 }

--- a/integration/standalone_test.go
+++ b/integration/standalone_test.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/internal"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRun_WithTar(t *testing.T) {
@@ -343,16 +342,17 @@ func TestRun_WithTar(t *testing.T) {
 		},
 	}
 
+	// Copy DB file
+	cacheDir, err := gunzipDB()
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	// Setup CLI App
+	app := internal.NewApp("dev")
+	app.Writer = ioutil.Discard
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			// Copy DB file
-			cacheDir, err := gunzipDB()
-			require.NoError(t, err)
-			defer os.RemoveAll(cacheDir)
-
-			// Setup CLI App
-			app := internal.NewApp(c.testArgs.Version)
-			app.Writer = ioutil.Discard
 
 			osArgs := []string{"trivy", "--cache-dir", cacheDir, "--format", c.testArgs.Format}
 			if c.testArgs.SkipUpdate {

--- a/internal/standalone/run.go
+++ b/internal/standalone/run.go
@@ -43,6 +43,7 @@ func run(c config.Config) (err error) {
 	if err != nil {
 		return xerrors.Errorf("unable to initialize the cache: %w", err)
 	}
+	defer cacheClient.Close()
 
 	cacheOperation := operation.NewCache(cacheClient)
 	log.Logger.Debugf("cache dir:  %s", utils.CacheDir())
@@ -67,6 +68,7 @@ func run(c config.Config) (err error) {
 	if err = db.Init(c.CacheDir); err != nil {
 		return xerrors.Errorf("error in vulnerability DB initialize: %w", err)
 	}
+	defer db.Close()
 
 	var scanner scanner.Scanner
 	ctx := context.Background()

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -497,7 +497,7 @@ func TestCacheServer_MissingLayers(t *testing.T) {
 			getLayerExpectations: []cache.LocalImageCacheGetLayerExpectation{
 				{
 					Args: cache.LocalImageCacheGetLayerArgs{
-						LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 					},
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: ftypes.LayerInfo{},
@@ -505,7 +505,7 @@ func TestCacheServer_MissingLayers(t *testing.T) {
 				},
 				{
 					Args: cache.LocalImageCacheGetLayerArgs{
-						LayerID: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+						DiffID: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
 					},
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: ftypes.LayerInfo{
@@ -545,7 +545,7 @@ func TestCacheServer_MissingLayers(t *testing.T) {
 			getLayerExpectations: []cache.LocalImageCacheGetLayerExpectation{
 				{
 					Args: cache.LocalImageCacheGetLayerArgs{
-						LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 					},
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: ftypes.LayerInfo{
@@ -555,7 +555,7 @@ func TestCacheServer_MissingLayers(t *testing.T) {
 				},
 				{
 					Args: cache.LocalImageCacheGetLayerArgs{
-						LayerID: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+						DiffID: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
 					},
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: ftypes.LayerInfo{


### PR DESCRIPTION
# Overview
`gunzipDB` copies a database file to the temporal directory every time. It consumes a lot of disk spaces even if the file is removed by `defer os.RemoveAll(cacheDir)`. This is because the test process is still running, so the removed file can't be seen, but exists until the test process finishes.
ref. https://access.redhat.com/solutions/2316

After all, it reaches the capacity of disk and returns the error "no space left on device". This PR changed tests so that the database file can be copied only once.

# Blocker
- [ ] Apply `go get -u` after https://github.com/aquasecurity/fanal/pull/104 is merged