### PR TITLE
feat: add support for scanning Debian sid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,18 +1364,18 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 
 | OS                           | Supported Versions                       | Target Packages               | Detection of unfixed vulnerabilities |
 | ---------------------------- | ---------------------------------------- | ----------------------------- | :----------------------------------: |
-| Alpine Linux                 | 2.2 - 2.7, 3.0 - 3.11                    | Installed by apk              |                  NO                  |
-| Red Hat Universal Base Image | 7, 8                                     | Installed by yum/rpm          |                 YES                  |
-| Red Hat Enterprise Linux     | 6, 7, 8                                  | Installed by yum/rpm          |                 YES                  |
-| CentOS                       | 6, 7                                     | Installed by yum/rpm          |                 YES                  |
-| Oracle Linux                 | 5, 6, 7, 8                               | Installed by yum/rpm          |                  NO                  |
-| Amazon Linux                 | 1, 2                                     | Installed by yum/rpm          |                  NO                  |
-| openSUSE Leap                | 42, 15                                   | Installed by zypper/rpm       |                  NO                  |
-| SUSE Enterprise Linux        | 11, 12, 15                               | Installed by zypper/rpm       |                  NO                  |
-| Photon OS                    | 1.0, 2.0, 3.0                            | Installed by tdnf/yum/rpm     |                  NO                  |
-| Debian GNU/Linux             | wheezy, jessie, stretch, buster          | Installed by apt/apt-get/dpkg |                 YES                  |
-| Ubuntu                       | 12.04, 14.04, 16.04, 18.04, 18.10, 19.04 | Installed by apt/apt-get/dpkg |                 YES                  |
-| Distroless                   | Any                                      | Installed by apt/apt-get/dpkg |                 YES                  |
+| Alpine Linux                 | 2.2 - 2.7, 3.0 - 3.11                         | Installed by apk              |                  NO                  |
+| Red Hat Universal Base Image | 7, 8                                          | Installed by yum/rpm          |                 YES                  |
+| Red Hat Enterprise Linux     | 6, 7, 8                                       | Installed by yum/rpm          |                 YES                  |
+| CentOS                       | 6, 7                                          | Installed by yum/rpm          |                 YES                  |
+| Oracle Linux                 | 5, 6, 7, 8                                    | Installed by yum/rpm          |                  NO                  |
+| Amazon Linux                 | 1, 2                                          | Installed by yum/rpm          |                  NO                  |
+| openSUSE Leap                | 42, 15                                        | Installed by zypper/rpm       |                  NO                  |
+| SUSE Enterprise Linux        | 11, 12, 15                                    | Installed by zypper/rpm       |                  NO                  |
+| Photon OS                    | 1.0, 2.0, 3.0                                 | Installed by tdnf/yum/rpm     |                  NO                  |
+| Debian GNU/Linux             | wheezy, jessie, stretch, buster, sid          | Installed by apt/apt-get/dpkg |                 YES                  |
+| Ubuntu                       | 12.04, 14.04, 16.04, 18.04, 18.10, 19.04      | Installed by apt/apt-get/dpkg |                 YES                  |
+| Distroless                   | Any                                           | Installed by apt/apt-get/dpkg |                 YES                  |
 
 RHEL, CentOS, Oracle Linux, SUSE, Amazon Linux and Photon OS package information is stored in a binary format, and Trivy uses the `rpm` executable to parse this information when scanning an image based on RHEL or CentOS. The Trivy container image includes `rpm`, and the installers include it as a dependency. If you installed the `trivy` binary using `wget` or `curl`, or if you build it from source, you will also need to ensure that `rpm` is available.
 

--- a/README.md
+++ b/README.md
@@ -1365,17 +1365,17 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 | OS                           | Supported Versions                       | Target Packages               | Detection of unfixed vulnerabilities |
 | ---------------------------- | ---------------------------------------- | ----------------------------- | :----------------------------------: |
 | Alpine Linux                 | 2.2 - 2.7, 3.0 - 3.11                         | Installed by apk              |                  NO                  |
-| Red Hat Universal Base Image | 7, 8                                          | Installed by yum/rpm          |                 YES                  |
-| Red Hat Enterprise Linux     | 6, 7, 8                                       | Installed by yum/rpm          |                 YES                  |
-| CentOS                       | 6, 7                                          | Installed by yum/rpm          |                 YES                  |
-| Oracle Linux                 | 5, 6, 7, 8                                    | Installed by yum/rpm          |                  NO                  |
-| Amazon Linux                 | 1, 2                                          | Installed by yum/rpm          |                  NO                  |
-| openSUSE Leap                | 42, 15                                        | Installed by zypper/rpm       |                  NO                  |
-| SUSE Enterprise Linux        | 11, 12, 15                                    | Installed by zypper/rpm       |                  NO                  |
-| Photon OS                    | 1.0, 2.0, 3.0                                 | Installed by tdnf/yum/rpm     |                  NO                  |
-| Debian GNU/Linux             | wheezy, jessie, stretch, buster, sid          | Installed by apt/apt-get/dpkg |                 YES                  |
-| Ubuntu                       | 12.04, 14.04, 16.04, 18.04, 18.10, 19.04      | Installed by apt/apt-get/dpkg |                 YES                  |
-| Distroless                   | Any                                           | Installed by apt/apt-get/dpkg |                 YES                  |
+| Red Hat Universal Base Image | 7, 8                                     | Installed by yum/rpm          |                 YES                  |
+| Red Hat Enterprise Linux     | 6, 7, 8                                  | Installed by yum/rpm          |                 YES                  |
+| CentOS                       | 6, 7                                     | Installed by yum/rpm          |                 YES                  |
+| Oracle Linux                 | 5, 6, 7, 8                               | Installed by yum/rpm          |                  NO                  |
+| Amazon Linux                 | 1, 2                                     | Installed by yum/rpm          |                  NO                  |
+| openSUSE Leap                | 42, 15                                   | Installed by zypper/rpm       |                  NO                  |
+| SUSE Enterprise Linux        | 11, 12, 15                               | Installed by zypper/rpm       |                  NO                  |
+| Photon OS                    | 1.0, 2.0, 3.0                            | Installed by tdnf/yum/rpm     |                  NO                  |
+| Debian GNU/Linux             | wheezy, jessie, stretch, buster, sid     | Installed by apt/apt-get/dpkg |                 YES                  |
+| Ubuntu                       | 12.04, 14.04, 16.04, 18.04, 18.10, 19.04 | Installed by apt/apt-get/dpkg |                 YES                  |
+| Distroless                   | Any                                      | Installed by apt/apt-get/dpkg |                 YES                  |
 
 RHEL, CentOS, Oracle Linux, SUSE, Amazon Linux and Photon OS package information is stored in a binary format, and Trivy uses the `rpm` executable to parse this information when scanning an image based on RHEL or CentOS. The Trivy container image includes `rpm`, and the installers include it as a dependency. If you installed the `trivy` binary using `wget` or `curl`, or if you build it from source, you will also need to ensure that `rpm` is available.
 

--- a/README.md
+++ b/README.md
@@ -1364,7 +1364,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 
 | OS                           | Supported Versions                       | Target Packages               | Detection of unfixed vulnerabilities |
 | ---------------------------- | ---------------------------------------- | ----------------------------- | :----------------------------------: |
-| Alpine Linux                 | 2.2 - 2.7, 3.0 - 3.11                         | Installed by apk              |                  NO                  |
+| Alpine Linux                 | 2.2 - 2.7, 3.0 - 3.11                    | Installed by apk              |                  NO                  |
 | Red Hat Universal Base Image | 7, 8                                     | Installed by yum/rpm          |                 YES                  |
 | Red Hat Enterprise Linux     | 6, 7, 8                                  | Installed by yum/rpm          |                 YES                  |
 | CentOS                       | 6, 7                                     | Installed by yum/rpm          |                 YES                  |

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -55,7 +55,7 @@ func NewScanner() *Scanner {
 func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Debian vulnerabilities...")
 
-	if strings.HasSuffix(osVer, "/sid"){
+	if strings.HasSuffix(osVer, "/sid") {
 		// Short-circuit support for sid.
 		// trivy-db writes all the sid entires as "unstable".
 		// They must be looked up by "unstable".

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -55,6 +55,13 @@ func NewScanner() *Scanner {
 func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Debian vulnerabilities...")
 
+	if strings.HasSuffix(osVer, "/sid"){
+		// Short-circuit support for sid.
+		// trivy-db writes all the sid entires as "unstable".
+		// They must be looked up by "unstable".
+		osVer = "unstable"
+	}
+
 	if strings.Count(osVer, ".") > 0 {
 		osVer = osVer[:strings.Index(osVer, ".")]
 	}
@@ -121,6 +128,12 @@ func (s *Scanner) IsSupportedVersion(osFamily, osVer string) bool {
 }
 
 func (s *Scanner) isSupportedVersion(now time.Time, osFamily, osVer string) bool {
+	if strings.HasSuffix(osVer, "/sid") {
+		// If this is Debian sid, short-circuit support it.
+		log.Logger.Debugf("Debian sid detected. Using short-circuit supported version approval.")
+		return true
+	}
+	
 	if strings.Count(osVer, ".") > 0 {
 		osVer = osVer[:strings.Index(osVer, ".")]
 	}

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -133,7 +133,7 @@ func (s *Scanner) isSupportedVersion(now time.Time, osFamily, osVer string) bool
 		log.Logger.Debugf("Debian sid detected. Using short-circuit supported version approval.")
 		return true
 	}
-	
+
 	if strings.Count(osVer, ".") > 0 {
 		osVer = osVer[:strings.Index(osVer, ".")]
 	}

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -87,6 +87,12 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			osVersion: "9",
 			expected:  true,
 		},
+		"unstable": {
+			now:       time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+			osFamily:  "debian",
+			osVersion: "bullseye/sid",
+			expected:  true,
+		},
 		"unknown": {
 			now:       time.Date(2020, 7, 31, 23, 59, 59, 0, time.UTC),
 			osFamily:  "debian",


### PR DESCRIPTION
This PR adds the ability to scan Debian sid for vulnerabilities. The entries required to do this already appear to exist in trivy-db. Trivy simply needed to be updated to pass along the correct version strings to get the results to come back.

### Before
```
PS C:\Users\mattl> docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v C:\.cache:\.cache\ aquasec/trivy debian:sid

2020-05-06T19:09:58.184Z        WARN    This OS version is not on the EOL list: debian bullseye/sid
2020-05-06T19:09:58.184Z        INFO    Detecting Debian vulnerabilities...
2020-05-06T19:09:58.184Z        WARN    This OS version is no longer supported by the distribution: debian bullseye/sid
2020-05-06T19:09:58.185Z        WARN    The vulnerability detection may be insufficient because security updates are not provided
```

### After
```
root@37e7a3b52207:/go/trivy# trivy -q debian:sid

debian:sid (debian bullseye/sid)
================================
Total: 51 (UNKNOWN: 0, LOW: 48, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

[RESULTS REDACTED DUE TO SPACE]
```