### PR TITLE
chore: bump up urfave/cli to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.4.0
 	github.com/twitchtv/twirp v5.10.1+incompatible
-	github.com/urfave/cli v1.22.1
+	github.com/urfave/cli/v2 v2.2.0
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -418,9 +418,10 @@ github.com/twitchtv/twirp v5.10.1+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3v
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
-github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
+github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.17.4/go.mod h1:inCTmtUdr5KJbreVojo06krnTgaeAz/Z7lynpPk/Q2c=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 
 	"github.com/aquasecurity/trivy/internal"
 )

--- a/internal/app.go
+++ b/internal/app.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/types"
@@ -27,145 +27,145 @@ type VersionInfo struct {
 
 var (
 	templateFlag = cli.StringFlag{
-		Name:   "template, t",
-		Value:  "",
-		Usage:  "output template",
-		EnvVar: "TRIVY_TEMPLATE",
+		Name:    "template, t",
+		Value:   "",
+		Usage:   "output template",
+		EnvVars: []string{"TRIVY_TEMPLATE"},
 	}
 
 	formatFlag = cli.StringFlag{
-		Name:   "format, f",
-		Value:  "table",
-		Usage:  "format (table, json, template)",
-		EnvVar: "TRIVY_FORMAT",
+		Name:    "format, f",
+		Value:   "table",
+		Usage:   "format (table, json, template)",
+		EnvVars: []string{"TRIVY_FORMAT"},
 	}
 
 	inputFlag = cli.StringFlag{
-		Name:   "input, i",
-		Value:  "",
-		Usage:  "input file path instead of image name",
-		EnvVar: "TRIVY_INPUT",
+		Name:    "input, i",
+		Value:   "",
+		Usage:   "input file path instead of image name",
+		EnvVars: []string{"TRIVY_INPUT"},
 	}
 
 	severityFlag = cli.StringFlag{
-		Name:   "severity, s",
-		Value:  strings.Join(types.SeverityNames, ","),
-		Usage:  "severities of vulnerabilities to be displayed (comma separated)",
-		EnvVar: "TRIVY_SEVERITY",
+		Name:    "severity, s",
+		Value:   strings.Join(types.SeverityNames, ","),
+		Usage:   "severities of vulnerabilities to be displayed (comma separated)",
+		EnvVars: []string{"TRIVY_SEVERITY"},
 	}
 
 	outputFlag = cli.StringFlag{
-		Name:   "output, o",
-		Usage:  "output file name",
-		EnvVar: "TRIVY_OUTPUT",
+		Name:    "output, o",
+		Usage:   "output file name",
+		EnvVars: []string{"TRIVY_OUTPUT"},
 	}
 
 	exitCodeFlag = cli.IntFlag{
-		Name:   "exit-code",
-		Usage:  "Exit code when vulnerabilities were found",
-		Value:  0,
-		EnvVar: "TRIVY_EXIT_CODE",
+		Name:    "exit-code",
+		Usage:   "Exit code when vulnerabilities were found",
+		Value:   0,
+		EnvVars: []string{"TRIVY_EXIT_CODE"},
 	}
 
 	skipUpdateFlag = cli.BoolFlag{
-		Name:   "skip-update",
-		Usage:  "skip db update",
-		EnvVar: "TRIVY_SKIP_UPDATE",
+		Name:    "skip-update",
+		Usage:   "skip db update",
+		EnvVars: []string{"TRIVY_SKIP_UPDATE"},
 	}
 
 	downloadDBOnlyFlag = cli.BoolFlag{
-		Name:   "download-db-only",
-		Usage:  "download/update vulnerability database but don't run a scan",
-		EnvVar: "TRIVY_DOWNLOAD_DB_ONLY",
+		Name:    "download-db-only",
+		Usage:   "download/update vulnerability database but don't run a scan",
+		EnvVars: []string{"TRIVY_DOWNLOAD_DB_ONLY"},
 	}
 
 	resetFlag = cli.BoolFlag{
-		Name:   "reset",
-		Usage:  "remove all caches and database",
-		EnvVar: "TRIVY_RESET",
+		Name:    "reset",
+		Usage:   "remove all caches and database",
+		EnvVars: []string{"TRIVY_RESET"},
 	}
 
 	clearCacheFlag = cli.BoolFlag{
-		Name:   "clear-cache, c",
-		Usage:  "clear image caches without scanning",
-		EnvVar: "TRIVY_CLEAR_CACHE",
+		Name:    "clear-cache, c",
+		Usage:   "clear image caches without scanning",
+		EnvVars: []string{"TRIVY_CLEAR_CACHE"},
 	}
 
 	quietFlag = cli.BoolFlag{
-		Name:   "quiet, q",
-		Usage:  "suppress progress bar and log output",
-		EnvVar: "TRIVY_QUIET",
+		Name:    "quiet, q",
+		Usage:   "suppress progress bar and log output",
+		EnvVars: []string{"TRIVY_QUIET"},
 	}
 
 	noProgressFlag = cli.BoolFlag{
-		Name:   "no-progress",
-		Usage:  "suppress progress bar",
-		EnvVar: "TRIVY_NO_PROGRESS",
+		Name:    "no-progress",
+		Usage:   "suppress progress bar",
+		EnvVars: []string{"TRIVY_NO_PROGRESS"},
 	}
 
 	ignoreUnfixedFlag = cli.BoolFlag{
-		Name:   "ignore-unfixed",
-		Usage:  "display only fixed vulnerabilities",
-		EnvVar: "TRIVY_IGNORE_UNFIXED",
+		Name:    "ignore-unfixed",
+		Usage:   "display only fixed vulnerabilities",
+		EnvVars: []string{"TRIVY_IGNORE_UNFIXED"},
 	}
 
 	debugFlag = cli.BoolFlag{
-		Name:   "debug, d",
-		Usage:  "debug mode",
-		EnvVar: "TRIVY_DEBUG",
+		Name:    "debug, d",
+		Usage:   "debug mode",
+		EnvVars: []string{"TRIVY_DEBUG"},
 	}
 
 	removedPkgsFlag = cli.BoolFlag{
-		Name:   "removed-pkgs",
-		Usage:  "detect vulnerabilities of removed packages (only for Alpine)",
-		EnvVar: "TRIVY_REMOVED_PKGS",
+		Name:    "removed-pkgs",
+		Usage:   "detect vulnerabilities of removed packages (only for Alpine)",
+		EnvVars: []string{"TRIVY_REMOVED_PKGS"},
 	}
 
 	vulnTypeFlag = cli.StringFlag{
-		Name:   "vuln-type",
-		Value:  "os,library",
-		Usage:  "comma-separated list of vulnerability types (os,library)",
-		EnvVar: "TRIVY_VULN_TYPE",
+		Name:    "vuln-type",
+		Value:   "os,library",
+		Usage:   "comma-separated list of vulnerability types (os,library)",
+		EnvVars: []string{"TRIVY_VULN_TYPE"},
 	}
 
 	cacheDirFlag = cli.StringFlag{
-		Name:   "cache-dir",
-		Value:  utils.DefaultCacheDir(),
-		Usage:  "cache directory",
-		EnvVar: "TRIVY_CACHE_DIR",
+		Name:    "cache-dir",
+		Value:   utils.DefaultCacheDir(),
+		Usage:   "cache directory",
+		EnvVars: []string{"TRIVY_CACHE_DIR"},
 	}
 
 	ignoreFileFlag = cli.StringFlag{
-		Name:   "ignorefile",
-		Value:  vulnerability.DefaultIgnoreFile,
-		Usage:  "specify .trivyignore file",
-		EnvVar: "TRIVY_IGNOREFILE",
+		Name:    "ignorefile",
+		Value:   vulnerability.DefaultIgnoreFile,
+		Usage:   "specify .trivyignore file",
+		EnvVars: []string{"TRIVY_IGNOREFILE"},
 	}
 
 	timeoutFlag = cli.DurationFlag{
-		Name:   "timeout",
-		Value:  time.Second * 120,
-		Usage:  "docker timeout",
-		EnvVar: "TRIVY_TIMEOUT",
+		Name:    "timeout",
+		Value:   time.Second * 120,
+		Usage:   "docker timeout",
+		EnvVars: []string{"TRIVY_TIMEOUT"},
 	}
 
 	lightFlag = cli.BoolFlag{
-		Name:   "light",
-		Usage:  "light mode: it's faster, but vulnerability descriptions and references are not displayed",
-		EnvVar: "TRIVY_LIGHT",
+		Name:    "light",
+		Usage:   "light mode: it's faster, but vulnerability descriptions and references are not displayed",
+		EnvVars: []string{"TRIVY_LIGHT"},
 	}
 
 	token = cli.StringFlag{
-		Name:   "token",
-		Usage:  "for authentication",
-		EnvVar: "TRIVY_TOKEN",
+		Name:    "token",
+		Usage:   "for authentication",
+		EnvVars: []string{"TRIVY_TOKEN"},
 	}
 
 	tokenHeader = cli.StringFlag{
-		Name:   "token-header",
-		Value:  "Trivy-Token",
-		Usage:  "specify a header name for token",
-		EnvVar: "TRIVY_TOKEN_HEADER",
+		Name:    "token-header",
+		Value:   "Trivy-Token",
+		Usage:   "specify a header name for token",
+		EnvVars: []string{"TRIVY_TOKEN_HEADER"},
 	}
 )
 
@@ -199,46 +199,46 @@ OPTIONS:
 	app.EnableBashCompletion = true
 
 	app.Flags = []cli.Flag{
-		templateFlag,
-		formatFlag,
-		inputFlag,
-		severityFlag,
-		outputFlag,
-		exitCodeFlag,
-		skipUpdateFlag,
-		downloadDBOnlyFlag,
-		resetFlag,
-		clearCacheFlag,
-		quietFlag,
-		noProgressFlag,
-		ignoreUnfixedFlag,
-		debugFlag,
-		removedPkgsFlag,
-		vulnTypeFlag,
-		cacheDirFlag,
-		ignoreFileFlag,
-		timeoutFlag,
-		lightFlag,
+		&templateFlag,
+		&formatFlag,
+		&inputFlag,
+		&severityFlag,
+		&outputFlag,
+		&exitCodeFlag,
+		&skipUpdateFlag,
+		&downloadDBOnlyFlag,
+		&resetFlag,
+		&clearCacheFlag,
+		&quietFlag,
+		&noProgressFlag,
+		&ignoreUnfixedFlag,
+		&debugFlag,
+		&removedPkgsFlag,
+		&vulnTypeFlag,
+		&cacheDirFlag,
+		&ignoreFileFlag,
+		&timeoutFlag,
+		&lightFlag,
 
 		// deprecated options
-		cli.StringFlag{
-			Name:   "only-update",
-			Usage:  "deprecated",
-			EnvVar: "TRIVY_ONLY_UPDATE",
+		&cli.StringFlag{
+			Name:    "only-update",
+			Usage:   "deprecated",
+			EnvVars: []string{"TRIVY_ONLY_UPDATE"},
 		},
-		cli.BoolFlag{
-			Name:   "refresh",
-			Usage:  "deprecated",
-			EnvVar: "TRIVY_REFRESH",
+		&cli.BoolFlag{
+			Name:    "refresh",
+			Usage:   "deprecated",
+			EnvVars: []string{"TRIVY_REFRESH"},
 		},
-		cli.BoolFlag{
-			Name:   "auto-refresh",
-			Usage:  "deprecated",
-			EnvVar: "TRIVY_AUTO_REFRESH",
+		&cli.BoolFlag{
+			Name:    "auto-refresh",
+			Usage:   "deprecated",
+			EnvVars: []string{"TRIVY_AUTO_REFRESH"},
 		},
 	}
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		NewClientCommand(),
 		NewServerCommand(),
 	}
@@ -288,69 +288,69 @@ func showVersion(cacheDir, outputFormat, version string, outputWriter io.Writer)
 	}
 }
 
-func NewClientCommand() cli.Command {
-	return cli.Command{
+func NewClientCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "client",
 		Aliases: []string{"c"},
 		Usage:   "client mode",
 		Action:  client.Run,
 		Flags: []cli.Flag{
-			templateFlag,
-			formatFlag,
-			inputFlag,
-			severityFlag,
-			outputFlag,
-			exitCodeFlag,
-			clearCacheFlag,
-			quietFlag,
-			ignoreUnfixedFlag,
-			debugFlag,
-			removedPkgsFlag,
-			vulnTypeFlag,
-			ignoreFileFlag,
-			cacheDirFlag,
-			timeoutFlag,
+			&templateFlag,
+			&formatFlag,
+			&inputFlag,
+			&severityFlag,
+			&outputFlag,
+			&exitCodeFlag,
+			&clearCacheFlag,
+			&quietFlag,
+			&ignoreUnfixedFlag,
+			&debugFlag,
+			&removedPkgsFlag,
+			&vulnTypeFlag,
+			&ignoreFileFlag,
+			&cacheDirFlag,
+			&timeoutFlag,
 
 			// original flags
-			token,
-			tokenHeader,
-			cli.StringFlag{
-				Name:   "remote",
-				Value:  "http://localhost:4954",
-				Usage:  "server address",
-				EnvVar: "TRIVY_REMOTE",
+			&token,
+			&tokenHeader,
+			&cli.StringFlag{
+				Name:    "remote",
+				Value:   "http://localhost:4954",
+				Usage:   "server address",
+				EnvVars: []string{"TRIVY_REMOTE"},
 			},
-			cli.StringSliceFlag{
-				Name:   "custom-headers",
-				Usage:  "custom headers",
-				EnvVar: "TRIVY_CUSTOM_HEADERS",
+			&cli.StringSliceFlag{
+				Name:    "custom-headers",
+				Usage:   "custom headers",
+				EnvVars: []string{"TRIVY_CUSTOM_HEADERS"},
 			},
 		},
 	}
 }
 
-func NewServerCommand() cli.Command {
-	return cli.Command{
+func NewServerCommand() *cli.Command {
+	return &cli.Command{
 		Name:    "server",
 		Aliases: []string{"s"},
 		Usage:   "server mode",
 		Action:  server.Run,
 		Flags: []cli.Flag{
-			skipUpdateFlag,
-			downloadDBOnlyFlag,
-			resetFlag,
-			quietFlag,
-			debugFlag,
-			cacheDirFlag,
+			&skipUpdateFlag,
+			&downloadDBOnlyFlag,
+			&resetFlag,
+			&quietFlag,
+			&debugFlag,
+			&cacheDirFlag,
 
 			// original flags
-			token,
-			tokenHeader,
-			cli.StringFlag{
-				Name:   "listen",
-				Value:  "localhost:4954",
-				Usage:  "listen address",
-				EnvVar: "TRIVY_LISTEN",
+			&token,
+			&tokenHeader,
+			&cli.StringFlag{
+				Name:    "listen",
+				Value:   "localhost:4954",
+				Usage:   "listen address",
+				EnvVars: []string{"TRIVY_LISTEN"},
 			},
 		},
 	}

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/genuinetools/reg/registry"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
@@ -105,12 +105,12 @@ func (c *Config) Init() (err error) {
 		return nil
 	}
 
-	args := c.context.Args()
-	if c.Input == "" && len(args) == 0 {
+	ctx := c.context
+	if c.Input == "" && ctx.NArg() == 0 {
 		c.logger.Error(`trivy requires at least 1 argument or --input option`)
 		cli.ShowAppHelp(c.context)
 		return xerrors.New("arguments error")
-	} else if len(args) > 1 {
+	} else if ctx.NArg() > 1 {
 		c.logger.Error(`multiple images cannot be specified`)
 		return xerrors.New("arguments error")
 	}
@@ -123,7 +123,7 @@ func (c *Config) Init() (err error) {
 	}
 
 	if c.Input == "" {
-		c.ImageName = args[0]
+		c.ImageName = ctx.Args().First()
 	}
 
 	// Check whether 'latest' tag is used

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
 )
 
 func TestNew(t *testing.T) {
@@ -107,7 +106,6 @@ func TestConfig_Init(t *testing.T) {
 			},
 			args: []string{"alpine:3.10"},
 			want: Config{
-				AppVersion:  "0.0.0",
 				Severities:  []dbTypes.Severity{dbTypes.SeverityCritical},
 				severities:  "CRITICAL",
 				ImageName:   "alpine:3.10",
@@ -133,7 +131,6 @@ func TestConfig_Init(t *testing.T) {
 				"unknown severity option: unknown severity: INVALID",
 			},
 			want: Config{
-				AppVersion:    "0.0.0",
 				Severities:    []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 				severities:    "CRITICAL,INVALID",
 				ImageName:     "centos:7",
@@ -155,7 +152,6 @@ func TestConfig_Init(t *testing.T) {
 				"You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed",
 			},
 			want: Config{
-				AppVersion:    "0.0.0",
 				Severities:    []dbTypes.Severity{dbTypes.SeverityLow},
 				severities:    "LOW",
 				ImageName:     "gcr.io/distroless/base",

--- a/internal/client/run.go
+++ b/internal/client/run.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"os"
 
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+
 	"github.com/aquasecurity/trivy/internal/client/config"
 	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -12,8 +15,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/scanner"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
-	"github.com/urfave/cli"
-	"golang.org/x/xerrors"
 )
 
 func Run(cliCtx *cli.Context) error {

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 )
 

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 )
 
 func TestNew(t *testing.T) {
@@ -95,8 +96,7 @@ func TestConfig_Init(t *testing.T) {
 			},
 			args: []string{"alpine:3.10"},
 			want: Config{
-				AppVersion: "0.0.0",
-				Quiet:      true,
+				Quiet: true,
 			},
 		},
 		{
@@ -108,8 +108,7 @@ func TestConfig_Init(t *testing.T) {
 			},
 			args: []string{"alpine:3.10"},
 			want: Config{
-				AppVersion: "0.0.0",
-				Reset:      true,
+				Reset: true,
 			},
 		},
 		{

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/fanal/cache"

--- a/internal/standalone/config/config.go
+++ b/internal/standalone/config/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/genuinetools/reg/registry"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
@@ -125,12 +125,12 @@ func (c *Config) Init() (err error) {
 		return nil
 	}
 
-	args := c.context.Args()
-	if c.Input == "" && len(args) == 0 {
+	ctx := c.context
+	if c.Input == "" && ctx.NArg() == 0 {
 		c.logger.Error(`trivy requires at least 1 argument or --input option`)
 		cli.ShowAppHelp(c.context)
 		return xerrors.New("arguments error")
-	} else if len(args) > 1 {
+	} else if ctx.NArg() > 1 {
 		c.logger.Error(`multiple images cannot be specified`)
 		return xerrors.New("arguments error")
 	}
@@ -143,7 +143,7 @@ func (c *Config) Init() (err error) {
 	}
 
 	if c.Input == "" {
-		c.ImageName = args[0]
+		c.ImageName = ctx.Args().First()
 	}
 
 	// Check whether 'latest' tag is used

--- a/internal/standalone/config/config_test.go
+++ b/internal/standalone/config/config_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
 )
 
 func TestNew(t *testing.T) {
@@ -99,7 +99,6 @@ func TestConfig_Init(t *testing.T) {
 			},
 			args: []string{"alpine:3.10"},
 			want: Config{
-				AppVersion: "0.0.0",
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 				severities: "CRITICAL",
 				ImageName:  "alpine:3.10",
@@ -118,7 +117,6 @@ func TestConfig_Init(t *testing.T) {
 			},
 			args: []string{"alpine:3.10"},
 			want: Config{
-				AppVersion: "0.0.0",
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 				severities: "CRITICAL",
 				VulnType:   []string{"os"},
@@ -137,7 +135,6 @@ func TestConfig_Init(t *testing.T) {
 				"unknown severity option: unknown severity: INVALID",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 				severities: "CRITICAL,INVALID",
 				ImageName:  "centos:7",
@@ -158,7 +155,6 @@ func TestConfig_Init(t *testing.T) {
 				"--only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				severities: "LOW",
 				ImageName:  "debian:buster",
@@ -179,7 +175,6 @@ func TestConfig_Init(t *testing.T) {
 				"--template is ignored because --format template is not specified. Use --template option with --format template option.",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
 				Output:     os.Stdout,
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
@@ -200,7 +195,6 @@ func TestConfig_Init(t *testing.T) {
 				"--template is ignored because --format json is specified. Use --template option with --format template option.",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				Format:     "json",
 				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
 				Output:     os.Stdout,
@@ -221,7 +215,6 @@ func TestConfig_Init(t *testing.T) {
 				"--format template is ignored because --template not is specified. Specify --template option when you use --format template.",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				Format:     "template",
 				ImageName:  "gitlab/gitlab-ce:12.7.2-ce.0",
 				Output:     os.Stdout,
@@ -243,7 +236,6 @@ func TestConfig_Init(t *testing.T) {
 				"You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed",
 			},
 			want: Config{
-				AppVersion: "0.0.0",
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				severities: "LOW",
 				ImageName:  "gcr.io/distroless/base",

--- a/internal/standalone/run.go
+++ b/internal/standalone/run.go
@@ -5,9 +5,11 @@ import (
 	l "log"
 	"os"
 
-	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/fanal/cache"
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/internal/operation"
 	"github.com/aquasecurity/trivy/internal/standalone/config"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -15,8 +17,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/scanner"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
-	"github.com/urfave/cli"
-	"golang.org/x/xerrors"
 )
 
 func Run(cliCtx *cli.Context) error {


### PR DESCRIPTION
## Overview
bump up github.com/urfave/cli to v2

## TODO
- [x] EnvVar → EnvVars
- [x] replace import path
- [x] use pointer for cli.Flag and cli.Command
- [x] use NArg()
- [x] replace 0.0.0 with empty string