### PR TITLE
added: display last db update whenever trivy server is started 

### DIFF
--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -80,7 +80,6 @@ func ListenAndServe(c config.Config, fsCache cache.FSCache) error {
 		log.Logger.Errorf("%+v\n", err)
 	}
 
-
 	log.Logger.Infof("Listening %s...", c.Listen)
 
 	return http.ListenAndServe(c.Listen, mux)
@@ -166,7 +165,7 @@ func showLastDbUpdate(cacheDir string) error {
 		return xerrors.Errorf("something wrong with DB: %w", err)
 	}
 	log.Logger.Infof("Last DB Update at: %s",
-	metadata.UpdatedAt)
+		metadata.UpdatedAt)
 
 	return nil
 }


### PR DESCRIPTION
#346 
**Results before the change**
`trivy server --listen localhost:8080`
2020-06-23T10:28:45.072+0530	INFO	Listening localhost:8080...

**Results after the change**
`trivy server --listen localhost:8080`
2020-06-23T10:28:45.072+0530	INFO	Last DB Update at: 2020-06-23 00:18:04.500501189 +0000 UTC
2020-06-23T10:28:45.072+0530	INFO	Listening localhost:8080...