### PR TITLE
Added function to escape string in failure message title and descriptions

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -10,7 +10,7 @@
         {{- end -}}
         {{ range .Vulnerabilities }}
         <testcase classname="{{ .PkgName }}-{{ .InstalledVersion }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
-            <failure message={{ .Title | printf "%q" }} type="description">{{ .Description | printf "%q" }}</failure>
+            <failure message={{escapeXML .Title | printf "%q" }} type="description">{{escapeXML .Description | printf "%q" }}</failure>
         </testcase>
     {{- end }}
     </testsuite>

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -3,6 +3,7 @@ package report
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"os"
@@ -41,7 +42,11 @@ func WriteResults(format string, output io.Writer, results Results, outputTempla
 	case "json":
 		writer = &JsonWriter{Output: output}
 	case "template":
-		tmpl, err := template.New("output template").Parse(outputTemplate)
+		tmpl, err := template.New("output template").Funcs(template.FuncMap{
+			"escapeString": func(input string) string {
+				return html.EscapeString(input)
+			},
+		}).Parse(outputTemplate)
 		if err != nil {
 			return xerrors.Errorf("error parsing template: %w", err)
 		}

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -44,10 +44,10 @@ func WriteResults(format string, output io.Writer, results Results, outputTempla
 		writer = &JsonWriter{Output: output}
 	case "template":
 		tmpl, err := template.New("output template").Funcs(template.FuncMap{
-			"escapeString": func(input string) string {
+			"escapeXML": func(input string) string {
 				escaped := &bytes.Buffer{}
 				if err := xml.EscapeText(escaped, []byte(input)); err != nil {
-					fmt.Println("error while escapeString to XML: %v", err.Error())
+					fmt.Printf("error while escapeString to XML: %v", err.Error())
 					return input
 				}
 				return escaped.String()

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -1,9 +1,10 @@
 package report
 
 import (
+	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
-	"html"
 	"io"
 	"io/ioutil"
 	"os"
@@ -44,7 +45,12 @@ func WriteResults(format string, output io.Writer, results Results, outputTempla
 	case "template":
 		tmpl, err := template.New("output template").Funcs(template.FuncMap{
 			"escapeString": func(input string) string {
-				return html.EscapeString(input)
+				escaped := &bytes.Buffer{}
+				if err := xml.EscapeText(escaped, []byte(input)); err != nil {
+					fmt.Println("error while escapeString to XML: %v", err.Error())
+					return input
+				}
+				return escaped.String()
 			},
 		}).Parse(outputTemplate)
 		if err != nil {

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -239,8 +239,8 @@ func TestReportWriter_Template(t *testing.T) {
 					InstalledVersion: "1.2.3",
 					FixedVersion:     "3.4.5",
 					Vulnerability: dbTypes.Vulnerability{
-						Title:       "foobar",
-						Description: "baz",
+						Title:       `gcc: POWER9 "DARN" RNG intrinsic produces repeated output`,
+						Description: `curl version curl 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl < 7.20.0 and curl >= 7.60.0.`,
 						Severity:    "HIGH",
 					},
 				},
@@ -257,7 +257,7 @@ func TestReportWriter_Template(t *testing.T) {
         {{- end -}}
         {{ range .Vulnerabilities }}
         <testcase classname="{{ .PkgName }}-{{ .InstalledVersion }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
-            <failure message={{ .Title | printf "%q" }} type="description">{{ .Description | printf "%q" }}</failure>
+            <failure message={{escapeString .Title | printf "%q" }} type="description">{{escapeString .Description | printf "%q" }}</failure>
         </testcase>
     {{- end }}
 	</testsuite>
@@ -270,7 +270,7 @@ func TestReportWriter_Template(t *testing.T) {
             <property name="type" value="test"></property>
         </properties>
         <testcase classname="foo-1.2.3" name="[HIGH] 123" time="">
-            <failure message="foobar" type="description">"baz"</failure>
+            <failure message="gcc: POWER9 &#34;DARN&#34; RNG intrinsic produces repeated output" type="description">"curl version curl 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl &lt; 7.20.0 and curl &gt;= 7.60.0."</failure>
         </testcase>
 	</testsuite>
 </testsuites>`,

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -257,7 +257,7 @@ func TestReportWriter_Template(t *testing.T) {
         {{- end -}}
         {{ range .Vulnerabilities }}
         <testcase classname="{{ .PkgName }}-{{ .InstalledVersion }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
-            <failure message={{escapeString .Title | printf "%q" }} type="description">{{escapeString .Description | printf "%q" }}</failure>
+            <failure message={{escapeXML .Title | printf "%q" }} type="description">{{escapeXML .Description | printf "%q" }}</failure>
         </testcase>
     {{- end }}
 	</testsuite>


### PR DESCRIPTION
[Issue](https://github.com/aquasecurity/trivy/issues/549)
* Failure and Title should be escaped before exporting to template