### PR TITLE
Adding contrib/junit.tpl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM alpine:3.12
 RUN apk --no-cache add ca-certificates git rpm
 COPY trivy /usr/local/bin/trivy
 COPY contrib/gitlab.tpl contrib/gitlab.tpl
+COPY contrib/junit.tpl contrib/junit.tpl
 ENTRYPOINT ["trivy"]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -94,3 +94,4 @@ dockers:
       - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"
     extra_files:
     - contrib/gitlab.tpl
+    - contrib/junit.tpl


### PR DESCRIPTION
Adding junit.tpl to docker image for easy of use during CI/CD pipelines
