### PR TITLE
Fixing `Error retrieving template from path` when --format is not template but template is provided

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -28,14 +28,6 @@ type Result struct {
 }
 
 func WriteResults(format string, output io.Writer, results Results, outputTemplate string, light bool) error {
-	if strings.HasPrefix(outputTemplate, "@") {
-		buf, err := ioutil.ReadFile(strings.TrimPrefix(outputTemplate, "@"))
-		if err != nil {
-			return xerrors.Errorf("Error retrieving template from path: %w", err)
-		}
-		outputTemplate = string(buf)
-	}
-
 	var writer Writer
 	switch format {
 	case "table":
@@ -43,6 +35,13 @@ func WriteResults(format string, output io.Writer, results Results, outputTempla
 	case "json":
 		writer = &JsonWriter{Output: output}
 	case "template":
+		if strings.HasPrefix(outputTemplate, "@") {
+			buf, err := ioutil.ReadFile(strings.TrimPrefix(outputTemplate, "@"))
+			if err != nil {
+				return xerrors.Errorf("Error retrieving template from path: %w", err)
+			}
+			outputTemplate = string(buf)
+		}
 		tmpl, err := template.New("output template").Funcs(template.FuncMap{
 			"escapeXML": func(input string) string {
 				escaped := &bytes.Buffer{}


### PR DESCRIPTION

When `--format` is set to something different than `template` trivy is printing a warning:
`WARN	--template is ignored because --format json is specified. Use --template option with --format template option.`

But after report is generated it fails with error:
`FATAL	unable to write results: Error retrieving template from path: open contrib/junit.tpl: no such file or directory`

Seems that checking for `outputTemplate` is happening too soon and should only be done when `--format` is `template`