### PR TITLE
List all OS & App packages in the output

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	types2 "github.com/aquasecurity/fanal/types"
 	"io"
 	"io/ioutil"
 	"os"
@@ -25,6 +26,8 @@ type Result struct {
 	Target          string                        `json:"Target"`
 	Type            string                        `json:"Type,omitempty"`
 	Vulnerabilities []types.DetectedVulnerability `json:"Vulnerabilities"`
+	OsPackages		[]types.OsPackage			  `json:"OsPackages"`
+	AppPackages		[]types2.LibraryInfo			  `json:"AppPackages"`
 }
 
 func WriteResults(format string, output io.Writer, results Results, outputTemplate string, light bool) error {

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -125,12 +125,12 @@ func (s Scanner) scanOSPkg(target, osFamily, osName string, pkgs []ftypes.Packag
 		return nil, false, xerrors.Errorf("failed vulnerability detection of OS packages: %w", err)
 	}
 
+	// appending OS packages to the results
 	var ps []types.OsPackage
 	for _, pkg := range pkgs {
 		p := &types.OsPackage{
 			PkgName:          pkg.Name,
 			InstalledVersion: pkg.Version,
-			Package:          types.Package{},
 		}
 		ps = append(ps, *p)
 	}
@@ -152,7 +152,7 @@ func (s Scanner) scanLibrary(apps []ftypes.Application) (report.Results, error) 
 		if err != nil {
 			return nil, xerrors.Errorf("failed vulnerability detection of libraries: %w", err)
 		}
-
+		// appending App packages to the results
 		results = append(results, report.Result{
 			Target:          app.FilePath,
 			Vulnerabilities: vulns,

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -93,6 +93,7 @@ func (s Scanner) Scan(target string, imageID string, layerIDs []string, options 
 		}
 
 		var result *report.Result
+
 		result, eosl, err = s.scanOSPkg(target, imageDetail.OS.Family, imageDetail.OS.Name, pkgs)
 		if err != nil {
 			return nil, nil, false, xerrors.Errorf("failed to scan OS packages: %w", err)
@@ -124,11 +125,22 @@ func (s Scanner) scanOSPkg(target, osFamily, osName string, pkgs []ftypes.Packag
 		return nil, false, xerrors.Errorf("failed vulnerability detection of OS packages: %w", err)
 	}
 
+	var ps []types.OsPackage
+	for _, pkg := range pkgs {
+		p := &types.OsPackage{
+			PkgName:          pkg.Name,
+			InstalledVersion: pkg.Version,
+			Package:          types.Package{},
+		}
+		ps = append(ps, *p)
+	}
+
 	imageDetail := fmt.Sprintf("%s (%s %s)", target, osFamily, osName)
 	result := &report.Result{
 		Target:          imageDetail,
 		Vulnerabilities: vulns,
 		Type:            osFamily,
+		OsPackages: 	 ps,
 	}
 	return result, eosl, nil
 }
@@ -145,6 +157,7 @@ func (s Scanner) scanLibrary(apps []ftypes.Application) (report.Results, error) 
 			Target:          app.FilePath,
 			Vulnerabilities: vulns,
 			Type:            app.Type,
+			AppPackages: 	 app.Libraries,
 		})
 	}
 	sort.Slice(results, func(i, j int) bool {

--- a/pkg/types/os_package.go
+++ b/pkg/types/os_package.go
@@ -1,17 +1,14 @@
 package types
 
-import (
-	ftypes "github.com/aquasecurity/fanal/types"
-	"github.com/aquasecurity/trivy-db/pkg/types"
-)
-
-type DetectedVulnerability struct {
-	VulnerabilityID  string       `json:",omitempty"`
+type OsPackage struct {
 	PkgName          string       `json:",omitempty"`
 	InstalledVersion string       `json:",omitempty"`
-	FixedVersion     string       `json:",omitempty"`
-	Layer            ftypes.Layer `json:",omitempty"`
-	SeveritySource   string       `json:",omitempty"`
 
-	types.Vulnerability
+	Package
+}
+
+type Package struct {
+	Title          string         `json:",omitempty"`
+	Description    string         `json:",omitempty"`
+	References     []string       `json:",omitempty"`
 }

--- a/pkg/types/os_package.go
+++ b/pkg/types/os_package.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	ftypes "github.com/aquasecurity/fanal/types"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+)
+
+type DetectedVulnerability struct {
+	VulnerabilityID  string       `json:",omitempty"`
+	PkgName          string       `json:",omitempty"`
+	InstalledVersion string       `json:",omitempty"`
+	FixedVersion     string       `json:",omitempty"`
+	Layer            ftypes.Layer `json:",omitempty"`
+	SeveritySource   string       `json:",omitempty"`
+
+	types.Vulnerability
+}

--- a/pkg/types/os_package.go
+++ b/pkg/types/os_package.go
@@ -3,12 +3,4 @@ package types
 type OsPackage struct {
 	PkgName          string       `json:",omitempty"`
 	InstalledVersion string       `json:",omitempty"`
-
-	Package
-}
-
-type Package struct {
-	Title          string         `json:",omitempty"`
-	Description    string         `json:",omitempty"`
-	References     []string       `json:",omitempty"`
 }

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -1,17 +1,14 @@
 package types
 
-import (
-	ftypes "github.com/aquasecurity/fanal/types"
-	"github.com/aquasecurity/trivy-db/pkg/types"
-)
-
-type DetectedVulnerability struct {
-	VulnerabilityID  string       `json:",omitempty"`
+type OsPackage struct {
 	PkgName          string       `json:",omitempty"`
 	InstalledVersion string       `json:",omitempty"`
-	FixedVersion     string       `json:",omitempty"`
-	Layer            ftypes.Layer `json:",omitempty"`
-	SeveritySource   string       `json:",omitempty"`
 
-	types.Vulnerability
+	Package
+}
+
+type Package struct {
+	Title          string         `json:",omitempty"`
+	Description    string         `json:",omitempty"`
+	References     []string       `json:",omitempty"`
 }

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -1,14 +1,17 @@
 package types
 
-type OsPackage struct {
+import (
+	ftypes "github.com/aquasecurity/fanal/types"
+	"github.com/aquasecurity/trivy-db/pkg/types"
+)
+
+type DetectedVulnerability struct {
+	VulnerabilityID  string       `json:",omitempty"`
 	PkgName          string       `json:",omitempty"`
 	InstalledVersion string       `json:",omitempty"`
+	FixedVersion     string       `json:",omitempty"`
+	Layer            ftypes.Layer `json:",omitempty"`
+	SeveritySource   string       `json:",omitempty"`
 
-	Package
-}
-
-type Package struct {
-	Title          string         `json:",omitempty"`
-	Description    string         `json:",omitempty"`
-	References     []string       `json:",omitempty"`
+	types.Vulnerability
 }


### PR DESCRIPTION
Few code additions that would spit out both OS and APP dependencies in the JSON output

The output would look like this:

`[
  {
    "Target": "ubuntu 18.04",
    "Type": "ubuntu",
    "Vulnerabilities": null,
    "OsPackages": [
      {
        "PkgName": "perl",
        "InstalledVersion": "5.26.1-6ubuntu0.3"
      },.....
    ]
  },
  {
    "Target": ".....Cargo.lock",
    "Type": "cargo",
    "Vulnerabilities": null,
    "OsPackages": null,
    "AppPackages": [
      {
        "Library": {
          "Name": "addr2line",
          "Version": "0.12.2"
        },
        "Layer": {
          "DiffID": "sha256:69204c59b291063d2d3f80fbc7d694003a959a3dcbd1fc4ef793c75fb217e792"
        }
      },.....
     ]
    }
   ]`