### PR TITLE
ci: Add code coverage

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@1.1.0
 
 defaults: &defaults
   docker :
@@ -24,6 +26,9 @@ jobs:
       - run:
           name: Test
           command: make test
+      - codecov/upload:
+          file: ./coverage.txt
+
   release:
     <<: *defaults
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@
 thumbs.db
 
 # test fixtures
+coverage.txt
 integration/testdata/fixtures/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(GOBIN)/golangci-lint:
 
 .PHONY: test
 test:
-	go test -v -short ./...
+	go test -v -short -coverprofile=coverage.txt -covermode=atomic ./...
 
 integration/testdata/fixtures/*.tar.gz:
 	git clone https://github.com/aquasecurity/trivy-test-images.git integration/testdata/fixtures

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/aquasecurity/trivy)](https://goreportcard.com/report/github.com/aquasecurity/trivy)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/aquasecurity/trivy/blob/master/LICENSE)
 [![Docker image](https://images.microbadger.com/badges/version/aquasec/trivy.svg)](https://microbadger.com/images/aquasec/trivy "Get your own version badge on microbadger.com")
+[![codecov](https://codecov.io/gh/aquasecurity/trivy/branch/master/graph/badge.svg)](https://codecov.io/gh/aquasecurity/trivy)
 
 A Simple and Comprehensive Vulnerability Scanner for Containers and other Artifacts, Suitable for CI.
 


### PR DESCRIPTION
This adds code coverage to each PR we create.

Addresses: https://github.com/aquasecurity/trivy/issues/563

Signed-off-by: Simarpreet Singh <simar@linux.com>