### PR TITLE
Mention Homebrew on Linux in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ yay -Sy trivy-bin
 
 ## Homebrew
 
-You can use homebrew on macOS.
+You can use homebrew on macOS and Linux.
 
 ```
 $ brew install aquasecurity/trivy/trivy


### PR DESCRIPTION
Homebrew can be used on Linux and Windows Subsystem for Linux (WSL)
https://docs.brew.sh/Homebrew-on-Linux

I didn't know, but GoReleaser already supports Homebrew on Linux as well as macOS. It means Trivy also supports it transparently.
https://github.com/aquasecurity/homebrew-trivy/blob/master/trivy.rb