### PR TITLE
Added template fucntion to escape string before output

### DIFF
--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -20,10 +20,10 @@
               "id": "[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "{{ .VulnerabilityID }} Package: {{ .PkgName }}"
+                "text": "{{ .VulnerabilityID }} Package: {{ .PkgName }}."
               },
               "fullDescription": {
-                "text": "{{ endWithPeriod .Title }}"
+                "text": "{{ endWithPeriod (escapeString .Title) }}"
               },
               "help": {
                 "text": "Vulnerability {{ .VulnerabilityID }}\nSeverity: {{ .Vulnerability.Severity }}\nPackage: {{ .PkgName }}\nInstalled Version: {{ .InstalledVersion }}\nFixed Version: {{ .FixedVersion }}\nLink: [{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})",
@@ -57,7 +57,7 @@
           "ruleIndex": {{ $index }},
           "level": "error",
           "message": {
-            "text": {{ endWithPeriod $vulnerability.Description | printf "%q" }}
+            "text": {{ endWithPeriod (escapeString $vulnerability.Description) | printf "%q" }}
           },
           "locations": [{
             "physicalLocation": {

--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -12,7 +12,7 @@
               "id": "[MEDIUM] CVE-2019-1549",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "CVE-2019-1549 Package: openssl"
+                "text": "CVE-2019-1549 Package: openssl."
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in fork()."
@@ -34,7 +34,7 @@
               "id": "[MEDIUM] CVE-2019-1551",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "CVE-2019-1551 Package: openssl"
+                "text": "CVE-2019-1551 Package: openssl."
               },
               "fullDescription": {
                 "text": "openssl: Integer overflow in RSAZ modular exponentiation on x86_64."
@@ -56,7 +56,7 @@
               "id": "[MEDIUM] CVE-2019-1563",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "CVE-2019-1563 Package: openssl"
+                "text": "CVE-2019-1563 Package: openssl."
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in PKCS7_dataDecode and CMS_decrypt_set1_pkey."
@@ -78,7 +78,7 @@
               "id": "[LOW] CVE-2019-1547",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "CVE-2019-1547 Package: openssl"
+                "text": "CVE-2019-1547 Package: openssl."
               },
               "fullDescription": {
                 "text": "openssl: side-channel weak encryption vulnerability."

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"html"
 	"io"
 	"io/ioutil"
 	"os"
@@ -61,6 +62,9 @@ func WriteResults(format string, output io.Writer, severities []dbTypes.Severity
 			},
 			"toLower": func(input string) string {
 				return strings.ToLower(input)
+			},
+			"escapeString": func(input string) string {
+				return html.EscapeString(input)
 			},
 		}).Parse(outputTemplate)
 		if err != nil {

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -292,9 +292,16 @@ func TestReportWriter_Template(t *testing.T) {
 						Description: "with period.",
 					},
 				},
+				{
+					VulnerabilityID: "CVE-2019-0000",
+					PkgName:         "bar",
+					Vulnerability: dbTypes.Vulnerability{
+						Description: `with period and unescaped string curl: Use-after-free when closing 'easy' handle in Curl_close().`,
+					},
+				},
 			},
-			template: `{{ range . }}{{ range .Vulnerabilities}}{{.VulnerabilityID}} {{ endWithPeriod .Description | printf "%q" }}{{ end }}{{ end }}`,
-			expected: `CVE-2019-0000 "without period."CVE-2019-0000 "with period."`,
+			template: `{{ range . }}{{ range .Vulnerabilities}}{{.VulnerabilityID}} {{ endWithPeriod (escapeString .Description) | printf "%q" }}{{ end }}{{ end }}`,
+			expected: `CVE-2019-0000 "without period."CVE-2019-0000 "with period."CVE-2019-0000 "with period and unescaped string curl: Use-after-free when closing &#39;easy&#39; handle in Curl_close()."`,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Unescaped strings like https://gist.github.com/simar7/da144ed1d9b6d53f5c9af1e9282a3e68#file-gistfile1-txt-L81-L84 in output SARIF results in invalid SARIF file, this PR will fix the case