### PR TITLE
feat: add --skip-directories option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A Simple and Comprehensive Vulnerability Scanner for Containers and other Artifa
     + [Filter the vulnerabilities by severities](#filter-the-vulnerabilities-by-severities)
     + [Filter the vulnerabilities by type](#filter-the-vulnerabilities-by-type)
     + [Filter the vulnerabilities by Open Policy Agent](#filter-the-vulnerabilities-by-open-policy-agent-policy)
+    + [Skip traversal in the specific directory](#skip-traversal-in-the-specific-directory)
     + [Skip update of vulnerability DB](#skip-update-of-vulnerability-db)
     + [Only download vulnerability database](#only-download-vulnerability-database)
     + [Ignore unfixed vulnerabilities](#ignore-unfixed-vulnerabilities)
@@ -1134,6 +1135,13 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)
 
 </details>
 
+### Skip traversal in the specific directory
+Trivy traversals directories and look for all lock files by default. If your image contains lock files which are not maintained by you, you can skip traversal in the specific directory.
+
+```
+$ trivy image --skip-directories "/usr/lib/ruby/gems,/etc" fluent/fluentd:edge
+```
+
 
 ### Skip update of vulnerability DB
 
@@ -1733,6 +1741,7 @@ OPTIONS:
    --timeout value     docker timeout (default: 2m0s) [$TRIVY_TIMEOUT]
    --light             light mode: it's faster, but vulnerability descriptions and references are not displayed (default: false) [$TRIVY_LIGHT]
    --list-all-pkgs     enabling the option will output all packages regardless of vulnerability [$TRIVY_LIST_ALL_PKGS]
+   --skip-directories value    specify the directory where the traverse is skipped [$TRIVY_SKIP_DIRECTORIES]
    --help, -h          show help (default: false)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)
 Trivy traversals directories and look for all lock files by default. If your image contains lock files which are not maintained by you, you can skip traversal in the specific directory.
 
 ```
-$ trivy image --skip-directories "/usr/lib/ruby/gems,/etc" fluent/fluentd:edge
+$ trivy image --skip-dirs "/usr/lib/ruby/gems,/etc" fluent/fluentd:edge
 ```
 
 
@@ -1741,7 +1741,7 @@ OPTIONS:
    --timeout value     docker timeout (default: 2m0s) [$TRIVY_TIMEOUT]
    --light             light mode: it's faster, but vulnerability descriptions and references are not displayed (default: false) [$TRIVY_LIGHT]
    --list-all-pkgs     enabling the option will output all packages regardless of vulnerability [$TRIVY_LIST_ALL_PKGS]
-   --skip-directories value    specify the directory where the traverse is skipped [$TRIVY_SKIP_DIRECTORIES]
+   --skip-dirs value           specify the directory where the traverse is skipped [$TRIVY_SKIP_DIRS]
    --help, -h          show help (default: false)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1741,7 +1741,7 @@ OPTIONS:
    --timeout value     docker timeout (default: 2m0s) [$TRIVY_TIMEOUT]
    --light             light mode: it's faster, but vulnerability descriptions and references are not displayed (default: false) [$TRIVY_LIGHT]
    --list-all-pkgs     enabling the option will output all packages regardless of vulnerability [$TRIVY_LIST_ALL_PKGS]
-   --skip-dirs value           specify the directory where the traverse is skipped [$TRIVY_SKIP_DIRS]
+   --skip-dirs value   specify the directory where the traversal is skipped [$TRIVY_SKIP_DIRS]
    --help, -h          show help (default: false)
 ```
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -189,9 +189,9 @@ var (
 	}
 
 	skipDirectories = cli.StringFlag{
-		Name:    "skip-directories",
+		Name:    "skip-dirs",
 		Usage:   "specify the directory where the traverse is skipped",
-		EnvVars: []string{"TRIVY_SKIP_DIRECTORIES"},
+		EnvVars: []string{"TRIVY_SKIP_DIRS"},
 	}
 
 	globalFlags = []cli.Flag{

--- a/internal/app.go
+++ b/internal/app.go
@@ -188,6 +188,12 @@ var (
 		EnvVars: []string{"TRIVY_LIST_ALL_PKGS"},
 	}
 
+	skipDirectories = cli.StringFlag{
+		Name:    "skip-directories",
+		Usage:   "specify the directory where the traverse is skipped",
+		EnvVars: []string{"TRIVY_SKIP_DIRECTORIES"},
+	}
+
 	globalFlags = []cli.Flag{
 		&quietFlag,
 		&debugFlag,
@@ -214,6 +220,7 @@ var (
 		&lightFlag,
 		&ignorePolicy,
 		&listAllPackages,
+		&skipDirectories,
 	}
 
 	// deprecated options
@@ -368,6 +375,7 @@ func NewFilesystemCommand() *cli.Command {
 			&noProgressFlag,
 			&ignorePolicy,
 			&listAllPackages,
+			&skipDirectories,
 		},
 	}
 }
@@ -398,6 +406,7 @@ func NewRepositoryCommand() *cli.Command {
 			&noProgressFlag,
 			&ignorePolicy,
 			&listAllPackages,
+			&skipDirectories,
 		},
 	}
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -190,7 +190,7 @@ var (
 
 	skipDirectories = cli.StringFlag{
 		Name:    "skip-dirs",
-		Usage:   "specify the directory where the traverse is skipped",
+		Usage:   "specify the directory where the traversal is skipped",
 		EnvVars: []string{"TRIVY_SKIP_DIRS"},
 	}
 

--- a/internal/artifact/run.go
+++ b/internal/artifact/run.go
@@ -77,6 +77,7 @@ func run(c config.Config, initializeScanner InitializeScanner) error {
 		VulnType:            c.VulnType,
 		ScanRemovedPackages: c.ScanRemovedPkgs, // this is valid only for image subcommand
 		ListAllPackages:     c.ListAllPkgs,
+		SkipDirectories:     c.SkipDirectories,
 	}
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)
 

--- a/internal/config/artifact.go
+++ b/internal/config/artifact.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -13,15 +14,19 @@ type ArtifactConfig struct {
 	Timeout    time.Duration
 	ClearCache bool
 
+	skipDirectories string
+	SkipDirectories []string
+
 	// this field is populated in Init()
 	Target string
 }
 
 func NewArtifactConfig(c *cli.Context) ArtifactConfig {
 	return ArtifactConfig{
-		Input:      c.String("input"),
-		Timeout:    c.Duration("timeout"),
-		ClearCache: c.Bool("clear-cache"),
+		Input:           c.String("input"),
+		Timeout:         c.Duration("timeout"),
+		ClearCache:      c.Bool("clear-cache"),
+		skipDirectories: c.String("skip-directories"),
 	}
 }
 
@@ -38,6 +43,10 @@ func (c *ArtifactConfig) Init(args cli.Args, logger *zap.SugaredLogger) (err err
 
 	if c.Input == "" {
 		c.Target = args.First()
+	}
+
+	if c.skipDirectories != "" {
+		c.SkipDirectories = strings.Split(c.skipDirectories, ",")
 	}
 
 	return nil

--- a/internal/config/artifact.go
+++ b/internal/config/artifact.go
@@ -26,7 +26,7 @@ func NewArtifactConfig(c *cli.Context) ArtifactConfig {
 		Input:           c.String("input"),
 		Timeout:         c.Duration("timeout"),
 		ClearCache:      c.Bool("clear-cache"),
-		skipDirectories: c.String("skip-directories"),
+		skipDirectories: c.String("skip-dirs"),
 	}
 }
 

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -2,6 +2,8 @@ package local
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -110,7 +112,7 @@ func (s Scanner) Scan(target string, imageID string, layerIDs []string, options 
 	}
 
 	if utils.StringInSlice("library", options.VulnType) {
-		libResults, err := s.scanLibrary(imageDetail.Applications, options.ListAllPackages)
+		libResults, err := s.scanLibrary(imageDetail.Applications, options)
 		if err != nil {
 			return nil, nil, false, xerrors.Errorf("failed to scan application libraries: %w", err)
 		}
@@ -140,19 +142,24 @@ func (s Scanner) scanOSPkg(target, osFamily, osName string, pkgs []ftypes.Packag
 	return result, eosl, nil
 }
 
-func (s Scanner) scanLibrary(apps []ftypes.Application, listAllPackages bool) (report.Results, error) {
+func (s Scanner) scanLibrary(apps []ftypes.Application, options types.ScanOptions) (report.Results, error) {
 	var results report.Results
 	for _, app := range apps {
 		vulns, err := s.libDetector.Detect("", app.FilePath, time.Time{}, app.Libraries)
 		if err != nil {
 			return nil, xerrors.Errorf("failed vulnerability detection of libraries: %w", err)
 		}
+
+		if skipped(app.FilePath, options.SkipDirectories) {
+			continue
+		}
+
 		libReport := report.Result{
 			Target:          app.FilePath,
 			Vulnerabilities: vulns,
 			Type:            app.Type,
 		}
-		if listAllPackages {
+		if options.ListAllPackages {
 			var pkgs []ftypes.Package
 			for _, lib := range app.Libraries {
 				pkgs = append(pkgs, ftypes.Package{
@@ -172,6 +179,21 @@ func (s Scanner) scanLibrary(apps []ftypes.Application, listAllPackages bool) (r
 		return results[i].Target < results[j].Target
 	})
 	return results, nil
+}
+
+func skipped(filePath string, skipDirectories []string) bool {
+	for _, skipDir := range skipDirectories {
+		skipDir = strings.TrimLeft(filepath.Clean(skipDir), string(os.PathSeparator))
+		rel, err := filepath.Rel(skipDir, filePath)
+		if err != nil {
+			log.Logger.Warn(err)
+			return false
+		}
+		if !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+	return false
 }
 
 func mergePkgs(pkgs, pkgsFromCommands []ftypes.Package) []ftypes.Package {

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -186,7 +186,7 @@ func skipped(filePath string, skipDirectories []string) bool {
 		skipDir = strings.TrimLeft(filepath.Clean(skipDir), string(os.PathSeparator))
 		rel, err := filepath.Rel(skipDir, filePath)
 		if err != nil {
-			log.Logger.Warn(err)
+			log.Logger.Warnf("Unexpected error while skipping directories: %s", err)
 			return false
 		}
 		if !strings.HasPrefix(rel, "..") {

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -4,4 +4,5 @@ type ScanOptions struct {
 	VulnType            []string
 	ScanRemovedPackages bool
 	ListAllPackages     bool
+	SkipDirectories     []string
 }


### PR DESCRIPTION
Fix https://github.com/aquasecurity/trivy/issues/282
Fix https://github.com/aquasecurity/trivy/issues/366
Fix https://github.com/aquasecurity/trivy/issues/244

```
$ trivy image --vuln-type library fluent/fluentd:edge
2020-08-11T11:26:26.939+0300    INFO     Detecting bundler vulnerabilities...
2020-08-11T11:26:26.942+0300    INFO     Detecting bundler vulnerabilities...

usr/lib/ruby/gems/2.5.0/gems/async-http-0.50.7/examples/fetch/Gemfile.lock
==========================================================================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+--------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+---------+------------------+----------+-------------------+---------------+--------------------------------+
| rack    | CVE-2020-8184    | MEDIUM   | 2.2.2             | 2.2.3, 2.1.4  | rubygem-rack: percent-encoded  |
|         |                  |          |                   |               | cookies can be used to         |
|         |                  |          |                   |               | overwrite existing prefixed    |
|         |                  |          |                   |               | cookie names...                |
+---------+------------------+----------+-------------------+---------------+--------------------------------+

usr/lib/ruby/gems/2.5.0/gems/http_parser.rb-0.6.0/Gemfile.lock
==============================================================
Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 0, CRITICAL: 1)

+-----------+------------------+----------+-------------------+---------------+--------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+-----------+------------------+----------+-------------------+---------------+--------------------------------+
| ffi       | CVE-2018-1000201 | MEDIUM   | 1.0.11            | 1.9.24        | ruby-ffi DDL loading issue on  |
|           |                  |          |                   |               | Windows OS                     |
+           +                  +          +-------------------+               +                                +
|           |                  |          | 1.0.11-java       |               |                                |
|           |                  |          |                   |               |                                |
+-----------+------------------+          +-------------------+---------------+--------------------------------+
| json      | CVE-2020-10663   |          | 1.8.0             | 2.3.0         | rubygem-json: Unsafe Object    |
|           |                  |          |                   |               | Creation Vulnerability in JSON |
+           +                  +          +-------------------+               +                                +
|           |                  |          | 1.8.0-java        |               |                                |
|           |                  |          |                   |               |                                |
+-----------+------------------+----------+-------------------+---------------+--------------------------------+
| rake      | CVE-2020-8130    | CRITICAL | 0.9.2             | 12.3.3        | rake: OS Command Injection via |
|           |                  |          |                   |               | egrep in Rake::FileList        |
+-----------+------------------+----------+-------------------+---------------+--------------------------------+
| yajl-ruby | CVE-2017-16516   | MEDIUM   | 1.1.0             | 1.3.1         | rubygem-yajl-ruby:             |
|           |                  |          |                   |               | Yajl::Parser.new.parse         |
|           |                  |          |                   |               | incorrect parsing              |
+-----------+------------------+----------+-------------------+---------------+--------------------------------+
```

The lock files under `usr/lib/ruby/gems/2.5.0/gems/` might be noise. In that case, `--skip-dirs` can skip traversal in the directories.

```
$ trivy image --vuln-type library --skip-dirs "/usr/lib/ruby/gems"  fluent/fluentd:edge
2020-08-11T11:29:49.967+0300    INFO     Detecting bundler vulnerabilities...
2020-08-11T11:29:49.973+0300    INFO     Detecting bundler vulnerabilities...
```

