### PR TITLE
Fix: fullDescription field in SARIF output is not correctly escaped

### DIFF
--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -20,20 +20,20 @@
               "id": "[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "{{ .VulnerabilityID }} Package: {{ .PkgName }}"
+                "text": "{{ .VulnerabilityID }} Package: {{ .PkgName | printf "%v" }}"
               },
               "fullDescription": {
                 "text": {{ endWithPeriod (escapeString .Title) | printf "%q" }}
               },
               "help": {
-                "text": "Vulnerability {{ .VulnerabilityID }}\nSeverity: {{ .Vulnerability.Severity }}\nPackage: {{ .PkgName }}\nInstalled Version: {{ .InstalledVersion }}\nFixed Version: {{ .FixedVersion }}\nLink: [{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})",
-                "markdown": "**Vulnerability {{ .VulnerabilityID }}**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|{{ .Vulnerability.Severity }}|{{ .PkgName }}|{{ .InstalledVersion }}|{{ .FixedVersion }}|[{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})|\n"
+                "text": "Vulnerability {{ .VulnerabilityID }}\nSeverity: {{ .Vulnerability.Severity }}\nPackage: {{ .PkgName | printf "%v" }}\nInstalled Version: {{ .InstalledVersion }}\nFixed Version: {{ .FixedVersion }}\nLink: [{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})",
+                "markdown": "**Vulnerability {{ .VulnerabilityID }}**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|{{ .Vulnerability.Severity }}|{{ .PkgName | printf "%v" }}|{{ .InstalledVersion }}|{{ .FixedVersion }}|[{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})|\n"
               },
               "properties": {
                 "tags": [
                   "vulnerability",
                   "{{ .Vulnerability.Severity }}",
-                  "{{ .PkgName }}"
+                  "{{ .PkgName | printf "%v" }}"
                 ],
                 "precision": "very-high"
               }

--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -23,7 +23,7 @@
                 "text": "{{ .VulnerabilityID }} Package: {{ .PkgName }}"
               },
               "fullDescription": {
-                "text": "{{ endWithPeriod (escapeString .Title) }}"
+                "text": {{ endWithPeriod (escapeString .Title) | printf "%q" }}
               },
               "help": {
                 "text": "Vulnerability {{ .VulnerabilityID }}\nSeverity: {{ .Vulnerability.Severity }}\nPackage: {{ .PkgName }}\nInstalled Version: {{ .InstalledVersion }}\nFixed Version: {{ .FixedVersion }}\nLink: [{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})",

--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -20,20 +20,20 @@
               "id": "[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}",
               "name": "dockerfile_scan",
               "shortDescription": {
-                "text": "{{ .VulnerabilityID }} Package: {{ .PkgName | printf "%v" }}"
+                "text": {{ printf "%v Package: %v" .VulnerabilityID .PkgName | printf "%q" }}
               },
               "fullDescription": {
                 "text": {{ endWithPeriod (escapeString .Title) | printf "%q" }}
               },
               "help": {
-                "text": "Vulnerability {{ .VulnerabilityID }}\nSeverity: {{ .Vulnerability.Severity }}\nPackage: {{ .PkgName | printf "%v" }}\nInstalled Version: {{ .InstalledVersion }}\nFixed Version: {{ .FixedVersion }}\nLink: [{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})",
-                "markdown": "**Vulnerability {{ .VulnerabilityID }}**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|{{ .Vulnerability.Severity }}|{{ .PkgName | printf "%v" }}|{{ .InstalledVersion }}|{{ .FixedVersion }}|[{{ .VulnerabilityID }}](https://nvd.nist.gov/vuln/detail/{{ .VulnerabilityID | toLower }})|\n"
+                "text": {{ printf "Vulnerability %v\nSeverity: %v\nPackage: %v\nInstalled Version: %v\nFixed Version: %v\nLink: [%v](https://nvd.nist.gov/vuln/detail/%v)" .VulnerabilityID .Vulnerability.Severity .PkgName .InstalledVersion .FixedVersion .VulnerabilityID (.VulnerabilityID | toLower) | printf "%q"}},
+                "markdown": {{ printf "**Vulnerability %v**\n| Severity | Package | Installed Version | Fixed Version | Link |\n| --- | --- | --- | --- | --- |\n|%v|%v|%v|%v|[%v](https://nvd.nist.gov/vuln/detail/%v)|\n" .VulnerabilityID .Vulnerability.Severity .PkgName .InstalledVersion .FixedVersion .VulnerabilityID (.VulnerabilityID | toLower) | printf "%q"}}
               },
               "properties": {
                 "tags": [
                   "vulnerability",
                   "{{ .Vulnerability.Severity }}",
-                  "{{ .PkgName | printf "%v" }}"
+                  {{ .PkgName | printf "%q" }}
                 ],
                 "precision": "very-high"
               }

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -242,7 +242,7 @@ func TestReportWriter_Template(t *testing.T) {
 					FixedVersion:     "3.4.5",
 					Vulnerability: dbTypes.Vulnerability{
 						Title:       `gcc: POWER9 "DARN" RNG intrinsic produces repeated output`,
-						Description: `curl version curl 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl < 7.20.0 and curl >= 7.60.0.`,
+						Description: `curl version curl \X 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl < 7.20.0 and curl >= 7.60.0.`,
 						Severity:    "HIGH",
 					},
 				},
@@ -259,7 +259,7 @@ func TestReportWriter_Template(t *testing.T) {
         {{- end -}}
         {{ range .Vulnerabilities }}
         <testcase classname="{{ .PkgName }}-{{ .InstalledVersion }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
-            <failure message={{escapeXML .Title | printf "%q" }} type="description">{{escapeXML .Description | printf "%q" }}</failure>
+            <failure message={{escapeXML .Title | printf "%q" }} type="description">{{ endWithPeriod (escapeString .Description) | printf "%q" }}</failure>
         </testcase>
     {{- end }}
 	</testsuite>
@@ -272,7 +272,7 @@ func TestReportWriter_Template(t *testing.T) {
             <property name="type" value="test"></property>
         </properties>
         <testcase classname="foo-1.2.3" name="[HIGH] 123" time="">
-            <failure message="gcc: POWER9 &#34;DARN&#34; RNG intrinsic produces repeated output" type="description">"curl version curl 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl &lt; 7.20.0 and curl &gt;= 7.60.0."</failure>
+            <failure message="gcc: POWER9 &#34;DARN&#34; RNG intrinsic produces repeated output" type="description">"curl version curl \\X 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl &lt; 7.20.0 and curl &gt;= 7.60.0."</failure>
         </testcase>
 	</testsuite>
 </testsuites>`,

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -237,7 +237,7 @@ func TestReportWriter_Template(t *testing.T) {
 			detectedVulns: []types.DetectedVulnerability{
 				{
 					VulnerabilityID:  "123",
-					PkgName:          "foo",
+					PkgName:          `foo \ test`,
 					InstalledVersion: "1.2.3",
 					FixedVersion:     "3.4.5",
 					Vulnerability: dbTypes.Vulnerability{
@@ -258,7 +258,7 @@ func TestReportWriter_Template(t *testing.T) {
         </properties>
         {{- end -}}
         {{ range .Vulnerabilities }}
-        <testcase classname="{{ .PkgName }}-{{ .InstalledVersion }}" name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
+        <testcase classname={{ printf "%v-%v" .PkgName .InstalledVersion | printf "%q" }} name="[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }}" time="">
             <failure message={{escapeXML .Title | printf "%q" }} type="description">{{ endWithPeriod (escapeString .Description) | printf "%q" }}</failure>
         </testcase>
     {{- end }}
@@ -271,7 +271,7 @@ func TestReportWriter_Template(t *testing.T) {
         <properties>
             <property name="type" value="test"></property>
         </properties>
-        <testcase classname="foo-1.2.3" name="[HIGH] 123" time="">
+        <testcase classname="foo \\ test-1.2.3" name="[HIGH] 123" time="">
             <failure message="gcc: POWER9 &#34;DARN&#34; RNG intrinsic produces repeated output" type="description">"curl version curl \\X 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl &lt; 7.20.0 and curl &gt;= 7.60.0."</failure>
         </testcase>
 	</testsuite>


### PR DESCRIPTION
[Issue](https://github.com/aquasecurity/trivy/issues/604)