### PR TITLE
Add all templates to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.12
 RUN apk --no-cache add ca-certificates git rpm
 COPY trivy /usr/local/bin/trivy
-COPY contrib/gitlab.tpl contrib/gitlab.tpl
-COPY contrib/junit.tpl contrib/junit.tpl
-COPY contrib/sarif.tpl contrib/sarif.tpl
+COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
Before this change, only a subset of templates were included in the docker image.
Now all templates which are part of the git repo will be included when the docker image will be build, a future commit for every new template is not needed anymore

Fixes #618