### PR TITLE
Improve Gitlab CI installation step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1538,11 +1538,9 @@ trivy:
     DOCKER_TLS_CERTDIR: ""
     IMAGE: trivy-ci-test:$CI_COMMIT_SHA
   before_script:
-    - apk add --no-cache curl
-    - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-    - echo $VERSION
-    - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
-    - tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+    - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    - echo $TRIVY_VERSION
+    - wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O - | tar -zxvf -
   allow_failure: true
   script:
     # Build image


### PR DESCRIPTION
This improves the installation step in `.gitlab-ci.yml`. 

- Removes unnecessary installation and use of `curl` (replaces it with `wget`)
- Removes storing the intermediate file by using a pipe to `tar`
- Rename `VERSION` to `TRIVY_VERSION`, to circumvent ambiguities in case there's other version variables in the CI configuration