### PR TITLE
chore(image): push the official image to GitHub Container Registry as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,11 @@ jobs:
       - setup_remote_docker:
           version: 18.06.0-ce
       - run:
-          name: setup docker
+          name: login to Docker Hub
           command: echo $DOCKER_PASS | docker login --username $DOCKER_USER --password-stdin
+      - run:
+          name: login to GitHub Container Registry
+          command: echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_USER --password-stdin
       - run:
           name: Release
           command: goreleaser --rm-dist

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -81,6 +81,8 @@ dockers:
   - image_templates:
       - "docker.io/aquasec/trivy:{{ .Version }}"
       - "docker.io/aquasec/trivy:latest"
+      - "ghcr.io/aquasecurity/trivy:{{ .Version }}"
+      - "ghcr.io/aquasecurity/trivy:latest"
     binaries:
       - trivy
     build_flag_templates:


### PR DESCRIPTION
## Overview
Docker has new rate limits on image pulls, so it is better to push our official image to GitHub Container Registry as well.
https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/

## TODO
- [x] add permissions around GHCR
- [x] set GITHUB_TOKEN/GITHUB_USER as environment variable
- [x] make the image public

## Reference
https://github.blog/2020-09-01-introducing-github-container-registry/
https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images