### PR TITLE
fix(cli): show help for subcommands

### DIFF
--- a/internal/config/artifact.go
+++ b/internal/config/artifact.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -36,7 +37,8 @@ func NewArtifactConfig(c *cli.Context) ArtifactConfig {
 func (c *ArtifactConfig) Init(ctx *cli.Context, logger *zap.SugaredLogger) (err error) {
 	if c.Input == "" && ctx.Args().Len() == 0 {
 		logger.Debug(`trivy requires at least 1 argument or --input option`)
-		cli.ShowAppHelpAndExit(ctx, 0)
+		_ = cli.ShowSubcommandHelp(ctx)
+		os.Exit(0)
 	} else if ctx.Args().Len() > 1 {
 		logger.Error(`multiple targets cannot be specified`)
 		return xerrors.New("arguments error")


### PR DESCRIPTION
# Change
Before

```
$ trivy image
NAME:
   trivy - A simple and comprehensive vulnerability scanner for containers

USAGE:
   trivy command [command options] target

COMMANDS:
   image, i          scan an image
   filesystem, fs    scan local filesystem
   repository, repo  scan remote repository
   client, c         client mode
   server, s         server mode
   help, h           Shows a list of commands or help for one command

OPTIONS:
   --quiet, -q        suppress progress bar and log output (default: false) [$TRIVY_QUIET]
   --debug, -d        debug mode (default: false) [$TRIVY_DEBUG]
   --cache-dir value  cache directory (default: "/Users/teppei/Library/Caches/trivy") [$TRIVY_CACHE_DIR]
   --help, -h         show help (default: false)
   --version, -v      print the version (default: false)
```

After

```
$ trivy image
NAME:
   trivy image - scan an image

USAGE:
   trivy image [command options] image_name

OPTIONS:
   --template value, -t value  output template [$TRIVY_TEMPLATE]
   --format value, -f value    format (table, json, template) (default: "table") [$TRIVY_FORMAT]
   --input value, -i value     input file path instead of image name [$TRIVY_INPUT]
   --severity value, -s value  severities of vulnerabilities to be displayed (comma separated) (default: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL") [$TRIVY_SEVERITY]
   --output value, -o value    output file name [$TRIVY_OUTPUT]
   --exit-code value           Exit code when vulnerabilities were found (default: 0) [$TRIVY_EXIT_CODE]
   --skip-update               skip db update (default: false) [$TRIVY_SKIP_UPDATE]
   --download-db-only          download/update vulnerability database but don't run a scan (default: false) [$TRIVY_DOWNLOAD_DB_ONLY]
   --reset                     remove all caches and database (default: false) [$TRIVY_RESET]
   --clear-cache, -c           clear image caches without scanning (default: false) [$TRIVY_CLEAR_CACHE]
   --no-progress               suppress progress bar (default: false) [$TRIVY_NO_PROGRESS]
   --ignore-unfixed            display only fixed vulnerabilities (default: false) [$TRIVY_IGNORE_UNFIXED]
   --removed-pkgs              detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
   --vuln-type value           comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
   --ignorefile value          specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
   --timeout value             docker timeout (default: 2m0s) [$TRIVY_TIMEOUT]
   --light                     light mode: it's faster, but vulnerability descriptions and references are not displayed (default: false) [$TRIVY_LIGHT]
   --ignore-policy value       specify the Rego file to evaluate each vulnerability [$TRIVY_IGNORE_POLICY]
   --list-all-pkgs             enabling the option will output all packages regardless of vulnerability (default: false) [$TRIVY_LIST_ALL_PKGS]
   --skip-files value          specify the file path to skip traversal [$TRIVY_SKIP_FILES]
   --skip-dirs value           specify the directory where the traversal is skipped [$TRIVY_SKIP_DIRS]
   --help, -h                  show help (default: false)
```

# Note
We'll replace ShowSubcommandHelp and os.Exit with ShowSubcommandHelpAndExit if https://github.com/urfave/cli/pull/1183 is merged.