### PR TITLE
goreleaser.yml: Add all templates to archive

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -64,6 +64,8 @@ archives:
       - README.md
       - LICENSE
       - contrib/gitlab.tpl
+      - contrib/junit.tpl
+      - contrib/sarif.tpl
 
 brews:
   -


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy/issues/631