### PR TITLE
Add health check endpoint to trivy server

### DIFF
--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -74,6 +74,9 @@ func ListenAndServe(c config.Config, fsCache cache.FSCache) error {
 	libHandler := rpcDetector.NewLibDetectorServer(initializeLibServer(), nil)
 	mux.Handle(rpcDetector.LibDetectorPathPrefix, withToken(withWaitGroup(libHandler), c.Token, c.TokenHeader))
 
+	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("ok"))
+	})
 	log.Logger.Infof("Listening %s...", c.Listen)
 
 	return http.ListenAndServe(c.Listen, mux)


### PR DESCRIPTION
Closes #534

```shell
$ curl http://127.0.0.1:4954/healthz 
ok

$ curl http://127.0.0.1:4954/healthz -v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4954 (#0)
> GET /healthz HTTP/1.1
> Host: 127.0.0.1:4954
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sun, 20 Sep 2020 03:11:57 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 127.0.0.1 left intact
ok
```