### PR TITLE
update readme for parallel run issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1980,6 +1980,12 @@ $ trivy image --reset
 ```
 ---
 
+### Running in parallel takes same time as series run 
+When running trivy on multiple images simultaneously, it will take same time as running trivy in series.  
+This is because of a limitation of boltdb.  
+> Bolt obtains a file lock on the data file so multiple processes cannot open the same database at the same time. Opening an already open Bolt database will cause it to hang until the other process closes it.
+Reference : [boltdb: Opening a database](https://github.com/boltdb/bolt#opening-a-database).
+
 # Credits
 
 - Special thanks to [Tomoya Amachi](https://github.com/tomoyamachi)

--- a/README.md
+++ b/README.md
@@ -1960,6 +1960,12 @@ $ brew unlink trivy && brew uninstall trivy
 $ brew install aquasecurity/trivy/trivy
 ```
 
+### Running in parallel takes same time as series run 
+When running trivy on multiple images simultaneously, it will take same time as running trivy in series.  
+This is because of a limitation of boltdb.  
+> Bolt obtains a file lock on the data file so multiple processes cannot open the same database at the same time. Opening an already open Bolt database will cause it to hang until the other process closes it.
+Reference : [boltdb: Opening a database](https://github.com/boltdb/bolt#opening-a-database).
+
 ## Others
 
 ### GitHub Rate limiting
@@ -1979,12 +1985,6 @@ Try again with `--reset` option:
 $ trivy image --reset
 ```
 ---
-
-### Running in parallel takes same time as series run 
-When running trivy on multiple images simultaneously, it will take same time as running trivy in series.  
-This is because of a limitation of boltdb.  
-> Bolt obtains a file lock on the data file so multiple processes cannot open the same database at the same time. Opening an already open Bolt database will cause it to hang until the other process closes it.
-Reference : [boltdb: Opening a database](https://github.com/boltdb/bolt#opening-a-database).
 
 # Credits
 


### PR DESCRIPTION
Updates readme's Q&A section to add about running trivy on multiple images in parallel taking same time as a series run. 
Fixes #650 .