### PR TITLE
Fix release download links for Ubuntu RPM and RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $ sudo yum -y install trivy
 or
 
 ```
-$ rpm -ivh https://github.com/aquasecurity/trivy/releases/download/{TRIVY_VERSION}/trivy_{TRIVY_VERSION}_Linux-64bit.rpm
+$ rpm -ivh https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.rpm
 ```
 
 ## Debian/Ubuntu
@@ -168,8 +168,8 @@ or
 
 ```
 $ sudo apt-get install rpm
-$ wget https://github.com/aquasecurity/trivy/releases/download/{TRIVY_VERSION}/trivy_{TRIVY_VERSION}_Linux-64bit.deb
-$ sudo dpkg -i trivy_{TRIVY_VERSION}_Linux-64bit.deb
+$ wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+$ sudo dpkg -i trivy_${TRIVY_VERSION}_Linux-64bit.deb
 ```
 
 


### PR DESCRIPTION
The URL did not contain the `v` that is present in the Git/Github version tags. This `v` is present in the rest of the documentation.

This PR fixes the issue for Ubuntu/Debian and RHEL/CentOS.