### PR TITLE
Skip packages from unsupported repository (remi)

### DIFF
--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -1,7 +1,6 @@
 package redhat
 
 import (
-	"regexp"
 	"strings"
 	"time"
 
@@ -36,8 +35,8 @@ var (
 		// N/A
 		"8": time.Date(3000, 6, 30, 23, 59, 59, 0, time.UTC),
 	}
-	excludedVendorsRe = []*regexp.Regexp{
-		regexp.MustCompile("\\.remi$"),
+	excludedVendorsSuffix = []string{
+		".remi",
 	}
 )
 
@@ -136,8 +135,8 @@ func (s *Scanner) isSupportedVersion(now time.Time, osFamily, osVer string) bool
 }
 
 func (s *Scanner) isFromSupportedVendor(pkg ftypes.Package) bool {
-	for _, re := range excludedVendorsRe {
-		if re.MatchString(pkg.Release) {
+	for _, s := range excludedVendorsSuffix {
+		if strings.HasSuffix(pkg.Release, s) {
 			return false
 		}
 	}

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -208,6 +208,45 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "happy path: packages from remi repository are skipped",
+			args: args{
+				osVer: "7.6",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "php",
+						Version:    "7.3.23",
+						Release:    "1.el7.remi",
+						Arch:       "x86_64",
+						Epoch:      0,
+						SrcName:    "php",
+						SrcVersion: "7.3.23",
+						SrcRelease: "1.el7.remi",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:c27b3cf4d516baf5932d5df3a573c6a571ddace3ee2a577492292d2e849c112b",
+						},
+					},
+				},
+			},
+			get: []dbTypes.GetExpectation{
+				{
+					Args: dbTypes.GetArgs{
+						Release: "7",
+						PkgName: "php",
+					},
+					Returns: dbTypes.GetReturns{
+						Advisories: []dbTypes.Advisory{
+							{
+								VulnerabilityID: "CVE-2011-4718",
+								FixedVersion:    "",
+							},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability(nil),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds a capability of skipping specific RPM packages (RedHat or CentOS) during the scan based on pre-defined patterns.
Currently only the `remi` repository is listed as unsupported.

Resolves #649.
