### PR TITLE
feat: package-revisions

### DIFF
--- a/pkg/scanner/utils/utils.go
+++ b/pkg/scanner/utils/utils.go
@@ -50,25 +50,30 @@ func MatchVersions(currentVersion *semver.Version, rangeVersions []string) bool 
 			if len(part) > 1 {
 				c2, err = semver.NewConstraint(part[0]) // Set new constraint to only version.
 				if err != nil {
-					c2 = c // Just reset and let it fail.
+					c2 = c // Just reset and let it fail later on.
 				}
-				conRev, _ = strconv.Atoi(part[1])
+				conRev, err = strconv.Atoi(part[1])
+				if err != nil {
+					log.Logger.Debug("Atoi", "error", err)
+				}
 			}
 
 			curPatch := currentVersion.Patch()
-			curRev, _ := strconv.Atoi(currentVersion.Metadata())
-			// In case the revision of current is other than the one of the constraint we either  + or - on the  patch val.
-			if curRev > conRev {
-				curPatch++
-			} else if curRev < conRev {
-				curPatch--
-			}
+			curRev, err2 := strconv.Atoi(currentVersion.Metadata())
+			if err == nil && err2 == nil {
+				// In case the revision of current is other than the one of the constraint we either  + or - on the  patch val.
+				if curRev > conRev {
+					curPatch++
+				} else if curRev < conRev {
+					curPatch--
+				}
 
-			v2, err := semver.NewVersion(fmt.Sprintf("%v.%v.%v", currentVersion.Major(), currentVersion.Minor(), curPatch))
-			if err == nil {
-				valid, _ = c2.Validate(v2)
-				if valid {
-					return true
+				v2, err := semver.NewVersion(fmt.Sprintf("%v.%v.%v", currentVersion.Major(), currentVersion.Minor(), curPatch))
+				if err == nil {
+					valid, _ = c2.Validate(v2)
+					if valid {
+						return true
+					}
 				}
 			}
 		}

--- a/pkg/scanner/utils/utils_test.go
+++ b/pkg/scanner/utils/utils_test.go
@@ -76,6 +76,41 @@ func TestMatchVersions(t *testing.T) {
 			expectedCheck:  true,
 		},
 		{
+			name:           "expect none-revision to not care about revision number",
+			currentVersion: "1.2.3",
+			rangeVersion:   []string{"<1.2.3.1"},
+			expectedCheck:  false,
+		},
+		{
+			name:           "expect ",
+			currentVersion: "1.2.3.4",
+			rangeVersion:   []string{"<1.2.3.5", ">1.2.3.3"},
+			expectedCheck:  true,
+		},
+		{
+			name:           "expect revision to be higher than same minor but lower than higher minor",
+			currentVersion: "1.2.3.4",
+			rangeVersion:   []string{">1.2.3", "<1.2.4"},
+			expectedCheck:  true,
+		},
+		{
+			name:           "expect revision to not be lower than none-revision",
+			currentVersion: "1.2.3.4",
+			rangeVersion:   []string{"<1.2.3"},
+		},
+		{
+			name:           "expect revision numbers to be tested",
+			currentVersion: "1.2.3.4",
+			rangeVersion:   []string{">1.2.3.3", "<1.2.3.5"},
+			expectedCheck:  true,
+		},
+		{
+			name:           "expect revision to equal same revision",
+			currentVersion: "1.2.3.4",
+			rangeVersion:   []string{"1.2.3.4"},
+			expectedCheck:  true,
+		},
+		{
 			name:           "expect prerelease suffixed in minor version to work",
 			currentVersion: "4.1a",
 			rangeVersion:   []string{`< 4.2b1`},
@@ -128,19 +163,19 @@ func TestFormatPatchVersio(t *testing.T) {
 			expectedVersion: "1.2.3-beta.1",
 		},
 		{
-			name:            "patch with dots after integer patch version should append dash and join rest versions parts",
+			name:            "patch with dots after integer patch version should append plus and join rest versions parts",
 			currentVersion:  "1.2.3.4",
-			expectedVersion: "1.2.3-4",
+			expectedVersion: "1.2.3+4",
 		},
 		{
-			name:            "patch with dots after integer patch version should append dash and join extra versions parts",
+			name:            "patch with dots after integer patch version should append plus and join extra versions parts",
 			currentVersion:  "1.2.3.4.5",
-			expectedVersion: "1.2.3-4.5",
+			expectedVersion: "1.2.3+4.5",
 		},
 		{
 			name:            "unchanged case",
 			currentVersion:  "1.2.3.4-5",
-			expectedVersion: "1.2.3-4-5",
+			expectedVersion: "1.2.3+4-5",
 		},
 		{
 			name:            "prerelease suffixed in minor",


### PR DESCRIPTION
This pull request changes the parsing of package revisions (x.x.x.x) to instead of seeing it as a pre-release, see it as what it is:

1. The `FormatPatchVersion` in `scanner/utils` will no longer change a x.x.x.x value to x.x.x-x but rather x.x.x+x (sub to add).  

2. The MatchVersion will now, in case the constraint fails, check if there is a `Metadata` value in the current version.
In case there is, it will differ the Metadata (revision) version with the constraint values revision (which, if it does not exist, is 0), it will then create new constraint if needed and either add or sub 1 from the patch version of the `currentVersion` to allow for a clean constraint test.


**Why is this needed?**

Not all package managers uses a standard `semver` versioning scheme. A lot do, but some have a legacy version spec (nuget, ruby and possibly more), which use a 4 part versioning scheme instead.  
This has been handled by changing the version to a pre-release instead of changing it to a revision version, which is actually is.

Merging this PR should fix issues such as #702 and also issues encountered during the implementation of #686 