### PR TITLE
fix(ci/deb): do not remove old packages for EOL versions

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -5,7 +5,7 @@ UBUNTU_RELEASES=$(ubuntu-distro-info --supported)
 
 cd trivy-repo/deb
 
-for release in $(reprepro ls trivy | awk -F "|" '{print $3}' | sed 's/ //g'); do
+for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Removing deb package of $release"
   reprepro -A i386 remove $release trivy
   reprepro -A amd64 remove $release trivy


### PR DESCRIPTION
The deploy script removes all packages once and adds new packages only for supported versions. `stretch` recently reached EOL and this script removed a package for `stretch`. We should keep packages even for EOL versions. This PR changes the script to remove only packages of supported versions.

Ref. https://github.com/aquasecurity/trivy/issues/689