### PR TITLE
Update BUG_REPORT.md using H2

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -4,28 +4,28 @@ labels: kind/bug
 about: If something isn't working as expected.
 ---
 
-**Description**
+## Description
 
 <!--
 Briefly describe the problem you are having in a few paragraphs.
 -->
 
-**What did you expect to happen?**
+## What did you expect to happen?
 
 
-**What happened instead?**
+## What happened instead?
 
 
-**Output of run with `-debug`:**
-
-```
-(paste your output here)
-```
-
-**Output of `trivy -v`:**
+## Output of run with `-debug`:
 
 ```
 (paste your output here)
 ```
 
-**Additional details (base image name, container registry info...):**
+## Output of `trivy -v`:
+
+```
+(paste your output here)
+```
+
+## Additional details (base image name, container registry info...):


### PR DESCRIPTION
In this template, for the sections, I suggest to use H2 instead of bold

Details: https://github.com/aquasecurity/trivy/issues/711