### PR TITLE
Add back support for FreeBSD & OpenBSD

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,6 +12,8 @@ builds:
     goos:
       - darwin
       - linux
+      - freebsd
+      - openbsd
     goarch:
       - amd64
       - 386


### PR DESCRIPTION
Reverts 7fc94ad95c920289e35a2dcc9e3df289918055a4

Fixes https://github.com/aquasecurity/trivy/issues/725

`goreleaser release --skip-publish --skip-validate --rm-dist` ran successfully


Feel free to close if this needs to be run by a maintainer 

cc @knqyf263
