### PR TITLE
Add suse sles 15.2 to the EOL list as well

### DIFF
--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -39,7 +39,9 @@ var (
 		"15":   time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.1": time.Date(2021, 1, 31, 23, 59, 59, 0, time.UTC),
 		// 6 months after SLES 15 SP3 release
-		// "15.2":   time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
+		"15.2": time.Date(2021, 10, 31, 23, 59, 59, 0, time.UTC),
+		// 6 months after SLES 15 SP4 release
+		// "15.3":   time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{


### PR DESCRIPTION
without that you get this arning:
  WARN	This OS version is not on the EOL list: suse linux enterprise server 15.2

which is actually misleading because 15.2 is the most current release,
we just don't know when it ends. we can however assume that it runs
for at least another year.

Signed-off-by: Dirk Mueller <dirk@dmllr.de>
Signed-off-by: Dirk Mueller <dmueller@suse.com>