### PR TITLE
updated Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,11 +1602,10 @@ But, I can't recommend using ENV vars in your local machine to you.
 
 ### Docker Hub
 
-Docker Hub needs `TRIVY_AUTH_URL`, `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
+Docker Hub needs `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
 You don't need to set ENV vars when download from public repository.
 
 ```bash
-export TRIVY_AUTH_URL=https://registry.hub.docker.com
 export TRIVY_USERNAME={DOCKERHUB_USERNAME}
 export TRIVY_PASSWORD={DOCKERHUB_PASSWORD}
 ```


### PR DESCRIPTION
I Removed the unused env var TRIVY_AUTH_URL from README.md

I searched the code and could not find any appearance of this variable. I tried to scan private images without this env var and it worked fine too.

