### PR TITLE
fix(oracle): handle ksplice advisories

### DIFF
--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -65,7 +65,10 @@ func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedV
 		installed := utils.FormatVersion(pkg)
 		installedVersion := version.NewVersion(installed)
 		for _, adv := range advisories {
-			// TODO: We don't seem to ignore advisories with no FixedVersion like we do elsewhere, expected?
+			// Skip if only one of them contains .ksplice1.
+			if strings.Contains(adv.FixedVersion, ".ksplice1.") != strings.Contains(pkg.Release, ".ksplice1.") {
+				continue
+			}
 			fixedVersion := version.NewVersion(adv.FixedVersion)
 			vuln := types.DetectedVulnerability{
 				VulnerabilityID:  adv.VulnerabilityID,

--- a/pkg/detector/ospkg/oracle/testdata/fixtures/invalid-type.yaml
+++ b/pkg/detector/ospkg/oracle/testdata/fixtures/invalid-type.yaml
@@ -1,0 +1,9 @@
+- bucket: Oracle Linux 7
+  pairs:
+    - bucket: curl
+      pairs:
+        - key: CVE-2020-8177
+          value:
+            FixedVersion:
+              - foo
+              - bar

--- a/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
+++ b/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
@@ -1,0 +1,12 @@
+- bucket: Oracle Linux 7
+  pairs:
+    - bucket: curl
+      pairs:
+        - key: CVE-2020-8177
+          value:
+            FixedVersion: "7.29.0-59.0.1.el7_9.1"
+    - bucket: glibc
+      pairs:
+        - key: CVE-2017-1000364
+          value:
+            FixedVersion: "2:2.17-157.ksplice1.el7_3.4"


### PR DESCRIPTION
## Overview
`ksplice` is for zero-downtime updates and it doesn't seem to be used in a container image.
https://ksplice.oracle.com/

There are two patches for the same vulnerability.
1. Normal patch
2. Zero-downtime patch

They have different versioning. You can see the following advisories. The first one is the normal patch, while the second one is the zero-downtime patch.

1. https://linux.oracle.com/errata/ELSA-2019-2304.html
2. https://linux.oracle.com/errata/ELSA-2019-4754.html

If a package is installed without `ksplice` patch, we should not use `ksplice` advisories for vulnerability detection because they have different versioning and it causes false positives. This PR skips `ksplice` advisories when the installed package is not a `ksplice` package. Also, if the package is a `ksplice` one, we should not use the normal advisories.

## Issue
Close https://github.com/aquasecurity/trivy/issues/736