### PR TITLE
Add redis cache backend configuration options

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.2.0
-appVersion: "0.14.0"
+version: 0.3.0
+appVersion: "0.15.0"
 description: Trivy helm chart
 keywords:
   - scanner

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -55,6 +55,8 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.debugMode`             | The flag to enable or disable Trivy debug mode                          | `false` |
 | `trivy.gitHubToken`           | The GitHub access token to download Trivy DB                            |      |
 | `trivy.skipUpdate`            | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
+| `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
+| `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
 | `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
 | `service.port`                        | Kubernetes service port                                                 | `4954`      |
 | `httpProxy`                           | The URL of the HTTP proxy server                                        |     |
@@ -75,3 +77,8 @@ $ helm install my-release . \
 ## Storage
 
 This chart uses a PersistentVolumeClaim to reduce the number of database downloads between POD restarts or updates. The storageclass should have the reclaim policy  `Retain`.
+
+## Caching
+
+You can specify a Redis server as cache backend. This Redis server has to be already present. You can use the [bitname chart](https://bitnami.com/stack/redis/helm).
+More Information about the caching backends can be found [here](https://github.com/aquasecurity/trivy#specify-cache-backend).

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -51,6 +51,10 @@ spec:
               value: "0.0.0.0:{{ .Values.service.port | default 4954 }}"
             - name: "TRIVY_CACHE_DIR"
               value: "/home/scanner/.cache/trivy"
+            {{- if .Values.trivy.cache.redis.enabled }}
+            - name: "TRIVY_CACHE_BACKEND"
+              value: {{ .Values.trivy.cache.redis.url | quote }}
+            {{- end }}
             - name: "TRIVY_DEBUG"
               value: {{ .Values.trivy.debugMode | default false | quote }}
             - name: "TRIVY_SKIP_UPDATE"

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 image:
   registry: docker.io
   repository: aquasec/trivy
-  tag: 0.14.0
+  tag: 0.15.0
   pullPolicy: IfNotPresent
 
 replicaCount: 1
@@ -61,6 +61,18 @@ trivy:
   # If the flag is enabled you have to manually download the `trivy.db` file and mount it in the
   # `/home/scanner/.cache/trivy/db/trivy.db` path (see `cacheDir`).
   skipUpdate: false
+  # Trivy supports filesystem and redis as caching backend
+  # https://github.com/aquasecurity/trivy#specify-cache-backend
+  # This location is only used for the cache, not the db storage: https://github.com/aquasecurity/trivy/issues/765#issue-756010345
+  #
+  # In case you specify redis as backend, make sure you installed a redis server yourself, e.g.
+  # https://bitnami.com/stack/redis/helm
+  #
+  # In case redis is not enabled, the filesystem will be used
+  cache:
+    redis:
+      enabled: false
+      url: "" # e.g. redis://redis.redis.svc:6379
 
 service:
   # type Kubernetes service type


### PR DESCRIPTION
You can now specify redis as caching as backend.
The default is still the filesystem.

In case redis is added as caching backend, the cache-dir is still
used for the vulnerability database.

Fixes #781

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>