### PR TITLE
Parse redis backend url

### DIFF
--- a/internal/operation/operation.go
+++ b/internal/operation/operation.go
@@ -32,9 +32,11 @@ type Cache struct {
 func NewCache(backend string) (Cache, error) {
 	if strings.HasPrefix(backend, "redis://") {
 		log.Logger.Infof("Redis cache: %s", backend)
-		redisCache := cache.NewRedisCache(&redis.Options{
-			Addr: strings.TrimPrefix(backend, "redis://"),
-		})
+		options, err := redis.ParseURL(backend)
+		if err != nil {
+			return Cache{}, err
+		}
+		redisCache := cache.NewRedisCache(options)
 		return Cache{Cache: redisCache}, nil
 	}
 	fsCache, err := cache.NewFSCache(utils.CacheDir())


### PR DESCRIPTION
As suggested by the go-redis client, parse the url to get the config.
This will fix problems, when the url contains a username and/or password.

Fixes #798

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>