### PR TITLE
#813 "Use your github token" output is confusing to the user

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -62,7 +62,7 @@ func NewClient() Client {
 	var client *http.Client
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken != "" {
-		log.Logger.Info("Use your github token")
+		log.Logger.Info("Using your github token")
 		ctx := context.Background()
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: githubToken})
 		client = oauth2.NewClient(ctx, ts)


### PR DESCRIPTION
Changed the output string to "Using your github token".