### PR TITLE
fix(python): follow PEP 440

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
-	github.com/aquasecurity/go-version v0.0.0-20201115065329-578079e4ab05
+	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
+	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
 	github.com/aquasecurity/trivy-db v0.0.0-20210105160501-c5bf4e153277
 	github.com/caarlos0/env/v6 v6.0.0
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -99,10 +99,12 @@ github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgB
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798 h1:eveqE9ivrt30CJ7dOajOfBavhZ4zPqHcZe/4tKp0alc=
 github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798/go.mod h1:hxbJZtKlO4P8sZ9nztizR6XLoE33O+BkPmuYQ4ACyz0=
+github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46 h1:vmXNl+HDfqqXgr0uY1UgK1GAhps8nbAAtqHNBcgyf+4=
+github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46/go.mod h1:olhPNdiiAAMiSujemd1O/sc6GcyePr23f/6uGKtthNg=
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a h1:SMEtDBnLyP/EVOeJhj4yeR8GYPFpBsFBk3lSrpjZ8yI=
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
-github.com/aquasecurity/go-version v0.0.0-20201115065329-578079e4ab05 h1:q0ZpFBjwzDk1ofey7gJ2kfA6ZNi2PeBWxNzmRPrfetA=
-github.com/aquasecurity/go-version v0.0.0-20201115065329-578079e4ab05/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
+github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 h1:rcEG5HI490FF0a7zuvxOxen52ddygCfNVjP0XOCMl+M=
+github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
 github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a h1:hsw7PpiymXP64evn/K7gsj3hWzMqLrdoeE6JkqDocVg=
 github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a/go.mod h1:psfu0MVaiTDLpNxCoNsTeILSKY2EICBwv345f3M+Ffs=
 github.com/aquasecurity/trivy-db v0.0.0-20210105160501-c5bf4e153277 h1:lXN72H9uNM1exUArIsN++n7b67PIaqhZON2cVWxwmpg=

--- a/pkg/detector/library/node/compare_test.go
+++ b/pkg/detector/library/node/compare_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-func TestNpmComparer_MatchVersion(t *testing.T) {
+func TestNpmComparer_IsVulnerable(t *testing.T) {
 	type args struct {
 		currentVersion string
 		advisory       dbTypes.Advisory

--- a/pkg/detector/library/python/advisory.go
+++ b/pkg/detector/library/python/advisory.go
@@ -21,7 +21,7 @@ type Advisory struct {
 func NewAdvisory() *Advisory {
 	return &Advisory{
 		vs:       python.NewVulnSrc(),
-		comparer: comparer.GenericComparer{},
+		comparer: Pep440Comparer{},
 	}
 }
 

--- a/pkg/detector/library/python/advisory_test.go
+++ b/pkg/detector/library/python/advisory_test.go
@@ -29,13 +29,13 @@ func TestAdvisory_DetectVulnerabilities(t *testing.T) {
 			name: "detected",
 			args: args{
 				pkgName: "django",
-				pkgVer:  "2.2.11-alpha",
+				pkgVer:  "2.2.11a1",
 			},
 			fixtures: []string{"testdata/fixtures/pip.yaml"},
 			want: []types.DetectedVulnerability{
 				{
 					PkgName:          "django",
-					InstalledVersion: "2.2.11-alpha",
+					InstalledVersion: "2.2.11a1",
 					VulnerabilityID:  "CVE-2020-9402",
 					FixedVersion:     "1.11.29, 2.2.11, 3.0.4",
 				},

--- a/pkg/detector/library/python/compare.go
+++ b/pkg/detector/library/python/compare.go
@@ -3,7 +3,7 @@ package python
 import (
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/go-pep440-version"
+	version "github.com/aquasecurity/go-pep440-version"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library/comparer"
 )

--- a/pkg/detector/library/python/compare.go
+++ b/pkg/detector/library/python/compare.go
@@ -1,0 +1,32 @@
+package python
+
+import (
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/go-pep440-version"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/detector/library/comparer"
+)
+
+// Pep440Comparer represents a comparer for PEP 440
+type Pep440Comparer struct{}
+
+// IsVulnerable checks if the package version is vulnerable to the advisory.
+func (n Pep440Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
+	return comparer.IsVulnerable(ver, advisory, n.matchVersion)
+}
+
+// matchVersion checks if the package version satisfies the given constraint.
+func (n Pep440Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
+	v, err := version.Parse(currentVersion)
+	if err != nil {
+		return false, xerrors.Errorf("python version error (%s): %s", currentVersion, err)
+	}
+
+	c, err := version.NewSpecifiers(constraint, version.WithPreRelease(true))
+	if err != nil {
+		return false, xerrors.Errorf("python constraint error (%s): %s", constraint, err)
+	}
+
+	return c.Check(v), nil
+}

--- a/pkg/detector/library/python/compare_test.go
+++ b/pkg/detector/library/python/compare_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-func TestPep440Comparer_MatchVersion(t *testing.T) {
+func TestPep440Comparer_IsVulnerable(t *testing.T) {
 	type args struct {
 		currentVersion string
 		advisory       dbTypes.Advisory

--- a/pkg/detector/library/python/compare_test.go
+++ b/pkg/detector/library/python/compare_test.go
@@ -1,0 +1,118 @@
+package python_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/detector/library/python"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+func TestPep440Comparer_MatchVersion(t *testing.T) {
+	type args struct {
+		currentVersion string
+		advisory       dbTypes.Advisory
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				currentVersion: "1.0.0",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"<=1.0"},
+					PatchedVersions:    []string{">=1.1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no patch",
+			args: args{
+				currentVersion: "1.2.3",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"<=99.999.99999"},
+					PatchedVersions:    []string{"<0.0.0"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no patch with wildcard",
+			args: args{
+				currentVersion: "1.2.3",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"*"},
+					PatchedVersions:    nil,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pre-release",
+			args: args{
+				currentVersion: "1.2.3a1",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"<=1.2.2"},
+					PatchedVersions:    []string{">=1.2.2"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple constraints",
+			args: args{
+				currentVersion: "2.0.0",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{">=1.7.0 <1.7.16", ">=1.8.0 <1.8.8", ">=2.0.0 <2.0.8", ">=3.0.0b1 <3.0.0b7"},
+					PatchedVersions:    []string{">=3.0.0b7", ">=2.0.8 <3.0.0b1", ">=1.8.8 <2.0.0", ">=1.7.16 <1.8.0"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "exact versions",
+			args: args{
+				currentVersion: "2.1.0.post1",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"2.1.0.post1", "2.0.0"},
+					PatchedVersions:    []string{">=2.1.1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "invalid version",
+			args: args{
+				currentVersion: "1.2..4",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"<1.0.0"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "invalid constraint",
+			args: args{
+				currentVersion: "1.2.4",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{"!1.0.0"},
+				},
+			},
+			want: false,
+		},
+	}
+	log.InitLogger(false, false)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := python.Pep440Comparer{}
+			got := c.IsVulnerable(tt.args.currentVersion, tt.args.advisory)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Python defines a scheme for identifying versions of Python software distributions in PEP 440.
https://www.python.org/dev/peps/pep-0440/

This PR replaces go-version with [go-pep440-version](https://github.com/aquasecurity/go-pep440-version) so that Trivy can align with the definition.
