### PR TITLE
README: add Gitlab job that uses a container with trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1609,6 +1609,38 @@ Example: https://gitlab.com/aquasecurity/trivy-ci-test/pipelines
 
 Repository: https://github.com/aquasecurity/trivy-ci-test
 
+### GitLab CI using Trivy container
+
+```yaml
+container_scanning:
+  image:                           docker.io/aquasec/trivy:latest
+  variables:
+    FULL_IMAGE_NAME:               $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+  script:
+    - cd /
+    # cache cleanup is needed when scanning images with the same tags, it does not remove the database
+    - time trivy image --clear-cache
+    # update vulnerabilities db
+    - time trivy --download-db-only --no-progress --cache-dir .trivycache/
+    # Builds report and puts it in the default workdir $CI_PROJECT_DIR, so `artifacts:` can take it from there
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl"
+        --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$FULL_IMAGE_NAME"
+    # Prints full report
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$FULL_IMAGE_NAME"
+    # Fails on high and critical vulnerabilities
+    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
+  cache:
+    paths:
+      - .trivycache/
+  # Enables https://docs.gitlab.com/ee/user/application_security/container_scanning/ (Container Scanning report is available on GitLab EE Ultimate or GitLab.com Gold)
+  artifacts:
+    when:                          always
+    reports:
+      container_scanning:          gl-container-scanning-report.json
+  tags:
+    - docker-runner
+```
+
 ## AWS CodePipeline
 
 See [this blog post](https://aws.amazon.com/blogs/containers/scanning-images-with-trivy-in-an-aws-codepipeline/) for an example of using Trivy within AWS CodePipeline.


### PR DESCRIPTION
Hi, I was adding `trivy` instead of a broken built in GitLab for my use case `clair`, and made it work a simpler way than you describe it in `README`. This job takes ~15 sec given the image is cached.
Please correct me if I'm wrong somewhere.