### PR TITLE
fix(eol): update EOL dates

### DIFF
--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -33,8 +33,8 @@ var (
 		"6.0": time.Date(2016, 2, 29, 23, 59, 59, 0, time.UTC),
 		"7":   time.Date(2018, 5, 31, 23, 59, 59, 0, time.UTC),
 		"8":   time.Date(2020, 6, 30, 23, 59, 59, 0, time.UTC),
-		"9":   time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
-		"10":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"9":   time.Date(2022, 6, 30, 23, 59, 59, 0, time.UTC),
+		"10":  time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		"11":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 		"12":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -87,6 +87,24 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			osVersion: "9",
 			expected:  true,
 		},
+		"debian9 eol ends": {
+			now:       time.Date(2022, 7, 31, 23, 59, 59, 0, time.UTC),
+			osFamily:  "debian",
+			osVersion: "9",
+			expected:  false,
+		},
+		"debian10": {
+			now:       time.Date(2020, 7, 31, 23, 59, 59, 0, time.UTC),
+			osFamily:  "debian",
+			osVersion: "10",
+			expected:  true,
+		},
+		"debian10 eol ends": {
+			now:       time.Date(2024, 7, 31, 23, 59, 59, 0, time.UTC),
+			osFamily:  "debian",
+			osVersion: "10",
+			expected:  false,
+		},
 		"unknown": {
 			now:       time.Date(2020, 7, 31, 23, 59, 59, 0, time.UTC),
 			osFamily:  "debian",

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -31,8 +31,7 @@ var (
 		"5": time.Date(2017, 3, 31, 23, 59, 59, 0, time.UTC),
 		"6": time.Date(2020, 11, 30, 23, 59, 59, 0, time.UTC),
 		"7": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
-		// N/A
-		"8": time.Date(3000, 6, 30, 23, 59, 59, 0, time.UTC),
+		"8": time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC),
 	}
 	excludedVendorsSuffix = []string{
 		".remi",

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -349,6 +349,12 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			osVersion: "8.0",
 			expected:  true,
 		},
+		"centos8 (eol ends)": {
+			now:       time.Date(2022, 12, 1, 0, 0, 0, 0, time.UTC),
+			osFamily:  "centos",
+			osVersion: "8.0",
+			expected:  false,
+		},
 		"two dots": {
 			now:       time.Date(2019, 5, 31, 23, 59, 59, 0, time.UTC),
 			osFamily:  "centos",


### PR DESCRIPTION

- [Amazon Linux](https://aws.amazon.com/jp/blogs/aws/update-on-amazon-linux-ami-end-of-life/)
- [Debian](https://wiki.debian.org/LTS)
- [CentOS 8](https://en.wikipedia.org/wiki/CentOS#End-of-support_schedule)