### PR TITLE
feat: support Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Simple and Comprehensive Vulnerability Scanner for Containers and other Artifa
   * [Filesystem](#filesystem)
   * [Embed in Dockerfile](#embed-in-dockerfile)
   * [Git Repository](#git-repository)
+  * [Podman](#podman)
 - [Examples](#examples)
   * [Standalone](#standalone)
     + [Scan an image](#scan-an-image)
@@ -121,8 +122,9 @@ See [here](#continuous-integration-ci) for details.
 - Support multiple formats
   - container image
     - A local image in Docker Engine which is running as a daemon
+    - A local image in Podman (>=2.0) which is exposing a socket
     - A remote image in Docker Registry such as Docker Hub, ECR, GCR and ACR
-    - A tar archive stored in the `docker save` formatted file
+    - A tar archive stored in the `docker save` / `podman save` formatted file
     - An image directory compliant with [OCI Image Format](https://github.com/opencontainers/image-spec)
   - local filesystem
   - remote git repository
@@ -360,6 +362,26 @@ $ trivy repo https://github.com/knqyf263/trivy-ci-test
 ```
 
 Only public repositories are supported.
+
+## Podman
+[EXPERIMENTAL] This feature might change without preserving backwards compatibility.
+
+Scan your image in Podman (>=2.0) running locally. The remote Podman is not supported.
+Before performing Trivy commands, you must enable the podman.sock systemd service on your machine.
+For more details, see [here](https://www.redhat.com/sysadmin/podman-clients-macos-windows)
+
+```
+$ systemctl --user enable podman.socket
+```
+
+Then, you can scan your image in Podman.
+
+```
+$ podman images
+REPOSITORY                TAG     IMAGE ID      CREATED      SIZE
+localhost/test            latest  ed1b0762d815  3 weeks ago  5.85 MB
+$ trivy image localhost/test
+```
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -368,10 +368,10 @@ Only public repositories are supported.
 
 Scan your image in Podman (>=2.0) running locally. The remote Podman is not supported.
 Before performing Trivy commands, you must enable the podman.sock systemd service on your machine.
-For more details, see [here](https://www.redhat.com/sysadmin/podman-clients-macos-windows)
+For more details, see [here](https://github.com/containers/podman/blob/master/docs/tutorials/remote_client.md#enable-the-podman-service-on-the-server-machine)
 
 ```
-$ systemctl --user enable podman.socket
+$ systemctl --user enable --now podman.socket
 ```
 
 Then, you can scan your image in Podman.

--- a/README.md
+++ b/README.md
@@ -377,10 +377,14 @@ $ systemctl --user enable --now podman.socket
 Then, you can scan your image in Podman.
 
 ```
+$ cat Dockerfile
+FROM alpine:3.12
+RUN apk add --no-cache bash
+$ podman build -t test .
 $ podman images
 REPOSITORY                TAG     IMAGE ID      CREATED      SIZE
-localhost/test            latest  ed1b0762d815  3 weeks ago  5.85 MB
-$ trivy image localhost/test
+localhost/test            latest  efc372d4e0de  About a minute ago  7.94 MB
+$ trivy image test
 ```
 
 # Examples

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20201218050947-981a0510f9cb
+	github.com/aquasecurity/fanal v0.0.0-20210119051230-28c249da7cfd
 	github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/fanal v0.0.0-20201218050947-981a0510f9cb h1:T48y/j2wvl/xPX2IyV0ogFq+GeCLY+3548awySrUaJU=
-github.com/aquasecurity/fanal v0.0.0-20201218050947-981a0510f9cb/go.mod h1:arUN1lJnuAWLL0PUQ/UYrkAomU/Mby+gCXJMU90GHlA=
+github.com/aquasecurity/fanal v0.0.0-20210119051230-28c249da7cfd h1:meqa2AA+7K1r/nfNB19K2AP/v8+nemuWeQoTSqZ2R9s=
+github.com/aquasecurity/fanal v0.0.0-20210119051230-28c249da7cfd/go.mod h1:kur6SaohYhsjQLzijAdtn+X8rkTtwxawE51WyVCXLKk=
 github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0 h1:cLH3SebzhbJ+jU1GIad8A1N8p7m7OjHhtY6JePISiVc=
 github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0/go.mod h1:X42mTIRhgPalSm81Om2kD+3ydeunbC8TZtZj1bvgRo8=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
@@ -105,8 +105,8 @@ github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a h1:SMEtDBn
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 h1:rcEG5HI490FF0a7zuvxOxen52ddygCfNVjP0XOCMl+M=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
-github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a h1:hsw7PpiymXP64evn/K7gsj3hWzMqLrdoeE6JkqDocVg=
-github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a/go.mod h1:psfu0MVaiTDLpNxCoNsTeILSKY2EICBwv345f3M+Ffs=
+github.com/aquasecurity/testdocker v0.0.0-20210106133225-0b17fe083674 h1:Xq/HxWFGaB4G/prC6czH/F5woB91GMCCilJxs/5DnDk=
+github.com/aquasecurity/testdocker v0.0.0-20210106133225-0b17fe083674/go.mod h1:psfu0MVaiTDLpNxCoNsTeILSKY2EICBwv345f3M+Ffs=
 github.com/aquasecurity/trivy-db v0.0.0-20210105160501-c5bf4e153277 h1:lXN72H9uNM1exUArIsN++n7b67PIaqhZON2cVWxwmpg=
 github.com/aquasecurity/trivy-db v0.0.0-20210105160501-c5bf4e153277/go.mod h1:N7CWA/vjVw78GWAdCJGhFQVqNGEA4e47a6eIWm+C/Bc=
 github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2 h1:xbdUfr2KE4THsFx9CFWtWpU91lF+YhgP46moV94nYTA=


### PR DESCRIPTION
## Overview
This PR enables Trivy to scan images in Podman (>=2.0) running locally. The remote Podman is not supported.

The podman.sock systemd service must be enabled on a machine.

```
$ systemctl --user enable --now podman.socket
$ podman images
REPOSITORY                TAG     IMAGE ID      CREATED      SIZE
localhost/test            latest  ed1b0762d815  3 weeks ago  5.85 MB
$ trivy image localhost/test
```

## PRs
https://github.com/aquasecurity/fanal/pull/149