### PR TITLE
Add multiple report options

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,9 +949,9 @@ In the following example using the template `sarif.tpl` [Sarif](https://docs.git
 $ trivy image --format template --template "@contrib/sarif.tpl" -o report.sarif  golang:1.12-alpine
 ```
 This SARIF format can be uploaded to GitHub code scanning results, and there is a [Trivy GitHub Action](https://github.com/aquasecurity/trivy-action) for automating this process.
-In the following example using multi formats, the template `junit.tpl` XML and `htmlt.tpl` HTML can be generated.
+In the following example using multi formats, reports with json and `junit.tpl` XML template can be generated.
 ```
-$ trivy image --format template,template --template "@contrib/junit.tpl,@contrib/html.tpl" -o junit-report.xml  golang:1.12-alpine
+$ trivy image --format json,template --template "@contrib/junit.tpl" -o junit-report.xml  golang:1.12-alpine
 ```
 
 Trivy also supports an [ASFF template for reporting findings to AWS Security Hub](docs/integration/security-hub.md)

--- a/README.md
+++ b/README.md
@@ -949,6 +949,10 @@ In the following example using the template `sarif.tpl` [Sarif](https://docs.git
 $ trivy image --format template --template "@contrib/sarif.tpl" -o report.sarif  golang:1.12-alpine
 ```
 This SARIF format can be uploaded to GitHub code scanning results, and there is a [Trivy GitHub Action](https://github.com/aquasecurity/trivy-action) for automating this process.
+In the following example using multi formats, the template `junit.tpl` XML and `htmlt.tpl` HTML can be generated.
+```
+$ trivy image --format template,template --template "@contrib/junit.tpl,@contrib/html.tpl" -o junit-report.xml  golang:1.12-alpine
+```
 
 Trivy also supports an [ASFF template for reporting findings to AWS Security Hub](docs/integration/security-hub.md)
 ### Filter the vulnerabilities by severities

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -79,6 +79,26 @@ func TestClientServer(t *testing.T) {
 			golden: "testdata/alpine-310-ignore-cveids.json.golden",
 		},
 		{
+			name: "alpine 3.10 integration with gitlab template",
+			testArgs: args{
+				Format:       "template",
+				TemplatePath: "@../contrib/gitlab.tpl",
+				Version:      "dev",
+				Input:        "testdata/fixtures/alpine-310.tar.gz",
+			},
+			golden: "testdata/alpine-310.gitlab.golden",
+		},
+		{
+			name: "alpine 3.10 integration with sarif template",
+			testArgs: args{
+				Format:       "template",
+				TemplatePath: "@../contrib/sarif.tpl",
+				Version:      "dev",
+				Input:        "testdata/fixtures/alpine-310.tar.gz",
+			},
+			golden: "testdata/alpine-310.sarif.golden",
+		},
+		{
 			name: "alpine 3.9 integration",
 			testArgs: args{
 				Version: "dev",
@@ -291,26 +311,6 @@ func TestClientServer(t *testing.T) {
 				Input:   "testdata/fixtures/busybox-with-lockfile.tar.gz",
 			},
 			golden: "testdata/busybox-with-lockfile.json.golden",
-		},
-		{
-			name: "alpine 3.10 integration with gitlab template",
-			testArgs: args{
-				Format:       "template",
-				TemplatePath: "@../contrib/gitlab.tpl",
-				Version:      "dev",
-				Input:        "testdata/fixtures/alpine-310.tar.gz",
-			},
-			golden: "testdata/alpine-310.gitlab.golden",
-		},
-		{
-			name: "alpine 3.10 integration with sarif template",
-			testArgs: args{
-				Format:       "template",
-				TemplatePath: "@../contrib/sarif.tpl",
-				Version:      "dev",
-				Input:        "testdata/fixtures/alpine-310.tar.gz",
-			},
-			golden: "testdata/alpine-310.sarif.golden",
 		},
 		{
 			name: "alpine 3.10 integration with ASFF template",

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -79,26 +79,6 @@ func TestClientServer(t *testing.T) {
 			golden: "testdata/alpine-310-ignore-cveids.json.golden",
 		},
 		{
-			name: "alpine 3.10 integration with gitlab template",
-			testArgs: args{
-				Format:       "template",
-				TemplatePath: "@../contrib/gitlab.tpl",
-				Version:      "dev",
-				Input:        "testdata/fixtures/alpine-310.tar.gz",
-			},
-			golden: "testdata/alpine-310.gitlab.golden",
-		},
-		{
-			name: "alpine 3.10 integration with sarif template",
-			testArgs: args{
-				Format:       "template",
-				TemplatePath: "@../contrib/sarif.tpl",
-				Version:      "dev",
-				Input:        "testdata/fixtures/alpine-310.tar.gz",
-			},
-			golden: "testdata/alpine-310.sarif.golden",
-		},
-		{
 			name: "alpine 3.9 integration",
 			testArgs: args{
 				Version: "dev",
@@ -311,6 +291,26 @@ func TestClientServer(t *testing.T) {
 				Input:   "testdata/fixtures/busybox-with-lockfile.tar.gz",
 			},
 			golden: "testdata/busybox-with-lockfile.json.golden",
+		},
+		{
+			name: "alpine 3.10 integration with gitlab template",
+			testArgs: args{
+				Format:       "template",
+				TemplatePath: "@../contrib/gitlab.tpl",
+				Version:      "dev",
+				Input:        "testdata/fixtures/alpine-310.tar.gz",
+			},
+			golden: "testdata/alpine-310.gitlab.golden",
+		},
+		{
+			name: "alpine 3.10 integration with sarif template",
+			testArgs: args{
+				Format:       "template",
+				TemplatePath: "@../contrib/sarif.tpl",
+				Version:      "dev",
+				Input:        "testdata/fixtures/alpine-310.tar.gz",
+			},
+			golden: "testdata/alpine-310.sarif.golden",
 		},
 		{
 			name: "alpine 3.10 integration with ASFF template",

--- a/internal/app.go
+++ b/internal/app.go
@@ -62,7 +62,7 @@ var (
 	outputFlag = cli.StringFlag{
 		Name:    "output",
 		Aliases: []string{"o"},
-		Usage:   "output file name",
+		Usage:   "output file name (use stdout or empty string to output to shell)",
 		EnvVars: []string{"TRIVY_OUTPUT"},
 	}
 

--- a/internal/artifact/config/config_test.go
+++ b/internal/artifact/config/config_test.go
@@ -44,8 +44,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 			},
@@ -60,8 +60,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 			},
@@ -76,8 +76,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{
@@ -95,8 +95,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{
@@ -115,8 +115,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -137,8 +138,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"json": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -176,12 +178,14 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
-						"json": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -202,8 +206,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -224,8 +229,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"template": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "template",
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
@@ -243,16 +249,19 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
-						"template": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "template",
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
-						"json": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -274,8 +283,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{

--- a/internal/artifact/config/config_test.go
+++ b/internal/artifact/config/config_test.go
@@ -44,8 +44,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 			},
@@ -60,8 +60,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 			},
@@ -76,8 +76,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{
@@ -95,8 +95,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{
@@ -115,9 +115,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -138,9 +137,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "json",
+					Formats: map[string]config.MappedFormat{
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -178,14 +176,12 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
-						config.MappedFormat{
-							Format:   "json",
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -206,9 +202,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -220,18 +215,17 @@ func TestConfig_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "multi-format: invalid option combination: not enough matching --template",
+			name: "multi-format: invalid option combination: more than one --format template",
 			args: []string{"--format", "template,template", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
+				"--format template is ignored because it has been specified.",
 			},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "template",
+					Formats: map[string]config.MappedFormat{
+						"template": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
@@ -244,31 +238,23 @@ func TestConfig_Init(t *testing.T) {
 		},
 		{
 			name: "multi-format: valid option combination",
-			args: []string{"--format", "table,template,json,template", "--template", "@contrib/gitlab.tpl,@contrib/junit.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			args: []string{"--format", "table,template,json", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
-						config.MappedFormat{
-							Format:   "template",
+						"template": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
-						config.MappedFormat{
-							Format:   "json",
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
-						},
-						config.MappedFormat{
-							Format:   "template",
-							Output:   os.Stdout,
-							Template: "@contrib/junit.tpl",
 						},
 					},
 				},
@@ -288,8 +274,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 				ArtifactConfig: config.ArtifactConfig{

--- a/internal/artifact/run.go
+++ b/internal/artifact/run.go
@@ -99,8 +99,10 @@ func run(c config.Config, initializeScanner InitializeScanner) error {
 		results[i].Vulnerabilities = vulns
 	}
 
-	if err = report.WriteResults(c.Format, c.Output, c.Severities, results, c.Template, c.Light); err != nil {
-		return xerrors.Errorf("unable to write results: %w", err)
+	for _, f := range c.Formats {
+		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, c.Light); err != nil {
+			return xerrors.Errorf("unable to write results: %w", err)
+		}
 	}
 
 	if c.ExitCode != 0 {

--- a/internal/artifact/run.go
+++ b/internal/artifact/run.go
@@ -99,8 +99,8 @@ func run(c config.Config, initializeScanner InitializeScanner) error {
 		results[i].Vulnerabilities = vulns
 	}
 
-	for k, v := range c.Formats {
-		if err = report.WriteResults(k, v.Output, c.Severities, results, v.Template, c.Light); err != nil {
+	for _, f := range c.Formats {
+		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, c.Light); err != nil {
 			return xerrors.Errorf("unable to write results: %w", err)
 		}
 	}

--- a/internal/artifact/run.go
+++ b/internal/artifact/run.go
@@ -99,8 +99,8 @@ func run(c config.Config, initializeScanner InitializeScanner) error {
 		results[i].Vulnerabilities = vulns
 	}
 
-	for _, f := range c.Formats {
-		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, c.Light); err != nil {
+	for k, v := range c.Formats {
+		if err = report.WriteResults(k, v.Output, c.Severities, results, v.Template, c.Light); err != nil {
 			return xerrors.Errorf("unable to write results: %w", err)
 		}
 	}

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -45,7 +45,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os"},
-					Output:     os.Stdout,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
 				},
 				CustomHeaders: http.Header{},
 			},
@@ -56,8 +58,10 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "alpine:3.11",
@@ -75,8 +79,10 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "alpine:3.11",
@@ -93,8 +99,10 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "alpine:3.11",
@@ -112,8 +120,10 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "centos:7",
@@ -130,9 +140,14 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
-					Template:   "@contrib/gitlab.tpl",
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
+							Output:   os.Stdout,
+							Template: "",
+						},
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
@@ -144,15 +159,19 @@ func TestConfig_Init(t *testing.T) {
 			name: "invalid option combination: --template and --format json",
 			args: []string{"--format", "json", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--template is ignored because --format json is specified. Use --template option with --format template option.",
+				"--template is ignored because --format [json] is specified. Use --template option with --format template option.",
 			},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
-					Template:   "@contrib/gitlab.tpl",
-					Format:     "json",
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
+							Output:   os.Stdout,
+							Template: "",
+						},
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
@@ -164,14 +183,13 @@ func TestConfig_Init(t *testing.T) {
 			name: "invalid option combination: --format template without --template",
 			args: []string{"--format", "template", "--severity", "MEDIUM", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--format template is ignored because --template not is specified. Specify --template option when you use --format template.",
+				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
 			},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityMedium},
-					Output:     os.Stdout,
+					Formats:    nil,
 					VulnType:   []string{"os", "library"},
-					Format:     "template",
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
@@ -180,17 +198,111 @@ func TestConfig_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid option combination: --format template without --template",
-			args: []string{"--format", "template", "--severity", "MEDIUM", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			name: "multi-format: invalid option combination: --template enabled without matching --format template",
+			args: []string{"--format", "table,json", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--format template is ignored because --template not is specified. Specify --template option when you use --format template.",
+				"--template is ignored because --format [table json] is specified. Use --template option with --format template option.",
 			},
 			want: Config{
 				ReportConfig: config.ReportConfig{
-					Severities: []dbTypes.Severity{dbTypes.SeverityMedium},
-					Output:     os.Stdout,
+					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Format:     "template",
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
+							Output:   os.Stdout,
+							Template: "",
+						},
+						config.MappedFormat{
+							Format:   "json",
+							Output:   os.Stdout,
+							Template: "",
+						},
+					},
+				},
+				ArtifactConfig: config.ArtifactConfig{
+					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
+				},
+				CustomHeaders: http.Header{},
+			},
+		},
+		{
+			name: "multi-format: invalid option combination: --format template without --template",
+			args: []string{"--format", "table,template", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			logs: []string{
+				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
+			},
+			want: Config{
+				ReportConfig: config.ReportConfig{
+					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
+					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
+							Output:   os.Stdout,
+							Template: "",
+						},
+					},
+				},
+				ArtifactConfig: config.ArtifactConfig{
+					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
+				},
+				CustomHeaders: http.Header{},
+			},
+		},
+		{
+			name: "multi-format: invalid option combination: not enough matching --template",
+			args: []string{"--format", "template,template", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			logs: []string{
+				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
+			},
+			want: Config{
+				ReportConfig: config.ReportConfig{
+					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
+					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "template",
+							Output:   os.Stdout,
+							Template: "@contrib/gitlab.tpl",
+						},
+					},
+				},
+				ArtifactConfig: config.ArtifactConfig{
+					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
+				},
+				CustomHeaders: http.Header{},
+			},
+		},
+		{
+			name: "multi-format: valid option combination",
+			args: []string{"--format", "table,template,json,template", "--template", "@contrib/gitlab.tpl,@contrib/junit.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			want: Config{
+				ReportConfig: config.ReportConfig{
+					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
+					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
+							Output:   os.Stdout,
+							Template: "",
+						},
+						config.MappedFormat{
+							Format:   "template",
+							Output:   os.Stdout,
+							Template: "@contrib/gitlab.tpl",
+						},
+						config.MappedFormat{
+							Format:   "json",
+							Output:   os.Stdout,
+							Template: "",
+						},
+						config.MappedFormat{
+							Format:   "template",
+							Output:   os.Stdout,
+							Template: "@contrib/junit.tpl",
+						},
+					},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "gitlab/gitlab-ce:12.7.2-ce.0",
@@ -207,8 +319,10 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Output:     os.Stdout,
-					VulnType:   []string{"os", "library"},
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
+					},
+					VulnType: []string{"os", "library"},
 				},
 				ArtifactConfig: config.ArtifactConfig{
 					Target: "gcr.io/distroless/base",

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -45,8 +45,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 				},
 				CustomHeaders: http.Header{},
@@ -58,8 +58,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -79,8 +79,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -99,8 +99,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -120,8 +120,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -140,8 +140,9 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -163,8 +164,9 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"json": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -205,12 +207,14 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
-						"json": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -232,8 +236,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -255,8 +260,9 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"template": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "template",
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
@@ -275,16 +281,19 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: map[string]config.MappedFormat{
-						"table": config.MappedFormat{
+					Formats: []config.MappedFormat{
+						config.MappedFormat{
+							Format:   "table",
 							Output:   os.Stdout,
 							Template: "",
 						},
-						"template": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "template",
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
-						"json": config.MappedFormat{
+						config.MappedFormat{
+							Format:   "json",
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -305,8 +314,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: map[string]config.MappedFormat{
-						"table": config.DefaultFormat,
+					Formats: []config.MappedFormat{
+						config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -45,8 +45,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os"},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 				},
 				CustomHeaders: http.Header{},
@@ -58,8 +58,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -79,8 +79,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -99,8 +99,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -120,8 +120,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},
@@ -140,9 +140,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -164,9 +163,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "json",
+					Formats: map[string]config.MappedFormat{
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -207,14 +205,12 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
-						config.MappedFormat{
-							Format:   "json",
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -236,9 +232,8 @@ func TestConfig_Init(t *testing.T) {
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
@@ -251,18 +246,17 @@ func TestConfig_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "multi-format: invalid option combination: not enough matching --template",
+			name: "multi-format: invalid option combination: more than one --format template",
 			args: []string{"--format", "template,template", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
+				"--format template is ignored because it has been specified.",
 			},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "template",
+					Formats: map[string]config.MappedFormat{
+						"template": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
@@ -276,31 +270,23 @@ func TestConfig_Init(t *testing.T) {
 		},
 		{
 			name: "multi-format: valid option combination",
-			args: []string{"--format", "table,template,json,template", "--template", "@contrib/gitlab.tpl,@contrib/junit.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
+			args: []string{"--format", "table,template,json", "--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 					VulnType:   []string{"os", "library"},
-					Formats: []config.MappedFormat{
-						config.MappedFormat{
-							Format:   "table",
+					Formats: map[string]config.MappedFormat{
+						"table": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
 						},
-						config.MappedFormat{
-							Format:   "template",
+						"template": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "@contrib/gitlab.tpl",
 						},
-						config.MappedFormat{
-							Format:   "json",
+						"json": config.MappedFormat{
 							Output:   os.Stdout,
 							Template: "",
-						},
-						config.MappedFormat{
-							Format:   "template",
-							Output:   os.Stdout,
-							Template: "@contrib/junit.tpl",
 						},
 					},
 				},
@@ -319,8 +305,8 @@ func TestConfig_Init(t *testing.T) {
 			want: Config{
 				ReportConfig: config.ReportConfig{
 					Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
-					Formats: []config.MappedFormat{
-						config.DefaultFormat,
+					Formats: map[string]config.MappedFormat{
+						"table": config.DefaultFormat,
 					},
 					VulnType: []string{"os", "library"},
 				},

--- a/internal/client/run.go
+++ b/internal/client/run.go
@@ -91,8 +91,8 @@ func run(c config.Config) (err error) {
 		results[i].Vulnerabilities = vulns
 	}
 
-	for _, f := range c.Formats {
-		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, false); err != nil {
+	for k, v := range c.Formats {
+		if err = report.WriteResults(k, v.Output, c.Severities, results, v.Template, false); err != nil {
 			return xerrors.Errorf("unable to write results: %w", err)
 		}
 	}

--- a/internal/client/run.go
+++ b/internal/client/run.go
@@ -91,8 +91,10 @@ func run(c config.Config) (err error) {
 		results[i].Vulnerabilities = vulns
 	}
 
-	if err = report.WriteResults(c.Format, c.Output, c.Severities, results, c.Template, false); err != nil {
-		return xerrors.Errorf("unable to write results: %w", err)
+	for _, f := range c.Formats {
+		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, false); err != nil {
+			return xerrors.Errorf("unable to write results: %w", err)
+		}
 	}
 
 	if c.ExitCode != 0 {

--- a/internal/client/run.go
+++ b/internal/client/run.go
@@ -91,8 +91,8 @@ func run(c config.Config) (err error) {
 		results[i].Vulnerabilities = vulns
 	}
 
-	for k, v := range c.Formats {
-		if err = report.WriteResults(k, v.Output, c.Severities, results, v.Template, false); err != nil {
+	for _, f := range c.Formats {
+		if err = report.WriteResults(f.Format, f.Output, c.Severities, results, f.Template, false); err != nil {
 			return xerrors.Errorf("unable to write results: %w", err)
 		}
 	}

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -136,10 +136,6 @@ func (c *ReportConfig) splitSeverity(logger *zap.SugaredLogger, severity string)
 
 // mapFormat maps format and output for multi-format report
 func (c *ReportConfig) mapOutput(format []string, logger *zap.SugaredLogger) (output []*os.File, err error) {
-	if c.output == "" {
-		return []*os.File{os.Stdout}, nil
-	}
-
 	for _, v := range strings.Split(c.output, ",") {
 		var out *os.File
 		if v != "" && v != "stdout" {

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -136,7 +136,7 @@ func (c *ReportConfig) splitSeverity(logger *zap.SugaredLogger, severity string)
 
 // mapFormat maps format and output for multi-format report
 func (c *ReportConfig) mapOutput(format []string, logger *zap.SugaredLogger) (output []*os.File, err error) {
-	if c.output != "" {
+	if c.output == "" {
 		return []*os.File{os.Stdout}, nil
 	}
 

--- a/internal/config/report_test.go
+++ b/internal/config/report_test.go
@@ -24,7 +24,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 		ExitCode      int
 		VulnType      []string
 		Severities    []dbTypes.Severity
-		Formats       []MappedFormat
+		Formats       map[string]MappedFormat
 	}
 	tests := []struct {
 		name    string
@@ -44,9 +44,8 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 				VulnType:   []string{"os"},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -66,9 +65,8 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 				VulnType:   []string{"os", "library"},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -104,9 +102,8 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -127,9 +124,8 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "json",
+				Formats: map[string]MappedFormat{
+					"json": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -150,14 +146,12 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
-					MappedFormat{
-						Format:   "json",
+					"json": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -177,9 +171,8 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -187,7 +180,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "multi-format: invalid option combination: not enough matching --template",
+			name: "multi-format: invalid option combination: more than one --format template",
 			fields: fields{
 				format:     "template,template",
 				template:   "@contrib/gitlab.tpl",
@@ -195,14 +188,13 @@ func TestReportReportConfig_Init(t *testing.T) {
 			},
 			args: []string{"gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
-				"--format template is ignored because --template is not specified. Specify --template option when you use --format template.",
+				"--format template is ignored because it has been specified.",
 			},
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "template",
+				Formats: map[string]MappedFormat{
+					"template": MappedFormat{
 						Output:   os.Stdout,
 						Template: "@contrib/gitlab.tpl",
 					},
@@ -212,7 +204,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 		{
 			name: "multi-format: valid option combination",
 			fields: fields{
-				format:     "table,template,json,template",
+				format:     "table,template,json",
 				template:   "@contrib/gitlab.tpl,@contrib/junit.tpl",
 				severities: "LOW",
 			},
@@ -220,26 +212,18 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: []MappedFormat{
-					MappedFormat{
-						Format:   "table",
+				Formats: map[string]MappedFormat{
+					"table": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
 					},
-					MappedFormat{
-						Format:   "template",
+					"template": MappedFormat{
 						Output:   os.Stdout,
 						Template: "@contrib/gitlab.tpl",
 					},
-					MappedFormat{
-						Format:   "json",
+					"json": MappedFormat{
 						Output:   os.Stdout,
 						Template: "",
-					},
-					MappedFormat{
-						Format:   "template",
-						Output:   os.Stdout,
-						Template: "@contrib/junit.tpl",
 					},
 				},
 			},

--- a/internal/config/report_test.go
+++ b/internal/config/report_test.go
@@ -24,7 +24,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 		ExitCode      int
 		VulnType      []string
 		Severities    []dbTypes.Severity
-		Formats       map[string]MappedFormat
+		Formats       []MappedFormat
 	}
 	tests := []struct {
 		name    string
@@ -44,8 +44,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 				VulnType:   []string{"os"},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -65,8 +66,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityUnknown},
 				VulnType:   []string{"os", "library"},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -102,8 +104,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -124,8 +127,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"json": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "json",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -146,12 +150,14 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
-					"json": MappedFormat{
+					MappedFormat{
+						Format:   "json",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -171,8 +177,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
@@ -193,8 +200,9 @@ func TestReportReportConfig_Init(t *testing.T) {
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"template": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "template",
 						Output:   os.Stdout,
 						Template: "@contrib/gitlab.tpl",
 					},
@@ -205,23 +213,26 @@ func TestReportReportConfig_Init(t *testing.T) {
 			name: "multi-format: valid option combination",
 			fields: fields{
 				format:     "table,template,json",
-				template:   "@contrib/gitlab.tpl,@contrib/junit.tpl",
+				template:   "@contrib/gitlab.tpl",
 				severities: "LOW",
 			},
 			args: []string{"gitlab/gitlab-ce:12.7.2-ce.0"},
 			want: ReportConfig{
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 				VulnType:   []string{""},
-				Formats: map[string]MappedFormat{
-					"table": MappedFormat{
+				Formats: []MappedFormat{
+					MappedFormat{
+						Format:   "table",
 						Output:   os.Stdout,
 						Template: "",
 					},
-					"template": MappedFormat{
+					MappedFormat{
+						Format:   "template",
 						Output:   os.Stdout,
 						Template: "@contrib/gitlab.tpl",
 					},
-					"json": MappedFormat{
+					MappedFormat{
+						Format:   "json",
 						Output:   os.Stdout,
 						Template: "",
 					},


### PR DESCRIPTION
Resolve #720.
Close https://github.com/aquasecurity/trivy/issues/404

Use comma to separate multiple formats, outputs, or templates.

`trivy image --format json,table,template --template @contrib/html.tpl --output result.json,stdout,result.html`
This example will write:
1. json report to result.json
2. table report to stdout
3. html report to result.html