### PR TITLE
feat: publish helm repository

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,51 @@
+name: Publish Chart Helm
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm/trivy/**'
+  workflow_dispatch:
+env:
+  HELM_REP: helm-charts
+  GH_OWNER: aquasecurity
+  CHART_DIR: helm/trivy
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.0
+      - name: Install chart-releaser
+        run: |
+          wget https://github.com/helm/chart-releaser/releases/download/v1.1.1/chart-releaser_1.1.1_linux_amd64.tar.gz
+          tar xzvf chart-releaser_1.1.1_linux_amd64.tar.gz cr
+      - name: Package helm chart
+        run: |
+          ./cr package ${{ env.CHART_DIR }}
+      - name: Upload helm chart
+        # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
+        continue-on-error: true
+        ## Upload the tar in the Releases repository
+        run: |
+          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_GITHUB_TOKEN }} -p .cr-release-packages
+      - name: Index helm chart
+        run: |
+          ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml
+
+      - name: Push index file
+        uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.ORG_GITHUB_TOKEN }}
+        with:
+          source_file: 'index.yaml'
+          destination_repo: '${{ env.GH_OWNER }}/${{ env.HELM_REP }}'
+          destination_folder: '.'
+          destination_branch: 'gh-pages'
+          user_email: aqua-bot@users.noreply.github.com
+          user_name: 'aqua-bot'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.dll
 *.so
 *.dylib
+trivy
+
+## chart release
+.cr-release-packages
 
 # Test binary, build with `go test -c`
 *.test

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -164,3 +164,25 @@ The same image is hosted on [Amazon ECR Public](https://gallery.ecr.aws/aquasecu
 ```
 $ docker pull public.ecr.aws/aquasecurity/trivy:latest
 ```
+## Helm
+### Installing from the the Aqua Chart Repository
+
+```
+$ helm repo add aquasecurity https://aquasecurity.github.io/helm-charts/
+$ helm repo update
+$ helm search repo trivy
+$ helm install my-trivy aquasecurity/trivy
+```
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release .
+```
+
+The command deploys Trivy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters)
+section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`.

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -18,6 +18,15 @@ This chart bootstraps a Trivy deployment on a [Kubernetes](http://kubernetes.io)
 - Kubernetes 1.12+
 - Helm 3+
 
+## Installing from the the Aqua Chart Repository
+
+```
+helm repo add aquasecurity https://aquasecurity.github.io/helm-charts/
+helm repo update
+helm search repo trivy
+helm install my-trivy aquasecurity/trivy
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:


### PR DESCRIPTION
Related https://github.com/aquasecurity/trivy/issues/839, 
- GH action to publish helm chart in the aqua repository helm chart

Using the Aqua chart repository:

helm repo add aquasecurity https://aquasecurity.github.io/helm-charts/
helm repo update
helm search repo trivy
helm install my-trivy aquasecurity/trivy
