### PR TITLE
feat: gh-action for stale issues

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,22 @@
+name: "Stale issues"
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  stale:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been labeled with inactivity.'
+        stale-pr-message: 'This PR is stale because it has been labeled with inactivity.'
+        exempt-issue-labels: 'awaiting-approval,work-in-progress,priority/critical-urgent,priority/important-soon,priority/backlog,priority/awaiting-more-evidence'
+        exempt-pr-labels: 'awaiting-approval,work-in-progress'
+        stale-pr-label: 'no-pr-activity'
+        stale-issue-label: 'no-issue-activity'
+        days-before-stale: 90 # default 60
+        days-before-close: 20
+
+

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -9,14 +9,12 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        repo-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been labeled with inactivity.'
         stale-pr-message: 'This PR is stale because it has been labeled with inactivity.'
-        exempt-issue-labels: 'awaiting-approval,work-in-progress,priority/critical-urgent,priority/important-soon,priority/backlog,priority/awaiting-more-evidence'
-        exempt-pr-labels: 'awaiting-approval,work-in-progress'
-        stale-pr-label: 'no-pr-activity'
-        stale-issue-label: 'no-issue-activity'
-        days-before-stale: 90 # default 60
+        exempt-issue-labels: 'lifecycle/frozen,lifecycle/active,priority/critical-urgent,priority/important-soon,priority/important-longterm,priority/backlog,priority/awaiting-more-evidence'
+        exempt-pr-labels: 'lifecycle/active'
+        stale-pr-label: 'lifecycle/stale'
+        stale-issue-label: 'lifecycle/stale'
+        days-before-stale: 60
         days-before-close: 20
-
-


### PR DESCRIPTION
Bot for stale issues and PR that they doesn't have the labels awaiting-approval,work-in-progress,priority/*
- days-before-stale: 90
- days-before-close: 20. We have time to validate the bot results before close it.
- Use labels  'no-pr-activity',  'no-issue-activity'
