### PR TITLE
Update SARIF repot template

### DIFF
--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -27,10 +27,10 @@
               },
               "fullDescription": {
                 "text": {{ endWithPeriod (escapeString .Title) | printf "%q" }}
-              }
+              },
               "defaultConfiguration": {
                 "level": "{{ toSarifErrorLevel .Vulnerability.Severity }}"
-              },
+              }
               {{- with $help_uri := .PrimaryURL -}}
               ,
               {{ $help_uri | printf "\"helpUri\": %q," -}}

--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -75,7 +75,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "{{ $filePath }}",
+                "uri": "{{ toPathUri $filePath }}",
                 "uriBaseId": "ROOTPATH"
               }
             }

--- a/contrib/sarif.tpl
+++ b/contrib/sarif.tpl
@@ -8,10 +8,11 @@
           "name": "Trivy",
           "informationUri": "https://github.com/aquasecurity/trivy",
           "fullName": "Trivy Vulnerability Scanner",
-          "version": "v0.15.0",
+          "version": "0.15.0",
           "rules": [
         {{- $t_first := true }}
         {{- range . }}
+            {{- $vulnerabilityType := .Type }}
             {{- range .Vulnerabilities -}}
               {{- if $t_first -}}
                 {{- $t_first = false -}}
@@ -19,14 +20,17 @@
                 ,
               {{- end }}
             {
-              "id": "[{{ .Vulnerability.Severity }}] {{ .VulnerabilityID }} {{ .PkgName }}",
-              "name": "dockerfile_scan",
+              "id": "{{ .VulnerabilityID }}/{{ .PkgName }}",
+              "name": "{{ toSarifRuleName $vulnerabilityType }}",
               "shortDescription": {
                 "text": {{ printf "%v Package: %v" .VulnerabilityID .PkgName | printf "%q" }}
               },
               "fullDescription": {
                 "text": {{ endWithPeriod (escapeString .Title) | printf "%q" }}
               }
+              "defaultConfiguration": {
+                "level": "{{ toSarifErrorLevel .Vulnerability.Severity }}"
+              },
               {{- with $help_uri := .PrimaryURL -}}
               ,
               {{ $help_uri | printf "\"helpUri\": %q," -}}
@@ -54,6 +58,7 @@
       "results": [
     {{- $t_first := true }}
     {{- range . }}
+        {{- $filePath := .Target }}
         {{- range $index, $vulnerability := .Vulnerabilities -}}
           {{- if $t_first -}}
             {{- $t_first = false -}}
@@ -61,21 +66,17 @@
             ,
           {{- end }}
         {
-          "ruleId": "[{{ $vulnerability.Vulnerability.Severity }}] {{ $vulnerability.VulnerabilityID }} {{ $vulnerability.PkgName }}",
+          "ruleId": "{{ $vulnerability.VulnerabilityID }}/{{ $vulnerability.PkgName }}",
           "ruleIndex": {{ $index }},
-          "level": "error",
+          "level": "{{ toSarifErrorLevel $vulnerability.Vulnerability.Severity }}",
           "message": {
             "text": {{ endWithPeriod (escapeString $vulnerability.Description) | printf "%q" }}
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "{{ $filePath }}",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
@@ -83,7 +84,12 @@
         {{- end -}}
       {{- end -}}
       ],
-      "columnKind": "utf16CodeUnits"
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "/"
+        }
+      }
     }
   ]
 }

--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -8,16 +8,19 @@
           "name": "Trivy",
           "informationUri": "https://github.com/aquasecurity/trivy",
           "fullName": "Trivy Vulnerability Scanner",
-          "version": "v0.15.0",
+          "version": "0.15.0",
           "rules": [
             {
-              "id": "[MEDIUM] CVE-2019-1549 libcrypto1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1549/libcrypto1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1549 Package: libcrypto1.1"
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in fork()."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1549",
               "help": {
@@ -34,13 +37,16 @@
               }
             },
             {
-              "id": "[MEDIUM] CVE-2019-1551 libcrypto1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1551/libcrypto1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1551 Package: libcrypto1.1"
               },
               "fullDescription": {
                 "text": "openssl: Integer overflow in RSAZ modular exponentiation on x86_64."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1551",
               "help": {
@@ -57,13 +63,16 @@
               }
             },
             {
-              "id": "[MEDIUM] CVE-2019-1563 libcrypto1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1563/libcrypto1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1563 Package: libcrypto1.1"
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in PKCS7_dataDecode and CMS_decrypt_set1_pkey."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1563",
               "help": {
@@ -80,13 +89,16 @@
               }
             },
             {
-              "id": "[LOW] CVE-2019-1547 libcrypto1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1547/libcrypto1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1547 Package: libcrypto1.1"
               },
               "fullDescription": {
                 "text": "openssl: side-channel weak encryption vulnerability."
+              },
+              "defaultConfiguration": {
+                "level": "note"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1547",
               "help": {
@@ -103,13 +115,16 @@
               }
             },
             {
-              "id": "[MEDIUM] CVE-2019-1549 libssl1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1549/libssl1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1549 Package: libssl1.1"
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in fork()."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1549",
               "help": {
@@ -126,13 +141,16 @@
               }
             },
             {
-              "id": "[MEDIUM] CVE-2019-1551 libssl1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1551/libssl1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1551 Package: libssl1.1"
               },
               "fullDescription": {
                 "text": "openssl: Integer overflow in RSAZ modular exponentiation on x86_64."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1551",
               "help": {
@@ -149,13 +167,16 @@
               }
             },
             {
-              "id": "[MEDIUM] CVE-2019-1563 libssl1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1563/libssl1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1563 Package: libssl1.1"
               },
               "fullDescription": {
                 "text": "openssl: information disclosure in PKCS7_dataDecode and CMS_decrypt_set1_pkey."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1563",
               "help": {
@@ -172,13 +193,16 @@
               }
             },
             {
-              "id": "[LOW] CVE-2019-1547 libssl1.1",
-              "name": "dockerfile_scan",
+              "id": "CVE-2019-1547/libssl1.1",
+              "name": "Os Package Vulnerability Alpine",
               "shortDescription": {
                 "text": "CVE-2019-1547 Package: libssl1.1"
               },
               "fullDescription": {
                 "text": "openssl: side-channel weak encryption vulnerability."
+              },
+              "defaultConfiguration": {
+                "level": "note"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-2019-1547",
               "help": {
@@ -198,166 +222,139 @@
       },
       "results": [
         {
-          "ruleId": "[MEDIUM] CVE-2019-1549 libcrypto1.1",
+          "ruleId": "CVE-2019-1549/libcrypto1.1",
           "ruleIndex": 0,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[MEDIUM] CVE-2019-1551 libcrypto1.1",
+          "ruleId": "CVE-2019-1551/libcrypto1.1",
           "ruleIndex": 1,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[MEDIUM] CVE-2019-1563 libcrypto1.1",
+          "ruleId": "CVE-2019-1563/libcrypto1.1",
           "ruleIndex": 2,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "In situations where an attacker receives automated notification of the success or failure of a decryption attempt an attacker, after sending a very large number of messages to be decrypted, can recover a CMS/PKCS7 transported encryption key or decrypt any RSA encrypted message that was encrypted with the public RSA key, using a Bleichenbacher padding oracle attack. Applications are not affected if they use a certificate together with the private RSA key to the CMS_decrypt or PKCS7_decrypt functions to select the correct recipient info to decrypt. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[LOW] CVE-2019-1547 libcrypto1.1",
+          "ruleId": "CVE-2019-1547/libcrypto1.1",
           "ruleIndex": 3,
-          "level": "error",
+          "level": "note",
           "message": {
             "text": "Normally in OpenSSL EC groups always have a co-factor present and this is used in side channel resistant code paths. However, in some cases, it is possible to construct a group using explicit parameters (instead of using a named curve). In those cases it is possible that such a group does not have the cofactor present. This can occur even where all the parameters match a known named curve. If such a curve is used then OpenSSL falls back to non-side channel resistant code paths which may result in full key recovery during an ECDSA signature operation. In order to be vulnerable an attacker would have to have the ability to time the creation of a large number of signatures where explicit parameters with no co-factor present are in use by an application using libcrypto. For the avoidance of doubt libssl is not vulnerable because explicit parameters are never used. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[MEDIUM] CVE-2019-1549 libssl1.1",
+          "ruleId": "CVE-2019-1549/libssl1.1",
           "ruleIndex": 4,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[MEDIUM] CVE-2019-1551 libssl1.1",
+          "ruleId": "CVE-2019-1551/libssl1.1",
           "ruleIndex": 5,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[MEDIUM] CVE-2019-1563 libssl1.1",
+          "ruleId": "CVE-2019-1563/libssl1.1",
           "ruleIndex": 6,
-          "level": "error",
+          "level": "warning",
           "message": {
             "text": "In situations where an attacker receives automated notification of the success or failure of a decryption attempt an attacker, after sending a very large number of messages to be decrypted, can recover a CMS/PKCS7 transported encryption key or decrypt any RSA encrypted message that was encrypted with the public RSA key, using a Bleichenbacher padding oracle attack. Applications are not affected if they use a certificate together with the private RSA key to the CMS_decrypt or PKCS7_decrypt functions to select the correct recipient info to decrypt. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         },
         {
-          "ruleId": "[LOW] CVE-2019-1547 libssl1.1",
+          "ruleId": "CVE-2019-1547/libssl1.1",
           "ruleIndex": 7,
-          "level": "error",
+          "level": "note",
           "message": {
             "text": "Normally in OpenSSL EC groups always have a co-factor present and this is used in side channel resistant code paths. However, in some cases, it is possible to construct a group using explicit parameters (instead of using a named curve). In those cases it is possible that such a group does not have the cofactor present. This can occur even where all the parameters match a known named curve. If such a curve is used then OpenSSL falls back to non-side channel resistant code paths which may result in full key recovery during an ECDSA signature operation. In order to be vulnerable an attacker would have to have the ability to time the creation of a large number of signatures where explicit parameters with no co-factor present are in use by an application using libcrypto. For the avoidance of doubt libssl is not vulnerable because explicit parameters are never used. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s)."
           },
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         }],
-      "columnKind": "utf16CodeUnits"
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "/"
+        }
+      }
     }
   ]
 }

--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -12,7 +12,7 @@
           "rules": [
             {
               "id": "CVE-2019-1549/libcrypto1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1549 Package: libcrypto1.1"
               },
@@ -38,7 +38,7 @@
             },
             {
               "id": "CVE-2019-1551/libcrypto1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1551 Package: libcrypto1.1"
               },
@@ -64,7 +64,7 @@
             },
             {
               "id": "CVE-2019-1563/libcrypto1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1563 Package: libcrypto1.1"
               },
@@ -90,7 +90,7 @@
             },
             {
               "id": "CVE-2019-1547/libcrypto1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1547 Package: libcrypto1.1"
               },
@@ -116,7 +116,7 @@
             },
             {
               "id": "CVE-2019-1549/libssl1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1549 Package: libssl1.1"
               },
@@ -142,7 +142,7 @@
             },
             {
               "id": "CVE-2019-1551/libssl1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1551 Package: libssl1.1"
               },
@@ -168,7 +168,7 @@
             },
             {
               "id": "CVE-2019-1563/libssl1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1563 Package: libssl1.1"
               },
@@ -194,7 +194,7 @@
             },
             {
               "id": "CVE-2019-1547/libssl1.1",
-              "name": "Os Package Vulnerability Alpine",
+              "name": "OS Package Vulnerability (Alpine)",
               "shortDescription": {
                 "text": "CVE-2019-1547 Package: libssl1.1"
               },

--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -231,7 +231,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -247,7 +247,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -263,7 +263,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -279,7 +279,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -295,7 +295,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -311,7 +311,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -327,7 +327,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -343,7 +343,7 @@
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
+                "uri": "testdata/fixtures/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -200,35 +200,8 @@ func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter
 		}
 		return escaped.String()
 	}
-	templateFuncMap["toSarifErrorLevel"] = func(severity string) string {
-		var sarifErrorLevel string
-		switch severity {
-		case "CRITICAL", "HIGH":
-			sarifErrorLevel = "error"
-		case "MEDIUM":
-			sarifErrorLevel = "warning"
-		case "LOW", "Unknown":
-			sarifErrorLevel = "note"
-		default:
-			sarifErrorLevel = "none"
-		}
-		return sarifErrorLevel
-	}
-	templateFuncMap["toSarifRuleName"] = func(vulnerabilityType string) string {
-		var ruleName string
-		switch vulnerabilityType {
-		case vulnerability.Ubuntu, vulnerability.Alpine, vulnerability.RedHat, vulnerability.RedHatOVAL,
-			vulnerability.Debian, vulnerability.DebianOVAL, vulnerability.Fedora, vulnerability.Amazon,
-			vulnerability.OracleOVAL, vulnerability.SuseCVRF, vulnerability.OpenSuseCVRF, vulnerability.Photon,
-			vulnerability.CentOS:
-			ruleName = "Os Package Vulnerability "
-		case "npm", "yarn", "nuget", "pipenv", "poetry", "bundler", "cargo", "composer":
-			ruleName = "Programming Language Vulnerability "
-		default:
-			ruleName = "Other Vulnerability "
-		}
-		return ruleName + strings.Title(vulnerabilityType)
-	}
+	templateFuncMap["toSarifErrorLevel"] = toSarifErrorLevel
+	templateFuncMap["toSarifRuleName"] = toSarifRuleName
 	templateFuncMap["endWithPeriod"] = func(input string) string {
 		if !strings.HasSuffix(input, ".") {
 			input += "."
@@ -261,4 +234,35 @@ func (tw TemplateWriter) Write(results Results) error {
 		return xerrors.Errorf("failed to write with template: %w", err)
 	}
 	return nil
+}
+
+func toSarifRuleName(vulnerabilityType string) string {
+	var ruleName string
+	switch vulnerabilityType {
+	case vulnerability.Ubuntu, vulnerability.Alpine, vulnerability.RedHat, vulnerability.RedHatOVAL,
+		vulnerability.Debian, vulnerability.DebianOVAL, vulnerability.Fedora, vulnerability.Amazon,
+		vulnerability.OracleOVAL, vulnerability.SuseCVRF, vulnerability.OpenSuseCVRF, vulnerability.Photon,
+		vulnerability.CentOS:
+		ruleName = "Os Package Vulnerability "
+	case "npm", "yarn", "nuget", "pipenv", "poetry", "bundler", "cargo", "composer":
+		ruleName = "Programming Language Vulnerability "
+	default:
+		ruleName = "Other Vulnerability "
+	}
+	return ruleName + strings.Title(vulnerabilityType)
+}
+
+func toSarifErrorLevel(severity string) string {
+	var sarifErrorLevel string
+	switch severity {
+	case "CRITICAL", "HIGH":
+		sarifErrorLevel = "error"
+	case "MEDIUM":
+		sarifErrorLevel = "warning"
+	case "LOW", "Unknown":
+		sarifErrorLevel = "note"
+	default:
+		sarifErrorLevel = "none"
+	}
+	return sarifErrorLevel
 }

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -26,6 +27,9 @@ import (
 
 // Now returns the current time
 var Now = time.Now
+
+// regex to extract file path in case string includes (distro:version)
+var re = regexp.MustCompile(`(?P<path>.+?)(?:\s*\((?:.*?)\).*?)?$`)
 
 // Results to hold list of Result
 type Results []Result
@@ -213,6 +217,14 @@ func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter
 	}
 	templateFuncMap["escapeString"] = func(input string) string {
 		return html.EscapeString(input)
+	}
+	templateFuncMap["toPathUri"] = func(input string) string {
+		var matches = re.FindStringSubmatch(input)
+		if matches != nil {
+			input = matches[re.SubexpIndex("path")]
+		}
+		input = strings.ReplaceAll(input, "\\", "/")
+		return input
 	}
 	templateFuncMap["getEnv"] = func(key string) string {
 		return os.Getenv(key)

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -243,26 +243,24 @@ func toSarifRuleName(vulnerabilityType string) string {
 		vulnerability.Debian, vulnerability.DebianOVAL, vulnerability.Fedora, vulnerability.Amazon,
 		vulnerability.OracleOVAL, vulnerability.SuseCVRF, vulnerability.OpenSuseCVRF, vulnerability.Photon,
 		vulnerability.CentOS:
-		ruleName = "Os Package Vulnerability "
+		ruleName = "OS Package Vulnerability"
 	case "npm", "yarn", "nuget", "pipenv", "poetry", "bundler", "cargo", "composer":
-		ruleName = "Programming Language Vulnerability "
+		ruleName = "Programming Language Vulnerability"
 	default:
-		ruleName = "Other Vulnerability "
+		ruleName = "Other Vulnerability"
 	}
-	return ruleName + strings.Title(vulnerabilityType)
+	return fmt.Sprintf("%s (%s)", ruleName, strings.Title(vulnerabilityType))
 }
 
 func toSarifErrorLevel(severity string) string {
-	var sarifErrorLevel string
 	switch severity {
 	case "CRITICAL", "HIGH":
-		sarifErrorLevel = "error"
+		return "error"
 	case "MEDIUM":
-		sarifErrorLevel = "warning"
-	case "LOW", "Unknown":
-		sarifErrorLevel = "note"
+		return "warning"
+	case "LOW", "UNKNOWN":
+		return "note"
 	default:
-		sarifErrorLevel = "none"
+		return "none"
 	}
-	return sarifErrorLevel
 }

--- a/pkg/report/writer_internal_test.go
+++ b/pkg/report/writer_internal_test.go
@@ -1,0 +1,148 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReportWriter_toSarifRuleName(t *testing.T) {
+	tests := []struct {
+		vulnerabilityType string
+		sarifRuleName     string
+	}{
+		{
+			vulnerabilityType: vulnerability.Ubuntu,
+			sarifRuleName:     "Os Package Vulnerability Ubuntu",
+		},
+		{
+			vulnerabilityType: vulnerability.Alpine,
+			sarifRuleName:     "Os Package Vulnerability Alpine",
+		},
+		{
+			vulnerabilityType: vulnerability.RedHat,
+			sarifRuleName:     "Os Package Vulnerability Redhat",
+		},
+		{
+			vulnerabilityType: vulnerability.RedHatOVAL,
+			sarifRuleName:     "Os Package Vulnerability Redhat-Oval",
+		},
+		{
+			vulnerabilityType: vulnerability.Debian,
+			sarifRuleName:     "Os Package Vulnerability Debian",
+		},
+		{
+			vulnerabilityType: vulnerability.DebianOVAL,
+			sarifRuleName:     "Os Package Vulnerability Debian-Oval",
+		},
+		{
+			vulnerabilityType: vulnerability.Fedora,
+			sarifRuleName:     "Os Package Vulnerability Fedora",
+		},
+		{
+			vulnerabilityType: vulnerability.Amazon,
+			sarifRuleName:     "Os Package Vulnerability Amazon",
+		},
+		{
+			vulnerabilityType: vulnerability.OracleOVAL,
+			sarifRuleName:     "Os Package Vulnerability Oracle-Oval",
+		},
+		{
+			vulnerabilityType: vulnerability.SuseCVRF,
+			sarifRuleName:     "Os Package Vulnerability Suse-Cvrf",
+		},
+		{
+			vulnerabilityType: vulnerability.OpenSuseCVRF,
+			sarifRuleName:     "Os Package Vulnerability Opensuse-Cvrf",
+		},
+		{
+			vulnerabilityType: vulnerability.Photon,
+			sarifRuleName:     "Os Package Vulnerability Photon",
+		},
+		{
+			vulnerabilityType: vulnerability.CentOS,
+			sarifRuleName:     "Os Package Vulnerability Centos",
+		},
+		{
+			vulnerabilityType: "npm",
+			sarifRuleName:     "Programming Language Vulnerability Npm",
+		},
+		{
+			vulnerabilityType: "yarn",
+			sarifRuleName:     "Programming Language Vulnerability Yarn",
+		},
+		{
+			vulnerabilityType: "nuget",
+			sarifRuleName:     "Programming Language Vulnerability Nuget",
+		},
+		{
+			vulnerabilityType: "pipenv",
+			sarifRuleName:     "Programming Language Vulnerability Pipenv",
+		},
+		{
+			vulnerabilityType: "poetry",
+			sarifRuleName:     "Programming Language Vulnerability Poetry",
+		},
+		{
+			vulnerabilityType: "bundler",
+			sarifRuleName:     "Programming Language Vulnerability Bundler",
+		},
+		{
+			vulnerabilityType: "cargo",
+			sarifRuleName:     "Programming Language Vulnerability Cargo",
+		},
+		{
+			vulnerabilityType: "composer",
+			sarifRuleName:     "Programming Language Vulnerability Composer",
+		},
+		{
+			vulnerabilityType: "redis",
+			sarifRuleName:     "Other Vulnerability Redis",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.vulnerabilityType, func(t *testing.T) {
+			got := toSarifRuleName(tc.vulnerabilityType)
+			assert.Equal(t, tc.sarifRuleName, got, tc.vulnerabilityType)
+		})
+	}
+}
+
+func TestReportWriter_toSarifErrorLevel(t *testing.T) {
+	tests := []struct {
+		severity        string
+		sarifErrorLevel string
+	}{
+		{
+			severity:        "CRITICAL",
+			sarifErrorLevel: "error",
+		},
+		{
+			severity:        "HIGH",
+			sarifErrorLevel: "error",
+		},
+		{
+			severity:        "MEDIUM",
+			sarifErrorLevel: "warning",
+		},
+		{
+			severity:        "LOW",
+			sarifErrorLevel: "note",
+		},
+		{
+			severity:        "Unknown",
+			sarifErrorLevel: "note",
+		},
+		{
+			severity:        "OTHER",
+			sarifErrorLevel: "none",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.severity, func(t *testing.T) {
+			got := toSarifErrorLevel(tc.severity)
+			assert.Equal(t, tc.sarifErrorLevel, got, tc.severity)
+		})
+	}
+}

--- a/pkg/report/writer_internal_test.go
+++ b/pkg/report/writer_internal_test.go
@@ -103,8 +103,7 @@ func TestReportWriter_toSarifRuleName(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.vulnerabilityType, func(t *testing.T) {
-			got := toSarifRuleName(tc.vulnerabilityType)
-			assert.Equal(t, tc.sarifRuleName, got, tc.vulnerabilityType)
+			assert.Equal(t, tc.sarifRuleName, toSarifRuleName(tc.vulnerabilityType), tc.vulnerabilityType)
 		})
 	}
 }
@@ -141,8 +140,7 @@ func TestReportWriter_toSarifErrorLevel(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.severity, func(t *testing.T) {
-			got := toSarifErrorLevel(tc.severity)
-			assert.Equal(t, tc.sarifErrorLevel, got, tc.severity)
+			assert.Equal(t, tc.sarifErrorLevel, toSarifErrorLevel(tc.severity), tc.severity)
 		})
 	}
 }

--- a/pkg/report/writer_internal_test.go
+++ b/pkg/report/writer_internal_test.go
@@ -14,91 +14,91 @@ func TestReportWriter_toSarifRuleName(t *testing.T) {
 	}{
 		{
 			vulnerabilityType: vulnerability.Ubuntu,
-			sarifRuleName:     "Os Package Vulnerability Ubuntu",
+			sarifRuleName:     "OS Package Vulnerability (Ubuntu)",
 		},
 		{
 			vulnerabilityType: vulnerability.Alpine,
-			sarifRuleName:     "Os Package Vulnerability Alpine",
+			sarifRuleName:     "OS Package Vulnerability (Alpine)",
 		},
 		{
 			vulnerabilityType: vulnerability.RedHat,
-			sarifRuleName:     "Os Package Vulnerability Redhat",
+			sarifRuleName:     "OS Package Vulnerability (Redhat)",
 		},
 		{
 			vulnerabilityType: vulnerability.RedHatOVAL,
-			sarifRuleName:     "Os Package Vulnerability Redhat-Oval",
+			sarifRuleName:     "OS Package Vulnerability (Redhat-Oval)",
 		},
 		{
 			vulnerabilityType: vulnerability.Debian,
-			sarifRuleName:     "Os Package Vulnerability Debian",
+			sarifRuleName:     "OS Package Vulnerability (Debian)",
 		},
 		{
 			vulnerabilityType: vulnerability.DebianOVAL,
-			sarifRuleName:     "Os Package Vulnerability Debian-Oval",
+			sarifRuleName:     "OS Package Vulnerability (Debian-Oval)",
 		},
 		{
 			vulnerabilityType: vulnerability.Fedora,
-			sarifRuleName:     "Os Package Vulnerability Fedora",
+			sarifRuleName:     "OS Package Vulnerability (Fedora)",
 		},
 		{
 			vulnerabilityType: vulnerability.Amazon,
-			sarifRuleName:     "Os Package Vulnerability Amazon",
+			sarifRuleName:     "OS Package Vulnerability (Amazon)",
 		},
 		{
 			vulnerabilityType: vulnerability.OracleOVAL,
-			sarifRuleName:     "Os Package Vulnerability Oracle-Oval",
+			sarifRuleName:     "OS Package Vulnerability (Oracle-Oval)",
 		},
 		{
 			vulnerabilityType: vulnerability.SuseCVRF,
-			sarifRuleName:     "Os Package Vulnerability Suse-Cvrf",
+			sarifRuleName:     "OS Package Vulnerability (Suse-Cvrf)",
 		},
 		{
 			vulnerabilityType: vulnerability.OpenSuseCVRF,
-			sarifRuleName:     "Os Package Vulnerability Opensuse-Cvrf",
+			sarifRuleName:     "OS Package Vulnerability (Opensuse-Cvrf)",
 		},
 		{
 			vulnerabilityType: vulnerability.Photon,
-			sarifRuleName:     "Os Package Vulnerability Photon",
+			sarifRuleName:     "OS Package Vulnerability (Photon)",
 		},
 		{
 			vulnerabilityType: vulnerability.CentOS,
-			sarifRuleName:     "Os Package Vulnerability Centos",
+			sarifRuleName:     "OS Package Vulnerability (Centos)",
 		},
 		{
 			vulnerabilityType: "npm",
-			sarifRuleName:     "Programming Language Vulnerability Npm",
+			sarifRuleName:     "Programming Language Vulnerability (Npm)",
 		},
 		{
 			vulnerabilityType: "yarn",
-			sarifRuleName:     "Programming Language Vulnerability Yarn",
+			sarifRuleName:     "Programming Language Vulnerability (Yarn)",
 		},
 		{
 			vulnerabilityType: "nuget",
-			sarifRuleName:     "Programming Language Vulnerability Nuget",
+			sarifRuleName:     "Programming Language Vulnerability (Nuget)",
 		},
 		{
 			vulnerabilityType: "pipenv",
-			sarifRuleName:     "Programming Language Vulnerability Pipenv",
+			sarifRuleName:     "Programming Language Vulnerability (Pipenv)",
 		},
 		{
 			vulnerabilityType: "poetry",
-			sarifRuleName:     "Programming Language Vulnerability Poetry",
+			sarifRuleName:     "Programming Language Vulnerability (Poetry)",
 		},
 		{
 			vulnerabilityType: "bundler",
-			sarifRuleName:     "Programming Language Vulnerability Bundler",
+			sarifRuleName:     "Programming Language Vulnerability (Bundler)",
 		},
 		{
 			vulnerabilityType: "cargo",
-			sarifRuleName:     "Programming Language Vulnerability Cargo",
+			sarifRuleName:     "Programming Language Vulnerability (Cargo)",
 		},
 		{
 			vulnerabilityType: "composer",
-			sarifRuleName:     "Programming Language Vulnerability Composer",
+			sarifRuleName:     "Programming Language Vulnerability (Composer)",
 		},
 		{
 			vulnerabilityType: "redis",
-			sarifRuleName:     "Other Vulnerability Redis",
+			sarifRuleName:     "Other Vulnerability (Redis)",
 		},
 	}
 	for _, tc := range tests {
@@ -131,7 +131,7 @@ func TestReportWriter_toSarifErrorLevel(t *testing.T) {
 			sarifErrorLevel: "note",
 		},
 		{
-			severity:        "Unknown",
+			severity:        "UNKNOWN",
 			sarifErrorLevel: "note",
 		},
 		{

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -404,16 +404,19 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "name": "Trivy",
           "informationUri": "https://github.com/aquasecurity/trivy",
           "fullName": "Trivy Vulnerability Scanner",
-          "version": "v0.15.0",
+          "version": "0.15.0",
           "rules": [
             {
-              "id": "[CRITICAL] CVE-1234-5678 foopackage",
-              "name": "dockerfile_scan",
+              "id": "CVE-1234-5678/foopackage",
+              "name": "Other Vulnerability Footype",
               "shortDescription": {
                 "text": "CVE-1234-5678 Package: foopackage"
               },
               "fullDescription": {
                 "text": "foovuln."
+              },
+              "defaultConfiguration": {
+                "level": "error"
               },
               "help": {
                 "text": "Vulnerability CVE-1234-5678\nSeverity: CRITICAL\nPackage: foopackage\nInstalled Version: 1.2.3\nFixed Version: 4.5.6\nLink: [CVE-1234-5678]()",
@@ -432,7 +435,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
       },
       "results": [
         {
-          "ruleId": "[CRITICAL] CVE-1234-5678 foopackage",
+          "ruleId": "CVE-1234-5678/foopackage",
           "ruleIndex": 0,
           "level": "error",
           "message": {
@@ -441,17 +444,18 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "footarget",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         }],
-      "columnKind": "utf16CodeUnits"
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "/"
+        }
+      }
     }
   ]
 }`,
@@ -483,16 +487,19 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "name": "Trivy",
           "informationUri": "https://github.com/aquasecurity/trivy",
           "fullName": "Trivy Vulnerability Scanner",
-          "version": "v0.15.0",
+          "version": "0.15.0",
           "rules": [
             {
-              "id": "[CRITICAL] CVE-1234-5678 foopackage",
-              "name": "dockerfile_scan",
+              "id": "CVE-1234-5678/foopackage",
+              "name": "Other Vulnerability Footype",
               "shortDescription": {
                 "text": "CVE-1234-5678 Package: foopackage"
               },
               "fullDescription": {
                 "text": "foovuln."
+              },
+              "defaultConfiguration": {
+                "level": "error"
               },
               "helpUri": "https://avd.aquasec.com/nvd/cve-1234-5678",
               "help": {
@@ -512,7 +519,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
       },
       "results": [
         {
-          "ruleId": "[CRITICAL] CVE-1234-5678 foopackage",
+          "ruleId": "CVE-1234-5678/foopackage",
           "ruleIndex": 0,
           "level": "error",
           "message": {
@@ -521,17 +528,18 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "Dockerfile"
-              },
-              "region": {
-                "startLine": 1,
-                "startColumn": 1,
-                "endColumn": 1
+                "uri": "footarget",
+                "uriBaseId": "ROOTPATH"
               }
             }
           }]
         }],
-      "columnKind": "utf16CodeUnits"
+      "columnKind": "utf16CodeUnits",
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "/"
+        }
+      }
     }
   ]
 }`,

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -374,11 +374,13 @@ func TestReportWriter_Template(t *testing.T) {
 func TestReportWriter_Template_SARIF(t *testing.T) {
 	testCases := []struct {
 		name          string
+		target        string
 		detectedVulns []types.DetectedVulnerability
 		want          string
 	}{
 		{
-			name: "no primary url",
+			name:   "no primary url",
+			target: "foo/target/alpine-310.tar.gz (alpine 3.10.2)",
 			detectedVulns: []types.DetectedVulnerability{
 				{
 					VulnerabilityID:  "CVE-1234-5678",
@@ -444,7 +446,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "footarget",
+                "uri": "foo/target/alpine-310.tar.gz",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -461,7 +463,8 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
 }`,
 		},
 		{
-			name: "with primary url",
+			name:   "with primary url",
+			target: "rust-app\\Cargo.lock",
 			detectedVulns: []types.DetectedVulnerability{
 				{
 					VulnerabilityID:  "CVE-1234-5678",
@@ -528,7 +531,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "locations": [{
             "physicalLocation": {
               "artifactLocation": {
-                "uri": "footarget",
+                "uri": "rust-app/Cargo.lock",
                 "uriBaseId": "ROOTPATH"
               }
             }
@@ -555,7 +558,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
 
 			inputResults := report.Results{
 				report.Result{
-					Target:          "footarget",
+					Target:          tc.target,
 					Type:            "footype",
 					Vulnerabilities: tc.detectedVulns,
 				},

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -408,7 +408,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "rules": [
             {
               "id": "CVE-1234-5678/foopackage",
-              "name": "Other Vulnerability Footype",
+              "name": "Other Vulnerability (Footype)",
               "shortDescription": {
                 "text": "CVE-1234-5678 Package: foopackage"
               },
@@ -491,7 +491,7 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
           "rules": [
             {
               "id": "CVE-1234-5678/foopackage",
-              "name": "Other Vulnerability Footype",
+              "name": "Other Vulnerability (Footype)",
               "shortDescription": {
                 "text": "CVE-1234-5678 Package: foopackage"
               },


### PR DESCRIPTION
Fixes #930

- Remove character 'v' from start of version string.
- Update rule name according to .Type value.
- Update rule id format, remove severity from id to convert to sarif level.
- Update result location Uri points to file.
- Add base Uri id.
- Remove region property for now.

Attached the sarif result generated with these changes: [report.zip](https://github.com/aquasecurity/trivy/files/6295273/report.zip)

