### PR TITLE
Upgrade to Codecov GitHub action with fix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
         run: make test
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.4.1
         with:
           files: ./coverage.txt
 


### PR DESCRIPTION
Fix for bash uploader vulnerability, see
https://about.codecov.io/security-update/ and
https://github.com/codecov/codecov-action/releases/tag/v1.4.1

The latest version of the Codecov GH Action has now implemented SHA checksum checking of the Codecov bash uploader script.