### PR TITLE
feat: show a help message when the context's deadline passes

### DIFF
--- a/pkg/commands/artifact/fs.go
+++ b/pkg/commands/artifact/fs.go
@@ -22,8 +22,8 @@ func filesystemScanner(ctx context.Context, dir string, ac cache.ArtifactCache, 
 }
 
 // FilesystemRun runs scan on filesystem
-func FilesystemRun(cliCtx *cli.Context) error {
-	c, err := NewConfig(cliCtx)
+func FilesystemRun(ctx *cli.Context) error {
+	c, err := NewConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -33,5 +33,5 @@ func FilesystemRun(cliCtx *cli.Context) error {
 		return xerrors.Errorf("failed to initialize options: %w", err)
 	}
 
-	return run(c, filesystemScanner)
+	return run(ctx.Context, c, filesystemScanner)
 }

--- a/pkg/commands/artifact/image.go
+++ b/pkg/commands/artifact/image.go
@@ -32,21 +32,21 @@ func dockerScanner(ctx context.Context, imageName string, ac cache.ArtifactCache
 }
 
 // ImageRun runs scan on docker image
-func ImageRun(cliCtx *cli.Context) error {
-	c, err := NewConfig(cliCtx)
+func ImageRun(ctx *cli.Context) error {
+	c, err := NewConfig(ctx)
 	if err != nil {
 		return err
 	}
 
 	// initialize config
-	if err := c.Init(); err != nil {
+	if err = c.Init(); err != nil {
 		return xerrors.Errorf("failed to initialize options: %w", err)
 	}
 
 	if c.Input != "" {
 		// scan tar file
-		return run(c, archiveScanner)
+		return run(ctx.Context, c, archiveScanner)
 	}
 
-	return run(c, dockerScanner)
+	return run(ctx.Context, c, dockerScanner)
 }

--- a/pkg/commands/artifact/repository.go
+++ b/pkg/commands/artifact/repository.go
@@ -23,8 +23,8 @@ func repositoryScanner(ctx context.Context, dir string, ac cache.ArtifactCache, 
 }
 
 // RepositoryRun runs scan on repository
-func RepositoryRun(cliCtx *cli.Context) error {
-	c, err := NewConfig(cliCtx)
+func RepositoryRun(ctx *cli.Context) error {
+	c, err := NewConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -34,5 +34,5 @@ func RepositoryRun(cliCtx *cli.Context) error {
 		return xerrors.Errorf("failed to initialize options: %w", err)
 	}
 
-	return run(c, repositoryScanner)
+	return run(ctx.Context, c, repositoryScanner)
 }

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -18,22 +18,26 @@ import (
 )
 
 // Run runs the scan
-func Run(cliCtx *cli.Context) error {
-	c, err := NewConfig(cliCtx)
+func Run(ctx *cli.Context) error {
+	c, err := NewConfig(ctx)
 	if err != nil {
 		return err
 	}
-	return run(c)
+	return run(ctx.Context, c)
 }
 
-func run(conf Config) error {
+func run(ctx context.Context, conf Config) error {
 	ctx, cancel := context.WithTimeout(context.Background(), conf.Timeout)
 	defer cancel()
 
-	return runWithContext(ctx, conf)
+	err := runWithTimeout(ctx, conf)
+	if xerrors.Is(err, context.DeadlineExceeded) {
+		log.Logger.Warn("Increase --timeout value")
+	}
+	return err
 }
 
-func runWithContext(ctx context.Context, conf Config) error {
+func runWithTimeout(ctx context.Context, conf Config) error {
 	if err := initialize(&conf); err != nil {
 		return xerrors.Errorf("initialize error: %w", err)
 	}


### PR DESCRIPTION
```
$ trivy image -timeout 1s sequenceiq/hadoop-docker:2.7.0
2021-04-27T20:35:06.245+0900    WARN    increase --timeout value
2021-04-27T20:35:06.245+0900    FATAL   scan error: image scan failed: failed analysis: analyze error: timeout: context deadline exceeded
```