### PR TITLE
fix(table): skip zero vulnerabilities on java

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/fanal/analyzer/library"
 	ftypes "github.com/aquasecurity/fanal/types"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -80,7 +81,8 @@ type TableWriter struct {
 // Write writes the result on standard output
 func (tw TableWriter) Write(results Results) error {
 	for _, result := range results {
-		if len(result.Vulnerabilities) == 0 {
+		// Skip zero vulnerabilities on Java archives (JAR/WAR/EAR)
+		if result.Type == library.Jar && len(result.Vulnerabilities) == 0 {
 			continue
 		}
 		tw.write(result)


### PR DESCRIPTION
Before:

```
2021-04-30T02:24:46.045+0900    INFO    Detecting Alpine vulnerabilities...
2021-04-30T02:24:46.048+0900    INFO    Trivy skips scanning programming language libraries because no supported file was detected
```

After:

```
2021-04-30T02:24:02.354+0900    INFO    Detecting Alpine vulnerabilities...
2021-04-30T02:24:02.357+0900    INFO    Trivy skips scanning programming language libraries because no supported file was detected

alpine:3.11.11 (alpine 3.11.11)
===============================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```