### PR TITLE
chore(ci): clone trivy-repo after releasing binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,13 +39,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Checkout trivy-repo
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ github.repository_owner }}/trivy-repo
-          path: trivy-repo
-          fetch-depth: 0
-          token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Login to docker.io registry
         uses: docker/login-action@v1
         with:
@@ -70,6 +63,13 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout trivy-repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/trivy-repo
+          path: trivy-repo
+          fetch-depth: 0
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Setup git settings
         run: |
           git config --global user.email "knqyf263@gmail.com"


### PR DESCRIPTION
GoReleaser fails due to trivy-repo.

```
   ⨯ release failed after 0.11s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
?? trivy-repo/
```