### PR TITLE
chore(ci): replace GITHUB_TOKEN with ORG_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           version: v0.164.0
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
       - name: Checkout trivy-repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
GITHUB_TOKEN doesn't have the permission for aquasecurity/homebrew-trivy.