### PR TITLE
docs: Add HIGH severity to Trivy command in GitLab CI example to match comment

### DIFF
--- a/docs/integrations/gitlab-ci.md
+++ b/docs/integrations/gitlab-ci.md
@@ -78,8 +78,8 @@ container_scanning:
         --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$FULL_IMAGE_NAME"
     # Prints full report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$FULL_IMAGE_NAME"
-    # Fails on high and critical vulnerabilities
-    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL,HIGH --no-progress "$FULL_IMAGE_NAME"
+    # Fail on critical vulnerabilities
+    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
   cache:
     paths:
       - .trivycache/

--- a/docs/integrations/gitlab-ci.md
+++ b/docs/integrations/gitlab-ci.md
@@ -79,7 +79,7 @@ container_scanning:
     # Prints full report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$FULL_IMAGE_NAME"
     # Fails on high and critical vulnerabilities
-    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
+    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL,HIGH --no-progress "$FULL_IMAGE_NAME"
   cache:
     paths:
       - .trivycache/


### PR DESCRIPTION
Just saw this small error in the GitLab CI example while using it in an existing pipeline and wanted to clear up any confusion for new users looking at the examples.