### PR TITLE
chore(ci): change to more granular tokens

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
         ## Upload the tar in the Releases repository
         run: |
-          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_GITHUB_TOKEN }} -p .cr-release-packages
+          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }} -p .cr-release-packages
       - name: Index helm chart
         run: |
           ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Push index file
         uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
         env:
-          API_TOKEN_GITHUB: ${{ secrets.ORG_GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.ORG_REPO_TOKEN }}
         with:
           source_file: 'index.yaml'
           destination_repo: '${{ env.GH_OWNER }}/${{ env.HELM_REP }}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ env.GH_USER }}
-          password: ${{ secrets.ORG_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to ECR
         uses: docker/login-action@v1
         with:
@@ -62,14 +62,14 @@ jobs:
           version: v0.164.0
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
       - name: Checkout trivy-repo
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository_owner }}/trivy-repo
           path: trivy-repo
           fetch-depth: 0
-          token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          token: ${{ secrets.ORG_REPO_TOKEN }}
       - name: Setup git settings
         run: |
           git config --global user.email "knqyf263@gmail.com"


### PR DESCRIPTION
## Overview
### Authenticating to the GitHub Container Registry
To authenticate to the GHCR within a GitHub Actions workflow, we can use the GITHUB_TOKEN now. 
https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry

Replace `secrets.ORG_GITHUB_TOKEN` with `secrets.GITHUB_TOKEN`.

### Push to other repositories
Replace `secrets.ORG_GITHUB_TOKEN` with `secrets.ORG_REPO_TOKEN` having `repo` scope.