### PR TITLE
feat(plugin): add aqua plugin

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,6 +25,7 @@ var (
 
 	officialPlugins = map[string]string{
 		"kubectl": "github.com/aquasecurity/trivy-plugin-kubectl",
+		"aqua":    "github.com/aquasecurity/trivy-plugin-aqua",
 	}
 )
 


### PR DESCRIPTION
## Overview
https://github.com/aquasecurity/trivy/pull/1020 is based on `support_config` branch, but the change is independent of the feature of config scanning. This PR toward `main` branch replaces #1020. Once this PR gets merged, I'll merge this change into `support_config` branch.