### PR TITLE
Only resource detection support

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -219,6 +219,12 @@ var (
 		EnvVars: []string{"TRIVY_SKIP_DIRS"},
 	}
 
+	analyseOnlyFlag = cli.BoolFlag{
+		Name:    "analyse-only",
+		Usage:   "enabling this option will output all scanned resource without vulnerabilites",
+		EnvVars: []string{"TRIVY_ANALYSE_ONLY"},
+	}
+
 	globalFlags = []cli.Flag{
 		&quietFlag,
 		&debugFlag,
@@ -249,6 +255,7 @@ var (
 		&skipFiles,
 		&skipDirs,
 		&cacheBackendFlag,
+		&analyseOnlyFlag,
 	}
 
 	// deprecated options
@@ -424,6 +431,7 @@ func NewFilesystemCommand() *cli.Command {
 			&listAllPackages,
 			&skipFiles,
 			&skipDirs,
+			&analyseOnlyFlag,
 		},
 	}
 }
@@ -457,6 +465,7 @@ func NewRepositoryCommand() *cli.Command {
 			&listAllPackages,
 			&skipFiles,
 			&skipDirs,
+			&analyseOnlyFlag,
 		},
 	}
 }

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -137,6 +137,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		ListAllPackages:     opt.ListAllPkgs,
 		SkipFiles:           opt.SkipFiles,
 		SkipDirs:            opt.SkipDirs,
+		AnalyseOnly:         opt.AnalyseOnly,
 	}
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)
 

--- a/pkg/commands/option/artifact.go
+++ b/pkg/commands/option/artifact.go
@@ -15,8 +15,9 @@ type ArtifactOption struct {
 	Timeout    time.Duration
 	ClearCache bool
 
-	SkipDirs  []string
-	SkipFiles []string
+	SkipDirs    []string
+	SkipFiles   []string
+	AnalyseOnly bool
 
 	// this field is populated in Init()
 	Target string
@@ -25,11 +26,12 @@ type ArtifactOption struct {
 // NewArtifactOption is the factory method to return artifact option
 func NewArtifactOption(c *cli.Context) ArtifactOption {
 	return ArtifactOption{
-		Input:      c.String("input"),
-		Timeout:    c.Duration("timeout"),
-		ClearCache: c.Bool("clear-cache"),
-		SkipFiles:  c.StringSlice("skip-files"),
-		SkipDirs:   c.StringSlice("skip-dirs"),
+		Input:       c.String("input"),
+		Timeout:     c.Duration("timeout"),
+		ClearCache:  c.Bool("clear-cache"),
+		SkipFiles:   c.StringSlice("skip-files"),
+		SkipDirs:    c.StringSlice("skip-dirs"),
+		AnalyseOnly: c.Bool("analyse-only"),
 	}
 }
 

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -8,4 +8,5 @@ type ScanOptions struct {
 	ListAllPackages     bool
 	SkipFiles           []string
 	SkipDirs            []string
+	AnalyseOnly         bool
 }


### PR DESCRIPTION
This Pull request adds a new boolean flag analyse-only with default value False.
If this flag is enabled, all the scanned resources will be returned without vulnerability detection.
This flag will work for image, repo, and filesystem scanning.