### PR TITLE
Update ASFF template to use label for severity

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -8,21 +8,10 @@
 {{- else -}}
   ,
 {{- end -}}
-{{- $trivyProductSev := 0 -}}
-{{- $trivyNormalizedSev := 0 -}}
-{{- if eq .Severity "LOW" -}}
-    {{- $trivyProductSev = 1 -}}
-    {{- $trivyNormalizedSev = 10 -}}
-  {{- else if eq .Severity "MEDIUM" -}}
-    {{- $trivyProductSev = 4 -}}
-    {{- $trivyNormalizedSev = 40 -}}
-  {{- else if eq .Severity "HIGH" -}}
-    {{- $trivyProductSev = 7 -}}
-    {{- $trivyNormalizedSev = 70 -}}
-  {{- else if eq .Severity "CRITICAL" -}}
-    {{- $trivyProductSev = 9 -}}
-    {{- $trivyNormalizedSev = 90 -}}
-{{- end }}
+{{- $severity := .Severity -}}
+{{- if eq $severity "UNKNOWN" -}}
+{{- $severity = "INFORMATIONAL" -}}
+{{- end -}}
 {{- $description := .Description -}}
 {{- if gt (len $description ) 1021 -}}
     {{- $description = (slice $description 0 1021) | printf "%v .." -}}
@@ -37,8 +26,7 @@
         "CreatedAt": "{{ getCurrentTime }}",
         "UpdatedAt": "{{ getCurrentTime }}",
         "Severity": {
-            "Product": {{ $trivyProductSev }},
-            "Normalized": {{ $trivyNormalizedSev }}
+            "Label": "{{ .Severity }}"
         },
         "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
         "Description": {{ escapeString $description | printf "%q" }},

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -26,7 +26,7 @@
         "CreatedAt": "{{ getCurrentTime }}",
         "UpdatedAt": "{{ getCurrentTime }}",
         "Severity": {
-            "Label": "{{ .Severity }}"
+            "Label": "{{ $severity }}"
         },
         "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
         "Description": {{ escapeString $description | printf "%q" }},

--- a/integration/testdata/alpine-310.asff.golden
+++ b/integration/testdata/alpine-310.asff.golden
@@ -9,8 +9,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1549 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
@@ -55,8 +54,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1551 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t).",
@@ -101,8 +99,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1563 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "In situations where an attacker receives automated notification of the success or failure of a decryption attempt an attacker, after sending a very large number of messages to be decrypted, can recover a CMS/PKCS7 transported encryption key or decrypt any RSA encrypted message that was encrypted with the public RSA key, using a Bleichenbacher padding oracle attack. Applications are not affected if they use a certificate together with the private RSA key to the CMS_decrypt or PKCS7_decrypt functions to select the correct recipient info to decrypt. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s).",
@@ -147,8 +144,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 1,
-            "Normalized": 10
+            "Label": "LOW"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1547 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "Normally in OpenSSL EC groups always have a co-factor present and this is used in side channel resistant code paths. However, in some cases, it is possible to construct a group using explicit parameters (instead of using a named curve). In those cases it is possible that such a group does not have the cofactor present. This can occur even where all the parameters match a known named curve. If such a curve is used then OpenSSL falls back to non-side channel resistant code paths which may result in full key recovery during an ECDSA signature operation. In order to be vulnerable an attacker would have to have the ability to time the creation of a large number of signatures where explicit parameters with no co-factor present are in use by an application using libcrypto. For the avoidance of doubt libssl is not vulnerable because explicit parameters are never used. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s).",
@@ -193,8 +189,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1549 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
@@ -239,8 +234,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1551 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e-dev (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u-dev (Affected 1.0.2-1.0.2t).",
@@ -285,8 +279,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 4,
-            "Normalized": 40
+            "Label": "MEDIUM"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1563 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "In situations where an attacker receives automated notification of the success or failure of a decryption attempt an attacker, after sending a very large number of messages to be decrypted, can recover a CMS/PKCS7 transported encryption key or decrypt any RSA encrypted message that was encrypted with the public RSA key, using a Bleichenbacher padding oracle attack. Applications are not affected if they use a certificate together with the private RSA key to the CMS_decrypt or PKCS7_decrypt functions to select the correct recipient info to decrypt. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s).",
@@ -331,8 +324,7 @@
         "CreatedAt": "2020-08-10T07:28:17.000958601Z",
         "UpdatedAt": "2020-08-10T07:28:17.000958601Z",
         "Severity": {
-            "Product": 1,
-            "Normalized": 10
+            "Label": "LOW"
         },
         "Title": "Trivy found a vulnerability to CVE-2019-1547 in container testdata/fixtures/alpine-310.tar.gz (alpine 3.10.2)",
         "Description": "Normally in OpenSSL EC groups always have a co-factor present and this is used in side channel resistant code paths. However, in some cases, it is possible to construct a group using explicit parameters (instead of using a named curve). In those cases it is possible that such a group does not have the cofactor present. This can occur even where all the parameters match a known named curve. If such a curve is used then OpenSSL falls back to non-side channel resistant code paths which may result in full key recovery during an ECDSA signature operation. In order to be vulnerable an attacker would have to have the ability to time the creation of a large number of signatures where explicit parameters with no co-factor present are in use by an application using libcrypto. For the avoidance of doubt libssl is not vulnerable because explicit parameters are never used. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c). Fixed in OpenSSL 1.1.0l (Affected 1.1.0-1.1.0k). Fixed in OpenSSL 1.0.2t (Affected 1.0.2-1.0.2s).",


### PR DESCRIPTION
Use of the `Normalized` and `Product` fields is deprecated in the [ASFF spec](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format-attributes.html#asff-severity). Instead, we should just provide the severity as a `Label`, which simplifies the logic in this template quite a bit as well.