### PR TITLE
fix(asff): replace slice with substr

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -25,7 +25,7 @@
 {{- end }}
 {{- $description := .Description -}}
 {{- if gt (len $description ) 1021 -}}
-    {{- $description = (slice $description 0 1021) | printf "%v .." -}}
+    {{- $description = (substr 0 1021 $description) | printf "%v .." -}}
 {{- end}}
     {
         "SchemaVersion": "2018-10-08",


### PR DESCRIPTION
Masterminds/sprig breaks compatibility. The builtin `slice` accepts string, while `slice` from sprig doesn't allow it.
https://github.com/Masterminds/sprig/pull/306

```
$ AWS_REGION=us-west-1 AWS_ACCOUNT_ID=123456789012 ./trivy image --format template --template "@contrib/asff.tpl" -o report.asff knqyf263/vuln-image
...
2021-06-10T11:42:17.722+0300    FATAL   unable to write results: failed to write results: failed to write with template: template: output template:17:24: executing "output template" at <slice $description 0 1021>: error calling slice: list should be type of slice or array but string
```