### PR TITLE
suse: mark sle 15.3 as maintained, add opensuse 15.3

### DIFF
--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -38,10 +38,11 @@ var (
 		"12.5": time.Date(2024, 10, 31, 23, 59, 59, 0, time.UTC),
 		"15":   time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.1": time.Date(2021, 1, 31, 23, 59, 59, 0, time.UTC),
-		// 6 months after SLES 15 SP3 release
-		"15.2": time.Date(2021, 10, 31, 23, 59, 59, 0, time.UTC),
+		"15.2": time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC),
 		// 6 months after SLES 15 SP4 release
-		// "15.3":   time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
+		"15.3": time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
+		// 6 months after SLES 15 SP5 release
+		// "15.4":   time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{
@@ -52,6 +53,7 @@ var (
 		"15.0": time.Date(2019, 12, 3, 23, 59, 59, 0, time.UTC),
 		"15.1": time.Date(2020, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.2": time.Date(2021, 11, 30, 23, 59, 59, 0, time.UTC),
+		"15.3": time.Date(2022, 11, 30, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION
SLE 15.3 is about to be released and will be maintained until
6 months after 15.4. this allows us to guess the 15 SP2 EOL date,
so updating that as well.