### PR TITLE
GitLab CI examples.

### DIFF
--- a/contrib/gitlab-ds.tpl
+++ b/contrib/gitlab-ds.tpl
@@ -1,0 +1,78 @@
+{{- /* Template based on https://docs.gitlab.com/ee/user/application_security/dependency_scanning/#reports-json-format */ -}}
+{
+    "version": "2.0",
+    "vulnerabilities": [
+    {{- $t_first := true }}
+    {{- range . }}
+        {{- $target := .Target }}
+        {{- range .Vulnerabilities -}}
+            {{- if $t_first -}}
+                {{- $t_first = false -}}
+            {{ else -}}
+                ,
+            {{- end }}
+            {
+            "id": "{{ .VulnerabilityID }}",
+            "category": "dependency_scanning",
+            "message": {{ .Title | printf "%q" }},
+            "description": {{ .Description | printf "%q" }},
+            {{- /* cve is a deprecated key, use id instead */}}
+            "cve": "{{ .VulnerabilityID }}",
+            "severity": {{ if eq .Severity "UNKNOWN" -}}
+                "Unknown"
+            {{- else if eq .Severity "LOW" -}}
+                "Low"
+            {{- else if eq .Severity "MEDIUM" -}}
+                "Medium"
+            {{- else if eq .Severity "HIGH" -}}
+                "High"
+            {{- else if eq .Severity "CRITICAL" -}}
+                "Critical"
+            {{-  else -}}
+                "{{ .Severity }}"
+            {{- end }},
+            "solution": {{ if .FixedVersion -}}
+                "Upgrade {{ .PkgName }} to {{ .FixedVersion }}"
+            {{- else -}}
+                "No solution provided"
+            {{- end }},
+            "scanner": {
+                "id": "trivy",
+                "name": "trivy"
+            },
+            "location": {
+                "dependency": {
+                    "package": {
+                        "name": "{{ .PkgName }}"
+                    },
+                    "version": "{{ .InstalledVersion }}"
+                }
+            },
+            "identifiers": [
+                {
+                {{- /* TODO: Type not extractable - https://github.com/aquasecurity/trivy-db/pull/24 */}}
+                    "type": "cve",
+                    "name": "{{ .VulnerabilityID }}",
+                    "value": "{{ .VulnerabilityID }}",
+                    "url": "{{ .PrimaryURL }}"
+                }
+            ],
+            "links": [
+                {{- $l_first := true -}}
+                {{- range .References -}}
+                    {{- if $l_first -}}
+                        {{- $l_first = false }}
+                    {{- else -}}
+                        ,
+                    {{- end -}}
+                    {
+                        "url": "{{ . }}"
+                    }
+                {{- end }}
+            ]
+            }
+        {{- end -}}
+    {{- end }}
+    ],
+    "remediations": []
+}


### PR DESCRIPTION
This pull request introduces a new template for GitLab-CI dependency scanning as well as examples for:

* Remote server (gitlab-ci)
* Auto - Dependency scan (gitlab-ci)

It also includes a notice about gitlab changing their default container scanning engine to Trivy in their upcoming major version release (14).

Observe:  
The copy written for the examples was quite hastily written and due to me not being a native English speaker, there might be mistakes, feel free to edit or send a notice to me if you want me to change anything!

Refer to https://github.com/aquasecurity/trivy/pull/479  and https://github.com/aquasecurity/trivy/pull/479#issuecomment-840827666 for reason of the pull-request.