### PR TITLE
feat(report): add artifact metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8
+	github.com/aquasecurity/fanal v0.0.0-20210628083154-9556a040f4ad
 	github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20210602054043-49bfafe39808
+	github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8
 	github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbj
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/fanal v0.0.0-20210602054043-49bfafe39808 h1:4HP/nkDXLtRIxZyZfqEWMalN2xtNHh86PI0u2ofk0Ms=
-github.com/aquasecurity/fanal v0.0.0-20210602054043-49bfafe39808/go.mod h1:s4rJj8D45R28N3PNz5+hpjSHzD3YhaIbYrQtuYciGdY=
+github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8 h1:2ihY3hgw3ynHPNIjC+qA+aEzhMlSChtJlIAnSf+DxAM=
+github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8/go.mod h1:s4rJj8D45R28N3PNz5+hpjSHzD3YhaIbYrQtuYciGdY=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62 h1:aahEMQZXrwhpCMlDgXi2d7jJVNDTpYGJOgLyNptGQoY=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62/go.mod h1:Cv/FOCXy6gwvDbz/KX48+y//SmbnKroFwW5hquXn5G4=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbj
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8 h1:2ihY3hgw3ynHPNIjC+qA+aEzhMlSChtJlIAnSf+DxAM=
-github.com/aquasecurity/fanal v0.0.0-20210620132215-eeccbae86ff8/go.mod h1:s4rJj8D45R28N3PNz5+hpjSHzD3YhaIbYrQtuYciGdY=
+github.com/aquasecurity/fanal v0.0.0-20210628083154-9556a040f4ad h1:YnvGxCuiIQeXVpo4XO62vaaegXIRWz1+fl7bhTi/sU8=
+github.com/aquasecurity/fanal v0.0.0-20210628083154-9556a040f4ad/go.mod h1:s4rJj8D45R28N3PNz5+hpjSHzD3YhaIbYrQtuYciGdY=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62 h1:aahEMQZXrwhpCMlDgXi2d7jJVNDTpYGJOgLyNptGQoY=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62/go.mod h1:Cv/FOCXy6gwvDbz/KX48+y//SmbnKroFwW5hquXn5G4=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -16,10 +16,20 @@ var Now = time.Now
 
 // Report represents a scan result
 type Report struct {
-	ArtifactID  string   `json:",omitempty"`
+	ArtifactName string              `json:",omitempty"`
+	ArtifactID   string              `json:",omitempty"`
+	ArtifactType ftypes.ArtifactType `json:",omitempty"`
+	Metadata     Metadata            `json:",omitempty"`
+	Results      Results             `json:",omitempty"`
+}
+
+type Metadata struct {
+	Size int64      `json:",omitempty"`
+	OS   *ftypes.OS `json:",omitempty"`
+
+	// Container image
 	RepoTags    []string `json:",omitempty"`
 	RepoDigests []string `json:",omitempty"`
-	Results     Results  `json:",omitempty"`
 }
 
 // Results to hold list of Result

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -23,6 +23,7 @@ type Report struct {
 	Results      Results             `json:",omitempty"`
 }
 
+// Metadata represents a metadata of artifact
 type Metadata struct {
 	Size int64      `json:",omitempty"`
 	OS   *ftypes.OS `json:",omitempty"`

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -108,9 +108,14 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (r
 	}
 
 	return report.Report{
-		ArtifactID:  artifactInfo.ID,
-		RepoTags:    artifactInfo.RepoTags,
-		RepoDigests: artifactInfo.RepoDigests,
-		Results:     results,
+		ArtifactName: artifactInfo.Name,
+		ArtifactID:   artifactInfo.ID,
+		ArtifactType: artifactInfo.Type,
+		Metadata: report.Metadata{
+			OS:          osFound,
+			RepoTags:    artifactInfo.RepoTags,
+			RepoDigests: artifactInfo.RepoDigests,
+		},
+		Results: results,
 	}, nil
 }

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -90,9 +90,16 @@ func TestScanner_ScanArtifact(t *testing.T) {
 				},
 			},
 			want: report.Report{
-				ArtifactID:  "sha256:e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a",
-				RepoTags:    []string{"alpine:3.11"},
-				RepoDigests: []string{"alpine@sha256:0bd0e9e03a022c3b0226667621da84fc9bf562a9056130424b5bfbd8bcb0397f"},
+				ArtifactName: "alpine:3.11",
+				ArtifactID:   "sha256:e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a",
+				Metadata: report.Metadata{
+					OS: &ftypes.OS{
+						Family: "alpine",
+						Name:   "3.10",
+					},
+					RepoTags:    []string{"alpine:3.11"},
+					RepoDigests: []string{"alpine@sha256:0bd0e9e03a022c3b0226667621da84fc9bf562a9056130424b5bfbd8bcb0397f"},
+				},
 				Results: report.Results{
 					{
 						Target: "alpine:3.11",


### PR DESCRIPTION
## Overview

```
$ TRIVY_NEW_JSON_SCHEMA=true ./trivy image -f json alpine:3.12
{
  "ArtifactName": "alpine:3.12",
  "ArtifactID": "sha256:5049df74eab8db41c3d5992a298c331bbf4a2251d19aa790bed3f27f9a183207",
  "ArtifactType": "container_image",
  "Metadata": {
    "OS": {
      "Family": "alpine",
      "Name": "3.12.7"
    },
    "RepoTags": [
      "alpine:3.12"
    ],
    "RepoDigests": [
      "alpine@sha256:87703314048c40236c6d674424159ee862e2b96ce1c37c62d877e21ed27a387e"
    ]
  },
  "Results": [
    {
      "Target": "alpine:3.12 (alpine 3.12.7)",
      "Type": "alpine"
    }
  ]
}
```


## Related Issues/PRs
- Close https://github.com/aquasecurity/trivy/issues/1066
- https://github.com/aquasecurity/fanal/pull/185
- https://github.com/aquasecurity/trivy/discussions/1050
