### PR TITLE
added OS EOL flag

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -76,6 +76,13 @@ var (
 		EnvVars: []string{"TRIVY_EXIT_CODE"},
 	}
 
+	ignoreEOLOSFlag = cli.BoolFlag{
+		Name:    "ignore-eol-os",
+		Usage:   "ignore eol os",
+		Value:   true,
+		EnvVars: []string{"TRIVY_IGNORE_EOL_OS"},
+	}
+
 	skipUpdateFlag = cli.BoolFlag{
 		Name:    "skip-update",
 		Usage:   "skip db update",
@@ -232,6 +239,7 @@ var (
 		&severityFlag,
 		&outputFlag,
 		&exitCodeFlag,
+		&ignoreEOLOSFlag,
 		&skipUpdateFlag,
 		&downloadDBOnlyFlag,
 		&resetFlag,

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -137,6 +137,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		ListAllPackages:     opt.ListAllPkgs,
 		SkipFiles:           opt.SkipFiles,
 		SkipDirs:            opt.SkipDirs,
+		IgnoreEOLOS:         opt.ImageOption.IgnoreEOLOS,
 	}
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)
 

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -56,6 +56,7 @@ func runWithTimeout(ctx context.Context, opt Option) error {
 		SecurityChecks:      opt.SecurityChecks,
 		ScanRemovedPackages: opt.ScanRemovedPkgs,
 		ListAllPackages:     opt.ListAllPkgs,
+		IgnoreEOLOS:         opt.ImageOption.IgnoreEOLOS,
 	}
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)
 

--- a/pkg/commands/option/image.go
+++ b/pkg/commands/option/image.go
@@ -8,6 +8,7 @@ import (
 type ImageOption struct {
 	ScanRemovedPkgs bool
 	ListAllPkgs     bool
+	IgnoreEOLOS     bool
 }
 
 // NewImageOption is the factory method to return ImageOption
@@ -15,5 +16,6 @@ func NewImageOption(c *cli.Context) ImageOption {
 	return ImageOption{
 		ScanRemovedPkgs: c.Bool("removed-pkgs"),
 		ListAllPkgs:     c.Bool("list-all-pkgs"),
+		IgnoreEOLOS:     c.Bool("ignore-eol-os"),
 	}
 }

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -103,8 +103,12 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (r
 		return report.Report{}, xerrors.Errorf("scan failed: %w", err)
 	}
 	if eosl {
-		log.Logger.Warnf("This OS version is no longer supported by the distribution: %s %s", osFound.Family, osFound.Name)
-		log.Logger.Warnf("The vulnerability detection may be insufficient because security updates are not provided")
+		if options.IgnoreEOLOS {
+			log.Logger.Warnf("This OS version is no longer supported by the distribution: %s %s", osFound.Family, osFound.Name)
+			log.Logger.Warnf("The vulnerability detection may be insufficient because security updates are not provided")
+		} else {
+			log.Logger.Fatalf("This OS version is no longer supported by the distribution: %s %s. The vulnerability detection is insufficient because security updates are not provided", osFound.Family, osFound.Name)
+		}
 	}
 
 	return report.Report{

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -6,6 +6,7 @@ type ScanOptions struct {
 	SecurityChecks      []string
 	ScanRemovedPackages bool
 	ListAllPackages     bool
+	IgnoreEOLOS         bool
 	SkipFiles           []string
 	SkipDirs            []string
 }


### PR DESCRIPTION
Thanks in advance for your review!
This is my first PR in the repo, so apologies for anything obvious I've missed.

This addresses #1082, adding a flag to treat an old and unsupported OS as a failure rather than success, keeping the default as it is (ignore it) to avoid making this a breaking change.

Please let me know if I'm on the right track and I can update docs, etc
Also let me know if you think this requires it's own test or not?

Fixes #1082 
Relates #897

Output from testing locally:
```shell
$ make build
go build -ldflags "-s -w -X=main.version=v0.18.3-25-g175483a" ./cmd/trivy

$ ./trivy --exit-code 1 debian:8; echo $?
2021-07-01T14:20:41.144+0100	INFO	Detected OS: debian
2021-07-01T14:20:41.161+0100	INFO	Detecting Debian vulnerabilities...
2021-07-01T14:20:41.167+0100	INFO	Number of PL dependency files: 0
2021-07-01T14:20:41.167+0100	WARN	This OS version is no longer supported by the distribution: debian 8.11
2021-07-01T14:20:41.167+0100	WARN	The vulnerability detection may be insufficient because security updates are not provided

debian:8 (debian 8.11)
======================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

0

$ ./trivy --exit-code 1 --ignore-eol-os=true debian:8; echo $?
2021-07-01T14:20:52.697+0100	INFO	Detected OS: debian
2021-07-01T14:20:52.711+0100	INFO	Detecting Debian vulnerabilities...
2021-07-01T14:20:52.716+0100	INFO	Number of PL dependency files: 0
2021-07-01T14:20:52.716+0100	WARN	This OS version is no longer supported by the distribution: debian 8.11
2021-07-01T14:20:52.716+0100	WARN	The vulnerability detection may be insufficient because security updates are not provided

debian:8 (debian 8.11)
======================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

0

$ TRIVY_IGNORE_EOL_OS=true ./trivy --exit-code 1 debian:8; echo $?
2021-07-01T14:24:56.495+0100	INFO	Detected OS: debian
2021-07-01T14:24:56.506+0100	INFO	Detecting Debian vulnerabilities...
2021-07-01T14:24:56.513+0100	INFO	Number of PL dependency files: 0
2021-07-01T14:24:56.513+0100	WARN	This OS version is no longer supported by the distribution: debian 8.11
2021-07-01T14:24:56.513+0100	WARN	The vulnerability detection may be insufficient because security updates are not provided

debian:8 (debian 8.11)
======================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

0

$ ./trivy --exit-code 1 --ignore-eol-os=false debian:8; echo $?
2021-07-01T14:20:58.629+0100	INFO	Detected OS: debian
2021-07-01T14:20:58.630+0100	INFO	Detecting Debian vulnerabilities...
2021-07-01T14:20:58.635+0100	INFO	Number of PL dependency files: 0
2021-07-01T14:20:58.635+0100	FATAL	This OS version is no longer supported by the distribution: debian 8.11. The vulnerability detection is insufficient because security updates are not provided
1

$ TRIVY_IGNORE_EOL_OS=false ./trivy --exit-code 1 debian:8; echo $?
2021-07-01T14:24:47.339+0100	INFO	Detected OS: debian
2021-07-01T14:24:47.340+0100	INFO	Detecting Debian vulnerabilities...
2021-07-01T14:24:47.355+0100	INFO	Number of PL dependency files: 0
2021-07-01T14:24:47.355+0100	FATAL	This OS version is no longer supported by the distribution: debian 8.11. The vulnerability detection is insufficient because security updates are not provided
1

```