### PR TITLE
Fix typo for word `finish` in custom index.md

### DIFF
--- a/docs/misconfiguration/custom/index.md
+++ b/docs/misconfiguration/custom/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 You can write custom policies in [Rego][rego].
-Once you fisnish writing custom policies, you can pass the directory where those policies are stored with `--policy` option.
+Once you finish writing custom policies, you can pass the directory where those policies are stored with `--policy` option.
 
 ``` bash
 trivy conf --policy /path/to/custom_policies --namespaces user /path/to/config_dir


### PR DESCRIPTION
Fix typo for word `finish` in custom index.md