### PR TITLE
update cyclonedx github action to v0.3.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,11 +57,11 @@ jobs:
           username: ${{ secrets.ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
       - name: Generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v0.2.0
+        uses: CycloneDX/gh-gomod-generate-sbom@v0.3.0
         with:
           json: true
           output: bom.json
-          version: latest
+          version: ^v0
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
use version `^v0` instead of `latest` to avoid breaking the build when cyclonedx-gomod introduces breaking changes in a new major version. See https://github.com/CycloneDX/gh-gomod-generate-sbom/releases/tag/v0.3.0