### PR TITLE
GitLab CI integration documentation

### DIFF
--- a/docs/advanced/integrations/gitlab-ci.md
+++ b/docs/advanced/integrations/gitlab-ci.md
@@ -1,5 +1,11 @@
 # GitLab CI
 
+If you're a GitLab Ultimate customer, GitLab 14.0 and above include out-of-the-box integration with Trivy. To enable it for your project, simply add the container scanning template to your `.gitlab-ci.yml` file. For more details, please refer to [GitLab's documentation](https://docs.gitlab.com/ee/user/application_security/container_scanning/).
+
+If you're using an earlier version of GitLab, you can still use the new integration by copying the [contents of the 14.0 template](https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml) to your configuration.
+
+Alternatively, you can always use the example configurations below.
+
 ```yaml
 stages:
   - test


### PR DESCRIPTION
This is a suggestion to use the native integration, which is a lot simpler than the custom configurations currently recommended in the [documentation](https://aquasecurity.github.io/trivy/v0.19.2/advanced/integrations/gitlab-ci/).

I considered removing them altogether but thought it was best to let a maintainer weight-in before doing so.