### PR TITLE
Dockerfile package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.12
-RUN apk --no-cache add ca-certificates git rpm
+RUN apk --no-cache add ca-certificates=20191127-r4 git=2.26.3-r0 rpm=4.15.1-r2
 COPY trivy /usr/local/bin/trivy
-COPY contrib/*.tpl contrib/
+COPY contrib/*tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.12
 RUN apk --no-cache add ca-certificates=20191127-r4 git=2.26.3-r0 rpm=4.15.1-r2
 COPY trivy /usr/local/bin/trivy
-COPY contrib/*tpl contrib/
+COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,7 @@ cache:
 ```
 
 Example: https://travis-ci.org/aquasecurity/trivy-ci-test
+
 Repository: https://github.com/aquasecurity/trivy-ci-test
 
 ## CircleCI
@@ -1524,6 +1525,7 @@ workflows:
 ```
 
 Example: https://circleci.com/gh/aquasecurity/trivy-ci-test
+
 Repository: https://github.com/aquasecurity/trivy-ci-test
 
 ## GitLab CI
@@ -1568,6 +1570,10 @@ trivy:
     reports:
       container_scanning: gl-container-scanning-report.json
 ```
+
+Example: https://gitlab.com/aquasecurity/trivy-ci-test/pipelines
+
+Repository: https://github.com/aquasecurity/trivy-ci-test
 
 ## AWS CodePipeline
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ You also need to install `rpm` command for scanning images based on RHEL/CentOS.
 
 ## Image
 
-Simply specify an image name (and a tag). **The `latest` tag should be avoided as problems occur with the image cache.** See [Clear image caches](#clear-image-caches).
+Simply specify an image name (and a tag). **The `latest` tag should be avoided as problems occur with the image cache.** See [Clear caches](#clear-caches).
 
 ### Basic
 


### PR DESCRIPTION
due to good and best security practices, in this Dockerfile the versions of the packages that need to be installed were specified, reducing the attack surface

Old line : RUN apk --no-cache add ca-certificates git= rpm
New line 👍🏼  RUN apk --no-cache add ca-certificates=20191127-r4 git=2.26.3-r0 rpm=4.15.1-r2