### PR TITLE
Update the Dockerfile with specific version of pkg it needs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.14
-RUN apk --no-cache add ca-certificates git
+RUN apk --no-cache add ca-certificates=20191127-r5 git=2.32.0-r0
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
due to good and best security practices, in this Dockerfile the versions of the packages that need to be installed were specified, reducing the attack surface

Old line : RUN apk --no-cache add ca-certificates git
New line 👍🏼  RUN apk --no-cache add ca-certificates=20191127-r5 git=2.32.0-r0

Best Practices for apk in alpine