### PR TITLE
docs(ruby): allow commercial use of Ruby Advisory Database

### DIFF
--- a/docs/vulnerability/detection/data-source.md
+++ b/docs/vulnerability/detection/data-source.md
@@ -23,7 +23,7 @@
 |                              | [GitHub Advisory Database (Composer)][php-ghsa]  | ✅              | -        |
 | Python                       | [Safety DB][python]                              | ❌              | 1 month  |
 |                              | [GitHub Advisory Database (pip)][python-ghsa]    | ✅              | -        |
-| Ruby                         | [Ruby Advisory Database][ruby]                   | ❌ (partially)  | -        |
+| Ruby                         | [Ruby Advisory Database][ruby]                   | ✅              | -        |
 |                              | [GitHub Advisory Database (RubyGems)][ruby-ghsa] | ✅              | -        |
 | Node.js                      | [Ecosystem Security Working Group][nodejs]       | ✅              | -        |
 |                              | [GitHub Advisory Database (npm)][nodejs-ghsa]    | ✅              | -        |


### PR DESCRIPTION
Trivy no longer depends on OSVDB and can use "Ruby Advisory Database" for commercial usage.

Fixes #1208