### PR TITLE
Add trivy image --skip-analyzers option

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -225,6 +225,12 @@ var (
 		EnvVars: []string{"TRIVY_SKIP_DIRS"},
 	}
 
+	skipAnalyzers = cli.StringSliceFlag{
+		Name:    "skip-analyzers",
+		Usage:   "specify analyzers to skip",
+		EnvVars: []string{"TRIVY_SKIP_ANALYZERS"},
+	}
+
 	// For misconfigurations
 	configPolicy = cli.StringSliceFlag{
 		Name:    "config-policy",
@@ -311,6 +317,7 @@ var (
 		&cacheBackendFlag,
 		stringSliceFlag(skipFiles),
 		stringSliceFlag(skipDirs),
+		stringSliceFlag(skipAnalyzers),
 	}
 
 	// deprecated options
@@ -488,6 +495,7 @@ func NewFilesystemCommand() *cli.Command {
 			&listAllPackages,
 			stringSliceFlag(skipFiles),
 			stringSliceFlag(skipDirs),
+			stringSliceFlag(skipAnalyzers),
 			stringSliceFlag(configPolicy),
 			stringSliceFlag(configData),
 			stringSliceFlag(policyNamespaces),
@@ -525,6 +533,7 @@ func NewRepositoryCommand() *cli.Command {
 			&listAllPackages,
 			stringSliceFlag(skipFiles),
 			stringSliceFlag(skipDirs),
+			stringSliceFlag(skipAnalyzers),
 		},
 	}
 }
@@ -620,6 +629,7 @@ func NewConfigCommand() *cli.Command {
 			&timeoutFlag,
 			stringSliceFlag(skipFiles),
 			stringSliceFlag(skipDirs),
+			stringSliceFlag(skipAnalyzers),
 			stringSliceFlag(configPolicyAlias),
 			stringSliceFlag(configDataAlias),
 			stringSliceFlag(policyNamespaces),

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -148,6 +148,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		ListAllPackages:     opt.ListAllPkgs,
 		SkipFiles:           opt.SkipFiles,
 		SkipDirs:            opt.SkipDirs,
+		SkipAnalyzers:       opt.SkipAnalyzers,
 	}
 	log.Logger.Debugf("Vulnerability type:  %s", scanOptions.VulnType)
 
@@ -155,6 +156,9 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 	disabledAnalyzers := []analyzer.Type{analyzer.TypeApkCommand}
 	if opt.ScanRemovedPkgs {
 		disabledAnalyzers = []analyzer.Type{}
+	}
+	for a := range opt.SkipAnalyzers {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.Type(a))
 	}
 
 	// ScannerOptions is filled only when config scanning is enabled.

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -123,6 +123,9 @@ func initializeScanner(ctx context.Context, opt Option) (scanner.Scanner, func()
 	if opt.ScanRemovedPkgs {
 		disabledAnalyzers = []analyzer.Type{}
 	}
+	for a := range opt.SkipAnalyzers {
+		disabledAnalyzers = append(disabledAnalyzers, analyzer.Type(a))
+	}
 
 	// ScannerOptions is filled only when config scanning is enabled.
 	var configScannerOptions config.ScannerOption

--- a/pkg/commands/option/artifact.go
+++ b/pkg/commands/option/artifact.go
@@ -15,8 +15,9 @@ type ArtifactOption struct {
 	Timeout    time.Duration
 	ClearCache bool
 
-	SkipDirs  []string
-	SkipFiles []string
+	SkipDirs       []string
+	SkipFiles      []string
+	SkipAnalyzers  []string
 
 	// this field is populated in Init()
 	Target string
@@ -25,11 +26,12 @@ type ArtifactOption struct {
 // NewArtifactOption is the factory method to return artifact option
 func NewArtifactOption(c *cli.Context) ArtifactOption {
 	return ArtifactOption{
-		Input:      c.String("input"),
-		Timeout:    c.Duration("timeout"),
-		ClearCache: c.Bool("clear-cache"),
-		SkipFiles:  c.StringSlice("skip-files"),
-		SkipDirs:   c.StringSlice("skip-dirs"),
+		Input:         c.String("input"),
+		Timeout:       c.Duration("timeout"),
+		ClearCache:    c.Bool("clear-cache"),
+		SkipFiles:     c.StringSlice("skip-files"),
+		SkipDirs:      c.StringSlice("skip-dirs"),
+		SkipAnalyzers: c.StringSlice("skip-analyzers"),
 	}
 }
 

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -8,4 +8,5 @@ type ScanOptions struct {
 	ListAllPackages     bool
 	SkipFiles           []string
 	SkipDirs            []string
+	SkipAnalyzers       []string
 }


### PR DESCRIPTION
Allows disabling analyzers from outside.

Mainly to disable jar analyzer which can go to network which may be
undesired and introduce scan flakiness. But sounds generic enough
to have other uses too.

related to #1191 and #1233

not thoroughly tested yet, no unit tests too, but can add if the feature sounds useful