### PR TITLE
feat(debian): support the versions that reached EOL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
-	github.com/aquasecurity/trivy-db v0.0.0-20210907100132-2ec74c43526d
+	github.com/aquasecurity/trivy-db v0.0.0-20210916043317-726b7b72a47b
 	github.com/caarlos0/env/v6 v6.0.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cheggaaa/pb/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbp
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516/go.mod h1:gTd97VdQ0rg8Mkiic3rPgNOQdprZ7feTAhiD5mGQjgM=
 github.com/aquasecurity/tfsec v0.46.0 h1:R9djHTpk+YrFuFv2GRdfU4rRz6uk5wLrgfx1fp9K1es=
 github.com/aquasecurity/tfsec v0.46.0/go.mod h1:Dafx5dX/1QV1d5en62shpzEXfq5F31IG6oNNxhleV5Y=
-github.com/aquasecurity/trivy-db v0.0.0-20210907100132-2ec74c43526d h1:AMuCVa54YX5wVmvqeUZY/PSfMbHtiX1PukVZHocCLr0=
-github.com/aquasecurity/trivy-db v0.0.0-20210907100132-2ec74c43526d/go.mod h1:lcUx+KZjKYLu7gCe8Gwe3ZUBUsxeRUg3mwkvzikP6kQ=
+github.com/aquasecurity/trivy-db v0.0.0-20210916043317-726b7b72a47b h1:RaS93vlHzgreZk3CYqcNgoqukwbsBEYhAiE6qmhLwB0=
+github.com/aquasecurity/trivy-db v0.0.0-20210916043317-726b7b72a47b/go.mod h1:5h8GV7Qxp/SMJ4awWHs0KRxwVkKzcwOnRkORWOnCXRU=
 github.com/aquasecurity/vuln-list-update v0.0.0-20191016075347-3d158c2bf9a2/go.mod h1:6NhOP0CjZJL27bZZcaHECtzWdwDDm2g6yCY0QgXEGQQ=
 github.com/araddon/dateparse v0.0.0-20190426192744-0d74ffceef83/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fake "k8s.io/utils/clock/testing"
+
 	ftypes "github.com/aquasecurity/fanal/types"
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
 	"github.com/aquasecurity/trivy/pkg/types"
-
-	fake "k8s.io/utils/clock/testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -49,6 +50,7 @@ func TestScanner_Detect(t *testing.T) {
 				{
 					PkgName:          "htpasswd",
 					VulnerabilityID:  "CVE-2020-11985",
+					VendorIDs:        []string{"DSA-4884-1"},
 					InstalledVersion: "2.4.24",
 					FixedVersion:     "2.4.25-1",
 					Layer: ftypes.Layer{
@@ -59,6 +61,10 @@ func TestScanner_Detect(t *testing.T) {
 					PkgName:          "htpasswd",
 					VulnerabilityID:  "CVE-2021-31618",
 					InstalledVersion: "2.4.24",
+					SeveritySource:   vulnerability.Debian,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityMedium.String(),
+					},
 					Layer: ftypes.Layer{
 						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 					},

--- a/pkg/detector/ospkg/debian/testdata/fixtures/debian.yaml
+++ b/pkg/detector/ospkg/debian/testdata/fixtures/debian.yaml
@@ -5,6 +5,7 @@
         - key: CVE-2021-31618
           value:
             FixedVersion: ""
+            Severity: 2
 - bucket: debian oval 9
   pairs:
     - bucket: apache2
@@ -15,3 +16,5 @@
         - key: CVE-2020-11985
           value:
             FixedVersion: "2.4.25-1"
+            VendorIDs:
+              - DSA-4884-1

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -202,6 +202,37 @@ func TestClient_FillVulnerabilityInfo(t *testing.T) {
 			},
 		},
 		{
+			name:     "happy path, with package-specific severity",
+			fixtures: []string{"testdata/fixtures/full.yaml"},
+			args: args{
+				vulns: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2019-0001",
+						SeveritySource:  vulnerability.Debian,
+						Vulnerability: dbTypes.Vulnerability{
+							Severity: dbTypes.SeverityLow.String(),
+						},
+					},
+				},
+				reportType: vulnerability.Debian,
+			},
+			expectedVulnerabilities: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2019-0001",
+					SeveritySource:  vulnerability.Debian,
+					Vulnerability: dbTypes.Vulnerability{
+						Title:            "dos",
+						Description:      "dos vulnerability",
+						Severity:         dbTypes.SeverityLow.String(),
+						References:       []string{"http://example.com"},
+						LastModifiedDate: utils.MustTimeParse("2020-01-01T01:01:00Z"),
+						PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
+					},
+					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2019-0001",
+				},
+			},
+		},
+		{
 			name:     "GetVulnerability returns an error",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			args: args{

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -8,6 +8,7 @@ import (
 // DetectedVulnerability holds the information of detected vulnerabilities
 type DetectedVulnerability struct {
 	VulnerabilityID  string       `json:",omitempty"`
+	VendorIDs        []string     `json:",omitempty"`
 	PkgName          string       `json:",omitempty"`
 	PkgPath          string       `json:",omitempty"` // It will be filled in the case of language-specific packages such as egg/wheel and gemspec
 	InstalledVersion string       `json:",omitempty"`


### PR DESCRIPTION
## Overview
Trivy used to use [OVAL](https://www.debian.org/security/oval/) and [JSON API](https://security-tracker.debian.org/tracker/data/json) for Debian scanning, but this PR migrates to [Debian repository](https://salsa.debian.org/security-tracker-team/security-tracker). This is because JSON API will no longer return security advisories of EOSL versions. We want to keep supporting old versions as well. This PR allows it.

## PRs
Need to merge the below PRs first

- https://github.com/aquasecurity/vuln-list-update/pull/95
- https://github.com/aquasecurity/trivy-db/pull/137