### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/integration/docker/docker.go
+++ b/integration/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -78,7 +77,7 @@ func (d Docker) ReplicateImage(ctx context.Context, imageRef, imagePath string, 
 	if err != nil {
 		return err
 	}
-	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil {
 		return err
 	}
 	defer resp.Body.Close()
@@ -110,7 +109,7 @@ func (d Docker) ReplicateImage(ctx context.Context, imageRef, imagePath string, 
 	}
 	defer pushOut.Close()
 
-	if _, err = io.Copy(ioutil.Discard, pushOut); err != nil {
+	if _, err = io.Copy(io.Discard, pushOut); err != nil {
 		return err
 	}
 	return nil

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -6,7 +6,6 @@ package integration
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -270,14 +269,14 @@ func TestRun_WithDockerEngine(t *testing.T) {
 				// load image into docker engine
 				res, err := cli.ImageLoad(ctx, testfile, true)
 				require.NoError(t, err, tc.name)
-				io.Copy(ioutil.Discard, res.Body)
+				io.Copy(io.Discard, res.Body)
 
 				// tag our image to something unique
 				err = cli.ImageTag(ctx, tc.imageTag, tc.testfile)
 				require.NoError(t, err, tc.name)
 			}
 
-			of, err := ioutil.TempFile("", "integration-docker-engine-output-file-*")
+			of, err := os.CreateTemp("", "integration-docker-engine-output-file-*")
 			require.NoError(t, err, tc.name)
 			defer os.Remove(of.Name())
 
@@ -301,7 +300,7 @@ func TestRun_WithDockerEngine(t *testing.T) {
 			}
 			if len(tc.ignoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
-				err := ioutil.WriteFile(trivyIgnore, []byte(strings.Join(tc.ignoreIDs, "\n")), 0444)
+				err := os.WriteFile(trivyIgnore, []byte(strings.Join(tc.ignoreIDs, "\n")), 0444)
 				assert.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
@@ -318,9 +317,9 @@ func TestRun_WithDockerEngine(t *testing.T) {
 			}
 
 			// check for vulnerability output info
-			got, err := ioutil.ReadAll(of)
+			got, err := io.ReadAll(of)
 			assert.NoError(t, err, tc.name)
-			want, err := ioutil.ReadFile(tc.expectedOutputFile)
+			want, err := os.ReadFile(tc.expectedOutputFile)
 			assert.NoError(t, err, tc.name)
 			assert.JSONEq(t, string(want), string(got), tc.name)
 

--- a/integration/registry_test.go
+++ b/integration/registry_test.go
@@ -9,7 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -236,7 +236,7 @@ func scan(t *testing.T, imageRef name.Reference, baseDir, goldenFile string, opt
 	if *update && goldenFile != "" {
 		outputFile = goldenFile
 	} else {
-		output, err := ioutil.TempFile("", "integration")
+		output, err := os.CreateTemp("", "integration")
 		if err != nil {
 			return "", cleanup, err
 		}
@@ -256,7 +256,7 @@ func scan(t *testing.T, imageRef name.Reference, baseDir, goldenFile string, opt
 
 	// Setup CLI App
 	app := commands.NewApp("dev")
-	app.Writer = ioutil.Discard
+	app.Writer = io.Discard
 
 	osArgs := []string{"trivy", "--cache-dir", cacheDir, "--format", "json", "--skip-update", "--output", outputFile, imageRef.Name()}
 
@@ -306,7 +306,7 @@ func unsetEnv() error {
 
 func requestRegistryToken(imageRef name.Reference, baseDir string, opt registryOption) (string, error) {
 	// Create a CA certificate pool and add cert.pem to it
-	caCert, err := ioutil.ReadFile(filepath.Join(baseDir, "data", "certs", "cert.pem"))
+	caCert, err := os.ReadFile(filepath.Join(baseDir, "data", "certs", "cert.pem"))
 	if err != nil {
 		return "", err
 	}

--- a/integration/standalone_tar_test.go
+++ b/integration/standalone_tar_test.go
@@ -4,7 +4,7 @@
 package integration
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -377,7 +377,7 @@ func TestRun_WithTar(t *testing.T) {
 
 	// Setup CLI App
 	app := commands.NewApp("dev")
-	app.Writer = ioutil.Discard
+	app.Writer = io.Discard
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -402,7 +402,7 @@ func TestRun_WithTar(t *testing.T) {
 			}
 			if len(c.testArgs.IgnoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
-				err := ioutil.WriteFile(trivyIgnore, []byte(strings.Join(c.testArgs.IgnoreIDs, "\n")), 0444)
+				err := os.WriteFile(trivyIgnore, []byte(strings.Join(c.testArgs.IgnoreIDs, "\n")), 0444)
 				assert.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
@@ -427,7 +427,7 @@ func TestRun_WithTar(t *testing.T) {
 			if *update {
 				outputFile = c.golden
 			} else {
-				output, _ := ioutil.TempFile("", "integration")
+				output, _ := os.CreateTemp("", "integration")
 				assert.Nil(t, output.Close())
 				defer os.Remove(output.Name())
 				outputFile = output.Name()
@@ -439,9 +439,9 @@ func TestRun_WithTar(t *testing.T) {
 			assert.Nil(t, app.Run(osArgs))
 
 			// Compare want and got
-			want, err := ioutil.ReadFile(c.golden)
+			want, err := os.ReadFile(c.golden)
 			assert.NoError(t, err)
-			got, err := ioutil.ReadFile(outputFile)
+			got, err := os.ReadFile(outputFile)
 			assert.NoError(t, err)
 
 			assert.JSONEq(t, string(want), string(got))

--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,7 +80,7 @@ Vulnerability DB:
 			case tt.args.cacheDir != "":
 				cacheDir = tt.args.cacheDir
 			default:
-				cacheDir, _ = ioutil.TempDir("", "Test_showVersion-*")
+				cacheDir, _ = os.MkdirTemp("", "Test_showVersion-*")
 				defer os.RemoveAll(cacheDir)
 			}
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -246,7 +245,7 @@ func TestClient_Download(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			metadata := NewMetadata(fs, "/cache")
 
-			dir, err := ioutil.TempDir("", "db")
+			dir, err := os.MkdirTemp("", "db")
 			require.NoError(t, err, tc.name)
 			defer os.RemoveAll(dir)
 
@@ -349,7 +348,7 @@ func TestClient_UpdateMetadata(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			metadata := NewMetadata(fs, "/cache")
 
-			dir, err := ioutil.TempDir("", "db")
+			dir, err := os.MkdirTemp("", "db")
 			require.NoError(t, err, tc.name)
 			defer os.RemoveAll(dir)
 

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -122,7 +121,7 @@ func TestClient_DownloadDB(t *testing.T) {
 				{
 					input: 100,
 					output: downloadAssetOutput{
-						rc: ioutil.NopCloser(strings.NewReader("foo")),
+						rc: io.NopCloser(strings.NewReader("foo")),
 					},
 				},
 			},
@@ -217,7 +216,7 @@ func TestClient_DownloadDB(t *testing.T) {
 				{
 					input: 300,
 					output: downloadAssetOutput{
-						rc: ioutil.NopCloser(strings.NewReader("foo")),
+						rc: io.NopCloser(strings.NewReader("foo")),
 					},
 				},
 			},
@@ -268,7 +267,7 @@ func TestClient_DownloadDB(t *testing.T) {
 				{
 					input: 200,
 					output: downloadAssetOutput{
-						rc: ioutil.NopCloser(strings.NewReader("foo")),
+						rc: io.NopCloser(strings.NewReader("foo")),
 					},
 				},
 			},

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -31,7 +30,7 @@ type TemplateWriter struct {
 // NewTemplateWriter is the factory method to return TemplateWriter object
 func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter, error) {
 	if strings.HasPrefix(outputTemplate, "@") {
-		buf, err := ioutil.ReadFile(strings.TrimPrefix(outputTemplate, "@"))
+		buf, err := os.ReadFile(strings.TrimPrefix(outputTemplate, "@"))
 		if err != nil {
 			return nil, xerrors.Errorf("error retrieving template from path: %w", err)
 		}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -262,7 +261,7 @@ func toSlice(uniqVulns map[string]types.DetectedVulnerability) []types.DetectedV
 
 func applyPolicy(ctx context.Context, vulns []types.DetectedVulnerability, misconfs []types.DetectedMisconfiguration,
 	policyFile string) ([]types.DetectedVulnerability, []types.DetectedMisconfiguration, error) {
-	policy, err := ioutil.ReadFile(policyFile)
+	policy, err := os.ReadFile(policyFile)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("unable to read the policy file: %w", err)
 	}

--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -140,7 +139,7 @@ func (w dbWorker) update(ctx context.Context, appVersion, cacheDir string,
 }
 
 func (w dbWorker) hotUpdate(ctx context.Context, cacheDir string, dbUpdateWg, requestWg *sync.WaitGroup) error {
-	tmpDir, err := ioutil.TempDir("", "db")
+	tmpDir, err := os.MkdirTemp("", "db")
 	if err != nil {
 		return xerrors.Errorf("failed to create a temp dir: %w", err)
 	}

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -106,7 +105,7 @@ func Test_dbWorker_update(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cacheDir, err := ioutil.TempDir("", "server-test")
+			cacheDir, err := os.MkdirTemp("", "server-test")
 			require.NoError(t, err, tt.name)
 
 			require.NoError(t, db.Init(cacheDir), tt.name)
@@ -121,13 +120,13 @@ func Test_dbWorker_update(t *testing.T) {
 				mockDBClient.On("Download", mock.Anything, mock.Anything, false).Run(
 					func(args mock.Arguments) {
 						// fake download: copy testdata/new.db to tmpDir/db/trivy.db
-						content, err := ioutil.ReadFile("testdata/new.db")
+						content, err := os.ReadFile("testdata/new.db")
 						require.NoError(t, err, tt.name)
 
 						tmpDir := args.String(1)
 						dbPath := db.Path(tmpDir)
 						require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0777), tt.name)
-						err = ioutil.WriteFile(dbPath, content, 0444)
+						err = os.WriteFile(dbPath, content, 0444)
 						require.NoError(t, err, tt.name)
 					}).Return(tt.download.err)
 			}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -25,14 +24,14 @@ func touch(t *testing.T, name string) {
 }
 
 func write(t *testing.T, name string, content string) {
-	err := ioutil.WriteFile(name, []byte(content), 0666)
+	err := os.WriteFile(name, []byte(content), 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestFileWalk(t *testing.T) {
-	td, err := ioutil.TempDir("", "walktest")
+	td, err := os.MkdirTemp("", "walktest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +61,7 @@ func TestFileWalk(t *testing.T) {
 			sawFoo2 = true
 		}
 		if strings.HasSuffix(path, "foo3") {
-			contentFoo3, err = ioutil.ReadAll(r)
+			contentFoo3, err = io.ReadAll(r)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -163,7 +162,7 @@ func TestCopyFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			src := tt.args.src
 			if tt.args.src == "" {
-				s, err := ioutil.TempFile("", "src")
+				s, err := os.CreateTemp("", "src")
 				require.NoError(t, err, tt.name)
 				_, err = s.Write(tt.content)
 				require.NoError(t, err, tt.name)
@@ -172,7 +171,7 @@ func TestCopyFile(t *testing.T) {
 
 			dst := tt.args.dst
 			if tt.args.dst == "" {
-				d, err := ioutil.TempFile("", "dst")
+				d, err := os.CreateTemp("", "dst")
 				require.NoError(t, err, tt.name)
 				dst = d.Name()
 				require.NoError(t, d.Close(), tt.name)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Special notes for reviewers
No breaking changes.