### PR TITLE
fix: brew test command

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -88,7 +88,7 @@ brews:
     homepage: "https://github.com/aquasecurity/trivy"
     description: ""
     test: |
-      system "#{bin}/program --version"
+      system "#{bin}/trivy --version"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
An error occurred while executing brew test command:

```shell
% brew test trivy
==> Testing aquasecurity/trivy/trivy
==> /usr/local/Cellar/trivy/0.19.2/bin/program --version
Last 15 lines from /Users/minchao/Library/Logs/Homebrew/trivy/test.01.program:
2021-09-26 21:25:13 +0800

/usr/local/Cellar/trivy/0.19.2/bin/program --version

Error: aquasecurity/trivy/trivy: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/local/Cellar/trivy/0.19.2/bin/program --version
/usr/local/Homebrew/Library/Homebrew/formula.rb:2297:in `block in system'
omit...
```

This fix will correct the `program`  to `trivy`.

