### PR TITLE
Add target name to contrib HTML table section header

### DIFF
--- a/contrib/html.tpl
+++ b/contrib/html.tpl
@@ -19,7 +19,6 @@
       table, th, td {
         border: 1px solid black;
         border-collapse: collapse;
-        white-space: nowrap;
         padding: .3em;
       }
       table {
@@ -85,7 +84,7 @@
     <h1>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ getCurrentTime }}</h1>
     <table>
     {{- range . }}
-      <tr class="group-header"><th colspan="6">{{ escapeXML .Type }}</th></tr>
+      <tr class="group-header"><th colspan="6">{{ escapeXML .Type }}: {{ escapeXML .Target }}</th></tr>
       {{- if (eq (len .Vulnerabilities) 0) }}
       <tr><th colspan="6">No Vulnerabilities found</th></tr>
       {{- else }}


### PR DESCRIPTION
I'm having an issue similar to the one stated in #1246. While running a report that has multiple components, it's impossible to know to what the HTML section (from contrib's directory HTML template), the vulnerabilities are from. I added the target name, and fixed the table size to the browser width, or to the longest text. Therefore, while the original issue suggests some CSS styling, it's not really necessary, as the table will grow.

This is how it looks now:
![image](https://user-images.githubusercontent.com/27286/135562061-5013c99f-fadf-43bf-be92-1b85106aea78.png)
![image](https://user-images.githubusercontent.com/27286/135562122-a2a8a87f-68ee-4f3f-a777-f78250149f94.png)

Fixes #1246.