### PR TITLE
Add new networking API features to Ingress

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.4
+version: 0.4.5
 appVersion: "0.18.3"
 description: Trivy helm chart
 keywords:
@@ -8,4 +8,4 @@ keywords:
   - trivy
   - vulnerability
 sources:
-- https://github.com/aquasecurity/trivy
+  - https://github.com/aquasecurity/trivy

--- a/helm/trivy/templates/ingress.yaml
+++ b/helm/trivy/templates/ingress.yaml
@@ -1,6 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "trivy.fullname" . -}}
+{{- $apiV1 := false -}}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0" .Capabilities.KubeVersion.Version) -}}
+apiVersion: networking.k8s.io/v1
+{{- $apiV1 = true -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "trivy.fullname" . }}
@@ -12,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if and (.Values.ingress.ingressClassName) (semverCompare ">= v1.18.0" .Capabilities.KubeVersion.Version) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -27,9 +36,19 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          {{- if $apiV1 }}
+          - path: {{ $.Values.ingress.path }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $.Values.service.port -}}
+          {{- else }}
           - path: {{ $.Values.ingress.path }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $.Values.service.port -}}
+          {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -95,11 +95,15 @@ service:
 
 ingress:
   enabled: false
+  # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+  ingressClassName:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
   hosts:
     - host: trivy.example.com
   path: "/"
+  # type is only needed for networking.k8s.io/v1 in k8s 1.19+
+  pathType: Prefix
   tls: []
   #  - secretName: trivy-example-tls
   #    hosts:


### PR DESCRIPTION
This PR adds `v1` of the networking API introduced with k8s 1.19.
It also adds the new field `ingressClassName` introduced with k8s 1.18.

Fixes #1261