### PR TITLE
chore: send debug and info logs to stdout in install.sh, not stderr.

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -182,11 +182,11 @@ log_tag() {
 }
 log_debug() {
   log_priority 7 || return 0
-  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+  echo "$(log_prefix)" "$(log_tag 7)" "$@"
 }
 log_info() {
   log_priority 6 || return 0
-  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+  echo "$(log_prefix)" "$(log_tag 6)" "$@"
 }
 log_err() {
   log_priority 3 || return 0


### PR DESCRIPTION
The current install.sh script logs all messages to stderr via ```echoerr()``` function, including debug and info; debug and info should go to stdout.

Since godownloader was used to generate install.sh and that project is no longer maintained, it seems reasonable to update install.sh here and simply ```echo``` info and debug messages.