### PR TITLE
feat(commands): remove deprecated options

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -312,25 +312,6 @@ var (
 		stringSliceFlag(skipFiles),
 		stringSliceFlag(skipDirs),
 	}
-
-	// deprecated options
-	deprecatedFlags = []cli.Flag{
-		&cli.StringFlag{
-			Name:    "only-update",
-			Usage:   "deprecated",
-			EnvVars: []string{"TRIVY_ONLY_UPDATE"},
-		},
-		&cli.BoolFlag{
-			Name:    "refresh",
-			Usage:   "deprecated",
-			EnvVars: []string{"TRIVY_REFRESH"},
-		},
-		&cli.BoolFlag{
-			Name:    "auto-refresh",
-			Usage:   "deprecated",
-			EnvVars: []string{"TRIVY_AUTO_REFRESH"},
-		},
-	}
 )
 
 // NewApp is the factory method to return Trivy CLI
@@ -346,8 +327,7 @@ func NewApp(version string) *cli.App {
 	app.Usage = "A simple and comprehensive vulnerability scanner for containers"
 	app.EnableBashCompletion = true
 
-	flags := append(globalFlags, setHidden(deprecatedFlags, true)...)
-	flags = append(flags, setHidden(imageFlags, true)...)
+	flags := append(globalFlags, setHidden(imageFlags, true)...)
 
 	app.Flags = flags
 	app.Commands = []*cli.Command{

--- a/pkg/commands/artifact/option.go
+++ b/pkg/commands/artifact/option.go
@@ -16,13 +16,6 @@ type Option struct {
 	option.ReportOption
 	option.CacheOption
 	option.ConfigOption
-
-	// deprecated
-	onlyUpdate string
-	// deprecated
-	refresh bool
-	// deprecated
-	autoRefresh bool
 }
 
 // NewOption is the factory method to return options
@@ -40,19 +33,11 @@ func NewOption(c *cli.Context) (Option, error) {
 		ReportOption:   option.NewReportOption(c),
 		CacheOption:    option.NewCacheOption(c),
 		ConfigOption:   option.NewConfigOption(c),
-
-		onlyUpdate:  c.String("only-update"),
-		refresh:     c.Bool("refresh"),
-		autoRefresh: c.Bool("auto-refresh"),
 	}, nil
 }
 
 // Init initializes the artifact options
 func (c *Option) Init() error {
-	if c.onlyUpdate != "" || c.refresh || c.autoRefresh {
-		c.Logger.Warn("--only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.")
-	}
-
 	if err := c.initPreScanOptions(); err != nil {
 		return err
 	}

--- a/pkg/commands/artifact/option_test.go
+++ b/pkg/commands/artifact/option_test.go
@@ -94,25 +94,6 @@ func TestOption_Init(t *testing.T) {
 			},
 		},
 		{
-			name: "deprecated options",
-			args: []string{"--only-update", "alpine", "--severity", "LOW", "debian:buster"},
-			logs: []string{
-				"--only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.",
-			},
-			want: Option{
-				ReportOption: option.ReportOption{
-					Severities:     []dbTypes.Severity{dbTypes.SeverityLow},
-					Output:         os.Stdout,
-					VulnType:       []string{types.VulnTypeOS, types.VulnTypeLibrary},
-					SecurityChecks: []string{types.SecurityCheckVulnerability},
-				},
-				ArtifactOption: option.ArtifactOption{
-					Target: "debian:buster",
-				},
-				onlyUpdate: "alpine",
-			},
-		},
-		{
 			name: "invalid option combination: --template enabled without --format",
 			args: []string{"--template", "@contrib/gitlab.tpl", "gitlab/gitlab-ce:12.7.2-ce.0"},
 			logs: []string{
@@ -196,11 +177,9 @@ func TestOption_Init(t *testing.T) {
 			set.Bool("reset", false, "")
 			set.Bool("skip-db-update", false, "")
 			set.Bool("download-db-only", false, "")
-			set.Bool("auto-refresh", false, "")
 			set.String("severity", "CRITICAL", "")
 			set.String("vuln-type", "os,library", "")
 			set.String("security-checks", "vuln", "")
-			set.String("only-update", "", "")
 			set.String("template", "", "")
 			set.String("format", "", "")
 


### PR DESCRIPTION
## Description
This PR removes the following options:
- `--only-update`
- `--refresh`
- `--auto-refresh`

These options were deprecated a while ago and the warning has been displayed.

```
2021-10-04T14:18:32.603+0300    WARN    --only-update, --refresh and --auto-refresh are unnecessary and ignored now. These commands will be removed in the next version.
```

This PR finally removed them.