### PR TITLE
fix(docs): fix template paths

### DIFF
--- a/docs/vulnerability/examples/report.md
+++ b/docs/vulnerability/examples/report.md
@@ -186,13 +186,13 @@ $ trivy image --format template --template "@/path/to/template" golang:1.12-alpi
 #### XML
 In the following example using the template `junit.tpl` XML can be generated.
 ```
-$ trivy image --format template --template "@contrib/junit.tpl" -o junit-report.xml  golang:1.12-alpine
+$ trivy image --format template --template "@/contrib/junit.tpl" -o junit-report.xml  golang:1.12-alpine
 ```
 
 #### SARIF
 In the following example using the template `sarif.tpl` [Sarif][sarif] can be generated.
 ```
-$ trivy image --format template --template "@contrib/sarif.tpl" -o report.sarif  golang:1.12-alpine
+$ trivy image --format template --template "@/contrib/sarif.tpl" -o report.sarif  golang:1.12-alpine
 ```
 This SARIF format can be uploaded to GitHub code scanning results, and there is a [Trivy GitHub Action][action] for automating this process.
 
@@ -201,7 +201,7 @@ Trivy also supports an [ASFF template for reporting findings to AWS Security Hub
 #### HTML
 
 ```
-$ trivy image --format template --template "@contrib/html.tpl" -o report.html golang:1.12-alpine
+$ trivy image --format template --template "@/contrib/html.tpl" -o report.html golang:1.12-alpine
 ```
 
 [new-json]: https://github.com/aquasecurity/trivy/discussions/1050


### PR DESCRIPTION
fix template paths for xml, sarif and html example