### PR TITLE
fix(cli): fix incorrect comparison of DB metadata type.

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -410,9 +410,9 @@ func showVersion(cacheDir, outputFormat, version string, outputWriter io.Writer)
 		if dbMeta != nil {
 			var dbType string
 			switch dbMeta.Type {
-			case 0:
+			case db.TypeFull:
 				dbType = "Full"
-			case 1:
+			case db.TypeLight:
 				dbType = "Light"
 			}
 			output += fmt.Sprintf(`Vulnerability DB:

--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -35,7 +35,7 @@ func Test_showVersion(t *testing.T) {
 			},
 			expectedOutput: `Version: v1.2.3
 Vulnerability DB:
-  Type: Light
+  Type: Full
   Version: 42
   UpdatedAt: 2020-03-16 23:40:20 +0000 UTC
   NextUpdate: 2020-03-16 23:57:00 +0000 UTC


### PR DESCRIPTION
Fix incorrect comparison of DB metadata type.

-- Incorrect Db metadata type comparison resulted in wrong print in show version.

This fixes #1275.

Signed-off-by: Bes Dollma <besi7dollma@gmail.com>