### PR TITLE
feat(javascript) : Initialize npm driver for javascript packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20211005172059-69527b46560c
+	github.com/aquasecurity/fanal v0.0.0-20211007060930-f7efd1b3357e
 	github.com/aquasecurity/go-dep-parser v0.0.0-20210919151457-76db061b9305
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/fanal v0.0.0-20211005172059-69527b46560c h1:pBpjKZpfpWdcotMqZ2J6hMI/lDK5pKshdj2o7+xzLkg=
-github.com/aquasecurity/fanal v0.0.0-20211005172059-69527b46560c/go.mod h1:nXdCM1C89phZEkn/sHQ6S5IjcvxdTnXLSKcftmhFodg=
+github.com/aquasecurity/fanal v0.0.0-20211007060930-f7efd1b3357e h1:SoOAaEMLjW7S9wnxH6c24bVdhfX+wty1o3XQF0bhp6o=
+github.com/aquasecurity/fanal v0.0.0-20211007060930-f7efd1b3357e/go.mod h1:nXdCM1C89phZEkn/sHQ6S5IjcvxdTnXLSKcftmhFodg=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210919151457-76db061b9305 h1:xsniAD6IrP+stY8tkytxE2tk8czkzSN3XaUvzoi1hCk=
 github.com/aquasecurity/go-dep-parser v0.0.0-20210919151457-76db061b9305/go.mod h1:Zc7Eo6tFl9l4XcqsWeabD7jHnXRBK/LdgZuu9GTSVLU=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -31,7 +31,7 @@ func NewDriver(libType string) (Driver, error) {
 		driver = newCargoDriver()
 	case ftypes.Composer:
 		driver = newComposerDriver()
-	case ftypes.Npm, ftypes.Yarn, ftypes.NodePkg:
+	case ftypes.Npm, ftypes.Yarn, ftypes.NodePkg, ftypes.JavaScript:
 		driver = newNpmDriver()
 	case ftypes.Pipenv, ftypes.Poetry, ftypes.Pip, ftypes.PythonPkg:
 		driver = newPipDriver()


### PR DESCRIPTION
This commit adds functionality to initialise npm driver for javascript packages which are detected by custom js analyser

