### PR TITLE
chore(release): bump up GoReleaser to v0.182.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.164.0
+          version: v0.182.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}


### PR DESCRIPTION
## Description
GoReleaser less than v0.175.0 accidentally ignores darwin/arm64 with Go 1.17.

## Issue
Close https://github.com/aquasecurity/trivy/issues/1296

## Reference
https://github.com/goreleaser/goreleaser/issues/2412
