### PR TITLE
docs: typo fix

### DIFF
--- a/docs/vulnerability/detection/language.md
+++ b/docs/vulnerability/detection/language.md
@@ -2,7 +2,7 @@
 
 `Trivy` automatically detects the following files in the container and scans vulnerabilities in the application dependencies.
 
-| Language | File                     | Image[^6] | Rootfs[^7] | Filesysetm[^8] |  Repository[^9] |Dev dependencies |
+| Language | File                     | Image[^6] | Rootfs[^7] | Filesystem[^8] |  Repository[^9] |Dev dependencies |
 |----------|--------------------------|:---------:|:----------:|:--------------:|:---------------:|-----------------|
 | Ruby     | Gemfile.lock             | -         | -          | ✅             | ✅              | included        |
 |          | gemspec                  | ✅        | ✅         | -              | -               | included        |


### PR DESCRIPTION
Just fixing a typo in the docs "Filesysetm" --> "Filesystem"