### PR TITLE
docs: add section about Github API Token to db

### DIFF
--- a/docs/vulnerability/examples/db.md
+++ b/docs/vulnerability/examples/db.md
@@ -72,3 +72,10 @@ Total: 3 (UNKNOWN: 0, LOW: 1, MEDIUM: 2, HIGH: 0, CRITICAL: 0)
 +---------+------------------+----------+-------------------+---------------+
 ```
 </details>
+
+## Using a Github API token
+Trivy downloads its vulnerability information directly from Github (https://github.com/aquasecurity/trivy-db/releases). This is an anynoymous API call that is limited to 60 requests per hour. 
+
+This rate limit can be reached on bigger workloads so it is possible to increase the rate limit to 5000 API call per hour by providing a Github API token (see https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line about how to create a token).
+
+The environment variable `GITHUB_TOKEN` has to be set with the Github API token. Trivy will then use this token to download the Trivy-DB.


### PR DESCRIPTION
On our project we encountered issues with the Github API limit when using Trivy. I was digging a bit into the trivy code and found that there is the possibility to provide a Github API token (which is great btw!). It was not mentioned in the docu so I thought this should be mentioned there.

As review the env variable is read here: https://github.com/aquasecurity/trivy/blob/main/pkg/github/github.go#L63
The helm configuration also mentions the token: https://github.com/aquasecurity/trivy/blob/main/helm/trivy/values.yaml#L55

Feel free to improve my spelling as I am not a native speaker.