### PR TITLE
chore: bump GoReleaser to v0.183.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.182.1
+          version: v0.183.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}


### PR DESCRIPTION
Fixes aquasecurity/homebrew-trivy#2