### PR TITLE
chore: fix issues with Homebrew formula

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -86,9 +86,9 @@ brews:
       owner: aquasecurity
       name: homebrew-trivy
     homepage: "https://github.com/aquasecurity/trivy"
-    description: ""
+    description: "Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues"
     test: |
-      system "#{bin}/trivy --version"
+      system "#{bin}/trivy", "--version"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
```
$ brew audit trivy
aquasecurity/trivy/trivy:
  * 6: col 3: The desc (description) should not be an empty string.
  * 38: col 12: Separate `system` commands into `"#{bin}/trivy", "--version"`
Error: 2 problems in 1 formula detected
```