### PR TITLE
Provide --ignore-ids command line

### DIFF
--- a/docs/getting-started/cli/client.md
+++ b/docs/getting-started/cli/client.md
@@ -19,6 +19,7 @@ OPTIONS:
    --removed-pkgs              detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
    --vuln-type value           comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
    --ignorefile value          specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
+   --ignore-ids value          comma-separated list of CVEs to ignore (default: "") [$TRIVY_IGNORE_IDS]
    --timeout value             timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --ignore-policy value       specify the Rego file to evaluate each vulnerability [$TRIVY_IGNORE_POLICY]
    --list-all-pkgs             enabling the option will output all packages regardless of vulnerability (default: false) [$TRIVY_LIST_ALL_PKGS]

--- a/docs/getting-started/cli/config.md
+++ b/docs/getting-started/cli/config.md
@@ -17,6 +17,7 @@ OPTIONS:
    --reset                                        remove all caches and database (default: false) [$TRIVY_RESET]
    --clear-cache, -c                              clear image caches without scanning (default: false) [$TRIVY_CLEAR_CACHE]
    --ignorefile value                             specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
+   --ignore-ids value          comma-separated list of CVEs to ignore (default: "") [$TRIVY_IGNORE_IDS]
    --timeout value                                timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --skip-files value                             specify the file paths to skip traversal [$TRIVY_SKIP_FILES]
    --skip-dirs value                              specify the directories where the traversal is skipped [$TRIVY_SKIP_DIRS]

--- a/docs/getting-started/cli/image.md
+++ b/docs/getting-started/cli/image.md
@@ -23,6 +23,7 @@ OPTIONS:
    --removed-pkgs              detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
    --vuln-type value           comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
    --ignorefile value          specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
+   --ignore-ids value          comma-separated list of CVEs to ignore (default: "") [$TRIVY_IGNORE_IDS]
    --timeout value             timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --light                     light mode: it's faster, but vulnerability descriptions and references are not displayed (default: false) [$TRIVY_LIGHT]
    --ignore-policy value       specify the Rego file to evaluate each vulnerability [$TRIVY_IGNORE_POLICY]

--- a/docs/getting-started/cli/repo.md
+++ b/docs/getting-started/cli/repo.md
@@ -20,6 +20,7 @@ OPTIONS:
    --removed-pkgs              detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
    --vuln-type value           comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
    --ignorefile value          specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
+   --ignore-ids value          comma-separated list of CVEs to ignore (default: "") [$TRIVY_IGNORE_IDS]
    --cache-backend value       cache backend (e.g. redis://localhost:6379) (default: "fs") [$TRIVY_CACHE_BACKEND]
    --timeout value             timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --no-progress               suppress progress bar (default: false) [$TRIVY_NO_PROGRESS]

--- a/docs/getting-started/cli/rootfs.md
+++ b/docs/getting-started/cli/rootfs.md
@@ -20,6 +20,7 @@ OPTIONS:
    --vuln-type value                              comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
    --security-checks value                        comma-separated list of what security issues to detect (vuln,config) (default: "vuln") [$TRIVY_SECURITY_CHECKS]
    --ignorefile value                             specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
+   --ignore-ids value          comma-separated list of CVEs to ignore (default: "") [$TRIVY_IGNORE_IDS]
    --cache-backend value                          cache backend (e.g. redis://localhost:6379) (default: "fs") [$TRIVY_CACHE_BACKEND]
    --timeout value                                timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --no-progress                                  suppress progress bar (default: false) [$TRIVY_NO_PROGRESS]

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -531,10 +531,7 @@ func setupClient(t *testing.T, c csArgs, addr string, cacheDir string, golden st
 	}
 
 	if len(c.IgnoreIDs) != 0 {
-		trivyIgnore := filepath.Join(t.TempDir(), ".trivyignore")
-		err := os.WriteFile(trivyIgnore, []byte(strings.Join(c.IgnoreIDs, "\n")), 0444)
-		require.NoError(t, err, "failed to write .trivyignore")
-		osArgs = append(osArgs, []string{"--ignorefile", trivyIgnore}...)
+		osArgs = append(osArgs, []string{"--ignore-ids", strings.Join(",", c.IgnoreIDs)}...)
 	}
 	if c.ClientToken != "" {
 		osArgs = append(osArgs, []string{"--token", c.ClientToken, "--token-header", c.ClientTokenHeader}...)

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -175,6 +175,13 @@ var (
 		EnvVars: []string{"TRIVY_IGNOREFILE"},
 	}
 
+	ignoreIDsFlag = cli.StringFlag{
+		Name:    "ignore-ids",
+		Value:   "",
+		Usage:   "specify comma-separated list of CVE IDs to ignore",
+		EnvVars: []string{"TRIVY_IGNORE_IDS"},
+	}
+
 	timeoutFlag = cli.DurationFlag{
 		Name:    "timeout",
 		Value:   time.Second * 300,

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -219,12 +219,13 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 }
 
 func filter(ctx context.Context, opt Option, report pkgReport.Report) (pkgReport.Report, error) {
+	ignoreIds := utils.ReadIgnoreFile(opt.IgnoreFile)
 	resultClient := initializeResultClient()
 	results := report.Results
 	for i := range results {
 		resultClient.FillVulnerabilityInfo(results[i].Vulnerabilities, results[i].Type)
 		vulns, misconfSummary, misconfs, err := resultClient.Filter(ctx, results[i].Vulnerabilities, results[i].Misconfigurations,
-			opt.Severities, opt.IgnoreUnfixed, opt.IncludeNonFailures, opt.IgnoreFile, opt.IgnorePolicy)
+			opt.Severities, opt.IgnoreUnfixed, opt.IncludeNonFailures, ignoreIds, opt.IgnorePolicy)
 		if err != nil {
 			return pkgReport.Report{}, xerrors.Errorf("unable to filter vulnerabilities: %w", err)
 		}

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -73,9 +73,18 @@ func runWithTimeout(ctx context.Context, opt Option) error {
 
 	resultClient := initializeResultClient()
 	results := report.Results
+
+	var ignoredIDs []string
+	if opt.IgnoreFile != "" {
+		ignoredIDs = utils.ReadIgnoreFile(opt.IgnoreFile)
+	}
+	if opt.IgnoredIDs != nil {
+		ignoredIDs = append(ignoredIDs, opt.IgnoredIDs...)
+	}
+
 	for i := range results {
 		vulns, misconfSummary, misconfs, err := resultClient.Filter(ctx, results[i].Vulnerabilities, results[i].Misconfigurations,
-			opt.Severities, opt.IgnoreUnfixed, opt.IncludeNonFailures, opt.IgnoreFile, opt.IgnorePolicy)
+			opt.Severities, opt.IgnoreUnfixed, opt.IncludeNonFailures, ignoredIDs, opt.IgnorePolicy)
 		if err != nil {
 			return xerrors.Errorf("filter error: %w", err)
 		}

--- a/pkg/commands/option/report.go
+++ b/pkg/commands/option/report.go
@@ -28,12 +28,14 @@ type ReportOption struct {
 	securityChecks string
 	output         string
 	severities     string
+	ignoredIds     string
 
 	// these variables are populated by Init()
 	VulnType       []string
 	SecurityChecks []string
 	Output         *os.File
 	Severities     []dbTypes.Severity
+	IgnoredIDs     []string
 }
 
 // NewReportOption is the factory method to return ReportOption
@@ -48,6 +50,7 @@ func NewReportOption(c *cli.Context) ReportOption {
 		securityChecks: c.String("security-checks"),
 		severities:     c.String("severity"),
 		IgnoreFile:     c.String("ignorefile"),
+		ignoredIds:     c.String("ignore-ids"),
 		IgnoreUnfixed:  c.Bool("ignore-unfixed"),
 		ExitCode:       c.Int("exit-code"),
 	}
@@ -69,7 +72,7 @@ func (c *ReportOption) Init(logger *zap.SugaredLogger) error {
 	}
 
 	c.Severities = splitSeverity(logger, c.severities)
-
+	c.IgnoredIDs = splitIgnoreIds(logger, c.ignoredIds)
 	if err = c.populateVulnTypes(); err != nil {
 		return xerrors.Errorf("vuln type: %w", err)
 	}
@@ -124,4 +127,12 @@ func splitSeverity(logger *zap.SugaredLogger, severity string) []dbTypes.Severit
 		severities = append(severities, severity)
 	}
 	return severities
+}
+
+func splitIgnoreIds(logger *zap.SugaredLogger, ignoreIds string) []string {
+	logger.Debugf("Ignore IDs: %s", ignoreIds)
+	if ignoreIds == "" {
+		return nil
+	}
+	return strings.Split(ignoreIds, ",")
 }

--- a/pkg/commands/option/report_test.go
+++ b/pkg/commands/option/report_test.go
@@ -23,6 +23,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 		securityChecks string
 		severities     string
 		IgnoreFile     string
+		IgnoredIDs     []string
 		IgnoreUnfixed  bool
 		ExitCode       int
 		VulnType       []string
@@ -149,6 +150,7 @@ func TestReportReportConfig_Init(t *testing.T) {
 				securityChecks: tt.fields.securityChecks,
 				severities:     tt.fields.severities,
 				IgnoreFile:     tt.fields.IgnoreFile,
+				IgnoredIDs:     tt.fields.IgnoredIDs,
 				IgnoreUnfixed:  tt.fields.IgnoreUnfixed,
 				ExitCode:       tt.fields.ExitCode,
 				Output:         tt.fields.Output,

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -10,11 +10,12 @@ import (
 	ftypes "github.com/aquasecurity/fanal/types"
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/aquasecurity/trivy-db/pkg/utils"
+	dbUtils "github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
 	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/utils"
 )
 
 func TestClient_FillVulnerabilityInfo(t *testing.T) {
@@ -45,8 +46,8 @@ func TestClient_FillVulnerabilityInfo(t *testing.T) {
 						Description:      "dos vulnerability",
 						Severity:         dbTypes.SeverityMedium.String(),
 						References:       []string{"http://example.com"},
-						LastModifiedDate: utils.MustTimeParse("2020-01-01T01:01:00Z"),
-						PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
+						LastModifiedDate: dbUtils.MustTimeParse("2020-01-01T01:01:00Z"),
+						PublishedDate:    dbUtils.MustTimeParse("2001-01-01T01:01:00Z"),
 					},
 					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2019-0001",
 				},
@@ -69,8 +70,8 @@ func TestClient_FillVulnerabilityInfo(t *testing.T) {
 						Description:      "dos vulnerability",
 						Severity:         dbTypes.SeverityLow.String(),
 						References:       []string{"http://example.com"},
-						LastModifiedDate: utils.MustTimeParse("2020-01-01T01:01:00Z"),
-						PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
+						LastModifiedDate: dbUtils.MustTimeParse("2020-01-01T01:01:00Z"),
+						PublishedDate:    dbUtils.MustTimeParse("2001-01-01T01:01:00Z"),
 					},
 					SeveritySource: vulnerability.NVD,
 					PrimaryURL:     "https://avd.aquasec.com/nvd/cve-2019-0002",
@@ -225,8 +226,8 @@ func TestClient_FillVulnerabilityInfo(t *testing.T) {
 						Description:      "dos vulnerability",
 						Severity:         dbTypes.SeverityLow.String(),
 						References:       []string{"http://example.com"},
-						LastModifiedDate: utils.MustTimeParse("2020-01-01T01:01:00Z"),
-						PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
+						LastModifiedDate: dbUtils.MustTimeParse("2020-01-01T01:01:00Z"),
+						PublishedDate:    dbUtils.MustTimeParse("2001-01-01T01:01:00Z"),
 					},
 					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2019-0001",
 				},
@@ -753,8 +754,9 @@ func TestClient_Filter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Client{}
+			ignoredIDs := utils.ReadIgnoreFile(tt.args.ignoreFile)
 			gotVulns, gotMisconfSummary, gotMisconfs, err := c.Filter(context.Background(), tt.args.vulns, tt.args.misconfs,
-				tt.args.severities, tt.args.ignoreUnfixed, false, tt.args.ignoreFile, tt.args.policyFile)
+				tt.args.severities, tt.args.ignoreUnfixed, false, ignoredIDs, tt.args.policyFile)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantVulns, gotVulns)
 			assert.Equal(t, tt.wantMisconfSummary, gotMisconfSummary)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -126,4 +127,28 @@ func CopyFile(src, dst string) (int64, error) {
 	defer destination.Close()
 	n, err := io.Copy(destination, source)
 	return n, err
+}
+
+// ReadIgnoreFile reads the ignore file and retuns a list
+// of the vulnerability IDs to ignore
+func ReadIgnoreFile(ignoreFile string) []string {
+	var ignoredIDs []string
+	if ignoreFile == "" {
+		return ignoredIDs
+	}
+	f, err := os.Open(ignoreFile)
+	if err != nil {
+		// trivy must work even if no .trivyignore exist
+		return ignoredIDs
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		ignoredIDs = append(ignoredIDs, line)
+	}
+	return ignoredIDs
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -187,3 +187,38 @@ func TestCopyFile(t *testing.T) {
 		})
 	}
 }
+
+func TestReadIgnoreFile(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		content []byte
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "empty ignore file",
+			content: []byte(""),
+			want:    nil,
+		},
+		{
+			name:    "ignore file with content",
+			content: []byte("CVE-123\nCVE-245"),
+			want:    []string{"CVE-123", "CVE-245"},
+		},
+		{
+			name:    "ignore file with comments and blanks",
+			content: []byte("CVE-123\n#ignore me\n\nCVE-245"),
+			want:    []string{"CVE-123", "CVE-245"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ignore, err := os.CreateTemp("", "ignore")
+			require.NoError(t, err, tt.name)
+			ignore.Write([]byte(tt.content))
+			got := ReadIgnoreFile(ignore.Name())
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
While .trivyignore is useful, passing a CLI arg of vulnerability
IDs to ignore is easier when running under CI or any environment
where writing files (e.g. through mounting volumes) is at all tricky.