### PR TITLE
fix(helm): externalize env vars to configMap

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.7
+version: 0.4.8
 appVersion: "0.21.0"
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/templates/configmap.yaml
+++ b/helm/trivy/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+data:
+  TRIVY_LISTEN: "0.0.0.0:{{ .Values.service.port }}"
+  TRIVY_CACHE_DIR: "/home/scanner/.cache/trivy"
+{{- if .Values.trivy.cache.redis.enabled }}
+  TRIVY_CACHE_BACKEND: {{ .Values.trivy.cache.redis.url | quote }}
+{{- end }}
+  TRIVY_DEBUG: {{ .Values.trivy.debugMode | quote }}
+  TRIVY_SKIP_UPDATE: {{ .Values.trivy.skipUpdate | quote }}
+{{- if .Values.httpProxy }}
+  HTTP_PROXY: {{ .Values.httpProxy | quote }}
+{{- end }}
+{{- if .Values.httpsProxy }}
+  HTTPS_PROXY: {{ .Values.httpsProxy | quote }}
+{{- end }}
+{{- if .Values.noProxy }}
+  NO_PROXY: {{ .Values.noProxy | quote }}
+{{- end }}

--- a/helm/trivy/templates/secret.yaml
+++ b/helm/trivy/templates/secret.yaml
@@ -6,4 +6,4 @@ metadata:
 {{ include "trivy.labels" . | indent 4 }}
 type: Opaque
 data:
-  gitHubToken: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+  GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -62,30 +62,11 @@ spec:
           {{- end }}
           args:
             - server
-          env:
-            - name: "TRIVY_LISTEN"
-              value: "0.0.0.0:{{ .Values.service.port | default 4954 }}"
-            - name: "TRIVY_CACHE_DIR"
-              value: "/home/scanner/.cache/trivy"
-            {{- if .Values.trivy.cache.redis.enabled }}
-            - name: "TRIVY_CACHE_BACKEND"
-              value: {{ .Values.trivy.cache.redis.url | quote }}
-            {{- end }}
-            - name: "TRIVY_DEBUG"
-              value: {{ .Values.trivy.debugMode | default false | quote }}
-            - name: "TRIVY_SKIP_UPDATE"
-              value: {{ .Values.trivy.skipUpdate | default false | quote }}
-            - name: "GITHUB_TOKEN"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "trivy.fullname" . }}
-                  key: gitHubToken
-            - name: "HTTP_PROXY"
-              value: {{ .Values.httpProxy | quote }}
-            - name: "HTTPS_PROXY"
-              value: {{ .Values.httpsProxy | quote }}
-            - name: "NO_PROXY"
-              value: {{ .Values.noProxy | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "trivy.fullname" . }}
+            - secretRef:
+                name: {{ include "trivy.fullname" . }}
           ports:
             - name: trivy-http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
Asa mentioned in #1343, This is about storing environment variables into the right k8s resources : ConfigMap & Secret if it's sensitive data.
Once environment variables are stored in these resources, the pod definition can load these env vars with `spec.containers.envFrom` instead of putting directly the env vars with `spec.containers.env`.

This design has many benefits:

1. Meet k8s standards
2. distributed configuration
3. keeping pod template definition more stable as maintenance of env vars are shifted to configmap or/and secret template definition
4. Help to secure reading env vars with k8s RBAC ( .i.e restrict access to Secret resources, and pod exec verb )

