### PR TITLE
fix(gitlab tpl): Escape double quote

### DIFF
--- a/contrib/gitlab-codequality.tpl
+++ b/contrib/gitlab-codequality.tpl
@@ -13,7 +13,7 @@
       "type": "issue",
       "check_name": "container_scanning",
       "categories": [ "Security" ],
-      "description": "{{ .VulnerabilityID }}: {{ .Title }}",
+      "description": {{ cat .VulnerabilityID ": " .Title|toJson }},
       "content": {{ .Description | printf "%q" }},
       "severity": {{ if eq .Severity "LOW" -}}
                     "info"


### PR DESCRIPTION
The actual template does not work when there is double quote in the title.  It is the case for instance with the CVE-2018-11813. The produced json report is invalid and can't be parsed by GitLab.

The description below for CVE-2018-11813 is invalid around "cjpeg" .

```json
{
      "type": "issue",
      "check_name": "container_scanning",
      "categories": [ "Security" ],
      "description": "CVE-2018-11813 :  libjpeg: "cjpeg" utility large loop because read_pixel in rdtarga.c mishandles EOF",
      "content": "libjpeg 9c has a large loop because read_pixel in rdtarga.c mishandles EOF.",
      "severity": "info",
      "location": {
        "path": "libjpeg62-turbo-1:1.5.1-2",
        "lines": {
          "begin": 1
        }
      }
    },
```

I have tested the usage of the `cat` and `toJson` function to fix the problem and it seems to work fine.