### PR TITLE
fix(doc): gitlab integration

### DIFF
--- a/docs/advanced/integrations/gitlab-ci.md
+++ b/docs/advanced/integrations/gitlab-ci.md
@@ -135,14 +135,14 @@ trivy:
     # Build image
     - docker build -t $IMAGE .
     # Build report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab-codeclimate.tpl" -o gl-codeclimate.json $IMAGE
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate.json $IMAGE
   cache:
     paths:
       - .trivycache/
   # Enables https://docs.gitlab.com/ee/user/application_security/container_scanning/ (Container Scanning report is available on GitLab EE Ultimate or GitLab.com Gold)
   artifacts:
     paths:
-      gl-codeclimate.json
+      - gl-codeclimate.json
     reports:
       codequality: gl-codeclimate.json
 ```


### PR DESCRIPTION
The GitLab CI yml alernative does not work.

- yml invalid: `artifacts:paths` is a list and a `-` is missing
- `--template` option: there is no `contrib/gitlab-codeclimate.tpl` file, you meant `contrib/gitlab-codequality.tpl` instead

And I did not suggest a change, but I had to change the docker images from 'docker:stable' and 'docker:dind' respectively to 'docker:19-stable' and 'docker:19-dind'. This is probably due to my gitlab-runner configuration, but a note could help some others in my situation.