### PR TITLE
chore(release): add ubuntu older versions to deploy script

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEBIAN_RELEASES=$(debian-distro-info --supported)
-UBUNTU_RELEASES=$(ubuntu-distro-info --supported-esm)
+UBUNTU_RELEASES=$(sort <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported) | uniq)
 
 cd trivy-repo/deb
 

--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEBIAN_RELEASES=$(debian-distro-info --supported)
-UBUNTU_RELEASES=$(sort <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported) | uniq)
+UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-info --supported))
 
 cd trivy-repo/deb
 


### PR DESCRIPTION
`ubuntu-distro-info --supported` returns only versions: `bionic`, `focal`, `hirsute`, `impish` and `jammy`.

`ubuntu-distro-info --supported-esm` returns another versions: `trusty`, `xenial`, `bionic`, `focal` and `jammy`.

we should use the union of these sets for the release script .

Fixes #1194