### PR TITLE
docs: provide more information on scanning Google's GCR

### DIFF
--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -2,7 +2,7 @@
 None, Trivy uses Google Cloud SDK. You don't need to install `gcloud` command.
 
 # Privileges
-Credential file should have the `roles/storage.objectViewer` permissions.
+Credential file must have the `roles/storage.objectViewer` permissions.
 More information can be found in [Google's documentation](https://cloud.google.com/container-registry/docs/access-control)
 
 ## JSON File Format

--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -1,7 +1,41 @@
-Trivy uses Google Cloud SDK. You don't need to install `gcloud` command.
+# Requirements
+None, Trivy uses Google Cloud SDK. You don't need to install `gcloud` command.
 
-If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`.
+# Privileges
+Credential file should have the `roles/storage.objectViewer` permissions.
+More information can be found one [Google's documentation](https://cloud.google.com/container-registry/docs/access-control)
+
+## JSON File Format
+The JSON file specified has the following format (to know you are on the right track):
+
+```json
+{
+  "type": "service_account",
+  "project_id": "your_special_project",
+  "private_key_id": "XXXXXXXXXXXXXXXXXXXXxx",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nNONONONO\n-----END PRIVATE KEY-----\n",
+  "client_email": "somedude@your_special_project.iam.gserviceaccount.com",
+  "client_id": "1234567890",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/somedude%40your_special_project.iam.gserviceaccount.com"
+}
+```
+
+# Usage
+If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIALS`.
 ```bash
 # must set TRIVY_USERNAME empty char
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
+```
+
+# Testing
+You can test credentials in the following manner (assuming they are in `/tmp` on host machine).
+
+```bash
+docker run -it --rm -v /tmp:/tmp\
+  -v /var/run/docker.sock:/var/run/docker.sock\
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json\
+  aquasec/trivy image gcr.io/your_special_project/your_special_image:your_special_tag
 ```

--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -24,7 +24,7 @@ The JSON file specified should have the following format provided by google's se
 ```
 
 # Usage
-If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIALS`.
+If you want to use target project's repository, you can set them via `GOOGLE_APPLICATION_CREDENTIALS`.
 ```bash
 # must set TRIVY_USERNAME empty char
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json

--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -35,7 +35,6 @@ You can test credentials in the following manner (assuming they are in `/tmp` on
 
 ```bash
 docker run -it --rm -v /tmp:/tmp\
-  -v /var/run/docker.sock:/var/run/docker.sock\
   -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/service_account.json\
   aquasec/trivy image gcr.io/your_special_project/your_special_image:your_special_tag
 ```

--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -3,7 +3,7 @@ None, Trivy uses Google Cloud SDK. You don't need to install `gcloud` command.
 
 # Privileges
 Credential file should have the `roles/storage.objectViewer` permissions.
-More information can be found one [Google's documentation](https://cloud.google.com/container-registry/docs/access-control)
+More information can be found in [Google's documentation](https://cloud.google.com/container-registry/docs/access-control)
 
 ## JSON File Format
 The JSON file specified has the following format (to know you are on the right track):

--- a/docs/advanced/private-registries/gcr.md
+++ b/docs/advanced/private-registries/gcr.md
@@ -6,7 +6,7 @@ Credential file should have the `roles/storage.objectViewer` permissions.
 More information can be found in [Google's documentation](https://cloud.google.com/container-registry/docs/access-control)
 
 ## JSON File Format
-The JSON file specified has the following format (to know you are on the right track):
+The JSON file specified should have the following format provided by google's service account mechanisms:
 
 ```json
 {


### PR DESCRIPTION
I found setting up and using the GCR difficult to figure out the exact credentials needed and the expected file format. Part this was confusion caused ISSUE #783 which wasn't what I needed to know. Hopefully this saves someone else a lot of time.