### PR TITLE
[doc] Update git-repository.md with instruction about scanning private repos

### DIFF
--- a/docs/vulnerability/scanning/git-repository.md
+++ b/docs/vulnerability/scanning/git-repository.md
@@ -6,8 +6,6 @@ Scan your remote git repository
 $ trivy repo https://github.com/knqyf263/trivy-ci-test
 ```
 
-Only public repositories are supported.
-
 <details>
 <summary>Result</summary>
 
@@ -148,3 +146,20 @@ Total: 20 (UNKNOWN: 3, LOW: 0, MEDIUM: 7, HIGH: 5, CRITICAL: 5)
 ```
 
 </details>
+
+## Scanning Private Repositories
+
+In order to scan private GitHub or GitLab repositories, the environment variable `GITHUB_TOKEN` or `GITLAB_TOKEN` must be set, respectively, with a valid token that has access to the private repository being scanned.
+
+The `GITHUB_TOKEN` environment variable will take precedence over `GITLAB_TOKEN`, so if a private GitLab repository will be scanned, then `GITHUB_TOKEN` must be unset.
+
+For example:
+
+```
+$ export GITHUB_TOKEN="your_private_github_token"
+$ trivy repo <your private GitHub repo URL>
+$
+$ # or
+$ export GITLAB_TOKEN="your_private_gitlab_token"
+$ trivy repo <your private GitLab repo URL>
+```


### PR DESCRIPTION
Update instructions on how to scan private git repositories, as according to https://github.com/aquasecurity/fanal/pull/253 .