### PR TITLE
trivyignore filter : notice about too old file

### DIFF
--- a/docs/vulnerability/examples/filter.md
+++ b/docs/vulnerability/examples/filter.md
@@ -143,6 +143,11 @@ Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
 </details>
 
+Notice that a too old `.trivyignore` will be ignored by trivy and will produce the following log:
+```bash
+Trivy ignore file available but too old. Make a new commit to re-activate it.
+```
+
 ## By Type
 Use `--vuln-type` option.
 


### PR DESCRIPTION
As trivy user, I would like to find in the documentation a notice about too old `.trivyignore` file that trivy will ignore