### PR TITLE
feat: added misconfiguration field for html.tpl

### DIFF
--- a/contrib/html.tpl
+++ b/contrib/html.tpl
@@ -112,6 +112,30 @@
       </tr>
         {{- end }}
       {{- end }}
+      {{- if (eq (len .Misconfigurations ) 0) }}
+      <tr><th colspan="6">No Misconfigurations found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Type</th>
+        <th>Misconf ID</th>
+        <th>Check</th>
+        <th>Severity</th>
+        <th>Links</th>
+      </tr>
+        {{- range .Misconfigurations }}
+      <tr class="severity-{{ escapeXML .Severity }}">
+        <td class="misconf-type">{{ escapeXML .Type }}</td>
+        <td>{{ escapeXML .ID }}</td>
+        <td class="misconf-check">{{ escapeXML .Title }}</td>
+        <td class="severity">{{ escapeXML .Severity }}</td>
+        <td class="links" data-more-links="off">
+          {{- range .References }}
+          <a href={{ escapeXML . | printf "%q" }}>{{ escapeXML . }}</a>
+          {{- end }}
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
     {{- end }}
     </table>
 {{- else }}

--- a/contrib/html.tpl
+++ b/contrib/html.tpl
@@ -120,7 +120,7 @@
         <th>Misconf ID</th>
         <th>Check</th>
         <th>Severity</th>
-        <th>Links</th>
+        <th>Message</th>
       </tr>
         {{- range .Misconfigurations }}
       <tr class="severity-{{ escapeXML .Severity }}">
@@ -128,10 +128,11 @@
         <td>{{ escapeXML .ID }}</td>
         <td class="misconf-check">{{ escapeXML .Title }}</td>
         <td class="severity">{{ escapeXML .Severity }}</td>
-        <td class="links" data-more-links="off">
-          {{- range .References }}
-          <a href={{ escapeXML . | printf "%q" }}>{{ escapeXML . }}</a>
-          {{- end }}
+        <td class="link" data-more-links="off"  style="white-space:normal;"">
+          {{ escapeXML .Message }}
+          <br>
+            <a href={{ escapeXML .PrimaryURL | printf "%q" }}>{{ escapeXML .PrimaryURL }}</a>
+          </br>
         </td>
       </tr>
         {{- end }}

--- a/integration/testdata/alpine-310.html.golden
+++ b/integration/testdata/alpine-310.html.golden
@@ -232,6 +232,7 @@
           <a href="https://www.openssl.org/news/secadv/20190910.txt">https://www.openssl.org/news/secadv/20190910.txt</a>
         </td>
       </tr>
+      <tr><th colspan="6">No Misconfigurations found</th></tr>
     </table>
   </body>
 </html>


### PR DESCRIPTION
Trivi there is only tables of vulnerabilities for the html.tpl config.
For example.:
```
➜ ls
Dockerfile
➜  trivy config .

2021-12-09T10:45:09.460+0600	INFO	Detected config files: 1

Dockerfile (dockerfile)
=======================
Tests: 23 (SUCCESSES: 22, FAILURES: 1, EXCEPTIONS: 0)
Failures: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+---------------------------+------------+-----------+----------+------------------------------------------+
|           TYPE            | MISCONF ID |   CHECK   | SEVERITY |                 MESSAGE                  |
+---------------------------+------------+-----------+----------+------------------------------------------+
| Dockerfile Security Check |   DS002    | root user |   HIGH   | Specify at least 1 USER                  |
|                           |            |           |          | command in Dockerfile with               |
|                           |            |           |          | non-root user as argument                |
|                           |            |           |          | -->avd.aquasec.com/appshield/ds002       |
+---------------------------+------------+-----------+----------+------------------------------------------+
➜  trivy config --format=template --template='@contrib/html.tpl' .
```
Trivy now generates valid html with no misconfigurations: 
![misconf-old](https://user-images.githubusercontent.com/91113035/145336451-97831322-4717-457e-ae83-afd60da9c60a.png)

I added new tables for report misconfiguration:
![misconf-new](https://user-images.githubusercontent.com/91113035/145383202-2b80fe66-2ab8-4c00-a84b-5a79014a5937.png)



