### PR TITLE
feat(plugin): Add option to update plugin

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -686,6 +686,12 @@ func NewPluginCommand() *cli.Command {
 				ArgsUsage: "PLUGIN_NAME [PLUGIN_OPTIONS]",
 				Action:    plugin.Run,
 			},
+			{
+				Name:      "update",
+				Usage:     "update an existing plugin",
+				ArgsUsage: "PLUGIN_NAME",
+				Action:    plugin.Update,
+			},
 		},
 	}
 }

--- a/pkg/commands/plugin/plugin.go
+++ b/pkg/commands/plugin/plugin.go
@@ -90,6 +90,24 @@ func List(c *cli.Context) error {
 	return nil
 }
 
+// Update updates an existing plugin
+func Update(c *cli.Context) error {
+	if c.NArg() != 1 {
+		cli.ShowSubcommandHelpAndExit(c, 1)
+	}
+
+	if err := initLogger(c); err != nil {
+		return xerrors.Errorf("initialize error: %w", err)
+	}
+
+	pluginName := c.Args().First()
+	if err := plugin.Update(pluginName); err != nil {
+		return xerrors.Errorf("plugin update error: %w", err)
+	}
+
+	return nil
+}
+
 // Run runs the plugin
 func Run(c *cli.Context) error {
 	if c.NArg() < 1 {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/downloader"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -185,6 +185,35 @@ func Uninstall(name string) error {
 	return os.RemoveAll(pluginDir)
 }
 
+// Update updates an existing plugin
+func Update(name string) error {
+	pluginDir := filepath.Join(dir(), name)
+
+	if _, err := os.Stat(pluginDir); err != nil {
+		if os.IsNotExist(err) {
+			return xerrors.Errorf("could not find a plugin called '%s' to update: %w", name, err)
+		}
+		return err
+	}
+
+	plugin, err := loadMetadata(pluginDir)
+	if err != nil {
+		return err
+	}
+	log.Logger.Infof("Updating plugin '%s'", name)
+	updated, err := Install(nil, plugin.Repository, true)
+	if err != nil {
+		return xerrors.Errorf("unable to perform an update installation: %w", err)
+	}
+
+	if plugin.Version == updated.Version {
+		log.Logger.Infof("The %s plugin is the latest version. [%s]", name, plugin.Version)
+	} else {
+		log.Logger.Infof("Updated '%s' from %s to %s", name, plugin.Version, updated.Version)
+	}
+	return nil
+}
+
 // Information gets the information about an installed plugin
 func Information(name string) (string, error) {
 	pluginDir := filepath.Join(dir(), name)
@@ -206,7 +235,6 @@ Plugin: %s
   Description: %s
   Version:     %s
   Usage:       %s
-
 `, plugin.Name, plugin.Description, plugin.Version, plugin.Usage), nil
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -185,35 +185,6 @@ func Uninstall(name string) error {
 	return os.RemoveAll(pluginDir)
 }
 
-// Update updates an existing plugin
-func Update(name string) error {
-	pluginDir := filepath.Join(dir(), name)
-
-	if _, err := os.Stat(pluginDir); err != nil {
-		if os.IsNotExist(err) {
-			return xerrors.Errorf("could not find a plugin called '%s' to update: %w", name, err)
-		}
-		return err
-	}
-
-	plugin, err := loadMetadata(pluginDir)
-	if err != nil {
-		return err
-	}
-	log.Logger.Infof("Updating plugin '%s'", name)
-	updated, err := Install(nil, plugin.Repository, true)
-	if err != nil {
-		return xerrors.Errorf("unable to perform an update installation: %w", err)
-	}
-
-	if plugin.Version == updated.Version {
-		log.Logger.Infof("The %s plugin is the latest version. [%s]", name, plugin.Version)
-	} else {
-		log.Logger.Infof("Updated '%s' from %s to %s", name, plugin.Version, updated.Version)
-	}
-	return nil
-}
-
 // Information gets the information about an installed plugin
 func Information(name string) (string, error) {
 	pluginDir := filepath.Join(dir(), name)
@@ -256,6 +227,35 @@ func List() (string, error) {
 	}
 
 	return strings.Join(pluginList, "\n"), nil
+}
+
+// Update updates an existing plugin
+func Update(name string) error {
+	pluginDir := filepath.Join(dir(), name)
+
+	if _, err := os.Stat(pluginDir); err != nil {
+		if os.IsNotExist(err) {
+			return xerrors.Errorf("could not find a plugin called '%s' to update: %w", name, err)
+		}
+		return err
+	}
+
+	plugin, err := loadMetadata(pluginDir)
+	if err != nil {
+		return err
+	}
+	log.Logger.Infof("Updating plugin '%s'", name)
+	updated, err := Install(nil, plugin.Repository, true)
+	if err != nil {
+		return xerrors.Errorf("unable to perform an update installation: %w", err)
+	}
+
+	if plugin.Version == updated.Version {
+		log.Logger.Infof("The %s plugin is the latest version. [%s]", name, plugin.Version)
+	} else {
+		log.Logger.Infof("Updated '%s' from %s to %s", name, plugin.Version, updated.Version)
+	}
+	return nil
 }
 
 // LoadAll loads all plugins

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -316,7 +316,7 @@ description: A simple test plugin`
 	// Get Information for the plugin
 	info, err := plugin.Information(pluginName)
 	require.NoError(t, err)
-	assert.Equal(t, "\nPlugin: test_plugin\n  Description: A simple test plugin\n  Version:     0.1.0\n  Usage:       test\n\n", info)
+	assert.Equal(t, "\nPlugin: test_plugin\n  Description: A simple test plugin\n  Version:     0.1.0\n  Usage:       test\n", info)
 
 	// Get Information for unknown plugin
 	info, err = plugin.Information("unknown")


### PR DESCRIPTION
## Example usage

Update existing plugins to the latest version

### Updating existing that needs update

```bash
./trivy plugin update aqua

2021-12-13T09:12:54.577Z        INFO    Updating plugin 'aqua'
2021-12-13T09:12:54.577Z        INFO    Installing the plugin from github.com/aquasecurity/trivy-plugin-aqua...
2021-12-13T09:12:56.503Z        INFO    Loading the plugin metadata...
2021-12-13T09:12:58.535Z        INFO    Updated 'aqua' from v0.7.0 to v0.7.2
```
### Updating existing that does not need updating

```bash
./trivy plugin update aqua

2021-12-13T09:14:36.535Z        INFO    Updating plugin 'aqua'
2021-12-13T09:14:36.535Z        INFO    Installing the plugin from github.com/aquasecurity/trivy-plugin-aqua...
2021-12-13T09:14:38.373Z        INFO    Loading the plugin metadata...
2021-12-13T09:14:39.497Z        INFO    The aqua plugin is the latest version. [v0.7.2]
```

### Attempt to update not installed

```bash
./trivy plugin update not_installed

2021-12-13T09:15:27.344Z        FATAL   plugin uninstall error: Could not find a plugin called 'not_installed' to update
```

