### PR TITLE
Resolves #491 - Added capability to filter data sources.

### DIFF
--- a/docs/vulnerability/examples/filter.md
+++ b/docs/vulnerability/examples/filter.md
@@ -143,6 +143,19 @@ Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 
 </details>
 
+## By Severity Sources
+
+Use `.trivyignore`.
+
+```bash
+$ cat .trivyignore
+# Accept the severity source - the prefix is needed.
+SeveritySource: python-safety-db
+
+$ trivy image python:3.4-alpine3.9
+```
+
+
 ## By Type
 Use `--vuln-type` option.
 

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -334,13 +334,14 @@ func parseIgnoreFile(ignoreFile string) (ignoredIDs []string, excludedSeveritySo
 		if strings.HasPrefix(line, "#") || line == "" {
 			continue
 		}
-		// Check if the line is CVE that should be filtered.
-		if strings.HasPrefix(line, "CVE") {
-			cve := line
-			ignoredIDs = append(ignoredIDs, cve)
-		} else if strings.HasPrefix(line, "SeveritySource:") { // Check if the line is severity source that should be filtered.
+
+		// Check if the line is severity source that should be filtered.
+		if strings.HasPrefix(line, "SeveritySource:") {
 			severitySource := strings.TrimSpace(line[len("SeveritySource:"):])
 			excludedSeveritySources = append(excludedSeveritySources, severitySource)
+		} else { // Default is ignored ids (relevant for ignored vulnerabilities and ignored misconfigurations).
+			ignoredID := line
+			ignoredIDs = append(ignoredIDs, ignoredID)
 		}
 	}
 	return ignoredIDs, excludedSeveritySources


### PR DESCRIPTION
Fix [ISSUE 491](https://github.com/aquasecurity/trivy/issues/491)
Add capabillity to filter data sources.
Data sources should be mentiond in the .trivyignore file in the following format:

SeveritySource: python-safety-db