### PR TITLE
feat(config): add missing iac metadata

### DIFF
--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -308,6 +308,8 @@ func toDetectedMisconfiguration(res ftypes.MisconfResult, defaultSeverity dbType
 		Traces:      res.Traces,
 		IacMetadata: ftypes.IacMetadata{
 			Resource:  res.Resource,
+			Provider:  res.Provider,
+			Service:   res.Service,
 			StartLine: res.StartLine,
 			EndLine:   res.EndLine,
 		},


### PR DESCRIPTION
This is for the plugin to get the richer information

- Add missing IacMetdata for service and provider information
