### PR TITLE
BREAKING: disable JAR detection in fs/repo scanning

### DIFF
--- a/docs/vulnerability/detection/language.md
+++ b/docs/vulnerability/detection/language.md
@@ -17,6 +17,7 @@
 |          | package.json             | ✅        | ✅         |       -        |       -        | excluded        |
 | .NET     | packages.lock.json       | ✅        | ✅         |       ✅        |       ✅        | included        |
 | Java     | JAR/WAR/EAR[^3][^4]      | ✅        | ✅         |       -        |       -        | included        |
+|          | pom.xml                  | -         | -          |       ✅        |       ✅        | excluded        |
 | Go       | Binaries built by Go[^5] | ✅        | ✅         |       -        |       -        | excluded        |
 |          | go.sum                   | -         | -          |       ✅        |       ✅        | included        |
 

--- a/docs/vulnerability/detection/language.md
+++ b/docs/vulnerability/detection/language.md
@@ -2,23 +2,23 @@
 
 `Trivy` automatically detects the following files in the container and scans vulnerabilities in the application dependencies.
 
-| Language | File                     | Image[^6] | Rootfs[^7] | Filesystem[^8] |  Repository[^9] |Dev dependencies |
-|----------|--------------------------|:---------:|:----------:|:--------------:|:---------------:|-----------------|
-| Ruby     | Gemfile.lock             | -         | -          | ✅             | ✅              | included        |
-|          | gemspec                  | ✅        | ✅         | -              | -               | included        |
-| Python   | Pipfile.lock             | -         | -          | ✅             | ✅              | excluded        |
-|          | poetry.lock              | -         | -          | ✅             | ✅              | included        |
-|          | requirements.txt         | -         | -          | ✅             | ✅              | included        |
-|          | egg package[^1]          | ✅        | ✅         | -              | -               | excluded        |
-|          | wheel package[^2]        | ✅        | ✅         | -              | -               | excluded        |
-| PHP      | composer.lock            | ✅        | ✅         | ✅             | ✅              | excluded        |
-| Node.js  | package-lock.json        | -         | -          | ✅             | ✅              | excluded        |
-|          | yarn.lock                | -         | -          | ✅             | ✅              | included        |
-|          | package.json             | ✅        | ✅         | -              | -               | excluded        |
-| .NET     | packages.lock.json       | ✅        | ✅         | ✅             | ✅              | included        |
-| Java     | JAR/WAR/EAR[^3][^4]      | ✅        | ✅         | ✅             | ✅              | included        |
-| Go       | Binaries built by Go[^5] | ✅        | ✅         | -              | -               | excluded        |
-|          | go.sum                   | -         | -          | ✅             | ✅              | included        |
+| Language | File                     | Image[^6] | Rootfs[^7] | Filesystem[^8] | Repository[^9] |Dev dependencies |
+|----------|--------------------------|:---------:|:----------:|:--------------:|:--------------:|-----------------|
+| Ruby     | Gemfile.lock             | -         | -          |       ✅        |       ✅        | included        |
+|          | gemspec                  | ✅        | ✅         |       -        |       -        | included        |
+| Python   | Pipfile.lock             | -         | -          |       ✅        |       ✅        | excluded        |
+|          | poetry.lock              | -         | -          |       ✅        |       ✅        | included        |
+|          | requirements.txt         | -         | -          |       ✅        |       ✅        | included        |
+|          | egg package[^1]          | ✅        | ✅         |       -        |       -        | excluded        |
+|          | wheel package[^2]        | ✅        | ✅         |       -        |       -        | excluded        |
+| PHP      | composer.lock            | ✅        | ✅         |       ✅        |       ✅        | excluded        |
+| Node.js  | package-lock.json        | -         | -          |       ✅        |       ✅        | excluded        |
+|          | yarn.lock                | -         | -          |       ✅        |       ✅        | included        |
+|          | package.json             | ✅        | ✅         |       -        |       -        | excluded        |
+| .NET     | packages.lock.json       | ✅        | ✅         |       ✅        |       ✅        | included        |
+| Java     | JAR/WAR/EAR[^3][^4]      | ✅        | ✅         |       -        |       -        | included        |
+| Go       | Binaries built by Go[^5] | ✅        | ✅         |       -        |       -        | excluded        |
+|          | go.sum                   | -         | -          |       ✅        |       ✅        | included        |
 
 The path of these files does not matter.
 
@@ -27,7 +27,7 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 [^1]: `*.egg-info`, `*.egg-info/PKG-INFO`, `*.egg` and `EGG-INFO/PKG-INFO`
 [^2]: `.dist-info/META-DATA`
 [^3]: `*.jar`, `*.war`, and `*.ear`
-[^4]: It requires the Internet access
+[^4]: It requires Internet access
 [^5]: UPX-compressed binaries don't work
 [^6]: ✅ means "enabled" and `-` means "disabled" in the image scanning
 [^7]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning

--- a/docs/vulnerability/detection/language.md
+++ b/docs/vulnerability/detection/language.md
@@ -2,7 +2,7 @@
 
 `Trivy` automatically detects the following files in the container and scans vulnerabilities in the application dependencies.
 
-| Language | File                     | Image[^6] | Rootfs[^7] | Filesystem[^8] | Repository[^9] |Dev dependencies |
+| Language | File                     | Image[^7] | Rootfs[^8] | Filesystem[^9] | Repository[^10] |Dev dependencies |
 |----------|--------------------------|:---------:|:----------:|:--------------:|:--------------:|-----------------|
 | Ruby     | Gemfile.lock             | -         | -          |       ✅        |       ✅        | included        |
 |          | gemspec                  | ✅        | ✅         |       -        |       -        | included        |
@@ -17,8 +17,8 @@
 |          | package.json             | ✅        | ✅         |       -        |       -        | excluded        |
 | .NET     | packages.lock.json       | ✅        | ✅         |       ✅        |       ✅        | included        |
 | Java     | JAR/WAR/EAR[^3][^4]      | ✅        | ✅         |       -        |       -        | included        |
-|          | pom.xml                  | -         | -          |       ✅        |       ✅        | excluded        |
-| Go       | Binaries built by Go[^5] | ✅        | ✅         |       -        |       -        | excluded        |
+|          | pom.xml[^5]              | -         | -          |       ✅        |       ✅        | excluded        |
+| Go       | Binaries built by Go[^6] | ✅        | ✅         |       -        |       -        | excluded        |
 |          | go.sum                   | -         | -          |       ✅        |       ✅        | included        |
 
 The path of these files does not matter.
@@ -29,8 +29,9 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 [^2]: `.dist-info/META-DATA`
 [^3]: `*.jar`, `*.war`, and `*.ear`
 [^4]: It requires Internet access
-[^5]: UPX-compressed binaries don't work
-[^6]: ✅ means "enabled" and `-` means "disabled" in the image scanning
-[^7]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
-[^8]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
-[^9]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning
+[^5]: It requires Internet access when the POM doesn't exist in your local repository
+[^6]: UPX-compressed binaries don't work
+[^7]: ✅ means "enabled" and `-` means "disabled" in the image scanning
+[^8]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
+[^9]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
+[^10]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20211223181536-672696605858
-	github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2
+	github.com/aquasecurity/fanal v0.0.0-20211224100238-68daa38623b1
+	github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -207,10 +207,10 @@ github.com/aquasecurity/cfsec v0.2.2 h1:hq6MZlg7XFZsrerCv297N4HRlnJM7K6LLd/l/xCz
 github.com/aquasecurity/cfsec v0.2.2/go.mod h1:sUELRJqIPXTOZiHUx7TzyyFFzuk0W22IG6IWAoV8T6U=
 github.com/aquasecurity/defsec v0.0.37 h1:zdZndlKrW257b8VLK1UwfmXiyPuDrNA+wzBilHRk1LA=
 github.com/aquasecurity/defsec v0.0.37/go.mod h1:csaBEcJ3AKy44expnW0dCANEZcS/c1vcJjwBCbnKWBM=
-github.com/aquasecurity/fanal v0.0.0-20211223181536-672696605858 h1:K+OhavtHOe6weJpCvSDDiObrJDBk4hXtcqBBJ0mTzjE=
-github.com/aquasecurity/fanal v0.0.0-20211223181536-672696605858/go.mod h1:cLmcWHV2gIXcwNEOVVVoas/5wSyhIvMHJACbenvGUCg=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2 h1:B+lL7tKxen+aWygRCv5YRjwq08YokAEHMrTsrujURrc=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
+github.com/aquasecurity/fanal v0.0.0-20211224100238-68daa38623b1 h1:HCMCjzpRT1m/55RQGesoFCeNT/d2FrOEuQUt7mE6tnU=
+github.com/aquasecurity/fanal v0.0.0-20211224100238-68daa38623b1/go.mod h1:Uj+SCSOPxrU4xrxu9fFVvRWimkktPXv/VWzSfMx/dog=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab h1:/i0NsV3rYRcW0hkcCCrHmppX5rAr3rlWVIGKdeKBThU=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798 h1:eveqE9ivrt30CJ7dOajOfBavhZ4zPqHcZe/4tKp0alc=


### PR DESCRIPTION
## Description
Trivy looks for JAR files even in filesystem and repository scanning, though it should be only in container image scanning. It is no longer necessary as `pom.xml` is supported now.

Before:
- JAR scanning
  - image
  - filesystem
  - root filesystem
  - repository

After
- JAR scanning
  - image
  - root filesystem
- pom.xml scanning
  - filesystem
  - repository

## Blockers
- [x] https://github.com/aquasecurity/fanal/pull/350
  - Need to update `go.mod` after this PR gets merged.

## Notes
JAR scanning is disabled here.
- https://github.com/aquasecurity/trivy/blob/1c9ccb5e03b2b84f12aee0b96042e873fafcc64c/pkg/commands/artifact/fs.go#L34
- https://github.com/aquasecurity/trivy/blob/1c9ccb5e03b2b84f12aee0b96042e873fafcc64c/pkg/commands/artifact/repository.go#L38