### PR TITLE
feat(cli): warning for root command

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands/plugin"
 	"github.com/aquasecurity/trivy/pkg/commands/server"
 	tdb "github.com/aquasecurity/trivy/pkg/db"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/result"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
@@ -351,7 +352,10 @@ func NewApp(version string) *cli.App {
 
 	runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN")
 	if runAsPlugin == "" {
-		app.Action = artifact.ImageRun
+		app.Action = func(ctx *cli.Context) error {
+			log.Logger.Warn("The root command will be removed. Please migrate to 'trivy image' command. See https://github.com/aquasecurity/trivy/discussions/1515")
+			return artifact.ImageRun(ctx)
+		}
 	} else {
 		app.Action = func(ctx *cli.Context) error {
 			return plugin.RunWithArgs(ctx.Context, runAsPlugin, ctx.Args().Slice())


### PR DESCRIPTION
## Description
See https://github.com/aquasecurity/trivy/discussions/1515

```
$ trivy alpine:3.10.7
2021-12-24T22:39:01.192+0200    WARN    The root command will be removed. Please migrate to 'trivy image' command. See https://github.com/aquasecurity/trivy/discussions/1515
2021-12-24T22:39:03.878+0200    INFO    Detected OS: alpine
2021-12-24T22:39:03.878+0200    INFO    Detecting Alpine vulnerabilities...
...
```