### PR TITLE
added note about default template path when Trivy installed using rpm

### DIFF
--- a/docs/vulnerability/examples/report.md
+++ b/docs/vulnerability/examples/report.md
@@ -183,6 +183,9 @@ $ trivy image --format template --template "@/path/to/template" golang:1.12-alpi
 ```
 
 ### Default Templates
+
+If Trivy is installed using rpm then default templates can be found at `/usr/local/share/trivy/templates`.
+
 #### XML
 In the following example using the template `junit.tpl` XML can be generated.
 ```
@@ -203,6 +206,13 @@ Trivy also supports an [ASFF template for reporting findings to AWS Security Hub
 ```
 $ trivy image --format template --template "@contrib/html.tpl" -o report.html golang:1.12-alpine
 ```
+
+The following example shows use of default HTML template when Trivy is installed using rpm.
+
+```
+$ trivy image --format template --template "@/usr/local/share/trivy/templates/html.tpl" -o report.html golang:1.12-alpine
+```
+
 
 [new-json]: https://github.com/aquasecurity/trivy/discussions/1050
 [action]: https://github.com/aquasecurity/trivy-action


### PR DESCRIPTION
When Trivy is installed using rpm then default templates are present at location /usr/local/share/trivy/templates.

In this change, I've updated documentation so users know location where to find it and also added example command for html template.