### PR TITLE
Add the ability to set dockerhub credentials in the helm chart

### DIFF
--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -64,6 +64,9 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
 | `trivy.debugMode`             | The flag to enable or disable Trivy debug mode                          | `false` |
 | `trivy.gitHubToken`           | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                          |      |
+| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
+| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
+| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
 | `trivy.skipUpdate`            | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |

--- a/helm/trivy/templates/secret.yaml
+++ b/helm/trivy/templates/secret.yaml
@@ -7,3 +7,7 @@ metadata:
 type: Opaque
 data:
   GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+{{- if not .Values.trivy.registryCredentialsExistingSecret }}
+    TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
+    TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}
+{{- end -}}

--- a/helm/trivy/templates/secret.yaml
+++ b/helm/trivy/templates/secret.yaml
@@ -8,6 +8,6 @@ type: Opaque
 data:
   GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
 {{- if not .Values.trivy.registryCredentialsExistingSecret }}
-    TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
-    TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}
+  TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
+  TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}
 {{- end -}}

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.trivy.registryCredentialsExistingSecret }}
                   key: TRIVY_PASSWORD
-          {{- end -}}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "trivy.fullname" . }}

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -62,6 +62,19 @@ spec:
           {{- end }}
           args:
             - server
+          {{- if .Values.trivy.registryCredentialsExistingSecret }}
+          env:
+            - name: TRIVY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.trivy.registryCredentialsExistingSecret }}
+                  key: TRIVY_USERNAME
+            - name: TRIVY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.trivy.registryCredentialsExistingSecret }}
+                  key: TRIVY_PASSWORD
+          {{- end -}}
           envFrom:
             - configMapRef:
                 name: {{ include "trivy.fullname" . }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -70,6 +70,24 @@ trivy:
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
   gitHubToken: ""
+  # Docker registry credentials
+  # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
+  #
+  # Either
+  # Directly in this file
+  #
+  # TRIVY_USERNAME
+  registryUsername: ""
+  # TRIVY_PASSWORD
+  registryPassword: ""
+  #
+  # Or
+  # From an existing secret
+  #
+  # The secret must be Opaque and just contain "TRIVY_USERNAME: your_user" and "TRIVY_PASSWORD: your_password" as k/v pairs.
+  # NOTE: When this is set the previous parameters are ignored.
+  #
+  # registryCredentialsExistingSecret: name-of-existing-secret
   # skipUpdate the flag to enable or disable Trivy DB downloads from GitHub
   #
   # You might want to enable this flag in test or CI/CD environments to avoid GitHub rate limiting issues.


### PR DESCRIPTION
Fixes #1568

2 options to set these credentials implemented.
Either directly in the values.yaml file or via an existing Secret.