### PR TITLE
docs: updated integration document for gitlab ci

### DIFF
--- a/docs/advanced/integrations/gitlab-ci.md
+++ b/docs/advanced/integrations/gitlab-ci.md
@@ -32,11 +32,11 @@ trivy:
     # Build image
     - docker build -t $IMAGE .
     # Build report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
+    - ./trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
     # Print report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE
+    - ./trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress --severity HIGH $IMAGE
     # Fail on severe vulnerabilities
-    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE
+    - ./trivy --cache-dir .trivycache/ image --exit-code 1 --severity CRITICAL --no-progress $IMAGE
   cache:
     paths:
       - .trivycache/
@@ -79,12 +79,12 @@ container_scanning:
     # update vulnerabilities db
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Builds report and puts it in the default workdir $CI_PROJECT_DIR, so `artifacts:` can take it from there
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@/contrib/gitlab.tpl"
+    - time trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress --format template --template "@/contrib/gitlab.tpl"
         --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$FULL_IMAGE_NAME"
     # Prints full report
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$FULL_IMAGE_NAME"
+    - time trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress "$FULL_IMAGE_NAME"
     # Fail on critical vulnerabilities
-    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
+    - time trivy --cache-dir .trivycache/ image --exit-code 1 --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
   cache:
     paths:
       - .trivycache/
@@ -135,7 +135,7 @@ trivy:
     # Build image
     - docker build -t $IMAGE .
     # Build report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate.json $IMAGE
+    - ./trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate.json $IMAGE
   cache:
     paths:
       - .trivycache/


### PR DESCRIPTION
With the command change of `trivy` to `trivy image` in v0.23.0 issue #1515. I've updated the document for GitLab CI integration as it was throwing a warning to update the command in my pipeline.



