### PR TITLE
docs: add Rust to Language-specific Packages Table

### DIFF
--- a/docs/vulnerability/detection/language.md
+++ b/docs/vulnerability/detection/language.md
@@ -20,6 +20,7 @@
 |          | pom.xml[^5]              | -         | -          |       ✅        |       ✅        | excluded        |
 | Go       | Binaries built by Go[^6] | ✅        | ✅         |       -        |       -        | excluded        |
 |          | go.sum                   | -         | -          |       ✅        |       ✅        | included        |
+| Rust     | Cargo.lock               | ✅        | ✅         |       ✅        |       ✅        | included        |
 
 The path of these files does not matter.
 


### PR DESCRIPTION
It seems that there is no description of Rust (Cargo.lock) in [Language-specific Packages](https://aquasecurity.github.io/trivy/v0.22.0/vulnerability/detection/language/), so I added it.