### PR TITLE
fix(alma): skip modular package because MODULARITYLABEL is not set

### DIFF
--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -65,8 +65,12 @@ func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedV
 	log.Logger.Debugf("AlmaLinux: os version: %s", osVer)
 	log.Logger.Debugf("AlmaLinux: the number of packages: %d", len(pkgs))
 
+	log.Logger.Info("Skip Modular Package because MODULARITYLABEL is not set and cannot be detected correctly. See also: https://bugs.almalinux.org/view.php?id=173")
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
+		if strings.Contains(pkg.Release, ".module_el") {
+			continue
+		}
 		pkgName := addModularNamespace(pkg.Name, pkg.Modularitylabel)
 		advisories, err := s.vs.Get(osVer, pkgName)
 		if err != nil {

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -60,6 +60,30 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "skip modular package",
+			fixtures: []string{"testdata/fixtures/modular.yaml"},
+			args: args{
+				osVer: "8.4",
+				pkgs: []ftypes.Package{
+					{
+						Name:            "nginx",
+						Epoch:           1,
+						Version:         "1.14.1",
+						Release:         "8.module_el8.3.0+2165+af250afe.alma",
+						Arch:            "x86_64",
+						SrcName:         "nginx",
+						SrcEpoch:        1,
+						SrcVersion:      "1.14.1",
+						SrcRelease:      "8.module_el8.3.0+2165+af250afe.alma",
+						Modularitylabel: "nginx:1.14:8040020210610090123:9f9e2e7e", // actual: "", ref: https://bugs.almalinux.org/view.php?id=173
+						License:         "BSD",
+						Layer:           ftypes.Layer{},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
 			name:     "Get returns an error",
 			fixtures: []string{"testdata/fixtures/invalid.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/alma/testdata/fixtures/modular.yaml
+++ b/pkg/detector/ospkg/alma/testdata/fixtures/modular.yaml
@@ -1,0 +1,7 @@
+- bucket: alma 8
+  pairs:
+    - bucket: nginx:1.14::nginx
+      pairs:
+        - key: CVE-2019-9511
+          value:
+            FixedVersion: "1:1.14.1-9.module_el8.3.0+2165+af250afe.alma"


### PR DESCRIPTION
Since the MODULARITYLABEL is not set, it will not be able to detect the Modular Package correctly. Therefore, it will skip the Modular Package.
refs: 
- https://github.com/aquasecurity/trivy/issues/1021#issuecomment-1011890917
- https://bugs.almalinux.org/view.php?id=173