### PR TITLE
feat(repo): supress git clone output

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -205,6 +205,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		SkipFiles:         opt.SkipFiles,
 		SkipDirs:          opt.SkipDirs,
 		Offline:           opt.OfflineScan,
+		Quiet:             opt.Quiet,
 	}
 
 	s, cleanup, err := initializeScanner(ctx, target, cacheClient, cacheClient, opt.Timeout, artifactOpt, configScannerOptions)


### PR DESCRIPTION
Resolves #927

Following https://github.com/aquasecurity/fanal/pull/335
Pass the `--quiet` flag to the `NewArtifact` function when initializing a scanner.

<details>
<summary>Before: (the `--quite` flag doesn't suppress the git clone output)</summary>

```sh
./trivy --quiet repo https://github.com/aquasecurity/vuln-list-update
Enumerating objects: 435, done.
Counting objects: 100% (435/435), done.
Compressing objects: 100% (293/293), done.
Total 435 (delta 78), reused 356 (delta 61), pack-reused 0

go.sum (gomod)
==============
Total: 8 (UNKNOWN: 4, LOW: 0, MEDIUM: 1, HIGH: 3, CRITICAL: 0)

+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
|              LIBRARY              | VULNERABILITY ID | SEVERITY | INSTALLED VERSION  |            FIXED VERSION             |                 TITLE                 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/apache/thrift          | CVE-2020-13949   | HIGH     | 0.13.0             | v0.14.0                              | libthrift: potential DoS when         |
|                                   |                  |          |                    |                                      | processing untrusted payloads         |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2020-13949 |
+-----------------------------------+------------------+          +--------------------+--------------------------------------+---------------------------------------+
| github.com/dgrijalva/jwt-go       | CVE-2020-26160   |          | 3.2.0+incompatible |                                      | jwt-go: access restriction            |
|                                   |                  |          |                    |                                      | bypass vulnerability                  |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2020-26160 |
+-----------------------------------+------------------+          +--------------------+--------------------------------------+---------------------------------------+
| github.com/gogo/protobuf          | CVE-2021-3121    |          | 1.2.1              | 1.3.2                                | gogo/protobuf:                        |
|                                   |                  |          |                    |                                      | plugin/unmarshal/unmarshal.go         |
|                                   |                  |          |                    |                                      | lacks certain index validation        |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/miekg/dns              | CVE-2019-19794   | MEDIUM   | 1.0.14             | 1.1.25-0.20191211073109-8ebf2e419df7 | golang-github-miekg-dns: predictable  |
|                                   |                  |          |                    |                                      | TXID can lead to response forgeries   |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2019-19794 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/nats-io/nats-server/v2 | GMS-2021-96      | UNKNOWN  | 2.1.2              | 2.1.9                                | Incorrect handling of                 |
|                                   |                  |          |                    |                                      | credential expiry by NATS             |
|                                   |                  |          |                    |                                      | Server                                |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-97      |          |                    | 2.2.0                                | Import loops in account               |
|                                   |                  |          |                    |                                      | imports, nats-server DoS              |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-98      |          |                    | 2.1.9                                | Nil dereference in NATS JWT,          |
|                                   |                  |          |                    |                                      | DoS of nats-server                    |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-99      |          |                    | 2.2.0                                | Import token permissions              |
|                                   |                  |          |                    |                                      | checking not enforced                 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
```


</details>

<details>
<summary> After: </summary>

```sh
./trivy --quiet repo https://github.com/aquasecurity/vuln-list-update

go.sum (gomod)
==============
Total: 8 (UNKNOWN: 4, LOW: 0, MEDIUM: 1, HIGH: 3, CRITICAL: 0)

+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
|              LIBRARY              | VULNERABILITY ID | SEVERITY | INSTALLED VERSION  |            FIXED VERSION             |                 TITLE                 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/apache/thrift          | CVE-2020-13949   | HIGH     | 0.13.0             | v0.14.0                              | libthrift: potential DoS when         |
|                                   |                  |          |                    |                                      | processing untrusted payloads         |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2020-13949 |
+-----------------------------------+------------------+          +--------------------+--------------------------------------+---------------------------------------+
| github.com/dgrijalva/jwt-go       | CVE-2020-26160   |          | 3.2.0+incompatible |                                      | jwt-go: access restriction            |
|                                   |                  |          |                    |                                      | bypass vulnerability                  |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2020-26160 |
+-----------------------------------+------------------+          +--------------------+--------------------------------------+---------------------------------------+
| github.com/gogo/protobuf          | CVE-2021-3121    |          | 1.2.1              | 1.3.2                                | gogo/protobuf:                        |
|                                   |                  |          |                    |                                      | plugin/unmarshal/unmarshal.go         |
|                                   |                  |          |                    |                                      | lacks certain index validation        |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2021-3121  |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/miekg/dns              | CVE-2019-19794   | MEDIUM   | 1.0.14             | 1.1.25-0.20191211073109-8ebf2e419df7 | golang-github-miekg-dns: predictable  |
|                                   |                  |          |                    |                                      | TXID can lead to response forgeries   |
|                                   |                  |          |                    |                                      | -->avd.aquasec.com/nvd/cve-2019-19794 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+
| github.com/nats-io/nats-server/v2 | GMS-2021-96      | UNKNOWN  | 2.1.2              | 2.1.9                                | Incorrect handling of                 |
|                                   |                  |          |                    |                                      | credential expiry by NATS             |
|                                   |                  |          |                    |                                      | Server                                |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-97      |          |                    | 2.2.0                                | Import loops in account               |
|                                   |                  |          |                    |                                      | imports, nats-server DoS              |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-98      |          |                    | 2.1.9                                | Nil dereference in NATS JWT,          |
|                                   |                  |          |                    |                                      | DoS of nats-server                    |
+                                   +------------------+          +                    +--------------------------------------+---------------------------------------+
|                                   | GMS-2021-99      |          |                    | 2.2.0                                | Import token permissions              |
|                                   |                  |          |                    |                                      | checking not enforced                 |
+-----------------------------------+------------------+----------+--------------------+--------------------------------------+---------------------------------------+

```

</details>