### PR TITLE
Detect packages when --list-all-pkgs provided no matter the vuln type configuration

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -66,6 +66,13 @@ type Result struct {
 	Misconfigurations []types.DetectedMisconfiguration `json:"Misconfigurations,omitempty"`
 }
 
+func (r Result) Empty() bool {
+	return len(r.Packages) == 0 &&
+		len(r.Vulnerabilities) == 0 &&
+		len(r.Misconfigurations) == 0 &&
+		(r.MisconfSummary == nil || r.MisconfSummary.Empty())
+}
+
 type MisconfSummary struct {
 	Successes  int
 	Failures   int

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -311,6 +311,286 @@ func TestScanner_Scan(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path with list all packages no matter vulnerability type (os)",
+			args: args{
+				target:   "alpine:latest",
+				layerIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				options: types.ScanOptions{
+					VulnType:        []string{types.VulnTypeOS},
+					SecurityChecks:  []string{types.SecurityCheckVulnerability},
+					ListAllPackages: true,
+				},
+			},
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			applyLayersExpectation: ApplierApplyLayersExpectation{
+				Args: ApplierApplyLayersArgs{
+					BlobIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				},
+				Returns: ApplierApplyLayersReturns{
+					Detail: ftypes.ArtifactDetail{
+						OS: &ftypes.OS{
+							Family: "alpine",
+							Name:   "3.11",
+						},
+						Packages: []ftypes.Package{
+							{
+								Name:    "musl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+							{
+								Name:    "ausl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+						},
+						Applications: []ftypes.Application{
+							{
+								Type:     "bundler",
+								FilePath: "/app/Gemfile.lock",
+								Libraries: []ftypes.Package{
+									{
+										Name:    "rails",
+										Version: "4.0.2",
+										Layer: ftypes.Layer{
+											DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ospkgDetectExpectations: []OspkgDetectorDetectExpectation{
+				{
+					Args: OspkgDetectorDetectArgs{
+						OsFamily: "alpine",
+						OsName:   "3.11",
+						Pkgs: []ftypes.Package{
+							{
+								Name:    "musl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+							{
+								Name:    "ausl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+						},
+					},
+					Returns: OspkgDetectorDetectReturns{
+						DetectedVulns: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2020-9999",
+								PkgName:          "musl",
+								InstalledVersion: "1.2.3",
+								FixedVersion:     "1.2.4",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+						},
+						Eosl: false,
+					},
+				},
+			},
+			wantResults: report.Results{
+				{
+					Target: "alpine:latest (alpine 3.11)",
+					Packages: []ftypes.Package{
+						{
+							Name:    "ausl",
+							Version: "1.2.3",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+							},
+						},
+						{
+							Name:    "musl",
+							Version: "1.2.3",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+							},
+						},
+					},
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID:  "CVE-2020-9999",
+							PkgName:          "musl",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+							},
+						},
+					},
+					Class: report.ClassOSPkg,
+					Type:  vulnerability.Alpine,
+				},
+				{
+					Target: "/app/Gemfile.lock",
+					Packages: []ftypes.Package{
+						{
+							Name:    "rails",
+							Version: "4.0.2",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
+							},
+						},
+					},
+					Class: report.ClassLangPkg,
+					Type:  ftypes.Bundler,
+				},
+			},
+			wantOS: &ftypes.OS{
+				Family: "alpine",
+				Name:   "3.11",
+			},
+		},
+		{
+			name: "happy path with list all packages no matter vulnerability type (library)",
+			args: args{
+				target:   "alpine:latest",
+				layerIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				options: types.ScanOptions{
+					VulnType:        []string{types.VulnTypeLibrary},
+					SecurityChecks:  []string{types.SecurityCheckVulnerability},
+					ListAllPackages: true,
+				},
+			},
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			applyLayersExpectation: ApplierApplyLayersExpectation{
+				Args: ApplierApplyLayersArgs{
+					BlobIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				},
+				Returns: ApplierApplyLayersReturns{
+					Detail: ftypes.ArtifactDetail{
+						OS: &ftypes.OS{
+							Family: "alpine",
+							Name:   "3.11",
+						},
+						Packages: []ftypes.Package{
+							{
+								Name:    "musl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+							{
+								Name:    "ausl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+						},
+						Applications: []ftypes.Application{
+							{
+								Type:     "bundler",
+								FilePath: "/app/Gemfile.lock",
+								Libraries: []ftypes.Package{
+									{
+										Name:    "rails",
+										Version: "4.0.2",
+										Layer: ftypes.Layer{
+											DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ospkgDetectExpectations: []OspkgDetectorDetectExpectation{
+				{
+					Args: OspkgDetectorDetectArgs{
+						OsFamily: "alpine",
+						OsName:   "3.11",
+						Pkgs: []ftypes.Package{
+							{
+								Name:    "musl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+							{
+								Name:    "ausl",
+								Version: "1.2.3",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantResults: report.Results{
+				{
+					Target: "alpine:latest (alpine 3.11)",
+					Packages: []ftypes.Package{
+						{
+							Name:    "ausl",
+							Version: "1.2.3",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:bbf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+							},
+						},
+						{
+							Name:    "musl",
+							Version: "1.2.3",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888",
+							},
+						},
+					},
+					Class: report.ClassOSPkg,
+					Type:  vulnerability.Alpine,
+				},
+				{
+					Target: "/app/Gemfile.lock",
+					Packages: []ftypes.Package{
+						{
+							Name:    "rails",
+							Version: "4.0.2",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
+							},
+						},
+					},
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID:  "CVE-2014-0081",
+							PkgName:          "rails",
+							InstalledVersion: "4.0.2",
+							FixedVersion:     "4.0.3, 3.2.17",
+							Layer: ftypes.Layer{
+								DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
+							},
+						},
+					},
+					Class: report.ClassLangPkg,
+					Type:  ftypes.Bundler,
+				},
+			},
+			wantOS: &ftypes.OS{
+				Family: "alpine",
+				Name:   "3.11",
+			},
+		},
+		{
 			name: "happy path with empty os",
 			args: args{
 				target:   "alpine:latest",
@@ -418,11 +698,6 @@ func TestScanner_Scan(t *testing.T) {
 				},
 			},
 			wantResults: report.Results{
-				{
-					Target: "alpine:latest (alpine 3.11)",
-					Class:  report.ClassOSPkg,
-					Type:   vulnerability.Alpine,
-				},
 				{
 					Target: "/app/Gemfile.lock",
 					Vulnerabilities: []types.DetectedVulnerability{


### PR DESCRIPTION
Resolves #828

The current workflow of the `scan` module is calling the `checkVulnerabilities` function
is vulnerabilities oriented.
It checks each vulnerability type (currently library and OS) that it was provided with.
In addition, in case `--list-all-pkgs` is specified, it also looks for each
vulnerability type packages.

This PR adds the support of when providing the `--list-all-pkgs` flag, it will look into
every vulnerability type, no matter the `--vuln-type` flag that was provided.

This behavior should require more design changes but for now, in order to keep this code
backward compatible, this is a valid solution.
