### PR TITLE
docs(contribution): change role who should resolve comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for taking interest in contributing to Trivy!
 4. Please add the associated Issue link in the PR description.
 2. Your PR is more likely to be accepted if it focuses on just one change.
 5. There's no need to add or tag reviewers.
-6. If a reviewer commented on your code or asked for changes, please remember to mark the discussion as resolved after you address it. PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).
+6. If a reviewer commented on your code or asked for changes, please remember to respond with comment. Do not mark discussion as resolved. It's up to reviewer to mark it resolved (in case if suggested fix addresses problem properly). PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).
 7. Please include a comment with the results before and after your change.
 8. Your PR is more likely to be accepted if it includes tests (We have not historically been very strict about tests, but we would like to improve this!).
 9. If your PR affects the user experience in some way, please update the README.md and the CLI help accordingly.


### PR DESCRIPTION
## Description
Update to contribution rules to change person who is responsible for resolving comments. This way it's more ease to track what is addressed for reviewers when they are doing repeated review.

## Checklist
- [ ] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [ ] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](../docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).