### PR TITLE
fix: update example Rego files and docs

### DIFF
--- a/contrib/example_policy/advanced.rego
+++ b/contrib/example_policy/advanced.rego
@@ -5,30 +5,42 @@ import data.lib.trivy
 default ignore = false
 
 nvd_v3_vector = v {
-	v := input.CVSS.nvd.v3
+	v := input.CVSS.nvd.V3Vector
+}
+
+redhat_v3_vector = v {
+	v := input.CVSS.redhat.V3Vector
 }
 
 # Ignore a vulnerability which requires high privilege
 ignore {
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
-	cvss_vector.PrivilegesRequired == "High"
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector.PrivilegesRequired == "High"
+
+        # Check against RedHat scores as well as NVD
+	redhat_cvss_vector := trivy.parse_cvss_vector_v3(redhat_v3_vector)
+	redhat_cvss_vector.PrivilegesRequired == "High"
 }
 
 # Ignore a vulnerability which requires user interaction
 ignore {
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
-	cvss_vector.UserInteraction == "Required"
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector.UserInteraction == "Required"
+
+        # Check against RedHat scores as well as NVD
+	redhat_cvss_vector := trivy.parse_cvss_vector_v3(redhat_v3_vector)
+	redhat_cvss_vector.UserInteraction == "Required"
 }
 
 ignore {
 	input.PkgName == "openssl"
 
 	# Split CVSSv3 vector
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
 
 	# Evaluate Attack Vector
 	ignore_attack_vectors := {"Physical", "Local"}
-	cvss_vector.AttackVector == ignore_attack_vectors[_]
+	nvd_cvss_vector.AttackVector == ignore_attack_vectors[_]
 }
 
 ignore {
@@ -50,11 +62,11 @@ ignore {
 	input.PkgName == "bash"
 
 	# Split CVSSv3 vector
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
 
 	# Evaluate Attack Vector
 	ignore_attack_vectors := {"Physical", "Local", "Adjacent"}
-	cvss_vector.AttackVector == ignore_attack_vectors[_]
+	nvd_cvss_vector.AttackVector == ignore_attack_vectors[_]
 
 	# Evaluate severity
 	input.Severity == {"LOW", "MEDIUM", "HIGH"}[_]
@@ -64,11 +76,11 @@ ignore {
 	input.PkgName == "django"
 
 	# Split CVSSv3 vector
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
 
 	# Evaluate Attack Vector
 	ignore_attack_vectors := {"Physical", "Local"}
-	cvss_vector.AttackVector == ignore_attack_vectors[_]
+	nvd_cvss_vector.AttackVector == ignore_attack_vectors[_]
 
 	# Evaluate severity
 	input.Severity == {"LOW", "MEDIUM"}[_]
@@ -86,7 +98,7 @@ ignore {
 	input.PkgName == "jquery"
 
 	# Split CVSSv3 vector
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
 
 	# Evaluate CWE-ID
 	deny_cwe_ids := {"CWE-79"} # XSS

--- a/contrib/example_policy/basic.rego
+++ b/contrib/example_policy/basic.rego
@@ -9,7 +9,11 @@ ignore_pkgs := {"bash", "bind-license", "rpm", "vim", "vim-minimal"}
 ignore_severities := {"LOW", "MEDIUM"}
 
 nvd_v3_vector = v {
-	v := input.CVSS.nvd.v3
+	v := input.CVSS.nvd.V3Vector
+}
+
+redhat_v3_vector = v {
+	v := input.CVSS.redhat.V3Vector
 }
 
 ignore {
@@ -22,20 +26,29 @@ ignore {
 
 # Ignore a vulnerability which is not remotely exploitable
 ignore {
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
-	cvss_vector.AttackVector != "Network"
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector.AttackVector != "Network"
+
+	redhat_cvss_vector := trivy.parse_cvss_vector_v3(redhat_v3_vector)
+	redhat_cvss_vector.AttackVector != "Network"
 }
 
 # Ignore a vulnerability which requires high privilege
 ignore {
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
-	cvss_vector.PrivilegesRequired == "High"
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector.PrivilegesRequired == "High"
+
+	redhat_cvss_vector := trivy.parse_cvss_vector_v3(redhat_v3_vector)
+	redhat_cvss_vector.PrivilegesRequired == "High"
 }
 
 # Ignore a vulnerability which requires user interaction
 ignore {
-	cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
-	cvss_vector.UserInteraction == "Required"
+	nvd_cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+	nvd_cvss_vector.UserInteraction == "Required"
+
+	redhat_cvss_vector := trivy.parse_cvss_vector_v3(redhat_v3_vector)
+	redhat_cvss_vector.UserInteraction == "Required"
 }
 
 # Ignore CSRF

--- a/docs/vulnerability/examples/filter.md
+++ b/docs/vulnerability/examples/filter.md
@@ -294,25 +294,60 @@ There is a built-in Rego library with helper functions that you can import into 
 To get started, see the [example policy][policy].
 
 ```bash
-$ trivy image --ignore-policy contrib/example_filter/basic.rego centos:7
+$ trivy image --ignore-policy contrib/example_policy/basic.rego centos:7
 ```
 
 <details>
 <summary>Result</summary>
 
 ```bash
-centos:7 (centos 7.8.2003)
+centos:7 (centos 7.9.2009)
 ==========================
-Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)
+Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 5)
 
-+---------+------------------+----------+-------------------+---------------+--------------------------------+
-| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
-+---------+------------------+----------+-------------------+---------------+--------------------------------+
-| glib2   | CVE-2016-3191    | HIGH     | 2.56.1-5.el7      |               | pcre: workspace overflow       |
-|         |                  |          |                   |               | for (*ACCEPT) with deeply      |
-|         |                  |          |                   |               | nested parentheses (8.39/13,   |
-|         |                  |          |                   |               | 10.22/12)                      |
-+---------+------------------+----------+-------------------+---------------+--------------------------------+
++--------------+------------------+----------+-------------------+-------------------+-----------------------------------------+
+|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |   FIXED VERSION   |                  TITLE                  |
++--------------+------------------+----------+-------------------+-------------------+-----------------------------------------+
+| glib2        | CVE-2015-8385    | HIGH     | 2.56.1-7.el7      |                   | pcre: buffer overflow caused            |
+|              |                  |          |                   |                   | by named forward reference              |
+|              |                  |          |                   |                   | to duplicate group number...            |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2015-8385    |
++              +------------------+          +                   +-------------------+-----------------------------------------+
+|              | CVE-2016-3191    |          |                   |                   | pcre: workspace overflow for            |
+|              |                  |          |                   |                   | (*ACCEPT) with deeply nested            |
+|              |                  |          |                   |                   | parentheses (8.39/13, 10.22/12)         |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2016-3191    |
++              +------------------+          +                   +-------------------+-----------------------------------------+
+|              | CVE-2021-27219   |          |                   | 2.56.1-9.el7_9    | glib: integer overflow in               |
+|              |                  |          |                   |                   | g_bytes_new function on                 |
+|              |                  |          |                   |                   | 64-bit platforms due to an...           |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2021-27219   |
++--------------+------------------+----------+-------------------+-------------------+-----------------------------------------+
+| glibc        | CVE-2019-1010022 | CRITICAL | 2.17-317.el7      |                   | glibc: stack guard protection bypass    |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2019-1010022 |
++--------------+                  +          +                   +-------------------+                                         +
+| glibc-common |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
++--------------+------------------+          +-------------------+-------------------+-----------------------------------------+
+| nss          | CVE-2021-43527   |          | 3.53.1-3.el7_9    | 3.67.0-4.el7_9    | nss: Memory corruption in               |
+|              |                  |          |                   |                   | decodeECorDsaSignature with             |
+|              |                  |          |                   |                   | DSA signatures (and RSA-PSS)            |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2021-43527   |
++--------------+                  +          +                   +                   +                                         +
+| nss-sysinit  |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
++--------------+                  +          +                   +                   +                                         +
+| nss-tools    |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
+|              |                  |          |                   |                   |                                         |
++--------------+------------------+----------+-------------------+-------------------+-----------------------------------------+
+| openssl-libs | CVE-2020-1971    | HIGH     | 1:1.0.2k-19.el7   | 1:1.0.2k-21.el7_9 | openssl: EDIPARTYNAME                   |
+|              |                  |          |                   |                   | NULL pointer de-reference               |
+|              |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2020-1971    |
++--------------+------------------+----------+-------------------+-------------------+-----------------------------------------+
 ```
 
 </details>


### PR DESCRIPTION
## Description

This request contains a fix to the example `--ignore-policy` files to make them work with the current structure of the `output` variable that they process.  It also updates the documentation to fix a broken file path and to reflect the updated command output.

For more details see #1627.

I have not added a test for this, nor run the test suite.  I am not proficient in go and I don't think the files that have been changed are covered by tests.  To confirm that the fix works, run the following scan from the issue and notice the vulnerability in `passwd` is no longer included.

```
trivy image --ignore-policy contrib/example_policy/basic.rego python:3.6-slim
```

I added the RedHat vector to the tests in the policy as I found that sometimes contained information where the NVD vector didn't.

## Related issues
- Close #1627

## Checklist
- [x] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](../docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

Thank you for all your work on Trivy.