### PR TITLE
feat(list-all-pkgs option): added warning about using format other than json

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -83,6 +83,7 @@ func runWithTimeout(ctx context.Context, opt Option, initializeScanner Initializ
 		OutputTemplate:     opt.Template,
 		IncludeNonFailures: opt.IncludeNonFailures,
 		Trace:              opt.Trace,
+		ListAllPkgs:        opt.ListAllPkgs,
 	}); err != nil {
 		return xerrors.Errorf("unable to write results: %w", err)
 	}

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -102,11 +102,19 @@ type Option struct {
 	// For misconfigurations
 	IncludeNonFailures bool
 	Trace              bool
+	ListAllPkgs        bool
 }
 
 // Write writes the result to output, format as passed in argument
 func Write(report Report, option Option) error {
 	var writer Writer
+
+	//--list-all-pkgs option is available only with --format json.
+	// If user specifies --list-all-pkgs with other than --format json, we should warn it.
+	if option.ListAllPkgs && option.Format != "json" {
+		log.Logger.Warn(`"--list-all-pkgs" option is available only with "--format json".`)
+	}
+
 	switch option.Format {
 	case "table":
 		writer = &TableWriter{


### PR DESCRIPTION
## Description
Added a warning if the user specifies `--list-all-pkgs` with an option other than `--format json`. 

## Checklist
- [ ] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [ ] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](../docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).