### PR TITLE
fix(contribution): change links in pull_request_template to static URLs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@
 Remove this section if you don't have related PRs.
 
 ## Checklist
-- [ ] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
-- [ ] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
+- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
+- [ ] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
 - [ ] I've added tests that prove my fix is effective or that my feature works.
-- [ ] I've updated the [documentation](../docs) with the relevant information (if needed).
+- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
 - [ ] I've added usage information (if the PR introduces new options)
 - [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).


### PR DESCRIPTION
## Description
URLs don't work when creating a new PR. Created static URLs. 

## Checklist
- [x] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](../docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).