### PR TITLE
fix(gitlab tpl): Escape double quote

### DIFF
--- a/contrib/gitlab-codequality.tpl
+++ b/contrib/gitlab-codequality.tpl
@@ -13,7 +13,7 @@
       "type": "issue",
       "check_name": "container_scanning",
       "categories": [ "Security" ],
-      "description": "{{ .VulnerabilityID }}: {{ .Title }}",
+      "description": {{ list .VulnerabilityID .Title | join ": " | printf "%q" }},
       "fingerprint": "{{ .VulnerabilityID | sha1sum }}",
       "content": {{ .Description | printf "%q" }},
       "severity": {{ if eq .Severity "LOW" -}}


### PR DESCRIPTION

## Description
Some CVEs have double quotes in the title (e.g. CVE-2018-11813, CVE-2019-15847). The solution is to quote the title.


## Related issues
- #1553

## Related PRs
-  #1380

## Checklist
- [x] I've read the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](../CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](../docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).