### PR TITLE
docs: commercial use available

### DIFF
--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -58,9 +58,6 @@ See [Integrations][integrations] for details.
 
 Please see [LICENSE][license] for Trivy licensing information.
 
-!!! note
-    Trivy uses vulnerability information from a variety of sources, some of which are licensed for non-commercial use only.
-
 [vuln]: ../vulnerability/scanning/index.md
 [misconf]: ../misconfiguration/index.md
 [container]: ../vulnerability/scanning/image.md


### PR DESCRIPTION
## Description
Trivy DB v2+ is now available for commercial use.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/491

## Related PRs
- [x] https://github.com/aquasecurity/trivy-db/issues/173
- [x] https://github.com/rubysec/ruby-advisory-db/pull/456

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
