### PR TITLE
feat(option): show a link to GitHub Discussions for --light deprecation

### DIFF
--- a/pkg/commands/option/db.go
+++ b/pkg/commands/option/db.go
@@ -33,7 +33,7 @@ func (c *DBOption) Init() (err error) {
 		return xerrors.New("--skip-db-update and --download-db-only options can not be specified both")
 	}
 	if c.Light {
-		log.Logger.Warn("'--light' option is deprecated and will be removed")
+		log.Logger.Warn("'--light' option is deprecated and will be removed. See also: https://github.com/aquasecurity/trivy/discussions/1649")
 	}
 	return nil
 }

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -96,7 +96,6 @@ type Option struct {
 	Output         io.Writer
 	Severities     []dbTypes.Severity
 	OutputTemplate string
-	Light          bool
 	AppVersion     string
 
 	// For misconfigurations


### PR DESCRIPTION
## Description
Add a link to GitHub Discussions

#### Before

```
$ trivy image --light alpine:3.11
2022-01-31T14:18:37.618+0200    WARN    '--light' option is deprecated and will be removed
```

#### After

```
$ trivy image --light alpine:3.11
2022-01-31T14:18:37.618+0200    WARN    '--light' option is deprecated and will be removed. See also: https://github.com/aquasecurity/trivy/discussions/1649
```

## Related PRs
- [x] https://github.com/aquasecurity/trivy-db/pull/160
- [x] https://github.com/aquasecurity/trivy/pull/1539

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
