### PR TITLE
build: Replace `make protoc` with `for loop` to return an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ protoc:
 	docker run --rm -it -v ${PWD}:/app -w /app trivy-protoc make _$@
 
 _protoc:
-	find ./rpc/ -name "*.proto" -type f -exec protoc --twirp_out=. --twirp_opt=paths=source_relative --go_out=. --go_opt=paths=source_relative {} \;
+	for path in `find ./rpc/ -name "*.proto" -type f`; do \
+		protoc --twirp_out=. --twirp_opt=paths=source_relative --go_out=. --go_opt=paths=source_relative $${path} || exit; \
+	done
 
 .PHONY: install
 install:


### PR DESCRIPTION
## Description

Find the `*.proto` files and run in a `for loop` to run `protoc`
for each file in a separated command. If fail, `|| exit` will exit
with the returned error.
    
The POSIX standard specifies that the return status of `find` is 0
unless an error occurred while traversing the directories;
the return status of executed commands doesn't enter into it.
    
To overcome this limitation, the `-exec ... +` pattern could be used
From the docs (https://man7.org/linux/man-pages/man1/find.1.html):
"If any invocation with the `+' form returns a non-zero
value as exit status, then find returns a non-zero exit
status."
    
But as well, "This variant of the -exec action runs the specified command
on the selected files, but the command line is built by appending each selected
file name at the end;"
    
Unfortunately, at the moment `protoc-gen-twirp` plugin doesn't
support multiple files from different packages when the `go_package` option
is explicitly mentioned.
https://github.com/twitchtv/twirp/blob/main/protoc-gen-twirp/generator.go#L181-L185


Before

```sh
➜  trivy git:(main) ✗ make protoc
find ./rpc/ -name "*.proto" -type f -exec protoc --proto_path=/home/yuvalgold/go/src:. --twirp_out=. --twirp_opt=paths=source_relative --go_out=. --go_opt=paths=source_relative {} \;
github.com/aquasecurity/trivy/rpc/common/service.proto: File not found.
rpc/cache/service.proto:7:1: Import "github.com/aquasecurity/trivy/rpc/common/service.proto" was not found or had errors.
rpc/cache/service.proto:22:12: "common.Package" is not defined.
rpc/cache/service.proto:32:3: "common.OS" is not defined.
rpc/cache/service.proto:33:12: "common.PackageInfo" is not defined.
rpc/cache/service.proto:34:12: "common.Application" is not defined.
rpc/cache/service.proto:35:12: "common.Misconfiguration" is not defined.
rpc/cache/service.proto:48:3: "common.OS" is not defined.
github.com/aquasecurity/trivy/rpc/common/service.proto: File not found.
rpc/scanner/service.proto:6:1: Import "github.com/aquasecurity/trivy/rpc/common/service.proto" was not found or had errors.
rpc/scanner/service.proto:26:3: "common.OS" is not defined.
rpc/scanner/service.proto:33:12: "common.Vulnerability" is not defined.
rpc/scanner/service.proto:34:12: "common.DetectedMisconfiguration" is not defined.
rpc/scanner/service.proto:37:12: "common.Package" is not defined.
➜  trivy git:(main) ✗ echo $?
0
```

After

```sh
➜  trivy git:(main) ✗ make protoc
for path in `find ./rpc/ -name "*.proto" -type f`; do \
	protoc --proto_path=/go/src:. --twirp_out=. --twirp_opt=paths=source_relative --go_out=. --go_opt=paths=source_relative ${path} || exit; \
done
github.com/aquasecurity/trivy/rpc/common/service.proto: File not found.
rpc/cache/service.proto:7:1: Import "github.com/aquasecurity/trivy/rpc/common/service.proto" was not found or had errors.
rpc/cache/service.proto:22:12: "common.Package" is not defined.
rpc/cache/service.proto:32:3: "common.OS" is not defined.
rpc/cache/service.proto:33:12: "common.PackageInfo" is not defined.
rpc/cache/service.proto:34:12: "common.Application" is not defined.
rpc/cache/service.proto:35:12: "common.Misconfiguration" is not defined.
rpc/cache/service.proto:48:3: "common.OS" is not defined.
make: *** [Makefile:60: _protoc] Error 1
➜  trivy git:(main) ✗ echo $?    
2
```

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
