### PR TITLE
fix(repo): --no-progress suppresses git output

### DIFF
--- a/docs/getting-started/cli/repo.md
+++ b/docs/getting-started/cli/repo.md
@@ -23,6 +23,7 @@ OPTIONS:
    --cache-backend value       cache backend (e.g. redis://localhost:6379) (default: "fs") [$TRIVY_CACHE_BACKEND]
    --timeout value             timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --no-progress               suppress progress bar (default: false) [$TRIVY_NO_PROGRESS]
+   --quiet, -q                      suppress progress bar and log output (default: false) [$TRIVY_QUIET]
    --ignore-policy value       specify the Rego file to evaluate each vulnerability [$TRIVY_IGNORE_POLICY]
    --list-all-pkgs             enabling the option will output all packages regardless of vulnerability (default: false) [$TRIVY_LIST_ALL_PKGS]
    --offline-scan              do not issue API requests to identify dependencies (default: false) [$TRIVY_OFFLINE_SCAN]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123
+	github.com/aquasecurity/fanal v0.0.0-20220202141603-7fbf7b8cb8ae
 	github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -40,7 +40,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.11.1
 	github.com/twitchtv/twirp v8.1.0+incompatible
-	github.com/urfave/cli v1.22.5
 	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/zap v1.20.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220129174924-b9e05fcccc57
+	github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123
 	github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -40,6 +40,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.11.1
 	github.com/twitchtv/twirp v8.1.0+incompatible
+	github.com/urfave/cli v1.22.5
 	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/zap v1.20.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/aquasecurity/cfsec v0.2.2 h1:hq6MZlg7XFZsrerCv297N4HRlnJM7K6LLd/l/xCz
 github.com/aquasecurity/cfsec v0.2.2/go.mod h1:sUELRJqIPXTOZiHUx7TzyyFFzuk0W22IG6IWAoV8T6U=
 github.com/aquasecurity/defsec v0.0.37 h1:zdZndlKrW257b8VLK1UwfmXiyPuDrNA+wzBilHRk1LA=
 github.com/aquasecurity/defsec v0.0.37/go.mod h1:csaBEcJ3AKy44expnW0dCANEZcS/c1vcJjwBCbnKWBM=
-github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123 h1:kpxbYLWvan77R4KBkC+6ZCvyghqEPdUtY7BHo0aN7gs=
-github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123/go.mod h1:aU+dKT2D+DLsTEmy/axt19XEIXayz0V9giXCwiypCgQ=
+github.com/aquasecurity/fanal v0.0.0-20220202141603-7fbf7b8cb8ae h1:JPKy8PH3EebR3QRDCnzdXdWnMlbxx4M4zy7gcHsJyxk=
+github.com/aquasecurity/fanal v0.0.0-20220202141603-7fbf7b8cb8ae/go.mod h1:aU+dKT2D+DLsTEmy/axt19XEIXayz0V9giXCwiypCgQ=
 github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff h1:JCKEV3TgUNh9fn+8hXyIdsF9yErA0rUbCkgt2flRKt4=
 github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff/go.mod h1:8fJ//Ob6/03lxbn4xa1F+G/giVtiVLxnZNpBp5xOxNk=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/aquasecurity/cfsec v0.2.2 h1:hq6MZlg7XFZsrerCv297N4HRlnJM7K6LLd/l/xCz
 github.com/aquasecurity/cfsec v0.2.2/go.mod h1:sUELRJqIPXTOZiHUx7TzyyFFzuk0W22IG6IWAoV8T6U=
 github.com/aquasecurity/defsec v0.0.37 h1:zdZndlKrW257b8VLK1UwfmXiyPuDrNA+wzBilHRk1LA=
 github.com/aquasecurity/defsec v0.0.37/go.mod h1:csaBEcJ3AKy44expnW0dCANEZcS/c1vcJjwBCbnKWBM=
-github.com/aquasecurity/fanal v0.0.0-20220129174924-b9e05fcccc57 h1:/xe+XRO1uQXebv6y1XIM9424XQXVnVZ1dr+V4clegHA=
-github.com/aquasecurity/fanal v0.0.0-20220129174924-b9e05fcccc57/go.mod h1:aU+dKT2D+DLsTEmy/axt19XEIXayz0V9giXCwiypCgQ=
+github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123 h1:kpxbYLWvan77R4KBkC+6ZCvyghqEPdUtY7BHo0aN7gs=
+github.com/aquasecurity/fanal v0.0.0-20220202110459-3920c3bc3123/go.mod h1:aU+dKT2D+DLsTEmy/axt19XEIXayz0V9giXCwiypCgQ=
 github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff h1:JCKEV3TgUNh9fn+8hXyIdsF9yErA0rUbCkgt2flRKt4=
 github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff/go.mod h1:8fJ//Ob6/03lxbn4xa1F+G/giVtiVLxnZNpBp5xOxNk=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -545,6 +545,7 @@ func NewRepositoryCommand() *cli.Command {
 			&redisBackendKey,
 			&timeoutFlag,
 			&noProgressFlag,
+			&quietFlag,
 			&ignorePolicy,
 			&listAllPackages,
 			&offlineScan,

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -205,7 +205,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		SkipDirs:          opt.SkipDirs,
 		InsecureSkipTLS:   opt.Insecure,
 		Offline:           opt.OfflineScan,
-		Quiet:             opt.Quiet,
+		NoProgress:        opt.NoProgress || opt.Quiet,
 	}
 
 	s, cleanup, err := initializeScanner(ctx, target, cacheClient, cacheClient, opt.Insecure, artifactOpt, configScannerOptions)


### PR DESCRIPTION
## Description
`--no-progress` with the `repo` subcommand doesn't work properly. This PR fixes the bug.

Before:
```
$ trivy repo --no-progress github.com/aquasecurity/trivy-ci-test
Enumerating objects: 6, done.
Counting objects: 100% (6/6), done.
Compressing objects: 100% (5/5), done.
Total 6 (delta 0), reused 3 (delta 0), pack-reused 0
2022-02-02T12:51:31.689+0200	INFO	Number of language-specific files: 1
2022-02-02T12:51:31.689+0200	INFO	Detecting cargo vulnerabilities...
```

After:
```
$ trivy repo --no-progress github.com/aquasecurity/trivy-ci-test
bash-3.2$ trivy repo --no-progress --severity CRITICAL github.com/aquasecurity/rust-app
2022-02-02T13:04:15.114+0200	INFO	Number of language-specific files: 1
2022-02-02T13:04:15.114+0200	INFO	Detecting cargo vulnerabilities...
```

## Related PRs
- [ ] https://github.com/aquasecurity/fanal/pull/392

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
