### PR TITLE
docs(image): Update image tag to one present on Docker Hub

### DIFF
--- a/docs/vulnerability/scanning/image.md
+++ b/docs/vulnerability/scanning/image.md
@@ -38,49 +38,52 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
 ## Tar Files
 
 ```
-$ docker save ruby:2.3.0-alpine3.9 -o ruby-2.3.0.tar
-$ trivy image --input ruby-2.3.0.tar
+$ docker pull ruby:3.1-alpine3.15
+$ docker save ruby:3.1-alpine3.15 -o ruby-3.1.tar
+$ trivy image --input ruby-3.1.tar
 ```
 
 <details>
 <summary>Result</summary>
 
 ```
-2019-05-16T12:45:57.332+0900    INFO    Updating vulnerability database...
-2019-05-16T12:45:59.119+0900    INFO    Detecting Debian vulnerabilities...
+2022-02-03T10:08:19.127Z        INFO    Detected OS: alpine
+2022-02-03T10:08:19.127Z        WARN    This OS version is not on the EOL list: alpine 3.15
+2022-02-03T10:08:19.127Z        INFO    Detecting Alpine vulnerabilities...
+2022-02-03T10:08:19.127Z        INFO    Number of language-specific files: 2
+2022-02-03T10:08:19.127Z        INFO    Detecting gemspec vulnerabilities...
+2022-02-03T10:08:19.128Z        INFO    Detecting node-pkg vulnerabilities...
+2022-02-03T10:08:19.128Z        WARN    This OS version is no longer supported by the distribution: alpine 3.15.0
+2022-02-03T10:08:19.128Z        WARN    The vulnerability detection may be insufficient because security updates are not provided
 
-ruby-2.3.0.tar (debian 8.4)
-===========================
-Total: 7447 (UNKNOWN: 5, LOW: 326, MEDIUM: 5695, HIGH: 1316, CRITICAL: 105)
+ruby-3.1.tar (alpine 3.15.0)
+============================
+Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 3, CRITICAL: 0)
 
-+------------------------------+---------------------+----------+----------------------------+----------------------------------+-----------------------------------------------------+
-|           LIBRARY            |  VULNERABILITY ID   | SEVERITY |     INSTALLED VERSION      |          FIXED VERSION           |                        TITLE                        |
-+------------------------------+---------------------+----------+----------------------------+----------------------------------+-----------------------------------------------------+
-| apt                          | CVE-2019-3462       | CRITICAL | 1.0.9.8.3                  | 1.0.9.8.5                        | Incorrect sanitation of the                         |
-|                              |                     |          |                            |                                  | 302 redirect field in HTTP                          |
-|                              |                     |          |                            |                                  | transport method of...                              |
-+                              +---------------------+----------+                            +----------------------------------+-----------------------------------------------------+
-|                              | CVE-2016-1252       | MEDIUM   |                            | 1.0.9.8.4                        | The apt package in Debian                           |
-|                              |                     |          |                            |                                  | jessie before 1.0.9.8.4, in                         |
-|                              |                     |          |                            |                                  | Debian unstable before...                           |
-+                              +---------------------+----------+                            +----------------------------------+-----------------------------------------------------+
-|                              | CVE-2011-3374       | LOW      |                            |                                  |                                                     |
-+------------------------------+---------------------+----------+----------------------------+----------------------------------+-----------------------------------------------------+
-| bash                         | CVE-2016-7543       | HIGH     | 4.3-11                     | 4.3-11+deb8u1                    | bash: Specially crafted                             |
-|                              |                     |          |                            |                                  | SHELLOPTS+PS4 variables allows                      |
-|                              |                     |          |                            |                                  | command substitution                                |
-+                              +---------------------+          +                            +----------------------------------+-----------------------------------------------------+
-|                              | CVE-2019-9924       |          |                            | 4.3-11+deb8u2                    | bash: BASH_CMD is writable in                       |
-|                              |                     |          |                            |                                  | restricted bash shells                              |
-+                              +---------------------+----------+                            +----------------------------------+-----------------------------------------------------+
-|                              | CVE-2016-0634       | MEDIUM   |                            | 4.3-11+deb8u1                    | bash: Arbitrary code execution                      |
-|                              |                     |          |                            |                                  | via malicious hostname                              |
-+                              +---------------------+----------+                            +----------------------------------+-----------------------------------------------------+
-|                              | CVE-2016-9401       | LOW      |                            | 4.3-11+deb8u2                    | bash: popd controlled free                          |
-+                              +---------------------+          +                            +----------------------------------+-----------------------------------------------------+
-|                              | TEMP-0841856-B18BAF |          |                            |                                  |                                                     |
-+------------------------------+---------------------+----------+----------------------------+----------------------------------+-----------------------------------------------------
-...
++----------+------------------+----------+-------------------+---------------+---------------------------------------+
+| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
++----------+------------------+----------+-------------------+---------------+---------------------------------------+
+| gmp      | CVE-2021-43618   | HIGH     | 6.2.1-r0          | 6.2.1-r1      | gmp: Integer overflow and resultant   |
+|          |                  |          |                   |               | buffer overflow via crafted input     |
+|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-43618 |
++----------+                  +          +                   +               +                                       +
+| gmp-dev  |                  |          |                   |               |                                       |
+|          |                  |          |                   |               |                                       |
+|          |                  |          |                   |               |                                       |
++----------+                  +          +                   +               +                                       +
+| libgmpxx |                  |          |                   |               |                                       |
+|          |                  |          |                   |               |                                       |
+|          |                  |          |                   |               |                                       |
++----------+------------------+----------+-------------------+---------------+---------------------------------------+
+
+Node.js (node-pkg)
+==================
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
+
+
+Ruby (gemspec)
+==============
+Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 ```
 
 </details>


### PR DESCRIPTION
## Description

The current documentation for container image scanning uses a ruby image, where the tag is no longer present on Docker Hub (`ruby:2.3.0-alpine3.9`).

This change just updates the command and output to a currently supported tag. Also adds a line to pull the image before using Docker save, so it's local on the host.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
