### PR TITLE
refactor: move result structs under types

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/metadata"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
-	"github.com/aquasecurity/trivy/pkg/report"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -85,14 +85,14 @@ func waitPort(ctx context.Context, addr string) error {
 	}
 }
 
-func readReport(t *testing.T, filePath string) report.Report {
+func readReport(t *testing.T, filePath string) types.Report {
 	t.Helper()
 
 	f, err := os.Open(filePath)
 	require.NoError(t, err, filePath)
 	defer f.Close()
 
-	var res report.Report
+	var res types.Report
 	err = json.NewDecoder(f).Decode(&res)
 	require.NoError(t, err, filePath)
 

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -190,7 +190,7 @@ func initializeScanner(ctx context.Context, opt Option) (scanner.Scanner, func()
 	return s, cleanup, nil
 }
 
-func exit(c Option, results pkgReport.Results) {
+func exit(c Option, results types.Results) {
 	if c.ExitCode != 0 {
 		for _, result := range results {
 			if len(result.Vulnerabilities) > 0 {

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/aquasecurity/trivy/pkg/types"
 	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // JSONWriter implements result Writer

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aquasecurity/trivy/pkg/types"
 	"golang.org/x/xerrors"
 )
 
@@ -14,7 +15,7 @@ type JSONWriter struct {
 }
 
 // Write writes the results in JSON format
-func (jw JSONWriter) Write(report Report) error {
+func (jw JSONWriter) Write(report types.Report) error {
 	output, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return xerrors.Errorf("failed to marshal json: %w", err)

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -16,7 +16,7 @@ func TestReportWriter_JSON(t *testing.T) {
 	testCases := []struct {
 		name          string
 		detectedVulns []types.DetectedVulnerability
-		want          report.Report
+		want          types.Report
 	}{
 		{
 			name: "happy path",
@@ -34,11 +34,11 @@ func TestReportWriter_JSON(t *testing.T) {
 					},
 				},
 			},
-			want: report.Report{
+			want: types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "alpine:3.14",
-				Results: report.Results{
-					report.Result{
+				Results: types.Results{
+					types.Result{
 						Target: "foojson",
 						Vulnerabilities: []types.DetectedVulnerability{
 							{
@@ -66,10 +66,10 @@ func TestReportWriter_JSON(t *testing.T) {
 			jsonWritten := bytes.Buffer{}
 			jw.Output = &jsonWritten
 
-			inputResults := report.Report{
+			inputResults := types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "alpine:3.14",
-				Results: report.Results{
+				Results: types.Results{
 					{
 						Target:          "foojson",
 						Vulnerabilities: tc.detectedVulns,
@@ -83,7 +83,7 @@ func TestReportWriter_JSON(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			var got report.Report
+			var got types.Report
 			err = json.Unmarshal(jsonWritten.Bytes(), &got)
 			assert.NoError(t, err, "invalid json written")
 

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -106,7 +106,7 @@ func getRuleIndex(id string, indexes map[string]int) int {
 	}
 }
 
-func (sw SarifWriter) Write(report Report) error {
+func (sw SarifWriter) Write(report types.Report) error {
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return xerrors.Errorf("error creating a new sarif template: %w", err)
@@ -174,11 +174,11 @@ func (sw SarifWriter) Write(report Report) error {
 
 func toSarifRuleName(class string) string {
 	switch class {
-	case ClassOSPkg:
+	case types.ClassOSPkg:
 		return sarifOsPackageVulnerability
-	case ClassLangPkg:
+	case types.ClassLangPkg:
 		return sarifLanguageSpecificVulnerability
-	case ClassConfig:
+	case types.ClassConfig:
 		return sarifConfigFiles
 	default:
 		return sarifUnknownIssue

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -26,16 +26,16 @@ func getIntPointer(i int) *int {
 func TestReportWriter_Sarif(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       report.Results
+		input       types.Results
 		wantRules   []*sarif.ReportingDescriptor
 		wantResults []*sarif.Result
 	}{
 		{
 			name: "report with vulnerabilities",
-			input: report.Results{
+			input: types.Results{
 				{
 					Target: "test",
-					Class:  report.ClassOSPkg,
+					Class:  types.ClassOSPkg,
 					Vulnerabilities: []types.DetectedVulnerability{
 						{
 							VulnerabilityID:  "CVE-2020-0001",
@@ -110,10 +110,10 @@ func TestReportWriter_Sarif(t *testing.T) {
 		},
 		{
 			name: "report with misconfigurations",
-			input: report.Results{
+			input: types.Results{
 				{
 					Target: "test",
-					Class:  report.ClassConfig,
+					Class:  types.ClassConfig,
 					Misconfigurations: []types.DetectedMisconfiguration{
 						{
 							Type:       "Kubernetes Security Check",
@@ -231,7 +231,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sarifWritten := bytes.Buffer{}
-			err := report.Write(report.Report{Results: tt.input}, report.Option{
+			err := report.Write(types.Report{Results: tt.input}, report.Option{
 				Format: "sarif",
 				Output: &sarifWritten,
 			})

--- a/pkg/report/table.go
+++ b/pkg/report/table.go
@@ -25,14 +25,14 @@ type TableWriter struct {
 }
 
 // Write writes the result on standard output
-func (tw TableWriter) Write(report Report) error {
+func (tw TableWriter) Write(report types.Report) error {
 	for _, result := range report.Results {
 		tw.write(result)
 	}
 	return nil
 }
 
-func (tw TableWriter) write(result Result) {
+func (tw TableWriter) write(result types.Result) {
 	table := tablewriter.NewWriter(tw.Output)
 
 	var severityCount map[string]int
@@ -45,7 +45,7 @@ func (tw TableWriter) write(result Result) {
 	total, summaries := tw.summary(severityCount)
 
 	target := result.Target
-	if result.Class != ClassOSPkg {
+	if result.Class != types.ClassOSPkg {
 		target += fmt.Sprintf(" (%s)", result.Type)
 	}
 
@@ -198,7 +198,7 @@ func (tw TableWriter) setMisconfRows(table *tablewriter.Table, misconfs []types.
 	return severityCount
 }
 
-func (tw TableWriter) outputTrace(result Result) {
+func (tw TableWriter) outputTrace(result types.Result) {
 	blue := color.New(color.FgBlue).SprintFunc()
 	green := color.New(color.FgGreen).SprintfFunc()
 	red := color.New(color.FgRed).SprintfFunc()

--- a/pkg/report/table_test.go
+++ b/pkg/report/table_test.go
@@ -14,13 +14,13 @@ import (
 func TestReportWriter_Table(t *testing.T) {
 	testCases := []struct {
 		name               string
-		results            report.Results
+		results            types.Results
 		expectedOutput     string
 		includeNonFailures bool
 	}{
 		{
 			name: "happy path full",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -49,7 +49,7 @@ func TestReportWriter_Table(t *testing.T) {
 		},
 		{
 			name: "no title for vuln and missing primary link",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -75,7 +75,7 @@ func TestReportWriter_Table(t *testing.T) {
 		},
 		{
 			name: "long title for vuln",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -104,7 +104,7 @@ func TestReportWriter_Table(t *testing.T) {
 		},
 		{
 			name: "happy path misconfigurations",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Misconfigurations: []types.DetectedMisconfiguration{
@@ -143,7 +143,7 @@ func TestReportWriter_Table(t *testing.T) {
 		{
 			name:               "happy path misconfigurations with successes",
 			includeNonFailures: true,
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Misconfigurations: []types.DetectedMisconfiguration{
@@ -187,7 +187,7 @@ func TestReportWriter_Table(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tableWritten := bytes.Buffer{}
-			err := report.Write(report.Report{Results: tc.results}, report.Option{
+			err := report.Write(types.Report{Results: tc.results}, report.Option{
 				Format:             "table",
 				Output:             &tableWritten,
 				IncludeNonFailures: tc.includeNonFailures,

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -14,6 +14,7 @@ import (
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // CustomTemplateFuncMap is used to overwrite existing functions for testing.
@@ -70,7 +71,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter
 }
 
 // Write writes result
-func (tw TemplateWriter) Write(report Report) error {
+func (tw TemplateWriter) Write(report types.Report) error {
 	err := tw.Template.Execute(tw.Output, report.Results)
 	if err != nil {
 		return xerrors.Errorf("failed to write with template: %w", err)

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -165,8 +165,8 @@ func TestReportWriter_Template(t *testing.T) {
 			}
 			os.Setenv("AWS_ACCOUNT_ID", "123456789012")
 			got := bytes.Buffer{}
-			inputReport := report.Report{
-				Results: report.Results{
+			inputReport := types.Report{
+				Results: types.Results{
 					{
 						Target:          "foojunit",
 						Type:            "test",
@@ -203,8 +203,8 @@ func TestReportWriter_Template_SARIF(t *testing.T) {
 			template, err := os.ReadFile(templateFile)
 			require.NoError(t, err, tc.name)
 
-			inputReport := report.Report{
-				Results: report.Results{
+			inputReport := types.Report{
+				Results: types.Results{
 					{
 						Target:          tc.target,
 						Type:            "footype",

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -6,10 +6,8 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"golang.org/x/xerrors"
 
-	ftypes "github.com/aquasecurity/fanal/types"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -21,75 +19,6 @@ const (
 
 // Now returns the current time
 var Now = time.Now
-
-// Report represents a scan result
-type Report struct {
-	SchemaVersion int                 `json:",omitempty"`
-	ArtifactName  string              `json:",omitempty"`
-	ArtifactType  ftypes.ArtifactType `json:",omitempty"`
-	Metadata      Metadata            `json:",omitempty"`
-	Results       Results             `json:",omitempty"`
-}
-
-// Metadata represents a metadata of artifact
-type Metadata struct {
-	Size int64      `json:",omitempty"`
-	OS   *ftypes.OS `json:",omitempty"`
-
-	// Container image
-	ImageID     string        `json:",omitempty"`
-	DiffIDs     []string      `json:",omitempty"`
-	RepoTags    []string      `json:",omitempty"`
-	RepoDigests []string      `json:",omitempty"`
-	ImageConfig v1.ConfigFile `json:",omitempty"`
-}
-
-// Results to hold list of Result
-type Results []Result
-
-type ResultClass string
-
-const (
-	ClassOSPkg   = "os-pkgs"
-	ClassLangPkg = "lang-pkgs"
-	ClassConfig  = "config"
-)
-
-// Result holds a target and detected vulnerabilities
-type Result struct {
-	Target            string                           `json:"Target"`
-	Class             ResultClass                      `json:"Class,omitempty"`
-	Type              string                           `json:"Type,omitempty"`
-	Packages          []ftypes.Package                 `json:"Packages,omitempty"`
-	Vulnerabilities   []types.DetectedVulnerability    `json:"Vulnerabilities,omitempty"`
-	MisconfSummary    *MisconfSummary                  `json:"MisconfSummary,omitempty"`
-	Misconfigurations []types.DetectedMisconfiguration `json:"Misconfigurations,omitempty"`
-}
-
-type MisconfSummary struct {
-	Successes  int
-	Failures   int
-	Exceptions int
-}
-
-func (s MisconfSummary) Empty() bool {
-	return s.Successes == 0 && s.Failures == 0 && s.Exceptions == 0
-}
-
-// Failed returns whether the result includes any vulnerabilities or misconfigurations
-func (results Results) Failed() bool {
-	for _, r := range results {
-		if len(r.Vulnerabilities) > 0 {
-			return true
-		}
-		for _, m := range r.Misconfigurations {
-			if m.Status == types.StatusFailure {
-				return true
-			}
-		}
-	}
-	return false
-}
 
 type Option struct {
 	Format         string
@@ -104,7 +33,7 @@ type Option struct {
 }
 
 // Write writes the result to output, format as passed in argument
-func Write(report Report, option Option) error {
+func Write(report types.Report, option Option) error {
 	var writer Writer
 	switch option.Format {
 	case "table":
@@ -141,5 +70,5 @@ func Write(report Report, option Option) error {
 
 // Writer defines the result write operation
 type Writer interface {
-	Write(Report) error
+	Write(types.Report) error
 }

--- a/pkg/report/writer_test.go
+++ b/pkg/report/writer_test.go
@@ -5,19 +5,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 func TestResults_Failed(t *testing.T) {
 	tests := []struct {
 		name    string
-		results report.Results
+		results types.Results
 		want    bool
 	}{
 		{
 			name: "no vulnerabilities and misconfigurations",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Type:   "test",
@@ -27,7 +26,7 @@ func TestResults_Failed(t *testing.T) {
 		},
 		{
 			name: "vulnerabilities found",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Type:   "test",
@@ -43,7 +42,7 @@ func TestResults_Failed(t *testing.T) {
 		},
 		{
 			name: "failed misconfigurations",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Type:   "test",
@@ -60,7 +59,7 @@ func TestResults_Failed(t *testing.T) {
 		},
 		{
 			name: "passed misconfigurations",
-			results: report.Results{
+			results: types.Results{
 				{
 					Target: "test",
 					Type:   "test",

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -16,7 +16,6 @@ import (
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy/pkg/log"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
 )
@@ -134,7 +133,7 @@ func (c Client) getPrimaryURL(vulnID string, refs []string, source dbTypes.Sourc
 // Filter filter out the vulnerabilities
 func (c Client) Filter(ctx context.Context, vulns []types.DetectedVulnerability, misconfs []types.DetectedMisconfiguration,
 	severities []dbTypes.Severity, ignoreUnfixed, includeNonFailures bool, ignoreFile, policyFile string) (
-	[]types.DetectedVulnerability, *report.MisconfSummary, []types.DetectedMisconfiguration, error) {
+	[]types.DetectedVulnerability, *types.MisconfSummary, []types.DetectedMisconfiguration, error) {
 	ignoredIDs := getIgnoredIDs(ignoreFile)
 
 	filteredVulns := filterVulnerabilities(vulns, severities, ignoreUnfixed, ignoredIDs)
@@ -185,9 +184,9 @@ func filterVulnerabilities(vulns []types.DetectedVulnerability, severities []dbT
 }
 
 func filterMisconfigurations(misconfs []types.DetectedMisconfiguration, severities []dbTypes.Severity,
-	includeNonFailures bool, ignoredIDs []string) (*report.MisconfSummary, []types.DetectedMisconfiguration) {
+	includeNonFailures bool, ignoredIDs []string) (*types.MisconfSummary, []types.DetectedMisconfiguration) {
 	var filtered []types.DetectedMisconfiguration
-	summary := new(report.MisconfSummary)
+	summary := new(types.MisconfSummary)
 
 	for _, misconf := range misconfs {
 		// Filter misconfigurations by severity
@@ -216,7 +215,7 @@ func filterMisconfigurations(misconfs []types.DetectedMisconfiguration, severiti
 	return summary, filtered
 }
 
-func summarize(status types.MisconfStatus, summary *report.MisconfSummary) {
+func summarize(status types.MisconfStatus, summary *types.MisconfSummary) {
 	switch status {
 	case types.StatusFailure:
 		summary.Failures++

--- a/pkg/result/result_test.go
+++ b/pkg/result/result_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -364,7 +363,7 @@ func TestClient_Filter(t *testing.T) {
 		name               string
 		args               args
 		wantVulns          []types.DetectedVulnerability
-		wantMisconfSummary *report.MisconfSummary
+		wantMisconfSummary *types.MisconfSummary
 		wantMisconfs       []types.DetectedMisconfiguration
 	}{
 		{
@@ -476,7 +475,7 @@ func TestClient_Filter(t *testing.T) {
 					},
 				},
 			},
-			wantMisconfSummary: &report.MisconfSummary{
+			wantMisconfSummary: &types.MisconfSummary{
 				Successes:  0,
 				Failures:   1,
 				Exceptions: 0,

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/wire"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy/pkg/report"
 	r "github.com/aquasecurity/trivy/pkg/rpc"
 	rpc "github.com/aquasecurity/trivy/rpc/scanner"
 )
@@ -45,7 +44,7 @@ func NewScanner(customHeaders CustomHeaders, s rpc.Scanner) Scanner {
 }
 
 // Scan scans the image
-func (s Scanner) Scan(target, artifactKey string, blobKeys []string, options types.ScanOptions) (report.Results, *ftypes.OS, error) {
+func (s Scanner) Scan(target, artifactKey string, blobKeys []string, options types.ScanOptions) (types.Results, *ftypes.OS, error) {
 	ctx := WithCustomHeaders(context.Background(), http.Header(s.customHeaders))
 
 	var res *rpc.ScanResponse

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -13,7 +13,6 @@ import (
 	ftypes "github.com/aquasecurity/fanal/types"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/rpc/common"
 	"github.com/aquasecurity/trivy/rpc/scanner"
@@ -99,7 +98,7 @@ func TestScanner_Scan(t *testing.T) {
 		fields          fields
 		args            args
 		scanExpectation scanExpectation
-		wantResults     report.Results
+		wantResults     types.Results
 		wantOS          *ftypes.OS
 		wantEosl        bool
 		wantErr         string
@@ -183,7 +182,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "alpine:3.11",
 					Vulnerabilities: []types.DetectedVulnerability{

--- a/pkg/rpc/convert.go
+++ b/pkg/rpc/convert.go
@@ -11,7 +11,6 @@ import (
 	deptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/log"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/rpc/cache"
 	"github.com/aquasecurity/trivy/rpc/common"
@@ -193,15 +192,15 @@ func ConvertToRPCDataSource(ds *dbTypes.DataSource) *common.DataSource {
 	}
 }
 
-// ConvertFromRPCResults converts scanner.Result to report.Result
-func ConvertFromRPCResults(rpcResults []*scanner.Result) []report.Result {
-	var results []report.Result
+// ConvertFromRPCResults converts scanner.Result to types.Result
+func ConvertFromRPCResults(rpcResults []*scanner.Result) []types.Result {
+	var results []types.Result
 	for _, result := range rpcResults {
-		results = append(results, report.Result{
+		results = append(results, types.Result{
 			Target:            result.Target,
 			Vulnerabilities:   ConvertFromRPCVulns(result.Vulnerabilities),
 			Misconfigurations: ConvertFromRPCMisconfs(result.Misconfigurations),
-			Class:             report.ResultClass(result.Class),
+			Class:             types.ResultClass(result.Class),
 			Type:              result.Type,
 			Packages:          ConvertFromRPCPkgs(result.Packages),
 		})
@@ -518,8 +517,8 @@ func ConvertToMissingBlobsRequest(imageID string, layerIDs []string) *cache.Miss
 	}
 }
 
-// ConvertToRPCScanResponse converts report.Result to ScanResponse
-func ConvertToRPCScanResponse(results report.Results, fos *ftypes.OS) *scanner.ScanResponse {
+// ConvertToRPCScanResponse converts types.Result to ScanResponse
+func ConvertToRPCScanResponse(results types.Results, fos *ftypes.OS) *scanner.ScanResponse {
 	var rpcResults []*scanner.Result
 	for _, result := range results {
 		rpcResults = append(rpcResults, &scanner.Result{

--- a/pkg/rpc/convert_test.go
+++ b/pkg/rpc/convert_test.go
@@ -12,7 +12,6 @@ import (
 	ptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/rpc/common"
 	"github.com/aquasecurity/trivy/rpc/scanner"
@@ -345,7 +344,7 @@ func TestConvertFromRPCResults(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []report.Result
+		want []types.Result
 	}{
 		{
 			name: "happy path",
@@ -388,7 +387,7 @@ func TestConvertFromRPCResults(t *testing.T) {
 					},
 				}},
 			},
-			want: []report.Result{
+			want: []types.Result{
 				{
 					Target: "alpine:3.10",
 					Type:   fos.Alpine,
@@ -468,7 +467,7 @@ func TestConvertFromRPCResults(t *testing.T) {
 					},
 				}},
 			},
-			want: []report.Result{
+			want: []types.Result{
 				{
 					Target: "alpine:3.10",
 					Type:   fos.Alpine,

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -19,7 +19,6 @@ import (
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/result"
 	"github.com/aquasecurity/trivy/pkg/scanner"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -63,7 +62,7 @@ func TestScanServer_Scan(t *testing.T) {
 					LayerIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
 				},
 				Returns: scanner.DriverScanReturns{
-					Results: report.Results{
+					Results: types.Results{
 						{
 							Target: "alpine:3.11 (alpine 3.11)",
 							Vulnerabilities: []types.DetectedVulnerability{

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
 	ospkgDetector "github.com/aquasecurity/trivy/pkg/detector/ospkg"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -29,7 +28,7 @@ func TestScanner_Scan(t *testing.T) {
 		fixtures                []string
 		applyLayersExpectation  ApplierApplyLayersExpectation
 		ospkgDetectExpectations []OspkgDetectorDetectExpectation
-		wantResults             report.Results
+		wantResults             types.Results
 		wantOS                  *ftypes.OS
 		wantErr                 string
 	}{
@@ -112,7 +111,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "alpine:latest (alpine 3.11)",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -126,7 +125,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassOSPkg,
+					Class: types.ClassOSPkg,
 					Type:  fos.Alpine,
 				},
 				{
@@ -142,7 +141,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  ftypes.Bundler,
 				},
 			},
@@ -246,7 +245,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "alpine:latest (alpine 3.11)",
 					Packages: []ftypes.Package{
@@ -276,7 +275,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassOSPkg,
+					Class: types.ClassOSPkg,
 					Type:  fos.Alpine,
 				},
 				{
@@ -301,7 +300,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  ftypes.Bundler,
 				},
 			},
@@ -346,7 +345,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "/app/Gemfile.lock",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -360,7 +359,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  "bundler",
 				},
 			},
@@ -417,10 +416,10 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "alpine:latest (alpine 3.11)",
-					Class:  report.ClassOSPkg,
+					Class:  types.ClassOSPkg,
 					Type:   fos.Alpine,
 				},
 				{
@@ -436,7 +435,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  "bundler",
 				},
 			},
@@ -495,7 +494,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "/app/Gemfile.lock",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -509,7 +508,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  ftypes.Bundler,
 				},
 			},
@@ -598,7 +597,7 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "/app/Gemfile.lock",
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -612,7 +611,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  ftypes.Bundler,
 				},
 				{
@@ -628,7 +627,7 @@ func TestScanner_Scan(t *testing.T) {
 							},
 						},
 					},
-					Class: report.ClassLangPkg,
+					Class: types.ClassLangPkg,
 					Type:  ftypes.Composer,
 				},
 			},
@@ -717,10 +716,10 @@ func TestScanner_Scan(t *testing.T) {
 					},
 				},
 			},
-			wantResults: report.Results{
+			wantResults: types.Results{
 				{
 					Target: "/app/configs/deployment.yaml",
-					Class:  report.ClassConfig,
+					Class:  types.ClassConfig,
 					Type:   ftypes.Kubernetes,
 					Misconfigurations: []types.DetectedMisconfiguration{
 						{
@@ -755,7 +754,7 @@ func TestScanner_Scan(t *testing.T) {
 				},
 				{
 					Target: "/app/configs/pod.yaml",
-					Class:  report.ClassConfig,
+					Class:  types.ClassConfig,
 					Type:   ftypes.Kubernetes,
 					Misconfigurations: []types.DetectedMisconfiguration{
 						{

--- a/pkg/scanner/mock_driver.go
+++ b/pkg/scanner/mock_driver.go
@@ -6,8 +6,6 @@ import (
 	fanaltypes "github.com/aquasecurity/fanal/types"
 	mock "github.com/stretchr/testify/mock"
 
-	report "github.com/aquasecurity/trivy/pkg/report"
-
 	types "github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -28,7 +26,7 @@ type DriverScanArgs struct {
 }
 
 type DriverScanReturns struct {
-	Results report.Results
+	Results types.Results
 	OsFound *fanaltypes.OS
 	Err     error
 }
@@ -70,15 +68,15 @@ func (_m *MockDriver) ApplyScanExpectations(expectations []DriverScanExpectation
 }
 
 // Scan provides a mock function with given fields: target, imageID, layerIDs, options
-func (_m *MockDriver) Scan(target string, artifactKey string, blobKeys []string, options types.ScanOptions) (report.Results, *fanaltypes.OS, error) {
+func (_m *MockDriver) Scan(target string, artifactKey string, blobKeys []string, options types.ScanOptions) (types.Results, *fanaltypes.OS, error) {
 	ret := _m.Called(target, artifactKey, blobKeys, options)
 
-	var r0 report.Results
-	if rf, ok := ret.Get(0).(func(string, string, []string, types.ScanOptions) report.Results); ok {
+	var r0 types.Results
+	if rf, ok := ret.Get(0).(func(string, string, []string, types.ScanOptions) types.Results); ok {
 		r0 = rf(target, artifactKey, blobKeys, options)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(report.Results)
+			r0 = ret.Get(0).(types.Results)
 		}
 	}
 

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -81,7 +81,7 @@ type Scanner struct {
 // Driver defines operations of scanner
 type Driver interface {
 	Scan(target string, artifactKey string, blobKeys []string, options types.ScanOptions) (
-		results report.Results, osFound *ftypes.OS, err error)
+		results types.Results, osFound *ftypes.OS, err error)
 }
 
 // NewScanner is the factory method of Scanner
@@ -90,15 +90,15 @@ func NewScanner(driver Driver, ar artifact.Artifact) Scanner {
 }
 
 // ScanArtifact scans the artifacts and returns results
-func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (report.Report, error) {
+func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (types.Report, error) {
 	artifactInfo, err := s.artifact.Inspect(ctx)
 	if err != nil {
-		return report.Report{}, xerrors.Errorf("failed analysis: %w", err)
+		return types.Report{}, xerrors.Errorf("failed analysis: %w", err)
 	}
 
 	results, osFound, err := s.driver.Scan(artifactInfo.Name, artifactInfo.ID, artifactInfo.BlobIDs, options)
 	if err != nil {
-		return report.Report{}, xerrors.Errorf("scan failed: %w", err)
+		return types.Report{}, xerrors.Errorf("scan failed: %w", err)
 	}
 
 	if osFound != nil && osFound.Eosl {
@@ -111,11 +111,11 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (r
 		removeLayer(results)
 	}
 
-	return report.Report{
+	return types.Report{
 		SchemaVersion: report.SchemaVersion,
 		ArtifactName:  artifactInfo.Name,
 		ArtifactType:  artifactInfo.Type,
-		Metadata: report.Metadata{
+		Metadata: types.Metadata{
 			OS:          osFound,
 			ImageID:     artifactInfo.ImageMetadata.ID,
 			DiffIDs:     artifactInfo.ImageMetadata.DiffIDs,
@@ -127,7 +127,7 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (r
 	}, nil
 }
 
-func removeLayer(results report.Results) {
+func removeLayer(results types.Results) {
 	for i := range results {
 		result := results[i]
 

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aquasecurity/fanal/artifact"
 	ftypes "github.com/aquasecurity/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -23,7 +22,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 		args               args
 		inspectExpectation artifact.ArtifactInspectExpectation
 		scanExpectation    DriverScanExpectation
-		want               report.Report
+		want               types.Report
 		wantErr            string
 	}{
 		{
@@ -58,7 +57,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 					Options:  types.ScanOptions{VulnType: []string{"os"}},
 				},
 				Returns: DriverScanReturns{
-					Results: report.Results{
+					Results: types.Results{
 						{
 							Target: "alpine:3.11",
 							Vulnerabilities: []types.DetectedVulnerability{
@@ -94,11 +93,11 @@ func TestScanner_ScanArtifact(t *testing.T) {
 					},
 				},
 			},
-			want: report.Report{
+			want: types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "alpine:3.11",
 				ArtifactType:  ftypes.ArtifactContainerImage,
-				Metadata: report.Metadata{
+				Metadata: types.Metadata{
 					OS: &ftypes.OS{
 						Family: "alpine",
 						Name:   "3.10",
@@ -109,7 +108,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 					RepoTags:    []string{"alpine:3.11"},
 					RepoDigests: []string{"alpine@sha256:0bd0e9e03a022c3b0226667621da84fc9bf562a9056130424b5bfbd8bcb0397f"},
 				},
-				Results: report.Results{
+				Results: types.Results{
 					{
 						Target: "alpine:3.11",
 						Vulnerabilities: []types.DetectedVulnerability{

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1" // nolint: goimports
 
 	ftypes "github.com/aquasecurity/fanal/types"
 )

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"github.com/google/go-containerregistry/pkg/v1"
+
+	ftypes "github.com/aquasecurity/fanal/types"
+)
+
+// Report represents a scan result
+type Report struct {
+	SchemaVersion int                 `json:",omitempty"`
+	ArtifactName  string              `json:",omitempty"`
+	ArtifactType  ftypes.ArtifactType `json:",omitempty"`
+	Metadata      Metadata            `json:",omitempty"`
+	Results       Results             `json:",omitempty"`
+}
+
+// Metadata represents a metadata of artifact
+type Metadata struct {
+	Size int64      `json:",omitempty"`
+	OS   *ftypes.OS `json:",omitempty"`
+
+	// Container image
+	ImageID     string        `json:",omitempty"`
+	DiffIDs     []string      `json:",omitempty"`
+	RepoTags    []string      `json:",omitempty"`
+	RepoDigests []string      `json:",omitempty"`
+	ImageConfig v1.ConfigFile `json:",omitempty"`
+}
+
+// Results to hold list of Result
+type Results []Result
+
+type ResultClass string
+
+const (
+	ClassOSPkg   = "os-pkgs"
+	ClassLangPkg = "lang-pkgs"
+	ClassConfig  = "config"
+)
+
+// Result holds a target and detected vulnerabilities
+type Result struct {
+	Target            string                     `json:"Target"`
+	Class             ResultClass                `json:"Class,omitempty"`
+	Type              string                     `json:"Type,omitempty"`
+	Packages          []ftypes.Package           `json:"Packages,omitempty"`
+	Vulnerabilities   []DetectedVulnerability    `json:"Vulnerabilities,omitempty"`
+	MisconfSummary    *MisconfSummary            `json:"MisconfSummary,omitempty"`
+	Misconfigurations []DetectedMisconfiguration `json:"Misconfigurations,omitempty"`
+}
+
+type MisconfSummary struct {
+	Successes  int
+	Failures   int
+	Exceptions int
+}
+
+func (s MisconfSummary) Empty() bool {
+	return s.Successes == 0 && s.Failures == 0 && s.Exceptions == 0
+}
+
+// Failed returns whether the result includes any vulnerabilities or misconfigurations
+func (results Results) Failed() bool {
+	for _, r := range results {
+		if len(r.Vulnerabilities) > 0 {
+			return true
+		}
+		for _, m := range r.Misconfigurations {
+			if m.Status == StatusFailure {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description
Move all structs under the `report` package under `types` package

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
