### PR TITLE
feat: add TLS support for server mode

### DIFF
--- a/docs/getting-started/cli/server.md
+++ b/docs/getting-started/cli/server.md
@@ -15,5 +15,7 @@ OPTIONS:
    --token value          for authentication [$TRIVY_TOKEN]
    --token-header value   specify a header name for token (default: "Trivy-Token") [$TRIVY_TOKEN_HEADER]
    --listen value         listen address (default: "localhost:4954") [$TRIVY_LISTEN]
+   --server-cert value    server certificate file location [$TRIVY_SERVER_CERT]
+   --server-key value     server key file location [$TRIVY_SERVER_KEY]
    --help, -h             show help (default: false)
 ```

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -631,6 +631,16 @@ func NewServerCommand() *cli.Command {
 				Usage:   "listen address",
 				EnvVars: []string{"TRIVY_LISTEN"},
 			},
+			&cli.StringFlag{
+				Name:    "server-cert",
+				Usage:   "server certificate file location",
+				EnvVars: []string{"TRIVY_SERVER_CERT"},
+			},
+			&cli.StringFlag{
+				Name:    "server-key",
+				Usage:   "server key file location",
+				EnvVars: []string{"TRIVY_SERVER_KEY"},
+			},
 		},
 	}
 }

--- a/pkg/commands/server/config.go
+++ b/pkg/commands/server/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	option.CacheOption
 
 	Listen      string
+	Cert        string
+	Key         string
 	Token       string
 	TokenHeader string
 }
@@ -27,6 +29,8 @@ func NewConfig(c *cli.Context) Config {
 		CacheOption:  option.NewCacheOption(c),
 
 		Listen:      c.String("listen"),
+		Cert:        c.Path("server-cert"),
+		Key:         c.Path("server-key"),
 		Token:       c.String("token"),
 		TokenHeader: c.String("token-header"),
 	}

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -52,6 +52,6 @@ func run(c Config) (err error) {
 		return xerrors.Errorf("error in vulnerability DB initialize: %w", err)
 	}
 
-	server := rpcServer.NewServer(c.AppVersion, c.Listen, c.CacheDir, c.Token, c.TokenHeader)
+	server := rpcServer.NewServer(c.AppVersion, c.Listen, c.Cert, c.Key, c.CacheDir, c.Token, c.TokenHeader)
 	return server.ListenAndServe(cache)
 }

--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -28,16 +28,20 @@ const updateInterval = 1 * time.Hour
 type Server struct {
 	appVersion  string
 	addr        string
+	cert        string
+	key         string
 	cacheDir    string
 	token       string
 	tokenHeader string
 }
 
 // NewServer returns an instance of Server
-func NewServer(appVersion, addr, cacheDir, token, tokenHeader string) Server {
+func NewServer(appVersion, addr, cert, key, cacheDir, token, tokenHeader string) Server {
 	return Server{
 		appVersion:  appVersion,
 		addr:        addr,
+		cert:        cert,
+		key:         key,
 		cacheDir:    cacheDir,
 		token:       token,
 		tokenHeader: tokenHeader,
@@ -62,6 +66,10 @@ func (s Server) ListenAndServe(serverCache cache.Cache) error {
 
 	mux := newServeMux(serverCache, dbUpdateWg, requestWg, s.token, s.tokenHeader)
 	log.Logger.Infof("Listening %s...", s.addr)
+
+	if s.cert != "" && s.key != "" {
+		return http.ListenAndServeTLS(s.addr, s.cert, s.key, mux)
+	}
 
 	return http.ListenAndServe(s.addr, mux)
 }


### PR DESCRIPTION
## Description

This PR adds two new flags (certificate and key respectively) to add TLS support for server mode. The name was chosen based on the other cert/key flags, let me know if it's good.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/524



## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
