### PR TITLE
feat(template) Add misconfigurations to junit report

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -14,5 +14,18 @@
         </testcase>
     {{- end }}
     </testsuite>
+{{- $failures := len .Misconfigurations }}
+    <testsuite tests="{{ $failures }}" failures="{{ $failures }}" name="{{  .Target }}" errors="0" skipped="0" time="">
+    {{- if not (eq .Type "") }}
+        <properties>
+            <property name="type" value="{{ .Type }}"></property>
+        </properties>
+        {{- end -}}
+        {{ range .Misconfigurations }}
+        <testcase classname="{{ .Type }}" name="[{{ .Severity }}] {{ .ID }}" time="">
+            <failure message="{{ escapeXML .Title }}" type="description">{{ escapeXML .Description }}</failure>
+        </testcase>
+    {{- end }}
+    </testsuite>
 {{- end }}
 </testsuites>


### PR DESCRIPTION
## Description

Junit report for misconfigurations was missing 

Usage example:
`trivy  fs  --security-checks config,vuln --format template --template "@junit.tpl" -o junit-report.xml {folder}`

![Screenshot from 2022-02-15 10-11-40](https://user-images.githubusercontent.com/12291998/154019923-9c62fc0b-762e-4d35-a028-22cdd31605d4.png)


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
