### PR TITLE
feat(helm): Add support for server token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-trivy
+/trivy
 
 ## chart release
 .cr-release-packages

--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.11
+version: 0.4.12
 appVersion: 0.24.0
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.skipUpdate`            | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
+| `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
 | `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
 | `service.port`                        | Kubernetes service port                                                 | `4954`      |
 | `httpProxy`                           | The URL of the HTTP proxy server                                        |     |

--- a/helm/trivy/templates/secret.yaml
+++ b/helm/trivy/templates/secret.yaml
@@ -7,6 +7,7 @@ metadata:
 type: Opaque
 data:
   GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+  TRIVY_TOKEN: {{ .Values.trivy.serverToken | default "" | b64enc | quote }}
 {{- if not .Values.trivy.registryCredentialsExistingSecret }}
   TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
   TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -111,6 +111,8 @@ trivy:
       # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
   # If you want to add custom labels to your statefulset and podTemplate
   labels: {}
+  # serverToken is the token to authenticate Trivy client with Trivy server.
+  serverToken: ""
 
 service:
   # type Kubernetes service type


### PR DESCRIPTION
## Description

Add support to the Helm chart for specifying `TRIVY_TOKEN`. Use `trivy.serverToken` to align with the Starboard chart.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
