### PR TITLE
feat(client): add local filesystem scan in client/server mode

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -602,6 +602,11 @@ func NewClientCommand() *cli.Command {
 				Usage:   "custom headers",
 				EnvVars: []string{"TRIVY_CUSTOM_HEADERS"},
 			},
+			&cli.BoolFlag{
+				Name:  "filesystem",
+				Value: false,
+				Usage: "scan local filesystem",
+			},
 		},
 	}
 }

--- a/pkg/commands/client/inject.go
+++ b/pkg/commands/client/inject.go
@@ -17,6 +17,12 @@ import (
 	"github.com/aquasecurity/trivy/pkg/scanner"
 )
 
+func initializeFilesystemScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
+	customHeaders client.CustomHeaders, url client.RemoteURL, insecure client.Insecure, artifactOption artifact.Option, configScannerOption config.ScannerOption) (scanner.Scanner, func(), error) {
+	wire.Build(scanner.RemoteFilesystemSet)
+	return scanner.Scanner{}, nil, nil
+}
+
 func initializeDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, customHeaders client.CustomHeaders,
 	url client.RemoteURL, insecure client.Insecure, dockerOpt types.DockerOption, artifactOption artifact.Option, configScannerOption config.ScannerOption) (
 	scanner.Scanner, func(), error) {

--- a/pkg/commands/client/option.go
+++ b/pkg/commands/client/option.go
@@ -31,8 +31,8 @@ type Option struct {
 	tokenHeader   string
 	customHeaders []string
 	// this field is populated in Init()
-	CustomHeaders http.Header
-	FileSystem    bool
+	CustomHeaders  http.Header
+	ScanFileSystem bool
 }
 
 // NewOption is the factory method for Option
@@ -53,7 +53,7 @@ func NewOption(c *cli.Context) (Option, error) {
 		token:          c.String("token"),
 		tokenHeader:    c.String("token-header"),
 		customHeaders:  c.StringSlice("custom-headers"),
-		FileSystem:     c.Bool("filesystem"),
+		ScanFileSystem: c.Bool("filesystem"),
 	}, nil
 }
 

--- a/pkg/commands/client/option.go
+++ b/pkg/commands/client/option.go
@@ -32,6 +32,7 @@ type Option struct {
 	customHeaders []string
 	// this field is populated in Init()
 	CustomHeaders http.Header
+	FileSystem    bool
 }
 
 // NewOption is the factory method for Option
@@ -52,6 +53,7 @@ func NewOption(c *cli.Context) (Option, error) {
 		token:          c.String("token"),
 		tokenHeader:    c.String("token-header"),
 		customHeaders:  c.StringSlice("custom-headers"),
+		FileSystem:     c.Bool("filesystem"),
 	}, nil
 }
 

--- a/pkg/commands/client/run.go
+++ b/pkg/commands/client/run.go
@@ -32,7 +32,7 @@ func Run(cliCtx *cli.Context) error {
 	ctx, cancel := context.WithTimeout(cliCtx.Context, opt.Timeout)
 	defer cancel()
 
-	if opt.FileSystem {
+	if opt.ScanFileSystem {
 		// Disable the individual package scanning
 		opt.DisabledAnalyzers = analyzer.TypeIndividualPkgs
 	} else {
@@ -180,7 +180,7 @@ func initializeScanner(ctx context.Context, opt Option) (scanner.Scanner, func()
 		return s, func() {}, nil
 	}
 
-	if opt.FileSystem {
+	if opt.ScanFileSystem {
 		s, cleanup, err := initializeFilesystemScanner(ctx, opt.Target, remoteCache, client.CustomHeaders(opt.CustomHeaders),
 			client.RemoteURL(opt.RemoteAddr), client.Insecure(opt.Insecure), artifactOpt, configScannerOptions)
 		if err != nil {

--- a/pkg/commands/client/wire_gen.go
+++ b/pkg/commands/client/wire_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aquasecurity/fanal/analyzer/config"
 	"github.com/aquasecurity/fanal/artifact"
 	image2 "github.com/aquasecurity/fanal/artifact/image"
+	"github.com/aquasecurity/fanal/artifact/local"
 	"github.com/aquasecurity/fanal/cache"
 	"github.com/aquasecurity/fanal/image"
 	"github.com/aquasecurity/fanal/types"
@@ -21,6 +22,18 @@ import (
 )
 
 // Injectors from inject.go:
+
+func initializeFilesystemScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache, customHeaders client.CustomHeaders, url client.RemoteURL, insecure client.Insecure, artifactOption artifact.Option, configScannerOption config.ScannerOption) (scanner.Scanner, func(), error) {
+	scannerScanner := client.NewProtobufClient(url, insecure)
+	clientScanner := client.NewScanner(customHeaders, scannerScanner)
+	artifactArtifact, err := local.NewArtifact(path, artifactCache, artifactOption, configScannerOption)
+	if err != nil {
+		return scanner.Scanner{}, nil, err
+	}
+	scanner2 := scanner.NewScanner(clientScanner, artifactArtifact)
+	return scanner2, func() {
+	}, nil
+}
 
 func initializeDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, customHeaders client.CustomHeaders, url client.RemoteURL, insecure client.Insecure, dockerOpt types.DockerOption, artifactOption artifact.Option, configScannerOption config.ScannerOption) (scanner.Scanner, func(), error) {
 	scannerScanner := client.NewProtobufClient(url, insecure)

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -54,7 +54,6 @@ var StandaloneRepositorySet = wire.NewSet(
 
 // RemoteSuperSet is used in the client mode
 var RemoteSuperSet = wire.NewSet(
-	aimage.NewArtifact,
 	client.SuperSet,
 	wire.Bind(new(Driver), new(client.Scanner)),
 	NewScanner,
@@ -62,12 +61,20 @@ var RemoteSuperSet = wire.NewSet(
 
 // RemoteDockerSet binds remote docker dependencies
 var RemoteDockerSet = wire.NewSet(
+	aimage.NewArtifact,
 	image.NewDockerImage,
+	RemoteSuperSet,
+)
+
+// RemoteFilesystemSet binds filesystem dependencies for client/server mode
+var RemoteFilesystemSet = wire.NewSet(
+	flocal.NewArtifact,
 	RemoteSuperSet,
 )
 
 // RemoteArchiveSet binds remote archive dependencies
 var RemoteArchiveSet = wire.NewSet(
+	aimage.NewArtifact,
 	image.NewArchiveImage,
 	RemoteSuperSet,
 )


### PR DESCRIPTION
## Description
Added a new option `--filesystem` to `client` command for support local filesystem scan in client/server mode.

## Related issues
- Close #634 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
