### PR TITLE
chore(deps): skipping vulnerabilities inside examples and packages for tests.

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -15,6 +15,8 @@ jobs:
           exit-code: '1'
           severity: 'CRITICAL'
           skip-dirs: integration
+          skip-dirs: examples
+          ignorefile: .trivyignore
 
       - name: Run Trivy vulnerability scanner to scan for Medium and High Vulnerabilities
         uses: aquasecurity/trivy-action@master
@@ -23,3 +25,5 @@ jobs:
           exit-code: '0'
           severity: 'HIGH,MEDIUM'
           skip-dirs: integration
+          skip-dirs: examples
+          ignorefile: .trivyignore

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# Accept the risk
+
+# github.com/satori/go.uuid uses only for tests. the binary file doesn't contain this library.
+CVE-2021-3538


### PR DESCRIPTION
## Description
There was added `.trivyignore` for skipping vulnerabilities inside packages for tests.
also PR excluded `example` folder from Scan Workflow.

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
