### PR TITLE
chore(deps): replace `satori` version and skipping examples folder 

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -14,7 +14,7 @@ jobs:
           scan-type: 'fs'
           exit-code: '1'
           severity: 'CRITICAL'
-          skip-dirs: integration
+          skip-dirs: integration,examples
 
       - name: Run Trivy vulnerability scanner to scan for Medium and High Vulnerabilities
         uses: aquasecurity/trivy-action@master
@@ -22,4 +22,4 @@ jobs:
           scan-type: 'fs'
           exit-code: '0'
           severity: 'HIGH,MEDIUM'
-          skip-dirs: integration
+          skip-dirs: integration,examples

--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 )
+
+replace github.com/satori/go.uuid v1.2.0 => github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,5 @@ require (
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 )
 
+// To resolve CVE-2021-3538. Note that it is used only for testing.
 replace github.com/satori/go.uuid v1.2.0 => github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102

--- a/go.sum
+++ b/go.sum
@@ -1467,7 +1467,7 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/saracen/walker v0.0.0-20191201085201-324a081bae7e h1:NO86zOn5ScSKW8wRbMaSIcjDZUFpWdCQQnexRqZ9h9A=
 github.com/saracen/walker v0.0.0-20191201085201-324a081bae7e/go.mod h1:G0Z6yVPru183i2MuRJx1DcR4dgIZtLcTdaaE/pC1BJU=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181016170032-d91630c85102/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=


### PR DESCRIPTION
## Description
`github.com/satori/go.uuid` was replaced to the latest version, because `github.com/satori/go.uuid@v1.2.0` contains CVE-2021-3538. **note**: this library uses only for tests.

Also `examples` folder was excluded from Scan Workflow.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
