### PR TITLE
doc(docker): Fix command to run trivy with docker on linux

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -118,7 +118,7 @@ Example:
 === "Linux"
 
     ``` bash
-    docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} [YOUR_IMAGE_NAME]
+    docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} image [YOUR_IMAGE_NAME]
     ```
 
 === "macOS"


### PR DESCRIPTION
## Description
Adds a missing `image` in the command to run trivy from the official docker image with `docker run`.
Without `image`, the image name itself is interpreted as a command (whereas the command we want to run here is `image`), and results in a failure with `No help topic for <IMAGE NAME>`.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
