### PR TITLE
fix(debian): use latest debian version to detect vulnerabilities

### DIFF
--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -2,23 +2,23 @@
 
 The unfixed/unfixable vulnerabilities mean that the patch has not yet been provided on their distribution. Trivy doesn't support self-compiled packages/binaries, but official packages provided by vendors such as Red Hat and Debian.
 
-| OS                               | Supported Versions                        | Target Packages               | Detection of unfixed vulnerabilities |
-| -------------------------------- |-------------------------------------------| ----------------------------- | :----------------------------------: |
-| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.15, edge               | Installed by apk              |                  NO                  |
-| Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |
-| Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
-| CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
-| AlmaLinux                        | 8                                         | Installed by yum/rpm          |                  NO                  |
-| Rocky Linux                      | 8                                         | Installed by yum/rpm          |                  NO                  |
-| Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
-| CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
-| Amazon Linux                     | 1, 2                                      | Installed by yum/rpm          |                  NO                  |
-| openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |
-| SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |
-| Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |
-| Debian GNU/Linux                 | wheezy, jessie, stretch, buster, bullseye | Installed by apt/apt-get/dpkg |                 YES                  |
-| Ubuntu                           | All versions supported by Canonical       | Installed by apt/apt-get/dpkg |                 YES                  |
-| Distroless[^2]                   | Any                                       | Installed by apt/apt-get/dpkg |                 YES                  |
+| OS                               | Supported Versions                        | Target Packages               | Detection of unfixed vulnerabilities | Detection of unfixed vulnerabilities at latest repository |
+| -------------------------------- |-------------------------------------------| ----------------------------- | :----------------------------------: | :-------------------------------------------------------: |
+| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.15, edge               | Installed by apk              |                  NO                  |                             NO                            |
+| Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |                             NO                            |
+| Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |                             NO                            |
+| CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |                             NO                            |
+| AlmaLinux                        | 8                                         | Installed by yum/rpm          |                  NO                  |                             NO                            |
+| Rocky Linux                      | 8                                         | Installed by yum/rpm          |                  NO                  |                             NO                            |
+| Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |                             NO                            |
+| CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |                             NO                            |
+| Amazon Linux                     | 1, 2                                      | Installed by yum/rpm          |                  NO                  |                             NO                            |
+| openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |                             NO                            |
+| SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |                             NO                            |
+| Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |                             NO                            |
+| Debian GNU/Linux                 | wheezy, jessie, stretch, buster, bullseye | Installed by apt/apt-get/dpkg |                 YES                  |                            YES                            |
+| Ubuntu                           | All versions supported by Canonical       | Installed by apt/apt-get/dpkg |                 YES                  |                             NO                            |
+| Distroless[^2]                   | Any                                       | Installed by apt/apt-get/dpkg |                 YES                  |                             NO                            |
 
 [^1]: https://developers.redhat.com/products/rhel/ubi
 [^2]: https://github.com/GoogleContainerTools/distroless

--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -136,6 +136,9 @@ $ trivy image -f json -o results.json golang:1.12-alpine
 
 `VulnerabilityID`, `PkgName`, `InstalledVersion`, and `Severity` in `Vulnerabilities` are always filled with values, but other fields might be empty.
 
+[`LatestPatch`](https://github.com/aquasecurity/trivy/pull/1764) only appears in `Vulnerabilities` when the package is vulnerable, and it could be fix
+with a release available in the latest repository version *(could be the same the image is using)*.
+
 ## SARIF
 [Sarif][sarif] can be generated with the `--format sarif` option.
 

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -119,7 +119,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 			}
 
 			// Check if there is a latest (probably unstable) patch for the specific vulnerability
-			latestPatch, err := s.hasAvailableFixedVersion(adv.VulnerabilityID, pkg.Name)
+			latestPatch, err := s.hasAvailableFixedVersion(adv.VulnerabilityID, pkg.SrcName)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to check latest fixed version: %w", err)
 			}

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -83,6 +83,55 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "latestPatch",
+			fixtures: []string{"testdata/fixtures/debian.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "9.1",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "libgcrypt20",
+						Version:    "1.8.7-6",
+						SrcName:    "libgcrypt20",
+						SrcVersion: "1.8.7-6",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "libgcrypt20",
+					VulnerabilityID:  "CVE-2018-6829",
+					InstalledVersion: "1.8.7-6",
+					FixedVersion:     "",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+				{
+					PkgName:          "libgcrypt20",
+					VulnerabilityID:  "CVE-2021-33560",
+					InstalledVersion: "1.8.7-6",
+					FixedVersion:     "",
+					LatestPatch:      "1.9.4-2",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+			},
+		},
+		{
 			name:     "invalid bucket",
 			fixtures: []string{"testdata/fixtures/invalid.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/debian/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/debian/testdata/fixtures/data-source.yaml
@@ -5,3 +5,8 @@
         ID: "debian"
         Name: "Debian Security Tracker"
         URL: "https://salsa.debian.org/security-tracker-team/security-tracker"
+    - key: debian 12
+      value:
+        ID: "debian"
+        Name: "Debian Testing Security Tracker"
+        URL: "https://salsa.debian.org/security-tracker-team/security-tracker"

--- a/pkg/detector/ospkg/debian/testdata/fixtures/debian.yaml
+++ b/pkg/detector/ospkg/debian/testdata/fixtures/debian.yaml
@@ -1,5 +1,14 @@
 - bucket: debian 9
   pairs:
+    - bucket: libgcrypt20
+      pairs:
+        - key: CVE-2021-33560
+          value:
+            FixedVersion: ""
+        - key: CVE-2018-6829
+          value:
+            FixedVersion: ""
+
     - bucket: apache2
       pairs:
         - key: CVE-2012-3499
@@ -14,3 +23,13 @@
           value:
             FixedVersion: ""
             Severity: 2
+- bucket: debian 12
+  pairs:
+    - bucket: libgcrypt20
+      pairs:
+        - key: CVE-2021-33560
+          value:
+            FixedVersion: "1.9.4-2"
+        - key: CVE-2018-6829
+          value:
+            FixedVersion: ""

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -13,6 +13,7 @@ type DetectedVulnerability struct {
 	PkgPath          string         `json:",omitempty"` // It will be filled in the case of language-specific packages such as egg/wheel and gemspec
 	InstalledVersion string         `json:",omitempty"`
 	FixedVersion     string         `json:",omitempty"`
+	LatestPatch      string         `json:",omitempty"`
 	Layer            ftypes.Layer   `json:",omitempty"`
 	SeveritySource   types.SourceID `json:",omitempty"`
 	PrimaryURL       string         `json:",omitempty"`


### PR DESCRIPTION
## Description
Hi!
I'm trying to address the issue described here: https://github.com/aquasecurity/trivy/issues/722
This is an opinionated approach I would like to discuss.
Currently, if you analyze the `debian:bullseye`, as an example, container image, it outputs a series of CVE, that's right. But the column specifying the patched version is not filled with the latest information. From my point of view, the information that should be there is the one available in the latest debian release (or pre-release), in this case, `bookworm`.

## Related issues
- Close #722

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).

<details>
<summary>Before</summary>

```bash
$ trivy i -f json --severity "HIGH" docker.io/library/debian:bullseye-slim
2022-03-08T08:47:53.907+0100    INFO    Detected OS: debian
2022-03-08T08:47:53.907+0100    INFO    Detecting Debian vulnerabilities...
2022-03-08T08:47:53.930+0100    INFO    Number of language-specific files: 0
{
  "SchemaVersion": 2,
  "ArtifactName": "docker.io/library/debian:bullseye-slim",
  "ArtifactType": "container_image",
  "Metadata": {
    "OS": {
      "Family": "debian",
      "Name": "11.2"
    },
    "ImageID": "sha256:7a8792605f8ca9b6d71c333681dc8ca98e96d8f76e1c97624b3c8c5338e4123b",
    "DiffIDs": [
      "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
    ],
    "RepoTags": [
      "debian:bullseye-slim"
    ],
    "RepoDigests": [
      "debian@sha256:4c25ffa6ef572cf0d57da8c634769a08ae94529f7de5be5587ec8ce7b9b50f9c"
    ],
    "ImageConfig": {
      "architecture": "amd64",
      "container": "9e9f310d3bbea14bc1a93fbc139ae01077b0938d0a7f95b00e0c5c53b43d41f7",
      "created": "2022-01-26T01:40:36.265271157Z",
      "docker_version": "20.10.7",
      "history": [
        {
          "created": "2022-01-26T01:40:35Z",
          "created_by": "/bin/sh -c #(nop) ADD file:90495c24c897ec47982e200f732f8be3109fcd791691ddffae0756898f91024f in / "
        },
        {
          "created": "2022-01-26T01:40:36Z",
          "created_by": "/bin/sh -c #(nop)  CMD [\"bash\"]",
          "empty_layer": true
        }
      ],
      "os": "linux",
      "rootfs": {
        "type": "layers",
        "diff_ids": [
          "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
        ]
      },
      "config": {
        "Cmd": [
          "bash"
        ],
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Image": "sha256:86744fc7ec6fbebfe215eacc65a96828bb9c6aea2fb37db38ea883dc72602c56"
      }
    }
  },
  "Results": [
    {
      "Target": "docker.io/library/debian:bullseye-slim (debian 11.2)",
      "Class": "os-pkgs",
      "Type": "debian",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2021-3999",
          "PkgName": "libc-bin",
          "InstalledVersion": "2.31-13+deb11u2",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-3999",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "glibc: Off-by-one buffer overflow/underflow in getcwd()",
          "Description": "A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.",
          "Severity": "HIGH",
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 7.4
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2021-3999",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3999",
            "https://ubuntu.com/security/notices/USN-5310-1",
            "https://ubuntu.com/security/notices/USN-5310-2",
            "https://www.openwall.com/lists/oss-security/2022/01/24/4"
          ]
        },
        {
          "VulnerabilityID": "CVE-2021-3999",
          "PkgName": "libc6",
          "InstalledVersion": "2.31-13+deb11u2",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-3999",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "glibc: Off-by-one buffer overflow/underflow in getcwd()",
          "Description": "A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.",
          "Severity": "HIGH",
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 7.4
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2021-3999",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3999",
            "https://ubuntu.com/security/notices/USN-5310-1",
            "https://ubuntu.com/security/notices/USN-5310-2",
            "https://www.openwall.com/lists/oss-security/2022/01/24/4"
          ]
        },
        {
          "VulnerabilityID": "CVE-2021-33560",
          "PkgName": "libgcrypt20",
          "InstalledVersion": "1.8.7-6",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "SeveritySource": "nvd",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-33560",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "libgcrypt: mishandles ElGamal encryption because it lacks exponent blinding to address a side-channel attack against mpi_powm",
          "Description": "Libgcrypt before 1.8.8 and 1.9.x before 1.9.3 mishandles ElGamal encryption because it lacks exponent blinding to address a side-channel attack against mpi_powm, and the window size is not chosen appropriately. This, for example, affects use of ElGamal in OpenPGP.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-203"
          ],
          "CVSS": {
            "nvd": {
              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
              "V2Score": 5,
              "V3Score": 7.5
            },
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
              "V3Score": 7.5
            }
          },
          "References": [
            "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-33560.json",
            "https://access.redhat.com/security/cve/CVE-2021-33560",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33560",
            "https://dev.gnupg.org/T5305",
            "https://dev.gnupg.org/T5328",
            "https://dev.gnupg.org/T5466",
            "https://dev.gnupg.org/rCe8b7f10be275bcedb5fc05ed4837a89bfd605c61",
            "https://eprint.iacr.org/2021/923",
            "https://linux.oracle.com/cve/CVE-2021-33560.html",
            "https://linux.oracle.com/errata/ELSA-2021-4409.html",
            "https://lists.debian.org/debian-lts-announce/2021/06/msg00021.html",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BKKTOIGFW2SGN3DO2UHHVZ7MJSYN4AAB/",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/R7OAPCUGPF3VLA7QAJUQSL255D4ITVTL/",
            "https://nvd.nist.gov/vuln/detail/CVE-2021-33560",
            "https://ubuntu.com/security/notices/USN-5080-1",
            "https://ubuntu.com/security/notices/USN-5080-2",
            "https://www.oracle.com/security-alerts/cpujan2022.html",
            "https://www.oracle.com/security-alerts/cpuoct2021.html"
          ],
          "PublishedDate": "2021-06-08T11:15:00Z",
          "LastModifiedDate": "2022-03-01T15:21:00Z"
        },
        {
          "VulnerabilityID": "CVE-2020-16156",
          "PkgName": "perl-base",
          "InstalledVersion": "5.32.1-4+deb11u2",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "SeveritySource": "nvd",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-16156",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "perl-CPAN: Bypass of verification of signatures in CHECKSUMS files",
          "Description": "CPAN 2.28 allows Signature Verification Bypass.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-347"
          ],
          "CVSS": {
            "nvd": {
              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V2Score": 6.8,
              "V3Score": 7.8
            },
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V3Score": 7.8
            }
          },
          "References": [
            "http://blogs.perl.org/users/neilb/2021/11/addressing-cpan-vulnerabilities-related-to-checksums.html",
            "https://access.redhat.com/security/cve/CVE-2020-16156",
            "https://blog.hackeriet.no/cpan-signature-verification-vulnerabilities/",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-16156",
            "https://github.com/andk/cpanpm/commit/b27c51adf0fda25dee84cb72cb2b1bf7d832148c",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SD6RYOJII7HRJ6WVORFNVTYNOFY5JDXN/",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SZ32AJIV4RHJMLWLU5QULGKMMIHYOMDC/",
            "https://metacpan.org/pod/distribution/CPAN/scripts/cpan"
          ],
          "PublishedDate": "2021-12-13T18:15:00Z",
          "LastModifiedDate": "2022-01-12T03:15:00Z"
        }
      ]
    }
  ]
}
```

</details>

<details>
<summary>After</summary>


```bash
trivy i -f json --severity "HIGH" docker.io/library/debian:bullseye-slim 
2022-03-08T08:46:59.642+0100    INFO    Need to update DB
2022-03-08T08:46:59.642+0100    INFO    Downloading DB...
29.85 MiB / 29.85 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24.62 MiB p/s 1.4s
2022-03-08T08:47:11.987+0100    INFO    Detected OS: debian
2022-03-08T08:47:11.987+0100    INFO    Detecting Debian vulnerabilities...
2022-03-08T08:47:12.211+0100    INFO    Number of language-specific files: 0
{
  "SchemaVersion": 2,
  "ArtifactName": "docker.io/library/debian:bullseye-slim",
  "ArtifactType": "container_image",
  "Metadata": {
    "OS": {
      "Family": "debian",
      "Name": "11.2"
    },
    "ImageID": "sha256:7a8792605f8ca9b6d71c333681dc8ca98e96d8f76e1c97624b3c8c5338e4123b",
    "DiffIDs": [
      "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
    ],
    "RepoTags": [
      "debian:bullseye-slim"
    ],
    "RepoDigests": [
      "debian@sha256:4c25ffa6ef572cf0d57da8c634769a08ae94529f7de5be5587ec8ce7b9b50f9c"
    ],
    "ImageConfig": {
      "architecture": "amd64",
      "container": "9e9f310d3bbea14bc1a93fbc139ae01077b0938d0a7f95b00e0c5c53b43d41f7",
      "created": "2022-01-26T01:40:36.265271157Z",
      "docker_version": "20.10.7",
      "history": [
        {
          "created": "2022-01-26T01:40:35Z",
          "created_by": "/bin/sh -c #(nop) ADD file:90495c24c897ec47982e200f732f8be3109fcd791691ddffae0756898f91024f in / "
        },
        {
          "created": "2022-01-26T01:40:36Z",
          "created_by": "/bin/sh -c #(nop)  CMD [\"bash\"]",
          "empty_layer": true
        }
      ],
      "os": "linux",
      "rootfs": {
        "type": "layers",
        "diff_ids": [
          "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
        ]
      },
      "config": {
        "Cmd": [
          "bash"
        ],
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Image": "sha256:86744fc7ec6fbebfe215eacc65a96828bb9c6aea2fb37db38ea883dc72602c56"
      }
    }
  },
  "Results": [
    {
      "Target": "docker.io/library/debian:bullseye-slim (debian 11.2)",
      "Class": "os-pkgs",
      "Type": "debian",
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2021-3999",
          "PkgName": "libc-bin",
          "InstalledVersion": "2.31-13+deb11u2",
          "LatestPatch": "2.33-4",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-3999",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "glibc: Off-by-one buffer overflow/underflow in getcwd()",
          "Description": "A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.",
          "Severity": "HIGH",
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 7.4
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2021-3999",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3999",
            "https://ubuntu.com/security/notices/USN-5310-1",
            "https://ubuntu.com/security/notices/USN-5310-2",
            "https://www.openwall.com/lists/oss-security/2022/01/24/4"
          ]
        },
        {
          "VulnerabilityID": "CVE-2021-3999",
          "PkgName": "libc6",
          "InstalledVersion": "2.31-13+deb11u2",
          "LatestPatch": "2.33-4",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-3999",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "glibc: Off-by-one buffer overflow/underflow in getcwd()",
          "Description": "A flaw was found in glibc. An off-by-one buffer overflow and underflow in getcwd() may lead to memory corruption when the size of the buffer is exactly 1. A local attacker who can control the input buffer and size passed to getcwd() in a setuid program could use this flaw to potentially execute arbitrary code and escalate their privileges on the system.",
          "Severity": "HIGH",
          "CVSS": {
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
              "V3Score": 7.4
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/CVE-2021-3999",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3999",
            "https://ubuntu.com/security/notices/USN-5310-1",
            "https://ubuntu.com/security/notices/USN-5310-2",
            "https://www.openwall.com/lists/oss-security/2022/01/24/4"
          ]
        },
        {
          "VulnerabilityID": "CVE-2021-33560",
          "PkgName": "libgcrypt20",
          "InstalledVersion": "1.8.7-6",
          "LatestPatch": "1.9.4-2",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "SeveritySource": "nvd",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-33560",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "libgcrypt: mishandles ElGamal encryption because it lacks exponent blinding to address a side-channel attack against mpi_powm",
          "Description": "Libgcrypt before 1.8.8 and 1.9.x before 1.9.3 mishandles ElGamal encryption because it lacks exponent blinding to address a side-channel attack against mpi_powm, and the window size is not chosen appropriately. This, for example, affects use of ElGamal in OpenPGP.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-203"
          ],
          "CVSS": {
            "nvd": {
              "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
              "V2Score": 5,
              "V3Score": 7.5
            },
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
              "V3Score": 7.5
            }
          },
          "References": [
            "https://access.redhat.com/hydra/rest/securitydata/cve/CVE-2021-33560.json",
            "https://access.redhat.com/security/cve/CVE-2021-33560",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33560",
            "https://dev.gnupg.org/T5305",
            "https://dev.gnupg.org/T5328",
            "https://dev.gnupg.org/T5466",
            "https://dev.gnupg.org/rCe8b7f10be275bcedb5fc05ed4837a89bfd605c61",
            "https://eprint.iacr.org/2021/923",
            "https://linux.oracle.com/cve/CVE-2021-33560.html",
            "https://linux.oracle.com/errata/ELSA-2021-4409.html",
            "https://lists.debian.org/debian-lts-announce/2021/06/msg00021.html",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/BKKTOIGFW2SGN3DO2UHHVZ7MJSYN4AAB/",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/R7OAPCUGPF3VLA7QAJUQSL255D4ITVTL/",
            "https://nvd.nist.gov/vuln/detail/CVE-2021-33560",
            "https://ubuntu.com/security/notices/USN-5080-1",
            "https://ubuntu.com/security/notices/USN-5080-2",
            "https://www.oracle.com/security-alerts/cpujan2022.html",
            "https://www.oracle.com/security-alerts/cpuoct2021.html"
          ],
          "PublishedDate": "2021-06-08T11:15:00Z",
          "LastModifiedDate": "2022-03-01T15:21:00Z"
        },
        {
          "VulnerabilityID": "CVE-2020-16156",
          "PkgName": "perl-base",
          "InstalledVersion": "5.32.1-4+deb11u2",
          "Layer": {
            "DiffID": "sha256:7d0ebbe3f5d26c1b5ec4d5dbb6fe3205d7061f9735080b0162d550530328abd6"
          },
          "SeveritySource": "nvd",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-16156",
          "DataSource": {
            "ID": "debian",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "perl-CPAN: Bypass of verification of signatures in CHECKSUMS files",
          "Description": "CPAN 2.28 allows Signature Verification Bypass.",
          "Severity": "HIGH",
          "CweIDs": [
            "CWE-347"
          ],
          "CVSS": {
            "nvd": {
              "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V2Score": 6.8,
              "V3Score": 7.8
            },
            "redhat": {
              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
              "V3Score": 7.8
            }
          },
          "References": [
            "http://blogs.perl.org/users/neilb/2021/11/addressing-cpan-vulnerabilities-related-to-checksums.html",
            "https://access.redhat.com/security/cve/CVE-2020-16156",
            "https://blog.hackeriet.no/cpan-signature-verification-vulnerabilities/",
            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-16156",
            "https://github.com/andk/cpanpm/commit/b27c51adf0fda25dee84cb72cb2b1bf7d832148c",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SD6RYOJII7HRJ6WVORFNVTYNOFY5JDXN/",
            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SZ32AJIV4RHJMLWLU5QULGKMMIHYOMDC/",
            "https://metacpan.org/pod/distribution/CPAN/scripts/cpan"
          ],
          "PublishedDate": "2021-12-13T18:15:00Z",
          "LastModifiedDate": "2022-01-12T03:15:00Z"
        }
      ]
    }
  ]
}
```

</details>

### Diff

```diff
63a64
>           "LatestPatch": "2.33-4",
93a95
>           "LatestPatch": "2.33-4",
123a126
>           "LatestPatch": "1.9.4-2",
```

#### Vulns
- [`CVE-2021-33560`](https://security-tracker.debian.org/tracker/CVE-2021-33560)
![Screenshot 2022-03-08 at 08 52 58](https://user-images.githubusercontent.com/14357604/157191415-91221e7f-cc90-4e54-a99d-b4e2698058e4.png)

- [`CVE-2021-3999`](https://security-tracker.debian.org/tracker/CVE-2021-3999)
![Screenshot 2022-03-08 at 08 53 23](https://user-images.githubusercontent.com/14357604/157191495-e99c7e63-05f9-4cd9-b51d-0cca2187a3f3.png)

