### PR TITLE
feat(helm): Add support for custom labels

### DIFF
--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "trivy.fullname" . }}
   labels:
 {{ include "trivy.labels" . | indent 4 }}
+    {{- with .Values.trivy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podManagementPolicy: "Parallel"
   serviceName: {{ include "trivy.fullname" . }}
@@ -29,6 +32,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "trivy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.trivy.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "trivy.fullname" . }}
       automountServiceAccountToken: false

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -109,6 +109,8 @@ trivy:
   serviceAccount:
     annotations: {}
       # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+  # If you want to add custom labels to your statefulset and podTemplate
+  labels: {}
 
 service:
   # type Kubernetes service type


### PR DESCRIPTION
## Description
Add custom labels to the pod and the statefulset. This can be be useful for a number of reasons but for example using MSI in Azure.

## Related issues
- Close #1766 

## Related PRs
N/A

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
