### PR TITLE
fix(helm): Indentation for ServiceAccount annotations

### DIFF
--- a/helm/trivy/templates/serviceaccount.yaml
+++ b/helm/trivy/templates/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
 {{ include "trivy.labels" . | indent 4 }}
 {{- if (.Values.trivy.serviceAccount).annotations }}
   annotations:
-{{ toYaml .Values.trivy.serviceAccount.annotations | indent 8 }}
+{{ toYaml .Values.trivy.serviceAccount.annotations | indent 4 }}
 {{- end }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Description
Fixes an issue with #1677 where the ServiceAccount annotations are indented incorrectly, rendering this invalid YAML.

## Related issues
- Close #1794

## Related PRs
- #1677 (Original feature implementation)

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
