### PR TITLE
feat(epel): support EPEL(Extra Packages for Enterprise Linux) scan

### DIFF
--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"testing"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 
 	ftypes "github.com/aquasecurity/fanal/types"
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -82,7 +82,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 
 	for testName, v := range vectors {
 		s := &Scanner{
-			vs:    oracleoval.NewVulnSrc(),
+			osVS:  oracleoval.NewVulnSrc(),
 			clock: v.clock,
 		}
 		t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
## Description
Supports vulnerability detection for packages installed from fedora EPEL Repository.

## Related issues

## Related PRs
- [ ] https://github.com/aquasecurity/vuln-list-update/pull/129
- [ ] https://github.com/aquasecurity/fanal/pull/420
- [ ] https://github.com/aquasecurity/trivy-db/pull/196

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
