### PR TITLE
feat(helm): Make Trivy service name configurable

### DIFF
--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -62,24 +62,25 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `image.pullPolicy`                    | Image pull policy                                                       | `IfNotPresent` |
 | `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry  | |
 | `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
-| `trivy.debugMode`             | The flag to enable or disable Trivy debug mode                          | `false` |
-| `trivy.gitHubToken`           | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                          |      |
+| `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                          | `false` |
+| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                          |      |
 | `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
 | `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
 | `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
 | `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
-| `trivy.skipUpdate`            | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
+| `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
 | `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
+| `service.name`                        | If specified, the name used for the Trivy service                       |     |
 | `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
 | `service.port`                        | Kubernetes service port                                                 | `4954`      |
 | `httpProxy`                           | The URL of the HTTP proxy server                                        |     |
 | `httpsProxy`                          | The URL of the HTTPS proxy server                                       |     |
 | `noProxy`                             | The URLs that the proxy settings do not apply to                        |     |
 | `nodeSelector`                        | Node labels for pod assignment                                              |     |
-| `affinity`                        | Affinity settings for pod assignment                                              |     |
-| `tolerations`                        | Tolerations for pod assignment                                              |     |
+| `affinity`                            | Affinity settings for pod assignment                                              |     |
+| `tolerations`                         | Tolerations for pod assignment                                              |     |
 
 The above parameters map to the env variables defined in [trivy](https://github.com/aquasecurity/trivy#configuration).
 

--- a/helm/trivy/templates/service.yaml
+++ b/helm/trivy/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "trivy.fullname" . }}
+  name: {{ .Values.service.name | default (include "trivy.fullname" .) }}
   labels:
 {{ include "trivy.labels" . | indent 4 }}
 spec:

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -115,6 +115,8 @@ trivy:
   serverToken: ""
 
 service:
+  # If specified, the name used for the Trivy service.
+  name:
   # type Kubernetes service type
   type: ClusterIP
   # port Kubernetes service port


### PR DESCRIPTION
## Description

Makes the Service name used for Trivy configurable in `values.yaml`.
(Also some whitespace cleanup for readability)

## Related issues
- Closes https://github.com/aquasecurity/trivy/issues/1824

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
