### PR TITLE
fix(docker): getting images without a tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220309115321-0183e4870f89
+	github.com/aquasecurity/fanal v0.0.0-20220317181013-c4fac2e5fe9c
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220302151315-ff6d77c26988
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.17.1 h1:gen/DInkQZ+BnV2X/UCI4Kb7SgJzPKiSb91duNhOWcg=
 github.com/aquasecurity/defsec v0.17.1/go.mod h1:fmymhKkorY0+cTGAML6LQI+BpCEP1zURaI8smST5rV0=
-github.com/aquasecurity/fanal v0.0.0-20220309115321-0183e4870f89 h1:owYWGe2dTRhXuBW3OUekU9+yWec8pNTZthGvTFMq9oY=
-github.com/aquasecurity/fanal v0.0.0-20220309115321-0183e4870f89/go.mod h1:PL2i7JtbuPnLlJVG5HVPAVLMmAUdpA9J/iV7b7E5Gbg=
+github.com/aquasecurity/fanal v0.0.0-20220317181013-c4fac2e5fe9c h1:Php9oTqRg5CyEfLaxaLROfKHu6Wldc20+PkJwJczaOI=
+github.com/aquasecurity/fanal v0.0.0-20220317181013-c4fac2e5fe9c/go.mod h1:PL2i7JtbuPnLlJVG5HVPAVLMmAUdpA9J/iV7b7E5Gbg=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220302151315-ff6d77c26988 h1:Hd6q0/VF/bC/MT1K/63W2u5ChRIy6cPSQk0YbJ3Vcb8=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220302151315-ff6d77c26988/go.mod h1:XxIz2s4UymZBcg9WwAc2km77lFt9rVE/LmKJe2YVOtY=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description
if a tag is skipped, `trivy` will get an image with a default tag (`latest`).

## Related issues
- Close #1848

## Related PRs
- https://github.com/aquasecurity/fanal/pull/425

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
