### PR TITLE
fix(cli): json format for trivy version

### DIFF
--- a/docs/getting-started/cli/index.md
+++ b/docs/getting-started/cli/index.md
@@ -18,6 +18,7 @@ COMMANDS:
    server, s         server mode
    config, conf      scan config files
    plugin, p         manage plugins
+   version           print the version. '--format json' flag is supported
    help, h           Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -358,13 +358,14 @@ func NewApp(version string) *cli.App {
 		NewServerCommand(),
 		NewConfigCommand(),
 		NewPluginCommand(),
+		NewVersionCommand(),
 	}
 	app.Commands = append(app.Commands, plugin.LoadCommands()...)
 
 	return app
 }
 
-func showVersion(cacheDir, outputFormat, version string, outputWriter io.Writer) {
+var showVersion = func(cacheDir, outputFormat, version string, outputWriter io.Writer) {
 	var dbMeta *metadata.Metadata
 
 	mc := metadata.NewClient(cacheDir)
@@ -715,6 +716,24 @@ func NewPluginCommand() *cli.Command {
 			},
 		},
 	}
+}
+
+// NewVersionCommand adds version command
+func NewVersionCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "version",
+		Usage:  "print the version. '--format json' flag is supported",
+		Action: versionRun,
+		Flags: []cli.Flag{
+			&formatFlag,
+		},
+	}
+}
+
+//cli.VersionPrinter doesn't support flags. Use 'version' command to format version output.
+func versionRun(ctx *cli.Context) error {
+	showVersion(ctx.String("cache-dir"), ctx.String("format"), ctx.App.Version, ctx.App.Writer)
+	return nil
 }
 
 // StringSliceFlag is defined globally. When the app runs multiple times,


### PR DESCRIPTION
## Description
"github.com/urfave/cli/v2" doesn't support flags for show program version.
For formatting trivy version was added `version` command.

### Was done:
- added `version` **command** to cli. `v` command **doesn't work!**
- added support for `--format json` flag for `version` command .
- `-v` and `-version` flags work as before.
- added tests for all ways to get trivy version.
- added information about `version` command in cli documentation. 

#### Examples:

<details><summary> trivy version</summary>

```
>> trivy version    
Version: v0.24.2
Vulnerability DB:
  Version: 2
  UpdatedAt: 2022-03-18 00:10:40.965461764 +0000 UTC
  NextUpdate: 2022-03-18 06:10:40.965461263 +0000 UTC
  DownloadedAt: 2022-03-18 04:13:14.125891552 +0000 UTC
```

</details>

<details><summary> trivy version --format json </summary>

```
>> trivy version --format json
{"Version":"v0.24.2","VulnerabilityDB":{"Version":2,"NextUpdate":"2022-03-18T06:10:40.965461263Z","UpdatedAt":"2022-03-18T00:10:40.965461764Z","DownloadedAt":"2022-03-18T04:13:14.125891552Z"}}
```

</details>

#### `-v` and `version` still work, but they don't support `--format` flag:
<details><summary> trivy -v </summary>

```
>> trivy -v   
Version: v0.24.2
Vulnerability DB:
  Version: 2
  UpdatedAt: 2022-03-18 00:10:40.965461764 +0000 UTC
  NextUpdate: 2022-03-18 06:10:40.965461263 +0000 UTC
  DownloadedAt: 2022-03-18 04:13:14.125891552 +0000 UTC
```

</details>

<details><summary> trivy -v --format json</summary>

```
>> trivy -v --format json   
Incorrect Usage. flag provided but not defined: -format

NAME:
   trivy - A simple and comprehensive vulnerability scanner for containers

USAGE:
   trivy [global options] command [command options] target

VERSION:
   v0.22.0-106-g4da04586

COMMANDS:
   image, i          scan an image
   filesystem, fs    scan local filesystem for language-specific dependencies and config files
   rootfs            scan rootfs
   repository, repo  scan remote repository
   client, c         client mode
   server, s         server mode
   config, conf      scan config files
   plugin, p         manage plugins
   version           print the version. '--format json' flag is supported
   help, h           Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --quiet, -q        suppress progress bar and log output (default: false) [$TRIVY_QUIET]
   --debug, -d        debug mode (default: false) [$TRIVY_DEBUG]
   --cache-dir value  cache directory (default: "/home/dmitriy/.cache/trivy") [$TRIVY_CACHE_DIR]
   --help, -h         show help (default: false)
   --version, -v      print the version (default: false)
2022-03-18T10:32:36.414+0600    FATAL   flag provided but not defined: -format
```

</details>

#### `v` command not supporting:
<details><summary> trivy v </summary>

```
>> trivy v                  
No help topic for 'v'

```

</details>

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
