### PR TITLE
docs: change URL for tfsec-checks

### DIFF
--- a/docs/misconfiguration/policy/builtin.md
+++ b/docs/misconfiguration/policy/builtin.md
@@ -29,7 +29,7 @@ Trivy checks for updates to OPA bundle on GHCR every 24 hours and pulls it if th
 [appshield]: https://github.com/aquasecurity/appshield
 [kubernetes]: https://github.com/aquasecurity/appshield/tree/master/kubernetes
 [docker]: https://github.com/aquasecurity/appshield/tree/master/docker
-[tfsec-checks]: https://tfsec.dev/docs/aws/home/
+[tfsec-checks]: https://tfsec.dev/
 [tfsec]: https://github.com/aquasecurity/tfsec
 [cfsec-checks]: https://cfsec.dev/
 [cfsec]: https://github.com/aquasecurity/cfsec


### PR DESCRIPTION
The current URL for the tfsec-checks is 404, so changing it in-line with what we've got for cfsec, which is just the base site URL.

