### PR TITLE
fix(option): hide false warning about remote options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/open-policy-agent/opa v0.37.2
 	github.com/owenrumney/go-sarif/v2 v2.1.1
 	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
-	github.com/spf13/afero v1.8.1
+	github.com/spf13/afero v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.12.0
 	github.com/twitchtv/twirp v8.1.1+incompatible

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/metadata"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
+	"github.com/aquasecurity/trivy/pkg/commands/option"
 	"github.com/aquasecurity/trivy/pkg/commands/plugin"
 	"github.com/aquasecurity/trivy/pkg/commands/server"
 	"github.com/aquasecurity/trivy/pkg/result"
@@ -215,7 +216,7 @@ var (
 
 	tokenHeader = cli.StringFlag{
 		Name:    "token-header",
-		Value:   "Trivy-Token",
+		Value:   option.DefaultTokenHeader,
 		Usage:   "specify a header name for token in client/server mode",
 		EnvVars: []string{"TRIVY_TOKEN_HEADER"},
 	}

--- a/pkg/commands/artifact/option_test.go
+++ b/pkg/commands/artifact/option_test.go
@@ -260,7 +260,7 @@ func TestOption_Init(t *testing.T) {
 			set.String("format", "", "")
 			set.String("server", "", "")
 			set.String("token", "", "")
-			set.String("token-header", "", "")
+			set.String("token-header", option.DefaultTokenHeader, "")
 			set.Var(&cli.StringSlice{}, "custom-headers", "")
 
 			ctx := cli.NewContext(app, set, nil)

--- a/pkg/commands/option/remote.go
+++ b/pkg/commands/option/remote.go
@@ -8,6 +8,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const DefaultTokenHeader = "Trivy-Token"
+
 // RemoteOption holds options for client/server
 type RemoteOption struct {
 	RemoteAddr    string
@@ -48,7 +50,7 @@ func (c *RemoteOption) Init(logger *zap.SugaredLogger) {
 	}
 
 	if c.RemoteAddr == "" {
-		if len(c.customHeaders) > 0 || c.token != "" || c.tokenHeader != "" {
+		if len(c.customHeaders) > 0 || c.token != "" || c.tokenHeader != DefaultTokenHeader {
 			logger.Warn(`'--token', '--token-header' and 'custom-header' can be used only with '--server'`)
 		}
 		return


### PR DESCRIPTION
## Description
`tokenHeader` flag was initialized by default value (not empty), so warning message was always shown.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
