### PR TITLE
chore(dockerfile): bump up alpine to 3.15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.3
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/


### PR DESCRIPTION
## Description
alpine:3.15.0 has several `HIGH` vulnerabilities.
<details> <summary> trivy v0.25.0 scan result </summary>

```
➜ trivy image aquasec/trivy:0.25.0
2022-03-31T18:42:15.098+0600    INFO    Detected OS: alpine
2022-03-31T18:42:15.098+0600    INFO    Detecting Alpine vulnerabilities...
2022-03-31T18:42:15.099+0600    INFO    Number of language-specific files: 0

aquasec/trivy:0.25.0 (alpine 3.15.0)
====================================
Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 0)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2022-0778    | HIGH     | 1.1.1l-r7         | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+--------------+                  +          +-------------------+---------------+                                       +
| libretls     |                  |          | 3.3.4-r2          | 3.3.4-r3      |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+                  +          +-------------------+---------------+                                       +
| libssl1.1    |                  |          | 1.1.1l-r7         | 1.1.1n-r0     |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| zlib         | CVE-2018-25032   |          | 1.2.11-r3         | 1.2.12-r0     | zlib: A flaw in zlib-1.2.11           |
|              |                  |          |                   |               | when compressing (not                 |
|              |                  |          |                   |               | decompressing!) certain inputs.       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-25032 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
```

</details>

Alpine base image updated from 3.15.0 to 3.15.3.

<details> <summary> scan result after updating alpine to 3.15.3  </summary>

```
➜ trivy image trivy:alpine3.15.3      
2022-03-31T18:44:41.891+0600    INFO    Detected OS: alpine
2022-03-31T18:44:41.891+0600    INFO    Detecting Alpine vulnerabilities...
2022-03-31T18:44:41.892+0600    INFO    Number of language-specific files: 0

trivy:alpine3.15.3 (alpine 3.15.3)
==================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```

</details>

## Related issues
- Close #1870

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
