### PR TITLE
fix(downloadDB): fixed download trivy-db in server mode 

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -649,6 +649,7 @@ func NewServerCommand() *cli.Command {
 			&redisBackendCACert,
 			&redisBackendCert,
 			&redisBackendKey,
+			&dbRepositoryFlag,
 
 			// original flags
 			&token,


### PR DESCRIPTION
## Description
Fixed error when Trivy try download DB in `server` mode.

## Related issues
- Close #1940

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
