### PR TITLE
fix(sbom): add --db-repository

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -777,6 +777,7 @@ func NewSbomCommand() *cli.Command {
 			&timeoutFlag,
 			&severityFlag,
 			&offlineScan,
+			&dbRepositoryFlag,
 			stringSliceFlag(skipFiles),
 			stringSliceFlag(skipDirs),
 


### PR DESCRIPTION
## Description
`--db-repository` is missing in `sbom` subcommand.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/1956
- [x] https://github.com/aquasecurity/trivy/pull/1873

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
