### PR TITLE
fix(oracle): Improve a handling of Oracle advisories contain fips versions - fixes #1967

### DIFF
--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -53,6 +53,16 @@ func extractKsplice(v string) string {
 	return ""
 }
 
+func isFips(v string) bool {
+	subs := strings.Split(strings.ToLower(v), ".")
+	for _, s := range subs {
+		if strings.Contains(s, "_fips") {
+			return true
+		}
+	}
+	return false
+}
+
 // Detect scans and return vulnerability in Oracle scanner
 func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Oracle Linux vulnerabilities...")
@@ -78,6 +88,10 @@ func (s *Scanner) Detect(osVer string, pkgs []ftypes.Package) ([]types.DetectedV
 			// extract kspliceX and compare it with kspliceY in advisories
 			// if kspliceX and kspliceY are different, we will skip the advisory
 			if extractKsplice(adv.FixedVersion) != extractKsplice(pkg.Release) {
+				continue
+			}
+			// when one of them doesn't have fips, we'll also skip it
+			if isFips(adv.FixedVersion) != isFips(pkg.Release) {
 				continue
 			}
 

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -140,6 +140,80 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "the installed version doesn't have fips",
+			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "gnutls",
+						Epoch:      10,
+						Version:    "3.6.16",
+						Release:    "4.0.1.el7_fips",
+						Arch:       "x86_64",
+						SrcName:    "gnutls",
+						SrcVersion: "3.6.16",
+						SrcRelease: "4.el7",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:     "the installed version has fips",
+			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "gnutls",
+						Epoch:      10,
+						Version:    "3.6.16",
+						Release:    "",
+						Arch:       "x86_64",
+						SrcEpoch:   2,
+						SrcName:    "gnutls",
+						SrcVersion: "3.6.168",
+						SrcRelease: "4.0.1.el7_fips",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:     "with fips",
+			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "gnutls",
+						Epoch:      10,
+						Version:    "3.6.16",
+						Release:    "4.0.0.el7_fips",
+						Arch:       "x86_64",
+						SrcEpoch:   10,
+						SrcName:    "gnutls",
+						SrcVersion: "3.6.16",
+						SrcRelease: "4.0.0.el7_fips",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2021-20231",
+					PkgName:          "gnutls",
+					InstalledVersion: "10:3.6.16-4.0.0.el7_fips",
+					FixedVersion:     "10:3.6.16-4.0.1.el7_fips",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.OracleOVAL,
+						Name: "Oracle Linux OVAL definitions",
+						URL:  "https://linux.oracle.com/security/oval/",
+					},
+				},
+			},
+		},
+		{
 			name:     "without ksplice",
 			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
+++ b/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
@@ -10,3 +10,13 @@
         - key: CVE-2017-1000364
           value:
             FixedVersion: "2:2.17-157.ksplice1.el7_3.4"
+    - bucket: gnutls
+      pairs:
+        - key: CVE-2021-20231
+          value:
+            FixedVersion: "10:3.6.16-4.0.1.el7_fips"
+    - bucket: libgcrypt
+      pairs:
+        - key: CVE-2021-33560
+          value:
+            FixedVersion: "10:1.8.5-6.el7_fips"


### PR DESCRIPTION
    * when one of them doesn't have fips, we'll skip it

## Description

## Related issues
- Close #1967 

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x ] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
