### PR TITLE
feat(go): support go.mod in Go 1.17+

### DIFF
--- a/docs/docs/vulnerability/languages/golang.md
+++ b/docs/docs/vulnerability/languages/golang.md
@@ -1,0 +1,62 @@
+# Go
+
+## Features
+Trivy supports two types of Go scanning, Go Modules and binaries built by Go.
+The following table provides an outline of the features Trivy offers.
+
+| Artifact | Offline[^1] | Dev dependencies |
+|----------|:-----------:|:-----------------|
+| Modules  |      ✓      | Include          |
+| Binaries |      ✓      | Exclude          |
+
+!!! note
+    Trivy scans only dependencies of the Go project.
+    Let's say you scan the Docker binary, Trivy doesn't detect vulnerabilities of Docker itself.
+    Also, when you scan go.mod in Kubernetes, the Kubernetes vulnerabilities will not be found.
+
+### Go Modules
+Depending on Go versions, the required files are different.
+
+| Version | Required files | Offline | License |
+|---------|:--------------:|:-------:|:-------:|
+| \>=1.17 |     go.mod     |    ✓    |    -    |
+| <1.16   | go.mod, go.sum |    ✓    |    -    |
+
+In Go 1.17+ projects, Trivy uses `go.mod` for direct/indirect dependencies.
+On the other hand, it uses `go.mod` for direct dependencies and `go.sum` for indirect dependencies in Go 1.16 or less.
+
+Go 1.17+ holds actually needed indirect dependencies in `go.mod`, and it reduces false detection.
+`go.sum` in Go 1.16 or less contains all indirect dependencies that are even not needed for compiling.
+If you want to have better detection, please consider updating the Go version in your project.
+
+!!! note
+    The Go version doesn't mean your CLI version, but the Go version in your go.mod.
+
+    ```
+    module github.com/aquasecurity/trivy
+    
+    go 1.18
+    
+    require (
+            github.com/CycloneDX/cyclonedx-go v0.5.0
+            ...
+    )
+    ```
+
+    To update the Go version in your project, you need to run the following command.
+
+    ```
+    $ go mod tidy -go=1.18
+    ```
+
+### Go binaries
+Trivy scans binaries built by Go.
+If there is a Go binary in your container image, Trivy automatically finds and scans it.
+
+Also, you can scan your local binaries.
+
+```
+$ trivy fs ./your_binary
+```
+
+[^1]: It doesn't require the Internet access.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220406084015-9cc93a8482b8
-	github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237
+	github.com/aquasecurity/fanal v0.0.0-20220413103552-a2db5fcf54ed
+	github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
@@ -40,7 +40,7 @@ require (
 	github.com/twitchtv/twirp v8.1.1+incompatible
 	github.com/urfave/cli/v2 v2.4.0
 	go.uber.org/zap v1.21.0
-	golang.org/x/exp v0.0.0-20220321124402-2d6d886f8a82
+	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4
 	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/protobuf v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -237,12 +237,9 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.28.4 h1:O0ukf2uMEqRRX3EHfu+9J0EyD39v50NDjwtf96nES8E=
 github.com/aquasecurity/defsec v0.28.4/go.mod h1:vUdThwusBM7y1gJ7CVX3+h3bsPvpmOIEp3NEdzTDkhA=
-github.com/aquasecurity/fanal v0.0.0-20220406084015-9cc93a8482b8 h1:upNoF0Y/HkO0I/ODEoZvlaYmpYl2YVkVuP70QBuI6uc=
-github.com/aquasecurity/fanal v0.0.0-20220406084015-9cc93a8482b8/go.mod h1:Yw8qKVnr4d9bz/nhozrnTAebVrXgpUD6jgXYinm85P0=
 github.com/aquasecurity/fanal v0.0.0-20220413103552-a2db5fcf54ed h1:8eCdv9koYS04ib1jVfyYGcUjkn9DcEF+W1WAigZmd4s=
 github.com/aquasecurity/fanal v0.0.0-20220413103552-a2db5fcf54ed/go.mod h1:P+PBmaNRkj5kBiRSM5vKtKviKxEm3kK179Mu9BVx1AQ=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237 h1:FX5MaNimz5xK6LYbp+mI23i2m6OmoKaHAEgRVehLDs8=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237/go.mod h1:MewgJXyrz9PgCHh8zunRNY4BY72ltNYWeTYAt1paaLc=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90 h1:uZcI5qV7J1pzOc6W49l7iEey/KtEVlaqsNU5l65vZLk=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90/go.mod h1:rK/5BoRt8/D7xXydoVVeBaQuk6zDJ6W+FWz/RqFuJxI=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
@@ -1656,8 +1653,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220321124402-2d6d886f8a82 h1:P3h2IfqHFILVjDaCKXyuKMprdEyIbrbKevbf2EB6lQI=
-golang.org/x/exp v0.0.0-20220321124402-2d6d886f8a82/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4 h1:K3x+yU+fbot38x5bQbU2QqUAVyYLEktdNH2GxZLnM3U=
 golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,11 @@ github.com/aquasecurity/defsec v0.28.4 h1:O0ukf2uMEqRRX3EHfu+9J0EyD39v50NDjwtf96
 github.com/aquasecurity/defsec v0.28.4/go.mod h1:vUdThwusBM7y1gJ7CVX3+h3bsPvpmOIEp3NEdzTDkhA=
 github.com/aquasecurity/fanal v0.0.0-20220406084015-9cc93a8482b8 h1:upNoF0Y/HkO0I/ODEoZvlaYmpYl2YVkVuP70QBuI6uc=
 github.com/aquasecurity/fanal v0.0.0-20220406084015-9cc93a8482b8/go.mod h1:Yw8qKVnr4d9bz/nhozrnTAebVrXgpUD6jgXYinm85P0=
+github.com/aquasecurity/fanal v0.0.0-20220413103552-a2db5fcf54ed h1:8eCdv9koYS04ib1jVfyYGcUjkn9DcEF+W1WAigZmd4s=
+github.com/aquasecurity/fanal v0.0.0-20220413103552-a2db5fcf54ed/go.mod h1:P+PBmaNRkj5kBiRSM5vKtKviKxEm3kK179Mu9BVx1AQ=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237 h1:FX5MaNimz5xK6LYbp+mI23i2m6OmoKaHAEgRVehLDs8=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237/go.mod h1:MewgJXyrz9PgCHh8zunRNY4BY72ltNYWeTYAt1paaLc=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90/go.mod h1:rK/5BoRt8/D7xXydoVVeBaQuk6zDJ6W+FWz/RqFuJxI=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798 h1:eveqE9ivrt30CJ7dOajOfBavhZ4zPqHcZe/4tKp0alc=
@@ -1655,6 +1658,7 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220321124402-2d6d886f8a82 h1:P3h2IfqHFILVjDaCKXyuKMprdEyIbrbKevbf2EB6lQI=
 golang.org/x/exp v0.0.0-20220321124402-2d6d886f8a82/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ nav:
                 - Vulnerability DB: docs/vulnerability/examples/db.md
                 - Cache: docs/vulnerability/examples/cache.md
                 - Others: docs/vulnerability/examples/others.md
+            - Languages:
+                - Go: docs/vulnerability/languages/golang.md
         - Misconfiguration:
             - Scanning:
                 - Overview: docs/misconfiguration/index.md


### PR DESCRIPTION
## Description
## Description
Go 1.17+ adds indirect dependencies to `go.mod`. This PR parses `go.mod` as well as `go.sum` and merges them according to the Go version in `go.mod`. 

- Go 1.17+
  - it takes only `go.mod` and ignores `go.sum`.
- Go 1.16 or less
  - it takes direct dependencies in `go.mod` and indirect dependencies in `go.sum`.

It reduces unused dependencies as shown below.

### Before
```
$ ./fanal fs --skip-dirs analyzer --skip-dirs artifact --skip-dirs config .
...
gomod (go.sum): 697
```

### After
```
$ ./fanal fs --skip-dirs analyzer --skip-dirs artifact --skip-dirs config .
...
gomod (go.mod): 164
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/1973

## Related PRs
- [ ] https://github.com/aquasecurity/go-dep-parser/pull/76
- [ ] https://github.com/aquasecurity/fanal/pull/465

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
