### PR TITLE
fix(go): set correct go modules type

### DIFF
--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -34,7 +34,7 @@ func NewDriver(libType string) (Driver, error) {
 	case ftypes.Composer:
 		ecosystem = vulnerability.Composer
 		comparer = compare.GenericComparer{}
-	case ftypes.GoBinary, ftypes.GoMod:
+	case ftypes.GoBinary, ftypes.GoModule:
 		ecosystem = vulnerability.Go
 		comparer = compare.GenericComparer{}
 	case ftypes.Jar, ftypes.Pom:


### PR DESCRIPTION
## Description
Go started using `go.mod` and `go.sum` for checks, so this driver type calls `gomod` now.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
