### PR TITLE
feat(report): support to query policy from remote OPA server

### DIFF
--- a/pkg/result/policy.go
+++ b/pkg/result/policy.go
@@ -1,0 +1,140 @@
+package result
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/open-policy-agent/opa/rego"
+	"golang.org/x/xerrors"
+)
+
+type PolicyStore interface {
+	Evaluate(ctx context.Context, input interface{}) (bool, error)
+}
+
+type LocalPolicyStore struct {
+	query rego.PreparedEvalQuery
+}
+
+func NewLocalPolicyStore(ctx context.Context, policyFile string) (PolicyStore, error) {
+	policy, err := ioutil.ReadFile(policyFile)
+	if err != nil {
+		err = xerrors.Errorf("unable to read policy file %s: %w", policyFile, err)
+		return nil, err
+	}
+
+	query, err := rego.New(
+		rego.Query("data.trivy.ignore"),
+		rego.Module("lib.rego", module),
+		rego.Module("trivy.rego", string(policy)),
+	).PrepareForEval(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to prepare for eval: %w", err)
+	}
+
+	return &LocalPolicyStore{query: query}, nil
+}
+
+func (l *LocalPolicyStore) Evaluate(ctx context.Context, input interface{}) (bool, error) {
+	results, err := l.query.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return false, xerrors.Errorf("unable to evaluate the policy: %w", err)
+	} else if len(results) == 0 {
+		// Handle undefined result.
+		return false, nil
+	}
+	ignore, ok := results[0].Expressions[0].Value.(bool)
+	if !ok {
+		// Handle unexpected result type.
+		return false, xerrors.New("the policy must return boolean")
+	}
+	return ignore, nil
+}
+
+type RemotePolicyStore struct {
+	remoteURL string
+}
+
+func NewRemotePolicyStore(remoteAddr string) (PolicyStore, error) {
+	u, err := url.Parse(remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, "/v1/data/trivy/ignore")
+
+	return &RemotePolicyStore{
+		remoteURL: u.String(),
+	}, nil
+}
+
+func (r *RemotePolicyStore) Evaluate(ctx context.Context, input interface{}) (bool, error) {
+	reqBody, err := processQueryInput(input)
+	if err != nil {
+		return false, xerrors.Errorf("unable to process policy input: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", r.remoteURL, reqBody)
+	if err != nil {
+		err = xerrors.Errorf("unable to create new policy request: %w", err)
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		err = xerrors.Errorf("unable to send query policy request: %w", err)
+		return false, err
+	}
+
+	return processQueryResult(resp)
+}
+
+func processQueryInput(input interface{}) (io.Reader, error) {
+	type opaRequest struct {
+		Input interface{} `json:"input"`
+	}
+
+	inputData := opaRequest{Input: input}
+	inputBytes, err := json.Marshal(&inputData)
+	if err != nil {
+		err = xerrors.Errorf("unable to marshal input data: %w", err)
+		return nil, err
+	}
+	return bytes.NewReader(inputBytes), nil
+
+}
+
+func processQueryResult(resp *http.Response) (bool, error) {
+	type opaResult struct {
+		Result  bool
+		Warning struct {
+			Code    string
+			Message string
+		}
+	}
+	var queryResult opaResult
+	var err error
+	var respBytes []byte
+
+	// From the API doc of OPA, non-HTTP 200 response codes indicate configuration
+	// or runtime errors.
+	if resp.StatusCode != http.StatusOK {
+		err = xerrors.Errorf("unable to get query result, response code is %d, want 200 instead", resp.StatusCode)
+		return false, err
+	}
+	if respBytes, err = ioutil.ReadAll(resp.Body); err != nil {
+		err = xerrors.Errorf("unable to read query response: %w", err)
+		return false, err
+	}
+	if err = json.Unmarshal(respBytes, &queryResult); err != nil {
+		err = xerrors.Errorf("unable to unmarshal query response: %w", err)
+		return false, err
+	}
+
+	return queryResult.Result, nil
+}

--- a/pkg/result/policy_test.go
+++ b/pkg/result/policy_test.go
@@ -1,0 +1,72 @@
+package result
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLocalPolicyStore(t *testing.T) {
+	policyFiles := map[string][]byte{
+		"good.rego": []byte(`
+package trivy
+
+default ignore = false
+
+focused_packages := {"org.apache.logging.log4j:log4j-core"}
+
+ignore_severities := {"LOW", "MEDIUM"}
+
+ignore {
+    input.PkgName != focused_packages[_]
+}
+`),
+		"bad.rego": []byte(`
+package trivy
+
+invalid rego file
+`),
+	}
+	tempDir := t.TempDir()
+	for filename, content := range policyFiles {
+		if err := ioutil.WriteFile(filepath.Join(tempDir, filename), content, 0600); err != nil {
+			t.Fatalf("unable to create temp file %s: %s", filename, err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		policyFile    string
+		expectedError string
+	}{
+		{
+			name:          "Good rego file",
+			policyFile:    filepath.Join(tempDir, "good.rego"),
+			expectedError: "",
+		},
+		{
+			name:          "Bad rego file",
+			policyFile:    filepath.Join(tempDir, "bad.rego"),
+			expectedError: "unable to prepare for eval: ",
+		},
+		{
+			name:          "Non-existing rego file",
+			policyFile:    filepath.Join(tempDir, "non-existing.rego"),
+			expectedError: "unable to read policy file ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewLocalPolicyStore(context.Background(), tt.policyFile)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError, tt.name)
+			} else {
+				assert.Nil(t, err, tt.expectedError, tt.name)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -74,4 +75,9 @@ func GetTLSConfig(caCertPath, certPath, keyPath string) (*x509.CertPool, tls.Cer
 	caCertPool.AppendCertsFromPEM(caCert)
 
 	return caCertPool, cert, nil
+}
+
+func IsValidURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }


### PR DESCRIPTION
## Description
Add support to query policy from remote OPA server when filtering vulnerabilities.

Implementation:
* integrate with the REST API of OPA. Related documentation is here: [Integrating with the REST API](https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-rest-api)

* I reused the `--ignore-policy` option. If the value is a valid URL, we'll query from the server. Otherwise, we'll treat it as a local policy file. But I don't think it's a good idea. Advise please.

* I preserved the built-in library `lib.rego` if the value of `--ignore-policy` is a local policy file. But I think it's redundant, we can migrate it to the documentation.

* As for the query, I still reused the previous `data.trivy.ignore`.

## Related issues
- Close #1785 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
