### PR TITLE
feat(report): support to query policy from remote OPA server

### DIFF
--- a/docs/docs/vulnerability/examples/filter.md
+++ b/docs/docs/vulnerability/examples/filter.md
@@ -288,8 +288,10 @@ Total: 4751 (UNKNOWN: 1, LOW: 150, MEDIUM: 3504, HIGH: 1013, CRITICAL: 83)
 
 Trivy supports Open Policy Agent (OPA) to filter vulnerabilities. You can specify a Rego file with `--ignore-policy` option.
 
-The Rego package name must be `trivy` and it must include a rule called `ignore` which determines if each individual vulnerability should be excluded (ignore=true) or not (ignore=false). In the policy, each vulnerability will be available for inspection as the `input` variable. The structure of each vulnerability input is the same as for the Trivy JSON output.  
+The Rego package name must be `trivy` and it must include a rule called `ignore` which determines if each individual vulnerability should be excluded (ignore=true) or not (ignore=false). In the policy, each vulnerability will be available for inspection as the `input` variable. The structure of each vulnerability input is the same as for the Trivy JSON output.
 There is a built-in Rego library with helper functions that you can import into your policy using: `import data.lib.trivy`. For more info about the helper functions, look at the library [here][helper]
+
+The `--ignore-policy` option accepts either a local policy file or a remote OPA server address. If it's a remote server address, Trivy will query policy by using OPA REST API through the remote server. The remote policy still obeys the rule mentioned above. For how to run an OPA server, please refer to the [documentation][running-opa] of OPA.
 
 To get started, see the [example policy][policy].
 
@@ -354,3 +356,4 @@ Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 5)
 
 [helper]: https://github.com/aquasecurity/trivy/tree/{{ git.tag }}/pkg/result/module.go
 [policy]: https://github.com/aquasecurity/trivy/tree/{{ git.tag }}/contrib/example_policy
+[running-opa]: https://www.openpolicyagent.org/docs/latest/#4-try-opa-run-server

--- a/pkg/result/policy.go
+++ b/pkg/result/policy.go
@@ -1,0 +1,140 @@
+package result
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/open-policy-agent/opa/rego"
+	"golang.org/x/xerrors"
+)
+
+type PolicyStore interface {
+	Evaluate(ctx context.Context, input interface{}) (bool, error)
+}
+
+type LocalPolicyStore struct {
+	query rego.PreparedEvalQuery
+}
+
+func NewLocalPolicyStore(ctx context.Context, policyFile string) (PolicyStore, error) {
+	policy, err := ioutil.ReadFile(policyFile)
+	if err != nil {
+		err = xerrors.Errorf("unable to read policy file %s: %w", policyFile, err)
+		return nil, err
+	}
+
+	query, err := rego.New(
+		rego.Query("data.trivy.ignore"),
+		rego.Module("lib.rego", module),
+		rego.Module("trivy.rego", string(policy)),
+	).PrepareForEval(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to prepare for eval: %w", err)
+	}
+
+	return &LocalPolicyStore{query: query}, nil
+}
+
+func (l *LocalPolicyStore) Evaluate(ctx context.Context, input interface{}) (bool, error) {
+	results, err := l.query.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return false, xerrors.Errorf("unable to evaluate the policy: %w", err)
+	} else if len(results) == 0 {
+		// Handle undefined result.
+		return false, nil
+	}
+	ignore, ok := results[0].Expressions[0].Value.(bool)
+	if !ok {
+		// Handle unexpected result type.
+		return false, xerrors.New("the policy must return boolean")
+	}
+	return ignore, nil
+}
+
+type RemotePolicyStore struct {
+	remoteURL string
+}
+
+func NewRemotePolicyStore(remoteAddr string) (PolicyStore, error) {
+	u, err := url.Parse(remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, "/v1/data/trivy/ignore")
+
+	return &RemotePolicyStore{
+		remoteURL: u.String(),
+	}, nil
+}
+
+func (r *RemotePolicyStore) Evaluate(ctx context.Context, input interface{}) (bool, error) {
+	reqBody, err := processQueryInput(input)
+	if err != nil {
+		return false, xerrors.Errorf("unable to process policy input: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", r.remoteURL, reqBody)
+	if err != nil {
+		err = xerrors.Errorf("unable to create new policy request: %w", err)
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		err = xerrors.Errorf("unable to send query policy request: %w", err)
+		return false, err
+	}
+
+	return processQueryResult(resp)
+}
+
+func processQueryInput(input interface{}) (io.Reader, error) {
+	type opaRequest struct {
+		Input interface{} `json:"input"`
+	}
+
+	inputData := opaRequest{Input: input}
+	inputBytes, err := json.Marshal(&inputData)
+	if err != nil {
+		err = xerrors.Errorf("unable to marshal input data: %w", err)
+		return nil, err
+	}
+	return bytes.NewReader(inputBytes), nil
+
+}
+
+func processQueryResult(resp *http.Response) (bool, error) {
+	type opaResult struct {
+		Result  bool
+		Warning struct {
+			Code    string
+			Message string
+		}
+	}
+	var queryResult opaResult
+	var err error
+	var respBytes []byte
+
+	// From the API doc of OPA, non-HTTP 200 response codes indicate configuration
+	// or runtime errors.
+	if resp.StatusCode != http.StatusOK {
+		err = xerrors.Errorf("unable to get query result, response code is %d, want 200 instead", resp.StatusCode)
+		return false, err
+	}
+	if respBytes, err = ioutil.ReadAll(resp.Body); err != nil {
+		err = xerrors.Errorf("unable to read query response: %w", err)
+		return false, err
+	}
+	if err = json.Unmarshal(respBytes, &queryResult); err != nil {
+		err = xerrors.Errorf("unable to unmarshal query response: %w", err)
+		return false, err
+	}
+
+	return queryResult.Result, nil
+}

--- a/pkg/result/policy_test.go
+++ b/pkg/result/policy_test.go
@@ -2,11 +2,12 @@ package result
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewLocalPolicyStore(t *testing.T) {
@@ -32,9 +33,8 @@ invalid rego file
 	}
 	tempDir := t.TempDir()
 	for filename, content := range policyFiles {
-		if err := ioutil.WriteFile(filepath.Join(tempDir, filename), content, 0600); err != nil {
-			t.Fatalf("unable to create temp file %s: %s", filename, err)
-		}
+		err := os.WriteFile(filepath.Join(tempDir, filename), content, 0600)
+		require.NoError(t, err)
 	}
 
 	tests := []struct {

--- a/pkg/result/policy_test.go
+++ b/pkg/result/policy_test.go
@@ -2,8 +2,11 @@ package result
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +70,109 @@ invalid rego file
 			} else {
 				assert.Nil(t, err, tt.expectedError, tt.name)
 			}
+		})
+	}
+}
+
+func TestRemotePolicyStore(t *testing.T) {
+	tsFactory := func(handlerFunc http.HandlerFunc) *httptest.Server {
+		return httptest.NewServer(handlerFunc)
+	}
+	happyHandler := func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, policyURI) {
+			result := []byte(`{"result": true}`)
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write(result)
+			require.NoError(t, err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		input         interface{}
+		want          bool
+		expectedError string
+		nilCtx        bool
+		cancelCtx     bool
+		ts            *httptest.Server
+	}{
+		{
+			name:          "invalid input data",
+			input:         make(chan int),
+			want:          false,
+			expectedError: "unable to process policy input:",
+		},
+		{
+			name:          "failure on creation of the new HTTP request",
+			input:         []byte(`input data`),
+			want:          false,
+			expectedError: "unable to create new policy request:",
+			nilCtx:        true,
+		},
+		{
+			name:          "failure on sending the HTTP request",
+			input:         []byte(`input data`),
+			want:          false,
+			expectedError: "unable to send query policy request:",
+			cancelCtx:     true,
+		},
+		{
+			name:          "failure on unexpected response status",
+			input:         []byte(`input data`),
+			want:          false,
+			expectedError: "unable to get query result,",
+			ts: tsFactory(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+		},
+		{
+			name:          "failure on invalid response data",
+			input:         []byte(`input data`),
+			want:          false,
+			expectedError: "unable to unmarshal query response:",
+			ts: tsFactory(func(w http.ResponseWriter, r *http.Request) {
+			}),
+		},
+		{
+			name:          "the final happy result",
+			input:         []byte(`input data`),
+			want:          true,
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				ctx         context.Context
+				cancel      context.CancelFunc
+				remoteStore PolicyStore
+				err         error
+			)
+
+			if tt.ts == nil {
+				tt.ts = tsFactory(happyHandler)
+			}
+			defer tt.ts.Close()
+			remoteStore, err = NewRemotePolicyStore(tt.ts.URL)
+			require.NoError(t, err)
+			require.NotNil(t, remoteStore)
+
+			if !tt.nilCtx {
+				ctx, cancel = context.WithCancel(context.Background())
+				defer cancel()
+			}
+			if tt.cancelCtx {
+				cancel()
+			}
+
+			result, err := remoteStore.Evaluate(ctx, tt.input)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError, tt.name)
+			} else {
+				assert.Nil(t, err, tt.name)
+			}
+			assert.Equal(t, tt.want, result, tt.name)
 		})
 	}
 }

--- a/pkg/result/policy_test.go
+++ b/pkg/result/policy_test.go
@@ -1,0 +1,72 @@
+package result
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLocalPolicyStore(t *testing.T) {
+	policyFiles := map[string][]byte{
+		"good.rego": []byte(`
+package trivy
+
+default ignore = false
+
+focused_packages := {"org.apache.logging.log4j:log4j-core"}
+
+ignore_severities := {"LOW", "MEDIUM"}
+
+ignore {
+    input.PkgName != focused_packages[_]
+}
+`),
+		"bad.rego": []byte(`
+package trivy
+
+invalid rego file
+`),
+	}
+	tempDir := t.TempDir()
+	for filename, content := range policyFiles {
+		if err := ioutil.WriteFile(filepath.Join(tempDir, filename), content, 0600); err != nil {
+			t.Fatalf("unable to create temp file %s: %s", filename, err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		policyFile    string
+		expectedError string
+	}{
+		{
+			name:          "Good rego file",
+			policyFile:    filepath.Join(tempDir, "good.rego"),
+			expectedError: "",
+		},
+		{
+			name:          "Bad rego file",
+			policyFile:    filepath.Join(tempDir, "bad.rego"),
+			expectedError: "unable to prepare for eval: ",
+		},
+		{
+			name:          "Non-existing rego file",
+			policyFile:    filepath.Join(tempDir, "non-existing.rego"),
+			expectedError: "unable to read policy file ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewLocalPolicyStore(context.Background(), tt.policyFile)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError, tt.name)
+			} else {
+				assert.Nil(t, err, tt.expectedError, tt.name)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -74,4 +75,9 @@ func GetTLSConfig(caCertPath, certPath, keyPath string) (*x509.CertPool, tls.Cer
 	caCertPool.AppendCertsFromPEM(caCert)
 
 	return caCertPool, cert, nil
+}
+
+func IsValidURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }


### PR DESCRIPTION
## Description
Add support to query policy from remote OPA server when filtering vulnerabilities.

Implementation:
* integrate with the REST API of OPA. Related documentation is here: [Integrating with the REST API](https://www.openpolicyagent.org/docs/latest/integration/#integrating-with-the-rest-api)

* I reused the `--ignore-policy` option. If the value is a valid URL, we'll query from the server. Otherwise, we'll treat it as a local policy file. But I don't think it's a good idea. Advise please.

* I preserved the built-in library `lib.rego` if the value of `--ignore-policy` is a local policy file. But I think it's redundant, we can migrate it to the documentation.

* As for the query, I still reused the previous `data.trivy.ignore`.

## Related issues
- Close #1785 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
