### PR TITLE
fix(report): correct check of old sarif template files

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"io"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -53,7 +52,7 @@ func Write(report types.Report, option Option) error {
 		writer = cyclonedx.NewWriter(option.Output, option.AppVersion)
 	case "template":
 		// We keep `sarif.tpl` template working for backward compatibility for a while.
-		if strings.HasPrefix(option.OutputTemplate, "@") && filepath.Base(option.OutputTemplate) == "sarif.tpl" {
+		if strings.HasPrefix(option.OutputTemplate, "@") && strings.HasSuffix(option.OutputTemplate, "sarif.tpl") {
 			log.Logger.Warn("Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571")
 			writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
 			break


### PR DESCRIPTION
## Description
If a customer sets a template `@sarif.tpl`, `filepath.Base(option.OutputTemplate)` will return `@sarif.tpl`, so Trivy will use this file, instead of embedded sarif template.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
