### PR TITLE
fix(report): truncate a description before escaping in ASFF template

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -34,7 +34,7 @@
                 "Label": "{{ $severity }}"
             },
             "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
-            "Description": {{ $description }},
+            "Description": {{ escapeString $description | printf "%q" }},
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -17,9 +17,9 @@
     {{- if eq $severity "UNKNOWN" -}}
     {{- $severity = "INFORMATIONAL" -}}
     {{- end -}}
-    {{- $description := escapeString .Description | printf "%q" -}}
-    {{- if gt (len $description ) 1020 -}}
-        {{- $description = (substr 0 1020 $description) | printf "%v ..\"" -}}
+    {{- $description := .Description -}}
+    {{- if gt (len $description ) 512 -}}
+        {{- $description = (substr 0 512 $description) | printf "%v .." -}}
     {{- end}}
         {
             "SchemaVersion": "2018-10-08",
@@ -34,7 +34,7 @@
                 "Label": "{{ $severity }}"
             },
             "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
-            "Description": {{ $description }},
+            "Description": {{ escapeString $description | printf "%q" }},
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -18,8 +18,8 @@
     {{- $severity = "INFORMATIONAL" -}}
     {{- end -}}
     {{- $description := escapeString .Description | printf "%q" -}}
-    {{- if gt (len $description ) 1021 -}}
-        {{- $description = (substr 0 1021 $description) | printf "%v .." -}}
+    {{- if gt (len $description ) 1020 -}}
+        {{- $description = (substr 0 1020 $description) | printf "%v ..\"" -}}
     {{- end}}
         {
             "SchemaVersion": "2018-10-08",

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -34,7 +34,7 @@
                 "Label": "{{ $severity }}"
             },
             "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
-            "Description": {{ escapeString $description | printf "%q" }},
+            "Description": {{ $description }},
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",

--- a/integration/testdata/alpine-310.asff.golden
+++ b/integration/testdata/alpine-310.asff.golden
@@ -13,7 +13,7 @@
                 "Label": "MEDIUM"
             },
             "Title": "Trivy found a vulnerability to CVE-2019-1549 in container testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)",
-            "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
+            "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an applicati ..",
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",
@@ -58,7 +58,7 @@
                 "Label": "MEDIUM"
             },
             "Title": "Trivy found a vulnerability to CVE-2019-1551 in container testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)",
-            "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
+            "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly us ..",
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",
@@ -103,7 +103,7 @@
                 "Label": "MEDIUM"
             },
             "Title": "Trivy found a vulnerability to CVE-2019-1549 in container testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)",
-            "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
+            "Description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an applicati ..",
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",
@@ -148,7 +148,7 @@
                 "Label": "MEDIUM"
             },
             "Title": "Trivy found a vulnerability to CVE-2019-1551 in container testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)",
-            "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
+            "Description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly us ..",
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",


### PR DESCRIPTION
## Description
there was an error for large descriptions:
```sh
$ cat result.asff | jq '.Findings'
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line ...
```
so there was truncated a description before escaping.

also the description size is also checked as half of the allowable.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
