### PR TITLE
fix: Omit Remediation if PrimaryURL is empty

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -35,12 +35,14 @@
             },
             "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
             "Description": {{ $description }},
+            {{ if not (empty .PrimaryURL) -}}
             "Remediation": {
                 "Recommendation": {
                     "Text": "More information on this vulnerability is provided in the hyperlink",
                     "Url": "{{ .PrimaryURL }}"
                 }
             },
+            {{ end -}}
             "ProductFields": { "Product Name": "Trivy" },
             "Resources": [
                 {


### PR DESCRIPTION
## Description
This change omits the `Recommendation` field if the `PrimaryURL` is empty, since the Security Hub API fails import if the `Recommendation.Remediation.Url` field is empty.  Please see the related issue for more context. 

Testing: 
The existing integration test case doesn't exercise this change, and I didn't see a simple way to update the `PrimaryURL` of the test image in order to do so (I'm open to feedback on this point).  However, I have tested this change manually by:
- running Trivy and generating ASFF that has an empty `PrimaryURL` (using a local copy of the template)
- encountering the ASFF import error with the Security Hub API
- updating the local copy of the template with this change
- seeing the ASFF import succeed

## Related issues
- [Close #1999](https://github.com/aquasecurity/trivy/issues/1999)

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
