### PR TITLE
test(deps): using a correct module inside go.mod for integration tests

### DIFF
--- a/integration/testdata/fixtures/fs/gomod/submod2/go.mod
+++ b/integration/testdata/fixtures/fs/gomod/submod2/go.mod
@@ -3,5 +3,5 @@ module github.com/testdata/testdata/submod2
 go 1.15
 
 require (
-	github.com/abc/abc v2.7.1+incompatible
+	github.com/davecgh/go-spew v1.1.0
 )


### PR DESCRIPTION
## Description
Using an incorrect module name was breaking some IDE.
Now we use correct module names for integration tests.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
