### PR TITLE
fix(fs): ignore permission errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220416191337-4f5b0beebbd3
+	github.com/aquasecurity/fanal v0.0.0-20220421095103-63f3f8193fa8
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.28.5-0.20220416075528-0f0c8fdf63b8 h1:TQOc6oTNT1943KbsivdxBnNHlZbp6cF3AcMzVLJCotg=
 github.com/aquasecurity/defsec v0.28.5-0.20220416075528-0f0c8fdf63b8/go.mod h1:vUdThwusBM7y1gJ7CVX3+h3bsPvpmOIEp3NEdzTDkhA=
-github.com/aquasecurity/fanal v0.0.0-20220416191337-4f5b0beebbd3 h1:N6cMeygIvTxJ2QryNasz1Q6PnFfu4E/1bCoR7bKdLCo=
-github.com/aquasecurity/fanal v0.0.0-20220416191337-4f5b0beebbd3/go.mod h1:PYU7igSuHlhOFTVNhMlv/P9oTYbcgMb0wn5+Sz+xkMs=
+github.com/aquasecurity/fanal v0.0.0-20220421095103-63f3f8193fa8 h1:3kXo5widBEz1euPnd292X5JSq0kEDuobi3YAXl4DbhU=
+github.com/aquasecurity/fanal v0.0.0-20220421095103-63f3f8193fa8/go.mod h1:PYU7igSuHlhOFTVNhMlv/P9oTYbcgMb0wn5+Sz+xkMs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90 h1:uZcI5qV7J1pzOc6W49l7iEey/KtEVlaqsNU5l65vZLk=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220412145205-d0501f906d90/go.mod h1:rK/5BoRt8/D7xXydoVVeBaQuk6zDJ6W+FWz/RqFuJxI=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description
We should not fail on permission errors and warn it instead.

```
$ trivy --cache-dir /tmp fs /
2022-04-21T08:42:23.598Z        FATAL   scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.runWithTimeout
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:94
  - image scan failed:
    github.com/aquasecurity/trivy/pkg/commands/artifact.scan
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:259
  - failed analysis:
    github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact
        /home/runner/work/trivy/trivy/pkg/scanner/scan.go:111
  - walk filesystem:
    github.com/aquasecurity/fanal/artifact/local.Artifact.Inspect
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/artifact/local/fs.go:105
  - walk error:
    github.com/aquasecurity/fanal/walker.FS.Walk
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/walker/fs.go:60
  - unknown error with /:
    github.com/aquasecurity/fanal/walker.FS.Walk.func2
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/walker/fs.go:54
  - unknown error with //run:
    github.com/aquasecurity/fanal/walker.FS.Walk.func2
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/walker/fs.go:54
  - unknown error with //run/cloud-init:
    github.com/aquasecurity/fanal/walker.FS.Walk.func2
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/walker/fs.go:54
  - failed to analyze file:
    github.com/aquasecurity/fanal/walker.FS.Walk.func1
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/walker/fs.go:42
  - analyze file (run/cloud-init/instance-data-sensitive.json):
    github.com/aquasecurity/fanal/artifact/local.Artifact.Inspect.func1
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/artifact/local/fs.go:100
  - unable to open run/cloud-init/instance-data-sensitive.json:
    github.com/aquasecurity/fanal/analyzer.AnalyzerGroup.AnalyzeFile
        /home/runner/go/pkg/mod/github.com/aquasecurity/fanal@v0.0.0-20220414083417-61bfa9f92483/analyzer/analyzer.go:245
  - open /run/cloud-init/instance-data-sensitive.json: permission denied
```

## Related PRs
- [ ] https://github.com/aquasecurity/fanal/pull/477

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
