### PR TITLE
chore: gh publish only with push the tag release

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -9,9 +9,8 @@ on:
     paths:
       - 'helm/trivy/**'
   push:
-    branches: [main]
-    paths:
-      - 'helm/trivy/**'
+    tags:
+      - "v*"
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
@@ -50,7 +49,7 @@ jobs:
           ct lint-and-install --validate-maintainers=false --charts helm/trivy
 
   publish-chart:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs:
       - test-chart
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description
Publish the helm chart only when it's pushed a release tag
