### PR TITLE
refactor: scanner options

### DIFF
--- a/pkg/commands/artifact/fs.go
+++ b/pkg/commands/artifact/fs.go
@@ -11,7 +11,7 @@ import (
 )
 
 // filesystemStandaloneScanner initializes a filesystem scanner in standalone mode
-func filesystemStandaloneScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func filesystemStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)
@@ -20,7 +20,7 @@ func filesystemStandaloneScanner(ctx context.Context, conf scannerConfig) (scann
 }
 
 // filesystemRemoteScanner initializes a filesystem scanner in client/server mode
-func filesystemRemoteScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRemoteFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.RemoteOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)

--- a/pkg/commands/artifact/image.go
+++ b/pkg/commands/artifact/image.go
@@ -13,7 +13,7 @@ import (
 
 // imageScanner initializes a container image scanner in standalone mode
 // $ trivy image alpine:3.15
-func imageScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func imageScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS)
 	if err != nil {
 		return scanner.Scanner{}, nil, err
@@ -28,7 +28,7 @@ func imageScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, fun
 
 // archiveScanner initializes an image archive scanner in standalone mode
 // $ trivy image --input alpine.tar
-func archiveScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func archiveScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, err := initializeArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize the archive scanner: %w", err)
@@ -38,7 +38,7 @@ func archiveScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, f
 
 // remoteImageScanner initializes a container image scanner in client/server mode
 // $ trivy image --server localhost:4954 alpine:3.15
-func remoteImageScanner(ctx context.Context, conf scannerConfig) (
+func remoteImageScanner(ctx context.Context, conf ScannerConfig) (
 	scanner.Scanner, func(), error) {
 	// Scan an image in Docker Engine, Docker Registry, etc.
 	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS)
@@ -56,7 +56,7 @@ func remoteImageScanner(ctx context.Context, conf scannerConfig) (
 
 // remoteArchiveScanner initializes an image archive scanner in client/server mode
 // $ trivy image --server localhost:4954 --input alpine.tar
-func remoteArchiveScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func remoteArchiveScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	// Scan tar file
 	s, err := initializeRemoteArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.RemoteOption, conf.ArtifactOption)
 	if err != nil {

--- a/pkg/commands/artifact/repository.go
+++ b/pkg/commands/artifact/repository.go
@@ -12,7 +12,7 @@ import (
 )
 
 // filesystemStandaloneScanner initializes a repository scanner in standalone mode
-func repositoryScanner(ctx context.Context, conf scannerConfig) (scanner.Scanner, func(), error) {
+func repositoryScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -29,7 +29,7 @@ const defaultPolicyNamespace = "appshield"
 
 var errSkipScan = errors.New("skip subsequent processes")
 
-type scannerConfig struct {
+type ScannerConfig struct {
 	// e.g. image name and file path
 	Target string
 
@@ -45,7 +45,7 @@ type scannerConfig struct {
 }
 
 // InitializeScanner defines the initialize function signature of scanner
-type InitializeScanner func(context.Context, scannerConfig) (scanner.Scanner, func(), error)
+type InitializeScanner func(context.Context, ScannerConfig) (scanner.Scanner, func(), error)
 
 // InitCache defines cache initializer
 type InitCache func(c Option) (cache.Cache, error)
@@ -233,7 +233,7 @@ func scan(ctx context.Context, opt Option, initializeScanner InitializeScanner, 
 		}
 	}
 
-	s, cleanup, err := initializeScanner(ctx, scannerConfig{
+	s, cleanup, err := initializeScanner(ctx, ScannerConfig{
 		Target:             target,
 		ArtifactCache:      cacheClient,
 		LocalArtifactCache: cacheClient,


### PR DESCRIPTION
To allow Trivy plugins create InitializeScanner signature scanner options need to be public

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
