### PR TITLE
docs(secret): fix rule path in docs

### DIFF
--- a/docs/docs/secret/configuration.md
+++ b/docs/docs/secret/configuration.md
@@ -14,8 +14,7 @@ rules:
     category: general
     title: Generic Rule
     severity: HIGH
-    path:
-      - .*\.sh
+    path: .*\.sh
     keywords:
       - secret
     regex: (?i)(?P<key>(secret))(=|:).{0,5}['"](?P<secret>[0-9a-zA-Z\-_=]{8,64})['"]


### PR DESCRIPTION
## Description
In secret custom rules documentation, the rule's path is an array. While actually, it's a single value.

## Related issues
- None, docs fix

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
