### PR TITLE
chore(os): more general support for os-release files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220430134203-bc6fd26a109e
+	github.com/aquasecurity/fanal v0.0.0-20220503160602-873c6de8f5ae
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220422134844-880747206031
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -55,7 +55,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v63.0.0+incompatible // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest v0.11.25 // indirect
+	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKn
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest v0.11.20/go.mod h1:o3tqFY+QR40VOlk+pV4d77mORO64jOXSgEnPQgLK6JY=
 github.com/Azure/go-autorest/autorest v0.11.24/go.mod h1:G6kyRlFnTuSbEYkQGawPfsCswgme4iYf6rfSKUDzbCc=
-github.com/Azure/go-autorest/autorest v0.11.25 h1:yp+V8DGur2aIUE87ebP8twPLz6k68jtJTlg61mEoByA=
-github.com/Azure/go-autorest/autorest v0.11.25/go.mod h1:7l8ybrIdUmGqZMTD0sRtAr8NvbHjfofbf8RSP2q7w7U=
+github.com/Azure/go-autorest/autorest v0.11.27 h1:F3R3q42aWytozkV8ihzcgMO4OA4cuqr3bNlsEuF6//A=
+github.com/Azure/go-autorest/autorest v0.11.27/go.mod h1:7l8ybrIdUmGqZMTD0sRtAr8NvbHjfofbf8RSP2q7w7U=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.8.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
 github.com/Azure/go-autorest/autorest/adal v0.8.1/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
@@ -250,8 +250,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.28.5-0.20220426090908-0df04f1fa28b h1:v3+rrNd5zXHsGZ6rQkox1z9/0H5tYLs0EJlQmgcP9Rc=
 github.com/aquasecurity/defsec v0.28.5-0.20220426090908-0df04f1fa28b/go.mod h1:3pFStAmcS8LE2OI0AE6IvxB5nu6kDqYRJBwrUZavN+U=
-github.com/aquasecurity/fanal v0.0.0-20220430134203-bc6fd26a109e h1:kD4OeyNl/f6Q3Ib0gw3jDZh7jnBI6YVb1SmbgM8Ym7M=
-github.com/aquasecurity/fanal v0.0.0-20220430134203-bc6fd26a109e/go.mod h1:p1NjKKUjCnIoITrl9dMwAYg5Rs7kkLd9VLS3SYmaBLQ=
+github.com/aquasecurity/fanal v0.0.0-20220503160602-873c6de8f5ae h1:9H3kbgjKp2VBn7Us/e62g2eKSi1gSkmeXKcXsxu+Qrc=
+github.com/aquasecurity/fanal v0.0.0-20220503160602-873c6de8f5ae/go.mod h1:6aJdaOfg6tAK1csaNltJq7oEpbhgC/aQhFvW7GkNTUk=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220422134844-880747206031 h1:4LtaaQ6nrd9EVpd1z5P0snZSSPfzCHiLljGipJlOQTs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220422134844-880747206031/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/integration/testdata/alpine-distroless.json.golden
+++ b/integration/testdata/alpine-distroless.json.golden
@@ -5,7 +5,7 @@
   "Metadata": {
     "OS": {
       "Family": "alpine",
-      "Name": "edge"
+      "Name": "3.16"
     },
     "ImageID": "sha256:22848737c0d272ad5d7c7369d8ca830a62929e63e38edcb22085139a6ae0688d",
     "DiffIDs": [
@@ -44,7 +44,7 @@
   },
   "Results": [
     {
-      "Target": "testdata/fixtures/images/alpine-distroless.tar.gz (alpine edge)",
+      "Target": "testdata/fixtures/images/alpine-distroless.tar.gz (alpine 3.16)",
       "Class": "os-pkgs",
       "Type": "alpine",
       "Vulnerabilities": [


### PR DESCRIPTION
## Description
Added OS version detection from OS release file for some dist:
- Alpine Linux
- openSUSE
- SLES
- Photon OS

## Related PRs
- [x] #aquasecurity/fanal/pull/470

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
