### PR TITLE
chore: fix make lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ deps:
 	go mod tidy
 
 $(GOBIN)/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.41.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.45.2
 
 .PHONY: test
 test:


### PR DESCRIPTION
## Description

Fixing make lint version to be the same as workflow:
https://github.com/aquasecurity/trivy/blob/fbb83c42d9ffcefa9ffab4df25da0bb0b4f9fafd/.github/workflows/test.yaml#L29

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
