### PR TITLE
docs(secret): Fix default value of --security-checks in docs

### DIFF
--- a/docs/docs/references/cli/image.md
+++ b/docs/docs/references/cli/image.md
@@ -22,7 +22,7 @@ OPTIONS:
    --ignore-unfixed                 display only fixed vulnerabilities (default: false) [$TRIVY_IGNORE_UNFIXED]
    --removed-pkgs                   detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
    --vuln-type value                comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
-   --security-checks value          comma-separated list of what security issues to detect (vuln,config) (default: "vuln") [$TRIVY_SECURITY_CHECKS]
+   --security-checks value          comma-separated list of what security issues to detect (vuln,config) (default: "vuln,secret") [$TRIVY_SECURITY_CHECKS]
    --ignorefile value               specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
    --timeout value                  timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --light                          deprecated (default: false) [$TRIVY_LIGHT]

--- a/docs/docs/references/cli/image.md
+++ b/docs/docs/references/cli/image.md
@@ -22,7 +22,7 @@ OPTIONS:
    --ignore-unfixed                 display only fixed vulnerabilities (default: false) [$TRIVY_IGNORE_UNFIXED]
    --removed-pkgs                   detect vulnerabilities of removed packages (only for Alpine) (default: false) [$TRIVY_REMOVED_PKGS]
    --vuln-type value                comma-separated list of vulnerability types (os,library) (default: "os,library") [$TRIVY_VULN_TYPE]
-   --security-checks value          comma-separated list of what security issues to detect (vuln,config) (default: "vuln,secret") [$TRIVY_SECURITY_CHECKS]
+   --security-checks value          comma-separated list of what security issues to detect (vuln,config,secret) (default: "vuln,secret") [$TRIVY_SECURITY_CHECKS]
    --ignorefile value               specify .trivyignore file (default: ".trivyignore") [$TRIVY_IGNOREFILE]
    --timeout value                  timeout (default: 5m0s) [$TRIVY_TIMEOUT]
    --light                          deprecated (default: false) [$TRIVY_LIGHT]


### PR DESCRIPTION
## Description

The default value for the `--security-checks` option is incorrect in the docs.

See https://github.com/aquasecurity/trivy/issues/2104

## Related issues
- Close #2104 

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/1901


Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
