### PR TITLE
docs: fix k8s doc

### DIFF
--- a/docs/docs/kubernetes/scanning.md
+++ b/docs/docs/kubernetes/scanning.md
@@ -23,7 +23,7 @@ $ trivy k8s -n default
 Scan a namespace for only `CRITICAL` Vulnerabilities and Misconfigurations:
 
 ```
-$ trivy k8s -n default -o results.json --severity CRITICAL
+$ trivy k8s -n default --severity CRITICAL
 ```
 
 Scan a cluster and generate a simple summary report. The only outputs currently supported are `all` and `summary`. The default report format is `summary`


### PR DESCRIPTION
The default report doesn't return json anymore.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
