### PR TITLE
feat: k8s resource scanning

### DIFF
--- a/docs/docs/kubernetes/scanning.md
+++ b/docs/docs/kubernetes/scanning.md
@@ -11,7 +11,7 @@ Trivy uses your local kubectl configuration to access the API server to list art
 Scan a full cluster and generate a simple summary report:
 
 ```
-$ trivy k8s
+$ trivy k8s --report=summary
 ```
 
 ![k8s Summary Report](../../imgs/k8s-summary.png)
@@ -21,26 +21,26 @@ The summary report is the default. To get all of the detail the output contains,
 Filter by severity:
 
 ```
-$ trivy k8s --severity=CRITICAL
+$ trivy k8s --severity=CRITICAL --report=all
 ```
 
 Scan a specific namespace:
 
 ```
-$ trivy k8s -n kube-system
+$ trivy k8s -n kube-system --report=summary
 ```
 
 Scan a specific resource and get all the output:
 
 ```
-$ trivy k8s -n default --report all deployment/appname
+$ trivy k8s deployment/appname
 ```
 
 The supported formats are `table`, which is the default, and `json`.
 To get a JSON output on a full cluster scan:
 
 ```
-$ trivy k8s --report all --format json -o results.json
+$ trivy k8s --format json -o results.json
 ```
 
 <details>

--- a/docs/docs/kubernetes/scanning.md
+++ b/docs/docs/kubernetes/scanning.md
@@ -18,6 +18,12 @@ $ trivy k8s
 
 The summary report is the default. To get all of the detail the output contains, use `--report all`.
 
+Filter by severity:
+
+```
+$ trivy k8s --severity=CRITICAL
+```
+
 Scan a specific namespace:
 
 ```

--- a/docs/docs/kubernetes/scanning.md
+++ b/docs/docs/kubernetes/scanning.md
@@ -8,25 +8,7 @@ Scan your Kubernetes cluster for both Vulnerabilities and Misconfigurations.
 
 Trivy uses your local kubectl configuration to access the API server to list artifacts.
 
-Scan a full cluster:
-
-```
-$ trivy k8s
-```
-
-Scan a specific namespace:
-
-```
-$ trivy k8s -n default
-```
-
-Scan a namespace for only `CRITICAL` Vulnerabilities and Misconfigurations:
-
-```
-$ trivy k8s -n default --severity CRITICAL
-```
-
-Scan a cluster and generate a simple summary report. The only outputs currently supported are `all` and `summary`. The default report format is `summary`
+Scan a full cluster and generate a simple summary report:
 
 ```
 $ trivy k8s
@@ -34,12 +16,26 @@ $ trivy k8s
 
 ![k8s Summary Report](../../imgs/k8s-summary.png)
 
-To get all of the detail the output contains, use `--report all`, to get JSON output:
+The summary report is the default. To get all of the detail the output contains, use `--report all`.
+
+Scan a specific namespace:
 
 ```
-$ trivy k8s --report all
+$ trivy k8s -n kube-system
 ```
 
+Scan a specific resource and get all the output:
+
+```
+$ trivy k8s -n default --report all deployment/appname
+```
+
+The supported formats are `table`, which is the default, and `json`.
+To get a JSON output on a full cluster scan:
+
+```
+$ trivy k8s --report all --format json -o results.json
+```
 
 <details>
 <summary>Result</summary>

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 
 require (
 	github.com/aquasecurity/table v1.5.1
-	github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01
+	github.com/aquasecurity/trivy-kubernetes v0.2.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220511115204-32614d79a234
+	github.com/aquasecurity/fanal v0.0.0-20220513163515-33f2cd8392ee
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -54,7 +54,7 @@ require (
 require (
 	cloud.google.com/go v0.99.0 // indirect
 	cloud.google.com/go/storage v1.14.0 // indirect
-	github.com/Azure/azure-sdk-for-go v63.0.0+incompatible // indirect
+	github.com/Azure/azure-sdk-for-go v64.0.0+incompatible // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
@@ -77,7 +77,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-	github.com/aquasecurity/defsec v0.57.3
+	github.com/aquasecurity/defsec v0.57.5
 	github.com/aws/aws-sdk-go v1.44.5 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
@@ -198,7 +198,7 @@ require (
 
 require (
 	github.com/aquasecurity/table v1.5.1
-	github.com/aquasecurity/trivy-kubernetes v0.1.0
+	github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -251,3 +251,6 @@ replace github.com/containerd/containerd v1.5.9 => github.com/containerd/contain
 
 // See https://github.com/moby/moby/issues/42939#issuecomment-1114255529
 replace github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220224222438-c78f6963a1c0+incompatible
+
+// TODO: remove once the feature is merged upstream
+replace github.com/aquasecurity/trivy-kubernetes v0.1.0 => github.com/josedonizetti/trivy-kubernetes v0.0.0-20220515001536-b6e8afada9c5

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v56.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v63.0.0+incompatible h1:whPsa+jCHQSo5wGMPNLw4bz8q9Co2+vnXHzXGctoTaQ=
 github.com/Azure/azure-sdk-for-go v63.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v64.0.0+incompatible h1:WAA77WBDWYtNfCC95V70VvkdzHe+wM/r2MQ9mG7fnQs=
+github.com/Azure/azure-sdk-for-go v64.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
@@ -182,8 +184,12 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.57.3 h1:oiATfUTxOAcxAuXSH31RdgjtXJdQznlVzMJWdVYGmXY=
 github.com/aquasecurity/defsec v0.57.3/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
+github.com/aquasecurity/defsec v0.57.5 h1:kOsRgMlQMxdOHYNEF0SCblZevrsdoz7c4fz5qYTTUFY=
+github.com/aquasecurity/defsec v0.57.5/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
 github.com/aquasecurity/fanal v0.0.0-20220511115204-32614d79a234 h1:NG9Qs4hocUWcGytaA0yhArPRoPmo12EPAUERwYCgvLA=
 github.com/aquasecurity/fanal v0.0.0-20220511115204-32614d79a234/go.mod h1:bqz0H4eqstkngJB0TJCk39GLXZcUtobMpuNr4ScC1vk=
+github.com/aquasecurity/fanal v0.0.0-20220513163515-33f2cd8392ee h1:O7cN19V4W7u7s7M3kME21/IDUA4iQULDeo9g3DS4gdU=
+github.com/aquasecurity/fanal v0.0.0-20220513163515-33f2cd8392ee/go.mod h1:1FqeeQo0AKRIgYgv60r0SOBNMBenxBQF3jAnnICEFIE=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff h1:YNlzRYB0n4mZtfuWx6AWaGEjnLVNekchyoFDlYFZegs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
@@ -200,6 +206,10 @@ github.com/aquasecurity/table v1.5.1/go.mod h1:1MFKrEPJ8NchM917BrVGvsqoXJo1OL1Ja
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e h1:NLm5KWGcnkwaUR1GODPePyhNsbuFiT6lgKYcCcW9c10=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e/go.mod h1:/nULgnDeq/JMPMVwE1dmf4kWlYn++7VrM3O2naj4BHA=
+github.com/aquasecurity/trivy-kubernetes v0.2.0 h1:c5eB+kZ9u1MVi5eoA23Wh4CaU+IHnZS0HiKa0UBJgO4=
+github.com/aquasecurity/trivy-kubernetes v0.2.0/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
+github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01 h1:UwLeid2EjVKVoElq0NO6tC0gSsjTzWvzX0a3V74PbI8=
+github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -819,8 +829,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/josedonizetti/trivy-kubernetes v0.0.0-20220515001536-b6e8afada9c5 h1:U9h3bt7ZiQCc4kFl9vTEB1/kDj530bwrKbyst0Xjil8=
-github.com/josedonizetti/trivy-kubernetes v0.0.0-20220515001536-b6e8afada9c5/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v56.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v63.0.0+incompatible h1:whPsa+jCHQSo5wGMPNLw4bz8q9Co2+vnXHzXGctoTaQ=
-github.com/Azure/azure-sdk-for-go v63.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v64.0.0+incompatible h1:WAA77WBDWYtNfCC95V70VvkdzHe+wM/r2MQ9mG7fnQs=
 github.com/Azure/azure-sdk-for-go v64.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -182,12 +180,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.57.3 h1:oiATfUTxOAcxAuXSH31RdgjtXJdQznlVzMJWdVYGmXY=
-github.com/aquasecurity/defsec v0.57.3/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
 github.com/aquasecurity/defsec v0.57.5 h1:kOsRgMlQMxdOHYNEF0SCblZevrsdoz7c4fz5qYTTUFY=
 github.com/aquasecurity/defsec v0.57.5/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
-github.com/aquasecurity/fanal v0.0.0-20220511115204-32614d79a234 h1:NG9Qs4hocUWcGytaA0yhArPRoPmo12EPAUERwYCgvLA=
-github.com/aquasecurity/fanal v0.0.0-20220511115204-32614d79a234/go.mod h1:bqz0H4eqstkngJB0TJCk39GLXZcUtobMpuNr4ScC1vk=
 github.com/aquasecurity/fanal v0.0.0-20220513163515-33f2cd8392ee h1:O7cN19V4W7u7s7M3kME21/IDUA4iQULDeo9g3DS4gdU=
 github.com/aquasecurity/fanal v0.0.0-20220513163515-33f2cd8392ee/go.mod h1:1FqeeQo0AKRIgYgv60r0SOBNMBenxBQF3jAnnICEFIE=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff h1:YNlzRYB0n4mZtfuWx6AWaGEjnLVNekchyoFDlYFZegs=
@@ -206,10 +200,8 @@ github.com/aquasecurity/table v1.5.1/go.mod h1:1MFKrEPJ8NchM917BrVGvsqoXJo1OL1Ja
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e h1:NLm5KWGcnkwaUR1GODPePyhNsbuFiT6lgKYcCcW9c10=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e/go.mod h1:/nULgnDeq/JMPMVwE1dmf4kWlYn++7VrM3O2naj4BHA=
-github.com/aquasecurity/trivy-kubernetes v0.2.0 h1:c5eB+kZ9u1MVi5eoA23Wh4CaU+IHnZS0HiKa0UBJgO4=
-github.com/aquasecurity/trivy-kubernetes v0.2.0/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
-github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01 h1:UwLeid2EjVKVoElq0NO6tC0gSsjTzWvzX0a3V74PbI8=
-github.com/aquasecurity/trivy-kubernetes v0.2.1-0.20220515055017-be8c01f56a01/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
+github.com/aquasecurity/trivy-kubernetes v0.2.1 h1:h7MeJpwZXd4+9f6mWRslrYQWSY/NXede50zUDx4kwLk=
+github.com/aquasecurity/trivy-kubernetes v0.2.1/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/aquasecurity/table v1.5.1/go.mod h1:1MFKrEPJ8NchM917BrVGvsqoXJo1OL1Ja
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e h1:NLm5KWGcnkwaUR1GODPePyhNsbuFiT6lgKYcCcW9c10=
 github.com/aquasecurity/trivy-db v0.0.0-20220510190819-8ca06716f46e/go.mod h1:/nULgnDeq/JMPMVwE1dmf4kWlYn++7VrM3O2naj4BHA=
-github.com/aquasecurity/trivy-kubernetes v0.1.0 h1:eE7JSdqo83Kn87c86DcUIsPAtW0K9UnkkHEQ4sGI030=
-github.com/aquasecurity/trivy-kubernetes v0.1.0/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -821,6 +819,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/josedonizetti/trivy-kubernetes v0.0.0-20220515001536-b6e8afada9c5 h1:U9h3bt7ZiQCc4kFl9vTEB1/kDj530bwrKbyst0Xjil8=
+github.com/josedonizetti/trivy-kubernetes v0.0.0-20220515001536-b6e8afada9c5/go.mod h1:9fU3sHz/wXN5ruZ5snUEJpzm2X6pUndKucv1mz9Walc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -219,7 +219,7 @@ var (
 
 	reportFlag = cli.StringFlag{
 		Name:  "report",
-		Value: "summary",
+		Value: "all",
 		Usage: "specify a report format for the output. (all,summary default: all)",
 	}
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -794,7 +794,17 @@ func NewK8sCommand() *cli.Command {
 		Name:    "kubernetes",
 		Aliases: []string{"k8s"},
 		Usage:   "scan kubernetes vulnerabilities and misconfigurations",
-		Action:  k8s.Run,
+		CustomHelpTemplate: cli.CommandHelpTemplate + `EXAMPLES:
+  - cluster scanning:
+      $ trivy k8s --report summary
+
+  - namespace scanning:
+      $ trivy k8s -n kube-system --report summary
+
+  - resource scanning:
+      $ trivy k8s deployment/orion
+`,
+		Action: k8s.Run,
 		Flags: []cli.Flag{
 			&namespaceFlag,
 			&reportFlag,

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -798,6 +798,7 @@ func NewK8sCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&namespaceFlag,
 			&reportFlag,
+			&formatFlag,
 			&outputFlag,
 			&severityFlag,
 			&exitCodeFlag,

--- a/pkg/k8s/json.go
+++ b/pkg/k8s/json.go
@@ -19,9 +19,9 @@ func (jw JSONWriter) Write(report Report) error {
 	var err error
 
 	switch jw.Report {
-	case "all":
+	case allReport:
 		output, err = json.MarshalIndent(report, "", "  ")
-	case "summary":
+	case summaryReport:
 		output, err = json.MarshalIndent(report.consolidate(), "", "  ")
 	default:
 		err = fmt.Errorf("report %s not supported", jw.Report)

--- a/pkg/k8s/json.go
+++ b/pkg/k8s/json.go
@@ -10,11 +10,23 @@ import (
 
 type JSONWriter struct {
 	Output io.Writer
+	Report string
 }
 
 // Write writes the results in JSON format
 func (jw JSONWriter) Write(report Report) error {
-	output, err := json.MarshalIndent(report, "", "  ")
+	var output []byte
+	var err error
+
+	switch jw.Report {
+	case "all":
+		output, err = json.MarshalIndent(report, "", "  ")
+	case "summary":
+		output, err = json.MarshalIndent(report.consolidate(), "", "  ")
+	default:
+		err = fmt.Errorf("report %s not supported", jw.Report)
+	}
+
 	if err != nil {
 		return xerrors.Errorf("failed to marshal json: %w", err)
 	}
@@ -22,5 +34,6 @@ func (jw JSONWriter) Write(report Report) error {
 	if _, err = fmt.Fprintln(jw.Output, string(output)); err != nil {
 		return xerrors.Errorf("failed to write json: %w", err)
 	}
+
 	return nil
 }

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -13,6 +13,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
+const (
+	allReport     = "all"
+	summaryReport = "summary"
+)
+
 type Option struct {
 	Format     string
 	Report     string

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -46,7 +46,7 @@ type Resource struct {
 	Error   string        `json:",omitempty"`
 
 	// original report
-	Report types.Report
+	Report types.Report `json:"-"`
 }
 
 // Failed returns whether the k8s report includes any vulnerabilities or misconfigurations

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -16,6 +16,9 @@ import (
 const (
 	allReport     = "all"
 	summaryReport = "summary"
+
+	tableFormat = "table"
+	jsonFormat  = "json"
 )
 
 type Option struct {
@@ -108,9 +111,9 @@ type Writer interface {
 func write(report Report, option Option) error {
 	var writer Writer
 	switch option.Format {
-	case "json":
+	case jsonFormat:
 		writer = &JSONWriter{Output: option.Output, Report: option.Report}
-	case "table":
+	case tableFormat:
 		writer = &TableWriter{
 			Output:     option.Output,
 			Report:     option.Report,

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -51,7 +51,11 @@ func Run(cliCtx *cli.Context) error {
 		}
 		return xerrors.Errorf("init error: %w", err)
 	}
-	defer runner.Close()
+	defer func() {
+		if err := runner.Close(); err != nil {
+			log.Logger.Errorf("failed to close runner: %s", err)
+		}
+	}()
 
 	cluster, err := k8s.GetCluster()
 	if err != nil {

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -25,6 +25,18 @@ func Run(cliCtx *cli.Context) error {
 	}
 
 	// Full-cluster scanning with '--format table' without explicit '--report all' is not allowed so that it won't mess up user's terminal.
+	// To show all the results, user needs to specify "--report all" explicitly
+	// even though the default value of "--report" is "all".
+	//
+	// e.g. $ trivy k8s --report all
+	//
+	// Or they can use "--format json" with implicit "--report all".
+	//
+	// e.g. $ trivy k8s --format json // All the results are shown in JSON
+	//
+	// Single resource scanning is allowed with implicit "--report all".
+	//
+	// e.g. $ trivy k8s pod myapp
 	if cliCtx.String("report") == allReport &&
 		!cliCtx.IsSet("report") &&
 		cliCtx.String("format") == tableFormat &&

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -17,7 +17,13 @@ import (
 )
 
 // Run runs scan on kubernetes cluster
+
 func Run(cliCtx *cli.Context) error {
+	opt, err := cmd.InitOption(cliCtx)
+	if err != nil {
+		return xerrors.Errorf("option error: %w", err)
+	}
+
 	// Full-cluster scanning with '--format table' without explicit '--report all' is not allowed so that it won't mess up user's terminal.
 	if cliCtx.String("report") == "all" &&
 		!cliCtx.IsSet("report") &&
@@ -27,11 +33,6 @@ func Run(cliCtx *cli.Context) error {
 		m := "All the results in the table format can mess up your terminal. Use \"--report all\" to tell Trivy to output it to your terminal anyway, or consider \"--report summary\" to show the summary output."
 
 		return xerrors.New(m)
-	}
-
-	opt, err := cmd.InitOption(cliCtx)
-	if err != nil {
-		return xerrors.Errorf("option error: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(cliCtx.Context, opt.Timeout)

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -18,6 +18,17 @@ import (
 
 // Run runs scan on kubernetes cluster
 func Run(cliCtx *cli.Context) error {
+	// Full-cluster scanning with '--format table' without explicit '--report all' is not allowed so that it won't mess up user's terminal.
+	if cliCtx.String("report") == "all" &&
+		!cliCtx.IsSet("report") &&
+		cliCtx.String("format") == "table" &&
+		!cliCtx.Args().Present() {
+
+		m := "All the results in the table format can mess up your terminal. Use \"--report all\" to tell Trivy to output it to your terminal anyway, or consider \"--report summary\" to show the summary output."
+
+		return xerrors.New(m)
+	}
+
 	opt, err := cmd.InitOption(cliCtx)
 	if err != nil {
 		return xerrors.Errorf("option error: %w", err)

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -82,10 +82,16 @@ func run(ctx context.Context, s *scanner, opt cmd.Option, artifacts []*artifacts
 }
 
 func getArtifacts(ctx context.Context, args cli.Args, cluster k8s.Cluster, namespace string) ([]*artifacts.Artifact, error) {
-	trivyk8s := trivyk8s.New(cluster).Namespace(namespace)
+	trivyk8s := trivyk8s.New(cluster)
 
 	if !args.Present() {
-		return trivyk8s.ListArtifacts(ctx)
+		return trivyk8s.Namespace(namespace).ListArtifacts(ctx)
+	}
+
+	// if scanning single resource, and namespace is empty
+	// uses default namespace
+	if len(namespace) == 0 {
+		namespace = cluster.GetCurrentNamespace()
 	}
 
 	kind, name, err := extractKindAndName(args)
@@ -93,7 +99,7 @@ func getArtifacts(ctx context.Context, args cli.Args, cluster k8s.Cluster, names
 		return nil, err
 	}
 
-	artifact, err := trivyk8s.GetArtifact(ctx, kind, name)
+	artifact, err := trivyk8s.Namespace(namespace).GetArtifact(ctx, kind, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -25,9 +25,9 @@ func Run(cliCtx *cli.Context) error {
 	}
 
 	// Full-cluster scanning with '--format table' without explicit '--report all' is not allowed so that it won't mess up user's terminal.
-	if cliCtx.String("report") == "all" &&
+	if cliCtx.String("report") == allReport &&
 		!cliCtx.IsSet("report") &&
-		cliCtx.String("format") == "table" &&
+		cliCtx.String("format") == tableFormat &&
 		!cliCtx.Args().Present() {
 
 		m := "All the results in the table format can mess up your terminal. Use \"--report all\" to tell Trivy to output it to your terminal anyway, or consider \"--report summary\" to show the summary output."

--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -107,7 +106,7 @@ func extractKindAndName(args cli.Args) (string, string, error) {
 	case 1:
 		s := strings.Split(args.Get(0), "/")
 		if len(s) != 2 {
-			return "", "", fmt.Errorf("can't parse arguments: %v", args.Slice())
+			return "", "", xerrors.Errorf("can't parse arguments: %v", args.Slice())
 		}
 
 		return s[0], s[1], nil
@@ -115,5 +114,5 @@ func extractKindAndName(args cli.Args) (string, string, error) {
 		return args.Get(0), args.Get(1), nil
 	}
 
-	return "", "", fmt.Errorf("can't parse arguments: %v", args.Slice())
+	return "", "", xerrors.Errorf("can't parse arguments: %v", args.Slice())
 }

--- a/pkg/k8s/scanner.go
+++ b/pkg/k8s/scanner.go
@@ -123,5 +123,4 @@ func (s *scanner) filter(ctx context.Context, report types.Report, artifact *art
 	}
 
 	return createResource(artifact, report, nil), nil
-
 }

--- a/pkg/k8s/table.go
+++ b/pkg/k8s/table.go
@@ -15,7 +15,7 @@ type TableWriter struct {
 
 func (tw TableWriter) Write(report Report) error {
 	switch tw.Report {
-	case "all":
+	case allReport:
 		t := pkgReport.TableWriter{Output: tw.Output, Severities: tw.Severities}
 		for _, r := range report.Vulnerabilities {
 			if r.Report.Results.Failed() {
@@ -33,7 +33,7 @@ func (tw TableWriter) Write(report Report) error {
 				}
 			}
 		}
-	case "summary":
+	case summaryReport:
 		writer := NewSummaryWriter(tw.Output, tw.Severities)
 		return writer.Write(report)
 	}

--- a/pkg/k8s/table.go
+++ b/pkg/k8s/table.go
@@ -1,0 +1,41 @@
+package k8s
+
+import (
+	"io"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	pkgReport "github.com/aquasecurity/trivy/pkg/report"
+)
+
+type TableWriter struct {
+	Report     string
+	Output     io.Writer
+	Severities []dbTypes.Severity
+}
+
+func (tw TableWriter) Write(report Report) error {
+	switch tw.Report {
+	case "all":
+		t := pkgReport.TableWriter{Output: tw.Output, Severities: tw.Severities}
+		for _, r := range report.Vulnerabilities {
+			if r.Report.Results.Failed() {
+				err := t.Write(r.Report)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		for _, r := range report.Misconfigurations {
+			if r.Report.Results.Failed() {
+				err := t.Write(r.Report)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	case "summary":
+		writer := NewSummaryWriter(tw.Output, tw.Severities)
+		return writer.Write(report)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

- Add support to kubernetes single resource scanning
- Add support to format (table or json) and report (summary or all).

```
# returns table with all information for deploy/orion
trivy k8s -n default --format table --report all deploy/orion 

# returns table with summary information for deploy/orion
trivy k8s -n default --format table --report summary deploy/orion 

# returns json with all information for deploy/orion
trivy k8s -n default --format json --report all deploy/orion 

# returns json with summary information for deploy/orion
trivy k8s -n default --format json --report summary deploy/orion 

# returns table with summary information for all resources
trivy k8s -n default --format json --report summary

# returns table with all information for all resources
trivy k8s -n default --format json --report all

...
```

When report `all` is chosen for table, the output table report for each resource (image or config) is the same as if you called those subcommands directly for 1 resource.

## Related PRs
- Depends on -> https://github.com/aquasecurity/trivy/pull/2116

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.