### PR TITLE
fix(k8s): security-checks panic

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -800,6 +800,11 @@ func NewPluginCommand() *cli.Command {
 
 // NewK8sCommand is the factory method to add k8s subcommand
 func NewK8sCommand() *cli.Command {
+	k8sSecurityChecksFlag := withValue(
+		securityChecksFlag,
+		fmt.Sprintf("%s,%s", types.SecurityCheckVulnerability, types.SecurityCheckConfig),
+	)
+
 	return &cli.Command{
 		Name:    "kubernetes",
 		Aliases: []string{"k8s"},
@@ -827,10 +832,7 @@ func NewK8sCommand() *cli.Command {
 			&clearCacheFlag,
 			&ignoreUnfixedFlag,
 			&vulnTypeFlag,
-			withValue(
-				&securityChecksFlag,
-				fmt.Sprintf("%s,%s", types.SecurityCheckVulnerability, types.SecurityCheckConfig),
-			),
+			&k8sSecurityChecksFlag,
 			&ignoreFileFlag,
 			&cacheBackendFlag,
 			&cacheTTL,
@@ -929,7 +931,7 @@ func stringSliceFlag(f cli.StringSliceFlag) *cli.StringSliceFlag {
 	return &f
 }
 
-func withValue(s *cli.StringFlag, value string) *cli.StringFlag {
+func withValue(s cli.StringFlag, value string) cli.StringFlag {
 	s.Value = value
 	return s
 }

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -154,6 +154,13 @@ var (
 		EnvVars: []string{"TRIVY_SECURITY_CHECKS"},
 	}
 
+	k8sSecurityChecksFlag = cli.StringFlag{
+		Name:    "security-checks",
+		Value:   fmt.Sprintf("%s,%s", types.SecurityCheckVulnerability, types.SecurityCheckConfig),
+		Usage:   "comma-separated list of what security issues to detect (vuln,config)",
+		EnvVars: []string{"TRIVY_SECURITY_CHECKS"},
+	}
+
 	cacheDirFlag = cli.StringFlag{
 		Name:    "cache-dir",
 		Value:   utils.DefaultCacheDir(),
@@ -827,7 +834,7 @@ func NewK8sCommand() *cli.Command {
 			&clearCacheFlag,
 			&ignoreUnfixedFlag,
 			&vulnTypeFlag,
-			&securityChecksFlag,
+			&k8sSecurityChecksFlag,
 			&ignoreFileFlag,
 			&cacheBackendFlag,
 			&cacheTTL,

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -154,13 +154,6 @@ var (
 		EnvVars: []string{"TRIVY_SECURITY_CHECKS"},
 	}
 
-	k8sSecurityChecksFlag = cli.StringFlag{
-		Name:    "security-checks",
-		Value:   fmt.Sprintf("%s,%s", types.SecurityCheckVulnerability, types.SecurityCheckConfig),
-		Usage:   "comma-separated list of what security issues to detect (vuln,config)",
-		EnvVars: []string{"TRIVY_SECURITY_CHECKS"},
-	}
-
 	cacheDirFlag = cli.StringFlag{
 		Name:    "cache-dir",
 		Value:   utils.DefaultCacheDir(),
@@ -834,7 +827,10 @@ func NewK8sCommand() *cli.Command {
 			&clearCacheFlag,
 			&ignoreUnfixedFlag,
 			&vulnTypeFlag,
-			&k8sSecurityChecksFlag,
+			withValue(
+				&securityChecksFlag,
+				fmt.Sprintf("%s,%s", types.SecurityCheckVulnerability, types.SecurityCheckConfig),
+			),
 			&ignoreFileFlag,
 			&cacheBackendFlag,
 			&cacheTTL,
@@ -931,4 +927,9 @@ func NewVersionCommand() *cli.Command {
 // The flag value is copied through this function to prevent the issue.
 func stringSliceFlag(f cli.StringSliceFlag) *cli.StringSliceFlag {
 	return &f
+}
+
+func withValue(s *cli.StringFlag, value string) *cli.StringFlag {
+	s.Value = value
+	return s
 }


### PR DESCRIPTION
## Description

Fixes security-checks flag.

```
trivy k8s deploy/orion

trivy k8s --security-checks=config deploy/orion

trivy k8s --security-checks=vuln deploy/orion
```


Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.