### PR TITLE
fix(k8s): fixed panic when security check does not contain vuln

### DIFF
--- a/pkg/k8s/scanner.go
+++ b/pkg/k8s/scanner.go
@@ -22,7 +22,10 @@ type scanner struct {
 
 func (s *scanner) run(ctx context.Context, artifacts []*artifacts.Artifact) (Report, error) {
 	// Todo move to run.go
-	s.opt.SecurityChecks = []string{types.SecurityCheckVulnerability, types.SecurityCheckConfig}
+	// default security check is `Vuln` and `Config`
+	if len(s.opt.SecurityChecks) == 0 {
+		s.opt.SecurityChecks = []string{types.SecurityCheckVulnerability, types.SecurityCheckConfig}
+	}
 
 	// progress bar
 	bar := pb.StartNew(len(artifacts))


### PR DESCRIPTION
## Description
Trivy have panic when security check does not contain vuln

Removed security check hardcode value. 
Added `vuln` and `config` default values, when `--security-check` flag is not set.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
