### PR TITLE
docs: fixed installation instruction for rhel/centos

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,10 +7,11 @@
     Add repository setting to `/etc/yum.repos.d`.
 
     ``` bash
+    RELEASE_VERSION=$(grep -Po '(?<=VERSION_ID=")[0-9]' /etc/os-release) 
     cat << EOF | sudo tee -a /etc/yum.repos.d/trivy.repo
     [trivy]
     name=Trivy repository
-    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$releasever/$basearch/
+    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$RELEASE_VERSION/\$basearch/
     gpgcheck=0
     enabled=1
     EOF


### PR DESCRIPTION
## Description

If there is no `distroverpkg` value in `/etc/yum.conf` file, then `$releasever` is `{version number}Client/Server`(e.g. `7Server`).
`os-release` file is used to correctly determine RHEL/CentOS version.
Also added backslash to `$basearch` yum variable. 

## Related issues
- Close #2099

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
