### PR TITLE
fix(k8s): summary report when when only vulns exit

### DIFF
--- a/pkg/k8s/json.go
+++ b/pkg/k8s/json.go
@@ -24,7 +24,7 @@ func (jw JSONWriter) Write(report Report) error {
 	case summaryReport:
 		output, err = json.MarshalIndent(report.consolidate(), "", "  ")
 	default:
-		return xerrors.Errorf("report %q not supported. please use \"summary\" or \"all\"", jw.Report)
+		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, jw.Report)
 	}
 
 	if err != nil {

--- a/pkg/k8s/json.go
+++ b/pkg/k8s/json.go
@@ -24,7 +24,7 @@ func (jw JSONWriter) Write(report Report) error {
 	case summaryReport:
 		output, err = json.MarshalIndent(report.consolidate(), "", "  ")
 	default:
-		err = fmt.Errorf("report %s not supported", jw.Report)
+		return xerrors.Errorf("report %q not supported. please use \"summary\" or \"all\"", jw.Report)
 	}
 
 	if err != nil {

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/fanal/types"
@@ -57,6 +59,10 @@ type Resource struct {
 	Report types.Report `json:"-"`
 }
 
+func (r Resource) fullname() string {
+	return strings.ToLower(fmt.Sprintf("%s/%s/%s", r.Namespace, r.Kind, r.Name))
+}
+
 // Failed returns whether the k8s report includes any vulnerabilities or misconfigurations
 func (r Report) Failed() bool {
 	for _, r := range r.Vulnerabilities {
@@ -80,25 +86,32 @@ func (r Report) consolidate() ConsolidatedReport {
 		ClusterName:   r.ClusterName,
 	}
 
+	index := make(map[string]Resource)
+
 	for _, m := range r.Misconfigurations {
-		found := false
-		for _, v := range r.Vulnerabilities {
-			if v.Kind == m.Kind && v.Name == m.Name && v.Namespace == m.Namespace {
-				consolidated.Findings = append(consolidated.Findings, Resource{
-					Namespace: v.Namespace,
-					Kind:      v.Kind,
-					Name:      v.Name,
-					Results:   append(v.Results, m.Results...),
-					Error:     v.Error,
-				})
-				found = true
-				continue
-			}
-		}
-		if !found {
-			consolidated.Findings = append(consolidated.Findings, m)
-		}
+		index[m.fullname()] = m
 	}
+
+	for _, v := range r.Vulnerabilities {
+		key := v.fullname()
+
+		if r, ok := index[key]; ok {
+			index[key] = Resource{
+				Namespace: r.Namespace,
+				Kind:      r.Kind,
+				Name:      r.Name,
+				Results:   append(r.Results, v.Results...),
+				Error:     r.Error,
+			}
+
+			continue
+		}
+
+		index[key] = v
+	}
+
+	consolidated.Findings = maps.Values(index)
+
 	return consolidated
 }
 

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -133,7 +133,7 @@ func write(report Report, option Option) error {
 			Severities: option.Severities,
 		}
 	default:
-		return xerrors.Errorf("unknown format %q. Use \"json\" or \"table\"", option.Format)
+		return xerrors.Errorf(`unknown format %q. Use "json" or "table"`, option.Format)
 	}
 
 	return writer.Write(report)

--- a/pkg/k8s/report.go
+++ b/pkg/k8s/report.go
@@ -133,7 +133,7 @@ func write(report Report, option Option) error {
 			Severities: option.Severities,
 		}
 	default:
-		return xerrors.Errorf("unknown format: %v", option.Format)
+		return xerrors.Errorf("unknown format %q. Use \"json\" or \"table\"", option.Format)
 	}
 
 	return writer.Write(report)

--- a/pkg/k8s/report_test.go
+++ b/pkg/k8s/report_test.go
@@ -1,0 +1,131 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	deployOrionWithMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Results: types.Results{
+			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
+		},
+	}
+
+	deployOrionWithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Results: types.Results{
+			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-8888"}}},
+		},
+	}
+
+	deployOrionWithBothVulnsAndMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Results: types.Results{
+			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
+			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-8888"}}},
+		},
+	}
+
+	cronjobHelloWithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Cronjob",
+		Name:      "hello",
+		Results: types.Results{
+			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-9999"}}},
+		},
+	}
+
+	podPrometheusWithMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Pod",
+		Name:      "prometheus",
+		Results: types.Results{
+			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
+		},
+	}
+)
+
+func TestReport_consolidate(t *testing.T) {
+	tests := []struct {
+		name             string
+		report           Report
+		expectedFindings map[string]Resource
+	}{
+		{
+			name: "report with both misconfigs and vulnerabilities",
+			report: Report{
+				Vulnerabilities:   []Resource{deployOrionWithVulns, cronjobHelloWithVulns},
+				Misconfigurations: []Resource{deployOrionWithMisconfigs, podPrometheusWithMisconfigs},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":   deployOrionWithBothVulnsAndMisconfigs,
+				"default/cronjob/hello":  cronjobHelloWithVulns,
+				"default/pod/prometheus": podPrometheusWithMisconfigs,
+			},
+		},
+		{
+			name: "report with only misconfigurations",
+			report: Report{
+				Misconfigurations: []Resource{deployOrionWithMisconfigs, podPrometheusWithMisconfigs},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":   deployOrionWithMisconfigs,
+				"default/pod/prometheus": podPrometheusWithMisconfigs,
+			},
+		},
+		{
+			name: "report with only vulnerabilities",
+			report: Report{
+				Vulnerabilities: []Resource{deployOrionWithVulns, cronjobHelloWithVulns},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":  deployOrionWithVulns,
+				"default/cronjob/hello": cronjobHelloWithVulns,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consolidateReport := tt.report.consolidate()
+			for _, f := range consolidateReport.Findings {
+				key := f.fullname()
+
+				expected, found := tt.expectedFindings[key]
+				if !found {
+					t.Errorf("key not found: %s", key)
+				}
+
+				assert.Equal(t, expected, f)
+			}
+		})
+	}
+}
+
+func TestResource_fullname(t *testing.T) {
+	tests := []struct {
+		expected string
+		resource Resource
+	}{
+		{"default/deploy/orion", deployOrionWithBothVulnsAndMisconfigs},
+		{"default/deploy/orion", deployOrionWithMisconfigs},
+		{"default/cronjob/hello", cronjobHelloWithVulns},
+		{"default/pod/prometheus", podPrometheusWithMisconfigs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.resource.fullname())
+		})
+	}
+}

--- a/pkg/k8s/table.go
+++ b/pkg/k8s/table.go
@@ -4,6 +4,9 @@ import (
 	"io"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+
+	"golang.org/x/xerrors"
+
 	pkgReport "github.com/aquasecurity/trivy/pkg/report"
 )
 
@@ -36,6 +39,9 @@ func (tw TableWriter) Write(report Report) error {
 	case summaryReport:
 		writer := NewSummaryWriter(tw.Output, tw.Severities)
 		return writer.Write(report)
+	default:
+		return xerrors.Errorf("report %q not supported. please use \"summary\" or \"all\"", tw.Report)
 	}
+
 	return nil
 }

--- a/pkg/k8s/table.go
+++ b/pkg/k8s/table.go
@@ -40,7 +40,7 @@ func (tw TableWriter) Write(report Report) error {
 		writer := NewSummaryWriter(tw.Output, tw.Severities)
 		return writer.Write(report)
 	default:
-		return xerrors.Errorf("report %q not supported. please use \"summary\" or \"all\"", tw.Report)
+		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

**Before**:
```
trivy k8s --security-checks=vuln --report summary  deploy app

Summary Report for minikube
┌───────────┬──────────┬───────────────────┬───────────────────┬───────────────────┐
│ Namespace │ Resource │  Vulnerabilities  │ Misconfigurations │      Secrets      │
│           │          ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│           │          │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
└───────────┴──────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

and

```
Summary Report for minikube
┌───────────┬────────────────────┬──────────────────────┬────────────────────┬───────────────────┐
│ Namespace │      Resource      │   Vulnerabilities    │ Misconfigurations  │      Secrets      │
│           │                    ├───┬────┬────┬────┬───┼───┬───┬───┬────┬───┼───┬───┬───┬───┬───┤
│           │                    │ C │ H  │ M  │ L  │ U │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │
├───────────┼────────────────────┼───┼────┼────┼────┼───┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┤
│ default   │ Deployment/app     │   │    │ 8  │ 11 │   │   │   │ 4 │ 8  │   │   │   │   │   │   │
│ default   │ Deployment/orion   │ 2 │ 14 │ 1  │ 61 │   │   │   │ 7 │ 16 │   │   │   │   │   │   │
│ default   │ Deployment/orion   │ 7 │ 20 │ 22 │ 92 │   │   │   │ 7 │ 16 │   │   │   │   │   │   │
│ default   │ Service/kubernetes │   │    │    │    │   │   │   │ 1 │    │   │   │   │   │   │   │
└───────────┴────────────────────┴───┴────┴────┴────┴───┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

**After**:
```
trivy k8s --security-checks=vuln --report summary  deploy app

Summary Report for minikube
┌───────────┬────────────────┬────────────────────┬───────────────────┬───────────────────┐
│ Namespace │    Resource    │  Vulnerabilities   │ Misconfigurations │      Secrets      │
│           │                ├───┬───┬───┬────┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│           │                │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├───────────┼────────────────┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ default   │ Deployment/app │   │   │ 8 │ 11 │   │   │   │   │   │   │   │   │   │   │   │
└───────────┴────────────────┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

and

```
Summary Report for minikube
┌───────────┬────────────────────┬───────────────────────┬────────────────────┬───────────────────┐
│ Namespace │      Resource      │    Vulnerabilities    │ Misconfigurations  │      Secrets      │
│           │                    ├───┬────┬────┬─────┬───┼───┬───┬───┬────┬───┼───┬───┬───┬───┬───┤
│           │                    │ C │ H  │ M  │  L  │ U │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │
├───────────┼────────────────────┼───┼────┼────┼─────┼───┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┤
│ default   │ Deployment/app     │   │    │ 8  │ 11  │   │   │   │ 4 │ 8  │   │   │   │   │   │   │
│ default   │ Deployment/orion   │ 9 │ 34 │ 23 │ 153 │   │   │   │ 7 │ 16 │   │   │   │   │   │   │
│ default   │ Service/kubernetes │   │    │    │     │   │   │   │ 1 │    │   │   │   │   │   │   │
└───────────┴────────────────────┴───┴────┴────┴─────┴───┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2133
- Close https://github.com/aquasecurity/trivy/issues/2138

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
