### PR TITLE
docs(misconf): Update further examples and docs to refer to builtin/defsec instead of appshield

### DIFF
--- a/docs/docs/misconfiguration/custom/index.md
+++ b/docs/docs/misconfiguration/custom/index.md
@@ -95,7 +95,7 @@ A package name must be unique per policy.
     package user.kubernetes.ID001
     ```
 
-By default, only `appshield.*` packages will be evaluated.
+By default, only `builtin.*` packages will be evaluated.
 If you define custom packages, you have to specify the package prefix via `--namespaces` option. 
 
 ``` bash

--- a/docs/docs/misconfiguration/custom/testing.md
+++ b/docs/docs/misconfiguration/custom/testing.md
@@ -22,7 +22,7 @@ For more details, see [Policy Testing][opa-testing].
     }
     ```
 
-To write tests for custom policies, you can refer to existing tests under [AppShield][appshield].
+To write tests for custom policies, you can refer to existing tests under [defsec][defsec].
 
 ## Go testing
 [Fanal][fanal] which is a core library of Trivy can be imported as a Go library.
@@ -85,6 +85,6 @@ The following example stores allowed and denied configuration files in a directo
 `Dockerfile.allowed` has one successful result in `Successes`, while `Dockerfile.denied` has one failure result in `Failures`.
 
 [opa-testing]: https://www.openpolicyagent.org/docs/latest/policy-testing/
-[appshield]: https://github.com/aquasecurity/appshield
+[defsec]: https://github.com/aquasecurity/defsec
 [table]: https://github.com/golang/go/wiki/TableDrivenTests
 [fanal]: https://github.com/aquasecurity/fanal

--- a/docs/docs/misconfiguration/options/policy.md
+++ b/docs/docs/misconfiguration/options/policy.md
@@ -26,7 +26,7 @@ trivy conf --policy ./policy --data ./data --namespaces user ./configs
 For more details, see [Custom Data](../custom/data.md).
 
 ## Pass namespaces
-By default, Trivy evaluate policies defined in `appshield.*`.
+By default, Trivy evaluates policies defined in `builtin.*`.
 If you want to evaluate custom policies in other packages, you have to specify package prefixes through `--namespaces` option.
 This can be repeated for specifying multiple packages.
 

--- a/docs/docs/misconfiguration/policy/builtin.md
+++ b/docs/docs/misconfiguration/policy/builtin.md
@@ -19,4 +19,4 @@ Ansible are coming soon.
 [rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
 [defsec]: https://github.com/aquasecurity/defsec
 [kubernetes]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/kubernetes
-[docker]: https://github.com/aquasecurity/appshield/tree/master/internal/rules/docker
+[docker]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/docker

--- a/examples/misconf/namespace-exception/README.md
+++ b/examples/misconf/namespace-exception/README.md
@@ -1,5 +1,5 @@
 # Namespace-based exceptions
-`policy/k8s_exception.rego` exempts all policies with `appshield.kubernetes` prefix.
+`policy/k8s_exception.rego` exempts all policies with `builtin.kubernetes` prefix.
 It means all built-in policies for Kubernetes are disabled.
 
 ``` bash

--- a/examples/misconf/namespace-exception/policy/k8s_exception.rego
+++ b/examples/misconf/namespace-exception/policy/k8s_exception.rego
@@ -4,5 +4,5 @@ import data.namespaces
 
 exception[ns] {
 	ns := data.namespaces[_]
-	startswith(ns, "appshield.kubernetes")
+	startswith(ns, "builtin.kubernetes")
 }

--- a/examples/misconf/rule-exception/policy/ksv006_exception.rego
+++ b/examples/misconf/rule-exception/policy/ksv006_exception.rego
@@ -1,4 +1,4 @@
-package appshield.kubernetes.KSV006
+package builtin.kubernetes.KSV006
 
 exception[rules] {
 	input.metadata.labels.mount == "docker.sock"


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy/issues/2141