### PR TITLE
perf(misconf): Improve performance when scanning very large files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220518094653-f400923828e8
+	github.com/aquasecurity/fanal v0.0.0-20220518124101-73d716d92a6c
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -77,7 +77,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-	github.com/aquasecurity/defsec v0.58.0
+	github.com/aquasecurity/defsec v0.58.1
 	github.com/aws/aws-sdk-go v1.44.5 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,10 +180,10 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.58.0 h1:ZSnSZroGYKIJNolE/74PBhT/t7z/Jpz1l1B2vvPyVPo=
-github.com/aquasecurity/defsec v0.58.0/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
-github.com/aquasecurity/fanal v0.0.0-20220518094653-f400923828e8 h1:yWtU5VEz/nARhMifLBRvDVEX/MD+NduQjc3vV3lh1xo=
-github.com/aquasecurity/fanal v0.0.0-20220518094653-f400923828e8/go.mod h1:7N56RaBZ7OebEAknemwgyAFxBi3IERzQ/Z6hC43giEA=
+github.com/aquasecurity/defsec v0.58.1 h1:AuMJPYeuy5qgXvkAFXZNbBp8Tq19/i5PSG/+bvm5MHk=
+github.com/aquasecurity/defsec v0.58.1/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
+github.com/aquasecurity/fanal v0.0.0-20220518124101-73d716d92a6c h1:FIzGPqMe7IKCg89BXfRYpnvV/EwVMCXh/xI87+oAt14=
+github.com/aquasecurity/fanal v0.0.0-20220518124101-73d716d92a6c/go.mod h1:fq4jhpPuCS7P4XPMwKz4cFKrNPbMlE2E5iQZIoTin14=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff h1:YNlzRYB0n4mZtfuWx6AWaGEjnLVNekchyoFDlYFZegs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>

## Description
Optimises scanning of very large files for misconfigurations. Large files containing many issues cause the file to be read once for each issue, and subsequently syntax highlighted, analysed and built into a result. By caching each file containing issues while building the results, things run much faster and with much less memory required.

For example, scanning [this large file](https://raw.githubusercontent.com/argoproj/argo-cd/master/manifests/install.yaml):

Before:
```shell
217.86s user 2.05s system 119% cpu 3:03.90 total
```

After:
```shell
12.58s user 0.85s system 189% cpu 7.099 total
```

## Related issues
- Close #2141
