### PR TITLE
docs(vuln): Include GitLab 15.0 integration

### DIFF
--- a/docs/docs/integrations/gitlab-ci.md
+++ b/docs/docs/integrations/gitlab-ci.md
@@ -1,10 +1,17 @@
 # GitLab CI
 
-If you're a GitLab Ultimate customer, GitLab 14.0 and above include out-of-the-box integration with Trivy. To enable it for your project, simply add the container scanning template to your `.gitlab-ci.yml` file. For more details, please refer to [GitLab's documentation](https://docs.gitlab.com/ee/user/application_security/container_scanning/).
+GitLab 15.0 includes [free](https://gitlab.com/groups/gitlab-org/-/epics/2233) integration with Trivy.
 
-If you're using an earlier version of GitLab, you can still use the new integration by copying the [contents of the 14.0 template](https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml) to your configuration.
+To [configure container scanning with Trivy in GitLab](https://docs.gitlab.com/ee/user/application_security/container_scanning/#configuration), simply include the CI template in your `.gitlab-ci.yml` file:
 
-Alternatively, you can always use the example configurations below.
+```yaml
+include:
+  - template: Security/Container-Scanning.gitlab-ci.yml
+```
+
+If you're a GitLab 14.x Ultimate customer, you can use the same configuration above.
+
+Alternatively, you can always use the example configurations below. Note that the examples use [`contrib/gitlab.tpl`](https://github.com/aquasecurity/trivy/blob/main/contrib/gitlab.tpl), which does not work with GitLab 15.0 and above (for details, see [issue 1598](https://github.com/aquasecurity/trivy/issues/1598)).
 
 ```yaml
 stages:


### PR DESCRIPTION
## Description

In GitLab 15.0, the integration with Trivy was moved to the free tier. Include this information in the Trivy docs so that users can benefit from a simpler, and GitLab-maintained, CI template.

## Related issues
- Related to https://github.com/aquasecurity/trivy/issues/1598

## Checklist

- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
