### PR TITLE
feat: more airgapped trivy options

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -30,6 +30,11 @@ type VersionInfo struct {
 }
 
 var (
+	// If set to true features like fetching the db that use networking will
+	// work by default.
+	// This allows for trivy to be built to default opt-out of networking
+	defaultUseNetworking = true
+
 	templateFlag = cli.StringFlag{
 		Name:    "template",
 		Aliases: []string{"t"},
@@ -81,6 +86,7 @@ var (
 		Aliases: []string{"skip-update"},
 		Usage:   "skip updating vulnerability database",
 		EnvVars: []string{"TRIVY_SKIP_UPDATE", "TRIVY_SKIP_DB_UPDATE"},
+		Value:   !defaultUseNetworking,
 	}
 
 	skipPolicyUpdateFlag = cli.BoolFlag{
@@ -271,6 +277,7 @@ var (
 		Name:    "offline-scan",
 		Usage:   "do not issue API requests to identify dependencies",
 		EnvVars: []string{"TRIVY_OFFLINE_SCAN"},
+		Value:   !defaultUseNetworking,
 	}
 
 	// For misconfigurations

--- a/pkg/commands/artifact/option.go
+++ b/pkg/commands/artifact/option.go
@@ -34,7 +34,7 @@ func NewOption(c *cli.Context) (Option, error) {
 		return Option{}, xerrors.Errorf("failed to initialize global options: %w", err)
 	}
 
-	return Option{
+	option := Option{
 		GlobalOption:     gc,
 		ArtifactOption:   option.NewArtifactOption(c),
 		DBOption:         option.NewDBOption(c),
@@ -46,7 +46,13 @@ func NewOption(c *cli.Context) (Option, error) {
 		SbomOption:       option.NewSbomOption(c),
 		SecretOption:     option.NewSecretOption(c),
 		KubernetesOption: option.NewKubernetesOption(c),
-	}, nil
+	}
+	if gc.DisableNetworking {
+		option.DBOption.SkipDBUpdate = true
+		option.ArtifactOption.OfflineScan = true
+	}
+
+	return option, nil
 }
 
 // Init initializes the artifact options

--- a/pkg/commands/option/artifact.go
+++ b/pkg/commands/option/artifact.go
@@ -9,6 +9,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// Allow for building trivy with remote API calls completely disabled
+var disableOnlineScanning string
+
 // ArtifactOption holds the options for an artifact scanning
 type ArtifactOption struct {
 	Input      string
@@ -26,13 +29,17 @@ type ArtifactOption struct {
 
 // NewArtifactOption is the factory method to return artifact option
 func NewArtifactOption(c *cli.Context) ArtifactOption {
+	offlineScan := c.Bool("offline-scan")
+	if disableOnlineScanning == "true" {
+		offlineScan = true
+	}
 	return ArtifactOption{
 		Input:       c.String("input"),
 		Timeout:     c.Duration("timeout"),
 		ClearCache:  c.Bool("clear-cache"),
 		SkipFiles:   c.StringSlice("skip-files"),
 		SkipDirs:    c.StringSlice("skip-dirs"),
-		OfflineScan: c.Bool("offline-scan"),
+		OfflineScan: offlineScan,
 		Insecure:    c.Bool("insecure"),
 	}
 }

--- a/pkg/commands/option/db.go
+++ b/pkg/commands/option/db.go
@@ -7,6 +7,9 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
+// Allow for building trivy with DB updates completely disabled
+var disableDBUpdates string
+
 // DBOption holds the options for trivy DB
 type DBOption struct {
 	Reset          bool
@@ -19,10 +22,14 @@ type DBOption struct {
 
 // NewDBOption is the factory method to return the DBOption
 func NewDBOption(c *cli.Context) DBOption {
+	skipDBUpdate := c.Bool("skip-db-update")
+	if disableDBUpdates == "true" {
+		skipDBUpdate = true
+	}
 	return DBOption{
 		Reset:          c.Bool("reset"),
 		DownloadDBOnly: c.Bool("download-db-only"),
-		SkipDBUpdate:   c.Bool("skip-db-update"),
+		SkipDBUpdate:   skipDBUpdate,
 		Light:          c.Bool("light"),
 		NoProgress:     c.Bool("no-progress"),
 		DBRepository:   c.String("db-repository"),

--- a/pkg/commands/option/global.go
+++ b/pkg/commands/option/global.go
@@ -8,21 +8,26 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
+// Allow for building trivy with networking capabilities completely disabled
+var disableNetworking string
+
 // GlobalOption holds the global options for trivy
 type GlobalOption struct {
 	Context *cli.Context
 	Logger  *zap.SugaredLogger
 
-	AppVersion string
-	Quiet      bool
-	Debug      bool
-	CacheDir   string
+	AppVersion        string
+	Quiet             bool
+	Debug             bool
+	CacheDir          string
+	DisableNetworking bool
 }
 
 // NewGlobalOption is the factory method to return GlobalOption
 func NewGlobalOption(c *cli.Context) (GlobalOption, error) {
 	quiet := c.Bool("quiet")
 	debug := c.Bool("debug")
+	noNetworking := disableNetworking == "true"
 	logger, err := log.NewLogger(debug, quiet)
 	if err != nil {
 		return GlobalOption{}, xerrors.New("failed to create a logger")
@@ -32,9 +37,10 @@ func NewGlobalOption(c *cli.Context) (GlobalOption, error) {
 		Context: c,
 		Logger:  logger,
 
-		AppVersion: c.App.Version,
-		Quiet:      quiet,
-		Debug:      debug,
-		CacheDir:   c.String("cache-dir"),
+		AppVersion:        c.App.Version,
+		Quiet:             quiet,
+		Debug:             debug,
+		CacheDir:          c.String("cache-dir"),
+		DisableNetworking: noNetworking,
 	}, nil
 }

--- a/pkg/commands/option/no_networking.go
+++ b/pkg/commands/option/no_networking.go
@@ -1,0 +1,8 @@
+//go:build offline
+// +build offline
+
+package option
+
+func init() {
+	disableNetworking = "true"
+}


### PR DESCRIPTION
## Description

This is a pretty WIP PR, just trying out a few options and interested in getting some feedback early.

The goal is to add more options for using trivy in an airgapped or restricted settings.

---

@controlplaneio we've had some clients that want some stronger guarantees programs wont try reach out to anything via the network (whether the device is fully airgapped or just restricted)

running `trivy scan fs --skip-db --offline-scan --skip-policy-update` is good and all but you can forget to add them. So being able to swap them to default true would be handy.

Another option would be to fully disable them from working so `trivy scan fs --skip-db=true` simply wouldn't do anything

This PR could do with a couple improvements out of the gate:
potentially removing those flags entirely when this is enabled?
Maybe an additional `--offline` global flag that means you don't need to set `--skip-db`, `--offline-scan` & `--skip-policy-update` separately
(I also skipped over `--skip-policy-update` in my draft changes)

---

Allow for building trivy default opt-out


Allow for fully disabling db fetching and api calls individually

`-ldflags=" ... -X=github.com/aquasecurity/trivy/pkg/commands/option.disableOnlineScanning=true"`

and

`-ldflags=" ... -X=github.com/aquasecurity/trivy/pkg/commands/option.disableDBUpdates=true"`

Allow for fully disabling networking

`-ldflags=" ... -X=github.com/aquasecurity/trivy/pkg/commands/option.disableNetworking=true"`

or

`-tags=offline`

e.g.:

```bash
$ make build
go build -ldflags "-s -w -X=main.version=v0.28.0-6-g3ecc65d6" -tags=offline ./cmd/trivy

$ ./trivy fs .
2022-05-20T10:41:14.494+0100	ERROR	The first run cannot skip downloading DB
2022-05-20T10:41:14.494+0100	FATAL	init error: DB error: database error: --skip-update cannot be specified on the first run
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
