### PR TITLE
fix(redhat): always use vulns with fixed version if there is one

### DIFF
--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -140,9 +140,6 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 	uniqVulns := map[string]types.DetectedVulnerability{}
 	for _, adv := range advisories {
 		vulnID := adv.VulnerabilityID
-		if vulnID == "CVE-2021-21705" {
-			fmt.Println()
-		}
 		vuln := types.DetectedVulnerability{
 			VulnerabilityID:  vulnID,
 			PkgName:          pkg.Name,
@@ -157,9 +154,8 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 
 		// unpatched vulnerabilities
 		if adv.FixedVersion == "" {
-			// RedHat may contain several advisories for package (RHSA advisories).
-			// We can overwrite fixed version here
-			// Therefore, we should skip unpatched vulnerabilities if they were added earlier
+			// Red Hat may contain several advisories for the same vulnerability (RHSA advisories).
+			// To avoid overwriting the fixed version by mistake, we should skip unpatched vulnerabilities if they were added earlier
 			if _, ok := uniqVulns[vulnID]; !ok {
 				uniqVulns[vulnID] = vuln
 			}

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -140,6 +140,9 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 	uniqVulns := map[string]types.DetectedVulnerability{}
 	for _, adv := range advisories {
 		vulnID := adv.VulnerabilityID
+		if vulnID == "CVE-2021-21705" {
+			fmt.Println()
+		}
 		vuln := types.DetectedVulnerability{
 			VulnerabilityID:  vulnID,
 			PkgName:          pkg.Name,
@@ -154,7 +157,12 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 
 		// unpatched vulnerabilities
 		if adv.FixedVersion == "" {
+			// RedHat may contain several advisories for package (RHSA advisories).
+			// We can overwrite fixed version here
+			// Therefore, we should skip unpatched vulnerabilities if they were added earlier
+			//if _, ok := uniqVulns[vulnID]; !ok {
 			uniqVulns[vulnID] = vuln
+			//}
 			continue
 		}
 

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -160,9 +160,9 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 			// RedHat may contain several advisories for package (RHSA advisories).
 			// We can overwrite fixed version here
 			// Therefore, we should skip unpatched vulnerabilities if they were added earlier
-			//if _, ok := uniqVulns[vulnID]; !ok {
-			uniqVulns[vulnID] = vuln
-			//}
+			if _, ok := uniqVulns[vulnID]; !ok {
+				uniqVulns[vulnID] = vuln
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Description
RedHat may have several advisories for package.
We should always use advisory with fixed version if there is one.

## Related issues
- Close #2085

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
