### PR TITLE
feat(redhat): added architecture versions check

### DIFF
--- a/integration/testdata/fixtures/db/redhat.yaml
+++ b/integration/testdata/fixtures/db/redhat.yaml
@@ -16,6 +16,7 @@
                   - 924
                 Cves:
                   - Severity: 1.0
+                Arch: x86_64
     - bucket: openssl
       pairs:
         - key: RHSA-2019:2304

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -8,6 +8,7 @@ import (
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 	"k8s.io/utils/clock"
 
@@ -139,6 +140,15 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 
 	uniqVulns := map[string]types.DetectedVulnerability{}
 	for _, adv := range advisories {
+		// We must skip package if found package Arch != advisory package Arch
+		// if found Arch package is empty or Arch recommender package is "noarch", use advisory for all Arch
+		if adv.Arch != "" && pkg.Arch != "noarch" { // affected Arches are merged with '|'
+			affectedArches := strings.Split(fmt.Sprintf("%v", adv.Arch), "|")
+			if !slices.Contains(affectedArches, pkg.Arch) {
+				continue
+			}
+		}
+
 		vulnID := adv.VulnerabilityID
 		vuln := types.DetectedVulnerability{
 			VulnerabilityID:  vulnID,

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -152,6 +152,82 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path: package without architecture",
+			fixtures: []string{
+				"testdata/fixtures/redhat.yaml",
+				"testdata/fixtures/cpe.yaml",
+			},
+			args: args{
+				osVer: "7.6",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "kernel-headers",
+						Version:    "3.10.0-326.36",
+						Release:    "3.el7",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "kernel-headers",
+						SrcVersion: "3.10.0-326.36",
+						SrcRelease: "3.el7",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{"rhel-7-server-rpms"},
+						},
+					},
+					{
+						Name:       "kernel-headers",
+						Version:    "3.10.0-1127.19",
+						Release:    "1.el7",
+						Epoch:      0,
+						Arch:       "noarch",
+						SrcName:    "kernel-headers",
+						SrcVersion: "3.10.0-1127.19",
+						SrcRelease: "1.el7",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{"rhel-7-server-rpms"},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2016-5195",
+					VendorIDs:        []string{"RHSA-2016:2098"},
+					PkgName:          "kernel-headers",
+					InstalledVersion: "3.10.0-326.36-3.el7",
+					FixedVersion:     "3.10.0-327.36.3.el7",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2016-5195",
+					VendorIDs:        []string{"RHSA-2017:0372"},
+					PkgName:          "kernel-headers",
+					InstalledVersion: "3.10.0-1127.19-1.el7",
+					FixedVersion:     "4.5.0-15.2.1.el7",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+			},
+		},
+		{
 			name: "no build info",
 			fixtures: []string{
 				"testdata/fixtures/redhat.yaml",

--- a/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
+++ b/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
@@ -69,9 +69,33 @@
         - key: CVE-2006-4023
           value:
             Entries:
-              - FixedVersion: """
+              - FixedVersion: ""
                 Affected:
                   - 0
                   - 1
                 Cves:
                   - Severity: 1
+    - bucket: kernel-headers
+      pairs:
+        - key: RHSA-2016:2098
+          value:
+            Entries:
+              - FixedVersion: 0:3.10.0-327.36.3.el7
+                Affected:
+                  - 0
+                  - 1
+                Cves:
+                  - ID: CVE-2016-5195
+                    Severity: 3
+                Arch: "ppc64|ppc64le|s390x|x86_64"
+        - key: RHSA-2017:0372
+          value:
+            Entries:
+              - FixedVersion: 0:4.5.0-15.2.1.el7
+                Affected:
+                  - 0
+                  - 1
+                Cves:
+                  - ID: CVE-2016-5195
+                    Severity: 3
+                Arch: "aarch64"


### PR DESCRIPTION
## Description
RedHat database may contain advisories with same `package name` and affected cpe list but with different architectures.
Added architecture version checking for rpm packages. 
More information [here](https://github.com/aquasecurity/trivy-db/pull/214)

## Related issues
- Close #1833

## Related PRs
- [ ] https://github.com/aquasecurity/trivy-db/pull/214

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
