### PR TITLE
fix(k8s): timeout error logging

### DIFF
--- a/pkg/k8s/run.go
+++ b/pkg/k8s/run.go
@@ -86,7 +86,10 @@ func Run(cliCtx *cli.Context) error {
 		opt:     opt,
 	}
 
-	return run(ctx, s, opt, artifacts)
+	// we assign the error here so the defer function can see the last error
+	// to check if it was a context.DeadlineExceeded, instead of returning directly
+	err = run(ctx, s, opt, artifacts)
+	return err
 }
 
 func run(ctx context.Context, s *scanner, opt cmd.Option, artifacts []*artifacts.Artifact) error {

--- a/pkg/k8s/scanner.go
+++ b/pkg/k8s/scanner.go
@@ -37,6 +37,17 @@ func (s *scanner) run(ctx context.Context, artifacts []*artifacts.Artifact) (Rep
 		return Report{}, xerrors.Errorf("logger error: %w", err)
 	}
 
+	// enable log, this is done in a defer function,
+	// to enable logs even when the function returns earlier
+	// due to an error
+	defer func() {
+		err = log.InitLogger(s.opt.Debug, false)
+		if err != nil {
+			// we use log.Fatal here because the error was to enable the logger
+			log.Fatal(xerrors.Errorf("can't enable logger error: %w", err))
+		}
+	}()
+
 	// Loops once over all artifacts, and execute scanners as necessary. Not every artifacts has an image,
 	// so image scanner is not always executed.
 	for _, artifact := range artifacts {
@@ -57,12 +68,6 @@ func (s *scanner) run(ctx context.Context, artifacts []*artifacts.Artifact) (Rep
 			}
 			misconfigs = append(misconfigs, resource)
 		}
-	}
-
-	// enable logs after scanning
-	err = log.InitLogger(s.opt.Debug, s.opt.Quiet)
-	if err != nil {
-		return Report{}, xerrors.Errorf("logger error: %w", err)
 	}
 
 	return Report{


### PR DESCRIPTION
## Description

- fixes log enable/disable after scanning
- fixes timeout warn

before:

![Screen Shot 2022-05-26 at 11 25 34 AM](https://user-images.githubusercontent.com/34032/170508076-78201b44-9eda-487c-a092-ee9c486c2ddb.png)

after:

<img width="1440" alt="Screen Shot 2022-05-24 at 8 43 22 PM" src="https://user-images.githubusercontent.com/34032/170149513-937c1f03-ca62-4603-947f-cc98e35c455e.png">

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2169

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.