### PR TITLE
fix(report): misconfig start line for code quality tpl

### DIFF
--- a/contrib/gitlab-codequality.tpl
+++ b/contrib/gitlab-codequality.tpl
@@ -62,7 +62,7 @@
       "location": {
         "path": "{{ $target }}",
         "lines": {
-          "begin": {{ .IacMetadata.StartLine }}
+          "begin": {{ .CauseMetadata.StartLine }}
         }
       }
     }


### PR DESCRIPTION
## Description
```
n:~/Documents/Repos/trivy-template$ ./trivy version
Version: 0.28.0
n:~/Documents/Repos/trivy-template$ ./trivy fs --security-checks config,vuln         --severity HIGH,CRITICAL --format template         --template "@contrib/gitlab-codequality.tpl"         --output raw-report.json .
2022-05-25T13:30:15.633+0100    FATAL   report error: unable to write results: failed to write results: failed to write with template: template: output template:65:34: executing "output template" at <.IacMetadata.StartLine>: can't evaluate field IacMetadata in type types.DetectedMisconfiguration
```
v0.28 updates the report output format specifically  IACMetadata -> CauseMetadata, update template to match

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
