### PR TITLE
fix(report): fixed panic if all misconf reports were removed in filter

### DIFF
--- a/pkg/report/table.go
+++ b/pkg/report/table.go
@@ -90,6 +90,9 @@ func (tw TableWriter) write(result types.Result) {
 		}
 		target += " (secrets)"
 	} else if result.Class != types.ClassOSPkg {
+		if result.Class == types.ClassConfig && len(result.Misconfigurations) == 0 {
+			return
+		}
 		target += fmt.Sprintf(" (%s)", result.Type)
 	}
 
@@ -103,10 +106,8 @@ func (tw TableWriter) write(result types.Result) {
 	if result.Class == types.ClassConfig {
 		// for misconfigurations
 		summary := result.MisconfSummary
-		if summary != nil {
-			fmt.Printf("Tests: %d (SUCCESSES: %d, FAILURES: %d, EXCEPTIONS: %d)\n",
-				summary.Successes+summary.Failures+summary.Exceptions, summary.Successes, summary.Failures, summary.Exceptions)
-		}
+		fmt.Printf("Tests: %d (SUCCESSES: %d, FAILURES: %d, EXCEPTIONS: %d)\n",
+			summary.Successes+summary.Failures+summary.Exceptions, summary.Successes, summary.Failures, summary.Exceptions)
 		fmt.Printf("Failures: %d (%s)\n\n", total, strings.Join(summaries, ", "))
 	} else {
 		// for vulnerabilities and secrets

--- a/pkg/report/table.go
+++ b/pkg/report/table.go
@@ -103,8 +103,10 @@ func (tw TableWriter) write(result types.Result) {
 	if result.Class == types.ClassConfig {
 		// for misconfigurations
 		summary := result.MisconfSummary
-		fmt.Printf("Tests: %d (SUCCESSES: %d, FAILURES: %d, EXCEPTIONS: %d)\n",
-			summary.Successes+summary.Failures+summary.Exceptions, summary.Successes, summary.Failures, summary.Exceptions)
+		if summary != nil {
+			fmt.Printf("Tests: %d (SUCCESSES: %d, FAILURES: %d, EXCEPTIONS: %d)\n",
+				summary.Successes+summary.Failures+summary.Exceptions, summary.Successes, summary.Failures, summary.Exceptions)
+		}
 		fmt.Printf("Failures: %d (%s)\n\n", total, strings.Join(summaries, ", "))
 	} else {
 		// for vulnerabilities and secrets

--- a/pkg/report/table.go
+++ b/pkg/report/table.go
@@ -62,7 +62,6 @@ func (tw TableWriter) isOutputToTerminal() bool {
 }
 
 func (tw TableWriter) write(result types.Result) {
-
 	tableWriter := table.New(tw.Output)
 	if tw.isOutputToTerminal() { // use ansi output if we're not piping elsewhere
 		tableWriter.SetHeaderStyle(table.StyleBold)
@@ -84,15 +83,14 @@ func (tw TableWriter) write(result types.Result) {
 	total, summaries := tw.summary(severityCount)
 
 	target := result.Target
-	if result.Class == types.ClassSecret {
+	if result.Class == types.ClassConfig && len(result.Misconfigurations) == 0 {
+		return
+	} else if result.Class == types.ClassSecret {
 		if len(result.Secrets) == 0 {
 			return
 		}
 		target += " (secrets)"
 	} else if result.Class != types.ClassOSPkg {
-		if result.Class == types.ClassConfig && len(result.Misconfigurations) == 0 {
-			return
-		}
 		target += fmt.Sprintf(" (%s)", result.Type)
 	}
 


### PR DESCRIPTION
## Description
If Trivy found misconf, but they were removed in filter(e.g. by severity), then this is a panic.
For example:
```
➜  trivy -d config ./secrets.tf 
2022-05-27T17:55:32.479+0600	DEBUG	Severities: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
2022-05-27T17:55:32.479+0600	DEBUG	cache dir:  /home/dmitriy/.cache/trivy
2022-05-27T17:55:32.479+0600	DEBUG	Vulnerability type:  []
2022-05-27T17:55:32.534+0600	DEBUG	OS is not detected.
2022-05-27T17:55:32.534+0600	INFO	Detected config files: 1
2022-05-27T17:55:32.534+0600	DEBUG	Scanned config file: secrets.tf

secrets.tf (terraform)

Tests: 1 (SUCCESSES: 0, FAILURES: 1, EXCEPTIONS: 0)
Failures: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

LOW: Secret explicitly uses the default key.
════════════════════════════════════════════════════════════════════════════════
Secrets Manager encrypts secrets by default using a default key created by AWS. To ensure control and granularity of secret encryption, CMK's should be used explicitly.

See https://avd.aquasec.com/misconfig/avd-aws-0098
────────────────────────────────────────────────────────────────────────────────
 secrets.tf:1-3
────────────────────────────────────────────────────────────────────────────────
   1 ┌ resource "aws_secretsmanager_secret" "foo" {
   2 │ 
   3 └ }
────────────────────────────────────────────────────────────────────────────────


➜ trivy -d config --severity HIGH ./secrets.tf
2022-05-27T17:56:00.224+0600	DEBUG	Severities: HIGH
2022-05-27T17:56:00.225+0600	DEBUG	cache dir:  /home/dmitriy/.cache/trivy
2022-05-27T17:56:00.225+0600	DEBUG	Vulnerability type:  []
2022-05-27T17:56:00.277+0600	DEBUG	OS is not detected.
2022-05-27T17:56:00.277+0600	INFO	Detected config files: 1
2022-05-27T17:56:00.277+0600	DEBUG	Scanned config file: secrets.tf

secrets.tf (terraform)

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x135ab46]

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/report.TableWriter.write({{0xc001fd1210, 0x1, 0x1}, {0x31b61e0, 0xc000130008}, 0xc001fd0940, 0x0, 0x0}, {{0xc001fd0850, 0xa}, ...})
	/home/runner/work/trivy/trivy/pkg/report/table.go:107 +0x7a6
github.com/aquasecurity/trivy/pkg/report.TableWriter.Write(...)
	/home/runner/work/trivy/trivy/pkg/report/table.go:48
github.com/aquasecurity/trivy/pkg/report.Write({0x2, {0xc001fd12f0, 0xa}, {0x2a917bf, 0xa}, {0x0, 0x0, {0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
	/home/runner/work/trivy/trivy/pkg/report/writer.go:73 +0x5bf
github.com/aquasecurity/trivy/pkg/commands/artifact.(*Runner).Report(_, {{0xc00001b000, 0xc00000f5e0, {0x31a9768, 0x6}, 0x0, 0x1, {0xc0010c4960, 0x1a}}, {{0x0, ...}, ...}, ...}, ...)
	/home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:210 +0x178
github.com/aquasecurity/trivy/pkg/commands/artifact.run({_, _}, {{0xc00001b000, 0xc00000f5e0, {0x31a9768, 0x6}, 0x0, 0x1, {0xc0010c4960, 0x1a}}, ...}, ...)
	/home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:343 +0xd65
github.com/aquasecurity/trivy/pkg/commands/artifact.ConfigRun(0xc00001b000)
	/home/runner/work/trivy/trivy/pkg/commands/artifact/config.go:26 +0x2a5
github.com/urfave/cli/v2.(*Command).Run(0xc000a75e60, 0xc000132140)
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.5.1/command.go:163 +0x5bb
github.com/urfave/cli/v2.(*App).RunContext(0xc00101a1a0, {0x31d1660?, 0xc000140020}, {0xc00011a180, 0x6, 0x6})
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.5.1/app.go:313 +0xb48
github.com/urfave/cli/v2.(*App).Run(...)
	/home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.5.1/app.go:224
main.main()
	/home/runner/work/trivy/trivy/cmd/trivy/main.go:16 +0x4f
```

after fix:
```
➜  go run cmd/trivy/main.go -d config --severity HIGH /home/dmitriy/work/temp/2087/
2022-05-30T11:06:45.971+0600    DEBUG   Severities: HIGH
2022-05-30T11:06:45.975+0600    DEBUG   cache dir:  /home/dmitriy/.cache/trivy
2022-05-30T11:06:45.975+0600    DEBUG   Vulnerability type:  []
2022-05-30T11:06:46.029+0600    DEBUG   OS is not detected.
2022-05-30T11:06:46.029+0600    INFO    Detected config files: 1
2022-05-30T11:06:46.029+0600    DEBUG   Scanned config file: secrets.tf

```


## Related issues
- Close #2087 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
