### PR TITLE
docs: added information about choosing advisory database

### DIFF
--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,12 +1,3 @@
-# Data source selection
-Trivy **only** consumes security advisories from the sources listed in the following tables.
-
-As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
-
-For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS](https://alas.aws.amazon.com/). But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
-
-This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
-The severity is from the selected data source. If the data source does not provide severity, it falls back to NVD, and if NVD does not have severity, it will be UNKNOWN.
 # OS
 
 | OS             | Source                                                                              |
@@ -53,6 +44,16 @@ The severity is from the selected data source. If the data source does not provi
 | Name                            | Source     |  
 | --------------------------------|------------|
 | National Vulnerability Database | [NVD][nvd] | 
+
+# Data source selection
+Trivy **only** consumes security advisories from the sources listed in the following tables.
+
+As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
+
+For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS](https://alas.aws.amazon.com/). But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
+
+This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
+The severity is from the selected data source. If the data source does not provide severity, it falls back to NVD, and if NVD does not have severity, it will be UNKNOWN.
 
 [arch]: https://security.archlinux.org/
 [alpine]: https://secdb.alpinelinux.org/

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -50,7 +50,7 @@ Trivy **only** consumes security advisories from the sources listed in the follo
 
 As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
 
-For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS](https://alas.aws.amazon.com/). But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
+For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS][amazon2]. But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
 
 This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
 The severity is from the selected data source. If the data source does not provide severity, it falls back to NVD, and if NVD does not have severity, it will be UNKNOWN.

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,4 +1,4 @@
-# Important
+# Data source selection
 Trivy **only** consumes security advisories from the sources listed in the following tables.
 
 As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,3 +1,12 @@
+# Important
+Trivy **only** receives advisories from the sources listed in the following tables.
+
+Also, for packages installed from package managers (`dpkg`, `yum`, `apk` and etc.), Trivy gets advisories from the appropriate **OS database**.
+
+For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from the `amazon database`. But for a  python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
+
+This is to avoid false positives when the vendor's OS fixes the vulnerability before the package owner fixes it.
+
 # OS
 
 | OS             | Source                                                                              |

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -3,7 +3,7 @@ Trivy **only** consumes security advisories from the sources listed in the follo
 
 As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
 
-For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from the `amazon database`. But for a  python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
+For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS](https://alas.aws.amazon.com/). But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
 
 This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
 

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,5 +1,5 @@
 # Important
-Trivy **only** receives advisories from the sources listed in the following tables.
+Trivy **only** consumes security advisories from the sources listed in the following tables.
 
 Also, for packages installed from package managers (`dpkg`, `yum`, `apk` and etc.), Trivy gets advisories from the appropriate **OS database**.
 

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,7 +1,7 @@
 # Important
 Trivy **only** consumes security advisories from the sources listed in the following tables.
 
-Also, for packages installed from package managers (`dpkg`, `yum`, `apk` and etc.), Trivy gets advisories from the appropriate **OS database**.
+As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
 
 For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from the `amazon database`. But for a  python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
 

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -6,7 +6,7 @@ As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.),
 For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from [ALAS](https://alas.aws.amazon.com/). But for a python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
 
 This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
-
+The severity is from the selected data source. If the data source does not provide severity, it falls back to NVD, and if NVD does not have severity, it will be UNKNOWN.
 # OS
 
 | OS             | Source                                                                              |

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -5,7 +5,7 @@ Also, for packages installed from package managers (`dpkg`, `yum`, `apk` and etc
 
 For example: for a python package installed from `yum` (Amazon linux), Trivy will only get advisories from the `amazon database`. But for a  python package installed from another source (e.g. `pip`), Trivy will get advisories from the `GitLab` and `GitHub` databases.
 
-This is to avoid false positives when the vendor's OS fixes the vulnerability before the package owner fixes it.
+This advisory selection is essential to avoid getting false positives because OS vendors usually backport upstream fixes, and the fixed version can be different from the upstream fixed version.
 
 # OS
 


### PR DESCRIPTION
## Description
There are similar issues with questions about various vulnerabilities between trivy result and `GitHub database` or why Trivy doesn't get advisories from `GitHub` or `GitLab` databases.

Added information on how Trivy chooses advisory database for package.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
