### PR TITLE
fix(secret): asymmetric private keys use only base64 characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220530063401-1d5d183bb29f
+	github.com/aquasecurity/fanal v0.0.0-20220531101952-e8bca3153e2b
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.58.2 h1:cT9c9Ybxmg2uiscBukfuUOi2llIsGm9sGhHZlF8OWSc=
 github.com/aquasecurity/defsec v0.58.2/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
-github.com/aquasecurity/fanal v0.0.0-20220530063401-1d5d183bb29f h1:RDRnlTtd7jEALZed9+D0UcAVhvXTDD3z7/01kSMfhmA=
-github.com/aquasecurity/fanal v0.0.0-20220530063401-1d5d183bb29f/go.mod h1:1N/p/orwp3237JpnorWj5A90YyUhzBZIZ7isICwctks=
+github.com/aquasecurity/fanal v0.0.0-20220531101952-e8bca3153e2b h1:L5UyVUtnVRxqyRlS7iwNwW4FvLB4ER7yxnCl90so7q8=
+github.com/aquasecurity/fanal v0.0.0-20220531101952-e8bca3153e2b/go.mod h1:1N/p/orwp3237JpnorWj5A90YyUhzBZIZ7isICwctks=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff h1:YNlzRYB0n4mZtfuWx6AWaGEjnLVNekchyoFDlYFZegs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description
Asymmetric private key can be obtained from any function.
For example([phpseclib/Crypt/RSA.php](https://github.com/phpseclib/phpseclib/blob/2.0.32/phpseclib/Crypt/RSA.php#L881-L883)):
```
...
 return "-----BEGIN OPENSSH PRIVATE KEY-----\r\n" .
             chunk_split(base64_encode($key), 70) .
        "-----END OPENSSH PRIVATE KEY-----";
...
```
Only base64 characters (with `=`) should be used to avoid false positives.

## Related issues
- Close #2190

## Related PRs
- [x] #https://github.com/aquasecurity/fanal/pull/539

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
