### PR TITLE
docs: clarifying parts of the k8s docs and updating links

### DIFF
--- a/docs/docs/kubernetes/cli/scanning.md
+++ b/docs/docs/kubernetes/cli/scanning.md
@@ -4,9 +4,13 @@
 
 This feature might change without preserving backwards compatibility.
 
-Scan your Kubernetes cluster for both Vulnerabilities, Secrets and Misconfigurations.
+The Trivy K8s CLI allows you to scan your Kubernetes cluster for Vulnerabilities, Secrets and Misconfigurations. You can either run the CLI locally or integrate it into your CI/CD pipeline. The difference to the Trivy CLI is that the Trivy K8s CLI allows you to scan running workloads directly within your cluster.
+
+If you are looking for continuous cluster audit scanning, have a look at the [Trivy K8s operator.](../operator/getting-started.md)
 
 Trivy uses your local kubectl configuration to access the API server to list artifacts.
+
+## CLI Commands
 
 Scan a full cluster and generate a simple summary report:
 
@@ -43,6 +47,14 @@ Scan a specific resource and get all the output:
 ```
 $ trivy k8s deployment/appname
 ```
+
+If you want to pass in flags before scanning specific workloads, you will have to do it before the resource name.
+For example, scanning a deployment in the app namespace of your Kubernetes cluster for critical vulnerabilities would be done through the following command:
+
+```
+$ trivy k8s -n app --severity=CRITICAL deployment/appname
+```
+This is specific to all Trivy CLI commands.
 
 The supported formats are `table`, which is the default, and `json`.
 To get a JSON output on a full cluster scan:
@@ -206,3 +218,4 @@ $ trivy k8s --format json -o results.json
 ```
 
 </details>
+

--- a/docs/docs/kubernetes/operator/getting-started.md
+++ b/docs/docs/kubernetes/operator/getting-started.md
@@ -3,11 +3,7 @@
 ## Before you Begin
 
 You need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your
-cluster. If you do not already have a cluster, you can create one by installing [minikube] or [kind], or you can use one
-of these Kubernetes playgrounds:
-
-* [Katacoda]
-* [Play with Kubernetes]
+cluster. If you do not already have a cluster, you can create one by installing [minikube], [kind] or [microk8s], or you can use the following [Kubernetes playground].
 
 You also need the Trivy-Operator to be installed in the `trivy-system` namespace, e.g. with
 [kubectl](./installation/kubectl.md) or [Helm](./installation/helm.md). Let's also assume that the operator is
@@ -194,8 +190,8 @@ No resources found in default namespace.
 
 [minikube]: https://minikube.sigs.k8s.io/docs/
 [kind]: https://kind.sigs.k8s.io/docs/
-[Katacoda]: https://www.katacoda.com/courses/kubernetes/playground/
-[Play with Kubernetes]: http://labs.play-with-k8s.com/
+[microk8s]: https://microk8s.io/
+[Kubernetes playground]: http://labs.play-with-k8s.com/
 [tree]: https://github.com/ahmetb/kubectl-tree
 [Private Registries]: ./../vulnerability-scanning/private-registries.md
 [Vulnerability Scanner]: ./../vulnerability-scanning/index.md

--- a/docs/docs/kubernetes/operator/troubleshooting.md
+++ b/docs/docs/kubernetes/operator/troubleshooting.md
@@ -24,7 +24,7 @@ The Trivy Operator will run a pod inside your cluster. If you have followed the 
 
 Make sure that the pod is in the `Running` status:
 ```
-kubectl get pods -n trivy-operator
+kubectl get pods -n trivy-system
 ```
 
 This is how it will look if it is running okay:

--- a/docs/docs/kubernetes/operator/vulnerability-scanning/index.md
+++ b/docs/docs/kubernetes/operator/vulnerability-scanning/index.md
@@ -17,5 +17,5 @@ Trivy may scan Kubernetes workloads that run images from [Private Registries] an
 
 [VulnerabilityReport]: ./../crds/vulnerability-report.md
 [Trivy]: ./trivy.md
-[Private Registries]: ./private-registries.md
+[Private Registries]: ./managed-registries.md
 [Managed Registries]: ./managed-registries.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
               - Configuration: docs/kubernetes/operator/configuration.md
               - Vulnerability Scanning:
                     - Overview: docs/kubernetes/operator/vulnerability-scanning/index.md 
-                    - Scan Configuration: docs/kubernetes/operator/vulnerability-scanning/config.md 
+                    - Scan Configuration: docs/kubernetes/operator/vulnerability-scanning/configuration.md 
                     - Managed registries: docs/kubernetes/operator/vulnerability-scanning/managed-registries.md 
                     - FAQ: docs/kubernetes/operator/vulnerability-scanning/faq.md 
               - Configuration Auditing:


### PR DESCRIPTION
Updated some of the descriptions, referenced namespaces, links in the docs on trivy k8s and removed katacoda since they no longer support it


