### PR TITLE
fix: mask redis credentials when logging

### DIFF
--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -33,7 +33,7 @@ type Cache struct {
 // NewCache is the factory method for Cache
 func NewCache(c option.CacheOption) (Cache, error) {
 	if strings.HasPrefix(c.CacheBackend, "redis://") {
-		log.Logger.Infof("Redis cache: %s", c.CacheBackend)
+		log.Logger.Infof("Redis cache: %s", c.CacheBackendMasked())
 		options, err := redis.ParseURL(c.CacheBackend)
 		if err != nil {
 			return Cache{}, err

--- a/pkg/commands/option/cache.go
+++ b/pkg/commands/option/cache.go
@@ -1,6 +1,7 @@
 package option
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -50,4 +51,16 @@ func (c *CacheOption) Init() error {
 		}
 	}
 	return nil
+}
+
+// CacheBackendMasked returns the redis connection string masking credentials
+func (c *CacheOption) CacheBackendMasked() string {
+	endIndex := strings.Index(c.CacheBackend, "@")
+	if endIndex == -1 {
+		return c.CacheBackend
+	}
+
+	startIndex := strings.Index(c.CacheBackend, "//")
+
+	return fmt.Sprintf("%s****%s", c.CacheBackend[:startIndex+2], c.CacheBackend[endIndex:])
 }

--- a/pkg/commands/option/cache_test.go
+++ b/pkg/commands/option/cache_test.go
@@ -90,3 +90,38 @@ func TestCacheOption_Init(t *testing.T) {
 		})
 	}
 }
+
+func TestCacheOption_CacheBackendMasked(t *testing.T) {
+	type fields struct {
+		backend string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "redis cache backend masked",
+			fields: fields{
+				backend: "redis://root:password@localhost:6379",
+			},
+			want: "redis://****@localhost:6379",
+		},
+		{
+			name: "redis cache backend masked does nothing",
+			fields: fields{
+				backend: "redis://localhost:6379",
+			},
+			want: "redis://localhost:6379",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &option.CacheOption{
+				CacheBackend: tt.fields.backend,
+			}
+
+			assert.Equal(t, tt.want, c.CacheBackendMasked())
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR masks the redis credentials when logging here https://github.com/aquasecurity/trivy/blob/b7ec64257279b5f9c47ac02063e12c5305f5af8a/pkg/commands/operation/operation.go#L36

## Related issues
- Close #2081 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
