### PR TITLE
feat(helm): add pod annotations

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,12 +2,11 @@
 
 ## RHEL/CentOS
 
-
 === "Repository"
     Add repository setting to `/etc/yum.repos.d`.
 
     ``` bash
-    RELEASE_VERSION=$(grep -Po '(?<=VERSION_ID=")[0-9]' /etc/os-release) 
+    RELEASE_VERSION=$(grep -Po '(?<=VERSION_ID=")[0-9]' /etc/os-release)
     cat << EOF | sudo tee -a /etc/yum.repos.d/trivy.repo
     [trivy]
     name=Trivy repository
@@ -45,9 +44,8 @@
     sudo dpkg -i trivy_{{ git.tag[1:] }}_Linux-64bit.deb
     ```
 
-
-
 ## Arch Linux
+
 Package trivy-bin can be installed from the Arch User Repository.
 
 === "pikaur"
@@ -82,8 +80,8 @@ nix-env --install trivy
 
 Or through your configuration on NixOS or with home-manager as usual
 
-
 ## Install Script
+
 This script downloads Trivy binary based on your OS and architecture.
 
 ```bash
@@ -108,7 +106,9 @@ go install
 ```
 
 ## Docker
+
 ### Docker Hub
+
 Replace [YOUR_CACHE_DIR] with the cache directory on your machine.
 
 ```bash
@@ -167,7 +167,6 @@ The same image is hosted on [GitHub Container Registry][registry] as well.
 docker pull ghcr.io/aquasecurity/trivy:{{ git.tag[1:] }}
 ```
 
-
 ### Amazon ECR Public
 
 The same image is hosted on [Amazon ECR Public][ecr] as well.
@@ -175,7 +174,9 @@ The same image is hosted on [Amazon ECR Public][ecr] as well.
 ```bash
 docker pull public.ecr.aws/aquasecurity/trivy:{{ git.tag[1:] }}
 ```
+
 ## Helm
+
 ### Installing from the Aqua Chart Repository
 
 ```
@@ -195,6 +196,43 @@ helm install my-release .
 
 The command deploys Trivy on the Kubernetes cluster in the default configuration. The [Parameters][helm]
 section lists the parameters that can be configured during installation.
+
+### AWS private registry permissions
+
+You may need to grant permissions to allow trivy to pull images from private registry (AWS ECR).
+
+It depends on how you want to provide AWS Role to trivy.
+
+- [IAM Role Service account](https://github.com/aws/amazon-eks-pod-identity-webhook)
+- [Kube2iam](https://github.com/jtblin/kube2iam) or [Kiam](https://github.com/uswitch/kiam)
+
+#### IAM Role Service account
+
+Add the AWS role in trivy's service account annotations:
+
+```yaml
+trivy:
+
+  serviceAccount:
+    annotations: {}
+      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+```
+
+#### Kube2iam or Kiam
+
+Add the AWS role to pod's annotations:
+
+```yaml
+trivy:
+
+  podAnnotations: {}
+    ## kube2iam/kiam annotation
+    # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+
+  serviceAccount:
+    annotations: {}
+      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+```
 
 > **Tip**: List all releases using `helm list`.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -228,10 +228,6 @@ trivy:
   podAnnotations: {}
     ## kube2iam/kiam annotation
     # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
-
-  serviceAccount:
-    annotations: {}
-      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
 ```
 
 > **Tip**: List all releases using `helm list`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -223,11 +223,9 @@ trivy:
 Add the AWS role to pod's annotations:
 
 ```yaml
-trivy:
-
-  podAnnotations: {}
-    ## kube2iam/kiam annotation
-    # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+podAnnotations: {}
+  ## kube2iam/kiam annotation
+  # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
 ```
 
 > **Tip**: List all releases using `helm list`.

--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.13
+version: 0.4.14
 appVersion: 0.27.0
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.14
+version: 0.4.15
 appVersion: 0.27.0
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.15
+version: 0.4.14
 appVersion: 0.27.0
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
 | `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
+| `trivy.podAnnotations`                | Annotations for pods created by statefulset                             | `{}` |
 | `service.name`                        | If specified, the name used for the Trivy service                       |     |
 | `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
 | `service.port`                        | Kubernetes service port                                                 | `4954`      |

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -29,10 +29,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- . | toYaml | nindent 8 }}
-      {{- end }}    
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "trivy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -74,9 +74,14 @@ trivy:
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
   gitHubToken: ""
+
+  ## Annotations for pods created by statefulset
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+
   podAnnotations: {}
     ## kube2iam/kiam annotation
     # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+
   # Docker registry credentials
   # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
   #

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -75,13 +75,6 @@ trivy:
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
   gitHubToken: ""
 
-  ## Annotations for pods created by statefulset
-  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-
-  podAnnotations: {}
-    ## kube2iam/kiam annotation
-    # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
-
   # Docker registry credentials
   # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
   #

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -74,6 +74,9 @@ trivy:
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
   gitHubToken: ""
+  podAnnotations: {}
+    ## kube2iam/kiam annotation
+    # iam.amazonaws.com/role: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
   # Docker registry credentials
   # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
   #


### PR DESCRIPTION
## Description

Before this PR, the only way to grant AWS Permission is by using IAM Role for ServiceAccount.

After this PR, we are able to grant permission with kube2iam or kiam role.

## Related issues
- Close #1889

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).

Just saw the similar PR #2265 