### PR TITLE
feat(cli): use stderr for all log messages

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -71,7 +71,7 @@ func NewLogger(debug, disable bool) (*zap.SugaredLogger, error) {
 
 	// High-priority output should also go to standard error, and low-priority
 	// output should also go to standard out.
-	consoleLogs := zapcore.Lock(os.Stdout)
+	consoleLogs := zapcore.Lock(os.Stderr)
 	consoleErrors := zapcore.Lock(os.Stderr)
 	if disable {
 		devNull, err := os.Create(os.DevNull)


### PR DESCRIPTION
## Description

Redirecting all log messages to stderr allows to process output with tools like jq.

A work-around is to pass `--quiet` but then you lose all messages.

Before:

```
trivy sbom --artifact-type fs . | jq .vulnerabilities | head
parse error: Invalid numeric literal at line 1, column 14
```

After:

```
trivy sbom --artifact-type fs . | jq .vulnerabilities | head
2022-06-08T17:44:12.504+0200    INFO    Number of language-specific files: 1
2022-06-08T17:44:12.504+0200    INFO    Detecting gomod vulnerabilities...
[]
```

## Related issues
- Close #381

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
