### PR TITLE
refactor: do not import defsec in fanal types package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/fanal v0.0.0-20220606114023-67ac2173b7d9
+	github.com/aquasecurity/fanal v0.0.0-20220607082632-cee9188f43ac
 	github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -76,7 +76,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-	github.com/aquasecurity/defsec v0.59.0
+	github.com/aquasecurity/defsec v0.59.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.25 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.59.0 h1:BmX5j5Y7+IhJ4hKYGIJWMcmVUqaIiTjtEqL5doT995Q=
 github.com/aquasecurity/defsec v0.59.0/go.mod h1:42FxKif2itz+MHFlJ3TJjdroL9Jzj3THoexlueBTU5w=
-github.com/aquasecurity/fanal v0.0.0-20220606114023-67ac2173b7d9 h1:bbwJnRN7C01+Uo7Qfewo7gSXoT5cB8NXzpSyLM44K44=
-github.com/aquasecurity/fanal v0.0.0-20220606114023-67ac2173b7d9/go.mod h1:c0Kqe6ffFdrugzH8NZuF5V4gllHJO6ef8u8DqXE8k9g=
+github.com/aquasecurity/fanal v0.0.0-20220607082632-cee9188f43ac h1:OzP+N2jZH2xmwiZXXfnOEUDw+dKtGvwtmOgXkWbZjMA=
+github.com/aquasecurity/fanal v0.0.0-20220607082632-cee9188f43ac/go.mod h1:c0Kqe6ffFdrugzH8NZuF5V4gllHJO6ef8u8DqXE8k9g=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff h1:YNlzRYB0n4mZtfuWx6AWaGEjnLVNekchyoFDlYFZegs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220503151658-d316f5cc2cff/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/report/misconfig_test.go
+++ b/pkg/report/misconfig_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/report"
 
-	"github.com/aquasecurity/defsec/pkg/scan"
 	ftypes "github.com/aquasecurity/fanal/types"
 
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -68,8 +67,8 @@ See https://google.com/search?q=bad%20config
 						Service:   "",
 						StartLine: 0,
 						EndLine:   0,
-						Code: scan.Code{
-							Lines: []scan.Line{
+						Code: ftypes.Code{
+							Lines: []ftypes.Line{
 								{
 									Number: 1,
 								},
@@ -120,8 +119,8 @@ See https://google.com/search?q=bad%20config
 					CauseMetadata: ftypes.CauseMetadata{
 						StartLine: 2,
 						EndLine:   2,
-						Code: scan.Code{
-							Lines: []scan.Line{
+						Code: ftypes.Code{
+							Lines: []ftypes.Line{
 								{
 									Number: 1,
 								},


### PR DESCRIPTION
## Description
see here: https://github.com/aquasecurity/fanal/pull/537

## Related PRs
- [x] https://github.com/aquasecurity/fanal/pull/537

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
