### PR TITLE
test: replace deprecated subcommand `client` in integration tests

### DIFF
--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -564,10 +564,10 @@ func setupServer(addr, token, tokenHeader, cacheDir, cacheBackend string) []stri
 
 func setupClient(t *testing.T, c csArgs, addr string, cacheDir string, golden string) ([]string, string) {
 	if c.Command == "" {
-		c.Command = "client"
+		c.Command = "image"
 	}
 	if c.RemoteAddrOption == "" {
-		c.RemoteAddrOption = "--remote"
+		c.RemoteAddrOption = "--server"
 	}
 	t.Helper()
 	osArgs := []string{"trivy", "--cache-dir", cacheDir, c.Command, c.RemoteAddrOption, "http://" + addr}


### PR DESCRIPTION
## Description
`client` subcommand is deprecated now. 
so we should update the integration tests and use `image --server`.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
