### PR TITLE
feat(alpine): add Alpine Linux 3.16

### DIFF
--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -4,7 +4,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 
 | OS                               | Supported Versions                        | Target Packages               | Detection of unfixed vulnerabilities |
 | -------------------------------- |-------------------------------------------| ----------------------------- | :----------------------------------: |
-| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.15, edge               | Installed by apk              |                  NO                  |
+| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.16, edge               | Installed by apk              |                  NO                  |
 | Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |
 | Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
 | CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -42,6 +42,7 @@ var (
 		"3.13": time.Date(2022, 11, 1, 23, 59, 59, 0, time.UTC),
 		"3.14": time.Date(2023, 5, 1, 23, 59, 59, 0, time.UTC),
 		"3.15": time.Date(2023, 11, 1, 23, 59, 59, 0, time.UTC),
+		"3.16": time.Date(2024, 5, 23, 23, 59, 59, 0, time.UTC),
 		"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 )

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -76,7 +76,7 @@ func WithClock(clock clock.Clock) option {
 	}
 }
 
-// Scanner implements the Alpine scanner
+// Scanner implements the RedHat scanner
 type Scanner struct {
 	vs redhat.VulnSrc
 	*options

--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -78,7 +78,7 @@ const (
 	OpenSUSE
 )
 
-// Scanner implements the Alpine scanner
+// Scanner implements the SUSE scanner
 type Scanner struct {
 	vs susecvrf.VulnSrc
 	*options

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -67,7 +67,7 @@ func WithClock(clock clock.Clock) option {
 	}
 }
 
-// Scanner implements the Alpine scanner
+// Scanner implements the Ubuntu scanner
 type Scanner struct {
 	vs ubuntu.VulnSrc
 	*options


### PR DESCRIPTION
## Description
add Alpine Linux 3.16.
https://alpinelinux.org/posts/Alpine-3.16.0-released.html

- before
```console
$ trivy image vuln-alpine:3.16
2022-06-14T23:19:11.654+0900	INFO	Detected OS: alpine
2022-06-14T23:19:11.654+0900	INFO	This OS version is not on the EOL list: alpine 3.16
2022-06-14T23:19:11.654+0900	INFO	Detecting Alpine vulnerabilities...
2022-06-14T23:19:11.658+0900	INFO	Number of language-specific files: 0

vuln-alpine:3.16 (alpine 3.16.0)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

- after
```console
$ trivy image vuln-alpine:3.16
2022-06-14T23:18:59.406+0900	INFO	Detected OS: alpine
2022-06-14T23:18:59.406+0900	INFO	Detecting Alpine vulnerabilities...
2022-06-14T23:18:59.407+0900	INFO	Number of language-specific files: 0

vuln-alpine:3.16 (alpine 3.16.0)

Total: 13 (UNKNOWN: 0, LOW: 0, MEDIUM: 7, HIGH: 6, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                             │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2018-14404 │ HIGH     │ 2.9.4-r3          │ 2.9.8-r1      │ libxml2: NULL pointer dereference in xmlXPathCompOpEval()    │
│         │                │          │                   │               │ function in xpath.c                                          │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2018-14404                   │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2019-20388 │ HIGH     │ 2.9.4-r3          │ 2.9.10-r4     │ libxml2: memory leak in xmlSchemaPreRun in xmlschemas.c      │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-20388                   │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2020-7595  │ HIGH     │ 2.9.4-r3          │ 2.9.8-r3      │ libxml2: infinite loop in xmlStringLenDecodeEntities in some │
│         │                │          │                   │               │ end-of-file situations                                       │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-7595                    │
│         ├────────────────┤          │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2021-3517  │          │                   │ 2.9.11-r0     │ libxml2: Heap-based buffer overflow in                       │
│         │                │          │                   │               │ xmlEncodeEntitiesInternal() in entities.c                    │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-3517                    │
│         ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2021-3518  │          │                   │               │ libxml2: Use-after-free in xmlXIncludeDoProcess() in         │
│         │                │          │                   │               │ xinclude.c                                                   │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-3518                    │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2022-23308 │ HIGH     │ 2.9.4-r3          │ 2.9.13-r0     │ libxml2: Use-after-free of ID and IDREF attributes           │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-23308                   │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2017-5969  │ MEDIUM   │ 2.9.4-r3          │ 2.9.4-r4      │ libxml2: Null pointer dereference in xmlSaveDoc              │
│         │                │          │                   │               │ implementation                                               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2017-5969                    │
│         ├────────────────┤          │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2018-14567 │          │                   │ 2.9.8-r1      │ libxml2: Infinite loop caused by incorrect error detection   │
│         │                │          │                   │               │ during LZMA decompression                                    │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2018-14567                   │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2018-9251  │ MEDIUM   │ 2.9.4-r3          │ 2.9.8-r1      │ libxml2: infinite loop in xz_decomp function in xzlib.c      │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2018-9251                    │
├─────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2020-24977 │ MEDIUM   │ 2.9.4-r3          │ 2.9.10-r5     │ libxml2: Buffer overflow vulnerability in                    │
│         │                │          │                   │               │ xmlEncodeEntitiesInternal() in entities.c                    │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-24977                   │
│         ├────────────────┤          │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2021-3537  │          │                   │ 2.9.11-r0     │ libxml2: NULL pointer dereference when post-validating mixed │
│         │                │          │                   │               │ content parsed in recovery mode...                           │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-3537                    │
│         ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2021-3541  │          │                   │               │ libxml2: Exponential entity expansion attack bypasses all    │
│         │                │          │                   │               │ existing protection mechanisms                               │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-3541                    │
│         ├────────────────┤          │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2022-29824 │          │                   │ 2.9.14-r0     │ libxml2: integer overflows in xmlBuf and xmlBuffer lead to   │
│         │                │          │                   │               │ out-of-bounds write                                          │
│         │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-29824                   │
└─────────┴────────────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

## Related issues

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
