### PR TITLE
docs: bump trivy-operator to v0.0.7

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,7 +166,7 @@ extra:
     provider: mike
   var:
     prev_git_tag: "v0.0.0"
-    operator_version: "v0.0.5"
+    operator_version: "v0.0.7"
 
 plugins:
   - search


### PR DESCRIPTION
Bump trivy-operator version.