### PR TITLE
refactor: change k8s namespace cmd to "everything"

### DIFF
--- a/docs/docs/kubernetes/cli/scanning.md
+++ b/docs/docs/kubernetes/cli/scanning.md
@@ -38,7 +38,7 @@ $ trivy k8s --security-checks=config --report=summary cluster
 Scan a specific namespace:
 
 ```
-$ trivy k8s -n kube-system --report=summary all
+$ trivy k8s -n kube-system --report=summary everything
 ```
 
 Scan a specific resource and get all the output:

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -855,7 +855,7 @@ func NewK8sCommand() *cli.Command {
   - cluster scanning:
       $ trivy k8s --report summary cluster
   - namespace scanning:
-      $ trivy k8s -n kube-system --report summary all
+      $ trivy k8s -n kube-system --report summary everything
   - resource scanning:
       $ trivy k8s deployment/orion
 `,

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	clusterArtifact = "cluster"
-	allArtifact     = "all"
+	clusterArtifact    = "cluster"
+	everythingArtifact = "everything"
 )
 
 // Run runs a k8s scan
@@ -36,7 +36,7 @@ func Run(cliCtx *cli.Context) error {
 	switch cliCtx.Args().Get(0) {
 	case clusterArtifact:
 		return clusterRun(cliCtx, opt, cluster)
-	case allArtifact:
+	case everythingArtifact:
 		return namespaceRun(cliCtx, opt, cluster)
 	default: // resourceArtifact
 		return resourceRun(cliCtx, opt, cluster)
@@ -93,7 +93,7 @@ func run(ctx context.Context, opt cmd.Option, cluster string, artifacts []*artif
 // even though the default value of "--report" is "all".
 //
 // e.g. $ trivy k8s --report all cluster
-//      $ trivy k8s --report all all
+//      $ trivy k8s --report all everything
 //
 // Or they can use "--format json" with implicit "--report all".
 //


### PR DESCRIPTION
@chen-keinan @knqyf263  Showing this feature to @itaysk, and he noticed that using `all` might pass the wrong idea. Because `kubectl get all` won't return everything in a namespace, just a select group of resources (`pod, svc, ds, deploy, rs, sts, job, cronjobs`) while other resources are ignore (`rc, ingress, roles, secrets, cm, limitranges, rolesbendings, networkpolicies, events, etc`). 

We want to scan everything in the namespace, not only a set of resources, so we thought adding another `virtual` resource idea like we did for cluster would be better:

```
$ trivy k8s everything # default namespace
$ trivy k8s --namespace kube-system everything # different namespace
$ trivy k8s -n kube-system everything # different namespace
```

Let me know what you think please.