### PR TITLE
docs: update nix installation info

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -70,15 +70,33 @@ brew install aquasecurity/trivy/trivy
 
 ## Nix/NixOS
 
-You can use nix on Linux or macOS and on others unofficially.
+Direct issues installing `trivy` via `nix` through the channels mentioned [here](https://nixos.wiki/wiki/Support)
 
-Note that trivy is currently only in the unstable channels.
+You can use `nix` on Linux or macOS and on other platforms unofficially.
 
-```bash
-nix-env --install trivy
+`nix-env --install -A nixpkgs.trivy`
+
+Or through your configuration as usual
+
+NixOS:
+
+```nix
+  # your other config ...
+  environment.systemPackages = with pkgs; [
+    # your other packages ...
+    trivy
+  ];
 ```
 
-Or through your configuration on NixOS or with home-manager as usual
+home-manager:
+
+```nix
+  # your other config ...
+  home.packages = with pkgs; [
+    # your other packages ...
+    trivy
+  ];
+```
 
 ## Install Script
 


### PR DESCRIPTION
## Description

Update the nix info to be more in depth and remove mention of unstable since trivy is in both stable (22.05 release) and unstable now :tada:

## Related issues

## Related PRs

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
