### PR TITLE
feat(helm): add support for trivy dbRepository

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.4.14
+version: 0.4.15
 appVersion: 0.27.0
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
 | `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
 | `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
+| `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from        | `ghcr.io/aquasecurity/trivy-db`        |
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
 | `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |

--- a/helm/trivy/templates/configmap.yaml
+++ b/helm/trivy/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
 {{- end }}
   TRIVY_DEBUG: {{ .Values.trivy.debugMode | quote }}
   TRIVY_SKIP_UPDATE: {{ .Values.trivy.skipUpdate | quote }}
+  TRIVY_DB_REPOSITORY: {{ .Values.trivy.dbRepository | quote }}
 {{- if .Values.httpProxy }}
   HTTP_PROXY: {{ .Values.httpProxy | quote }}
 {{- end }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -99,6 +99,8 @@ trivy:
   # If the flag is enabled you have to manually download the `trivy.db` file and mount it in the
   # `/home/scanner/.cache/trivy/db/trivy.db` path (see `cacheDir`).
   skipUpdate: false
+  # OCI repository to retrieve the trivy vulnerability database from
+  dbRepository: ghcr.io/aquasecurity/trivy-db
   # Trivy supports filesystem and redis as caching backend
   # https://github.com/aquasecurity/trivy#specify-cache-backend
   # This location is only used for the cache, not the db storage: https://github.com/aquasecurity/trivy/issues/765#issue-756010345


### PR DESCRIPTION
## Description

This adds Helm support for the `dbRepository` flag introduced in https://github.com/aquasecurity/trivy/pull/1873.

## Related issues
- Close #2344 

## Related PRs
- [ ] #1873

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
