### PR TITLE
feat(alma): support for scanning of modular packages for AlmaLinux

### DIFF
--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -68,7 +68,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	var vulns []types.DetectedVulnerability
 	var skipPkgs []string
 	for _, pkg := range pkgs {
-		if strings.Contains(pkg.Release, ".module_el") {
+		if strings.Contains(pkg.Release, ".module_el") && pkg.Modularitylabel == "" {
 			skipPkgs = append(skipPkgs, pkg.Name)
 			continue
 		}

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -85,13 +85,50 @@ func TestScanner_Detect(t *testing.T) {
 						SrcEpoch:        1,
 						SrcVersion:      "1.14.1",
 						SrcRelease:      "8.module_el8.3.0+2165+af250afe.alma",
-						Modularitylabel: "nginx:1.14:8040020210610090123:9f9e2e7e", // actual: "", ref: https://bugs.almalinux.org/view.php?id=173
+						Modularitylabel: "", // ref: https://bugs.almalinux.org/view.php?id=173 ,  https://github.com/aquasecurity/trivy/issues/2342#issuecomment-1158459628
 						License:         "BSD",
 						Layer:           ftypes.Layer{},
 					},
 				},
 			},
 			want: nil,
+		},
+		{
+			name:     "modular package",
+			fixtures: []string{"testdata/fixtures/modular.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "8.6",
+				pkgs: []ftypes.Package{
+					{
+						Name:            "httpd",
+						Epoch:           0,
+						Version:         "2.4.37",
+						Release:         "46.module_el8.6.0+2872+fe0ff7aa.1.alma",
+						Arch:            "x86_64",
+						SrcName:         "httpd",
+						SrcEpoch:        0,
+						SrcVersion:      "2.4.37",
+						SrcRelease:      "46.module_el8.6.0+2872+fe0ff7aa.1.alma",
+						Modularitylabel: "httpd:2.4:8060020220510105858:9edba152",
+						License:         "ASL 2.0",
+						Layer:           ftypes.Layer{},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "httpd",
+					VulnerabilityID:  "CVE-2020-35452",
+					InstalledVersion: "2.4.37-46.module_el8.6.0+2872+fe0ff7aa.1.alma",
+					FixedVersion:     "2.4.37-47.module_el8.6.0+2872+fe0ff7aa.1.alma",
+					Layer:            ftypes.Layer{},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Alma,
+						Name: "AlmaLinux Product Errata",
+						URL:  "https://errata.almalinux.org/",
+					},
+				},
+			},
 		},
 		{
 			name:     "Get returns an error",

--- a/pkg/detector/ospkg/alma/testdata/fixtures/modular.yaml
+++ b/pkg/detector/ospkg/alma/testdata/fixtures/modular.yaml
@@ -5,3 +5,8 @@
         - key: CVE-2019-9511
           value:
             FixedVersion: "1:1.14.1-9.module_el8.3.0+2165+af250afe.alma"
+    - bucket: httpd:2.4::httpd
+      pairs:
+        - key: CVE-2020-35452
+          value:
+            FixedVersion: "2.4.37-47.module_el8.6.0+2872+fe0ff7aa.1.alma"


### PR DESCRIPTION
## Description
As verified by this comment, the appropriate %{MODULARITYLABEL} is set in the modular package for AlmaLinux 8.6 (`module_el8.6` in %{RELEASE}).
https://github.com/aquasecurity/trivy/issues/2342#issuecomment-1158459628

Therefore, the previous skip was done for all modular packages, but now skip is done only when there is a `module_el` in %{RELEASE}, but %{MODULARITYLABEL}=="".

## Related issues
- Close #2342 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
