### PR TITLE
docs(repo): Link to installation documentation in readme shows 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 [getting-started]: https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [docs]: https://aquasecurity.github.io/trivy
 [integrations]:https://aquasecurity.github.io/trivy/latest/docs/integrations/
-[installation]:https://aquasecurity.github.io/trivy/latest/docs/getting-started/installation/
+[installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [releases]: https://github.com/aquasecurity/trivy/releases
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego


### PR DESCRIPTION
Link to installation documentation shows 404:

https://aquasecurity.github.io/trivy/latest/docs/getting-started/installation/

correct link:

https://aquasecurity.github.io/trivy/latest/getting-started/installation/

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
