### PR TITLE
fix(ruby): trim platform suffix in version number

### DIFF
--- a/pkg/detector/library/compare/rubygems/compare.go
+++ b/pkg/detector/library/compare/rubygems/compare.go
@@ -1,11 +1,25 @@
 package rubygems
 
 import (
+	"strings"
+
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/go-gem-version"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
+)
+
+var (
+	platformReplacer = strings.NewReplacer(
+		"-java", "",
+		"-mswin32", "",
+		"-mswin64", "",
+		"-universal-mingw32", "",
+		"-x64-mingw32", "",
+		"-x86_64-mingw32", "",
+		"-mingw32", "",
+	)
 )
 
 // Comparer represents a comparer for RubyGems
@@ -18,6 +32,10 @@ func (r Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 
 // matchVersion checks if the package version satisfies the given constraint.
 func (r Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
+	// There are same packages for ruby and jruby. We need trim platform suffix
+	// Otherwise suffix will recognize as pre-release version (https://semver.org/#spec-item-9)
+	// e.g. https://rubygems.org/gems/puma/versions/5.6.4-java and https://rubygems.org/gems/puma/versions/5.6.4
+	currentVersion = platformReplacer.Replace(currentVersion)
 	v, err := gem.NewVersion(currentVersion)
 	if err != nil {
 		return false, xerrors.Errorf("RubyGems version error (%s): %s", currentVersion, err)

--- a/pkg/detector/library/compare/rubygems/compare_test.go
+++ b/pkg/detector/library/compare/rubygems/compare_test.go
@@ -72,6 +72,17 @@ func TestRubyGemsComparer_IsVulnerable(t *testing.T) {
 			want: false,
 		},
 		{
+			// https://github.com/aquasecurity/trivy/issues/2353
+			name: "removed suffix",
+			args: args{
+				currentVersion: "5.6.4-java",
+				advisory: types.Advisory{
+					PatchedVersions: []string{">= 5.6.4"},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "invalid version",
 			args: args{
 				currentVersion: "1.2..4",


### PR DESCRIPTION
## Description
There are same packages for ruby and jruby. We need trim platform suffix
Otherwise suffix will recognize as pre-release version (https://semver.org/#spec-item-9)
e.g. 
- https://rubygems.org/gems/puma/versions/5.6.4-java 
- https://rubygems.org/gems/puma/versions/5.6.4

list of platform suffix gets from https://github.com/aquasecurity/trivy/pull/230

## Related issues
- Close #2353

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
