### PR TITLE
fix(misconf): Update defsec to v0.68.4 to resolve CF detection bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-	github.com/aquasecurity/defsec v0.68.3
+	github.com/aquasecurity/defsec v0.68.4
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/aws/aws-sdk-go v1.44.25
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.68.3 h1:fVjPBPDcgxHubEZiMihlnPxoY40jOWzCgG2Q1Vrak4o=
-github.com/aquasecurity/defsec v0.68.3/go.mod h1:m59o8MPMXFbMgulxFOvFRW8tVg4gcnqZ9Gi3uvd/6zg=
+github.com/aquasecurity/defsec v0.68.4 h1:moFF8/XDKduRlCzqnqoM2ltTJsWMFNxjaWOY0estKNw=
+github.com/aquasecurity/defsec v0.68.4/go.mod h1:m59o8MPMXFbMgulxFOvFRW8tVg4gcnqZ9Gi3uvd/6zg=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf h1:LE3sTKuErkJqkNsPOYvbPb/3VOKKZKyjqBQla1KBL0k=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/fanal/artifact/local/testdata/misconfig/cloudformation/passed/src/main.yaml
+++ b/pkg/fanal/artifact/local/testdata/misconfig/cloudformation/passed/src/main.yaml
@@ -1,5 +1,5 @@
 Resources:
-S3Bucket:
-Type: 'AWS::S3::Bucket'
-Properties:
-BucketName: public-bucket
+  S3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: public-bucket


### PR DESCRIPTION
## Description

CloudFormation detection was not strict enough. Now we ensure the `Resources` property in json/yaml is of the correct type before passing the detection test.

Additionally, we ignore invalid json/yaml CF files when parsing a complete filesystem.

## Related issues
- Close #2382
