### PR TITLE
feat(ruby): drop platform strings from dependency versions bundled with bundler v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           go mod tidy
           if [ -n "$(git status --porcelain)" ]; then
+            echo "Run 'go mod tidy' and push it"
             exit 1
           fi
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.21.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf
+	github.com/aquasecurity/go-dep-parser v0.0.0-20220620143653-00462f6a05c8
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/aquasecurity/defsec v0.68.4 h1:moFF8/XDKduRlCzqnqoM2ltTJsWMFNxjaWOY0e
 github.com/aquasecurity/defsec v0.68.4/go.mod h1:m59o8MPMXFbMgulxFOvFRW8tVg4gcnqZ9Gi3uvd/6zg=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf h1:LE3sTKuErkJqkNsPOYvbPb/3VOKKZKyjqBQla1KBL0k=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220620143653-00462f6a05c8 h1:N4Fwm2ClxZd862T3jNAIx+ZlQJPYilUoIukMG3triGw=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220620143653-00462f6a05c8/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798 h1:eveqE9ivrt30CJ7dOajOfBavhZ4zPqHcZe/4tKp0alc=

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.68.4 h1:moFF8/XDKduRlCzqnqoM2ltTJsWMFNxjaWOY0estKNw=
 github.com/aquasecurity/defsec v0.68.4/go.mod h1:m59o8MPMXFbMgulxFOvFRW8tVg4gcnqZ9Gi3uvd/6zg=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf h1:LE3sTKuErkJqkNsPOYvbPb/3VOKKZKyjqBQla1KBL0k=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220607141748-ab2deea55bdf/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220620143653-00462f6a05c8 h1:N4Fwm2ClxZd862T3jNAIx+ZlQJPYilUoIukMG3triGw=
 github.com/aquasecurity/go-dep-parser v0.0.0-20220620143653-00462f6a05c8/go.mod h1:7EOQWQmyavVPY3fScbbPdd3dB/b0Q4ZbJ/NZCvNKrLs=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description
Trivy fails to parse `Gemfile.lock` dependencies when the platform details are appended to the version string.

For example, run Trivy on this Rails [Gemfile.lock](https://github.com/rails/rails/blob/7f93661551b4e0bfa5296671e5eaf70efb21af0e/Gemfile.lock):
```
$ trivy fs Gemfile.lock
...
2022-06-22T14:50:44.264-0400	WARN	RubyGems version error (1.13.3-x86_64-darwin): invalid gem version
2022-06-22T14:50:44.264-0400	WARN	RubyGems version error (1.13.3-x86_64-linux): invalid gem version
...
```

As a result, checks are skipped from for those dependencies.

This update to [go-dep-parser](https://github.com/aquasecurity/go-dep-parser) drops the platform string that is appended to versions, so version checks and comparisons can be performed.

e.g. `1.13.3-x86_64-darwin` -> `1.13.3`

(This is achieved in a [similar way](https://github.com/rubygems/rubygems/blob/75bd5fec39bc9ba53bce07c5aae47cf0adaf4e81/bundler/lib/bundler/lockfile_parser.rb#L145-L153) that bundler parses dependencies in lockfiles.)

## Related issues
- https://github.com/aquasecurity/go-gem-version/issues/1

## Related PRs
- [x] https://github.com/aquasecurity/go-dep-parser/pull/109

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
