### PR TITLE
feat: extract stripe publishable and secret keys

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -169,14 +169,21 @@ var builtinRules = []Rule{
 		Regex:    MustCompile(`xox[baprs]-([0-9a-zA-Z]{10,48})?`),
 		Keywords: []string{"xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-"},
 	},
-
 	{
-		ID:       "stripe-access-token",
+		ID:       "stripe-publishable-token",
 		Category: CategoryStripe,
-		Title:    "Stripe",
-		Severity: "HIGH",
-		Regex:    MustCompile(`(?i)(sk|pk)_(test|live)_[0-9a-z]{10,32}`),
-		Keywords: []string{"sk_test_", "sk_live_", "pk_test_", "pk_live_"},
+		Title:    "Stripe Publishable Key",
+		Severity: "LOW",
+		Regex:    MustCompile(`(?i)pk_(test|live)_[0-9a-z]{10,32}`),
+		Keywords: []string{"pk_test_", "pk_live_"},
+	},
+	{
+		ID:       "stripe-secret-token",
+		Category: CategoryStripe,
+		Title:    "Stripe Secret Key",
+		Severity: "CRITICAL",
+		Regex:    MustCompile(`(?i)sk_(test|live)_[0-9a-z]{10,32}`),
+		Keywords: []string{"sk_test_", "sk_live_"},
 	},
 	{
 		ID:       "pypi-upload-token",


### PR DESCRIPTION
## Description

before:

```
{
      "Target": "/app/config/secret.yaml",
      "Class": "secret",
      "Secrets": [
        {
          "RuleID": "stripe-access-token",
          "Category": "Stripe",
          "Severity": "HIGH",
          "Title": "Stripe",
          "StartLine": 3,
          "EndLine": 3,
          "Match": "publishable_key: *****"
        },
        {
          "RuleID": "stripe-access-token",
          "Category": "Stripe",
          "Severity": "HIGH",
          "Title": "Stripe",
          "StartLine": 4,
          "EndLine": 4,
          "Match": "secret_key: *****"
        }
      ]
    }
```

after:

```
{
      "Target": "/app/config/secret.yaml",
      "Class": "secret",
      "Secrets": [
        {
          "RuleID": "stripe-publishable-token",
          "Category": "Stripe",
          "Severity": "LOW",
          "Title": "Stripe Publishable Key",
          "StartLine": 3,
          "EndLine": 3,
          "Match": "publishable_key: *****"
        },
        {
          "RuleID": "stripe-secret-token",
          "Category": "Stripe",
          "Severity": "CRITICAL",
          "Title": "Stripe Secret Key",
          "StartLine": 4,
          "EndLine": 4,
          "Match": "secret_key: *****"
        }
      ]
    }
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2391

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
