### PR TITLE
chore(helm): bump appVersion to latest release

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.4.15
-appVersion: 0.27.0
+version: 0.4.16
+appVersion: 0.29.2
 description: Trivy helm chart
 keywords:
   - scanner


### PR DESCRIPTION
## Description

But Helm chart appVersion to the latest trivy release.

If the Helm chart is published with releases of trivy, I would expect some automation to ensure the appVersion is kept up-to-date? Is this apparently not working because that automation is not implemented yet, or is there a bug somewhere? @krol3 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
