### PR TITLE
chore(suse): update EOL dates for SUSE SLES 15.3, 15.4 and OpenSUSE 15.4

### DIFF
--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -38,10 +38,10 @@ var (
 		"15":   time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.1": time.Date(2021, 1, 31, 23, 59, 59, 0, time.UTC),
 		"15.2": time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC),
-		// 6 months after SLES 15 SP4 release
-		"15.3": time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
+		"15.3": time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC),
 		// 6 months after SLES 15 SP5 release
-		// "15.4":   time.Date(2028, 7, 31, 23, 59, 59, 0, time.UTC),
+		"15.4": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
+		//"15.5": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{
@@ -53,6 +53,7 @@ var (
 		"15.1": time.Date(2020, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.2": time.Date(2021, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.3": time.Date(2022, 11, 30, 23, 59, 59, 0, time.UTC),
+		"15.4": time.Date(2023, 11, 30, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION
## Description
SUSE SLES 15.4 and OpenSUSE 15.4 were released, so this PR updates its EOL dates and also for SLES 15.3.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2402

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>