### PR TITLE
ci: auto generation configs for deb packages

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -12,6 +12,23 @@ for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   reprepro -A arm64 remove $release trivy
 done
 
+rm -r conf
+mkdir conf
+
+DEBIAN_ALL_RELEASES=$(debian-distro-info --all)
+UBUNTU_ALL_RELEASES=$(ubuntu-distro-info --all)
+
+for release in ${DEBIAN_ALL_RELEASES[@]} ${UBUNTU_ALL_RELEASES[@]}; do
+  echo "Origin: aquasecurity.github.io/trivy-repo/deb
+Label: github.io/aquasecurity
+Codename: $release
+Architectures: i386 amd64 arm64
+Components: main
+Description: Trivy repository
+SignWith: 2E2D3567461632C84BB6CD6FE9D0A3616276FA6C
+" >> conf/distributions
+done
+
 for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Adding deb package to $release"
   reprepro includedeb $release ../../dist/*Linux-64bit.deb


### PR DESCRIPTION
## Description
Added auto generation `conf/distributions` for building deb packages.

## Related issues
- Close #1692 
- the first PR #1775

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
