### PR TITLE
fix(server): hot update the db from a custom repository

### DIFF
--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -60,6 +60,6 @@ func run(c Option) (err error) {
 	}
 	m.Register()
 
-	server := rpcServer.NewServer(c.AppVersion, c.Listen, c.CacheDir, c.Token, c.TokenHeader)
+	server := rpcServer.NewServer(c.AppVersion, c.Listen, c.CacheDir, c.Token, c.TokenHeader, c.DBRepository)
 	return server.ListenAndServe(cache, c.Insecure)
 }

--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -26,21 +26,23 @@ const updateInterval = 1 * time.Hour
 
 // Server represents Trivy server
 type Server struct {
-	appVersion  string
-	addr        string
-	cacheDir    string
-	token       string
-	tokenHeader string
+	appVersion   string
+	addr         string
+	cacheDir     string
+	token        string
+	tokenHeader  string
+	dbRepository string
 }
 
 // NewServer returns an instance of Server
-func NewServer(appVersion, addr, cacheDir, token, tokenHeader string) Server {
+func NewServer(appVersion, addr, cacheDir, token, tokenHeader, dbRepository string) Server {
 	return Server{
-		appVersion:  appVersion,
-		addr:        addr,
-		cacheDir:    cacheDir,
-		token:       token,
-		tokenHeader: tokenHeader,
+		appVersion:   appVersion,
+		addr:         addr,
+		cacheDir:     cacheDir,
+		token:        token,
+		tokenHeader:  tokenHeader,
+		dbRepository: dbRepository,
 	}
 }
 
@@ -50,7 +52,7 @@ func (s Server) ListenAndServe(serverCache cache.Cache, insecure bool) error {
 	dbUpdateWg := &sync.WaitGroup{}
 
 	go func() {
-		worker := newDBWorker(dbc.NewClient(s.cacheDir, true, insecure))
+		worker := newDBWorker(dbc.NewClient(s.cacheDir, true, insecure, dbc.WithDBRepository(s.dbRepository)))
 		ctx := context.Background()
 		for {
 			time.Sleep(updateInterval)


### PR DESCRIPTION
## Description
A new db client in server mode didn't set up a custom repository, but we should do it for hot updates.
https://github.com/aquasecurity/trivy/blob/57ed5774590434acc8becfb131338f5889cab749/pkg/rpc/server/listen.go#L53

## Related issues
- Close #2376 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
