### PR TITLE
fix(cli): fix version string in docs link when secret scanning is enabled

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -3,7 +3,6 @@ package artifact
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
@@ -470,13 +469,9 @@ func initScannerConfig(opt Option, cacheClient cache.Cache) (ScannerConfig, type
 
 	// Do not load config file for secret scanning
 	if slices.Contains(opt.SecurityChecks, types.SecurityCheckSecret) {
-		ver := fmt.Sprintf("v%s", opt.AppVersion)
-		if opt.AppVersion == "dev" {
-			ver = opt.AppVersion
-		}
 		log.Logger.Info("Secret scanning is enabled")
 		log.Logger.Info("If your scanning is slow, please try '--security-checks vuln' to disable secret scanning")
-		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", ver)
+		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", opt.AppVersion)
 	} else {
 		opt.SecretConfigPath = ""
 	}


### PR DESCRIPTION
## Description

Looks like we were prefixing the version string with an extra `v` at some point.

This removes it 😄 

Before:

<img width="1584" alt="image" src="https://user-images.githubusercontent.com/5461940/176494575-e5170180-9dd0-46ce-bae5-ab32a09dcd0b.png">

After:

<img width="1584" alt="image" src="https://user-images.githubusercontent.com/5461940/176494990-483b4b0a-4567-4a89-b012-72580ba773fe.png">

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
