### PR TITLE
docs(nodejs): add docs about pnpm support

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,7 +28,7 @@ See [Integrations][integrations] for details.
 
 - Comprehensive vulnerability detection
     - [OS packages][os] (Alpine, Red Hat Universal Base Image, Red Hat Enterprise Linux, CentOS, AlmaLinux, Rocky Linux, CBL-Mariner, Oracle Linux, Debian, Ubuntu, Amazon Linux, openSUSE Leap, SUSE Enterprise Linux, Photon OS and Distroless)
-    - [**Language-specific packages**][lang] (Bundler, Composer, Pipenv, Poetry, npm, yarn, Cargo, NuGet, Maven, and Go)
+    - [**Language-specific packages**][lang] (Bundler, Composer, Pipenv, Poetry, npm, yarn, pnpm, Cargo, NuGet, Maven, and Go)
 - Detect IaC misconfigurations
     - A wide variety of [built-in policies][builtin] are provided **out of the box**:
         - Kubernetes

--- a/docs/docs/vulnerability/detection/language.md
+++ b/docs/docs/vulnerability/detection/language.md
@@ -2,26 +2,27 @@
 
 `Trivy` automatically detects the following files in the container and scans vulnerabilities in the application dependencies.
 
-| Language | File                     | Image[^8] | Rootfs[^9] | Filesystem[^10] | Repository[^11] |Dev dependencies |
-|----------|--------------------------|:---------:|:----------:|:--------------:|:--------------:|-----------------|
-| Ruby     | Gemfile.lock             | -         | -          |       ✅        |       ✅        | included        |
-|          | gemspec                  | ✅        | ✅         |       -        |       -        | included        |
-| Python   | Pipfile.lock             | -         | -          |       ✅        |       ✅        | excluded        |
-|          | poetry.lock              | -         | -          |       ✅        |       ✅        | included        |
-|          | requirements.txt         | -         | -          |       ✅        |       ✅        | included        |
-|          | egg package[^1]          | ✅        | ✅         |       -        |       -        | excluded        |
-|          | wheel package[^2]        | ✅        | ✅         |       -        |       -        | excluded        |
-| PHP      | composer.lock            | ✅        | ✅         |       ✅        |       ✅        | excluded        |
-| Node.js  | package-lock.json        | -         | -          |       ✅        |       ✅        | excluded        |
-|          | yarn.lock                | -         | -          |       ✅        |       ✅        | included        |
-|          | package.json             | ✅        | ✅         |       -        |       -        | excluded        |
-| .NET     | packages.lock.json       | ✅        | ✅         |       ✅        |       ✅        | included        |
-|          | packages.config          | ✅        | ✅         |       ✅        |       ✅        | excluded        |
-| Java     | JAR/WAR/PAR/EAR[^3][^4]  | ✅        | ✅         |       -        |       -        | included        |
-|          | pom.xml[^5]              | -         | -          |       ✅        |       ✅        | excluded        |
-| Go       | Binaries built by Go[^6] | ✅        | ✅         |       -        |       -        | excluded        |
-|          | go.mod[^7]               | -         | -          |       ✅        |       ✅        | included        |
-| Rust     | Cargo.lock               | ✅        | ✅         |       ✅        |       ✅        | included        |
+| Language | File                     | Image[^8] | Rootfs[^9] | Filesystem[^10] | Repository[^11] | Dev dependencies |
+| -------- | ------------------------ | :-------: | :--------: | :-------------: | :-------------: | ---------------- |
+| Ruby     | Gemfile.lock             |     -     |     -      |        ✅        |        ✅        | included         |
+|          | gemspec                  |     ✅     |     ✅      |        -        |        -        | included         |
+| Python   | Pipfile.lock             |     -     |     -      |        ✅        |        ✅        | excluded         |
+|          | poetry.lock              |     -     |     -      |        ✅        |        ✅        | included         |
+|          | requirements.txt         |     -     |     -      |        ✅        |        ✅        | included         |
+|          | egg package[^1]          |     ✅     |     ✅      |        -        |        -        | excluded         |
+|          | wheel package[^2]        |     ✅     |     ✅      |        -        |        -        | excluded         |
+| PHP      | composer.lock            |     ✅     |     ✅      |        ✅        |        ✅        | excluded         |
+| Node.js  | package-lock.json        |     -     |     -      |        ✅        |        ✅        | excluded         |
+|          | yarn.lock                |     -     |     -      |        ✅        |        ✅        | included         |
+|          | pnpm-lock.yaml           |     -     |     -      |        ✅        |        ✅        | excluded         |
+|          | package.json             |     ✅     |     ✅      |        -        |        -        | excluded         |
+| .NET     | packages.lock.json       |     ✅     |     ✅      |        ✅        |        ✅        | included         |
+|          | packages.config          |     ✅     |     ✅      |        ✅        |        ✅        | excluded         |
+| Java     | JAR/WAR/PAR/EAR[^3][^4]  |     ✅     |     ✅      |        -        |        -        | included         |
+|          | pom.xml[^5]              |     -     |     -      |        ✅        |        ✅        | excluded         |
+| Go       | Binaries built by Go[^6] |     ✅     |     ✅      |        -        |        -        | excluded         |
+|          | go.mod[^7]               |     -     |     -      |        ✅        |        ✅        | included         |
+| Rust     | Cargo.lock               |     ✅     |     ✅      |        ✅        |        ✅        | included         |
 
 The path of these files does not matter.
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -4,7 +4,7 @@ Trivy detects three types of security issues:
 
 - [Vulnerabilities][vuln]
     - [OS packages][os] (Alpine, Red Hat Universal Base Image, Red Hat Enterprise Linux, CentOS, AlmaLinux, Rocky Linux, CBL-Mariner, Oracle Linux, Debian, Ubuntu, Amazon Linux, openSUSE Leap, SUSE Enterprise Linux, Photon OS and Distroless)
-    - [Language-specific packages][lang] (Bundler, Composer, Pipenv, Poetry, npm, yarn, Cargo, NuGet, Maven, and Go)
+    - [Language-specific packages][lang] (Bundler, Composer, Pipenv, Poetry, npm, yarn, pnpm, Cargo, NuGet, Maven, and Go)
 - [Misconfigurations][misconf]
     - Kubernetes
     - Docker


### PR DESCRIPTION
## Description

This PR completes the PR #2414 adding references to the support of pnpm in the documentation.

I think this is all that is needed to reflect pnpm support, if I should update something else in the documentation let me know.

## Related PRs
- [ ] #2414 

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
