### PR TITLE
ci: add pushing canary build images to registries

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - '**.go'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -84,6 +84,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
 
+      ## push images to registries
+      ## only for canary build
+      - name: Build and push
+        if: ${{ inputs.goreleaser_config == 'goreleaser-canary.yml' }}
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64, linux/arm64
+          file: ./Dockerfile.canary # path to Dockerfile
+          context: .
+          push: true
+          tags: |
+            aquasec/trivy:canary
+            ghcr.io/aquasecurity/trivy:canary
+            public.ecr.aws/aquasecurity/trivy:canary
+
       - name: Cache Trivy binaries
         uses: actions/cache@v3.0.2
         with:

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,0 +1,7 @@
+FROM alpine:3.16.0
+RUN apk --no-cache add ca-certificates git
+ARG TARGETARCH
+# example dir with trivy arm64 binary: dist/trivy_canary_build_linux_arm64/trivy
+COPY "dist/trivy_canary_build_linux_${TARGETARCH}/trivy" /usr/local/bin/trivy
+COPY contrib/*.tpl contrib/
+ENTRYPOINT ["trivy"]

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,7 +1,10 @@
 FROM alpine:3.16.0
 RUN apk --no-cache add ca-certificates git
+
+# binaries were created with GoReleaser
+# need to copy binaries from folder with correct architecture
+# example architecture folder: dist/trivy_canary_build_linux_arm64/trivy
 ARG TARGETARCH
-# example dir with trivy arm64 binary: dist/trivy_canary_build_linux_arm64/trivy
 COPY "dist/trivy_canary_build_linux_${TARGETARCH}/trivy" /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
## Description
added pushing `canary build images` to registries.

#### Arch:
- amd64
- arm64

#### Registry:
- docker hub
- GHCR
- ECR

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
