### PR TITLE
feat(amazon): add support for 2022 version

### DIFF
--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,22 +1,23 @@
 # OS
 
-| OS             | Source                                                                              |
-| ---------------| ---------------------------------------- |
-| Arch Linux     | [Vulnerable Issues][arch]                |
-| Alpine Linux   | [secdb][alpine]                          |
-| Amazon Linux 1 | [Amazon Linux Security Center][amazon1]  |
-| Amazon Linux 2 | [Amazon Linux Security Center][amazon2]  |
-| Debian         | [Security Bug Tracker][debian-tracker]   |
-|                | [OVAL][debian-oval]                      |
-| Ubuntu         | [Ubuntu CVE Tracker][ubuntu]             |
-| RHEL/CentOS    | [OVAL][rhel-oval]                        |
-|                | [Security Data][rhel-api]                |
-| AlmaLinux      | [AlmaLinux Product Errata][alma]         |
-| Rocky Linux    | [Rocky Linux UpdateInfo][rocky]          |
-| Oracle Linux   | [OVAL][oracle]                           |
-| CBL-Mariner    | [OVAL][mariner]                          |
-| OpenSUSE/SLES	 | [CVRF][suse]                             |
-| Photon OS      | [Photon Security Advisory][photon]       |
+| OS                | Source                                     |
+|-------------------|--------------------------------------------|
+| Arch Linux        | [Vulnerable Issues][arch]                  |
+| Alpine Linux      | [secdb][alpine]                            |
+| Amazon Linux 1    | [Amazon Linux Security Center][amazon1]    |
+| Amazon Linux 2    | [Amazon Linux Security Center][amazon2]    |
+| Amazon Linux 2022 | [Amazon Linux Security Center][amazon2022] |
+| Debian            | [Security Bug Tracker][debian-tracker]     |
+|                   | [OVAL][debian-oval]                        |
+| Ubuntu            | [Ubuntu CVE Tracker][ubuntu]               |
+| RHEL/CentOS       | [OVAL][rhel-oval]                          |
+|                   | [Security Data][rhel-api]                  |
+| AlmaLinux         | [AlmaLinux Product Errata][alma]           |
+| Rocky Linux       | [Rocky Linux UpdateInfo][rocky]            |
+| Oracle Linux      | [OVAL][oracle]                             |
+| CBL-Mariner       | [OVAL][mariner]                            |
+| OpenSUSE/SLES     | [CVRF][suse]                               |
+| Photon OS         | [Photon Security Advisory][photon]         |
 
 # Programming Language
 
@@ -59,6 +60,7 @@ The severity is from the selected data source. If the data source does not provi
 [alpine]: https://secdb.alpinelinux.org/
 [amazon1]: https://alas.aws.amazon.com/
 [amazon2]: https://alas.aws.amazon.com/alas2.html
+[amazon2022]: https://alas.aws.amazon.com/alas2022.html
 [debian-tracker]: https://security-tracker.debian.org/tracker/
 [debian-oval]: https://www.debian.org/security/oval/
 [ubuntu]: https://ubuntu.com/security/cve

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -1,23 +1,21 @@
 # OS
 
-| OS                | Source                                     |
-|-------------------|--------------------------------------------|
-| Arch Linux        | [Vulnerable Issues][arch]                  |
-| Alpine Linux      | [secdb][alpine]                            |
-| Amazon Linux 1    | [Amazon Linux Security Center][amazon1]    |
-| Amazon Linux 2    | [Amazon Linux Security Center][amazon2]    |
-| Amazon Linux 2022 | [Amazon Linux Security Center][amazon2022] |
-| Debian            | [Security Bug Tracker][debian-tracker]     |
-|                   | [OVAL][debian-oval]                        |
-| Ubuntu            | [Ubuntu CVE Tracker][ubuntu]               |
-| RHEL/CentOS       | [OVAL][rhel-oval]                          |
-|                   | [Security Data][rhel-api]                  |
-| AlmaLinux         | [AlmaLinux Product Errata][alma]           |
-| Rocky Linux       | [Rocky Linux UpdateInfo][rocky]            |
-| Oracle Linux      | [OVAL][oracle]                             |
-| CBL-Mariner       | [OVAL][mariner]                            |
-| OpenSUSE/SLES     | [CVRF][suse]                               |
-| Photon OS         | [Photon Security Advisory][photon]         |
+| OS                 | Source                                      |
+|--------------------|---------------------------------------------|
+| Arch Linux         | [Vulnerable Issues][arch]                   |
+| Alpine Linux       | [secdb][alpine]                             |
+| Amazon Linux       | [Amazon Linux Security Center][amazon]      |
+| Debian             | [Security Bug Tracker][debian-tracker]      |
+|                    | [OVAL][debian-oval]                         |
+| Ubuntu             | [Ubuntu CVE Tracker][ubuntu]                |
+| RHEL/CentOS        | [OVAL][rhel-oval]                           |
+|                    | [Security Data][rhel-api]                   |
+| AlmaLinux          | [AlmaLinux Product Errata][alma]            |
+| Rocky Linux        | [Rocky Linux UpdateInfo][rocky]             |
+| Oracle Linux       | [OVAL][oracle]                              |
+| CBL-Mariner        | [OVAL][mariner]                             |
+| OpenSUSE/SLES      | [CVRF][suse]                                |
+| Photon OS          | [Photon Security Advisory][photon]          |
 
 # Programming Language
 
@@ -58,9 +56,7 @@ The severity is from the selected data source. If the data source does not provi
 
 [arch]: https://security.archlinux.org/
 [alpine]: https://secdb.alpinelinux.org/
-[amazon1]: https://alas.aws.amazon.com/
-[amazon2]: https://alas.aws.amazon.com/alas2.html
-[amazon2022]: https://alas.aws.amazon.com/alas2022.html
+[amazon]: https://alas.aws.amazon.com/
 [debian-tracker]: https://security-tracker.debian.org/tracker/
 [debian-oval]: https://www.debian.org/security/oval/
 [ubuntu]: https://ubuntu.com/security/cve

--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -12,7 +12,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 | Rocky Linux                      | 8                                         | Installed by yum/rpm          |                  NO                  |
 | Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
 | CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
-| Amazon Linux                     | 1, 2                                      | Installed by yum/rpm          |                  NO                  |
+| Amazon Linux                     | 1, 2, 2022                                | Installed by yum/rpm          |                  NO                  |
 | openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |
 | SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |
 | Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -65,7 +65,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	log.Logger.Info("Detecting Amazon Linux vulnerabilities...")
 
 	osVer = strings.Fields(osVer)[0]
-	if osVer != "2" {
+	if osVer != "2" && osVer != "2022" {
 		osVer = "1"
 	}
 	log.Logger.Debugf("amazon: os version: %s", osVer)

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -20,8 +20,9 @@ import (
 var (
 	eolDates = map[string]time.Time{
 		"1": time.Date(2023, 6, 30, 23, 59, 59, 0, time.UTC),
+		"2": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		// N/A
-		"2": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"2022": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}
 )
 

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -212,6 +212,15 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "amazon linux 2022",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "2022",
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -96,6 +96,38 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "amazon linux 2022",
+			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "2022",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "log4j",
+						Version: "2.14.0",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "log4j",
+					VulnerabilityID:  "CVE-2021-44228",
+					InstalledVersion: "2.14.0",
+					FixedVersion:     "2.15.0-1.amzn2022.0.1",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Amazon,
+						Name: "Amazon Linux Security Center",
+						URL:  "https://alas.aws.amazon.com/",
+					},
+				},
+			},
+		},
+		{
 			name:     "empty version",
 			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/amazon/testdata/fixtures/amazon.yaml
+++ b/pkg/detector/ospkg/amazon/testdata/fixtures/amazon.yaml
@@ -12,3 +12,10 @@
         - key: CVE-2019-9924
           value:
             FixedVersion: "4.2.46-34.amzn2"
+- bucket: amazon linux 2022
+  pairs:
+    - bucket: log4j
+      pairs:
+        - key: CVE-2021-44228
+          value:
+            FixedVersion: "2.15.0-1.amzn2022.0.1"

--- a/pkg/detector/ospkg/amazon/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/amazon/testdata/fixtures/data-source.yaml
@@ -10,3 +10,8 @@
         ID: "amazon"
         Name: "Amazon Linux Security Center"
         URL: "https://alas.aws.amazon.com/"
+    - key: amazon linux 2022
+      value:
+        ID: "amazon"
+        Name: "Amazon Linux Security Center"
+        URL: "https://alas.aws.amazon.com/"

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
@@ -3,7 +3,6 @@ package amazonlinux
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -25,7 +24,10 @@ func init() {
 
 const version = 1
 
-var requiredFiles = []string{"etc/system-release"}
+var requiredFiles = []string{
+	"etc/system-release",     // for 1 and 2 versions
+	"usr/lib/system-release", // for 2022 version
+}
 
 type amazonlinuxOSAnalyzer struct{}
 
@@ -51,7 +53,7 @@ func (a amazonlinuxOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 			}
 			return types.OS{
 				Family: aos.Amazon,
-				Name:   fmt.Sprintf("%s %s", fields[3], fields[4]),
+				Name:   strings.Join(fields[3:], " "),
 			}, nil
 		} else if strings.HasPrefix(line, "Amazon Linux") {
 			return types.OS{

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -48,6 +48,19 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path amazon linux 2022",
+			input: analyzer.AnalysisInput{
+				FilePath: "usr/lib/system-release",
+				Content:  strings.NewReader(`Amazon Linux release 2022 (Amazon Linux)`),
+			},
+			want: &analyzer.AnalysisResult{
+				OS: &types.OS{
+					Family: aos.Amazon,
+					Name:   "2022 (Amazon Linux)",
+				},
+			},
+		},
+		{
 			name: "sad path amazon linux 2 without code name",
 			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",


### PR DESCRIPTION
## Description
add support for Amazon Linux 2022

```
➜ trivy image --severity HIGH public.ecr.aws/amazonlinux/amazonlinux:2022.0.20220308.1
2022-06-30T17:37:25.120+0600    INFO    Vulnerability scanning is enabled
2022-06-30T17:37:25.120+0600    INFO    Secret scanning is enabled
2022-06-30T17:37:25.120+0600    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-06-30T17:37:25.120+0600    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2022-06-30T17:37:26.855+0600    INFO    Detected OS: amazon
2022-06-30T17:37:26.855+0600    INFO    Detecting Amazon Linux vulnerabilities...
2022-06-30T17:37:26.857+0600    INFO    Number of language-specific files: 0

public.ecr.aws/amazonlinux/amazonlinux:2022.0.20220308.1 (amazon 2022 (Amazon Linux))

Total: 2 (HIGH: 2)

┌──────────────┬───────────────┬──────────┬─────────────────────┬────────────────────────┬───────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability │ Severity │  Installed Version  │     Fixed Version      │                           Title                           │
├──────────────┼───────────────┼──────────┼─────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────┤
│ openssl-libs │ CVE-2022-0778 │ HIGH     │ 1:1.1.1l-2.amzn2022 │ 1:3.0.0-1.amzn2022.0.1 │ Package updates are available for Amazon Linux 2 that fix │
│              │               │          │                     │                        │ the following...                                          │
│              │               │          │                     │                        │ https://avd.aquasec.com/nvd/cve-2022-0778                 │
├──────────────┼───────────────┤          ├─────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────┤
│ xz-libs      │ CVE-2022-1271 │          │ 5.2.5-5.amzn2022    │ 5.2.5-9.amzn2022       │ Package updates are available for Amazon Linux 2 that fix │
│              │               │          │                     │                        │ the following...                                          │
│              │               │          │                     │                        │ https://avd.aquasec.com/nvd/cve-2022-1271                 │
└──────────────┴───────────────┴──────────┴─────────────────────┴────────────────────────┴───────────────────────────────────────────────────────────┘

```

## Related issues
- Close #2409

## Related PRs
- [x] #aquasecurity/trivy-db/pull/224/files
- [x] #aquasecurity/vuln-list-update/pull/166

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
