### PR TITLE
docs: remove links to removed content

### DIFF
--- a/docs/docs/kubernetes/operator/index.md
+++ b/docs/docs/kubernetes/operator/index.md
@@ -1,16 +1,10 @@
 # Trivy Operator  
 
-Trivy has a native [Kubernetes Operator](operator) which continuously scans your Kubernetes cluster for security issues, and generates security reports as Kubernetes [Custom Resources](crd). It does it by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.
+Trivy has a native [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which continuously scans your Kubernetes cluster for security issues, and generates security reports as Kubernetes [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). It does it by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.
 
 
 > Kubernetes-native security toolkit. ([Documentation](https://aquasecurity.github.io/trivy-operator/latest)).
 
-
 <figure>
   <figcaption>Workload reconcilers discover K8s controllers, manage scan jobs, and create VulnerabilityReport and ConfigAuditReport objects.</figcaption>
 </figure>
-
-[operator]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
-[crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[Starboard]: https://github.com/aquasecurity/starboard
-[starboard-announcement]: https://github.com/aquasecurity/starboard/discussions/1173

--- a/docs/docs/kubernetes/operator/index.md
+++ b/docs/docs/kubernetes/operator/index.md
@@ -7,7 +7,6 @@ Trivy has a native [Kubernetes Operator](operator) which continuously scans your
 
 
 <figure>
-  <img src="./images/operator/trivy-operator-workloads.png" />
   <figcaption>Workload reconcilers discover K8s controllers, manage scan jobs, and create VulnerabilityReport and ConfigAuditReport objects.</figcaption>
 </figure>
 

--- a/docs/docs/kubernetes/operator/index.md
+++ b/docs/docs/kubernetes/operator/index.md
@@ -1,10 +1,14 @@
 # Trivy Operator  
 
-Trivy has a native [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) which continuously scans your Kubernetes cluster for security issues, and generates security reports as Kubernetes [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/). It does it by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.
+Trivy has a native [Kubernetes Operator][operator] which continuously scans your Kubernetes cluster for security issues, and generates security reports as Kubernetes [Custom Resources][crd]. It does it by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.
 
 
-> Kubernetes-native security toolkit. ([Documentation](https://aquasecurity.github.io/trivy-operator/latest)).
+> Kubernetes-native security toolkit. ([Documentation][trivy-operator]).
 
 <figure>
   <figcaption>Workload reconcilers discover K8s controllers, manage scan jobs, and create VulnerabilityReport and ConfigAuditReport objects.</figcaption>
 </figure>
+
+[operator]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
+[crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[trivy-operator]: https://aquasecurity.github.io/trivy-operator/latest

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,16 +23,6 @@ All you need to do for scanning is to specify a target such as an image name of 
 </div>
 
 <figure style="text-align: center">
-  <img src="imgs/vuln-demo.gif" width="1000">
-  <figcaption>Demo: Vulnerability Detection</figcaption>
-</figure>
-
-<figure style="text-align: center">
-  <img src="imgs/misconf-demo.gif" width="1000">
-  <figcaption>Demo: Misconfiguration Detection</figcaption>
-</figure>
-
-<figure style="text-align: center">
   <img src="imgs/secret-demo.gif" width="1000">
   <figcaption>Demo: Secret Detection</figcaption>
 </figure>

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,20 @@ All you need to do for scanning is to specify a target such as an image name of 
 </div>
 
 <figure style="text-align: center">
+  <video width="1000">
+    <source src="https://user-images.githubusercontent.com/1161307/171013513-95f18734-233d-45d3-aaf5-d6aec687db0e.mov" type="video/mp4" />
+  </video>
+  <figcaption>Demo: Vulnerability Detection</figcaption>
+</figure>
+
+<figure style="text-align: center">
+  <video width="1000">
+    <source src="https://user-images.githubusercontent.com/1161307/171013917-b1f37810-f434-465c-b01a-22de036bd9b3.mov" type="video/mp4" />
+  </video>
+  <figcaption>Demo: Misconfiguration Detection</figcaption>
+</figure>
+
+<figure style="text-align: center">
   <img src="imgs/secret-demo.gif" width="1000">
   <figcaption>Demo: Secret Detection</figcaption>
 </figure>


### PR DESCRIPTION
## Description
the content about `trivy-operator` was removed #2372, but there are some links.
some links to `kubernetes.io` didn't build correctly.

also PR #2110 removed some gifs, but there is mention on the home page.

## Related issues
- Close #2417

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
