### PR TITLE
ci: add rhel 9 to rpm deploy

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -15,7 +15,7 @@ function create_rpm_repo () {
 
 cd trivy-repo
 
-VERSIONS=(5 6 7 8)
+VERSIONS=(5 6 7 8 9)
 for version in ${VERSIONS[@]}; do
         echo "Processing RHEL/CentOS $version..."
         create_rpm_repo $version


### PR DESCRIPTION
## Description
`Red Hat UBI 9` released.
Add RHEL 9 to rpm deploy.

Tested in fork:
- https://github.com/DmitriyLewen/trivy/runs/7148839349?check_suite_focus=true
- https://github.com/DmitriyLewen/trivy-repo/tree/main/rpm/releases/9/x86_64

## Related issues
- Close #2426

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
