### PR TITLE
fix: update initialisation of remote options

### DIFF
--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -83,14 +83,18 @@ func (f *RemoteFlags) AddFlags(cmd *cobra.Command) {
 func (f *RemoteFlags) ToOptions() RemoteOptions {
 	serverAddr := viper.GetString(ServerFlag)
 	customHeaders := splitCustomHeaders(viper.GetStringSlice(CustomHeadersFlag))
+	listen := viper.GetString(ServerListenFlag)
 	token := viper.GetString(ServerTokenFlag)
 	tokenHeader := viper.GetString(ServerTokenHeaderFlag)
+	if tokenHeader == "" {
+		tokenHeader = DefaultTokenHeader
+	}
 
 	if serverAddr == "" {
 		switch {
 		case len(lo.FromPtr(f.CustomHeaders)) > 0:
 			log.Logger.Warn(`"--custom-header"" can be used only with "--server"`)
-		case token != "":
+		case token != "" && listen == "":
 			log.Logger.Warn(`"--token" can be used only with "--server"`)
 		case tokenHeader != "" && tokenHeader != DefaultTokenHeader:
 			log.Logger.Warn(`'--token-header' can be used only with "--server"`)
@@ -106,7 +110,7 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 		TokenHeader:   tokenHeader,
 		ServerAddr:    serverAddr,
 		CustomHeaders: customHeaders,
-		Listen:        viper.GetString(ServerListenFlag),
+		Listen:        listen,
 	}
 }
 

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -57,7 +57,7 @@ func NewClientFlags() *RemoteFlags {
 func NewServerDefaultFlags() *RemoteFlags {
 	return &RemoteFlags{
 		Token:       lo.ToPtr(""),
-		TokenHeader: lo.ToPtr(""),
+		TokenHeader: lo.ToPtr(DefaultTokenHeader),
 		Listen:      lo.ToPtr("localhost:4954"),
 	}
 }
@@ -73,7 +73,7 @@ func (f *RemoteFlags) AddFlags(cmd *cobra.Command) {
 		cmd.Flags().String(ServerTokenFlag, *f.Token, "for authentication in client/server mode")
 	}
 	if f.TokenHeader != nil {
-		cmd.Flags().String(ServerTokenHeaderFlag, *f.Token, "specify a header name for token in client/server mode")
+		cmd.Flags().String(ServerTokenHeaderFlag, *f.TokenHeader, "specify a header name for token in client/server mode")
 	}
 	if f.Listen != nil {
 		cmd.Flags().String(ServerListenFlag, *f.Listen, "listen address")
@@ -86,9 +86,6 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 	listen := viper.GetString(ServerListenFlag)
 	token := viper.GetString(ServerTokenFlag)
 	tokenHeader := viper.GetString(ServerTokenHeaderFlag)
-	if tokenHeader == "" {
-		tokenHeader = DefaultTokenHeader
-	}
 
 	if serverAddr == "" {
 		switch {


### PR DESCRIPTION
## Description
`tokenHeader` was always empty by default. 

also there was a wrong warning for `server` mode:
```sh
$ trivy server --token testtoken
2022-07-06T16:14:08.866+0600    WARN    "--token" can be used only with "--server"
2022-07-06T16:14:08.870+0600    INFO    Listening localhost:4954...
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
