### PR TITLE
fix: don't show warnings for server mode

### DIFF
--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -90,11 +90,11 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 	if serverAddr == "" && listen == "" {
 		switch {
 		case len(customHeaders) > 0:
-			log.Logger.Warn(`"--custom-header" can be used only with "--server" or with "server" subcommand`)
+			log.Logger.Warn(`"--custom-header" can be used only with "--server"`)
 		case token != "":
-			log.Logger.Warn(`"--token" can be used only with "--server" or with "server" subcommand`)
+			log.Logger.Warn(`"--token" can be used only with "--server"`)
 		case tokenHeader != "" && tokenHeader != DefaultTokenHeader:
-			log.Logger.Warn(`"--token-header" can be used only with "--server" or with "server" subcommand`)
+			log.Logger.Warn(`"--token-header" can be used only with "--server"`)
 		}
 	}
 

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -90,11 +90,11 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 	if serverAddr == "" && listen == "" {
 		switch {
 		case len(lo.FromPtr(f.CustomHeaders)) > 0:
-			log.Logger.Warn(`"--custom-header"" can be used only with "--server" or with "server" subcommand`)
+			log.Logger.Warn(`"--custom-header" can be used only with "--server" or with "server" subcommand`)
 		case token != "":
 			log.Logger.Warn(`"--token" can be used only with "--server" or with "server" subcommand`)
 		case tokenHeader != "" && tokenHeader != DefaultTokenHeader:
-			log.Logger.Warn(`'--token-header' can be used only with "--server" or with "server" subcommand`)
+			log.Logger.Warn(`"--token-header" can be used only with "--server" or with "server" subcommand`)
 		}
 	}
 

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -87,14 +87,14 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 	token := viper.GetString(ServerTokenFlag)
 	tokenHeader := viper.GetString(ServerTokenHeaderFlag)
 
-	if serverAddr == "" {
+	if serverAddr == "" && listen == "" {
 		switch {
 		case len(lo.FromPtr(f.CustomHeaders)) > 0:
-			log.Logger.Warn(`"--custom-header"" can be used only with "--server"`)
-		case token != "" && listen == "":
-			log.Logger.Warn(`"--token" can be used only with "--server"`)
+			log.Logger.Warn(`"--custom-header"" can be used only with "--server" or with "server" subcommand`)
+		case token != "":
+			log.Logger.Warn(`"--token" can be used only with "--server" or with "server" subcommand`)
 		case tokenHeader != "" && tokenHeader != DefaultTokenHeader:
-			log.Logger.Warn(`'--token-header' can be used only with "--server"`)
+			log.Logger.Warn(`'--token-header' can be used only with "--server" or with "server" subcommand`)
 		}
 	}
 


### PR DESCRIPTION
## Description

We shouldn't show warnings about a token and headers for `server` subcommand too.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
