### PR TITLE
fix: check of custom headers length after `viper`

### DIFF
--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -89,7 +89,7 @@ func (f *RemoteFlags) ToOptions() RemoteOptions {
 
 	if serverAddr == "" {
 		switch {
-		case len(lo.FromPtr(f.CustomHeaders)) > 0:
+		case len(customHeaders) > 0:
 			log.Logger.Warn(`"--custom-header"" can be used only with "--server"`)
 		case token != "" && listen == "":
 			log.Logger.Warn(`"--token" can be used only with "--server"`)


### PR DESCRIPTION
## Description
it seems we should check a length of custom headers after getting it from `viper`:

https://github.com/aquasecurity/trivy/blob/27c5227e1c9aba223ada086d2da13d36b59e9739/pkg/flag/remote_flags.go#L85-L93

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
