### PR TITLE
feat(cli): add support config file

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -98,6 +98,13 @@ func loadPluginCommands() []*cobra.Command {
 }
 
 func initConfig() {
+	// TODO get filepath from flag
+	viper.AddConfigPath(".")
+	viper.SetConfigName("trivy-config") // may contain extension, but still need to run SetConfigType
+	viper.SetConfigType("yaml")
+	if err := viper.ReadInConfig(); err != nil {
+		log.Logger.Warnf("unable to read config file: %w", err)
+	}
 	// Configure environment variables
 	viper.SetEnvPrefix("trivy") // will be uppercased automatically
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
@@ -127,6 +134,10 @@ func NewRootCommand(version string, globalFlags *flag.GlobalFlags) *cobra.Comman
 				return err
 			}
 			if err := viper.BindPFlags(cmd.PersistentFlags()); err != nil {
+				return err
+			}
+
+			if err := bindFlagsFromConfig(cmd); err != nil {
 				return err
 			}
 
@@ -706,4 +717,8 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func bindFlagsFromConfig(cmd *cobra.Command) error {
+	return viper.BindPFlag(flag.PolicyNamespaceFlag, cmd.Flags().Lookup(flag.PolicyNamespaceFlag))
 }

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -15,7 +15,7 @@ const (
 	TraceFlag              = "trace"
 	ConfigPolicyFlag       = "config-policy"
 	ConfigDataFlag         = "config-data"
-	PolicyNamespaceFlag    = "policy-namespaces"
+	PolicyNamespaceFlag    = "misconfiguration.namespaces"
 )
 
 // MisconfFlags composes common printer flag structs used for commands providing misconfinguration scanning.

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -155,7 +155,7 @@ func flagNameNormalize(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = ConfigPolicyFlag
 	case "data":
 		name = ConfigDataFlag
-	case "namespaces":
+	case "namespaces", "policy-namespaces":
 		name = PolicyNamespaceFlag
 	case "ctx":
 		name = ClusterContextFlag


### PR DESCRIPTION
## Description
added support config file.
Filepath: `./trivy-config.yaml`(currently unchanged)
Supported flags(with structure): 
- --policy-namespaces(--namespaces):
  ```yaml
  misconfiguration:
    namespaces:
     - "foo"
     - "bar"
  ```

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
