### PR TITLE
feat(cli): add usage info for invalid command flag

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -812,5 +812,6 @@ func flagErrorFunc(command *cobra.Command, err error) error {
 	if err := command.Help(); err != nil {
 		return err
 	}
+	command.Println() //add empty line after list of flags
 	return err
 }

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -215,6 +215,8 @@ func NewImageCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	imageFlags.AddFlags(cmd)
 
 	return cmd
@@ -253,6 +255,8 @@ func NewFilesystemCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	fsFlags.AddFlags(cmd)
 
 	return cmd
@@ -289,6 +293,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	rootfsFlags.AddFlags(cmd)
 
 	return cmd
@@ -327,6 +332,7 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	repoFlags.AddFlags(cmd)
 
 	return cmd
@@ -378,6 +384,7 @@ func NewClientCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	clientFlags.AddFlags(cmd)
 
 	return cmd
@@ -409,6 +416,7 @@ func NewServerCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	serverFlags.AddFlags(cmd)
 
 	return cmd
@@ -458,6 +466,7 @@ func NewConfigCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	configFlags.AddFlags(cmd)
 
 	return cmd
@@ -560,6 +569,7 @@ func NewPluginCommand() *cobra.Command {
 			},
 		},
 	)
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	return cmd
 }
 
@@ -604,6 +614,7 @@ func NewModuleCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 			},
 		},
 	)
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	return cmd
 }
 
@@ -660,7 +671,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
-
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	k8sFlags.AddFlags(cmd)
 
 	return cmd
@@ -707,6 +718,7 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 	sbomFlags.AddFlags(cmd)
 
 	return cmd
@@ -727,6 +739,7 @@ func NewVersionCommand(globalFlags *flag.GlobalFlags) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	// Add version format flag, only json is supported
 	cmd.Flags().StringVarP(&versionFormat, flag.FormatFlag.Name, flag.FormatFlag.Shorthand, "", "version format (json)")
@@ -792,4 +805,12 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// show help on using the command when an invalid flag is encountered
+func flagErrorFunc(command *cobra.Command, err error) error {
+	if err := command.Help(); err != nil {
+		return err
+	}
+	return err
 }


### PR DESCRIPTION
## Description
show help on using the command when an invalid flag is encountered. For example:
```
➜  ./trivy image --invalid-flag 
scan a container image

Usage:
  trivy image [flags] IMAGE_NAME

Aliases:
  image, i

Flags:
      --cache-backend string        cache backend (e.g. redis://localhost:6379) (default "fs")
      --cache-ttl duration          cache TTL when using redis as cache backend
      --clear-cache                 clear image caches without scanning
      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
      --config-policy strings       specify paths to the Rego policy files directory, applying config files
      --custom-headers strings      custom headers in client mode
      --db-repository string        OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
      --dependency-tree             show dependency origin tree (EXPERIMENTAL)
      --download-db-only            download/update vulnerability database but don't run a scan
      --exit-code int               specify exit code when any security issues are found
      --file-patterns strings       specify config file patterns, available with '--security-checks config'
  -f, --format string               format (table, json, sarif, template, cyclonedx, spdx, spdx-json, github) (default "table")
  -h, --help                        help for image
      --ignore-policy string        specify the Rego file path to evaluate each vulnerability
      --ignore-unfixed              display only fixed vulnerabilities
      --ignorefile string           specify .trivyignore file (default ".trivyignore")
      --include-non-failures        include successes and exceptions, available with '--security-checks config'
      --input string                input file path instead of image name
      --light                       deprecated
      --list-all-pkgs               enabling the option will output all packages regardless of vulnerability
      --no-progress                 suppress progress bar
      --offline-scan                do not issue API requests to identify dependencies
  -o, --output string               output file name
      --policy-namespaces strings   Rego namespaces
      --redis-ca string             redis ca file location, if using redis as cache backend
      --redis-cert string           redis certificate file location, if using redis as cache backend
      --redis-key string            redis key file location, if using redis as cache backend
      --removed-pkgs                detect vulnerabilities of removed packages (only for Alpine)
      --reset                       remove all caches and database
      --secret-config string        specify a path to config file for secret scanning (default "trivy-secret.yaml")
      --security-checks string      comma-separated list of vulnerability types (os,library) (default "vuln,secret")
      --server string               server address in client mode
  -s, --severity string             severities of security issues to be displayed (comma separated) (default "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
      --skip-db-update              skip updating vulnerability database
      --skip-dirs string            specify the directories where the traversal is skipped
      --skip-files string           specify the file paths to skip traversal
      --skip-policy-update          deprecated
  -t, --template string             output template
      --token string                for authentication in client/server mode
      --token-header string         specify a header name for token in client/server mode (default "Trivy-Token")
      --trace                       enable more verbose trace output for custom queries
      --vuln-type string            comma-separated list of vulnerability types (os,library) (default "os,library")

Global Flags:
      --cache-dir string   cache directory (default "/home/dmitriy/.cache/trivy")
  -c, --config string      config path (default "trivy.yaml")
  -d, --debug              debug mode
      --insecure           allow insecure server connections when using TLS
  -q, --quiet              suppress progress bar and log output
      --timeout duration   timeout (default 5m0s)
  -v, --version            show version

2022-07-08T11:13:32.474+0600    FATAL   unknown flag: --invalid-flag

```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
