### PR TITLE
fix(cli): disable db download for reset and clear-cache flags

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -108,13 +108,13 @@ func NewRunner(ctx context.Context, cliOptions flag.Options, opts ...runnerOptio
 		opt(r)
 	}
 
+	if err := r.initCache(cliOptions); err != nil {
+		return nil, xerrors.Errorf("cache error: %w", err)
+	}
+
 	// Update the vulnerability database if needed.
 	if err := r.initDB(cliOptions); err != nil {
 		return nil, xerrors.Errorf("DB error: %w", err)
-	}
-
-	if err := r.initCache(cliOptions); err != nil {
-		return nil, xerrors.Errorf("cache error: %w", err)
 	}
 
 	// Initialize WASM modules


### PR DESCRIPTION
## Description
disable db download for `--reset` and `--clear-cache` flags

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
