### PR TITLE
feat: add support for flag groups

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -799,7 +799,6 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          flag.NewScanFlagGroup(),
 		SBOMFlagGroup:          flag.NewSBOMFlagGroup(),
-		SecretFlagGroup:        flag.NewSecretFlagGroup(),
 		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -499,7 +499,13 @@ func NewServerCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		Use:     "server [flags]",
 		Aliases: []string{"s"},
 		Short:   "Server mode",
-		Args:    cobra.ExactArgs(0),
+		Example: `  # Run a server
+  $ trivy server
+
+  # Listen on 0.0.0.0:10000
+  $ trivy server --listen 0.0.0.0:10000
+`,
+		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := serverFlags.Bind(cmd); err != nil {
 				return xerrors.Errorf("flag bind error: %w", err)

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -30,6 +30,32 @@ type VersionInfo struct {
 	VulnerabilityDB *metadata.Metadata `json:",omitempty"`
 }
 
+const (
+	usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+%s
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+)
+
 var (
 	outputWriter io.Writer = os.Stdout
 )
@@ -250,8 +276,9 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		SilenceUsage:  true,
 	}
 
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 	imageFlags.AddFlags(cmd)
+	cmd.SetFlagErrorFunc(flagErrorFunc)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, imageFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -300,6 +327,7 @@ func NewFilesystemCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	fsFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, fsFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -348,6 +376,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	rootfsFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, rootfsFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -392,6 +421,7 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	repoFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, repoFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -444,6 +474,7 @@ func NewClientCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	clientFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, clientFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -475,6 +506,7 @@ func NewServerCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	serverFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, serverFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -528,6 +560,7 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	configFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, configFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -736,6 +769,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	k8sFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, k8sFlags.Usages(cmd)))
 
 	return cmd
 }
@@ -766,7 +800,7 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
   $ trivy sbom --format cyclonedx /path/to/report.cdx
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := scanFlags.Bind(cmd); err != nil {
+			if err := sbomFlags.Bind(cmd); err != nil {
 				return xerrors.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
@@ -790,6 +824,7 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 	sbomFlags.AddFlags(cmd)
+	cmd.SetUsageTemplate(fmt.Sprintf(usageTemplate, sbomFlags.Usages(cmd)))
 
 	return cmd
 }

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -218,13 +218,15 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
 
 	imageFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		ImageFlagGroup:   flag.NewImageFlagGroup(), // container image specific
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		RemoteFlagGroup:  flag.NewClientFlags(), // for client/server mode
-		ReportFlagGroup:  reportFlagGroup,
-		ScanFlagGroup:    flag.NewScanFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		ImageFlagGroup:         flag.NewImageFlagGroup(), // container image specific
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		ReportFlagGroup:        reportFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{
@@ -288,12 +290,14 @@ func NewFilesystemCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
 
 	fsFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		RemoteFlagGroup:  flag.NewClientFlags(), // for client/server mode
-		ReportFlagGroup:  reportFlagGroup,
-		ScanFlagGroup:    flag.NewScanFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		ReportFlagGroup:        reportFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{
@@ -337,11 +341,13 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
 
 	rootfsFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		ReportFlagGroup:  reportFlagGroup,
-		ScanFlagGroup:    flag.NewScanFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		ReportFlagGroup:        reportFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{
@@ -386,12 +392,14 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
 
 	repoFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		RemoteFlagGroup:  flag.NewClientFlags(), // for client/server mode
-		ReportFlagGroup:  reportFlagGroup,
-		ScanFlagGroup:    flag.NewScanFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		ReportFlagGroup:        reportFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{
@@ -439,12 +447,13 @@ func NewClientCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	remoteFlags.ServerAddr = &remoteAddr // disable '--server' and enable '--remote' instead.
 
 	clientFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		RemoteFlagGroup:  remoteFlags,
-		ReportFlagGroup:  flag.NewReportFlagGroup(),
-		ScanFlagGroup:    flag.NewScanFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		RemoteFlagGroup:        remoteFlags,
+		ReportFlagGroup:        flag.NewReportFlagGroup(),
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{
@@ -723,12 +732,14 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	scanFlags.SecurityChecks = &securityChecks
 
 	k8sFlags := &flag.Flags{
-		CacheFlagGroup:   flag.NewCacheFlagGroup(),
-		DBFlagGroup:      flag.NewDBFlagGroup(),
-		K8sFlagGroup:     flag.NewK8sFlagGroup(), // kubernetes-specific flags
-		MisconfFlagGroup: flag.NewMisconfFlagGroup(),
-		ReportFlagGroup:  flag.NewReportFlagGroup(),
-		ScanFlagGroup:    scanFlags,
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		K8sFlagGroup:           flag.NewK8sFlagGroup(), // kubernetes-specific flags
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+		ReportFlagGroup:        flag.NewReportFlagGroup(),
+		ScanFlagGroup:          scanFlags,
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 	cmd := &cobra.Command{
 		Use:     "kubernetes [flags] { cluster | all | specific resources like kubectl. eg: pods, pod/NAME }",
@@ -782,12 +793,14 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	scanFlags.SecurityChecks = nil // disable '--security-checks' as it always scans for vulnerabilities
 
 	sbomFlags := &flag.Flags{
-		CacheFlagGroup:  flag.NewCacheFlagGroup(),
-		DBFlagGroup:     flag.NewDBFlagGroup(),
-		RemoteFlagGroup: flag.NewClientFlags(), // for client/server mode
-		ReportFlagGroup: reportFlagGroup,
-		ScanFlagGroup:   flag.NewScanFlagGroup(),
-		SBOMFlagGroup:   flag.NewSBOMFlagGroup(),
+		CacheFlagGroup:         flag.NewCacheFlagGroup(),
+		DBFlagGroup:            flag.NewDBFlagGroup(),
+		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		ReportFlagGroup:        reportFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
+		SBOMFlagGroup:          flag.NewSBOMFlagGroup(),
+		SecretFlagGroup:        flag.NewSecretFlagGroup(),
+		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 )
 
@@ -94,31 +93,20 @@ func NewCacheFlagGroup() *CacheFlagGroup {
 	}
 }
 
-func (f *CacheFlagGroup) flags() []*Flag {
-	return []*Flag{f.ClearCache, f.CacheBackend, f.CacheTTL, f.RedisCACert, f.RedisCert, f.RedisKey}
+func (fg *CacheFlagGroup) Name() string {
+	return "Cache"
 }
 
-func (f *CacheFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
+func (fg *CacheFlagGroup) Flags() []*Flag {
+	return []*Flag{fg.ClearCache, fg.CacheBackend, fg.CacheTTL, fg.RedisCACert, fg.RedisCert, fg.RedisKey}
 }
 
-func (f *CacheFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (f *CacheFlagGroup) ToOptions() (CacheOptions, error) {
-	cacheBackend := getString(f.CacheBackend)
+func (fg *CacheFlagGroup) ToOptions() (CacheOptions, error) {
+	cacheBackend := getString(fg.CacheBackend)
 	redisOptions := RedisOptions{
-		RedisCACert: getString(f.RedisCACert),
-		RedisCert:   getString(f.RedisCert),
-		RedisKey:    getString(f.RedisKey),
+		RedisCACert: getString(fg.RedisCACert),
+		RedisCert:   getString(fg.RedisCert),
+		RedisKey:    getString(fg.RedisKey),
 	}
 
 	// "redis://" or "fs" are allowed for now
@@ -135,9 +123,9 @@ func (f *CacheFlagGroup) ToOptions() (CacheOptions, error) {
 	}
 
 	return CacheOptions{
-		ClearCache:   getBool(f.ClearCache),
+		ClearCache:   getBool(fg.ClearCache),
 		CacheBackend: cacheBackend,
-		CacheTTL:     getDuration(f.CacheTTL),
+		CacheTTL:     getDuration(fg.CacheTTL),
 		RedisOptions: redisOptions,
 	}, nil
 }

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -84,12 +84,12 @@ type RedisOptions struct {
 // NewCacheFlagGroup returns a default CacheFlagGroup
 func NewCacheFlagGroup() *CacheFlagGroup {
 	return &CacheFlagGroup{
-		ClearCache:   lo.ToPtr(ClearCacheFlag),
-		CacheBackend: lo.ToPtr(CacheBackendFlag),
-		CacheTTL:     lo.ToPtr(CacheTTLFlag),
-		RedisCACert:  lo.ToPtr(RedisCACertFlag),
-		RedisCert:    lo.ToPtr(RedisCertFlag),
-		RedisKey:     lo.ToPtr(RedisKeyFlag),
+		ClearCache:   &ClearCacheFlag,
+		CacheBackend: &CacheBackendFlag,
+		CacheTTL:     &CacheTTLFlag,
+		RedisCACert:  &RedisCACertFlag,
+		RedisCert:    &RedisCertFlag,
+		RedisKey:     &RedisKeyFlag,
 	}
 }
 

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -2,7 +2,6 @@ package flag
 
 import (
 	"github.com/samber/lo"
-	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -46,6 +45,7 @@ var (
 		ConfigName: "db.light",
 		Value:      false,
 		Usage:      "deprecated",
+		Deprecated: true,
 	}
 )
 
@@ -80,23 +80,12 @@ func NewDBFlagGroup() *DBFlagGroup {
 	}
 }
 
-func (f *DBFlagGroup) flags() []*Flag {
+func (f *DBFlagGroup) Name() string {
+	return "DB"
+}
+
+func (f *DBFlagGroup) Flags() []*Flag {
 	return []*Flag{f.Reset, f.DownloadDBOnly, f.SkipDBUpdate, f.NoProgress, f.DBRepository, f.Light}
-}
-
-func (f *DBFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
-}
-
-func (f *DBFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (f *DBFlagGroup) ToOptions() (DBOptions, error) {

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -71,12 +70,12 @@ type DBOptions struct {
 // NewDBFlagGroup returns a default DBFlagGroup
 func NewDBFlagGroup() *DBFlagGroup {
 	return &DBFlagGroup{
-		Reset:          lo.ToPtr(ResetFlag),
-		DownloadDBOnly: lo.ToPtr(DownloadDBOnlyFlag),
-		SkipDBUpdate:   lo.ToPtr(SkipDBUpdateFlag),
-		Light:          lo.ToPtr(LightFlag),
-		NoProgress:     lo.ToPtr(NoProgressFlag),
-		DBRepository:   lo.ToPtr(DBRepositoryFlag),
+		Reset:          &ResetFlag,
+		DownloadDBOnly: &DownloadDBOnlyFlag,
+		SkipDBUpdate:   &SkipDBUpdateFlag,
+		Light:          &LightFlag,
+		NoProgress:     &NoProgressFlag,
+		DBRepository:   &DBRepositoryFlag,
 	}
 }
 

--- a/pkg/flag/image_flags.go
+++ b/pkg/flag/image_flags.go
@@ -1,9 +1,5 @@
 package flag
 
-import (
-	"github.com/spf13/cobra"
-)
-
 // e.g. config yaml
 // image:
 //   removed-pkgs: true
@@ -41,23 +37,12 @@ func NewImageFlagGroup() *ImageFlagGroup {
 	}
 }
 
-func (f *ImageFlagGroup) flags() []*Flag {
+func (f *ImageFlagGroup) Name() string {
+	return "Image"
+}
+
+func (f *ImageFlagGroup) Flags() []*Flag {
 	return []*Flag{f.Input, f.ScanRemovedPkgs}
-}
-
-func (f *ImageFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
-}
-
-func (f *ImageFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (f *ImageFlagGroup) ToOptions() ImageOptions {

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -1,9 +1,5 @@
 package flag
 
-import (
-	"github.com/samber/lo"
-)
-
 var (
 	ClusterContextFlag = Flag{
 		Name:       "context",
@@ -31,8 +27,8 @@ type K8sOptions struct {
 
 func NewK8sFlagGroup() *K8sFlagGroup {
 	return &K8sFlagGroup{
-		ClusterContext: lo.ToPtr(ClusterContextFlag),
-		Namespace:      lo.ToPtr(K8sNamespaceFlag),
+		ClusterContext: &ClusterContextFlag,
+		Namespace:      &K8sNamespaceFlag,
 	}
 }
 

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -2,7 +2,6 @@ package flag
 
 import (
 	"github.com/samber/lo"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -37,23 +36,12 @@ func NewK8sFlagGroup() *K8sFlagGroup {
 	}
 }
 
-func (f *K8sFlagGroup) flags() []*Flag {
+func (f *K8sFlagGroup) Name() string {
+	return "Kubernetes"
+}
+
+func (f *K8sFlagGroup) Flags() []*Flag {
 	return []*Flag{f.ClusterContext, f.Namespace}
-}
-
-func (f *K8sFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
-}
-
-func (f *K8sFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (f *K8sFlagGroup) ToOptions() K8sOptions {

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -2,7 +2,6 @@ package flag
 
 import (
 	"github.com/aquasecurity/trivy/pkg/log"
-	"github.com/samber/lo"
 )
 
 // e.g. config yaml
@@ -83,13 +82,13 @@ type MisconfOptions struct {
 
 func NewMisconfFlagGroup() *MisconfFlagGroup {
 	return &MisconfFlagGroup{
-		FilePatterns:       lo.ToPtr(FilePatternsFlag),
-		IncludeNonFailures: lo.ToPtr(IncludeNonFailuresFlag),
-		SkipPolicyUpdate:   lo.ToPtr(SkipPolicyUpdateFlag),
-		Trace:              lo.ToPtr(TraceFlag),
-		PolicyPaths:        lo.ToPtr(ConfigPolicyFlag),
-		DataPaths:          lo.ToPtr(ConfigDataFlag),
-		PolicyNamespaces:   lo.ToPtr(PolicyNamespaceFlag),
+		FilePatterns:       &FilePatternsFlag,
+		IncludeNonFailures: &IncludeNonFailuresFlag,
+		SkipPolicyUpdate:   &SkipPolicyUpdateFlag,
+		Trace:              &TraceFlag,
+		PolicyPaths:        &ConfigPolicyFlag,
+		DataPaths:          &ConfigDataFlag,
+		PolicyNamespaces:   &PolicyNamespaceFlag,
 	}
 }
 

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -1,10 +1,8 @@
 package flag
 
 import (
-	"github.com/samber/lo"
-	"github.com/spf13/cobra"
-
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/samber/lo"
 )
 
 // e.g. config yaml
@@ -30,6 +28,7 @@ var (
 		ConfigName: "misconfiguration.skip-policy-update",
 		Value:      false,
 		Usage:      "deprecated",
+		Deprecated: true,
 	}
 	TraceFlag = Flag{
 		Name:       "trace",
@@ -94,23 +93,12 @@ func NewMisconfFlagGroup() *MisconfFlagGroup {
 	}
 }
 
-func (f *MisconfFlagGroup) flags() []*Flag {
+func (f *MisconfFlagGroup) Name() string {
+	return "Misconfiguration"
+}
+
+func (f *MisconfFlagGroup) Flags() []*Flag {
 	return []*Flag{f.FilePatterns, f.IncludeNonFailures, f.SkipPolicyUpdate, f.Trace, f.PolicyPaths, f.DataPaths, f.PolicyNamespaces}
-}
-
-func (f *MisconfFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
-}
-
-func (f *MisconfFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (f *MisconfFlagGroup) ToOptions() (MisconfOptions, error) {

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -44,15 +44,17 @@ type FlagGroup interface {
 }
 
 type Flags struct {
-	CacheFlagGroup   *CacheFlagGroup
-	DBFlagGroup      *DBFlagGroup
-	ImageFlagGroup   *ImageFlagGroup
-	K8sFlagGroup     *K8sFlagGroup
-	MisconfFlagGroup *MisconfFlagGroup
-	RemoteFlagGroup  *RemoteFlagGroup
-	ReportFlagGroup  *ReportFlagGroup
-	SBOMFlagGroup    *SBOMFlagGroup
-	ScanFlagGroup    *ScanFlagGroup
+	CacheFlagGroup         *CacheFlagGroup
+	DBFlagGroup            *DBFlagGroup
+	ImageFlagGroup         *ImageFlagGroup
+	K8sFlagGroup           *K8sFlagGroup
+	MisconfFlagGroup       *MisconfFlagGroup
+	RemoteFlagGroup        *RemoteFlagGroup
+	ReportFlagGroup        *ReportFlagGroup
+	SBOMFlagGroup          *SBOMFlagGroup
+	ScanFlagGroup          *ScanFlagGroup
+	SecretFlagGroup        *SecretFlagGroup
+	VulnerabilityFlagGroup *VulnerabilityFlagGroup
 }
 
 // Options holds all the runtime configuration
@@ -67,6 +69,8 @@ type Options struct {
 	ReportOptions
 	SBOMOptions
 	ScanOptions
+	SecretOptions
+	VulnerabilityOptions
 
 	// Trivy's version, not populated via CLI flags
 	AppVersion string
@@ -161,6 +165,13 @@ func getDuration(flag *Flag) time.Duration {
 
 func (f *Flags) groups() []FlagGroup {
 	var groups []FlagGroup
+	// This order affects the usage message, so they are sorted by frequency of use.
+	if f.ScanFlagGroup != nil {
+		groups = append(groups, f.ScanFlagGroup)
+	}
+	if f.ReportFlagGroup != nil {
+		groups = append(groups, f.ReportFlagGroup)
+	}
 	if f.CacheFlagGroup != nil {
 		groups = append(groups, f.CacheFlagGroup)
 	}
@@ -170,23 +181,23 @@ func (f *Flags) groups() []FlagGroup {
 	if f.ImageFlagGroup != nil {
 		groups = append(groups, f.ImageFlagGroup)
 	}
-	if f.K8sFlagGroup != nil {
-		groups = append(groups, f.K8sFlagGroup)
+	if f.SBOMFlagGroup != nil {
+		groups = append(groups, f.SBOMFlagGroup)
+	}
+	if f.VulnerabilityFlagGroup != nil {
+		groups = append(groups, f.VulnerabilityFlagGroup)
 	}
 	if f.MisconfFlagGroup != nil {
 		groups = append(groups, f.MisconfFlagGroup)
 	}
+	if f.SecretFlagGroup != nil {
+		groups = append(groups, f.SecretFlagGroup)
+	}
+	if f.K8sFlagGroup != nil {
+		groups = append(groups, f.K8sFlagGroup)
+	}
 	if f.RemoteFlagGroup != nil {
 		groups = append(groups, f.RemoteFlagGroup)
-	}
-	if f.ReportFlagGroup != nil {
-		groups = append(groups, f.ReportFlagGroup)
-	}
-	if f.SBOMFlagGroup != nil {
-		groups = append(groups, f.SBOMFlagGroup)
-	}
-	if f.ScanFlagGroup != nil {
-		groups = append(groups, f.ScanFlagGroup)
 	}
 	return groups
 }
@@ -293,6 +304,14 @@ func (f *Flags) ToOptions(appVersion string, args []string, globalFlags *GlobalF
 
 	if f.ScanFlagGroup != nil {
 		opts.ScanOptions = f.ScanFlagGroup.ToOptions(args)
+	}
+
+	if f.SecretFlagGroup != nil {
+		opts.SecretOptions = f.SecretFlagGroup.ToOptions()
+	}
+
+	if f.VulnerabilityFlagGroup != nil {
+		opts.VulnerabilityOptions = f.VulnerabilityFlagGroup.ToOptions()
 	}
 
 	return opts, nil

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -224,7 +224,7 @@ func (f *Flags) Usages(cmd *cobra.Command) string {
 			}
 			flags.AddFlag(lflags.Lookup(flag.Name))
 		}
-		if !lflags.HasAvailableFlags() {
+		if !flags.HasAvailableFlags() {
 			continue
 		}
 

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
@@ -87,23 +85,12 @@ func NewServerFlags() *RemoteFlagGroup {
 	}
 }
 
-func (f *RemoteFlagGroup) flags() []*Flag {
+func (f *RemoteFlagGroup) Name() string {
+	return "Client/Server"
+}
+
+func (f *RemoteFlagGroup) Flags() []*Flag {
 	return []*Flag{f.Token, f.TokenHeader, f.ServerAddr, f.CustomHeaders, f.Listen}
-}
-
-func (f *RemoteFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (f *RemoteFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
 }
 
 func (f *RemoteFlagGroup) ToOptions() RemoteOptions {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -191,7 +191,7 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 		ExitCode:       getInt(f.ExitCode),
 		IgnorePolicy:   getString(f.IgnorePolicy),
 		Output:         out,
-		Severities:     splitSeverity(getString(f.Severity)),
+		Severities:     splitSeverity(getStringSlice(f.Severity)),
 	}, nil
 }
 
@@ -207,13 +207,16 @@ func (f *ReportFlagGroup) forceListAllPkgs(format string, listAllPkgs, dependenc
 	return false
 }
 
-func splitSeverity(severity string) []dbTypes.Severity {
-	if severity == "" {
+func splitSeverity(severity []string) []dbTypes.Severity {
+	switch {
+	case len(severity) == 0:
 		return nil
+	case len(severity) == 1 && strings.Contains(severity[0], ","): // get severities from flag
+		severity = strings.Split(severity[0], ",")
 	}
 
 	var severities []dbTypes.Severity
-	for _, s := range strings.Split(severity, ",") {
+	for _, s := range severity {
 		sev, err := dbTypes.NewSeverity(s)
 		if err != nil {
 			log.Logger.Warnf("unknown severity option: %s", err)

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
@@ -143,24 +142,13 @@ func NewReportFlagGroup() *ReportFlagGroup {
 	}
 }
 
-func (f *ReportFlagGroup) flags() []*Flag {
-	return []*Flag{f.Format, f.ReportFormat, f.Template, f.DependencyTree, f.ListAllPkgs, f.IgnoreUnfixed, f.IgnoreFile, f.IgnorePolicy,
-		f.ExitCode, f.Output, f.Severity}
+func (f *ReportFlagGroup) Name() string {
+	return "Report"
 }
 
-func (f *ReportFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
-}
-
-func (f *ReportFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
+func (f *ReportFlagGroup) Flags() []*Flag {
+	return []*Flag{f.Format, f.ReportFormat, f.Template, f.DependencyTree, f.ListAllPkgs, f.IgnoreUnfixed, f.IgnoreFile,
+		f.IgnorePolicy, f.ExitCode, f.Output, f.Severity}
 }
 
 func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
@@ -118,16 +117,16 @@ type ReportOptions struct {
 
 func NewReportFlagGroup() *ReportFlagGroup {
 	return &ReportFlagGroup{
-		Format:         lo.ToPtr(FormatFlag),
-		ReportFormat:   lo.ToPtr(ReportFormatFlag),
-		Template:       lo.ToPtr(TemplateFlag),
-		DependencyTree: lo.ToPtr(DependencyTreeFlag),
-		ListAllPkgs:    lo.ToPtr(ListAllPkgsFlag),
-		IgnoreFile:     lo.ToPtr(IgnoreFileFlag),
-		IgnorePolicy:   lo.ToPtr(IgnorePolicyFlag),
-		ExitCode:       lo.ToPtr(ExitCodeFlag),
-		Output:         lo.ToPtr(OutputFlag),
-		Severity:       lo.ToPtr(SeverityFlag),
+		Format:         &FormatFlag,
+		ReportFormat:   &ReportFormatFlag,
+		Template:       &TemplateFlag,
+		DependencyTree: &DependencyTreeFlag,
+		ListAllPkgs:    &ListAllPkgsFlag,
+		IgnoreFile:     &IgnoreFileFlag,
+		IgnorePolicy:   &IgnorePolicyFlag,
+		ExitCode:       &ExitCodeFlag,
+		Output:         &OutputFlag,
+		Severity:       &SeverityFlag,
 	}
 }
 

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -86,14 +86,6 @@ var (
 		Value:      strings.Join(dbTypes.SeverityNames, ","),
 		Usage:      "severities of security issues to be displayed (comma separated)",
 	}
-
-	// Vulnerabilities
-	IgnoreUnfixedFlag = Flag{
-		Name:       "ignore-unfixed",
-		ConfigName: "vulnerability.ignore-unfixed",
-		Value:      false,
-		Usage:      "display only fixed vulnerabilities",
-	}
 )
 
 // ReportFlagGroup composes common printer flag structs
@@ -104,7 +96,6 @@ type ReportFlagGroup struct {
 	Template       *Flag
 	DependencyTree *Flag
 	ListAllPkgs    *Flag
-	IgnoreUnfixed  *Flag
 	IgnoreFile     *Flag
 	IgnorePolicy   *Flag
 	ExitCode       *Flag
@@ -118,7 +109,6 @@ type ReportOptions struct {
 	Template       string
 	DependencyTree bool
 	ListAllPkgs    bool
-	IgnoreUnfixed  bool
 	IgnoreFile     string
 	ExitCode       int
 	IgnorePolicy   string
@@ -133,7 +123,6 @@ func NewReportFlagGroup() *ReportFlagGroup {
 		Template:       lo.ToPtr(TemplateFlag),
 		DependencyTree: lo.ToPtr(DependencyTreeFlag),
 		ListAllPkgs:    lo.ToPtr(ListAllPkgsFlag),
-		IgnoreUnfixed:  lo.ToPtr(IgnoreUnfixedFlag),
 		IgnoreFile:     lo.ToPtr(IgnoreFileFlag),
 		IgnorePolicy:   lo.ToPtr(IgnorePolicyFlag),
 		ExitCode:       lo.ToPtr(ExitCodeFlag),
@@ -147,7 +136,7 @@ func (f *ReportFlagGroup) Name() string {
 }
 
 func (f *ReportFlagGroup) Flags() []*Flag {
-	return []*Flag{f.Format, f.ReportFormat, f.Template, f.DependencyTree, f.ListAllPkgs, f.IgnoreUnfixed, f.IgnoreFile,
+	return []*Flag{f.Format, f.ReportFormat, f.Template, f.DependencyTree, f.ListAllPkgs, f.IgnoreFile,
 		f.IgnorePolicy, f.ExitCode, f.Output, f.Severity}
 }
 
@@ -199,7 +188,6 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 		Template:       template,
 		DependencyTree: dependencyTree,
 		ListAllPkgs:    listAllPkgs,
-		IgnoreUnfixed:  getBool(f.IgnoreUnfixed),
 		IgnoreFile:     getString(f.IgnoreFile),
 		ExitCode:       getInt(f.ExitCode),
 		IgnorePolicy:   getString(f.IgnorePolicy),

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -186,7 +186,6 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 				DependencyTree: &flag.DependencyTreeFlag,
 				ListAllPkgs:    &flag.ListAllPkgsFlag,
 				IgnoreFile:     &flag.IgnoreFileFlag,
-				IgnoreUnfixed:  &flag.IgnoreUnfixedFlag,
 				IgnorePolicy:   &flag.IgnorePolicyFlag,
 				ExitCode:       &flag.ExitCodeFlag,
 				Output:         &flag.OutputFlag,

--- a/pkg/flag/sbom_flags.go
+++ b/pkg/flag/sbom_flags.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -9,14 +8,18 @@ import (
 
 var (
 	ArtifactTypeFlag = Flag{
-		Name:  "artifact-type",
-		Value: "",
-		Usage: "deprecated",
+		Name:       "artifact-type",
+		ConfigName: "sbom.artifact-type",
+		Value:      "",
+		Usage:      "deprecated",
+		Deprecated: true,
 	}
 	SBOMFormatFlag = Flag{
-		Name:  "sbom-format",
-		Value: "",
-		Usage: "deprecated",
+		Name:       "sbom-format",
+		ConfigName: "sbom.format",
+		Value:      "",
+		Usage:      "deprecated",
+		Deprecated: true,
 	}
 )
 
@@ -37,20 +40,12 @@ func NewSBOMFlagGroup() *SBOMFlagGroup {
 	}
 }
 
-func (f *SBOMFlagGroup) AddFlags(cmd *cobra.Command) {
-	if f.ArtifactType != nil {
-		cmd.Flags().String(ArtifactTypeFlag.Name, "", "deprecated")
-		cmd.Flags().MarkHidden(ArtifactTypeFlag.Name) // nolint: gosec
-	}
-	if f.SBOMFormat != nil {
-		cmd.Flags().String(SBOMFormatFlag.Name, "", "deprecated")
-		cmd.Flags().MarkHidden(SBOMFormatFlag.Name) // nolint: gosec
-	}
+func (f *SBOMFlagGroup) Name() string {
+	return "SBOM"
 }
 
-func (f *SBOMFlagGroup) Bind(cmd *cobra.Command) error {
-	// All the flags are deprecated
-	return nil
+func (f *SBOMFlagGroup) Flags() []*Flag {
+	return []*Flag{f.ArtifactType, f.SBOMFormat}
 }
 
 func (f *SBOMFlagGroup) ToOptions() (SBOMOptions, error) {

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -55,10 +54,10 @@ type ScanOptions struct {
 
 func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
-		SkipDirs:       lo.ToPtr(SkipDirsFlag),
-		SkipFiles:      lo.ToPtr(SkipFilesFlag),
-		OfflineScan:    lo.ToPtr(OfflineScanFlag),
-		SecurityChecks: lo.ToPtr(SecurityChecksFlag),
+		SkipDirs:       &SkipDirsFlag,
+		SkipFiles:      &SkipFilesFlag,
+		OfflineScan:    &OfflineScanFlag,
+		SecurityChecks: &SecurityChecksFlag,
 	}
 }
 

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -86,23 +85,12 @@ func NewScanFlagGroup() *ScanFlagGroup {
 	}
 }
 
-func (f *ScanFlagGroup) flags() []*Flag {
+func (f *ScanFlagGroup) Name() string {
+	return "Scan"
+}
+
+func (f *ScanFlagGroup) Flags() []*Flag {
 	return []*Flag{f.SkipDirs, f.SkipFiles, f.OfflineScan, f.SecurityChecks, f.VulnType, f.SecretConfig}
-}
-
-func (f *ScanFlagGroup) Bind(cmd *cobra.Command) error {
-	for _, flag := range f.flags() {
-		if err := bind(cmd, flag); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (f *ScanFlagGroup) AddFlags(cmd *cobra.Command) {
-	for _, flag := range f.flags() {
-		addFlag(cmd, flag)
-	}
 }
 
 func (f *ScanFlagGroup) ToOptions(args []string) ScanOptions {

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -37,32 +37,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path for OS vulnerabilities",
-			args: []string{"alpine:latest"},
-			fields: fields{
-				vulnType:       "os",
-				securityChecks: "vuln",
-			},
-			want: flag.ScanOptions{
-				Target:         "alpine:latest",
-				VulnType:       []string{types.VulnTypeOS},
-				SecurityChecks: []string{types.SecurityCheckVulnerability},
-			},
-		},
-		{
-			name: "happy path for library vulnerabilities",
-			args: []string{"alpine:latest"},
-			fields: fields{
-				vulnType:       "library",
-				securityChecks: "vuln",
-			},
-			want: flag.ScanOptions{
-				Target:         "alpine:latest",
-				VulnType:       []string{types.VulnTypeLibrary},
-				SecurityChecks: []string{types.SecurityCheckVulnerability},
-			},
-		},
-		{
 			name: "happy path for configs",
 			args: []string{"alpine:latest"},
 			fields: fields{
@@ -83,18 +57,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			wantLogs: []string{
 				`unknown security check: WRONG-CHECK`,
-			},
-		},
-		{
-			name: "with wrong vuln type",
-			fields: fields{
-				vulnType: "os,nonevuln",
-			},
-			want: flag.ScanOptions{
-				VulnType: []string{types.VulnTypeOS},
-			},
-			wantLogs: []string{
-				`unknown vulnerability type: nonevuln`,
 			},
 		},
 		{
@@ -156,7 +118,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 				SkipDirs:       &flag.SkipDirsFlag,
 				SkipFiles:      &flag.SkipFilesFlag,
 				OfflineScan:    &flag.OfflineScanFlag,
-				VulnType:       &flag.VulnTypeFlag,
 				SecurityChecks: &flag.SecurityChecksFlag,
 			}
 

--- a/pkg/flag/secret_flags.go
+++ b/pkg/flag/secret_flags.go
@@ -1,9 +1,5 @@
 package flag
 
-import (
-	"github.com/samber/lo"
-)
-
 var (
 	SecretConfigFlag = Flag{
 		Name:       "secret-config",
@@ -23,7 +19,7 @@ type SecretOptions struct {
 
 func NewSecretFlagGroup() *SecretFlagGroup {
 	return &SecretFlagGroup{
-		SecretConfig: lo.ToPtr(SecretConfigFlag),
+		SecretConfig: &SecretConfigFlag,
 	}
 }
 

--- a/pkg/flag/secret_flags.go
+++ b/pkg/flag/secret_flags.go
@@ -1,0 +1,42 @@
+package flag
+
+import (
+	"github.com/samber/lo"
+)
+
+var (
+	SecretConfigFlag = Flag{
+		Name:       "secret-config",
+		ConfigName: "secret.config",
+		Value:      "trivy-secret.yaml",
+		Usage:      "specify a path to config file for secret scanning",
+	}
+)
+
+type SecretFlagGroup struct {
+	SecretConfig *Flag
+}
+
+type SecretOptions struct {
+	SecretConfigPath string
+}
+
+func NewSecretFlagGroup() *SecretFlagGroup {
+	return &SecretFlagGroup{
+		SecretConfig: lo.ToPtr(SecretConfigFlag),
+	}
+}
+
+func (f *SecretFlagGroup) Name() string {
+	return "Secret"
+}
+
+func (f *SecretFlagGroup) Flags() []*Flag {
+	return []*Flag{f.SecretConfig}
+}
+
+func (f *SecretFlagGroup) ToOptions() SecretOptions {
+	return SecretOptions{
+		SecretConfigPath: getString(f.SecretConfig),
+	}
+}

--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -3,7 +3,6 @@ package flag
 import (
 	"strings"
 
-	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -37,8 +36,8 @@ type VulnerabilityOptions struct {
 
 func NewVulnerabilityFlagGroup() *VulnerabilityFlagGroup {
 	return &VulnerabilityFlagGroup{
-		VulnType:      lo.ToPtr(VulnTypeFlag),
-		IgnoreUnfixed: lo.ToPtr(IgnoreUnfixedFlag),
+		VulnType:      &VulnTypeFlag,
+		IgnoreUnfixed: &IgnoreUnfixedFlag,
 	}
 }
 

--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -1,0 +1,77 @@
+package flag
+
+import (
+	"strings"
+
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
+
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+var (
+	VulnTypeFlag = Flag{
+		Name:       "vuln-type",
+		ConfigName: "vulnerability.type",
+		Value:      strings.Join([]string{types.VulnTypeOS, types.VulnTypeLibrary}, ","),
+		Usage:      "comma-separated list of vulnerability types (os,library)",
+	}
+	IgnoreUnfixedFlag = Flag{
+		Name:       "ignore-unfixed",
+		ConfigName: "vulnerability.ignore-unfixed",
+		Value:      false,
+		Usage:      "display only fixed vulnerabilities",
+	}
+)
+
+type VulnerabilityFlagGroup struct {
+	VulnType      *Flag
+	IgnoreUnfixed *Flag
+}
+
+type VulnerabilityOptions struct {
+	VulnType      []string
+	IgnoreUnfixed bool
+}
+
+func NewVulnerabilityFlagGroup() *VulnerabilityFlagGroup {
+	return &VulnerabilityFlagGroup{
+		VulnType:      lo.ToPtr(VulnTypeFlag),
+		IgnoreUnfixed: lo.ToPtr(IgnoreUnfixedFlag),
+	}
+}
+
+func (f *VulnerabilityFlagGroup) Name() string {
+	return "Vulnerability"
+}
+
+func (f *VulnerabilityFlagGroup) Flags() []*Flag {
+	return []*Flag{f.VulnType, f.IgnoreUnfixed}
+}
+
+func (f *VulnerabilityFlagGroup) ToOptions() VulnerabilityOptions {
+	return VulnerabilityOptions{
+		VulnType:      parseVulnType(getStringSlice(f.VulnType)),
+		IgnoreUnfixed: getBool(f.IgnoreUnfixed),
+	}
+}
+
+func parseVulnType(vulnType []string) []string {
+	switch {
+	case len(vulnType) == 0: // no types
+		return nil
+	case len(vulnType) == 1 && strings.Contains(vulnType[0], ","): // get checks from flag
+		vulnType = strings.Split(vulnType[0], ",")
+	}
+
+	var vulnTypes []string
+	for _, v := range vulnType {
+		if !slices.Contains(types.VulnTypes, v) {
+			log.Logger.Warnf("unknown vulnerability type: %s", v)
+			continue
+		}
+		vulnTypes = append(vulnTypes, v)
+	}
+	return vulnTypes
+}

--- a/pkg/flag/vulnerability_flags_test.go
+++ b/pkg/flag/vulnerability_flags_test.go
@@ -1,0 +1,87 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/aquasecurity/trivy/pkg/flag"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestVulnerabilityFlagGroup_ToOptions(t *testing.T) {
+	type fields struct {
+		vulnType string
+	}
+	tests := []struct {
+		name     string
+		args     []string
+		fields   fields
+		want     flag.VulnerabilityOptions
+		wantLogs []string
+	}{
+		{
+			name: "happy path for OS vulnerabilities",
+			args: []string{"alpine:latest"},
+			fields: fields{
+				vulnType: "os",
+			},
+			want: flag.VulnerabilityOptions{
+				VulnType: []string{types.VulnTypeOS},
+			},
+		},
+		{
+			name: "happy path for library vulnerabilities",
+			args: []string{"alpine:latest"},
+			fields: fields{
+				vulnType: "library",
+			},
+			want: flag.VulnerabilityOptions{
+				VulnType: []string{types.VulnTypeLibrary},
+			},
+		},
+		{
+			name: "wrong vuln type",
+			fields: fields{
+				vulnType: "os,nonevuln",
+			},
+			want: flag.VulnerabilityOptions{
+				VulnType: []string{types.VulnTypeOS},
+			},
+			wantLogs: []string{
+				`unknown vulnerability type: nonevuln`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level := zap.WarnLevel
+
+			core, obs := observer.New(level)
+			log.Logger = zap.New(core).Sugar()
+
+			viper.Set(flag.VulnTypeFlag.ConfigName, tt.fields.vulnType)
+
+			// Assert options
+			f := &flag.VulnerabilityFlagGroup{
+				VulnType: &flag.VulnTypeFlag,
+			}
+
+			got := f.ToOptions()
+			assert.Equalf(t, tt.want, got, "ToOptions()")
+
+			// Assert log messages
+			var gotMessages []string
+			for _, entry := range obs.AllUntimed() {
+				gotMessages = append(gotMessages, entry.Message)
+			}
+			assert.Equal(t, tt.wantLogs, gotMessages, tt.name)
+		})
+
+	}
+}


### PR DESCRIPTION
## Description
Improve usage messages by grouping flags.

As it is not yet implemented in cobra, this PR implemented flag groups on Trivy's end.
https://github.com/spf13/cobra/issues/1327

### Before

```
$ trivy image -h
...

Flags:
      --cache-backend string        cache backend (e.g. redis://localhost:6379) (default "fs")
      --cache-ttl duration          cache TTL when using redis as cache backend
      --clear-cache                 clear image caches without scanning
      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
      --config-policy strings       specify paths to the Rego policy files directory, applying config files
      --custom-headers strings      custom headers in client mode
      --db-repository string        OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
      --dependency-tree             show dependency origin tree (EXPERIMENTAL)
      --download-db-only            download/update vulnerability database but don't run a scan
      --exit-code int               specify exit code when any security issues are found
      --file-patterns strings       specify config file patterns, available with '--security-checks config'
  -f, --format string               format (table, json, sarif, template, cyclonedx, spdx, spdx-json, github) (default "table")
  -h, --help                        help for image
      --ignore-policy string        specify the Rego file path to evaluate each vulnerability
      --ignore-unfixed              display only fixed vulnerabilities
      --ignorefile string           specify .trivyignore file (default ".trivyignore")
      --include-non-failures        include successes and exceptions, available with '--security-checks config'
      --input string                input file path instead of image name
      --light                       deprecated
      --list-all-pkgs               enabling the option will output all packages regardless of vulnerability
      --no-progress                 suppress progress bar
      --offline-scan                do not issue API requests to identify dependencies
  -o, --output string               output file name
      --policy-namespaces strings   Rego namespaces
      --redis-ca string             redis ca file location, if using redis as cache backend
      --redis-cert string           redis certificate file location, if using redis as cache backend
      --redis-key string            redis key file location, if using redis as cache backend
      --removed-pkgs                detect vulnerabilities of removed packages (only for Alpine)
      --reset                       remove all caches and database
      --secret-config string        specify a path to config file for secret scanning (default "trivy-secret.yaml")
      --security-checks string      comma-separated list of what security issues to detect (vuln,config,secret) (default "vuln,secret")
      --server string               server address in client mode
  -s, --severity string             severities of security issues to be displayed (comma separated) (default "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
      --skip-db-update              skip updating vulnerability database
      --skip-dirs string            specify the directories where the traversal is skipped
      --skip-files string           specify the file paths to skip traversal
      --skip-policy-update          deprecated
  -t, --template string             output template
      --token string                for authentication in client/server mode
      --token-header string         specify a header name for token in client/server mode (default "Trivy-Token")
      --trace                       enable more verbose trace output for custom queries
      --vuln-type string            comma-separated list of vulnerability types (os,library) (default "os,library")
```

### After

```
$ trivy image -h
...

Scan Flags
      --offline-scan             do not issue API requests to identify dependencies
      --security-checks string   comma-separated list of what security issues to detect (vuln,config,secret) (default "vuln,secret")
      --skip-dirs string         specify the directories where the traversal is skipped
      --skip-files string        specify the file paths to skip traversal

Report Flags
      --dependency-tree        show dependency origin tree (EXPERIMENTAL)
      --exit-code int          specify exit code when any security issues are found
  -f, --format string          format (table, json, sarif, template, cyclonedx, spdx, spdx-json, github) (default "table")
      --ignore-policy string   specify the Rego file path to evaluate each vulnerability
      --ignorefile string      specify .trivyignore file (default ".trivyignore")
      --list-all-pkgs          enabling the option will output all packages regardless of vulnerability
  -o, --output string          output file name
  -s, --severity string        severities of security issues to be displayed (comma separated) (default "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
  -t, --template string        output template

Cache Flags
      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
      --cache-ttl duration     cache TTL when using redis as cache backend
      --clear-cache            clear image caches without scanning
      --redis-ca string        redis ca file location, if using redis as cache backend
      --redis-cert string      redis certificate file location, if using redis as cache backend
      --redis-key string       redis key file location, if using redis as cache backend

DB Flags
      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
      --download-db-only       download/update vulnerability database but don't run a scan
      --no-progress            suppress progress bar
      --reset                  remove all caches and database
      --skip-db-update         skip updating vulnerability database

Image Flags
      --input string   input file path instead of image name
      --removed-pkgs   detect vulnerabilities of removed packages (only for Alpine)

Vulnerability Flags
      --ignore-unfixed     display only fixed vulnerabilities
      --vuln-type string   comma-separated list of vulnerability types (os,library) (default "os,library")

Misconfiguration Flags
      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
      --config-policy strings       specify paths to the Rego policy files directory, applying config files
      --file-patterns strings       specify config file patterns, available with '--security-checks config'
      --include-non-failures        include successes and exceptions, available with '--security-checks config'
      --policy-namespaces strings   Rego namespaces
      --trace                       enable more verbose trace output for custom queries

Secret Flags
      --secret-config string   specify a path to config file for secret scanning (default "trivy-secret.yaml")

Client/Server Flags
      --custom-headers strings   custom headers in client mode
      --server string            server address in client mode
      --token string             for authentication in client/server mode
      --token-header string      specify a header name for token in client/server mode (default "Trivy-Token")

```


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
