### PR TITLE
feat: basic pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+- id: trivyfs-go
+  name: trivyfs-go
+  entry: trivy fs --exit-code 1
+  language: golang
+  pass_filenames: false
+
+- id: trivyfs-docker
+  name: trivyfs-docker
+  entry: aquasec/trivy fs --cache-dir /tmp/.cache --exit-code 1
+  language: docker_image
+  pass_filenames: false

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -228,6 +228,31 @@ podAnnotations: {}
 
 > **Tip**: List all releases using `helm list`.
 
+## pre-commit hook
+
+Add this to your [pre-commit](https://pre-commit.com/) `.pre-commit-config.yaml` config.
+
+You can use [trivy fs flags](../../docs/references/cli/fs/) to configure Trivy.
+Insert the required flags in the `args` field.
+
+There are mechanisms to run trivy via pre-commit hook.
+- `trivy-go`: pre-commit will use go (required) to compile trivy and execute it.
+- `trivy-docker`: pre-commit will use the latest `aquasecurity/trivy` docker image and run it inside a docker container
+
+```yaml
+repos:
+-   repo: https://github.com/aquasecurity/trivy.git
+    rev: {{ git.tag }}
+    hooks:
+    -   id: trivyfs-go # or trivy-docker
+        args:
+          - --skip-dirs
+          - ./tests
+          - . # last arg indicates the path to scan
+```
+
+According to [pre-commit](https://pre-commit.com/#golang) you will require [go](https://go.dev/) to be installed
+
 ## Other Tools to use and deploy Trivy
 
 For additional tools and ways to install and use Trivy in different envrionments such as in Docker Desktop and Kubernetes clusters, see the links in the [Ecosystem section](../ecosystem/tools.md).


### PR DESCRIPTION
## Description
This PR adds a pre-commit-hooks file which enables users trivy to be used in the https://pre-commit.com/#golang ecosystem

pre-commit compiles the trivy binaries on the fly

in this basic setup I create a plain `trivy` hook which needs to be configured on the user side and an opinionated `trivyfs` which will run the `trivy fs --exit-code 1 .`

eg:
```yaml
repos:
-   repo: https://github.com/aquasecurity/trivy.git
    rev: v0.30.0
    hooks:
    -   id: trivyfs
```

A potential feature for trivy would be to allow something like `trivy fs --files file1 file2 file/3.txt`. This could speedup the pre-commit validation as it supports the only staged file to be checked.

## Related issues
- Close #1858


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

