### PR TITLE
fix: remove dependency-tree flag for image subcommand

### DIFF
--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -63,33 +63,6 @@ Then, you can try to update **axios@0.21.4** and **cra-append-sw@2.7.0** to reso
 !!! note
     Only Node.js (package-lock.json) is supported at the moment.
 
-### JSON
-Similar structure is included in JSON output format
-```json
-          "VulnerabilityID": "CVE-2022-0235",
-          "PkgID": "node-fetch@1.7.3",
-          "PkgName": "node-fetch",
-          "PkgParents": [
-            {
-              "ID": "isomorphic-fetch@2.2.1",
-              "Parents": [
-                {
-                  "ID": "fbjs@0.8.18",
-                  "Parents": [
-                    {
-                      "ID": "styled-components@3.1.3"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-
-```
-
-!!! caution
-    As of May 2022 the feature is supported for `npm` dependency parser only
-
 ## JSON
 
 ```

--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -15,7 +15,7 @@ Modern software development relies on the use of third-party libraries.
 Third-party dependencies also depend on others so a list of dependencies can be represented as a dependency graph.
 In some cases, vulnerable dependencies are not linked directly, and it requires analyses of the tree.
 To make this task simpler Trivy can show a dependency origin tree with the `--dependency-tree` flag.
-This flag is available with the `--format table` flag only.
+This flag is only available with the `fs` or `repo` commands and the `--format table` flag.
 
 This tree is the reverse of the npm list command.
 However, if you want to resolve a vulnerability in a particular indirect dependency, the reversed tree is useful to know where that dependency comes from and identify which package you actually need to update.
@@ -63,7 +63,7 @@ Then, you can try to update **axios@0.21.4** and **cra-append-sw@2.7.0** to reso
 !!! note
     Only Node.js (package-lock.json) is supported at the moment.
 
-## JSON
+### JSON
 Similar structure is included in JSON output format
 ```json
           "VulnerabilityID": "CVE-2022-0235",
@@ -88,7 +88,7 @@ Similar structure is included in JSON output format
 ```
 
 !!! caution
-As of May 2022 the feature is supported for `npm` dependency parser only
+    As of May 2022 the feature is supported for `npm` dependency parser only
 
 ## JSON
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -215,7 +215,8 @@ func NewRootCommand(version string, globalFlags *flag.GlobalFlagGroup) *cobra.Co
 
 func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup := flag.NewReportFlagGroup()
-	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
+	reportFlagGroup.DependencyTree = nil // disable '--dependency-tree'
+	reportFlagGroup.ReportFormat = nil   // TODO: support --format summary
 
 	imageFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
@@ -796,7 +797,8 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 
 func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup := flag.NewReportFlagGroup()
-	reportFlagGroup.ReportFormat = nil // TODO: support --format summary
+	reportFlagGroup.DependencyTree = nil // disable '--dependency-tree'
+	reportFlagGroup.ReportFormat = nil   // TODO: support --format summary
 
 	scanFlags := flag.NewScanFlagGroup()
 	scanFlags.SecurityChecks = nil // disable '--security-checks' as it always scans for vulnerabilities

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -165,8 +165,11 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 	}
 
 	// "--dependency-tree" option is available only with "--format table".
-	if dependencyTree && format != report.FormatTable {
-		log.Logger.Warn(`"--dependency-tree" can be used only with "--format table".`)
+	if dependencyTree {
+		log.Logger.Infof(`"--dependency-tree" only shows dependencies for "package-lock.json" files`)
+		if format != report.FormatTable {
+			log.Logger.Warn(`"--dependency-tree" can be used only with "--format table".`)
+		}
 	}
 
 	// Enable '--list-all-pkgs' if needed

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"sync"
 
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/report/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/report/github"

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -51,6 +52,9 @@ func Write(report types.Report, option Option) error {
 	var writer Writer
 	switch option.Format {
 	case FormatTable:
+		if option.Tree && report.ArtifactType != ftypes.ArtifactFilesystem && report.ArtifactType != ftypes.ArtifactRemoteRepository {
+			log.Logger.Warn(`"--dependency-tree" can be used only with "fs" or "repo" commands.`)
+		}
 		writer = &TableWriter{
 			Output:             option.Output,
 			Severities:         option.Severities,

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -52,8 +52,18 @@ func Write(report types.Report, option Option) error {
 	var writer Writer
 	switch option.Format {
 	case FormatTable:
-		if option.Tree && report.ArtifactType != ftypes.ArtifactFilesystem && report.ArtifactType != ftypes.ArtifactRemoteRepository {
-			log.Logger.Warn(`"--dependency-tree" can be used only with "fs" or "repo" commands.`)
+		if option.Tree {
+			switch report.ArtifactType {
+			case ftypes.ArtifactFilesystem, ftypes.ArtifactRemoteRepository: // only `fs` and `repo` commands support `--dependency-tree` flag
+				for _, result := range report.Results {
+					if !strings.HasSuffix(result.Target, "package-lock.json") { // Only package-lock.json files are supported at the moment.
+						log.Logger.Warn(`"--dependency-tree" can be used only with nodejs (package-lock.json) dependencies"`)
+						break // Warning should be once
+					}
+				}
+			default: // other commands don't support `--dependency-tree` flag
+				log.Logger.Warn(`"--dependency-tree" can be used only with "fs" or "repo" commands.`)
+			}
 		}
 		writer = &TableWriter{
 			Output:             option.Output,

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/report/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/report/github"
@@ -52,19 +51,6 @@ func Write(report types.Report, option Option) error {
 	var writer Writer
 	switch option.Format {
 	case FormatTable:
-		if option.Tree {
-			switch report.ArtifactType {
-			case ftypes.ArtifactFilesystem, ftypes.ArtifactRemoteRepository: // only `fs` and `repo` commands support `--dependency-tree` flag
-				for _, result := range report.Results {
-					if !strings.HasSuffix(result.Target, "package-lock.json") { // Only package-lock.json files are supported at the moment.
-						log.Logger.Warn(`"--dependency-tree" can be used only with nodejs (package-lock.json) dependencies"`)
-						break // Warning should be once
-					}
-				}
-			default: // other commands don't support `--dependency-tree` flag
-				log.Logger.Warn(`"--dependency-tree" can be used only with "fs" or "repo" commands.`)
-			}
-		}
 		writer = &TableWriter{
 			Output:             option.Output,
 			Severities:         option.Severities,


### PR DESCRIPTION
## Description
`--dependency-tree` flag is currently only supported by `fs` or `repo` commands. Also, only `package-lock.json` files are currently supported.
- Remove `--dependency-tree` flag for `image` and `sbom` subcommand.
- Update docs(add info about supported subcommands)
- Add info message when using `--dependency-tree` flag.

## Related issues
- Close #2491 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
