### PR TITLE
fix: add shorthand for k8s namespace flag

### DIFF
--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -10,8 +10,9 @@ var (
 	K8sNamespaceFlag = Flag{
 		Name:       "namespace",
 		ConfigName: "kubernetes.namespace",
+		Shorthand:  "n",
 		Value:      "",
-		Usage:      "specify a namespace to sca",
+		Usage:      "specify a namespace to scan",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

The shorthand was probably removed during https://github.com/aquasecurity/trivy/pull/2458

```
trivy k8s -n kube-system --report=summary cluster
```
