### PR TITLE
fix: add dpkg license separation

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
@@ -64,7 +64,6 @@ func Test_dpkgLicenseAnalyzer_Analyze(t *testing.T) {
 						FilePath: "usr/share/doc/apt/copyright",
 						Findings: []types.LicenseFinding{
 							{Name: "GPL-2.0"},
-							{Name: "GPL-2.0"},
 						},
 						PkgName: "apt",
 					},
@@ -123,6 +122,42 @@ func Test_dpkgLicenseAnalyzer_Required(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := dpkgLicenseAnalyzer{}
 			assert.Equal(t, tt.want, a.Required(tt.filePath, nil))
+		})
+	}
+}
+
+func Test_dpkgLicenseAnalyzer_splitLicenses(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantLicenses []string
+	}{
+		{
+			name:         "or with spaces",
+			input:        "GPL-1+ or Artistic or Artistic-dist",
+			wantLicenses: []string{"GPL-1.0", "Artistic", "Artistic-dist"},
+		},
+		{
+			name:         "or with '_'",
+			input:        "LGPLv3+_or_GPLv2+",
+			wantLicenses: []string{"LGPLv3+", "GPL-2.0"},
+		},
+		{
+			name:         "and with spaces",
+			input:        "BSD-3-CLAUSE and GPL-2",
+			wantLicenses: []string{"BSD-3-Clause", "GPL-2.0"},
+		},
+		{
+			name:         "or + and",
+			input:        "GPL-1+ or Artistic, and BSD-4-clause-POWERDOG",
+			wantLicenses: []string{"GPL-1.0", "Artistic", "BSD-4-clause-POWERDOG"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			licenses := splitLicenses(tt.input)
+			assert.Equal(t, tt.wantLicenses, licenses)
 		})
 	}
 }

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -317,7 +317,6 @@ func TestArtifact_Inspect(t *testing.T) {
 									FilePath: "usr/share/doc/ca-certificates/copyright",
 									Findings: []types.LicenseFinding{
 										{Name: "GPL-2.0"},
-										{Name: "GPL-2.0"},
 										{Name: "MPL-2.0"},
 									},
 									PkgName: "ca-certificates",


### PR DESCRIPTION
## Description
`dpkg` copyright files can contain multiple licenses on a single line (e.g. `GPL-1+ or Artistic, and BSD-4-clause-POWERDOG`)
Added separation of these lines.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
