### PR TITLE
fix: scan vendor dir

### DIFF
--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// These variables are exported so that a tool importing Trivy as a library can override these values.
-	AppDirs    = []string{".git", "vendor"}
+	AppDirs    = []string{".git"}
 	SystemDirs = []string{"proc", "sys", "dev"}
 )
 

--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -52,6 +52,7 @@ var mapping = map[string]string{
 
 	"APACHE": Apache20, // 1? 2?
 	"ZLIB":   Zlib,
+	"RUBY":   Ruby,
 }
 
 func Normalize(name string) string {


### PR DESCRIPTION
## Description
Currently `vendor` dir is skipped, but some dependencies and licenses are stored in `vendor`.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
