### PR TITLE
fix: hide empty report when scanning resource

### DIFF
--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -22,5 +22,5 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 		return xerrors.Errorf("get k8s artifacts error: %w", err)
 	}
 
-	return run(ctx, opts, cluster.GetCurrentContext(), artifacts)
+	return run(ctx, opts, cluster.GetCurrentContext(), artifacts, true)
 }

--- a/pkg/k8s/commands/namespace.go
+++ b/pkg/k8s/commands/namespace.go
@@ -24,7 +24,7 @@ func namespaceRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) e
 		return xerrors.Errorf("get k8s artifacts error: %w", err)
 	}
 
-	return run(ctx, opts, cluster.GetCurrentContext(), artifacts)
+	return run(ctx, opts, cluster.GetCurrentContext(), artifacts, true)
 }
 
 func getNamespace(opts flag.Options, currentNamespace string) string {

--- a/pkg/k8s/commands/resource.go
+++ b/pkg/k8s/commands/resource.go
@@ -33,7 +33,7 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 			return err
 		}
 
-		return run(ctx, opts, cluster.GetCurrentContext(), targets)
+		return run(ctx, opts, cluster.GetCurrentContext(), targets, false)
 	}
 
 	// pod/NAME or pod NAME etc
@@ -42,7 +42,7 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 		return err
 	}
 
-	return run(ctx, opts, cluster.GetCurrentContext(), []*artifacts.Artifact{artifact})
+	return run(ctx, opts, cluster.GetCurrentContext(), []*artifacts.Artifact{artifact}, false)
 }
 
 func extractKindAndName(args []string) (string, string, error) {

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, args []string, opts flag.Options) error {
 	}
 }
 
-func run(ctx context.Context, opts flag.Options, cluster string, artifacts []*artifacts.Artifact) error {
+func run(ctx context.Context, opts flag.Options, cluster string, artifacts []*artifacts.Artifact, showEmpty bool) error {
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
@@ -76,7 +76,7 @@ func run(ctx context.Context, opts flag.Options, cluster string, artifacts []*ar
 		Report:     opts.ReportFormat,
 		Output:     opts.Output,
 		Severities: opts.Severities,
-	}, opts.ScanOptions.SecurityChecks); err != nil {
+	}, opts.ScanOptions.SecurityChecks, showEmpty); err != nil {
 		return xerrors.Errorf("unable to write results: %w", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

This change hides summary reports when scanning single resources only. I didn't make it a flag, because a flag would have to be consistent cross command, and the idea is that when you doing a scan for specific resource you see only the report you care about. Eg:

if you scanning, only roles, you only see rbac assesment:
```
trivy k8s clusterrole trivy-operator --report=summary -n kube-system
1 / 1 [----------------------------------------------------------------------------------------------------------] 100.00% ? p/s

Summary Report for minikube
┌───────────┬────────────────────────────┬───────────────────┐
│ Namespace │          Resource          │  RBAC Assessment  │
│           │                            ├───┬───┬───┬───┬───┤
│           │                            │ C │ H │ M │ L │ U │
├───────────┼────────────────────────────┼───┼───┼───┼───┼───┤
│           │ ClusterRole/trivy-operator │ 2 │ 1 │   │   │   │
└───────────┴────────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

if you scanning only a pod (or other resource that is not a role, you see only the summary report)
```
trivy k8s  pod kube-apiserver-minikube --report=summary -n kube-system
1 / 1 [----------------------------------------------------------------------------------------------------------] 100.00% 0 p/s

Summary Report for minikube
┌─────────────┬─────────────────────────────┬───────────────────┬───────────────────┬───────────────────┐
│  Namespace  │          Resource           │  Vulnerabilities  │ Misconfigurations │      Secrets      │
│             │                             ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│             │                             │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├─────────────┼─────────────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ kube-system │ Pod/kube-apiserver-minikube │   │ 1 │ 3 │ 8 │   │   │   │   │   │   │   │   │   │   │   │
└─────────────┴─────────────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

For `cluster` and `all` we always show both reports, even if empty.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2393

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
