### PR TITLE
fix: change a capital letter for `plugin uninstall` subcommand

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -617,7 +617,7 @@ func NewPluginCommand() *cobra.Command {
 			Aliases:               []string{"u"},
 			SilenceErrors:         true,
 			DisableFlagsInUseLine: true,
-			Short:                 "uninstall a plugin",
+			Short:                 "Uninstall a plugin",
 			Args:                  cobra.ExactArgs(1),
 			RunE: func(_ *cobra.Command, args []string) error {
 				if err := plugin.Uninstall(args[0]); err != nil {

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -613,7 +613,7 @@ func NewPluginCommand() *cobra.Command {
 			},
 		},
 		&cobra.Command{
-			Use:                   "Uninstall PLUGIN_NAME",
+			Use:                   "uninstall PLUGIN_NAME",
 			Aliases:               []string{"u"},
 			SilenceErrors:         true,
 			DisableFlagsInUseLine: true,


### PR DESCRIPTION
## Description
before:
```sh
$ trivy plugin Uninstall demo-trivy-plgn
```

after
```sh
$ trivy plugin uninstall demo-trivy-plgn
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
