### PR TITLE
fix(k8s): no error logged if trivy can't get docker image in kubernetes mode

### DIFF
--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -72,10 +72,6 @@ func run(ctx context.Context, opts flag.Options, cluster string, artifacts []*ar
 		return xerrors.Errorf("k8s scan error: %w", err)
 	}
 
-	for _, err := range r.GetErrors() {
-		log.Logger.Warnf("Failures during scan: %s", err)
-	}
-
 	if err := report.Write(r, report.Option{
 		Format:     opts.Format,
 		Report:     opts.ReportFormat,

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -71,6 +71,11 @@ func run(ctx context.Context, opts flag.Options, cluster string, artifacts []*ar
 	if err != nil {
 		return xerrors.Errorf("k8s scan error: %w", err)
 	}
+
+	for _, err := range r.GetErrors() {
+		log.Logger.Warnf("Failures during scan: %s", err)
+	}
+
 	if err := report.Write(r, report.Option{
 		Format:     opts.Format,
 		Report:     opts.ReportFormat,

--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -220,3 +220,21 @@ func CreateResource(artifact *artifacts.Artifact, report types.Report, err error
 
 	return r
 }
+
+func (r Report) GetErrors() []string {
+	var errors []string
+
+	for _, resource := range r.Vulnerabilities {
+		if resource.Error != "" {
+			errors = append(errors, resource.Error)
+		}
+	}
+
+	for _, resource := range r.Misconfigurations {
+		if resource.Error != "" {
+			errors = append(errors, resource.Error)
+		}
+	}
+
+	return errors
+}

--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -129,6 +130,8 @@ type Writer interface {
 
 // Write writes the results in the give format
 func Write(report Report, option Option, securityChecks []string, showEmpty bool) error {
+	report.printErrors()
+
 	switch option.Format {
 	case jsonFormat:
 		jwriter := JSONWriter{Output: option.Output, Report: option.Report}
@@ -221,20 +224,16 @@ func CreateResource(artifact *artifacts.Artifact, report types.Report, err error
 	return r
 }
 
-func (r Report) GetErrors() []string {
-	var errors []string
-
+func (r Report) printErrors() {
 	for _, resource := range r.Vulnerabilities {
 		if resource.Error != "" {
-			errors = append(errors, resource.Error)
+			log.Logger.Warnf("Error during vulnerabilities scan: %s", resource.Error)
 		}
 	}
 
 	for _, resource := range r.Misconfigurations {
 		if resource.Error != "" {
-			errors = append(errors, resource.Error)
+			log.Logger.Warnf("Error during misconfiguration scan: %s", resource.Error)
 		}
 	}
-
-	return errors
 }

--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -227,13 +227,13 @@ func CreateResource(artifact *artifacts.Artifact, report types.Report, err error
 func (r Report) printErrors() {
 	for _, resource := range r.Vulnerabilities {
 		if resource.Error != "" {
-			log.Logger.Warnf("Error during vulnerabilities scan: %s", resource.Error)
+			log.Logger.Errorf("Error during vulnerabilities scan: %s", resource.Error)
 		}
 	}
 
 	for _, resource := range r.Misconfigurations {
 		if resource.Error != "" {
-			log.Logger.Warnf("Error during misconfiguration scan: %s", resource.Error)
+			log.Logger.Errorf("Error during misconfiguration scan: %s", resource.Error)
 		}
 	}
 }

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -37,7 +37,7 @@ func (s *Scanner) Scan(ctx context.Context, artifacts []*artifacts.Artifact) (re
 	var vulns, misconfigs []report.Resource
 
 	// disable logs before scanning
-	err := log.InitLogger(s.opts.Debug, false)
+	err := log.InitLogger(s.opts.Debug, true)
 	if err != nil {
 		return report.Report{}, xerrors.Errorf("logger error: %w", err)
 	}

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -37,7 +37,7 @@ func (s *Scanner) Scan(ctx context.Context, artifacts []*artifacts.Artifact) (re
 	var vulns, misconfigs []report.Resource
 
 	// disable logs before scanning
-	err := log.InitLogger(s.opts.Debug, true)
+	err := log.InitLogger(s.opts.Debug, false)
 	if err != nil {
 		return report.Report{}, xerrors.Errorf("logger error: %w", err)
 	}
@@ -97,7 +97,7 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact) (
 		imageReport, err := s.runner.ScanImage(ctx, s.opts)
 
 		if err != nil {
-			log.Logger.Debugf("failed to scan image %s: %s", image, err)
+			log.Logger.Warnf("failed to scan image %s: %s", image, err)
 			resources = append(resources, report.CreateResource(artifact, imageReport, err))
 			continue
 		}


### PR DESCRIPTION
## Description
Enabling logs for k8s mode and increasing log level for the failed image scans from debug to warning. Should it be even error?
@josedonizetti mentioned that logging was disabled to not mess the output of report. But it looks like logs are printed before the reports, so looks fine for me. Please let me know if I'm missing anything.

### Before
```
❯ ./trivy k8s -n prod --security-checks vuln deployment/<deployment name>
1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 2 p/s
```
### After
```
❯ ./trivy k8s -n prod --security-checks vuln deployment/<deployment name>
2022-07-15T10:15:50.115+0300	INFO	Vulnerability scanning is enabled
1 / 1 [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% ? p/s2022-07-15T10:15:50.813+0300	WARN	failed to scan image XXX.dkr.ecr.us-east-1.amazonaws.com/XXXX: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
	* unable to inspect the image (XXX.dkr.ecr.us-east-1.amazonaws.com/XXXX): Error: No such image: XXX.dkr.ecr.us-east-1.amazonaws.com/XXXX
	* unable to initialize Podman client: no podman socket found: stat /run/user/1000/podman/podman.sock: no such file or directory
	* failed to initialize a containerd client: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
	* GET https://XXX.dkr.ecr.us-east-1.amazonaws.com/v2/XXXX: unexpected status code 401 Unauthorized: Not Authorized



1 / 1 [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 2 p/s
```

## Related issues
- Close #2505

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
