### PR TITLE
fix(cli): remove auto configure environment variables via viper

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -122,11 +121,6 @@ func loadPluginCommands() []*cobra.Command {
 }
 
 func initConfig(configFile string) error {
-	// Configure environment variables
-	viper.SetEnvPrefix("trivy") // will be uppercased automatically
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.AutomaticEnv()
-
 	// Read from config
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")


### PR DESCRIPTION
## Description
We bind flags and environment variables manually, so we don't need to use viper.AutomaticEnv.

## Related issues
- Close a part of #2525 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
