### PR TITLE
fix(flag): change a value type for `--skip-dirs` and `--skip-files`

### DIFF
--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -14,13 +14,13 @@ var (
 	SkipDirsFlag = Flag{
 		Name:       "skip-dirs",
 		ConfigName: "scan.skip-dirs",
-		Value:      "",
+		Value:      []string{},
 		Usage:      "specify the directories where the traversal is skipped",
 	}
 	SkipFilesFlag = Flag{
 		Name:       "skip-files",
 		ConfigName: "scan.skip-files",
-		Value:      "",
+		Value:      []string{},
 		Usage:      "specify the file paths to skip traversal",
 	}
 	OfflineScanFlag = Flag{


### PR DESCRIPTION
## Description
the initial values for `--skip-dirs` and `--skip-files` were `string` instead of `[]string`

## Related issues
- Close #2529 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
