### PR TITLE
fix: classifier loading only when scanning licenses

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aquasecurity/trivy/pkg/licensing"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
@@ -284,6 +285,11 @@ func NewAnalyzerGroup(groupName Group, disabledAnalyzers []Type) AnalyzerGroup {
 			continue
 		}
 		group.configAnalyzers = append(group.configAnalyzers, a)
+	}
+
+	// load classifier when scanning licenses
+	if !slices.Contains(disabledAnalyzers, TypeLicenseFile) {
+		licensing.NewClassifier()
 	}
 
 	return group

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aquasecurity/trivy/pkg/licensing"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
@@ -18,6 +17,7 @@ import (
 	aos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	"github.com/aquasecurity/trivy/pkg/fanal/log"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/licensing"
 )
 
 var (

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/aquasecurity/trivy/pkg/licensing"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
@@ -17,7 +18,6 @@ import (
 	aos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	"github.com/aquasecurity/trivy/pkg/fanal/log"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/licensing"
 )
 
 var (
@@ -287,10 +287,7 @@ func NewAnalyzerGroup(groupName Group, disabledAnalyzers []Type) AnalyzerGroup {
 		group.configAnalyzers = append(group.configAnalyzers, a)
 	}
 
-	// load classifier when scanning licenses
-	if !slices.Contains(disabledAnalyzers, TypeLicenseFile) {
-		licensing.NewClassifier()
-	}
+	licensing.NewClassifier()
 
 	return group
 }

--- a/pkg/fanal/analyzer/licensing/license_test.go
+++ b/pkg/fanal/analyzer/licensing/license_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aquasecurity/trivy/pkg/licensing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +55,7 @@ func Test_licenseAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			a := licenseFileAnalyzer{}
+			licensing.NewClassifier()
 			got, err := a.Analyze(context.TODO(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	classifier "github.com/google/licenseclassifier/v2"
-	"github.com/google/licenseclassifier/v2/assets"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
@@ -23,18 +21,10 @@ import (
 
 func init() {
 	analyzer.RegisterAnalyzer(&dpkgLicenseAnalyzer{})
-
-	var err error
-	licenseClassifier, err = assets.DefaultClassifier()
-	if err != nil {
-		panic(err)
-	}
 }
 
 var (
 	dpkgLicenseAnalyzerVersion = 1
-
-	licenseClassifier *classifier.Classifier
 
 	commonLicenseReferenceRegexp = regexp.MustCompile(`/?usr/share/common-licenses/([0-9A-Za-z_.+-]+[0-9A-Za-z+])`)
 	licenseSplitRegexp           = regexp.MustCompile("(,?[_ ]+or[_ ]+)|(,?[_ ]+and[_ ])|(,[ ]*)")
@@ -121,7 +111,7 @@ func (a dpkgLicenseAnalyzer) parseCopyright(r dio.ReadSeekerAt) ([]string, error
 	}
 
 	// Use 'github.com/google/licenseclassifier' to find licenses
-	result, err := licenseClassifier.MatchFrom(r)
+	result, err := licensing.LicenseClassifier.MatchFrom(r)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to match licenses: %w", err)
 	}

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aquasecurity/trivy/pkg/licensing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -83,6 +84,7 @@ func Test_dpkgLicenseAnalyzer_Analyze(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			licensing.NewClassifier()
 			f, err := os.Open(tt.testFile)
 			require.NoError(t, err)
 

--- a/pkg/licensing/classifier.go
+++ b/pkg/licensing/classifier.go
@@ -13,7 +13,7 @@ import (
 
 var cf *classifier.Classifier
 
-func init() {
+func NewClassifier() {
 	var err error
 	cf, err = assets.DefaultClassifier()
 	if err != nil {

--- a/pkg/licensing/classifier_test.go
+++ b/pkg/licensing/classifier_test.go
@@ -90,6 +90,7 @@ func TestClassifier_Classify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			licensing.NewClassifier()
 			contents, err := os.ReadFile(tt.filePath)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Description
License classifier loading consume a lot of time.
Load classifier only when scanning licenses.

## Related issues
- Close #2525

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
