### PR TITLE
docs: add attributes to the video tag to autoplay demo videos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,14 +23,14 @@ All you need to do for scanning is to specify a target such as an image name of 
 </div>
 
 <figure style="text-align: center">
-  <video width="1000">
+  <video width="1000" autoplay muted controls loop>
     <source src="https://user-images.githubusercontent.com/1161307/171013513-95f18734-233d-45d3-aaf5-d6aec687db0e.mov" type="video/mp4" />
   </video>
   <figcaption>Demo: Vulnerability Detection</figcaption>
 </figure>
 
 <figure style="text-align: center">
-  <video width="1000">
+  <video width="1000" autoplay muted controls loop>
     <source src="https://user-images.githubusercontent.com/1161307/171013917-b1f37810-f434-465c-b01a-22de036bd9b3.mov" type="video/mp4" />
   </video>
   <figcaption>Demo: Misconfiguration Detection</figcaption>


### PR DESCRIPTION
## Description
The demo videos in [v0.30.0](https://aquasecurity.github.io/trivy/v0.30.0/) do not play automatically because the video tag lacks some attributes for autoplay.

I have added the following attributes:
- [autoplay](https://www.w3schools.com/tags/tag_video.asp): play video automatically 
- [muted](https://www.w3schools.com/tags/att_video_muted.asp): some browsers require this attribute for autoplay ([ref](https://www.w3schools.com/tags/att_video_autoplay.asp))
- [loop](https://www.w3schools.com/tags/att_video_loop.asp): play the video again when finished 
- [controls](https://www.w3schools.com/tags/att_video_controls.asp): display control buttons such as a play/pause button

I built the mkdocs server locally and checked that the demo video played automatically with chrome and firefox.

## Related issues

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
