### PR TITLE
feat(rocky): set Rocky Linux 9 EOL

### DIFF
--- a/pkg/detector/ospkg/rocky/rocky.go
+++ b/pkg/detector/ospkg/rocky/rocky.go
@@ -20,6 +20,7 @@ var (
 		// Source:
 		// https://endoflife.date/rocky-linux
 		"8": time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC),
+		"9": time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION
## Description
Rocky Linux 9.0 is now GA and EOL is set.
https://rockylinux.org/news/rocky-linux-9-0-ga-release/

## Related issues

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
