### PR TITLE
fix(license): lazy loading of classifiers

### DIFF
--- a/pkg/fanal/analyzer/licensing/license.go
+++ b/pkg/fanal/analyzer/licensing/license.go
@@ -77,8 +77,10 @@ func (a licenseFileAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisI
 		filePath = fmt.Sprintf("/%s", filePath)
 	}
 
-	lf := licensing.Classify(filePath, content)
-	if len(lf.Findings) == 0 {
+	lf, err := licensing.FullClassify(filePath, content)
+	if err != nil {
+		return nil, xerrors.Errorf("license classification error: %w", err)
+	} else if len(lf.Findings) == 0 {
 		return nil, nil
 	}
 

--- a/pkg/licensing/classifier.go
+++ b/pkg/licensing/classifier.go
@@ -2,37 +2,85 @@ package licensing
 
 import (
 	"fmt"
-	"log"
+	"io"
+	"sync"
 
 	"github.com/go-enry/go-license-detector/v4/licensedb"
 	classifier "github.com/google/licenseclassifier/v2"
 	"github.com/google/licenseclassifier/v2/assets"
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 var cf *classifier.Classifier
+var classifierOnce sync.Once
+var licensedbOnce sync.Once
 
-func init() {
+func initGoogleClassifier() error {
+	// Initialize the default classifier once.
+	// This loading is expensive and should be called only when the license classification is needed.
 	var err error
-	cf, err = assets.DefaultClassifier()
-	if err != nil {
-		// It never reaches here.
-		log.Fatal(err)
-	}
-
-	licensedb.Preload()
+	classifierOnce.Do(func() {
+		log.Logger.Debug("Loading the the default license classifier...")
+		cf, err = assets.DefaultClassifier()
+	})
+	return err
 }
 
-// Classify detects and classifies the licensedFile found in a file
-func Classify(filePath string, contents []byte) types.LicenseFile {
-	licFile := googleClassifierLicense(filePath, contents)
+func initLicenseDB() {
+	// Preload the license database once.
+	// This preloading is expensive and should be called only when the license classification is needed.
+	licensedbOnce.Do(func() {
+		log.Logger.Debug("Loading the license database...")
+		licensedb.Preload()
+	})
+}
 
-	if len(licFile.Findings) == 0 {
-		return fallbackClassifyLicense(filePath, contents)
+// Classify uses a single classifier to detect and classify the license found in a file
+func Classify(r io.Reader) ([]types.LicenseFinding, error) {
+	if err := initGoogleClassifier(); err != nil {
+		return nil, err
 	}
 
-	return licFile
+	// Use 'github.com/google/licenseclassifier' to find licenses
+	result, err := cf.MatchFrom(r)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to match licenses: %w", err)
+	}
+
+	var findings []types.LicenseFinding
+	seen := map[string]struct{}{}
+	for _, match := range result.Matches {
+		if match.Confidence <= 0.9 {
+			continue
+		}
+
+		if _, ok := seen[match.Name]; !ok {
+			findings = append(findings, types.LicenseFinding{
+				Name: match.Name,
+			})
+			seen[match.Name] = struct{}{}
+		}
+	}
+	return findings, nil
+}
+
+// FullClassify uses two classifiers to detect and classify the license found in a file
+func FullClassify(filePath string, contents []byte) (types.LicenseFile, error) {
+	if err := initGoogleClassifier(); err != nil {
+		return types.LicenseFile{}, err
+	}
+
+	licFile := googleClassifierLicense(filePath, contents)
+
+	if len(licFile.Findings) != 0 {
+		return licFile, nil
+	}
+
+	initLicenseDB()
+	return fallbackClassifyLicense(filePath, contents), nil
 }
 
 func googleClassifierLicense(filePath string, contents []byte) types.LicenseFile {

--- a/pkg/licensing/classifier_test.go
+++ b/pkg/licensing/classifier_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
-func TestClassifier_Classify(t *testing.T) {
+func TestClassifier_FullClassify(t *testing.T) {
 	tests := []struct {
 		name     string
 		filePath string
@@ -93,7 +93,8 @@ func TestClassifier_Classify(t *testing.T) {
 			contents, err := os.ReadFile(tt.filePath)
 			require.NoError(t, err)
 
-			got := licensing.Classify(tt.filePath, contents)
+			got, err := licensing.FullClassify(tt.filePath, contents)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Description
Loading license classifiers are expensive. It should be done only when license scanning is needed.

## Related issues
- Close #2525

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
