### PR TITLE
chore(image): transform image name to lowercase

### DIFF
--- a/pkg/fanal/image/image.go
+++ b/pkg/fanal/image/image.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -60,7 +61,12 @@ func NewContainerImage(ctx context.Context, imageName string, option types.Docke
 	if option.NonSSL {
 		nameOpts = append(nameOpts, name.Insecure)
 	}
-	ref, err := name.ParseReference(imageName, nameOpts...)
+
+	// Docker image name can only contain lowercase letters
+	// Github user can contain upper case in username
+	// Users mistakenly use it in the image name
+	// We need to transform image name to lowercase.
+	ref, err := name.ParseReference(strings.ToLower(imageName), nameOpts...)
 	if err != nil {
 		return nil, func() {}, xerrors.Errorf("failed to parse the image name: %w", err)
 	}

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -159,7 +159,7 @@ func TestNewDockerImage(t *testing.T) {
 		{
 			name: "happy path with Docker Registry",
 			args: args{
-				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
+				imageName: fmt.Sprintf("%s/library/Alpine:3.10", serverAddr),
 			},
 			wantID:       "sha256:af341ccd2df8b0e2d67cf8dd32e087bfda4e5756ebd1c76bbf3efa0dc246590e",
 			wantLayerIDs: []string{"sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},


### PR DESCRIPTION
## Description
Docker image name can only contain lowercase letters.
Github user can contain upper case in username and users mistakenly use it in the image name
We need to transform image name to lowercase.

## Related issues
- Close #2555

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
