### PR TITLE
fix(cli): replace '-' to '_' for env vars

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -130,7 +130,7 @@ func bind(cmd *cobra.Command, flag *Flag) error {
 		}
 	}
 	// We don't use viper.AutomaticEnv, so we need to add a prefix manually here.
-	if err := viper.BindEnv(flag.ConfigName, strings.ToUpper("trivy_"+flag.Name)); err != nil {
+	if err := viper.BindEnv(flag.ConfigName, strings.ToUpper("trivy_"+strings.ReplaceAll(flag.Name, "-", "_"))); err != nil {
 		return err
 	}
 
@@ -202,9 +202,9 @@ func (f *Flags) groups() []FlagGroup {
 	if f.SecretFlagGroup != nil {
 		groups = append(groups, f.SecretFlagGroup)
 	}
-	if f.LicenseFlagGroup != nil {
-		groups = append(groups, f.LicenseFlagGroup)
-	}
+	//if f.LicenseFlagGroup != nil {
+	//	groups = append(groups, f.LicenseFlagGroup)
+	//}
 	if f.K8sFlagGroup != nil {
 		groups = append(groups, f.K8sFlagGroup)
 	}

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -202,9 +202,9 @@ func (f *Flags) groups() []FlagGroup {
 	if f.SecretFlagGroup != nil {
 		groups = append(groups, f.SecretFlagGroup)
 	}
-	//if f.LicenseFlagGroup != nil {
-	//	groups = append(groups, f.LicenseFlagGroup)
-	//}
+	if f.LicenseFlagGroup != nil {
+		groups = append(groups, f.LicenseFlagGroup)
+	}
 	if f.K8sFlagGroup != nil {
 		groups = append(groups, f.K8sFlagGroup)
 	}


### PR DESCRIPTION
## Description
Trivy env variables currently include "-"  instead of "_". 
Added replacement for these envs.

## Related issues
- Close #2559

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
