### PR TITLE
feat(report): export exitcode for license checks

### DIFF
--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -114,6 +114,9 @@ func (results Results) Failed() bool {
 		if len(r.Secrets) > 0 {
 			return true
 		}
+		if len(r.Licenses) > 0 {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Description
Currently the license check ignores the configured exit code; this fix add the license check

## Related issues
- Close #2562

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
