### PR TITLE
fix(flag): severity flag accepts lowercase

### DIFF
--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -220,7 +220,7 @@ func splitSeverity(severity []string) []dbTypes.Severity {
 
 	var severities []dbTypes.Severity
 	for _, s := range severity {
-		sev, err := dbTypes.NewSeverity(s)
+		sev, err := dbTypes.NewSeverity(strings.ToUpper(s))
 		if err != nil {
 			log.Logger.Warnf("unknown severity option: %s", err)
 			continue

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -44,6 +44,18 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path with a low case severity",
+			fields: fields{
+				severities: "critical",
+			},
+			want: flag.ReportOptions{
+				Output: os.Stdout,
+				Severities: []dbTypes.Severity{
+					dbTypes.SeverityCritical,
+				},
+			},
+		},
+		{
 			name: "happy path with an unknown severity",
 			fields: fields{
 				severities: "CRITICAL,INVALID",


### PR DESCRIPTION
## Description
`--severity` flag doesn't accept lowercase strings:
```sh
$ trivy image --severity high alpine:3.15.1
2022-07-21T19:41:18.737+0600	WARN	unknown severity option: unknown severity: high
```
fixed.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
