### PR TITLE
feat(spdx): add trivy-version in spdx

### DIFF
--- a/integration/sbom_test.go
+++ b/integration/sbom_test.go
@@ -14,9 +14,8 @@ import (
 
 func TestCycloneDX(t *testing.T) {
 	type args struct {
-		input        string
-		format       string
-		artifactType string
+		input  string
+		format string
 	}
 	tests := []struct {
 		name   string
@@ -26,18 +25,16 @@ func TestCycloneDX(t *testing.T) {
 		{
 			name: "centos7-bom by trivy",
 			args: args{
-				input:        "testdata/fixtures/sbom/centos-7-cyclonedx.json",
-				format:       "cyclonedx",
-				artifactType: "cyclonedx",
+				input:  "testdata/fixtures/sbom/centos-7-cyclonedx.json",
+				format: "cyclonedx",
 			},
 			golden: "testdata/centos-7-cyclonedx.json.golden",
 		},
 		{
 			name: "fluentd-multiple-lockfiles-bom by trivy",
 			args: args{
-				input:        "testdata/fixtures/sbom/fluentd-multiple-lockfiles-cyclonedx.json",
-				format:       "cyclonedx",
-				artifactType: "cyclonedx",
+				input:  "testdata/fixtures/sbom/fluentd-multiple-lockfiles-cyclonedx.json",
+				format: "cyclonedx",
 			},
 			golden: "testdata/fluentd-multiple-lockfiles-cyclonedx.json.golden",
 		},

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -1,10 +1,11 @@
 package spdx
 
 import (
+	"io"
+
 	"github.com/spdx/tools-golang/jsonsaver"
 	"github.com/spdx/tools-golang/tvsaver"
 	"golang.org/x/xerrors"
-	"io"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -13,7 +13,6 @@ import (
 
 type Writer struct {
 	output    io.Writer
-	version   string
 	format    string
 	marshaler *spdx.Marshaler
 }
@@ -21,9 +20,8 @@ type Writer struct {
 func NewWriter(output io.Writer, version string, spdxFormat string) Writer {
 	return Writer{
 		output:    output,
-		version:   version,
 		format:    spdxFormat,
-		marshaler: spdx.NewMarshaler(),
+		marshaler: spdx.NewMarshaler(version),
 	}
 }
 

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -1,185 +1,46 @@
 package spdx
 
 import (
-	"fmt"
-	"io"
-	"strings"
-	"time"
-
-	"github.com/google/uuid"
-	"github.com/mitchellh/hashstructure/v2"
 	"github.com/spdx/tools-golang/jsonsaver"
-	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/tvsaver"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
+	"io"
 
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-const (
-	SPDXVersion         = "SPDX-2.2"
-	DataLicense         = "CC0-1.0"
-	SPDXIdentifier      = "DOCUMENT"
-	DocumentNamespace   = "http://aquasecurity.github.io/trivy"
-	CreatorOrganization = "aquasecurity"
-	CreatorTool         = "trivy"
-)
-
-type Hash func(v interface{}, format hashstructure.Format, opts *hashstructure.HashOptions) (uint64, error)
-
 type Writer struct {
-	output  io.Writer
-	version string
-	*options
+	output    io.Writer
+	version   string
+	format    string
+	marshaler *spdx.Marshaler
 }
 
-type newUUID func() uuid.UUID
-
-type options struct {
-	format     spdx.Document2_1
-	clock      clock.Clock
-	newUUID    newUUID
-	hasher     Hash
-	spdxFormat string
-}
-
-type option func(*options)
-
-type spdxSaveFunction func(*spdx.Document2_2, io.Writer) error
-
-func WithClock(clock clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = clock
-	}
-}
-
-func WithNewUUID(newUUID newUUID) option {
-	return func(opts *options) {
-		opts.newUUID = newUUID
-	}
-}
-
-func WithHasher(hasher Hash) option {
-	return func(opts *options) {
-		opts.hasher = hasher
-	}
-}
-
-func NewWriter(output io.Writer, version string, spdxFormat string, opts ...option) Writer {
-	o := &options{
-		format:     spdx.Document2_1{},
-		clock:      clock.RealClock{},
-		newUUID:    uuid.New,
-		hasher:     hashstructure.Hash,
-		spdxFormat: spdxFormat,
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
-
+func NewWriter(output io.Writer, version string, spdxFormat string) Writer {
 	return Writer{
-		output:  output,
-		version: version,
-		options: o,
+		output:    output,
+		version:   version,
+		format:    spdxFormat,
+		marshaler: spdx.NewMarshaler(),
 	}
 }
 
-func (cw Writer) Write(report types.Report) error {
-	spdxDoc, err := cw.convertToBom(report, cw.version)
+func (w Writer) Write(report types.Report) error {
+	spdxDoc, err := w.marshaler.Marshal(report)
 	if err != nil {
-		return xerrors.Errorf("failed to convert bom: %w", err)
+		return xerrors.Errorf("failed to marshal spdx: %w", err)
 	}
 
-	var saveFunc spdxSaveFunction
-	if cw.spdxFormat != "spdx-json" {
-		saveFunc = tvsaver.Save2_2
+	if w.format == "spdx-json" {
+		if err := jsonsaver.Save2_2(spdxDoc, w.output); err != nil {
+			return xerrors.Errorf("failed to save spdx json: %w", err)
+		}
 	} else {
-		saveFunc = jsonsaver.Save2_2
-	}
-
-	if err = saveFunc(spdxDoc, cw.output); err != nil {
-		return xerrors.Errorf("failed to save bom: %w", err)
-	}
-	return nil
-}
-
-func (cw *Writer) convertToBom(r types.Report, version string) (*spdx.Document2_2, error) {
-	packages := make(map[spdx.ElementID]*spdx.Package2_2)
-
-	for _, result := range r.Results {
-		for _, pkg := range result.Packages {
-			spdxPackage, err := cw.pkgToSpdxPackage(pkg)
-			if err != nil {
-				return nil, xerrors.Errorf("failed to parse pkg: %w", err)
-			}
-			packages[spdxPackage.PackageSPDXIdentifier] = &spdxPackage
+		if err := tvsaver.Save2_2(spdxDoc, w.output); err != nil {
+			return xerrors.Errorf("failed to save spdx tag-value: %w", err)
 		}
 	}
 
-	return &spdx.Document2_2{
-		CreationInfo: &spdx.CreationInfo2_2{
-			SPDXVersion:          SPDXVersion,
-			DataLicense:          DataLicense,
-			SPDXIdentifier:       SPDXIdentifier,
-			DocumentName:         r.ArtifactName,
-			DocumentNamespace:    getDocumentNamespace(r, cw),
-			CreatorOrganizations: []string{CreatorOrganization},
-			CreatorTools:         []string{CreatorTool},
-			Created:              cw.clock.Now().UTC().Format(time.RFC3339Nano),
-		},
-		Packages: packages,
-	}, nil
-}
-
-func (cw *Writer) pkgToSpdxPackage(pkg ftypes.Package) (spdx.Package2_2, error) {
-	var spdxPackage spdx.Package2_2
-	license := getLicense(pkg)
-
-	pkgID, err := getPackageID(cw.hasher, pkg)
-	if err != nil {
-		return spdx.Package2_2{}, xerrors.Errorf("failed to get %s package ID: %w", pkg.Name, err)
-	}
-
-	spdxPackage.PackageSPDXIdentifier = spdx.ElementID(pkgID)
-	spdxPackage.PackageName = pkg.Name
-	spdxPackage.PackageVersion = pkg.Version
-
-	// The Declared License is what the authors of a project believe govern the package
-	spdxPackage.PackageLicenseConcluded = license
-
-	// The Concluded License field is the license the SPDX file creator believes governs the package
-	spdxPackage.PackageLicenseDeclared = license
-
-	return spdxPackage, nil
-}
-
-func getLicense(p ftypes.Package) string {
-	if len(p.Licenses) == 0 {
-		return "NONE"
-	}
-
-	return strings.Join(p.Licenses, ", ")
-}
-
-func getDocumentNamespace(r types.Report, cw *Writer) string {
-	return DocumentNamespace + "/" + string(r.ArtifactType) + "/" + r.ArtifactName + "-" + cw.newUUID().String()
-}
-
-func getPackageID(h Hash, p ftypes.Package) (string, error) {
-	// Not use these values for the hash
-	p.Layer = ftypes.Layer{}
-	p.FilePath = ""
-
-	f, err := h(p, hashstructure.FormatV2, &hashstructure.HashOptions{
-		ZeroNil:      true,
-		SlicesAsSets: true,
-	})
-	if err != nil {
-		return "", xerrors.Errorf("could not build package ID for package=%+v: %+v", p, err)
-	}
-
-	return fmt.Sprintf("%x", f), nil
+	return nil
 }

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -1,0 +1,153 @@
+package spdx
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/spdx/tools-golang/spdx"
+	"golang.org/x/xerrors"
+	"k8s.io/utils/clock"
+	"strings"
+	"time"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+const (
+	SPDXVersion         = "SPDX-2.2"
+	DataLicense         = "CC0-1.0"
+	SPDXIdentifier      = "DOCUMENT"
+	DocumentNamespace   = "http://aquasecurity.github.io/trivy"
+	CreatorOrganization = "aquasecurity"
+	CreatorTool         = "trivy"
+)
+
+type Marshaler struct {
+	format  spdx.Document2_1
+	clock   clock.Clock
+	newUUID newUUID
+	hasher  Hash
+}
+
+type Hash func(v interface{}, format hashstructure.Format, opts *hashstructure.HashOptions) (uint64, error)
+
+type newUUID func() uuid.UUID
+
+type marshalOption func(*Marshaler)
+
+func WithClock(clock clock.Clock) marshalOption {
+	return func(opts *Marshaler) {
+		opts.clock = clock
+	}
+}
+
+func WithNewUUID(newUUID newUUID) marshalOption {
+	return func(opts *Marshaler) {
+		opts.newUUID = newUUID
+	}
+}
+
+func WithHasher(hasher Hash) marshalOption {
+	return func(opts *Marshaler) {
+		opts.hasher = hasher
+	}
+}
+
+func NewMarshaler(opts ...marshalOption) *Marshaler {
+	e := &Marshaler{
+		format:  spdx.Document2_1{},
+		clock:   clock.RealClock{},
+		newUUID: uuid.New,
+		hasher:  hashstructure.Hash,
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+func (e *Marshaler) Marshal(r types.Report) (*spdx.Document2_2, error) {
+	packages := make(map[spdx.ElementID]*spdx.Package2_2)
+
+	for _, result := range r.Results {
+		for _, pkg := range result.Packages {
+			spdxPackage, err := e.pkgToSpdxPackage(pkg)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to parse pkg: %w", err)
+			}
+			packages[spdxPackage.PackageSPDXIdentifier] = &spdxPackage
+		}
+	}
+
+	return &spdx.Document2_2{
+		CreationInfo: &spdx.CreationInfo2_2{
+			SPDXVersion:          SPDXVersion,
+			DataLicense:          DataLicense,
+			SPDXIdentifier:       SPDXIdentifier,
+			DocumentName:         r.ArtifactName,
+			DocumentNamespace:    getDocumentNamespace(r, e),
+			CreatorOrganizations: []string{CreatorOrganization},
+			CreatorTools:         []string{CreatorTool},
+			Created:              e.clock.Now().UTC().Format(time.RFC3339Nano),
+		},
+		Packages: packages,
+	}, nil
+}
+
+func (e *Marshaler) pkgToSpdxPackage(pkg ftypes.Package) (spdx.Package2_2, error) {
+	var spdxPackage spdx.Package2_2
+	license := getLicense(pkg)
+
+	pkgID, err := getPackageID(e.hasher, pkg)
+	if err != nil {
+		return spdx.Package2_2{}, xerrors.Errorf("failed to get %s package ID: %w", pkg.Name, err)
+	}
+
+	spdxPackage.PackageSPDXIdentifier = spdx.ElementID(pkgID)
+	spdxPackage.PackageName = pkg.Name
+	spdxPackage.PackageVersion = pkg.Version
+
+	// The Declared License is what the authors of a project believe govern the package
+	spdxPackage.PackageLicenseConcluded = license
+
+	// The Concluded License field is the license the SPDX file creator believes governs the package
+	spdxPackage.PackageLicenseDeclared = license
+
+	return spdxPackage, nil
+}
+
+func getLicense(p ftypes.Package) string {
+	if len(p.Licenses) == 0 {
+		return "NONE"
+	}
+
+	return strings.Join(p.Licenses, ", ")
+}
+
+func getDocumentNamespace(r types.Report, e *Marshaler) string {
+	return fmt.Sprintf("%s/%s/%s-%s",
+		DocumentNamespace,
+		string(r.ArtifactType),
+		r.ArtifactName,
+		e.newUUID().String(),
+	)
+}
+
+func getPackageID(h Hash, p ftypes.Package) (string, error) {
+	// Not use these values for the hash
+	p.Layer = ftypes.Layer{}
+	p.FilePath = ""
+
+	f, err := h(p, hashstructure.FormatV2, &hashstructure.HashOptions{
+		ZeroNil:      true,
+		SlicesAsSets: true,
+	})
+	if err != nil {
+		return "", xerrors.Errorf("could not build package ID for package=%+v: %+v", p, err)
+	}
+
+	return fmt.Sprintf("%x", f), nil
+}

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -31,10 +31,11 @@ const (
 )
 
 type Marshaler struct {
-	format  spdx.Document2_1
-	clock   clock.Clock
-	newUUID newUUID
-	hasher  Hash
+	appVersion string
+	format     spdx.Document2_1
+	clock      clock.Clock
+	newUUID    newUUID
+	hasher     Hash
 }
 
 type Hash func(v interface{}, format hashstructure.Format, opts *hashstructure.HashOptions) (uint64, error)
@@ -61,12 +62,13 @@ func WithHasher(hasher Hash) marshalOption {
 	}
 }
 
-func NewMarshaler(opts ...marshalOption) *Marshaler {
+func NewMarshaler(version string, opts ...marshalOption) *Marshaler {
 	e := &Marshaler{
-		format:  spdx.Document2_1{},
-		clock:   clock.RealClock{},
-		newUUID: uuid.New,
-		hasher:  hashstructure.Hash,
+		appVersion: version,
+		format:     spdx.Document2_1{},
+		clock:      clock.RealClock{},
+		newUUID:    uuid.New,
+		hasher:     hashstructure.Hash,
 	}
 
 	for _, opt := range opts {
@@ -97,7 +99,7 @@ func (e *Marshaler) Marshal(r types.Report) (*spdx.Document2_2, error) {
 			DocumentName:         r.ArtifactName,
 			DocumentNamespace:    getDocumentNamespace(r, e),
 			CreatorOrganizations: []string{CreatorOrganization},
-			CreatorTools:         []string{CreatorTool},
+			CreatorTools:         []string{fmt.Sprintf("%s-%s", CreatorTool, e.appVersion)},
 			Created:              e.clock.Now().UTC().Format(time.RFC3339Nano),
 		},
 		Packages: packages,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -105,7 +105,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "rails:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-dev"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -233,7 +233,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "centos:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-dev"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -301,7 +301,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "masahiro331/CVE-2021-41098",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-dev"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -355,7 +355,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "test-aggregate",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-dev"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -392,7 +392,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "empty/path",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-dev"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{},
@@ -426,7 +426,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			marshaler := tspdx.NewMarshaler(tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
+			marshaler := tspdx.NewMarshaler("dev", tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
 			spdxDoc, err := marshaler.Marshal(tc.inputReport)
 			require.NoError(t, err)
 

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -2,23 +2,23 @@ package spdx_test
 
 import (
 	"fmt"
-	"github.com/aquasecurity/trivy/pkg/report"
-	"github.com/stretchr/testify/assert"
 	"hash/fnv"
 	"testing"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/uuid"
 	"github.com/mitchellh/hashstructure/v2"
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fake "k8s.io/utils/clock/testing"
 
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/report"
 	tspdx "github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/uuid"
-	"github.com/spdx/tools-golang/spdx"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 )
 
 func TestMarshaler_Marshal(t *testing.T) {
@@ -115,6 +115,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "7.0.1",
 						PackageLicenseConcluded: "NONE",
 						PackageLicenseDeclared:  "NONE",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:gem/actioncontroller@7.0.1",
+							},
+						},
 					},
 					spdx.ElementID("826226d056ff30c0"): {
 						PackageSPDXIdentifier:   spdx.ElementID("826226d056ff30c0"),
@@ -122,6 +129,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "7.0.1",
 						PackageLicenseConcluded: "NONE",
 						PackageLicenseDeclared:  "NONE",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:gem/actionpack@7.0.1",
+							},
+						},
 					},
 					spdx.ElementID("fd0dc3cf913d5bc3"): {
 						PackageSPDXIdentifier:   spdx.ElementID("fd0dc3cf913d5bc3"),
@@ -129,6 +143,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "2.30",
 						PackageLicenseConcluded: "GPLv3+",
 						PackageLicenseDeclared:  "GPLv3+",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+							},
+						},
 					},
 				},
 				UnpackagedFiles: nil,
@@ -222,6 +243,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "2.2.53",
 						PackageLicenseConcluded: "GPLv2+",
 						PackageLicenseDeclared:  "GPLv2+",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:rpm/centos/acl@1:2.2.53-1.el8?arch=aarch64&distro=centos-8.3.2011",
+							},
+						},
 					},
 					spdx.ElementID("826226d056ff30c0"): {
 						PackageSPDXIdentifier:   spdx.ElementID("826226d056ff30c0"),
@@ -229,6 +257,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "7.0.1",
 						PackageLicenseConcluded: "NONE",
 						PackageLicenseDeclared:  "NONE",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:gem/actionpack@7.0.1",
+							},
+						},
 					},
 				},
 				UnpackagedFiles: nil,
@@ -276,6 +311,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "6.1.4.1",
 						PackageLicenseConcluded: "NONE",
 						PackageLicenseDeclared:  "NONE",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:gem/actioncable@6.1.4.1",
+							},
+						},
 					},
 				},
 			},
@@ -323,6 +365,13 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageVersion:          "0.20.1",
 						PackageLicenseConcluded: "MIT",
 						PackageLicenseDeclared:  "MIT",
+						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
+							},
+						},
 					},
 				},
 			},
@@ -346,7 +395,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					CreatorTools:         []string{"trivy"},
 					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
-				Packages: nil,
+				Packages: map[spdx.ElementID]*spdx.Package2_2{},
 			},
 		},
 	}

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1,8 +1,9 @@
 package spdx_test
 
 import (
-	"bytes"
 	"fmt"
+	"github.com/aquasecurity/trivy/pkg/report"
+	"github.com/stretchr/testify/assert"
 	"hash/fnv"
 	"testing"
 	"time"
@@ -11,19 +12,16 @@ import (
 
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/report"
-	reportSpdx "github.com/aquasecurity/trivy/pkg/report/spdx"
+	tspdx "github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/uuid"
-	"github.com/spdx/tools-golang/jsonloader"
 	"github.com/spdx/tools-golang/spdx"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fake "k8s.io/utils/clock/testing"
 )
 
-func TestWriter_Write(t *testing.T) {
+func TestMarshaler_Marshal(t *testing.T) {
 	testCases := []struct {
 		name        string
 		inputReport types.Report
@@ -101,40 +99,36 @@ func TestWriter_Write(t *testing.T) {
 			},
 			wantSBOM: &spdx.Document2_2{
 				CreationInfo: &spdx.CreationInfo2_2{
-					SPDXVersion:                "SPDX-2.2",
-					DataLicense:                "CC0-1.0",
-					SPDXIdentifier:             "DOCUMENT",
-					DocumentName:               "rails:latest",
-					DocumentNamespace:          "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
-					CreatorOrganizations:       []string{"aquasecurity"},
-					CreatorTools:               []string{"trivy"},
-					Created:                    "2021-08-25T12:20:30.000000005Z",
-					ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+					SPDXVersion:          "SPDX-2.2",
+					DataLicense:          "CC0-1.0",
+					SPDXIdentifier:       "DOCUMENT",
+					DocumentName:         "rails:latest",
+					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
+					CreatorOrganizations: []string{"aquasecurity"},
+					CreatorTools:         []string{"trivy"},
+					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("eb0263038c3b445b"): {
-						PackageSPDXIdentifier:     spdx.ElementID("eb0263038c3b445b"),
-						PackageName:               "actioncontroller",
-						PackageVersion:            "7.0.1",
-						PackageLicenseConcluded:   "NONE",
-						PackageLicenseDeclared:    "NONE",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("eb0263038c3b445b"),
+						PackageName:             "actioncontroller",
+						PackageVersion:          "7.0.1",
+						PackageLicenseConcluded: "NONE",
+						PackageLicenseDeclared:  "NONE",
 					},
 					spdx.ElementID("826226d056ff30c0"): {
-						PackageSPDXIdentifier:     spdx.ElementID("826226d056ff30c0"),
-						PackageName:               "actionpack",
-						PackageVersion:            "7.0.1",
-						PackageLicenseConcluded:   "NONE",
-						PackageLicenseDeclared:    "NONE",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("826226d056ff30c0"),
+						PackageName:             "actionpack",
+						PackageVersion:          "7.0.1",
+						PackageLicenseConcluded: "NONE",
+						PackageLicenseDeclared:  "NONE",
 					},
 					spdx.ElementID("fd0dc3cf913d5bc3"): {
-						PackageSPDXIdentifier:     spdx.ElementID("fd0dc3cf913d5bc3"),
-						PackageName:               "binutils",
-						PackageVersion:            "2.30",
-						PackageLicenseConcluded:   "GPLv3+",
-						PackageLicenseDeclared:    "GPLv3+",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("fd0dc3cf913d5bc3"),
+						PackageName:             "binutils",
+						PackageVersion:          "2.30",
+						PackageLicenseConcluded: "GPLv3+",
+						PackageLicenseDeclared:  "GPLv3+",
 					},
 				},
 				UnpackagedFiles: nil,
@@ -212,32 +206,29 @@ func TestWriter_Write(t *testing.T) {
 			},
 			wantSBOM: &spdx.Document2_2{
 				CreationInfo: &spdx.CreationInfo2_2{
-					SPDXVersion:                "SPDX-2.2",
-					DataLicense:                "CC0-1.0",
-					SPDXIdentifier:             "DOCUMENT",
-					DocumentName:               "centos:latest",
-					DocumentNamespace:          "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
-					CreatorOrganizations:       []string{"aquasecurity"},
-					CreatorTools:               []string{"trivy"},
-					Created:                    "2021-08-25T12:20:30.000000005Z",
-					ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+					SPDXVersion:          "SPDX-2.2",
+					DataLicense:          "CC0-1.0",
+					SPDXIdentifier:       "DOCUMENT",
+					DocumentName:         "centos:latest",
+					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
+					CreatorOrganizations: []string{"aquasecurity"},
+					CreatorTools:         []string{"trivy"},
+					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("d8dccb186bafaf37"): {
-						PackageSPDXIdentifier:     spdx.ElementID("d8dccb186bafaf37"),
-						PackageName:               "acl",
-						PackageVersion:            "2.2.53",
-						PackageLicenseConcluded:   "GPLv2+",
-						PackageLicenseDeclared:    "GPLv2+",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("d8dccb186bafaf37"),
+						PackageName:             "acl",
+						PackageVersion:          "2.2.53",
+						PackageLicenseConcluded: "GPLv2+",
+						PackageLicenseDeclared:  "GPLv2+",
 					},
 					spdx.ElementID("826226d056ff30c0"): {
-						PackageSPDXIdentifier:     spdx.ElementID("826226d056ff30c0"),
-						PackageName:               "actionpack",
-						PackageVersion:            "7.0.1",
-						PackageLicenseConcluded:   "NONE",
-						PackageLicenseDeclared:    "NONE",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("826226d056ff30c0"),
+						PackageName:             "actionpack",
+						PackageVersion:          "7.0.1",
+						PackageLicenseConcluded: "NONE",
+						PackageLicenseDeclared:  "NONE",
 					},
 				},
 				UnpackagedFiles: nil,
@@ -269,24 +260,22 @@ func TestWriter_Write(t *testing.T) {
 			},
 			wantSBOM: &spdx.Document2_2{
 				CreationInfo: &spdx.CreationInfo2_2{
-					SPDXVersion:                "SPDX-2.2",
-					DataLicense:                "CC0-1.0",
-					SPDXIdentifier:             "DOCUMENT",
-					DocumentName:               "masahiro331/CVE-2021-41098",
-					DocumentNamespace:          "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
-					CreatorOrganizations:       []string{"aquasecurity"},
-					CreatorTools:               []string{"trivy"},
-					Created:                    "2021-08-25T12:20:30.000000005Z",
-					ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+					SPDXVersion:          "SPDX-2.2",
+					DataLicense:          "CC0-1.0",
+					SPDXIdentifier:       "DOCUMENT",
+					DocumentName:         "masahiro331/CVE-2021-41098",
+					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
+					CreatorOrganizations: []string{"aquasecurity"},
+					CreatorTools:         []string{"trivy"},
+					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("3da61e86d0530402"): {
-						PackageSPDXIdentifier:     spdx.ElementID("3da61e86d0530402"),
-						PackageName:               "actioncable",
-						PackageVersion:            "6.1.4.1",
-						PackageLicenseConcluded:   "NONE",
-						PackageLicenseDeclared:    "NONE",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("3da61e86d0530402"),
+						PackageName:             "actioncable",
+						PackageVersion:          "6.1.4.1",
+						PackageLicenseConcluded: "NONE",
+						PackageLicenseDeclared:  "NONE",
 					},
 				},
 			},
@@ -318,24 +307,22 @@ func TestWriter_Write(t *testing.T) {
 			},
 			wantSBOM: &spdx.Document2_2{
 				CreationInfo: &spdx.CreationInfo2_2{
-					SPDXVersion:                "SPDX-2.2",
-					DataLicense:                "CC0-1.0",
-					SPDXIdentifier:             "DOCUMENT",
-					DocumentName:               "test-aggregate",
-					DocumentNamespace:          "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
-					CreatorOrganizations:       []string{"aquasecurity"},
-					CreatorTools:               []string{"trivy"},
-					Created:                    "2021-08-25T12:20:30.000000005Z",
-					ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+					SPDXVersion:          "SPDX-2.2",
+					DataLicense:          "CC0-1.0",
+					SPDXIdentifier:       "DOCUMENT",
+					DocumentName:         "test-aggregate",
+					DocumentNamespace:    "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
+					CreatorOrganizations: []string{"aquasecurity"},
+					CreatorTools:         []string{"trivy"},
+					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("9f3d92e5ae2cadfb"): {
-						PackageSPDXIdentifier:     spdx.ElementID("9f3d92e5ae2cadfb"),
-						PackageName:               "ruby-typeprof",
-						PackageVersion:            "0.20.1",
-						PackageLicenseConcluded:   "MIT",
-						PackageLicenseDeclared:    "MIT",
-						IsFilesAnalyzedTagPresent: true,
+						PackageSPDXIdentifier:   spdx.ElementID("9f3d92e5ae2cadfb"),
+						PackageName:             "ruby-typeprof",
+						PackageVersion:          "0.20.1",
+						PackageLicenseConcluded: "MIT",
+						PackageLicenseDeclared:  "MIT",
 					},
 				},
 			},
@@ -350,15 +337,14 @@ func TestWriter_Write(t *testing.T) {
 			},
 			wantSBOM: &spdx.Document2_2{
 				CreationInfo: &spdx.CreationInfo2_2{
-					SPDXVersion:                "SPDX-2.2",
-					DataLicense:                "CC0-1.0",
-					SPDXIdentifier:             "DOCUMENT",
-					DocumentName:               "empty/path",
-					DocumentNamespace:          "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
-					CreatorOrganizations:       []string{"aquasecurity"},
-					CreatorTools:               []string{"trivy"},
-					Created:                    "2021-08-25T12:20:30.000000005Z",
-					ExternalDocumentReferences: map[string]spdx.ExternalDocumentRef2_2{},
+					SPDXVersion:          "SPDX-2.2",
+					DataLicense:          "CC0-1.0",
+					SPDXIdentifier:       "DOCUMENT",
+					DocumentName:         "empty/path",
+					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
+					CreatorOrganizations: []string{"aquasecurity"},
+					CreatorTools:         []string{"trivy"},
+					Created:              "2021-08-25T12:20:30.000000005Z",
 				},
 				Packages: nil,
 			},
@@ -391,17 +377,11 @@ func TestWriter_Write(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			output := bytes.NewBuffer(nil)
-			writer := reportSpdx.NewWriter(output, "dev", "spdx-json",
-				reportSpdx.WithClock(clock), reportSpdx.WithNewUUID(newUUID), reportSpdx.WithHasher(hasher))
-
-			err := writer.Write(tc.inputReport)
+			marshaler := tspdx.NewMarshaler(tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
+			spdxDoc, err := marshaler.Marshal(tc.inputReport)
 			require.NoError(t, err)
 
-			got, err := jsonloader.Load2_2(output)
-			require.NoError(t, err)
-
-			assert.Equal(t, *tc.wantSBOM, *got)
+			assert.Equal(t, tc.wantSBOM, spdxDoc)
 		})
 	}
 }


### PR DESCRIPTION
## Description
Add Trivy version for spdx.

before
```
{
        "SPDXID": "SPDXRef-DOCUMENT",
        "creationInfo": {
                "created": "2022-07-23T13:42:32.955489Z",
                "creators": [
                        "Tool: trivy",
                        "Organization: aquasecurity"
                ]
        },
...
}
```

after
```
{
        "SPDXID": "SPDXRef-DOCUMENT",
        "creationInfo": {
                "created": "2022-07-23T13:42:32.955489Z",
                "creators": [
                        "Tool: trivy-v0.29.2-83-g31581890",
                        "Organization: aquasecurity"
                ]
        },
...
}
```

## Related
- #2573

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
