### PR TITLE
fix: enable some features of the wasm runtime

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
 env:
   GO_VERSION: "1.18"
-  TINYGO_VERSION: "0.23.0"
+  TINYGO_VERSION: "0.24.0"
 jobs:
   test:
     name: Test

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -84,8 +84,15 @@ type Manager struct {
 func NewManager(ctx context.Context) (*Manager, error) {
 	m := &Manager{}
 
+	// The runtime must enable the following features because Tinygo uses these features to build.
+	// cf. https://github.com/tinygo-org/tinygo/blob/b65447c7d567eea495805656f45472cc3c483e03/targets/wasi.json#L4
+	c := wazero.NewRuntimeConfig().
+		WithFeatureBulkMemoryOperations(true).
+		WithFeatureNonTrappingFloatToIntConversion(true).
+		WithFeatureSignExtensionOps(true)
+
 	// Create a new WebAssembly Runtime.
-	m.runtime = wazero.NewRuntime()
+	m.runtime = wazero.NewRuntimeWithConfig(c)
 
 	// Load WASM modules in local
 	if err := m.loadModules(ctx); err != nil {


### PR DESCRIPTION
## Description

When we use tinygo in the latest version 0.24.0, unit tests fail because tinygo uses some new features(https://github.com/tinygo-org/tinygo/pull/2911) and the runtime needs to enable these features.

We got the following error message when we executed a wasm binary built by tinygo 0.24.0 on Trivy's wasm runtime.
```
invalid function[11]: memory.copy invalid as feature "bulk-memory-operations" is disabled
```

This PR enables required features when using tinygo 0.24.0.

I checked I could pass the unit tests with tinygo 0.24.0. I also checked the tinygo 0.23.0 for backward compatibility, and it was fine.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2570

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
