### PR TITLE
fix: allow subcommands with TRIVY_RUN_AS_PLUGIN

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
+
 	"github.com/aquasecurity/trivy/pkg/commands"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/plugin"
 )
 
 var (
@@ -10,6 +15,16 @@ var (
 )
 
 func main() {
+	// Trivy behaves as the specified plugin.
+	if runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN"); runAsPlugin != "" {
+		if !plugin.IsPredefined(runAsPlugin) {
+			log.Fatal(fmt.Errorf("unknown plugin: %s", runAsPlugin))
+		}
+		if err := plugin.RunWithArgs(context.Background(), runAsPlugin, os.Args); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	app := commands.NewApp(version)
 	if err := app.Execute(); err != nil {
 		log.Fatal(err)

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -68,15 +68,6 @@ func SetOut(out io.Writer) {
 func NewApp(version string) *cobra.Command {
 	globalFlags := flag.NewGlobalFlagGroup()
 	rootCmd := NewRootCommand(version, globalFlags)
-
-	if runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN"); runAsPlugin != "" {
-		rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
-			return plugin.RunWithArgs(cmd.Context(), runAsPlugin, args)
-		}
-		rootCmd.DisableFlagParsing = true
-		return rootCmd
-	}
-
 	rootCmd.AddCommand(
 		NewImageCommand(globalFlags),
 		NewFilesystemCommand(globalFlags),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -293,6 +293,11 @@ func RunWithArgs(ctx context.Context, url string, args []string) error {
 	return nil
 }
 
+func IsPredefined(name string) bool {
+	_, ok := officialPlugins[name]
+	return ok
+}
+
 func loadMetadata(dir string) (Plugin, error) {
 	filePath := filepath.Join(dir, configFile)
 	f, err := os.Open(filePath)


### PR DESCRIPTION
## Description
After cobra migration, it shows the following error.

```
$ TRIVY_RUN_AS_PLUGIN='aqua' ./trivy fs .
Error: unknown command "fs" for "trivy"
Usage:
  trivy [global flags] command [flags] target

Examples:
  # Scan a container image
  $ trivy image python:3.4-alpine

  # Scan a container image from a tar archive
  $ trivy image --input ruby-3.1.tar

  # Scan local filesystem
  $ trivy fs .

  # Run in server mode
  $ trivy server

Flags:
      --cache-dir string          cache directory (default "/Users/teppei/Library/Caches/trivy")
  -c, --config string             config path (default "trivy.yaml")
  -d, --debug                     debug mode
  -f, --format string             version format (json)
      --generate-default-config   write the default config to trivy-default.yaml
  -h, --help                      help for trivy
      --insecure                  allow insecure server connections when using TLS
  -q, --quiet                     suppress progress bar and log output
      --timeout duration          timeout (default 5m0s)
  -v, --version                   show version

2022-07-24T10:03:33.671+0300    FATAL   unknown command "fs" for "trivy"
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
