### PR TITLE
fix(vuln): GitLab report template

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -1,10 +1,11 @@
 {{- /* Template based on https://docs.gitlab.com/ee/user/application_security/container_scanning/#reports-json-format */ -}}
 {
-  "version": "2.3",
+  "version": "14.0.6",
   "vulnerabilities": [
   {{- $t_first := true }}
   {{- range . }}
   {{- $target := .Target }}
+    {{- $image := $target | regexFind "[^\\s]+" }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}
@@ -31,8 +32,6 @@
                   {{-  else -}}
                     "{{ .Severity }}"
                   {{- end }},
-      {{- /* TODO: Define confidence */}}
-      "confidence": "Unknown",
       "solution": {{ if .FixedVersion -}}
                     "Upgrade {{ .PkgName }} to {{ .FixedVersion }}"
                   {{- else -}}
@@ -51,7 +50,7 @@
         },
         {{- /* TODO: No mapping available - https://github.com/aquasecurity/trivy/issues/332 */}}
         "operating_system": "Unknown",
-        "image": "{{ $target }}"
+        "image": "{{ $image }}"
       },
       "identifiers": [
         {

--- a/docs/docs/integrations/gitlab-ci.md
+++ b/docs/docs/integrations/gitlab-ci.md
@@ -11,7 +11,7 @@ include:
 
 If you're a GitLab 14.x Ultimate customer, you can use the same configuration above.
 
-Alternatively, you can always use the example configurations below. Note that the examples use [`contrib/gitlab.tpl`](https://github.com/aquasecurity/trivy/blob/main/contrib/gitlab.tpl), which does not work with GitLab 15.0 and above (for details, see [issue 1598](https://github.com/aquasecurity/trivy/issues/1598)).
+Alternatively, you can always use the example configurations below.
 
 ```yaml
 stages:

--- a/integration/testdata/alpine-310.gitlab.golden
+++ b/integration/testdata/alpine-310.gitlab.golden
@@ -1,5 +1,5 @@
 {
-  "version": "2.3",
+  "version": "14.0.6",
   "vulnerabilities": [
     {
       "id": "CVE-2019-1549",
@@ -8,7 +8,6 @@
       "description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
       "cve": "CVE-2019-1549",
       "severity": "Medium",
-      "confidence": "Unknown",
       "solution": "Upgrade libcrypto1.1 to 1.1.1d-r0",
       "scanner": {
         "id": "trivy",
@@ -22,7 +21,7 @@
           "version": "1.1.1c-r0"
         },
         "operating_system": "Unknown",
-        "image": "testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)"
+        "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
         {
@@ -82,7 +81,6 @@
       "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
       "cve": "CVE-2019-1551",
       "severity": "Medium",
-      "confidence": "Unknown",
       "solution": "Upgrade libcrypto1.1 to 1.1.1d-r2",
       "scanner": {
         "id": "trivy",
@@ -96,7 +94,7 @@
           "version": "1.1.1c-r0"
         },
         "operating_system": "Unknown",
-        "image": "testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)"
+        "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
         {
@@ -176,7 +174,6 @@
       "description": "OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).",
       "cve": "CVE-2019-1549",
       "severity": "Medium",
-      "confidence": "Unknown",
       "solution": "Upgrade libssl1.1 to 1.1.1d-r0",
       "scanner": {
         "id": "trivy",
@@ -190,7 +187,7 @@
           "version": "1.1.1c-r0"
         },
         "operating_system": "Unknown",
-        "image": "testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)"
+        "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
         {
@@ -250,7 +247,6 @@
       "description": "There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).",
       "cve": "CVE-2019-1551",
       "severity": "Medium",
-      "confidence": "Unknown",
       "solution": "Upgrade libssl1.1 to 1.1.1d-r2",
       "scanner": {
         "id": "trivy",
@@ -264,7 +260,7 @@
           "version": "1.1.1c-r0"
         },
         "operating_system": "Unknown",
-        "image": "testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)"
+        "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
         {


### PR DESCRIPTION
## Description

- Upgrade to schema 14.0.6 (https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/v14.0.6/dist/container-scanning-report-format.json).
- Drop unsupported `confidence` property. Currently optional and will be removed by GitLab in schema 15-0-0.

I've generated a test report using:

```
trivy image --exit-code 0 --security-checks vuln --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json webgoat/webgoat-8.0:latest
```

And I've [validated locally](https://docs.gitlab.com/ee/development/integrations/secure.html#validate-locally):
```
Thiagos-MacBook-Pro:tmp thiago$ ruby validate.rb container-scanning-report-format_14-0-6.json ~/repos/aquasecurity/trivy/gl-container-scanning-report.json
property '/vulnerabilities/8/identifiers/0/url' does not match format: uri
property '/vulnerabilities/11/identifiers/0/url' does not match format: uri
property '/vulnerabilities/140/links/4/url' does not match format: uri
property '/vulnerabilities/140/links/5/url' does not match format: uri
property '/vulnerabilities/140/links/6/url' does not match format: uri
property '/vulnerabilities/147/links/6/url' does not match format: uri
property '/vulnerabilities/147/links/7/url' does not match format: uri
property '/vulnerabilities/148/links/21/url' does not match format: uri
property '/vulnerabilities/148/links/22/url' does not match format: uri
property '/vulnerabilities/177/identifiers/0/url' does not match format: uri
property '/vulnerabilities/267/identifiers/0/url' does not match format: uri
property '/vulnerabilities/317/links/22/url' does not match format: uri
property '/vulnerabilities/331/links/4/url' does not match format: uri
property '/vulnerabilities/354/links/4/url' does not match format: uri
property '/vulnerabilities/443/links/22/url' does not match format: uri
property '/vulnerabilities/469/identifiers/0/url' does not match format: uri
property '/vulnerabilities/470/identifiers/0/url' does not match format: uri
property '/vulnerabilities/471/identifiers/0/url' does not match format: uri
property '/vulnerabilities/472/identifiers/0/url' does not match format: uri
property '/vulnerabilities/473/identifiers/0/url' does not match format: uri
property '/vulnerabilities/474/identifiers/0/url' does not match format: uri
property '/vulnerabilities/486/links/3/url' does not match format: uri
```

The errors above are because:

1. Some Debian advisories are missing the `url`
   ```json
         "identifiers": [
           {
             "type": "cve",
             "name": "DLA-2424-1",
             "value": "DLA-2424-1",
             "url": ""
           }
         ],
   ```
2. Malformed URLs. E.g.: `"https://gitlab.freedesktop.org/dbus/dbus/-/commit/2b7948ef907669e844b52c4fa2268d6e3162a70c (dbus-1.13.18)"`. 

These invalid entries display as errors in the GitLab pipeline security tab, and are ignored when ingesting the data for vulnerability reports.

Finally, I was going to add a `scan` section, since this will be required soon. Unfortunately my Golang is lacking, and I can't seem to find an existing variable that I can use in the template to output the Trivy version. E.g.:

```json
  "scan": {
    "scanner": {
      "id": "trivy",
      "name": "Trivy",
      "url": "https://github.com/aquasecurity/trivy/",
      "vendor": {
        "name": "Aqua Security"
      },
      "version": "0.32.2"
    }
  },
```


## Related issues
- Close #1598

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/2153

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
