### PR TITLE
docs: split commands to download db for different versions of oras

### DIFF
--- a/docs/build/Dockerfile
+++ b/docs/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:8.2.10
+FROM squidfunk/mkdocs-material:8.3.9
 
 ## If you want to see exactly the same version as is published to GitHub pages
 ## use a private image for insiders, which requires authentication.

--- a/docs/build/requirements.txt
+++ b/docs/build/requirements.txt
@@ -11,13 +11,13 @@ mergedeep==1.3.4
 mike==1.1.2
 mkdocs==1.3.0
 mkdocs-macros-plugin==0.7.0
-mkdocs-material==8.2.10
+mkdocs-material==8.3.9
 mkdocs-material-extensions==1.0.3
 mkdocs-minify-plugin==0.5.0
 mkdocs-redirects==1.0.4
 packaging==21.3
-Pygments==2.11.2
-pymdown-extensions==9.3
+Pygments==2.12.0
+pymdown-extensions==9.5
 pyparsing==3.0.8
 python-dateutil==2.8.2
 PyYAML==6.0

--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -13,7 +13,7 @@ Download `db.tar.gz`:
 $ oras pull ghcr.io/aquasecurity/trivy-db:2
 ```
 
-for oras v0.12.0 or earlier, `-a` flag must be used:
+for `oras` v0.12.0 or earlier, `-a` flag must be used:
 ```
 $ oras pull ghcr.io/aquasecurity/trivy-db:2 -a
 ```

--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -9,7 +9,11 @@ At first, you need to download the vulnerability database for use in air-gapped 
 Please follow [oras installation instruction][oras].
 
 Download `db.tar.gz`:
+```
+$ oras pull ghcr.io/aquasecurity/trivy-db:2
+```
 
+for oras v0.12.0 or earlier, `-a` flag must be used:
 ```
 $ oras pull ghcr.io/aquasecurity/trivy-db:2 -a
 ```

--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -9,14 +9,18 @@ At first, you need to download the vulnerability database for use in air-gapped 
 Please follow [oras installation instruction][oras].
 
 Download `db.tar.gz`:
-```
-$ oras pull ghcr.io/aquasecurity/trivy-db:2
-```
 
-for `oras` v0.12.0 or earlier, `-a` flag must be used:
-```
-$ oras pull ghcr.io/aquasecurity/trivy-db:2 -a
-```
+=== "oras >= v0.13.0"
+
+    ```
+    $ oras pull ghcr.io/aquasecurity/trivy-db:2
+    ```
+
+=== "oras < v0.13.0"
+
+    ```
+    $ oras pull -a ghcr.io/aquasecurity/trivy-db:2
+    ```
 
 ### Transfer the DB file into the air-gapped environment
 The way of transfer depends on the environment.

--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -276,6 +276,6 @@ $ trivy image --format template --template "@/usr/local/share/trivy/templates/ht
 
 [new-json]: https://github.com/aquasecurity/trivy/discussions/1050
 [action]: https://github.com/aquasecurity/trivy-action
-[asff]: https://github.com/aquasecurity/trivy/blob/main/docs/advanced/integrations/aws-security-hub.md
+[asff]: https://github.com/aquasecurity/trivy/blob/main/docs/docs/integrations/aws-security-hub.md
 [sarif]: https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/managing-results-from-code-scanning
 [sprig]: http://masterminds.github.io/sprig/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections
+    - content.tabs.link
 
 markdown_extensions:
   - pymdownx.highlight
@@ -145,7 +146,8 @@ markdown_extensions:
   - admonition
   - footnotes
   - attr_list
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - def_list
   - pymdownx.details
   - pymdownx.emoji:


### PR DESCRIPTION
## Description
In `oras v0.13.0` the `-a/--allow-all` behavior is set by default and these flags have been removed(https://github.com/oras-project/oras/pull/387).
Also `grouping code blocks` was used:
e.g.:

![Снимок экрана от 2022-07-25 17-56-33](https://user-images.githubusercontent.com/91113035/180772374-2c7fc75b-a280-4242-b0b2-1b559945f5f7.png)





## Related issues
- Close #2580

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
