### PR TITLE
docs: add trivy with download-db-only flag to Air-Gapped Environment

### DIFF
--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -22,6 +22,15 @@ Download `db.tar.gz`:
     $ oras pull -a ghcr.io/aquasecurity/trivy-db:2
     ```
 
+=== "Trivy"
+
+    ```
+    $ TRIVY_TEMP_DIR=$(mktemp -d)
+    trivy --cache-dir $TRIVY_TEMP_DIR image --download-db-only
+    tar -cf ./db.tar.gz -C $TRIVY_TEMP_DIR/db metadata.json trivy.db
+    rm -rf $TRIVY_TEMP_DIR
+    ```
+
 ### Transfer the DB file into the air-gapped environment
 The way of transfer depends on the environment.
 

--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -5,30 +5,33 @@ Trivy can be used in air-gapped environments. Note that an allowlist is [here][a
 ## Air-Gapped Environment for vulnerabilities
 
 ### Download the vulnerability database
-At first, you need to download the vulnerability database for use in air-gapped environments.
-Please follow [oras installation instruction][oras].
+=== "Trivy"
 
-Download `db.tar.gz`:
+    ```
+    TRIVY_TEMP_DIR=$(mktemp -d)
+    trivy --cache-dir $TRIVY_TEMP_DIR image --download-db-only
+    tar -cf ./db.tar.gz -C $TRIVY_TEMP_DIR/db metadata.json trivy.db
+    rm -rf $TRIVY_TEMP_DIR
+    ```
 
 === "oras >= v0.13.0"
+    At first, you need to download the vulnerability database for use in air-gapped environments.
+    Please follow [oras installation instruction][oras].
+
+    Download `db.tar.gz`:
 
     ```
     $ oras pull ghcr.io/aquasecurity/trivy-db:2
     ```
 
 === "oras < v0.13.0"
+    At first, you need to download the vulnerability database for use in air-gapped environments.
+    Please follow [oras installation instruction][oras].
+
+    Download `db.tar.gz`:
 
     ```
     $ oras pull -a ghcr.io/aquasecurity/trivy-db:2
-    ```
-
-=== "Trivy"
-
-    ```
-    $ TRIVY_TEMP_DIR=$(mktemp -d)
-    trivy --cache-dir $TRIVY_TEMP_DIR image --download-db-only
-    tar -cf ./db.tar.gz -C $TRIVY_TEMP_DIR/db metadata.json trivy.db
-    rm -rf $TRIVY_TEMP_DIR
     ```
 
 ### Transfer the DB file into the air-gapped environment


### PR DESCRIPTION
## Description
User can use `--download-db-only` flag to download `trivy-db` to use in Air-Gapped Environment.
Added command for this.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
