### PR TITLE
feat(helm): allows users to define an existing secret for tokens

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.4.16
-appVersion: 0.29.2
+version: 0.5.0
+appVersion: 0.30.3
 description: Trivy helm chart
 keywords:
   - scanner

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -54,36 +54,37 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Trivy chart and their default values.
 
-|                 Parameter             |                                Description                              |    Default     |
-|---------------------------------------|-------------------------------------------------------------------------|----------------|
-| `image.registry`                      | Image registry                                                          | `docker.io`    |
-| `image.repository`                    | Image name                                                              | `aquasec/trivy` |
-| `image.tag`                           | Image tag                                                               | `{TAG_NAME}`   |
-| `image.pullPolicy`                    | Image pull policy                                                       | `IfNotPresent` |
-| `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry  | |
-| `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
-| `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                          | `false` |
-| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                          |      |
-| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
-| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
-| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
-| `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
-| `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
-| `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from        | `ghcr.io/aquasecurity/trivy-db`        |
-| `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
-| `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
-| `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
-| `trivy.podAnnotations`                | Annotations for pods created by statefulset                             | `{}` |
-| `service.name`                        | If specified, the name used for the Trivy service                       |     |
-| `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
-| `service.port`                        | Kubernetes service port                                                 | `4954`      |
-| `httpProxy`                           | The URL of the HTTP proxy server                                        |     |
-| `httpsProxy`                          | The URL of the HTTPS proxy server                                       |     |
-| `noProxy`                             | The URLs that the proxy settings do not apply to                        |     |
-| `nodeSelector`                        | Node labels for pod assignment                                              |     |
-| `affinity`                            | Affinity settings for pod assignment                                              |     |
-| `tolerations`                         | Tolerations for pod assignment                                              |     |
-| `podAnnotations`                      | Annotations for pods created by statefulset                             | `{}` |
+|                 Parameter             | Description                                                                                                                           |    Default   |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| `image.registry`                      | Image registry                                                                                                                        | `docker.io`  |
+| `image.repository`                    | Image name                                                                                                                            | `aquasec/trivy` |
+| `image.tag`                           | Image tag                                                                                                                             | `{TAG_NAME}` |
+| `image.pullPolicy`                    | Image pull policy                                                                                                                     | `IfNotPresent` |
+| `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry                                    | |
+| `replicaCount`                        | Number of Trivy Pods to run                                                                                                           | `1`          |
+| `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                                                                                        | `false` |
+| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                   |    |
+| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |    |
+| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |    |
+| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                        |    |
+| `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource                                                              |    |
+| `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub                                                                          | `false`      |
+| `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from                                                                      | `ghcr.io/aquasecurity/trivy-db`      |
+| `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                                                                                       | `false` |
+| `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379                                                                       | `` |
+| `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                                                                              | `` |
+| `trivy.podAnnotations`                | Annotations for pods created by statefulset                                                                                           | `{}` |
+| `trivy.existingSecret`                | existingSecret if an existing secret has been created outside the chart. Overrides gitHubToken, registryUsername, registryPassword, serverToken | `` |
+| `service.name`                        | If specified, the name used for the Trivy service                                                                                     |     |
+| `service.type`                        | Kubernetes service type                                                                                                               | `ClusterIP` |
+| `service.port`                        | Kubernetes service port                                                                                                               | `4954`      |
+| `httpProxy`                           | The URL of the HTTP proxy server                                                                                                      |     |
+| `httpsProxy`                          | The URL of the HTTPS proxy server                                                                                                     |     |
+| `noProxy`                             | The URLs that the proxy settings do not apply to                                                                                      |     |
+| `nodeSelector`                        | Node labels for pod assignment                                                                                                        |     |
+| `affinity`                            | Affinity settings for pod assignment                                                                                                  |     |
+| `tolerations`                         | Tolerations for pod assignment                                                                                                        |     |
+| `podAnnotations`                      | Annotations for pods created by statefulset                                                                                           | `{}` |
 
 The above parameters map to the env variables defined in [trivy](https://github.com/aquasecurity/trivy#configuration).
 

--- a/helm/trivy/templates/secret.yaml
+++ b/helm/trivy/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.trivy.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
   TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}
 {{- end -}}
+{{- end }}

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -90,7 +90,11 @@ spec:
             - configMapRef:
                 name: {{ include "trivy.fullname" . }}
             - secretRef:
+                {{- if not .Values.trivy.existingSecret }}
                 name: {{ include "trivy.fullname" . }}
+                {{- else }}
+                name: {{ .Values.trivy.existingSecret }}
+                {{- end }}
           ports:
             - name: trivy-http
               containerPort: {{ .Values.service.port }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -120,6 +120,9 @@ trivy:
   labels: {}
   # serverToken is the token to authenticate Trivy client with Trivy server.
   serverToken: ""
+  # existingSecret if an existing secret has been created outside the chart.
+  # Overrides gitHubToken, registryUsername, registryPassword, serverToken
+  existingSecret: ""
 
 service:
   # If specified, the name used for the Trivy service.


### PR DESCRIPTION
Signed-off-by: cebidhem <cebidhem@pm.me>

## Description

This will allow the users of the Helm chart to define an existing secret containing the env variables `GITHUB_TOKEN` `TRIVY_TOKEN` `TRIVY_USERNAME` `TRIVY_PASSWORD` as it is quite common for us to use external tools for creating secrets (could be external-secret or something else).
This would allow us to avoid putting tokens in a git repo.

I haven't seen a helm doc generator - but it's my very first PR here so I may have missed it - but I added it manually in the README.md of the chart.

I bumped the `appVersion` as it was quite old. Let me know if you'd rather do it in a separate PR.
I also bumped the Chart `version`, because I haven't seen a job under ci/ doing it. Let me know if it was wrong.

I tested locally with `helm template`, again let me know if I should add anything else.

## Related issues
- Close #2586 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
