### PR TITLE
feat(os): Add Windows support

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -55,6 +55,7 @@ jobs:
             suse
             photon
             distroless
+            windows
 
             ruby
             php

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -32,16 +32,16 @@ builds:
       - goos: freebsd
         goarch: arm64
       # only amd64 is supported on Windows
-      - goos: 386
-        goarch: windows
-      - goos: arm
-        goarch: windows
-      - goos: arm64
-        goarch: windows
-      - goos: s390x
-        goarch: windows
-      - goos: ppc64le
-        goarch: windows
+      - goos: windows
+        goarch: 386
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
 
 release:
     extra_files:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,6 +12,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
       - freebsd
     goarch:
       - amd64
@@ -30,6 +31,17 @@ builds:
         goarch: arm
       - goos: freebsd
         goarch: arm64
+      # only amd64 is supported on Windows
+      - goos: 386
+        goarch: windows
+      - goos: arm
+        goarch: windows
+      - goos: arm64
+        goarch: windows
+      - goos: s390x
+        goarch: windows
+      - goos: ppc64le
+        goarch: windows
 
 release:
     extra_files:
@@ -55,6 +67,7 @@ nfpms:
       ppc64le: PPC64LE
       darwin: macOS
       linux: Linux
+      windows: Windows
       openbsd: OpenBSD
       netbsd: NetBSD
       freebsd: FreeBSD
@@ -66,6 +79,9 @@ nfpms:
 archives:
   -
     format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
     name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
     replacements:
       amd64: 64bit
@@ -75,6 +91,7 @@ archives:
       ppc64le: PPC64LE
       darwin: macOS
       linux: Linux
+      windows: Windows
       openbsd: OpenBSD
       netbsd: NetBSD
       freebsd: FreeBSD


### PR DESCRIPTION
## Description
EDIT: Waiting #3037

It started to feel that #1469 was too big PR and has not got any feedback because of that. This one replaces it.

However when I tried to reproduce #73 with latest code base I was not able to do so I think that it have been already fixed as part of other Trivy or library updates so it should safe to re-enable Windows releases.

Test with pure Windows containers:
```powershell
docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
trivy.exe image mcr.microsoft.com/dotnet/samples:aspnetapp
2022-07-26T01:25:25.821-0700    INFO    Vulnerability scanning is enabled
2022-07-26T01:25:25.821-0700    INFO    Secret scanning is enabled
2022-07-26T01:25:25.822-0700    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-26T01:25:25.822-0700    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2022-07-26T01:25:25.832-0700    INFO    Number of language-specific files: 2
2022-07-26T01:25:25.832-0700    INFO    Detecting dotnet-core vulnerabilities...
```

Test with Windows CLI + Linux Docker engine with environment variable `$env:DOCKER_HOST="ssh://<user>@<ip>"`
```powershell
docker pull mcr.microsoft.com/dotnet/samples:aspnetapp
trivy.exe image mcr.microsoft.com/dotnet/samples:aspnetapp
2022-07-26T01:25:41.445-0700    INFO    Vulnerability scanning is enabled
2022-07-26T01:25:41.445-0700    INFO    Secret scanning is enabled
2022-07-26T01:25:41.446-0700    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-26T01:25:41.446-0700    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2022-07-26T01:25:42.424-0700    INFO    Number of language-specific files: 2
2022-07-26T01:25:42.424-0700    INFO    Detecting dotnet-core vulnerabilities...
```

I also uploaded Windows version of Trivy [v0.30.3](https://github.com/aquasecurity/trivy/releases/tag/v0.30.3) to [here](https://filebin.net/pqfzfyen5o3pwv9n/trivy.exe) in case someone want to test.

## Related issues
- Close #2058

## Related PRs
- [X] #278
- [X] #1469
- [ ] #3037

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
