### PR TITLE
fix: remove the first arg when running as a plugin

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -27,7 +27,7 @@ func run() error {
 		if !plugin.IsPredefined(runAsPlugin) {
 			return xerrors.Errorf("unknown plugin: %s", runAsPlugin)
 		}
-		if err := plugin.RunWithArgs(context.Background(), runAsPlugin, os.Args); err != nil {
+		if err := plugin.RunWithArgs(context.Background(), runAsPlugin, os.Args[1:]); err != nil {
 			return xerrors.Errorf("plugin error: %w", err)
 		}
 		return nil


### PR DESCRIPTION
## Description
Remove the first argument if TRIVY_RUN_AS_PLUGIN is set.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
