### PR TITLE
ci: add ClusterfuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/
+WORKDIR trivy
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,1 @@
+compile_go_fuzzer github.com/aquasecurity/trivy/pkg/sbom/cyclonedx FuzzUnmarshal fuzz_unmarshal

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite.yaml
+++ b/.github/workflows/cflite.yaml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: go
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 400
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/pkg/sbom/cyclonedx/fuzz.go
+++ b/pkg/sbom/cyclonedx/fuzz.go
@@ -1,0 +1,12 @@
+package cyclonedx
+
+import (
+	"bytes"
+)
+
+func FuzzUnmarshal(data []byte) int {
+	r := bytes.NewReader(data)
+	unmarshaler := NewJSONUnmarshaler()
+	_, _ = unmarshaler.Unmarshal(r)
+	return 1
+}


### PR DESCRIPTION
Signed-off-by: AdamKorcz <Adam@adalogics.com>

This PR adds [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/) and a simple fuzzer. 

ClusterfuzzLite will run fuzzers in the CI when PRs are made. It can be extended beyond this PR with code coverage and batch fuzzing: https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
