### PR TITLE
docs(mariner): use v2.0 in examples

### DIFF
--- a/docs/docs/vulnerability/distributions.md
+++ b/docs/docs/vulnerability/distributions.md
@@ -11,16 +11,45 @@ The following table provides an outline of the features Trivy offers.
 
 ### Examples
 
-```
-$ trivy image cblmariner.azurecr.io/base/core:1.0
-2022-01-31T15:02:27.754+0200    INFO    Detected OS: cbl-mariner
-2022-01-31T15:02:27.754+0200    INFO    Detecting CBL-Mariner vulnerabilities...
-2022-01-31T15:02:27.757+0200    INFO    Number of language-specific files: 0
+=== "image"
+    ```
+    ➜ trivy image mcr.microsoft.com/cbl-mariner/base/core:2.0
+    2022-07-27T14:48:20.355+0600	INFO	Detected OS: cbl-mariner
+    2022-07-27T14:48:20.355+0600	INFO	Detecting CBL-Mariner vulnerabilities...
+    2022-07-27T14:48:20.356+0600	INFO	Number of language-specific files: 0
+    
+    mcr.microsoft.com/cbl-mariner/base/core:2.0 (cbl-mariner 2.0.20220527)
+    
+    Total: 33 (UNKNOWN: 0, LOW: 0, MEDIUM: 15, HIGH: 13, CRITICAL: 5)
+    ```
 
-cblmariner.azurecr.io/base/core:1.0 (cbl-mariner 1.0.20220122)
-==============================================================
-Total: 14 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 4, CRITICAL: 5) 
-```
+=== "fs"
+    ```
+    ➜ docker run  -it --rm --entrypoint bin/bash mcr.microsoft.com/cbl-mariner/base/core:2.0 
+    
+    root [ / ]# yum install certificates
+    ...
+
+    root [ / ]# rpm -ivh https://github.com/aquasecurity/trivy/releases/download/v0.30.4/trivy_0.30.4_Linux-64bit.rpm
+    ...
+    
+    root [ / ]# trivy fs /
+    2022-07-27T09:30:06.815Z	INFO	Need to update DB
+    2022-07-27T09:30:06.815Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
+    2022-07-27T09:30:06.815Z	INFO	Downloading DB...
+    33.25 MiB / 33.25 MiB [------------------------------] 100.00% 4.20 MiB p/s 8.1s
+    2022-07-27T09:30:21.756Z	INFO	Vulnerability scanning is enabled
+    2022-07-27T09:30:21.756Z	INFO	Secret scanning is enabled
+    2022-07-27T09:30:21.756Z	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
+    2022-07-27T09:30:21.756Z	INFO	Please see also https://aquasecurity.github.io/trivy/0.30.4/docs/secret/scanning/#recommendation for faster secret detection
+    2022-07-27T09:30:22.205Z	INFO	Detected OS: cbl-mariner
+    2022-07-27T09:30:22.205Z	INFO	Detecting CBL-Mariner vulnerabilities...
+    2022-07-27T09:30:22.205Z	INFO	Number of language-specific files: 0
+    
+    40ba9a55397c (cbl-mariner 2.0.20220527)
+    
+    Total: 33 (UNKNOWN: 0, LOW: 0, MEDIUM: 15, HIGH: 13, CRITICAL: 5)
+    ```
 
 ### Data source
 See [here][source].


### PR DESCRIPTION
## Description
Add example with `fs` subcommand.
Use `cbl-mariner 2.0` in examples.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
