### PR TITLE
fix(cli): secret scanning perf link fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --tags --always)
+VERSION := $(subst v,,$(shell git describe --tags --abbrev=0))
 LDFLAGS := -ldflags "-s -w -X=main.version=$(VERSION)"
 
 GOPATH := $(shell go env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(subst v,,$(shell git describe --tags --abbrev=0))
+VERSION := $(patsubst v%,%,$(shell git describe --tags --always)) #Strips the v prefix from the tag
 LDFLAGS := -ldflags "-s -w -X=main.version=$(VERSION)"
 
 GOPATH := $(shell go env GOPATH)

--- a/docs/docs/vulnerability/distributions.md
+++ b/docs/docs/vulnerability/distributions.md
@@ -41,7 +41,7 @@ The following table provides an outline of the features Trivy offers.
     2022-07-27T09:30:21.756Z	INFO	Vulnerability scanning is enabled
     2022-07-27T09:30:21.756Z	INFO	Secret scanning is enabled
     2022-07-27T09:30:21.756Z	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
-    2022-07-27T09:30:21.756Z	INFO	Please see also https://aquasecurity.github.io/trivy/0.30.4/docs/secret/scanning/#recommendation for faster secret detection
+    2022-07-27T09:30:21.756Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.30.4/docs/secret/scanning/#recommendation for faster secret detection
     2022-07-27T09:30:22.205Z	INFO	Detected OS: cbl-mariner
     2022-07-27T09:30:22.205Z	INFO	Detecting CBL-Mariner vulnerabilities...
     2022-07-27T09:30:22.205Z	INFO	Number of language-specific files: 0

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
 	github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
 	github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -992,8 +992,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
-github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -6,7 +6,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X main.version=v{{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -6,7 +6,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X main.version={{.Version}}
+      - -X main.version=v{{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X main.version=v{{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X main.version={{.Version}}
+      - -X main.version=v{{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -6,13 +6,12 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/go-version/pkg/semver"
 	"github.com/aquasecurity/trivy-db/pkg/db"
-
 	tcache "github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -473,21 +472,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 	// Do not load config file for secret scanning
 	if slices.Contains(opts.SecurityChecks, types.SecurityCheckSecret) {
-		ver := opts.AppVersion
-		if ver != "dev" {
-			v, err := version.NewSemver(opts.AppVersion)
-			if err != nil {
-				return ScannerConfig{}, scanOptions, xerrors.Errorf("invalid app version: %w %s", err, opts.AppVersion)
-			}
-			// Replace pre-release with "dev"
-			// e.g. v0.34.0-beta1+snapshot-1
-			if v.Prerelease() != "" || v.Metadata() != "" {
-				ver = "dev"
-			} else {
-				// Add "v" prefix, "0.34.0" => "v0.34.0" for the url
-				ver = "v" + v.String()
-			}
-		}
+		ver := canonicalVersion(opts.AppVersion)
 		log.Logger.Info("Secret scanning is enabled")
 		log.Logger.Info("If your scanning is slow, please try '--security-checks vuln' to disable secret scanning")
 		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", ver)
@@ -559,4 +544,22 @@ func Exit(opts flag.Options, failedResults bool) {
 	if opts.ExitCode != 0 && failedResults {
 		os.Exit(opts.ExitCode)
 	}
+}
+
+func canonicalVersion(ver string) string {
+	if ver == "dev" {
+		return ver
+	}
+	v, err := semver.Parse(ver)
+	if err != nil {
+		return "dev"
+	}
+	// Replace pre-release with "dev"
+	// e.g. v0.34.0-beta1+snapshot-1
+	if v.IsPreRelease() || v.Metadata() != "" {
+		return "dev"
+	}
+
+	// Add "v" prefix, "0.34.0" => "v0.34.0" for the url
+	return "v" + ver
 }

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/viper"
@@ -473,12 +474,13 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 	// Do not load config file for secret scanning
 	if slices.Contains(opts.SecurityChecks, types.SecurityCheckSecret) {
-		var ver string
-		if opts.AppVersion == "dev" {
-			ver = opts.AppVersion
-		} else {
-			ver = fmt.Sprintf("v%s", opts.AppVersion)
+		VersionRegexpRaw := `^v?([0-9A-Za-z-]+(\.[0-9A-Za-z]+)*)`
+		r := regexp.MustCompile(VersionRegexpRaw)
+		ver := r.FindAllStringSubmatch(opts.AppVersion, -1)[0][1]
+		if ver != "dev" {
+			ver = fmt.Sprintf("v%s", ver)
 		}
+
 		log.Logger.Info("Secret scanning is enabled")
 		log.Logger.Info("If your scanning is slow, please try '--security-checks vuln' to disable secret scanning")
 		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", ver)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -40,6 +40,8 @@ const (
 	TargetRepository     TargetKind = "repo"
 	TargetImageArchive   TargetKind = "archive"
 	TargetSBOM           TargetKind = "sbom"
+
+	devVersion = "dev"
 )
 
 var (
@@ -547,17 +549,17 @@ func Exit(opts flag.Options, failedResults bool) {
 }
 
 func canonicalVersion(ver string) string {
-	if ver == "dev" {
+	if ver == devVersion {
 		return ver
 	}
 	v, err := semver.Parse(ver)
 	if err != nil {
-		return "dev"
+		return devVersion
 	}
 	// Replace pre-release with "dev"
 	// e.g. v0.34.0-beta1+snapshot-1
 	if v.IsPreRelease() || v.Metadata() != "" {
-		return "dev"
+		return devVersion
 	}
 
 	// Add "v" prefix, "0.34.0" => "v0.34.0" for the url

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
@@ -11,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+
 	tcache "github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -471,9 +473,15 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 	// Do not load config file for secret scanning
 	if slices.Contains(opts.SecurityChecks, types.SecurityCheckSecret) {
+		var ver string
+		if opts.AppVersion == "dev" {
+			ver = opts.AppVersion
+		} else {
+			ver = fmt.Sprintf("v%s", opts.AppVersion)
+		}
 		log.Logger.Info("Secret scanning is enabled")
 		log.Logger.Info("If your scanning is slow, please try '--security-checks vuln' to disable secret scanning")
-		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", opts.AppVersion)
+		log.Logger.Infof("Please see also https://aquasecurity.github.io/trivy/%s/docs/secret/scanning/#recommendation for faster secret detection", ver)
 	} else {
 		opts.SecretConfigPath = ""
 	}


### PR DESCRIPTION
## Description
Fixes the URL in the logs of the scanner

## Related issues
- Close #2606

## Before
```bash
2022-07-27T18:57:49.498+0530	INFO	Vulnerability scanning is enabled
2022-07-27T18:57:49.498+0530	INFO	Secret scanning is enabled
2022-07-27T18:57:49.498+0530	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-27T18:57:49.498+0530	INFO	Please see also https://aquasecurity.github.io/trivy/0.30.4/docs/secret/scanning/#recommendation for faster secret detection
```
## After
```bash
2022-07-27T18:57:49.498+0530	INFO	Vulnerability scanning is enabled
2022-07-27T18:57:49.498+0530	INFO	Secret scanning is enabled
2022-07-27T18:57:49.498+0530	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-07-27T18:57:49.498+0530	INFO	Please see also https://aquasecurity.github.io/trivy/v0.30.4/docs/secret/scanning/#recommendation for faster secret detection
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
