### PR TITLE
docs: remove unnecessary double quotation marks

### DIFF
--- a/docs/docs/references/cli/client.md
+++ b/docs/docs/references/cli/client.md
@@ -34,7 +34,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/fs.md
+++ b/docs/docs/references/cli/fs.md
@@ -42,7 +42,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/image.md
+++ b/docs/docs/references/cli/image.md
@@ -56,7 +56,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/repo.md
+++ b/docs/docs/references/cli/repo.md
@@ -39,7 +39,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/rootfs.md
+++ b/docs/docs/references/cli/rootfs.md
@@ -42,7 +42,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/sbom.md
+++ b/docs/docs/references/cli/sbom.md
@@ -39,7 +39,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/docs/docs/references/cli/server.md
+++ b/docs/docs/references/cli/server.md
@@ -26,7 +26,7 @@ Cache Flags
       --redis-key string       redis key file location, if using redis as cache backend
 
 DB Flags
-      --db-repository string   OCI repository to retrieve trivy-db from" (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --no-progress            suppress progress bar
       --reset                  remove all caches and database

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -37,7 +37,7 @@ var (
 		Name:       "db-repository",
 		ConfigName: "db.repository",
 		Value:      defaultDBRepository,
-		Usage:      "OCI repository to retrieve trivy-db from\"",
+		Usage:      "OCI repository to retrieve trivy-db from",
 	}
 	LightFlag = Flag{
 		Name:       "light",


### PR DESCRIPTION
## Description

`--db-repository` option contained extra double quotation marks, which were making [the cli reference](https://aquasecurity.github.io/trivy/v0.30.4/docs/references/cli/server/) look bad.
So this PR has removed unnecessary double quotations.


## Related issues


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
