### PR TITLE
docs(mariner): use tdnf in fs usage example

### DIFF
--- a/docs/docs/vulnerability/distributions.md
+++ b/docs/docs/vulnerability/distributions.md
@@ -27,7 +27,7 @@ The following table provides an outline of the features Trivy offers.
     ```
     ➜ docker run  -it --rm --entrypoint bin/bash mcr.microsoft.com/cbl-mariner/base/core:2.0 
     
-    root [ / ]# yum install certificates
+    root [ / ]# tdnf -y install ca-certificates
     ...
 
     root [ / ]# rpm -ivh https://github.com/aquasecurity/trivy/releases/download/v0.30.4/trivy_0.30.4_Linux-64bit.rpm


### PR DESCRIPTION
## Description
`yum` is deprecated, and not available in Mariner
certificates do not exist, used `ca-certificates`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
