### PR TITLE
fix: Fix --file-patterns flag

### DIFF
--- a/integration/fs_test.go
+++ b/integration/fs_test.go
@@ -23,6 +23,7 @@ func TestFilesystem(t *testing.T) {
 		listAllPkgs    bool
 		input          string
 		secretConfig   string
+		filePatterns   []string
 	}
 	tests := []struct {
 		name   string
@@ -78,6 +79,16 @@ func TestFilesystem(t *testing.T) {
 				namespaces:     []string{"testing"},
 			},
 			golden: "testdata/dockerfile.json.golden",
+		},
+		{
+			name: "dockerfile with custom file pattern",
+			args: args{
+				securityChecks: "config",
+				input:          "testdata/fixtures/fs/dockerfile_file_pattern",
+				namespaces:     []string{"testing"},
+				filePatterns:   []string{"dockerfile:Customfile"},
+			},
+			golden: "testdata/dockerfile_file_pattern.json.golden",
 		},
 		{
 			name: "dockerfile with rule exception",
@@ -176,6 +187,12 @@ func TestFilesystem(t *testing.T) {
 				err := os.WriteFile(trivyIgnore, []byte(strings.Join(tt.args.ignoreIDs, "\n")), 0444)
 				assert.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
+			}
+
+			if len(tt.args.filePatterns) != 0 {
+				for _, filePattern := range tt.args.filePatterns {
+					osArgs = append(osArgs, "--file-patterns", filePattern)
+				}
 			}
 
 			// Setup the output file

--- a/integration/testdata/dockerfile_file_pattern.json.golden
+++ b/integration/testdata/dockerfile_file_pattern.json.golden
@@ -1,0 +1,56 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "testdata/fixtures/fs/dockerfile_file_pattern",
+  "ArtifactType": "filesystem",
+  "Metadata": {
+    "ImageConfig": {
+      "architecture": "",
+      "created": "0001-01-01T00:00:00Z",
+      "os": "",
+      "rootfs": {
+        "type": "",
+        "diff_ids": null
+      },
+      "config": {}
+    }
+  },
+  "Results": [
+    {
+      "Target": "Customfile",
+      "Class": "config",
+      "Type": "dockerfile",
+      "MisconfSummary": {
+        "Successes": 21,
+        "Failures": 1,
+        "Exceptions": 0
+      },
+      "Misconfigurations": [
+        {
+          "Type": "Dockerfile Security Check",
+          "ID": "DS002",
+          "Title": "Image user should not be 'root'",
+          "Description": "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
+          "Message": "Specify at least 1 USER command in Dockerfile with non-root user as argument",
+          "Namespace": "builtin.dockerfile.DS002",
+          "Query": "data.builtin.dockerfile.DS002.deny",
+          "Resolution": "Add 'USER \u003cnon root user name\u003e' line to the Dockerfile",
+          "Severity": "HIGH",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds002",
+          "References": [
+            "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
+            "https://avd.aquasec.com/misconfig/ds002"
+          ],
+          "Status": "FAIL",
+          "Layer": {},
+          "CauseMetadata": {
+            "Provider": "Dockerfile",
+            "Service": "general",
+            "Code": {
+              "Lines": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/integration/testdata/fixtures/fs/dockerfile_file_pattern/Customfile
+++ b/integration/testdata/fixtures/fs/dockerfile_file_pattern/Customfile
@@ -1,0 +1,1 @@
+FROM alpine:3.13

--- a/pkg/fanal/handler/misconf/misconf.go
+++ b/pkg/fanal/handler/misconf/misconf.go
@@ -39,8 +39,8 @@ func init() {
 const version = 1
 
 type misconfPostHandler struct {
-	options  artifact.Option
-	scanners map[string]scanners.Scanner
+	filePatterns []string
+	scanners     map[string]scanners.Scanner
 }
 
 // for a given set of paths, find the most specific filesystem path that contains all the descendants
@@ -178,7 +178,7 @@ func newMisconfPostHandler(artifactOpt artifact.Option) (handler.PostHandler, er
 	}
 
 	return misconfPostHandler{
-		options: artifactOpt,
+		filePatterns: artifactOpt.MisconfScannerOption.FilePatterns,
 		scanners: map[string]scanners.Scanner{
 			types.Terraform:      tfscanner.New(opts...),
 			types.CloudFormation: cfscanner.New(opts...),
@@ -200,7 +200,7 @@ var enabledDefsecTypes = map[detection.FileType]string{
 }
 
 func (h misconfPostHandler) hasCustomPatternForType(t string) bool {
-	for _, pattern := range h.options.MisconfScannerOption.FilePatterns {
+	for _, pattern := range h.filePatterns {
 		if strings.HasPrefix(pattern, t+":") {
 			return true
 		}


### PR DESCRIPTION
Resolves #2608

Signed-off-by: Liam Galvin <liam.galvin@aquasec.com>

## Description
Fixes use of the `--file-patterns` flag. Defsec detection is now overridden when a custom file pattern is provided for the file type.

## Related issues
- Close #2608
