### PR TITLE
chore(image): skip symlinks and hardlinks from tar scan

### DIFF
--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -3,7 +3,6 @@ package walker
 import (
 	"archive/tar"
 	"bytes"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -45,10 +44,6 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 		filePath := hdr.Name
 		filePath = strings.TrimLeft(filepath.Clean(filePath), "/")
 		fileDir, fileName := filepath.Split(filePath)
-
-		if fileName == "packages.config" {
-			fmt.Println()
-		}
 
 		// e.g. etc/.wh..wh..opq
 		if opq == fileName {

--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -3,6 +3,7 @@ package walker
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -45,6 +46,10 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 		filePath = strings.TrimLeft(filepath.Clean(filePath), "/")
 		fileDir, fileName := filepath.Split(filePath)
 
+		if fileName == "packages.config" {
+			fmt.Println()
+		}
+
 		// e.g. etc/.wh..wh..opq
 		if opq == fileName {
 			opqDirs = append(opqDirs, fileDir)
@@ -64,10 +69,11 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 				skipDirs = append(skipDirs, filePath)
 				continue
 			}
-		case tar.TypeSymlink, tar.TypeLink, tar.TypeReg:
+		case tar.TypeReg:
 			if w.shouldSkipFile(filePath) {
 				continue
 			}
+		// symlinks and hardlinks have no content in reader, skip them
 		default:
 			continue
 		}


### PR DESCRIPTION
## Description
`symlinks` and `hardlinks` have no content in tar reader.
Skip them.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
