### PR TITLE
docs(secret): fix missing and broken links

### DIFF
--- a/docs/docs/secret/configuration.md
+++ b/docs/docs/secret/configuration.md
@@ -137,6 +137,6 @@ disable-allow-rules:
 ```
 
 
-[builtin]: https://github.com/aquasecurity/fanal/blob/main/secret/builtin-rules.go
-[builtin]: https://github.com/aquasecurity/fanal/blob/main/secret/builtin-allow-rules.go
+[builtin]: https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-rules.go
+[builtin-allow]: https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-allow-rules.go
 [examples]: ./examples.md

--- a/docs/docs/secret/scanning.md
+++ b/docs/docs/secret/scanning.md
@@ -116,8 +116,8 @@ $ trivy image --security-checks vuln alpine:3.15
 ## Credit
 This feature is inspired by [gitleaks][gitleaks]. 
 
-[builtin]: https://github.com/aquasecurity/fanal/blob/main/secret/builtin-rules.go
-[builtin-allow]: https://github.com/aquasecurity/fanal/blob/main/secret/builtin-allow-rules.go
+[builtin]: https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-rules.go
+[builtin-allow]: https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-allow-rules.go
 [configuration]: ./configuration.md
 [allow-rules]: ./configuration.md#allow-rules
 [enable-rules]: ./configuration.md#enable-rules


### PR DESCRIPTION
## Description

- Fixed missing and broken links in secret scanning docs

- Change ref to trivy repo instead of archived fanal repo

Before:
![Screen Shot 2022-08-07 at 17 45 09](https://user-images.githubusercontent.com/97836016/183296593-7d90251a-d0e3-45ee-921e-d782758d0197.png)

After:
![Screen Shot 2022-08-07 at 17 45 50](https://user-images.githubusercontent.com/97836016/183296620-0b650c6c-665f-4034-9b7b-b9420be2d6c0.png)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
