### PR TITLE
feat(image): Support listing all registered analyzers pool

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -71,6 +71,15 @@ func DeregisterAnalyzer(t Type) {
 	delete(analyzers, t)
 }
 
+// ListAnalyzers returns all registered types
+func ListAnalyzers() []Type {
+	list := []Type{}
+	for t, _ := range analyzers {
+		list = append(list, t)
+	}
+	return list
+}
+
 func RegisterConfigAnalyzer(analyzer configAnalyzer) {
 	configAnalyzers[analyzer.Type()] = analyzer
 }


### PR DESCRIPTION
## Description
If analyzers are registered on runtime instead of beginning of trivy, analyzers list is needed to make decision regarding registration. 
This PR add capability to list all registered analyzers, without exposing the interface methods.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
