### PR TITLE
fix(server): scanResponse rpc conversion for custom resources

### DIFF
--- a/pkg/rpc/convert.go
+++ b/pkg/rpc/convert.go
@@ -40,6 +40,26 @@ func ConvertToRPCPkgs(pkgs []ftypes.Package) []*common.Package {
 	return rpcPkgs
 }
 
+func ConvertToRPCCustomResources(resources []ftypes.CustomResource) []*common.CustomResource {
+	var rpcResources []*common.CustomResource
+	for _, r := range resources {
+		data, err := structpb.NewValue(r.Data)
+		if err != nil {
+			log.Logger.Warn(err)
+		}
+		rpcResources = append(rpcResources, &common.CustomResource{
+			Type:     r.Type,
+			FilePath: r.FilePath,
+			Layer: &common.Layer{
+				Digest: r.Layer.Digest,
+				DiffId: r.Layer.DiffID,
+			},
+			Data: data,
+		})
+	}
+	return rpcResources
+}
+
 // ConvertFromRPCPkgs returns list of Fanal package objects
 func ConvertFromRPCPkgs(rpcPkgs []*common.Package) []ftypes.Package {
 	var pkgs []ftypes.Package
@@ -575,6 +595,7 @@ func ConvertToRPCScanResponse(results types.Results, fos *ftypes.OS) *scanner.Sc
 			Vulnerabilities:   ConvertToRPCVulns(result.Vulnerabilities),
 			Misconfigurations: ConvertToRPCMisconfs(result.Misconfigurations),
 			Packages:          ConvertToRPCPkgs(result.Packages),
+			CustomResources:   ConvertToRPCCustomResources(result.CustomResources),
 		})
 	}
 


### PR DESCRIPTION
## Description
The server ftypes scan result when converted to RPC response using method ConvertToRPCScanResponse(), were dropping customerResources in conversion. This commit fixes the method to consider customResources as well

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
