### PR TITLE
refactor: disable vuln analyzers when --security-checks != vuln

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -423,8 +423,6 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 		} else { // disable all vuln analyzers
 			analyzers = append(analyzers, analyzer.TypeOSes...)
 			analyzers = append(analyzers, analyzer.TypeLanguages...)
-			analyzers = append(analyzers, analyzer.TypeLockfiles...)
-			analyzers = append(analyzers, analyzer.TypeIndividualPkgs...)
 		}
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -424,7 +424,7 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 			analyzers = append(analyzers, analyzer.TypeOSes...)
 			analyzers = append(analyzers, analyzer.TypeLanguages...)
 			analyzers = append(analyzers, analyzer.TypeLockfiles...)
-			analyzers = append(analyzers, analyzer.TypeConfigFiles...)
+			analyzers = append(analyzers, analyzer.TypeIndividualPkgs...)
 		}
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -414,7 +414,8 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 	}
 
 	// Do not perform vuln scanning when it is not specified.
-	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckVulnerability) {
+	// We need these analyzers to find packages for `cyclonedx` format. Vulns will be excluded in `Report` package
+	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckVulnerability) && opts.Format != "cyclonedx" {
 		// license scanning use some language and lock file analyzers
 		// e.g. `dpkgLicenseAnalyzer`, 'gemspecLibraryAnalyzer'
 		if slices.Contains(opts.SecurityChecks, types.SecurityCheckLicense) {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -413,6 +413,20 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 		analyzers = append(analyzers, analyzer.TypeLanguages...)
 	}
 
+	// Do not perform vuln scanning when it is not specified.
+	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckVulnerability) {
+		// license scanning use some language and lock file analyzers
+		// e.g. `dpkgLicenseAnalyzer`, 'gemspecLibraryAnalyzer'
+		if slices.Contains(opts.SecurityChecks, types.SecurityCheckLicense) {
+			analyzers = append(analyzers, analyzer.TypeVulnFilesWithoutLicenseInfo...)
+		} else { // disable all vuln analyzers
+			analyzers = append(analyzers, analyzer.TypeOSes...)
+			analyzers = append(analyzers, analyzer.TypeLanguages...)
+			analyzers = append(analyzers, analyzer.TypeLockfiles...)
+			analyzers = append(analyzers, analyzer.TypeConfigFiles...)
+		}
+	}
+
 	// Do not perform secret scanning when it is not specified.
 	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckSecret) {
 		analyzers = append(analyzers, analyzer.TypeSecret)

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -128,4 +128,11 @@ var (
 
 	// TypeConfigFiles has all config file analyzers
 	TypeConfigFiles = []Type{TypeYaml, TypeJSON, TypeDockerfile, TypeTerraform, TypeCloudFormation, TypeHelm}
+
+	// TypeVulnFilesWithoutLicenseInfo has all language and lock file analyzers without files which contains information about licenses
+	TypeVulnFilesWithoutLicenseInfo = []Type{TypeRpm, TypeRpmqa,
+		TypeApkRepo, TypeBundler, TypeCargo, TypeComposer, TypeJar, TypePom,
+		TypeNpmPkgLock, TypeYarn, TypePnpm, TypeNuget, TypeDotNetDeps, TypePip, TypePipenv, TypePoetry,
+		TypeGoBinary, TypeGoMod, TypeBundler, TypeNpmPkgLock, TypeYarn,
+		TypePnpm, TypePip, TypePipenv, TypePoetry, TypeGoMod, TypePom}
 )

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -133,6 +133,5 @@ var (
 	TypeVulnFilesWithoutLicenseInfo = []Type{TypeRpm, TypeRpmqa,
 		TypeApkRepo, TypeBundler, TypeCargo, TypeComposer, TypeJar, TypePom,
 		TypeNpmPkgLock, TypeYarn, TypePnpm, TypeNuget, TypeDotNetDeps, TypePip, TypePipenv, TypePoetry,
-		TypeGoBinary, TypeGoMod, TypeBundler, TypeNpmPkgLock, TypeYarn,
-		TypePnpm, TypePip, TypePipenv, TypePoetry, TypeGoMod, TypePom}
+		TypeGoBinary, TypeGoMod}
 )


### PR DESCRIPTION
## Description
Trivy always parses language and lock files, but doesn't result to report if `--security-checks != vuln`. But it wastes time and resources.
Added disabling analyzers for these files when `--security-checks != vuln`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
