### PR TITLE
docs: don't generate patch versions

### DIFF
--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -7,7 +7,7 @@ on:
         required: true
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+"
 jobs:
   deploy:
     name: Deploy the latest documentation

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -7,7 +7,7 @@ on:
         required: true
   push:
     tags:
-      - "v[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.0"
 jobs:
   deploy:
     name: Deploy the latest documentation


### PR DESCRIPTION
## Description
stops generating docs for patch versions

## Related issues
- partially fixes #2288 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
