### PR TITLE
fix(vuln): continue scanning when no vuln found in the first application

### DIFF
--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -290,7 +290,7 @@ func (s Scanner) scanLangPkgs(apps []ftypes.Application) (types.Results, error) 
 		if err != nil {
 			return nil, xerrors.Errorf("failed vulnerability detection of libraries: %w", err)
 		} else if len(vulns) == 0 {
-			return nil, nil
+			continue
 		}
 
 		target := app.FilePath

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -311,11 +311,24 @@ func TestScanner_Scan(t *testing.T) {
 						OS: &ftypes.OS{},
 						Applications: []ftypes.Application{
 							{
-								Type:     "bundler",
+								Type:     ftypes.Bundler,
 								FilePath: "/app/Gemfile.lock",
 								Libraries: []ftypes.Package{
 									{
-										Name:    "rails",
+										Name:    "innocent", // no vulnerability
+										Version: "1.2.3",
+										Layer: ftypes.Layer{
+											DiffID: "sha256:9922bc15eeefe1637b803ef2106f178152ce19a391f24aec838cbe2e48e73303",
+										},
+									},
+								},
+							},
+							{
+								Type:     ftypes.Bundler,
+								FilePath: "/app/Gemfile.lock",
+								Libraries: []ftypes.Package{
+									{
+										Name:    "rails", // one vulnerability
 										Version: "4.0.2",
 										Layer: ftypes.Layer{
 											DiffID: "sha256:9922bc15eeefe1637b803ef2106f178152ce19a391f24aec838cbe2e48e73303",


### PR DESCRIPTION
## Description
When the first application has no vulnerability, it exits from the scanning function and returns no vulnerability even though other applications have vulnerabilities.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/2701
- [x] https://github.com/aquasecurity/trivy/pull/2541

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
