### PR TITLE
feat(flag): add error when there are no supported security checks

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -361,7 +361,10 @@ func (f *Flags) ToOptions(appVersion string, args []string, globalFlags *GlobalF
 	}
 
 	if f.ScanFlagGroup != nil {
-		opts.ScanOptions = f.ScanFlagGroup.ToOptions(args)
+		opts.ScanOptions, err = f.ScanFlagGroup.ToOptions(args)
+		if err != nil {
+			return Options{}, xerrors.Errorf("scan flag error: %w", err)
+		}
 	}
 
 	if f.SecretFlagGroup != nil {

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -90,8 +90,8 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 
 func parseSecurityCheck(securityCheck []string) ([]string, error) {
 	switch {
-	case len(securityCheck) == 0: // no checks
-		return nil, xerrors.New("no security checks")
+	case len(securityCheck) == 0: // no checks. Can be empty when generating SBOM
+		return nil, nil
 	case len(securityCheck) == 1 && strings.Contains(securityCheck[0], ","): // get checks from flag
 		securityCheck = strings.Split(securityCheck[0], ",")
 	}
@@ -99,7 +99,7 @@ func parseSecurityCheck(securityCheck []string) ([]string, error) {
 	var securityChecks []string
 	for _, v := range securityCheck {
 		if !slices.Contains(types.SecurityChecks, v) {
-			return nil, xerrors.New(fmt.Sprintf("unknown security check: %s", v))
+			return nil, xerrors.Errorf("unknown security check: %s", v)
 		}
 		securityChecks = append(securityChecks, v)
 	}

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -26,14 +26,11 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		assertion require.ErrorAssertionFunc
 	}{
 		{
-			name: "happy path",
-			args: []string{"alpine:latest"},
-			fields: fields{
-				securityChecks: "vuln,secret",
-			},
+			name:   "happy path",
+			args:   []string{"alpine:latest"},
+			fields: fields{},
 			want: flag.ScanOptions{
-				Target:         "alpine:latest",
-				SecurityChecks: []string{"vuln", "secret"},
+				Target: "alpine:latest",
 			},
 			assertion: require.NoError,
 		},
@@ -50,14 +47,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
-			name:   "no security checks",
-			fields: fields{},
-			want:   flag.ScanOptions{},
-			assertion: func(t require.TestingT, err error, msgs ...interface{}) {
-				require.ErrorContains(t, err, "no security checks")
-			},
-		},
-		{
 			name: "with wrong security check",
 			fields: fields{
 				securityChecks: "vuln,WRONG-CHECK",
@@ -68,60 +57,46 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "without target (args)",
-			args: []string{},
-			fields: fields{
-				securityChecks: "vuln,secret",
-			},
-			want: flag.ScanOptions{
-				SecurityChecks: []string{"vuln", "secret"},
-			},
+			name:      "without target (args)",
+			args:      []string{},
+			fields:    fields{},
+			want:      flag.ScanOptions{},
 			assertion: require.NoError,
 		},
 		{
-			name: "with two or more targets (args)",
-			args: []string{"alpine:latest", "nginx:latest"},
-			fields: fields{
-				securityChecks: "vuln,secret",
-			},
-			want: flag.ScanOptions{
-				SecurityChecks: []string{"vuln", "secret"},
-			},
+			name:      "with two or more targets (args)",
+			args:      []string{"alpine:latest", "nginx:latest"},
+			fields:    fields{},
+			want:      flag.ScanOptions{},
 			assertion: require.NoError,
 		},
 		{
 			name: "skip two files",
 			fields: fields{
-				securityChecks: "vuln,secret",
-				skipFiles:      []string{"file1", "file2"},
+				skipFiles: []string{"file1", "file2"},
 			},
 			want: flag.ScanOptions{
-				SecurityChecks: []string{"vuln", "secret"},
-				SkipFiles:      []string{"file1", "file2"},
+				SkipFiles: []string{"file1", "file2"},
 			},
 			assertion: require.NoError,
 		},
 		{
 			name: "skip two folders",
 			fields: fields{
-				securityChecks: "vuln,secret",
-				skipDirs:       []string{"dir1", "dir2"},
+				skipDirs: []string{"dir1", "dir2"},
 			},
 			want: flag.ScanOptions{
-				SecurityChecks: []string{"vuln", "secret"},
-				SkipDirs:       []string{"dir1", "dir2"},
+				SkipDirs: []string{"dir1", "dir2"},
 			},
 			assertion: require.NoError,
 		},
 		{
 			name: "offline scan",
 			fields: fields{
-				securityChecks: "vuln,secret",
-				offlineScan:    true,
+				offlineScan: true,
 			},
 			want: flag.ScanOptions{
-				SecurityChecks: []string{"vuln", "secret"},
-				OfflineScan:    true,
+				OfflineScan: true,
 			},
 			assertion: require.NoError,
 		},

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -29,11 +29,14 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		wantLogs []string
 	}{
 		{
-			name:   "happy path",
-			args:   []string{"alpine:latest"},
-			fields: fields{},
+			name: "happy path",
+			args: []string{"alpine:latest"},
+			fields: fields{
+				securityChecks: "vuln,secret",
+			},
 			want: flag.ScanOptions{
-				Target: "alpine:latest",
+				Target:         "alpine:latest",
+				SecurityChecks: []string{"vuln", "secret"},
 			},
 		},
 		{
@@ -74,28 +77,34 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "skip two files",
 			fields: fields{
-				skipFiles: []string{"file1", "file2"},
+				securityChecks: "vuln,secret",
+				skipFiles:      []string{"file1", "file2"},
 			},
 			want: flag.ScanOptions{
-				SkipFiles: []string{"file1", "file2"},
+				SecurityChecks: []string{"vuln", "secret"},
+				SkipFiles:      []string{"file1", "file2"},
 			},
 		},
 		{
 			name: "skip two folders",
 			fields: fields{
-				skipDirs: []string{"dir1", "dir2"},
+				securityChecks: "vuln,secret",
+				skipDirs:       []string{"dir1", "dir2"},
 			},
 			want: flag.ScanOptions{
-				SkipDirs: []string{"dir1", "dir2"},
+				SecurityChecks: []string{"vuln", "secret"},
+				SkipDirs:       []string{"dir1", "dir2"},
 			},
 		},
 		{
 			name: "offline scan",
 			fields: fields{
-				offlineScan: true,
+				securityChecks: "vuln,secret",
+				offlineScan:    true,
 			},
 			want: flag.ScanOptions{
-				OfflineScan: true,
+				SecurityChecks: []string{"vuln", "secret"},
+				OfflineScan:    true,
 			},
 		},
 	}
@@ -121,7 +130,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 				SecurityChecks: &flag.SecurityChecksFlag,
 			}
 
-			got := f.ToOptions(tt.args)
+			got, _ := f.ToOptions(tt.args)
 			assert.Equalf(t, tt.want, got, "ToOptions()")
 
 			// Assert log messages


### PR DESCRIPTION
## Description
Trivy doesn't stop scan if `--security-checks` flag has only unsupported values.
We need to return error when parsing the flags.

Before: 
```
➜ trivy -d image --security-checks conf alpine:3.14.3           
2022-08-16T10:41:50.312+0600    DEBUG   Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2022-08-16T10:41:50.312+0600    WARN    unknown security check: conf
2022-08-16T10:41:50.315+0600    DEBUG   cache dir:  /home/dmitriy/.cache/trivy
2022-08-16T10:41:50.316+0600    DEBUG   Module dir: /home/dmitriy/.trivy/modules
2022-08-16T10:41:52.786+0600    DEBUG   Image ID: sha256:0a97eee8041e2b6c0e65abb2700b0705d0da5525ca69060b9e0bde8a3d17afdb
2022-08-16T10:41:52.786+0600    DEBUG   Diff IDs: [sha256:1a058d5342cc722ad5439cacae4b2b4eedde51d8fe8800fcf28444302355c16d]
2022-08-16T10:41:52.786+0600    DEBUG   Base Layers: []
```

After:
```
➜  ./trivy -d image --security-checks conf alpine:3.14.3 
2022-08-16T10:42:18.065+0600    DEBUG   Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2022-08-16T10:42:18.065+0600    WARN    unknown security check: conf
2022-08-16T10:42:18.065+0600    FATAL   flag error:
    github.com/aquasecurity/trivy/pkg/commands.NewImageCommand.func2
        /home/dmitriy/work/aquasecurity/trivy/pkg/commands/app.go:267
  - scan flag error:
    github.com/aquasecurity/trivy/pkg/flag.(*Flags).ToOptions
        /home/dmitriy/work/aquasecurity/trivy/pkg/flag/options.go:366
  - --security-check flag doesn't contain supported values:
    github.com/aquasecurity/trivy/pkg/flag.(*ScanFlagGroup).ToOptions
        /home/dmitriy/work/aquasecurity/trivy/pkg/flag/scan_flags.go:80
exit status 1

```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
