### PR TITLE
docs: add MacPorts install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Get Trivy by your favorite installation method. See [installation] section in th
 - `apt-get install trivy`
 - `yum install trivy`
 - `brew install aquasecurity/trivy/trivy`
+- `sudo port install trivy`
 - `docker run aquasec/trivy`
 - Download binary from https://github.com/aquasecurity/trivy/releases/latest/
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -68,6 +68,16 @@ You can use homebrew on macOS and Linux.
 brew install aquasecurity/trivy/trivy
 ```
 
+## MacPorts
+
+You can also install `trivy` via [MacPorts](https://www.macports.org) on macOS:
+
+```bash
+sudo port install trivy
+```
+
+More info [here](https://ports.macports.org/port/trivy/).
+
 ## Nix/NixOS
 
 Direct issues installing `trivy` via `nix` through the channels mentioned [here](https://nixos.wiki/wiki/Support)


### PR DESCRIPTION
## Description

`trivy` is also available via [MacPorts](https://www.macports.org) on macOS.  This PR adds information on how to install it that way.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
