### PR TITLE
fix(aws): Squat a typo in AWS usage help text

### DIFF
--- a/pkg/flag/aws_flags.go
+++ b/pkg/flag/aws_flags.go
@@ -23,7 +23,7 @@ var (
 		Name:       "account",
 		ConfigName: "cloud.aws.account",
 		Value:      "",
-		Usage:      "The AWS account to scan. It's useful to specify this when reviewing cached results for multipel accounts.",
+		Usage:      "The AWS account to scan. It's useful to specify this when reviewing cached results for multiple accounts.",
 	}
 	awsARNFlag = Flag{
 		Name:       "arn",


### PR DESCRIPTION
## Description
Fix a typo in the usage help.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
