### PR TITLE
feat(secret): Secret analyzer initialization using config object

### DIFF
--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -44,12 +44,12 @@ type ScannerOption struct {
 
 // SecretAnalyzer is an analyzer for secrets
 type SecretAnalyzer struct {
-	scanner    secret.Scanner
+	Scanner    secret.Scanner
 	configPath string
 }
 
 func RegisterSecretAnalyzer(opt ScannerOption) error {
-	a, err := newSecretAnalyzer(opt)
+	a, err := newSecretAnalyzer(opt.ConfigPath)
 	if err != nil {
 		return xerrors.Errorf("secret scanner init error: %w", err)
 	}
@@ -57,21 +57,14 @@ func RegisterSecretAnalyzer(opt ScannerOption) error {
 	return nil
 }
 
-func newSecretAnalyzer(opt ScannerOption) (SecretAnalyzer, error) {
-	if opt.Config != nil {
-		s, err := secret.NewScannerByConfig(*opt.Config)
-		if err != nil {
-			return SecretAnalyzer{}, xerrors.Errorf("secret scanner error: %w", err)
-		}
-		return SecretAnalyzer{scanner: s}, nil
-	}
-	s, err := secret.NewScanner(opt.ConfigPath)
+func newSecretAnalyzer(configPath string) (SecretAnalyzer, error) {
+	s, err := secret.NewScanner(configPath)
 	if err != nil {
 		return SecretAnalyzer{}, xerrors.Errorf("secret scanner error: %w", err)
 	}
 	return SecretAnalyzer{
-		scanner:    s,
-		configPath: opt.ConfigPath,
+		Scanner:    s,
+		configPath: configPath,
 	}, nil
 }
 
@@ -95,7 +88,7 @@ func (a SecretAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		filePath = fmt.Sprintf("/%s", filePath)
 	}
 
-	result := a.scanner.Scan(secret.ScanArgs{
+	result := a.Scanner.Scan(secret.ScanArgs{
 		FilePath: filePath,
 		Content:  content,
 	})
@@ -162,7 +155,7 @@ func (a SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 		return false
 	}
 
-	if a.scanner.AllowPath(filePath) {
+	if a.Scanner.AllowPath(filePath) {
 		return false
 	}
 

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -118,32 +118,6 @@ func TestSecretAnalyzer(t *testing.T) {
 			},
 		},
 		{
-			name:       "return results with config",
-			configPath: "",
-			config: &secret.Config{
-				CustomRules: []secret.Rule{
-					{
-						ID:              "rule1",
-						Category:        "general",
-						Title:           "Generic Rule",
-						Severity:        "HIGH",
-						Regex:           secret.MustCompile("(?i)(?P<key>(secret))(=|:).{0,5}['\"](?P<secret>[0-9a-zA-Z\\-_=]{8,64})['\"]"),
-						SecretGroupName: "secret",
-					},
-				},
-			},
-			filePath: "testdata/secret.txt",
-			dir:      ".",
-			want: &analyzer.AnalysisResult{
-				Secrets: []types.Secret{
-					{
-						FilePath: "testdata/secret.txt",
-						Findings: []types.SecretFinding{wantFinding1, wantFinding2},
-					},
-				},
-			},
-		},
-		{
 			name:       "image scan return result",
 			configPath: "testdata/image-config.yaml",
 			filePath:   "testdata/secret.txt",
@@ -178,7 +152,7 @@ func TestSecretAnalyzer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a, err := newSecretAnalyzer(ScannerOption{tt.configPath, tt.config})
+			a, err := newSecretAnalyzer(tt.configPath)
 			require.NoError(t, err)
 			content, err := os.Open(tt.filePath)
 			require.NoError(t, err)
@@ -233,7 +207,7 @@ func TestSecretRequire(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a, err := newSecretAnalyzer(ScannerOption{"", nil})
+			a, err := newSecretAnalyzer("")
 			require.NoError(t, err)
 
 			fi, err := os.Stat(tt.filePath)

--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -287,13 +287,16 @@ func NewScanner(configPath string) (Scanner, error) {
 
 	log.Logger.Infof("Loading %s for secret scanning...", configPath)
 
-	// reset global
-	global = Global{}
-
 	var config Config
 	if err = yaml.NewDecoder(f).Decode(&config); err != nil {
 		return Scanner{}, xerrors.Errorf("secrets config decode error: %w", err)
 	}
+
+	return NewScannerByConfig(config)
+}
+
+func NewScannerByConfig(config Config) (Scanner, error) {
+	global := &Global{}
 
 	enabledRules := builtinRules
 	if len(config.EnableBuiltinRuleIDs) != 0 {
@@ -319,7 +322,7 @@ func NewScanner(configPath string) (Scanner, error) {
 
 	global.ExcludeBlock = config.ExcludeBlock
 
-	return Scanner{Global: &global}, nil
+	return Scanner{Global: global}, nil
 }
 
 type ScanArgs struct {


### PR DESCRIPTION
## Description
Secret Analyzer initializes Scanner only via config file path only. This commit allows to initialize scanner if config is handy in memory 


## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
