### PR TITLE
fix: fix k8s rbac filter

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -422,7 +422,8 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 	}
 
 	// Do not perform misconfiguration scanning when it is not specified.
-	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckConfig) {
+	if !slices.Contains(opts.SecurityChecks, types.SecurityCheckConfig) &&
+		!slices.Contains(opts.SecurityChecks, types.SecurityCheckRbac) {
 		analyzers = append(analyzers, analyzer.TypeConfigFiles...)
 	}
 


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

```
trivy k8s --security-checks=rbac --report=summary cluster
178 / 178 [--------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4 p/s

Summary Report for minikube
┌──────────────┬─────────────────────────────────────────────────────────────────┬───────────────────┐
│  Namespace   │                            Resource                             │  RBAC Assessment  │
│              │                                                                 ├───┬───┬───┬───┬───┤
│              │                                                                 │ C │ H │ M │ L │ U │
├──────────────┼─────────────────────────────────────────────────────────────────┼───┼───┼───┼───┼───┤
│ trivy-system │ Role/trivy-operator                                             │   │   │ 1 │   │   │
│ kube-system  │ Role/system::leader-locking-kube-controller-manager             │   │   │ 1 │   │   │
│ kube-system  │ Role/system::leader-locking-kube-scheduler                      │   │   │ 1 │   │   │
│ kube-system  │ Role/system:controller:bootstrap-signer                         │ 1 │   │   │   │   │
│ kube-system  │ Role/system:controller:token-cleaner                            │ 1 │   │   │   │   │
│ kube-system  │ Role/system:persistent-volume-provisioner                       │   │ 2 │   │   │   │
│ kube-system  │ Role/system:controller:cloud-provider                           │   │   │ 1 │   │   │
│ kube-public  │ Role/system:controller:bootstrap-signer                         │   │   │ 1 │   │   │
│              │ ClusterRole/system:controller:endpointslicemirroring-controller │   │ 1 │   │   │   │
│              │ ClusterRole/system:controller:resourcequota-controller          │ 1 │   │   │   │   │
│              │ ClusterRole/system:kube-controller-manager                      │ 5 │ 2 │   │   │   │
│              │ ClusterRole/system:controller:horizontal-pod-autoscaler         │ 2 │   │   │   │   │
│              │ ClusterRole/system:controller:replication-controller            │   │ 1 │   │   │   │
│              │ ClusterRole/system:aggregate-to-admin                           │ 1 │   │   │   │   │
│              │ ClusterRole/system:controller:job-controller                    │   │ 1 │   │   │   │
│              │ ClusterRole/system:controller:root-ca-cert-publisher            │   │   │ 1 │   │   │
│              │ ClusterRole/edit                                                │ 2 │ 7 │ 1 │   │   │
│              │ ClusterRole/system:node                                         │ 1 │   │   │   │   │
│              │ ClusterRole/system:controller:persistent-volume-binder          │ 1 │ 2 │   │   │   │
│              │ ClusterRole/system:controller:generic-garbage-collector         │ 1 │   │   │   │   │
│              │ ClusterRole/system:controller:expand-controller                 │ 1 │   │   │   │   │
│              │ ClusterRole/admin                                               │ 3 │ 7 │ 1 │   │   │
│              │ ClusterRole/system:controller:endpoint-controller               │   │ 1 │   │   │   │
│              │ ClusterRole/system:controller:replicaset-controller             │   │ 1 │   │   │   │
│              │ ClusterRole/system:controller:endpointslice-controller          │   │ 1 │   │   │   │
│              │ ClusterRole/system:controller:cronjob-controller                │   │ 2 │   │   │   │
│              │ ClusterRole/system:kube-scheduler                               │   │ 2 │   │   │   │
│              │ ClusterRole/cluster-admin                                       │ 2 │   │   │   │   │
│              │ ClusterRole/system:aggregate-to-edit                            │ 2 │ 7 │ 1 │   │   │
│              │ ClusterRole/trivy-operator                                      │ 1 │ 1 │   │   │   │
│              │ ClusterRole/system:controller:deployment-controller             │   │ 2 │   │   │   │
│              │ ClusterRole/system:controller:namespace-controller              │ 1 │   │   │   │   │
└──────────────┴─────────────────────────────────────────────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2764

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
