### PR TITLE
feat: add affected package name to title

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -33,7 +33,7 @@
             "Severity": {
                 "Label": "{{ $severity }}"
             },
-            "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}",
+            "Title": "Trivy found a vulnerability in {{ .PkgName }} to {{ .VulnerabilityID }} in container {{ $target }}",
             "Description": {{ escapeString $description | printf "%q" }},
             {{ if not (empty .PrimaryURL) -}}
             "Remediation": {


### PR DESCRIPTION
## Description

This PR adds the package name that contains the vulnerability to the title of the finding. This way the finding is different from other findings with the same CVE but with a different package.  This is important because AWS Security Hub just updates and overrides an existing finding instead of creating a new one. Mor.e information can be found in the related issue

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/2774


Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added usage information (if the PR introduces new options)
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
