### PR TITLE
fix: fix k8s summary report

### DIFF
--- a/pkg/k8s/report/summary.go
+++ b/pkg/k8s/report/summary.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/table"
@@ -89,13 +90,14 @@ func (s SummaryWriter) Write(report Report) error {
 		vCount, mCount, sCount := accumulateSeverityCounts(finding)
 		name := fmt.Sprintf("%s/%s", finding.Kind, finding.Name)
 		rowParts := []string{finding.Namespace, name}
-		if len(vCount) > 0 {
+
+		if slices.Contains(s.ColumnsHeading, VulnerabilitiesColumn) {
 			rowParts = append(rowParts, s.generateSummary(vCount)...)
 		}
-		if len(mCount) > 0 {
+		if slices.Contains(s.ColumnsHeading, MisconfigurationsColumn) || slices.Contains(s.ColumnsHeading, RbacAssessmentColumn) {
 			rowParts = append(rowParts, s.generateSummary(mCount)...)
 		}
-		if len(sCount) > 0 {
+		if slices.Contains(s.ColumnsHeading, SecretsColumn) {
 			rowParts = append(rowParts, s.generateSummary(sCount)...)
 		}
 		t.AddRow(rowParts...)


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

## Description

only vuln:

```
trivy k8s -n kube-system --security-checks=vuln --report=summary Pod/kube-apiserver-minikube
1 / 1 [----------------------------------------------------------------------------------------------------------------------] 100.00% 0 p/s

Summary Report for minikube
┌───────────┬──────────┬───────────────────┐
│ Namespace │ Resource │  Vulnerabilities  │
│           │          ├───┬───┬───┬───┬───┤
│           │          │ C │ H │ M │ L │ U │
└───────────┴──────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

only config:
```
trivy k8s -n kube-system --security-checks=config --report=summary Pod/kube-apiserver-minikube
1 / 1 [----------------------------------------------------------------------------------------------------------------------] 100.00% 1 p/s

Summary Report for minikube
┌─────────────┬─────────────────────────────┬────────────────────┐
│  Namespace  │          Resource           │ Misconfigurations  │
│             │                             ├───┬───┬───┬────┬───┤
│             │                             │ C │ H │ M │ L  │ U │
├─────────────┼─────────────────────────────┼───┼───┼───┼────┼───┤
│ kube-system │ Pod/kube-apiserver-minikube │   │ 1 │ 4 │ 19 │   │
└─────────────┴─────────────────────────────┴───┴───┴───┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

vuln,config:
```
trivy k8s -n kube-system --security-checks=vuln,config --report=summary Pod/kube-apiserver-minikube
1 / 1 [----------------------------------------------------------------------------------------------------------------------] 100.00% 0 p/s

Summary Report for minikube
┌─────────────┬─────────────────────────────┬───────────────────┬────────────────────┐
│  Namespace  │          Resource           │  Vulnerabilities  │ Misconfigurations  │
│             │                             ├───┬───┬───┬───┬───┼───┬───┬───┬────┬───┤
│             │                             │ C │ H │ M │ L │ U │ C │ H │ M │ L  │ U │
├─────────────┼─────────────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼────┼───┤
│ kube-system │ Pod/kube-apiserver-minikube │   │   │   │   │   │   │ 1 │ 4 │ 19 │   │
└─────────────┴─────────────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```
## Related issues
- Close  https://github.com/aquasecurity/trivy/issues/2776

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
