### PR TITLE
build(): Sign releaser artifacts, not only container manifests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v3
       with:
         version: v1.4.1
-        args: release --snapshot --rm-dist --skip-publish --timeout 90m
+        args: release --skip-sign --snapshot --rm-dist --skip-publish --timeout 90m
 
   build-documents:
     name: Documentation Test

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -235,6 +235,21 @@ docker_manifests:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
 
+signs:
+- cmd: cosign
+  env:
+  - COSIGN_EXPERIMENTAL=1
+  signature: "${artifact}.sig"
+  certificate: "${artifact}.pem"
+  args:
+    - "sign-blob"
+    - "--oidc-issuer=https://token.actions.githubusercontent.com"
+    - "--output-certificate=${certificate}"
+    - "--output-signature=${signature}"
+    - "${artifact}"
+  artifacts: all
+  output: true
+
 docker_signs:
 - cmd: cosign
   env:


### PR DESCRIPTION
## Description

The current goreleaser configuration leverages cosign to sign the
goreleaser container manifests using public sigstore infrastructure.
This is great!

This PR also signs the rest of the releaser artifacts (binaries, sbom
file, etc), so we can verify them using the aforementioned public
infrastructure. This is very useful for folks consuming the binaries
from the public GitHub releases.

Note that this assumes that the OIDC issuer is GitHub, and thus ties
this signature to be triggered a GitHub action.

## Related issues
- Closes #2788

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
