### PR TITLE
fix(image): add logic to detect empty layers

### DIFF
--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -182,7 +182,7 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		return true
 	}
 	// commands here: 'ADD', COPY, RUN and WORKDIR != "/"
-	// Also RUN command may don't include 'RUN' prefix
+	// Also RUN command may not include 'RUN' prefix
 	// e.g. '/bin/sh -c mkdir test '
 	return false
 }

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	dimage "github.com/docker/docker/api/types/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -244,6 +245,64 @@ func Test_image_RawConfigFile(t *testing.T) {
 			require.NoError(t, err)
 
 			require.JSONEq(t, string(want), string(got))
+		})
+	}
+}
+
+func Test_image_emptyLayer(t *testing.T) {
+	tests := []struct {
+		name    string
+		history dimage.HistoryResponseItem
+		want    bool
+	}{
+		{
+			name: "size != 0",
+			history: dimage.HistoryResponseItem{
+				Size: 10,
+			},
+			want: false,
+		},
+		{
+			name: "ENV",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop) ENV TESTENV=TEST",
+			},
+			want: true,
+		},
+		{
+			name: "CMD",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+			},
+			want: true,
+		},
+		{
+			name: "WORKDIR == '/'",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop) WORKDIR /",
+			},
+			want: true,
+		},
+		{
+			name: "WORKDIR != '/'",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
+			},
+			want: false,
+		},
+		{
+			name: "without command",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c mkdir test",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			empty := emptyLayer(tt.history)
+			assert.Equal(t, tt.want, empty)
 		})
 	}
 }

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -270,6 +270,21 @@ func Test_image_emptyLayer(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "ENV created with buildkit",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "ENV BUILDKIT_ENV=TEST",
+				Comment:   "buildkit.dockerfile.v0",
+			},
+			want: true,
+		},
+		{
+			name: "ENV",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop) ENV TESTENV=TEST",
+			},
+			want: true,
+		},
+		{
 			name: "CMD",
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",


### PR DESCRIPTION
## Description
Added logic to detect empty layers.
Logic is taken from [buildkit](https://github.com/moby/buildkit/blob/2942d13ff489a2a49082c99e6104517e357e53ad/frontend/dockerfile/dockerfile2llb/convert.go).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
