### PR TITLE
docs: don't push patch versions

### DIFF
--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -35,7 +35,7 @@ jobs:
         if: ${{ github.event.inputs.version == '' }}
         run: |
           VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g")
-          mike deploy --push --update-aliases $VERSION latest
+          mike deploy --push --update-aliases ${VERSION%.*} latest
       - name: Deploy the latest documents from manual trigger
         if: ${{ github.event.inputs.version != '' }}
         run: mike deploy --push --update-aliases ${{ github.event.inputs.version }} latest


### PR DESCRIPTION
## Description
stop creating a documentation version for every patch version
keep triggering the workflow, and regenerating docs on every push including patch versions, BUT when pushing to mkdocs omit the patch version, meaning minor version will be overriden.

## Related issues
- Partially adressing #2288 

## Related PRs
- [ ] #2710

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
