### PR TITLE
docs: batch-import-findings limit

### DIFF
--- a/docs/docs/integrations/aws-security-hub.md
+++ b/docs/docs/integrations/aws-security-hub.md
@@ -22,6 +22,14 @@ Then, you can upload it with AWS CLI.
 $ aws securityhub batch-import-findings --findings file://report.asff
 ```
 
+### Note
+
+The [batch-import-findings](https://docs.aws.amazon.com/cli/latest/reference/securityhub/batch-import-findings.html#options) command limits the number of findings uploaded to 100 per request. The best known workaround to this problem is using [jq](https://stedolan.github.io/jq/) to run the following command
+
+```
+jq '.[:100]' report.asff 1> short_report.asff
+```
+
 ## Customize
 You can customize [asff.tpl](https://github.com/aquasecurity/trivy/blob/main/contrib/asff.tpl)
 


### PR DESCRIPTION
## Description

This doesn't really solve anything but points out issue and proposes work around. If someone has an actual fix I would really appreciate it

## Related issues
- Close #2849 

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).