### PR TITLE
fix: revert asff arn and add documentation

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -24,7 +24,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}/{{ .VulnerabilityID }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/aquasecurity/trivy",
             "GeneratorId": "Trivy/{{ .VulnerabilityID }}",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Software and Configuration Checks/Vulnerabilities/CVE" ],

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -24,7 +24,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}/{{ .VulnerabilityID }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
             "GeneratorId": "Trivy/{{ .VulnerabilityID }}",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Software and Configuration Checks/Vulnerabilities/CVE" ],
@@ -82,7 +82,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}/{{ .ID }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
             "GeneratorId": "Trivy/{{ .ID }}",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Software and Configuration Checks" ],

--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -24,7 +24,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}/{{ .VulnerabilityID }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/aquasecurity/trivy",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
             "GeneratorId": "Trivy/{{ .VulnerabilityID }}",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Software and Configuration Checks/Vulnerabilities/CVE" ],
@@ -82,7 +82,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}/{{ .ID }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/aquasecurity/trivy",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
             "GeneratorId": "Trivy/{{ .ID }}",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Software and Configuration Checks" ],

--- a/docs/docs/integrations/aws-security-hub.md
+++ b/docs/docs/integrations/aws-security-hub.md
@@ -16,7 +16,11 @@ The Product [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-nam
 "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
 ```
 
-In order to upload results you must first run [enable-import-findings-for-product](https://docs.aws.amazon.com/cli/latest/reference/securityhub/enable-import-findings-for-product.html) with `--product-arn` set to `arn:aws:securityhub:$AWS_DEFAULT_REGION::product/aquasecurity/aquasecurity`
+In order to upload results you must first run [enable-import-findings-for-product](https://docs.aws.amazon.com/cli/latest/reference/securityhub/enable-import-findings-for-product.html) like:
+
+```
+aws securityhub enable-import-findings-for-product --product-arn arn:aws:securityhub:<AWS_REGION>::product/aquasecurity/aquasecurity
+```
 
 Then, you can upload it with AWS CLI.
 

--- a/docs/docs/integrations/aws-security-hub.md
+++ b/docs/docs/integrations/aws-security-hub.md
@@ -10,11 +10,13 @@ $ AWS_REGION=us-west-1 AWS_ACCOUNT_ID=123456789012 trivy image --format template
 
 ASFF template needs AWS_REGION and AWS_ACCOUNT_ID from environment variables.
 
-The Product [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) field follows the pattern below to match what AWS requires for the [product resource type](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-custom-providers.html#securityhub-custom-providers-bfi-reqs:~:text=Use%20this%20product%20ARN%20as%20the%20value%20for%20the%20ProductArn%20attribute%20when%20invoking%20the%20BatchImportFindings%20API%20operation.).
+The Product [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) field follows the pattern below to match what AWS requires for the [product resource type](https://github.com/awsdocs/aws-security-hub-user-guide/blob/master/doc_source/securityhub-partner-providers.md#aqua-security--aqua-cloud-native-security-platform-sends-findings).
 
 ```
-"ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
+"ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
 ```
+
+In order to upload results you must first run [enable-import-findings-for-product](https://docs.aws.amazon.com/cli/latest/reference/securityhub/enable-import-findings-for-product.html) with `--product-arn` set to `arn:aws:securityhub:$AWS_DEFAULT_REGION::product/aquasecurity/aquasecurity`
 
 Then, you can upload it with AWS CLI.
 

--- a/docs/docs/integrations/aws-security-hub.md
+++ b/docs/docs/integrations/aws-security-hub.md
@@ -10,10 +10,10 @@ $ AWS_REGION=us-west-1 AWS_ACCOUNT_ID=123456789012 trivy image --format template
 
 ASFF template needs AWS_REGION and AWS_ACCOUNT_ID from environment variables.
 
-The Product [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) field follows the pattern below to match what AWS requires for the [product resource type](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awssecurityhub.html).
+The Product [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) field follows the pattern below to match what AWS requires for the [product resource type](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-custom-providers.html#securityhub-custom-providers-bfi-reqs:~:text=Use%20this%20product%20ARN%20as%20the%20value%20for%20the%20ProductArn%20attribute%20when%20invoking%20the%20BatchImportFindings%20API%20operation.).
 
 ```
-"ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/aquasecurity/trivy",
+"ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}:{{ env "AWS_ACCOUNT_ID" }}:product/{{ env "AWS_ACCOUNT_ID" }}/default",
 ```
 
 Then, you can upload it with AWS CLI.


### PR DESCRIPTION
## Description

This PR fixes the issues introduced in #2782. My understanding was that it was required to use the default ARN. This turns out not to be true. The PR fixes those issues and adds documentation for said issue as well as the required use of [enable-import-findings-for-product](https://docs.aws.amazon.com/cli/latest/reference/securityhub/enable-import-findings-for-product.html)

## Related PRs
- [X] #2782 

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
