### PR TITLE
fix: remove a patch number from the recommendation link

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
@@ -564,7 +565,6 @@ func canonicalVersion(ver string) string {
 	if v.IsPreRelease() || v.Metadata() != "" {
 		return devVersion
 	}
-
-	// Add "v" prefix, "0.34.0" => "v0.34.0" for the url
-	return "v" + ver
+	// Add "v" prefix and cut a patch number, "0.34.0" => "v0.34" for the url
+	return fmt.Sprintf("v%d.%d", v.Major(), v.Minor())
 }

--- a/pkg/commands/artifact/run_test.go
+++ b/pkg/commands/artifact/run_test.go
@@ -18,9 +18,9 @@ func TestCanonicalVersion(t *testing.T) {
 			want:  "v0.34",
 		},
 		{
-			title: "version with v",
+			title: "version with v - isn't right semver version",
 			input: "v0.34.0",
-			want:  "v0.34",
+			want:  devVersion,
 		},
 		{
 			title: "dev version",

--- a/pkg/commands/artifact/run_test.go
+++ b/pkg/commands/artifact/run_test.go
@@ -1,0 +1,48 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalVersion(t *testing.T) {
+	tests := []struct {
+		title string
+		input string
+		want  string
+	}{
+		{
+			title: "good way",
+			input: "0.34.0",
+			want:  "v0.34",
+		},
+		{
+			title: "version with v",
+			input: "v0.34.0",
+			want:  "v0.34",
+		},
+		{
+			title: "dev version",
+			input: devVersion,
+			want:  devVersion,
+		},
+		{
+			title: "pre-release",
+			input: "v0.34.0-beta1+snapshot-1",
+			want:  devVersion,
+		},
+		{
+			title: "no version",
+			input: "",
+			want:  devVersion,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			got := canonicalVersion(test.input)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Now Trivy omits patch versions in the docs now, so we should change the link.

there was added a little test to clarify logic and check casting `Part` to `int`.

## Related PRs
- [x] #2824

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
