### PR TITLE
chore: narrow the owner scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,8 @@ docs/docs/cloud             @owenrumney @liamg @knqyf263
 pkg/fanal/analyzer/config   @owenrumney @liamg @knqyf263
 pkg/fanal/handler/misconf   @owenrumney @liamg @knqyf263
 pkg/cloud                   @owenrumney @liamg @knqyf263
-pkg/flag                    @owenrumney @liamg @knqyf263
+pkg/flag/aws_flags.go       @owenrumney @liamg @knqyf263
+pkg/flag/misconf_flags.go   @owenrumney @liamg @knqyf263
 
 # Kubernetes scanning
 pkg/k8s/                @josedonizetti @chen-keinan @knqyf263


### PR DESCRIPTION
## Description
@liamg and @owenrumney are owners on `pkg/flag`, which is why reviews for irrelevant PRs are requested from them. Narrowing the scope to aws_flags.go and misconf_flags.go could be more relevant.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
