### PR TITLE
chore: run `go fmt`

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -54,7 +54,7 @@ Vulnerability DB:
 	}
 }
 
-//Check flag and command for print version
+// Check flag and command for print version
 func TestPrintVersion(t *testing.T) {
 	tableOutput := `Version: test
 Vulnerability DB:

--- a/rpc/cache/service.twirp.go
+++ b/rpc/cache/service.twirp.go
@@ -1484,9 +1484,12 @@ func sanitizeBaseURL(baseURL string) string {
 
 // baseServicePath composes the path prefix for the service (without <Method>).
 // e.g.: baseServicePath("/twirp", "my.pkg", "MyService")
-//       returns => "/twirp/my.pkg.MyService/"
+//
+//	returns => "/twirp/my.pkg.MyService/"
+//
 // e.g.: baseServicePath("", "", "MyService")
-//       returns => "/MyService/"
+//
+//	returns => "/MyService/"
 func baseServicePath(prefix, pkg, service string) string {
 	fullServiceName := service
 	if pkg != "" {

--- a/rpc/scanner/service.twirp.go
+++ b/rpc/scanner/service.twirp.go
@@ -645,9 +645,12 @@ func sanitizeBaseURL(baseURL string) string {
 
 // baseServicePath composes the path prefix for the service (without <Method>).
 // e.g.: baseServicePath("/twirp", "my.pkg", "MyService")
-//       returns => "/twirp/my.pkg.MyService/"
+//
+//	returns => "/twirp/my.pkg.MyService/"
+//
 // e.g.: baseServicePath("", "", "MyService")
-//       returns => "/MyService/"
+//
+//	returns => "/MyService/"
 func baseServicePath(prefix, pkg, service string) string {
 	fullServiceName := service
 	if pkg != "" {


### PR DESCRIPTION
## Description
go formatter chaged some files:
```sh
$ go fmt ./...
pkg/commands/app_test.go
rpc/cache/service.twirp.go
rpc/scanner/service.twirp.go

```


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
