### PR TITLE
fix(sbom): fix package name separation for gradle

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -64,8 +64,9 @@ func (p *PackageURL) Package() *ftypes.Package {
 		return pkg
 	}
 
-	if p.Type == packageurl.TypeMaven {
-		// Maven package separate ":"
+	// TODO: replace with packageurl.TypeGradle once they add it.
+	if p.Type == packageurl.TypeMaven || p.Type == ftypes.Gradle {
+		// Maven and Gradle packages separate ":"
 		// e.g. org.springframework:spring-core
 		pkg.Name = strings.Join([]string{p.Namespace, p.Name}, ":")
 	} else {
@@ -140,7 +141,7 @@ func NewPackageURL(t string, metadata types.Metadata, pkg ftypes.Package) (Packa
 		if metadata.OS != nil {
 			namespace = metadata.OS.Family
 		}
-	case packageurl.TypeMaven:
+	case packageurl.TypeMaven, string(ftypes.Gradle): // TODO: replace with packageurl.TypeGradle once they add it.
 		namespace, name = parseMaven(name)
 	case packageurl.TypePyPi:
 		name = parsePyPI(name)

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -42,6 +42,22 @@ func TestNewPackageURL(t *testing.T) {
 			},
 		},
 		{
+			name: "gradle package",
+			typ:  string(ftypes.Gradle),
+			pkg: ftypes.Package{
+				Name:    "org.springframework:spring-core",
+				Version: "5.3.14",
+			},
+			want: purl.PackageURL{
+				PackageURL: packageurl.PackageURL{
+					Type:      string(ftypes.Gradle),
+					Namespace: "org.springframework",
+					Name:      "spring-core",
+					Version:   "5.3.14",
+				},
+			},
+		},
+		{
 			name: "yarn package",
 			typ:  string(analyzer.TypeYarn),
 			pkg: ftypes.Package{

--- a/pkg/sbom/cyclonedx/testdata/happy/bom.json
+++ b/pkg/sbom/cyclonedx/testdata/happy/bom.json
@@ -105,6 +105,27 @@
       ]
     },
     {
+      "bom-ref": "pkg:gradle/com.example/example@0.0.1",
+      "type": "library",
+      "name": "com.example:example",
+      "version": "0.0.1",
+      "purl": "pkg:gradle/com.example/example@0.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:FilePath",
+          "value": "app/gradle/target/gradle.lockfile"
+        },
+        {
+          "name": "aquasecurity:trivy:LayerDiffID",
+          "value": "sha256:3c79e832b1b4891a1cb4a326ef8524e0bd14a2537150ac0e203a5677176c1ca1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gradle"
+        }
+      ]
+    },
+    {
       "bom-ref": "pkg:npm/bootstrap@5.0.2?file_path=app%2Fapp%2Fpackage.json",
       "type": "library",
       "name": "bootstrap",
@@ -225,6 +246,7 @@
       "dependsOn": [
         "60e9f57b-d4a6-4f71-ad14-0893ac609182",
         "pkg:maven/org.codehaus.mojo/child-project@1.0?file_path=app%2Fmaven%2Ftarget%2Fchild-project-1.0.jar",
+        "pkg:gradle/com.example/example@0.0.1",
         "pkg:npm/bootstrap@5.0.2?file_path=app%2Fapp%2Fpackage.json",
         "100925ff-7c0a-470f-a725-8fb973b40e7b",
         "1a111e6b-a682-470e-8b0e-aaa49d93cd39"

--- a/pkg/sbom/cyclonedx/unmarshal_test.go
+++ b/pkg/sbom/cyclonedx/unmarshal_test.go
@@ -81,6 +81,19 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 						},
 					},
 					{
+						Type: "gradle",
+						Libraries: []ftypes.Package{
+							{
+								Name:    "com.example:example",
+								Ref:     "pkg:gradle/com.example/example@0.0.1",
+								Version: "0.0.1",
+								Layer: ftypes.Layer{
+									DiffID: "sha256:3c79e832b1b4891a1cb4a326ef8524e0bd14a2537150ac0e203a5677176c1ca1",
+								},
+							},
+						},
+					},
+					{
 						Type: "jar",
 						Libraries: []ftypes.Package{
 							{


### PR DESCRIPTION
## Description
`Gradle` package name uses the ":" separator like `Maven`.

## Related issues
- Close #2886 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
