### PR TITLE
fix(flag): add file-patterns flag for config subcommand

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -533,8 +533,9 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 
 	scanFlags := &flag.ScanFlagGroup{
 		// Enable only '--skip-dirs' and '--skip-files' and disable other flags
-		SkipDirs:  &flag.SkipDirsFlag,
-		SkipFiles: &flag.SkipFilesFlag,
+		SkipDirs:     &flag.SkipDirsFlag,
+		SkipFiles:    &flag.SkipFilesFlag,
+		FilePatterns: &flag.FilePatternsFlag,
 	}
 
 	configFlags := &flag.Flags{


### PR DESCRIPTION
## Description
Add `--file-patterns` flag for `config` subcommand after [moving](https://github.com/aquasecurity/trivy/pull/2539) it to `scan` flags.

## Related issues
- Close #2923

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
