### PR TITLE
fix(cli): split env values with ',' for slice flags

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -168,7 +168,18 @@ func getStringSlice(flag *Flag) []string {
 	if flag == nil {
 		return nil
 	}
-	return viper.GetStringSlice(flag.ConfigName)
+	// viper always returns a string for ENV
+	// https://github.com/spf13/viper/blob/419fd86e49ef061d0d33f4d1d56d5e2a480df5bb/viper.go#L545-L553
+	// and uses strings.Field to separate values (whitespace only)
+	// we need to separate env values with ','
+	v := viper.GetStringSlice(flag.ConfigName)
+	switch {
+	case len(v) == 0: // no strings
+		return nil
+	case len(v) == 1 && strings.Contains(v[0], ","): // unseparated string
+		v = strings.Split(v[0], ",")
+	}
+	return v
 }
 
 func getInt(flag *Flag) int {

--- a/pkg/flag/options_test.go
+++ b/pkg/flag/options_test.go
@@ -1,0 +1,73 @@
+package flag
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getStringSlice(t *testing.T) {
+	type env struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name      string
+		flag      *Flag
+		flagValue interface{}
+		env       env
+		want      []string
+	}{
+		{
+			name:      "happy path. Empty value",
+			flag:      &SecurityChecksFlag,
+			flagValue: "",
+			want:      nil,
+		},
+		{
+			name:      "happy path. String value",
+			flag:      &SecurityChecksFlag,
+			flagValue: "license,vuln",
+			want:      []string{types.SecurityCheckLicense, types.SecurityCheckVulnerability},
+		},
+		{
+			name:      "happy path. Slice value",
+			flag:      &SecurityChecksFlag,
+			flagValue: []string{"license", "secret"},
+			want:      []string{types.SecurityCheckLicense, types.SecurityCheckSecret},
+		},
+		{
+			name: "happy path. Env value",
+			flag: &SecurityChecksFlag,
+			env: env{
+				key:   "TRIVY_SECURITY_CHECKS",
+				value: "rbac,config",
+			},
+			want: []string{types.SecurityCheckRbac, types.SecurityCheckConfig},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env.key == "" {
+				viper.Set(tt.flag.ConfigName, tt.flagValue)
+			} else {
+				err := viper.BindEnv(tt.flag.ConfigName, tt.env.key)
+				assert.NoError(t, err)
+
+				savedEnvValue := os.Getenv(tt.env.key)
+				err = os.Setenv(tt.env.key, tt.env.value)
+				assert.NoError(t, err)
+				defer os.Setenv(tt.env.key, savedEnvValue)
+			}
+
+			sl := getStringSlice(tt.flag)
+			assert.Equal(t, tt.want, sl)
+
+			viper.Reset()
+		})
+	}
+}

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -15,7 +15,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		skipDirs       []string
 		skipFiles      []string
 		offlineScan    bool
-		vulnType       string
 		securityChecks string
 	}
 	tests := []struct {
@@ -53,7 +52,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			want: flag.ScanOptions{},
 			assertion: func(t require.TestingT, err error, msgs ...interface{}) {
-				require.ErrorContains(t, err, "unknown security check")
+				require.ErrorContains(t, err, "unknown security check: WRONG-CHECK")
 			},
 		},
 		{
@@ -107,7 +106,6 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			viper.Set(flag.SkipDirsFlag.ConfigName, tt.fields.skipDirs)
 			viper.Set(flag.SkipFilesFlag.ConfigName, tt.fields.skipFiles)
 			viper.Set(flag.OfflineScanFlag.ConfigName, tt.fields.offlineScan)
-			viper.Set(flag.VulnTypeFlag.ConfigName, tt.fields.vulnType)
 			viper.Set(flag.SecurityChecksFlag.ConfigName, tt.fields.securityChecks)
 
 			// Assert options

--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -57,13 +57,6 @@ func (f *VulnerabilityFlagGroup) ToOptions() VulnerabilityOptions {
 }
 
 func parseVulnType(vulnType []string) []string {
-	switch {
-	case len(vulnType) == 0: // no types
-		return nil
-	case len(vulnType) == 1 && strings.Contains(vulnType[0], ","): // get checks from flag
-		vulnType = strings.Split(vulnType[0], ",")
-	}
-
 	var vulnTypes []string
 	for _, v := range vulnType {
 		if !slices.Contains(types.VulnTypes, v) {


### PR DESCRIPTION
## Description
`Viper` always [returns a string](https://github.com/spf13/viper/blob/419fd86e49ef061d0d33f4d1d56d5e2a480df5bb/viper.go#L545-L553) for ENVs.
And it [uses](https://github.com/spf13/cast/blob/2b0eb0f724e320b655240e331aef36d1175986c2/caste.go#L1275-L1276) `strings.Field` to separate values (by space only).

Added separation of env values with ','.

## Related issues
- Close #2922

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
