### PR TITLE
docs: fix broken link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 
 [getting-started]: https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [docs]: https://aquasecurity.github.io/trivy
-[integrations]:https://aquasecurity.github.io/trivy/latest/docs/integrations/
+[integrations]:https://aquasecurity.github.io/trivy/latest/tutorials/integrations/
 [installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [releases]: https://github.com/aquasecurity/trivy/releases
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/


### PR DESCRIPTION
## Description
Fixed broken link to `integrations section`.

## Related issues
- Close #2913

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
