### PR TITLE
feat(dotnet): Dotnet SDK project file support for Nuget references scan

### DIFF
--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
@@ -21,6 +21,28 @@ func Test_nugetibraryAnalyzer_Analyze(t *testing.T) {
 		wantErr   string
 	}{
 		{
+			name:      "happy path proj file",
+			inputFile: "testdata/test.csproj",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.NuGet,
+						FilePath: "testdata/test.csproj",
+						Libraries: []types.Package{
+							{
+								Name:    "Microsoft.AspNet.WebApi",
+								Version: "5.2.2",
+							},
+							{
+								Name:    "Newtonsoft.Json",
+								Version: "6.0.4",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:      "happy path config file",
 			inputFile: "testdata/packages.config",
 			want: &analyzer.AnalysisResult{
@@ -108,6 +130,21 @@ func Test_nugetLibraryAnalyzer_Required(t *testing.T) {
 		filePath string
 		want     bool
 	}{
+		{
+			name:     "csproj",
+			filePath: "test/packages.csproj",
+			want:     true,
+		},
+		{
+			name:     "fsproj",
+			filePath: "test/packages.fsproj",
+			want:     true,
+		},
+		{
+			name:     "vbproj",
+			filePath: "test/packages.vbproj",
+			want:     true,
+		},
 		{
 			name:     "config",
 			filePath: "test/packages.config",

--- a/pkg/fanal/analyzer/language/dotnet/nuget/proj_parser.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/proj_parser.go
@@ -1,0 +1,58 @@
+package nuget
+
+import (
+	"encoding/xml"
+
+	"golang.org/x/xerrors"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/go-dep-parser/pkg/utils"
+)
+
+type projPackageReference struct {
+	XMLName     xml.Name `xml:"PackageReference"`
+	Version     string   `xml:"Version,attr"`
+	PackageName string   `xml:"Include,attr"`
+}
+
+type projItemGroup struct {
+	XMLName           xml.Name               `xml:"ItemGroup"`
+	PackageReferences []projPackageReference `xml:"PackageReference"`
+}
+
+type projRoot struct {
+	XMLName    xml.Name        `xml:"Project"`
+	ItemGroups []projItemGroup `xml:"ItemGroup"`
+}
+
+type Parser struct{}
+
+func NewProjParser() types.Parser {
+	return &Parser{}
+}
+
+func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency, error) {
+	var projData projRoot
+	if err := xml.NewDecoder(r).Decode(&projData); err != nil {
+		return nil, nil, xerrors.Errorf("failed to decode proj file: %w", err)
+	}
+
+	libs := make([]types.Library, 0)
+	for _, groups := range projData.ItemGroups {
+		for _, pkg := range groups.PackageReferences {
+			if pkg.PackageName == "" {
+				continue
+			}
+
+			lib := types.Library{
+				Name:    pkg.PackageName,
+				Version: pkg.Version,
+			}
+
+			libs = append(libs, lib)
+		}
+	}
+
+	return utils.UniqueLibraries(libs), nil, nil
+}

--- a/pkg/fanal/analyzer/language/dotnet/nuget/testdata/test.csproj
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/testdata/test.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <RootNamespace>SomeTestNS</RootNamespace>
+        <AssemblyName>SomeTestNS</AssemblyName>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Newtonsoft.Json" Version="6.0.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Application\Application.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="secrets.json">
+            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="Resource.json" />
+        <EmbeddedResource Update="Resources\Resources.SharedResource.en.resx">
+            <LastGenOutput>Resources.SharedResource.en.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Update="Resources\Resources.SharedResource.en.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Resources.SharedResource.en.resx</DependentUpon>
+        </Compile>
+    </ItemGroup>
+
+</Project>

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -48,6 +48,7 @@ const (
 	// Language-specific file names
 	NuGetPkgsLock   = "packages.lock.json"
 	NuGetPkgsConfig = "packages.config"
+	NuGetPkgsProj   = "*.(cs|fs|vb)proj"
 
 	GoMod = "go.mod"
 	GoSum = "go.sum"


### PR DESCRIPTION
## Description

Added support for the dotnet sdk project files for Nuget references scan

https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files

## Related issues
- Close #2941



## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
