### PR TITLE
fix(java): use fields of dependency from dependencyManagement from upper pom.xml to parse deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -392,3 +392,5 @@ replace github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220224
 // v1.2.0 is taken from github.com/open-policy-agent/opa v0.42.0
 // v1.2.0 incompatible with github.com/docker/docker v20.10.3-0.20220224222438-c78f6963a1c0+incompatible
 replace oras.land/oras-go => oras.land/oras-go v1.1.1
+
+replace github.com/aquasecurity/go-dep-parser => github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.75.3
-	github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40
+	github.com/aquasecurity/go-dep-parser v0.0.0-20220928105313-d3a51fe400e4
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.75.3
-	github.com/aquasecurity/go-dep-parser v0.0.0-20220912084514-9d42a63ca964
+	github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
@@ -392,5 +392,3 @@ replace github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220224
 // v1.2.0 is taken from github.com/open-policy-agent/opa v0.42.0
 // v1.2.0 incompatible with github.com/docker/docker v20.10.3-0.20220224222438-c78f6963a1c0+incompatible
 replace oras.land/oras-go => oras.land/oras-go v1.1.1
-
-replace github.com/aquasecurity/go-dep-parser => github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.75.3 h1:mQ4ihStPsibq9zcTxq5Qz2pT23EAVJALO5b5KYTQWiY=
 github.com/aquasecurity/defsec v0.75.3/go.mod h1:XvXJkw8wiN7/rH913qAT4OoaPMoJeTIqZcevjZjUh3M=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220912084514-9d42a63ca964 h1:Ilqo8EEvGV2K8HVZwHCapLcQOyY/DhV5wcIZ1Xh6wwg=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220912084514-9d42a63ca964/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc h1:pRjduDVz3HF6vdS3Q/jDVijlr0KKVwWR5EK0yrFzNyY=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.75.3 h1:mQ4ihStPsibq9zcTxq5Qz2pT23EAVJALO5b5KYTQWiY=
 github.com/aquasecurity/defsec v0.75.3/go.mod h1:XvXJkw8wiN7/rH913qAT4OoaPMoJeTIqZcevjZjUh3M=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40 h1:e0oc+kQzS7/zilrL9ChCR4KjPtFooOrrmsWyfv6TNlM=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220928105313-d3a51fe400e4 h1:Bzwh7XCoC71R5CBCr6IHkuRt7UBdwaUHX8XPWfYkvDM=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220928105313-d3a51fe400e4/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.75.3 h1:mQ4ihStPsibq9zcTxq5Qz2pT23EAVJALO5b5KYTQWiY=
 github.com/aquasecurity/defsec v0.75.3/go.mod h1:XvXJkw8wiN7/rH913qAT4OoaPMoJeTIqZcevjZjUh3M=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc h1:pRjduDVz3HF6vdS3Q/jDVijlr0KKVwWR5EK0yrFzNyY=
-github.com/aquasecurity/go-dep-parser v0.0.0-20220926083925-e282eba8a8cc/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40 h1:e0oc+kQzS7/zilrL9ChCR4KjPtFooOrrmsWyfv6TNlM=
+github.com/aquasecurity/go-dep-parser v0.0.0-20220928101759-83f7ec9fec40/go.mod h1:6G1Y5nht5TL9kr1SzmrdE8PrmbNXo9nHx3qFR3qURg0=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=


### PR DESCRIPTION
## Description
See [#136](https://github.com/aquasecurity/go-dep-parser/pull/136)

## Related issues
- Close #2935

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/136
- [x] aquasecurity/go-dep-parser/pull/137

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
