### PR TITLE
fix: Removes accidentally exported wasm memory

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -245,7 +245,6 @@ func newWASMPlugin(ctx context.Context, r wazero.Runtime, code []byte) (*wasmMod
 
 	// Instantiate a Go-defined module named "env" that exports functions.
 	_, err := r.NewModuleBuilder("env").
-		ExportMemory("mem", 100).
 		ExportFunctions(exportFunctions).
 		Instantiate(ctx, ns)
 	if err != nil {


### PR DESCRIPTION
## Description
This removes an accidental assignment of memory to the host module. This api has never been used correctly and will be removed from the next wazero release. The actual memory used by host functions is that defined by the guest (%.wasm file).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.

