### PR TITLE
fix(go): Less function for slice sorting always returns `false`

### DIFF
--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -84,7 +84,7 @@ func Write(rep *Report, opt flag.Options, fromCache bool) error {
 				return err
 			}
 			sort.Slice(resCopy.Misconfigurations, func(i, j int) bool {
-				return resCopy.Misconfigurations[i].CauseMetadata.Resource < resCopy.Misconfigurations[i].CauseMetadata.Resource
+				return resCopy.Misconfigurations[i].CauseMetadata.Resource < resCopy.Misconfigurations[j].CauseMetadata.Resource
 			})
 			filtered = append(filtered, resCopy)
 		}


### PR DESCRIPTION
Signed-off-by: Salvador Cavadini <salvadorcavadini+github@gmail.com>

## Description
fix #2966 by using the right slice indexes in the return expression of the Less function passed to sort.Slice

## Related issues
- Close #2966

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
