### PR TITLE
feat(flag): Allow redis client to work in cluster mode [wip] 

### DIFF
--- a/pkg/fanal/cache/redis.go
+++ b/pkg/fanal/cache/redis.go
@@ -20,13 +20,13 @@ const (
 )
 
 type RedisCache struct {
-	client     *redis.Client
+	client     redis.UniversalClient
 	expiration time.Duration
 }
 
-func NewRedisCache(options *redis.Options, expiration time.Duration) RedisCache {
+func NewRedisCache(options *redis.UniversalOptions, expiration time.Duration) RedisCache {
 	return RedisCache{
-		client:     redis.NewClient(options),
+		client:     redis.NewUniversalClient(options),
 		expiration: expiration,
 	}
 }

--- a/pkg/fanal/cache/redis_test.go
+++ b/pkg/fanal/cache/redis_test.go
@@ -67,8 +67,8 @@ func TestRedisCache_PutArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			err = c.PutArtifact(tt.args.artifactID, tt.args.artifactConfig)
@@ -156,8 +156,8 @@ func TestRedisCache_PutBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			err = c.PutBlob(tt.args.blobID, tt.args.blobConfig)
@@ -241,8 +241,8 @@ func TestRedisCache_GetArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			got, err := c.GetArtifact(tt.artifactID)
@@ -334,8 +334,8 @@ func TestRedisCache_GetBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			got, err := c.GetBlob(tt.blobID)
@@ -445,8 +445,8 @@ func TestRedisCache_MissingBlobs(t *testing.T) {
 				addr = "dummy:6379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			missingArtifact, missingBlobIDs, err := c.MissingBlobs(tt.args.artifactID, tt.args.blobIDs)
@@ -470,8 +470,8 @@ func TestRedisCache_Close(t *testing.T) {
 	defer s.Close()
 
 	t.Run("close", func(t *testing.T) {
-		c := cache.NewRedisCache(&redis.Options{
-			Addr: s.Addr(),
+		c := cache.NewRedisCache(&redis.UniversalOptions{
+			Addrs: []string{s.Addr()},
 		}, 0)
 		closeErr := c.Close()
 		require.NoError(t, closeErr)
@@ -492,8 +492,8 @@ func TestRedisCache_Clear(t *testing.T) {
 	s.Set("foo", "bar")
 
 	t.Run("clear", func(t *testing.T) {
-		c := cache.NewRedisCache(&redis.Options{
-			Addr: s.Addr(),
+		c := cache.NewRedisCache(&redis.UniversalOptions{
+			Addrs: []string{s.Addr()},
 		}, 0)
 		require.NoError(t, c.Clear())
 		for i := 0; i < 200; i++ {
@@ -546,8 +546,8 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
+			c := cache.NewRedisCache(&redis.UniversalOptions{
+				Addrs: []string{addr},
 			}, 0)
 
 			err = c.DeleteBlobs(tt.args.blobIDs)

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -133,12 +133,18 @@ func (fg *CacheFlagGroup) ToOptions() (CacheOptions, error) {
 
 // CacheBackendMasked returns the redis connection string masking credentials
 func (o *CacheOptions) CacheBackendMasked() string {
-	endIndex := strings.Index(o.CacheBackend, "@")
-	if endIndex == -1 {
-		return o.CacheBackend
+	split_chr := ","
+	clients := []string{}
+
+	for _, u := range strings.Split(o.CacheBackend, split_chr) {
+
+		endIndex := strings.Index(u, "@")
+		if endIndex == -1 {
+			clients = append(clients, u)
+		} else {
+			startIndex := strings.Index(u, "//")
+			clients = append(clients, fmt.Sprintf("%s****%s", u[:startIndex+2], u[endIndex:]))
+		}
 	}
-
-	startIndex := strings.Index(o.CacheBackend, "//")
-
-	return fmt.Sprintf("%s****%s", o.CacheBackend[:startIndex+2], o.CacheBackend[endIndex:])
+	return strings.Join(clients, split_chr)
 }

--- a/pkg/flag/cache_flags_test.go
+++ b/pkg/flag/cache_flags_test.go
@@ -132,6 +132,20 @@ func TestCacheOptions_CacheBackendMasked(t *testing.T) {
 			},
 			want: "redis://localhost:6379",
 		},
+		{
+			name: "redis cache backend cluster, masked",
+			fields: fields{
+				backend: "redis://root:password@localhost:6379,redis://root:password@localhost:6380",
+			},
+			want: "redis://****@localhost:6379,redis://****@localhost:6380",
+		},
+		{
+			name: "redis cache backend cluster, masked does nothing",
+			fields: fields{
+				backend: "redis://localhost:6379,redis://localhost:6380",
+			},
+			want: "redis://localhost:6379,redis://localhost:6380",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Allows redis to be used in either cluster mode or single node mode.

This fixes #2772 , allowing the cache to use redis in cluster mode or single node mode.

This would allow you to configure a redis client in format `redis://localhost:6379,redis://localhost:6380`
@iliashkolyar is this how you'd expect to configure the cluster?

Logically, the redis argument parsing doesnt make sense where it is, but i'm not sure where it makes more sense

I'll update the docs with an example of usage if this looks sensible