### PR TITLE
docs(repo): troubleshooting $TMPDIR customization

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -120,6 +120,19 @@ To run multiple Trivy servers, you need to use Redis as the cache backend so tha
 Follow [this instruction][redis-cache] to do so.
 
 
+### Problems with `/tmp` on remote Git repository scans
+
+!!! error
+    FATAL repository scan error: scan error: unable to initialize a scanner: unable to initialize a filesystem scanner: git clone error: write /tmp/fanal-remote...
+
+Trivy clones remote Git repositories under the `/tmp` directory before scanning them. If `/tmp` doesn't work for you, you can change it by setting the `TMPDIR` environment variable.
+
+Try:
+
+```
+$ TMPDIR=/my/custom/path trivy repo ...
+```
+
 ## Homebrew
 ### Scope error
 !!! error


### PR DESCRIPTION
## Description
Adds a troubleshooting section for choosing a different directory other than `/tmp` when cloning a remote Git repository for scanning.

This is how it looks like in MkDocs:
![trivy-troubleshooting](https://user-images.githubusercontent.com/4765455/193441302-e4dedd1f-4e35-45ac-821a-efe659ebf989.png)


## Related issues
- Close #2921

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
