### PR TITLE
feat(report): add location.message to SARIF output (#3002)

### DIFF
--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -88,6 +88,9 @@
                   "endLine": 1,
                   "endColumn": 1
                 }
+              },
+              "message": {
+                "text": "testdata/fixtures/images/alpine-310.tar.gz: libcrypto1.1@1.1.1c-r0"
               }
             }
           ]
@@ -112,6 +115,9 @@
                   "endLine": 1,
                   "endColumn": 1
                 }
+              },
+              "message": {
+                "text": "testdata/fixtures/images/alpine-310.tar.gz: libcrypto1.1@1.1.1c-r0"
               }
             }
           ]
@@ -136,6 +142,9 @@
                   "endLine": 1,
                   "endColumn": 1
                 }
+              },
+              "message": {
+                "text": "testdata/fixtures/images/alpine-310.tar.gz: libssl1.1@1.1.1c-r0"
               }
             }
           ]
@@ -160,6 +169,9 @@
                   "endLine": 1,
                   "endColumn": 1
                 }
+              },
+              "message": {
+                "text": "testdata/fixtures/images/alpine-310.tar.gz: libssl1.1@1.1.1c-r0"
               }
             }
           ]

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -56,6 +56,7 @@ type sarifData struct {
 	url              string
 	resultIndex      int
 	artifactLocation string
+	locationMessage  string
 	message          string
 	cvssScore        string
 	startLine        int
@@ -104,7 +105,7 @@ func (sw *SarifWriter) addSarifResult(data *sarifData) {
 		WithRuleIndex(data.resultIndex).
 		WithMessage(sarif.NewTextMessage(data.message)).
 		WithLevel(toSarifErrorLevel(data.severity)).
-		WithLocations([]*sarif.Location{sarif.NewLocation().WithPhysicalLocation(location)})
+		WithLocations([]*sarif.Location{sarif.NewLocation().WithMessage(sarif.NewTextMessage(data.locationMessage)).WithPhysicalLocation(location)})
 	sw.run.AddResult(result)
 }
 
@@ -148,6 +149,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 				url:              vuln.PrimaryURL,
 				resourceClass:    string(res.Class),
 				artifactLocation: path,
+				locationMessage:  fmt.Sprintf("%v: %v@%v", path, vuln.PkgName, vuln.InstalledVersion),
 				resultIndex:      getRuleIndex(vuln.VulnerabilityID, ruleIndexes),
 				fullDescription:  html.EscapeString(fullDescription),
 				helpText: fmt.Sprintf("Vulnerability %v\nSeverity: %v\nPackage: %v\nFixed Version: %v\nLink: [%v](%v)\n%v",
@@ -167,6 +169,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 				url:              misconf.PrimaryURL,
 				resourceClass:    string(res.Class),
 				artifactLocation: target,
+				locationMessage:  target,
 				startLine:        misconf.CauseMetadata.StartLine,
 				endLine:          misconf.CauseMetadata.EndLine,
 				resultIndex:      getRuleIndex(misconf.ID, ruleIndexes),
@@ -188,6 +191,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 				url:              builtinRulesUrl,
 				resourceClass:    string(res.Class),
 				artifactLocation: target,
+				locationMessage:  target,
 				startLine:        secret.StartLine,
 				endLine:          secret.EndLine,
 				resultIndex:      getRuleIndex(secret.RuleID, ruleIndexes),

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -96,6 +96,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 					Message:   sarif.Message{Text: toPtr("Package: foo\nInstalled Version: 1.2.3\nVulnerability CVE-2020-0001\nSeverity: HIGH\nFixed Version: 3.4.5\nLink: [CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)")},
 					Locations: []*sarif.Location{
 						{
+							Message: &sarif.Message{Text: toPtr("library/test: foo@1.2.3")},
 							PhysicalLocation: &sarif.PhysicalLocation{
 								ArtifactLocation: &sarif.ArtifactLocation{
 									URI:       toPtr("library/test"),
@@ -149,6 +150,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nVulnerability KSV001\nSeverity: HIGH\nMessage: Message\nLink: [KSV001](https://avd.aquasec.com/appshield/ksv001)")},
 					Locations: []*sarif.Location{
 						{
+							Message: &sarif.Message{Text: toPtr("library/test")},
 							PhysicalLocation: &sarif.PhysicalLocation{
 								ArtifactLocation: &sarif.ArtifactLocation{
 									URI:       toPtr("library/test"),
@@ -171,6 +173,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nVulnerability KSV002\nSeverity: CRITICAL\nMessage: Message\nLink: [KSV002](https://avd.aquasec.com/appshield/ksv002)")},
 					Locations: []*sarif.Location{
 						{
+							Message: &sarif.Message{Text: toPtr("library/test")},
 							PhysicalLocation: &sarif.PhysicalLocation{
 								ArtifactLocation: &sarif.ArtifactLocation{
 									URI:       toPtr("library/test"),
@@ -263,6 +266,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nSecret AWS Secret Access Key\nSeverity: CRITICAL\nMatch: 'AWS_secret_KEY'=\"****************************************\"")},
 					Locations: []*sarif.Location{
 						{
+							Message: &sarif.Message{Text: toPtr("library/test")},
 							PhysicalLocation: &sarif.PhysicalLocation{
 								ArtifactLocation: &sarif.ArtifactLocation{
 									URI:       toPtr("library/test"),


### PR DESCRIPTION
## Description
SARIF allows a "message" to be provided for a location and that can have more useful information. See:
https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317675

It would be helpful to set this property so SARIF consumers can display better information. It would be particularly nice if Trivy includes the file and the package name and version (ex, `pom.xml:org.yaml:snakeyaml@1.30`).

## Related issues
- Close #3002

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
