### PR TITLE
fix(helm): make helm service port configurable to port 80

### DIFF
--- a/helm/trivy/templates/configmap.yaml
+++ b/helm/trivy/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "trivy.labels" . | indent 4 }}
 data:
-  TRIVY_LISTEN: "0.0.0.0:{{ .Values.service.port }}"
+  TRIVY_LISTEN: "0.0.0.0:4954"
   TRIVY_CACHE_DIR: "/home/scanner/.cache/trivy"
 {{- if .Values.trivy.cache.redis.enabled }}
   TRIVY_CACHE_BACKEND: {{ .Values.trivy.cache.redis.url | quote }}

--- a/helm/trivy/templates/service.yaml
+++ b/helm/trivy/templates/service.yaml
@@ -13,5 +13,5 @@ spec:
     - name: trivy-http
       protocol: TCP
       port: {{ .Values.service.port | default 4954 }}
-      targetPort: {{ .Values.service.port | default 4954 }}
+      targetPort: 4954
   sessionAffinity: ClientIP

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
                 {{- end }}
           ports:
             - name: trivy-http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 4954
           livenessProbe:
             httpGet:
               scheme: HTTP


### PR DESCRIPTION
## Description

This makes the Service port able to be configured to a normally privileged port like port 80. 

To do so, I'm pinning the containerPort to 4954 to match what `trivy server` runs on by default, and am making the `service.port` to not be "overloaded" to be the container port as well. 

I took a quick look at other charts like prometheus and grafana, to see if they allow containerPort to be configurable in the values.yml, but it looks like they don't, so I'm thinking it's not so common. I can't think of a use-case for configuring it at least, since all traffic to the Pod comes from the Service. I can make it configurable if you would like though.

### To test locally:

Set up a test cluster:
```
kind create cluster
# and to clean up after the test:
# kind delete cluster
```

#### Before

Confirm that setting the Service port to 80 causes the pod to crash:

```
git checkout main
helm install trivy-main ./helm/trivy --set service.port=80
kubectl logs trivy-main-0
```

![image](https://user-images.githubusercontent.com/7545665/195442889-c5e517ef-f978-4148-85db-a682c5f000ce.png)

#### After

Try the same from this branch, and confirm that pod isn't crashing:

```
gh pr checkout 3013
helm install trivy-patched ./helm/trivy --set service.port=80
kubectl logs trivy-patched-0
```

![Screenshot from 2022-10-12 16-39-47](https://user-images.githubusercontent.com/7545665/195446753-46cae8a2-ebd9-4c16-9158-3e6675a86ed0.png)

And confirm that we can access the Service on port 80:

```
kubectl run -it --rm --image alpine test
# in the test alpine pod now...
apk add curl
curl -i http://trivy-patched/healthz
```

![image](https://user-images.githubusercontent.com/7545665/195444254-673ade68-91d7-43b9-8cbc-5f3f4f13c09f.png)

## Related issues
- Close #2957 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
