### PR TITLE
feat(server): Add support for client/server mode to rootfs command

### DIFF
--- a/docs/docs/references/cli/rootfs.md
+++ b/docs/docs/references/cli/rootfs.md
@@ -17,10 +17,13 @@ Examples:
   / # trivy rootfs /
 
 Scan Flags
-      --offline-scan             do not issue API requests to identify dependencies
-      --security-checks string   comma-separated list of what security issues to detect (vuln,config,secret) (default "vuln,secret")
-      --skip-dirs strings        specify the directories where the traversal is skipped
-      --skip-files strings       specify the file paths to skip traversal
+      --file-patterns strings     specify config file patterns
+      --offline-scan              do not issue API requests to identify dependencies
+      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sbom-sources strings      [EXPERIMENTAL] try to retrieve SBOM from the specified sources (rekor)
+      --security-checks strings   comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --skip-dirs strings         specify the directories where the traversal is skipped
+      --skip-files strings        specify the file paths to skip traversal
 
 Report Flags
       --dependency-tree        show dependency origin tree (EXPERIMENTAL)
@@ -53,12 +56,12 @@ Vulnerability Flags
       --vuln-type string   comma-separated list of vulnerability types (os,library) (default "os,library")
 
 Misconfiguration Flags
-      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings       specify paths to the Rego policy files directory, applying config files
-      --file-patterns strings       specify config file patterns, available with '--security-checks config'
-      --include-non-failures        include successes and exceptions, available with '--security-checks config'
-      --policy-namespaces strings   Rego namespaces
-      --trace                       enable more verbose trace output for custom queries
+      --helm-set strings          specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings     specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings   specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings       specify paths to override the Helm values.yaml files
+      --include-non-failures      include successes and exceptions, available with '--security-checks config'
+      --tf-vars strings           specify paths to override the Terraform tfvars files
 
 Secret Flags
       --secret-config string   specify a path to config file for secret scanning (default "trivy-secret.yaml")
@@ -66,6 +69,18 @@ Secret Flags
 License Flags
       --ignored-licenses strings   specify a list of license to ignore
       --license-full               eagerly look for licenses in source code headers and license files
+
+Rego Flags
+      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings       specify paths to the Rego policy files directory, applying config files
+      --policy-namespaces strings   Rego namespaces
+      --trace                       enable more verbose trace output for custom queries
+
+Client/Server Flags
+      --custom-headers strings   custom headers in client mode
+      --server string            server address in client mode
+      --token string             for authentication in client/server mode
+      --token-header string      specify a header name for token in client/server mode (default "Trivy-Token")
 
 Global Flags:
       --cache-dir string          cache directory (default "/Users/teppei/Library/Caches/trivy")

--- a/docs/docs/references/modes/client-server.md
+++ b/docs/docs/references/modes/client-server.md
@@ -175,6 +175,30 @@ Total: 24 (CRITICAL: 24)
 +---------------------------------------------+------------------+----------+-------------------+--------------------------------+---------------------------------------+
 </details>
 
+## Remote scan of root filesystem
+Also, there is a way to scan root file system:
+```shell
+$ trivy rootfs --server http://localhost:8080 --severity CRITICAL /tmp/rootfs
+```
+**Note**: It's important to specify the protocol (http or https).
+<details>
+<summary>Result</summary>
+/tmp/rootfs (alpine 3.10.2)
+
+Total: 1 (CRITICAL: 1)
+
+┌───────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
+│  Library  │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
+├───────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
+│ apk-tools │ CVE-2021-36159 │ CRITICAL │ 2.10.4-r2         │ 2.10.7-r0     │ libfetch before 2021-07-26, as used in apk-tools, xbps, and │
+│           │                │          │                   │               │ other products, mishandles...                               │
+│           │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-36159                  │
+└───────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
+
+</details>
+
+
+
 ## Authentication
 
 ```

--- a/docs/docs/vulnerability/scanning/rootfs.md
+++ b/docs/docs/vulnerability/scanning/rootfs.md
@@ -6,7 +6,8 @@ Scan a root filesystem (such as a host machine, a virtual machine image, or an u
 $ trivy rootfs /path/to/rootfs
 ```
 
-## From Inside Containers
+## Standalone mode
+### From Inside Containers
 Scan your container from inside the container.
 
 ```bash
@@ -59,6 +60,40 @@ Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 6, CRITICAL: 0)
 ```
 
 </details>
+
+## Client/Server mode
+You must launch Trivy server in advance.
+
+```sh
+$ trivy server
+```
+
+Then, Trivy works as a client if you specify the `--server` option.
+
+```sh
+$ trivy rootfs --server http://localhost:4954 --severity CRITICAL /tmp/rootfs
+```
+
+<details>
+<summary>Result</summary>
+
+```
+/tmp/rootfs (alpine 3.10.2)
+
+Total: 1 (CRITICAL: 1)
+
+┌───────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
+│  Library  │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
+├───────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
+│ apk-tools │ CVE-2021-36159 │ CRITICAL │ 2.10.4-r2         │ 2.10.7-r0     │ libfetch before 2021-07-26, as used in apk-tools, xbps, and │
+│           │                │          │                   │               │ other products, mishandles...                               │
+│           │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2021-36159                  │
+└───────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
+
+```
+</details>
+
+
 
 ## Other Examples
 - [Embed in Dockerfile][embedding]

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -342,6 +342,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		DBFlagGroup:            flag.NewDBFlagGroup(),
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
+                RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          flag.NewScanFlagGroup(),

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -342,7 +342,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		DBFlagGroup:            flag.NewDBFlagGroup(),
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
-                RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          flag.NewScanFlagGroup(),


### PR DESCRIPTION
## Description
This PR adds support for client/server mode for the `trivy rootfs` command.

Before:
```
Scan rootfs

Usage:
  trivy rootfs [flags] ROOTDIR

Examples:
  # Scan unpacked filesystem
  $ docker export $(docker create alpine:3.10.2) | tar -C /tmp/rootfs -xvf -
  $ trivy rootfs /tmp/rootfs

  # Scan from inside a container
  $ docker run --rm -it alpine:3.11
  / # curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
  / # trivy rootfs /

Scan Flags
      --file-patterns strings     specify config file patterns
      --offline-scan              do not issue API requests to identify dependencies
      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
      --sbom-sources strings      [EXPERIMENTAL] try to retrieve SBOM from the specified sources (rekor)
      --security-checks strings   comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
      --skip-dirs strings         specify the directories where the traversal is skipped
      --skip-files strings        specify the file paths to skip traversal

Report Flags
      --dependency-tree        show dependency origin tree (EXPERIMENTAL)
      --exit-code int          specify exit code when any security issues are found
  -f, --format string          format (table, json, sarif, template, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
      --ignore-policy string   specify the Rego file path to evaluate each vulnerability
      --ignorefile string      specify .trivyignore file (default ".trivyignore")
      --list-all-pkgs          enabling the option will output all packages regardless of vulnerability
  -o, --output string          output file name
  -s, --severity string        severities of security issues to be displayed (comma separated) (default "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
  -t, --template string        output template

Cache Flags
      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
      --cache-ttl duration     cache TTL when using redis as cache backend
      --clear-cache            clear image caches without scanning
      --redis-ca string        redis ca file location, if using redis as cache backend
      --redis-cert string      redis certificate file location, if using redis as cache backend
      --redis-key string       redis key file location, if using redis as cache backend

DB Flags
      --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
      --download-db-only       download/update vulnerability database but don't run a scan
      --no-progress            suppress progress bar
      --reset                  remove all caches and database
      --skip-db-update         skip updating vulnerability database

Vulnerability Flags
      --ignore-unfixed     display only fixed vulnerabilities
      --vuln-type string   comma-separated list of vulnerability types (os,library) (default "os,library")

Misconfiguration Flags
      --config-data strings         specify paths from which data for the Rego policies will be recursively loaded
      --config-policy strings       specify paths to the Rego policy files directory, applying config files
      --helm-set strings            specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      --helm-set-file strings       specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
      --helm-set-string strings     specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      --helm-values strings         specify paths to override the Helm values.yaml files
      --include-non-failures        include successes and exceptions, available with '--security-checks config'
      --policy-namespaces strings   Rego namespaces
      --tf-vars strings             specify paths to override the Terraform tfvars files
      --trace                       enable more verbose trace output for custom queries

Secret Flags
      --secret-config string   specify a path to config file for secret scanning (default "trivy-secret.yaml")

License Flags
      --ignored-licenses strings   specify a list of license to ignore
      --license-full               eagerly look for licenses in source code headers and license files

Global Flags:
      --cache-dir string          cache directory (default "/home/ubuntu/.cache/trivy")
  -c, --config string             config path (default "trivy.yaml")
  -d, --debug                     debug mode
      --generate-default-config   write the default config to trivy-default.yaml
      --insecure                  allow insecure server connections when using TLS
  -q, --quiet                     suppress progress bar and log output
      --timeout duration          timeout (default 5m0s)
  -v, --version                   show version

2022-10-14T11:05:04.891+0200    FATAL   unknown flag: --server

```

After:
```
2022-10-14T11:05:31.560+0200    INFO    Vulnerability scanning is enabled
2022-10-14T11:05:31.561+0200    INFO    Secret scanning is enabled
2022-10-14T11:05:31.561+0200    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-10-14T11:05:31.561+0200    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2022-10-14T11:05:33.106+0200    INFO    Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Java (jar)

Total: 21 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 20, CRITICAL: 1)
...
```


## Related issues
- Close #3017

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
