### PR TITLE
refactor: use strings.TrimSuffix instead of strings.HasSuffix

### DIFF
--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -168,9 +168,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 //
 // https://github.com/rpm-software-management/yum/blob/043e869b08126c1b24e392f809c9f6871344c60d/rpmUtils/miscutils.py#L301
 func splitFileName(filename string) (name, ver, rel string, err error) {
-	if strings.HasSuffix(filename, ".rpm") {
-		filename = filename[:len(filename)-4]
-	}
+	filename = strings.TrimSuffix(filename, ".rpm")
 
 	archIndex := strings.LastIndex(filename, ".")
 	if archIndex == -1 {


### PR DESCRIPTION
## Description

Manually ran tests before/after this little chage:
```sh
% go test .  -v
=== RUN   TestParseRpmInfo
=== RUN   TestParseRpmInfo/Valid
=== RUN   TestParseRpmInfo/ValidBig
=== RUN   TestParseRpmInfo/ValidWithModularitylabel
--- PASS: TestParseRpmInfo (0.17s)
    --- PASS: TestParseRpmInfo/Valid (0.03s)
    --- PASS: TestParseRpmInfo/ValidBig (0.05s)
    --- PASS: TestParseRpmInfo/ValidWithModularitylabel (0.09s)
=== RUN   Test_splitFileName
=== RUN   Test_splitFileName/valid_name
=== RUN   Test_splitFileName/invalid_name
--- PASS: Test_splitFileName (0.00s)
    --- PASS: Test_splitFileName/valid_name (0.00s)
    --- PASS: Test_splitFileName/invalid_name (0.00s)
=== RUN   TestParseMarinerDistrolessManifest
=== RUN   TestParseMarinerDistrolessManifest/happy_path
=== RUN   TestParseMarinerDistrolessManifest/sab_path
--- PASS: TestParseMarinerDistrolessManifest (0.00s)
    --- PASS: TestParseMarinerDistrolessManifest/happy_path (0.00s)
    --- PASS: TestParseMarinerDistrolessManifest/sab_path (0.00s)
PASS
ok  	github.com/aquasecurity/trivy/pkg/fanal/analyzer/pkg/rpm	0.657s
```

## Related issues
- Close #3027 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
