### PR TITLE
docs(misconf): fix typo

### DIFF
--- a/docs/docs/misconfiguration/custom/index.md
+++ b/docs/docs/misconfiguration/custom/index.md
@@ -128,7 +128,7 @@ correct and do not reference incorrect properties/values.
 |----------------------------|------------------------------------------|:----------------------------:|:----------------:|:----------------:|
 | title                      | Any characters                           |             N/A              | :material-check: | :material-check: |
 | description                | Any characters                           |                              | :material-close: | :material-check: |
- | schemas.input              | `schema.input`                           | (applied to all input types) | :material-close: | :material-close: |
+| schemas.input              | `schema.input`                           | (applied to all input types) | :material-close: | :material-close: |
 | custom.id                  | Any characters                           |             N/A              | :material-check: | :material-check: |
 | custom.severity            | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`      |           UNKNOWN            | :material-check: | :material-check: |
 | custom.recommended_actions | Any characters                           |                              | :material-close: | :material-check: | 

--- a/docs/docs/misconfiguration/options/values.md
+++ b/docs/docs/misconfiguration/options/values.md
@@ -40,7 +40,7 @@ the `--helm-set-string` is the same as `--helm-set` but explicitly retains the v
 trivy config --helm-set-string name=false ./infrastructure/tf
 ```
 
-### Setting sepecific values from files
+### Setting specific values from files
 Specific override values can come from specific files
 
 ```bash


### PR DESCRIPTION
## Description

Fix a minor typo and remove extra brank.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
