### PR TITLE
docs: fix missing 'image' subcommand

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -110,7 +110,7 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
 
 ## Binary
 
-Download the archive file for your operating system/architecture from [here](https://github.com/aquasecurity/trivy/releases/tag/{{ git.tag }}). 
+Download the archive file for your operating system/architecture from [here](https://github.com/aquasecurity/trivy/releases/tag/{{ git.tag }}).
 Unpack the archive, and put the binary somewhere in your `$PATH` (on UNIX-y systems, /usr/local/bin or the like).
 Make sure it has execution bits turned on.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -146,7 +146,7 @@ Example:
 === "macOS"
 
     ``` bash
-    docker run --rm -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} image [YOUR_IMAGE_NAME
+    docker run --rm -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} image [YOUR_IMAGE_NAME]
     ```
 
 If you would like to scan the image on your host machine, you need to mount `docker.sock`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -153,7 +153,7 @@ If you would like to scan the image on your host machine, you need to mount `doc
 
 ```bash
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} python:3.4-alpine
+    -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:{{ git.tag[1:] }} image python:3.4-alpine
 ```
 
 Please re-pull latest `aquasec/trivy` if an error occurred.


### PR DESCRIPTION
When running:
```bash
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /root/.cache:/root/.cache docker.io/aquasec/trivy:0.32.1 node:18
```
I get the following error message:
```bash
Error: unknown command "node:18" for "trivy"
```

This will add the 'image' subcommand to the documentation.

(this will include some other 'nits and picks', but I can remove revert them in order to keep the PR changes clean if necessary)