### PR TITLE
feat: Allow override of containerd namespace

### DIFF
--- a/docs/docs/advanced/container/containerd.md
+++ b/docs/docs/advanced/container/containerd.md
@@ -19,4 +19,11 @@ $ export CONTAINERD_ADDRESS=/run/k3s/containerd/containerd.sock
 $ trivy image aquasec/nginx
 ```
 
+If your scan targets are images in a namespace other than containerd's default namespace (`default`), you can override it via `CONTAINERD_NAMESPACE`.
+
+```bash
+$ export CONTAINERD_NAMESPACE=k8s.io
+$ trivy image aquasec/nginx
+```
+
 [containerd]: https://containerd.io/

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -72,8 +72,12 @@ func ContainerdImage(ctx context.Context, imageName string) (Image, func(), erro
 		return nil, cleanup, xerrors.Errorf("failed to initialize a containerd client: %w", err)
 	}
 
-	// Need to specify a namespace
-	ctx = namespaces.WithNamespace(ctx, defaultContainerdNamespace)
+	namespace := os.Getenv("CONTAINERD_NAMESPACE")
+	if namespace == "" {
+		namespace = defaultContainerdNamespace
+	}
+
+	ctx = namespaces.WithNamespace(ctx, namespace)
 
 	img, err := client.GetImage(ctx, ref.String())
 	if err != nil {


### PR DESCRIPTION
## Description
Containerd allows you to specify a namespace for queries, pulls, storage, etc. Trivy currently only scans local images in the `default` containerd namespace. This PR enables trivy to scan other namespaces within the containerd store.

An excellent use case is scanning the containerd store on kubernetes clusters; by default, images used by kubernetes are pulled to the `k8s.io` namespace.

## Related issues
- Close #3059 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options) **does not introduce new options**
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change). **not a UI change**
