### PR TITLE
test: disable containerd fanal integration tests for non-amd64 arch

### DIFF
--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -383,6 +384,11 @@ func TestContainerd_LocalImage(t *testing.T) {
 			},
 		},
 	}
+	// Each architecture needs different images and test cases.
+	// Currently only amd64 architecture is supported
+	if runtime.GOARCH != "amd64" {
+		t.Skip("'Containerd' test only supports amd64 architecture")
+	}
 	ctx := namespaces.WithNamespace(context.Background(), "default")
 
 	tmpDir, socketPath := configureTestDataPaths(t)
@@ -512,6 +518,12 @@ func TestContainerd_PullImage(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	// Each architecture needs different images and test cases.
+	// Currently only amd64 architecture is supported
+	if runtime.GOARCH != "amd64" {
+		t.Skip("'Containerd' test only supports amd64 architecture")
 	}
 
 	ctx := namespaces.WithNamespace(context.Background(), "default")


### PR DESCRIPTION
## Description
Disable [containerd fanal integration tests](https://github.com/aquasecurity/trivy/blob/9b0e9794cb94a2292c506afbff2bcd8695170558/pkg/fanal/test/integration/containerd_test.go) for non-amd64 arch.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
