### PR TITLE
fix(flag): disable flag parsing for each plugin command

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -111,6 +111,7 @@ func loadPluginCommands() []*cobra.Command {
 				}
 				return nil
 			},
+			DisableFlagParsing: true,
 		}
 		commands = append(commands, cmd)
 	}


### PR DESCRIPTION
## Description
Disable flag parsing for each plugin command to pass arguments to the subcommand.

**before**
```
$ trivy attest --predicate ./bat.cdx --type cyclonedx ./bat-v0.20.0-x86_64-apple-darwin/bat
Error: unknown flag: --type
Usage:
  trivy attest [flags]

Flags:
  -h, --help   help for attest

Global Flags:
      --cache-dir string          cache directory (default "/Users/saso/Library/Caches/trivy")
  -c, --config string             config path (default "trivy.yaml")
  -d, --debug                     debug mode
      --generate-default-config   write the default config to trivy-default.yaml
      --insecure                  allow insecure server connections when using TLS
  -q, --quiet                     suppress progress bar and log output
      --timeout duration          timeout (default 5m0s)
  -v, --version                   show version

2022-10-25T22:59:54.882+0900    FATAL   unknown flag: --type
```

**after**
```
$ trivy attest --predicate ./bat.cdx --type cyclonedx ./bat-v0.20.0-x86_64-apple-darwin/bat
Generating ephemeral keys...
Retrieving signed certificate...

        Note that there may be personally identifiable information associated with this signed artifact.
        This may include the email address associated with the account with which you authenticate.
        This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
Your browser will now be opened to:
https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=xxxxxxx-yyyyyyy&code_challenge_method=S256&nonce=3GdBQL6qfFRQo6EV49hhoKydA7k&redirect_uri=http%3A%2F%2Flocalhost%3A52587%2Fauth%2Fcallback&response_type=code&scope=openid+email&state=2GdBQJcEkmdupiCJDBZgd6An4hW
^C⏎
```

## Related issues

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
