### PR TITLE
feat(containerd): scan image by digest

### DIFF
--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -30,6 +31,20 @@ const (
 	defaultContainerdSocket    = "/run/containerd/containerd.sock"
 	defaultContainerdNamespace = "default"
 )
+
+type familiarNamed string
+
+func (n familiarNamed) Name() string {
+	return strings.Split(string(n), ":")[0]
+}
+
+func (n familiarNamed) Tag() string {
+	return strings.Split(string(n), ":")[1]
+}
+
+func (n familiarNamed) String() string {
+	return string(n)
+}
 
 func imageWriter(client *containerd.Client, img containerd.Image) imageSave {
 	return func(ctx context.Context, ref []string) (io.ReadCloser, error) {
@@ -61,10 +76,9 @@ func ContainerdImage(ctx context.Context, imageName string) (Image, func(), erro
 		return nil, cleanup, xerrors.Errorf("containerd socket not found: %s", addr)
 	}
 
-	// Parse the image name
-	ref, err := refdocker.ParseDockerRef(imageName)
+	ref, searchFilters, err := parseReference(imageName)
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("parse error: %w", err)
+		return nil, cleanup, err
 	}
 
 	client, err := containerd.New(addr)
@@ -79,10 +93,16 @@ func ContainerdImage(ctx context.Context, imageName string) (Image, func(), erro
 
 	ctx = namespaces.WithNamespace(ctx, namespace)
 
-	img, err := client.GetImage(ctx, ref.String())
+	imgs, err := client.ListImages(ctx, searchFilters...)
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to get %s: %w", imageName, err)
+		return nil, cleanup, xerrors.Errorf("failed to list images from containerd client: %w", err)
 	}
+
+	if len(imgs) < 1 {
+		return nil, cleanup, xerrors.Errorf("image not found in containerd store: %s", imageName)
+	}
+
+	img := imgs[0]
 
 	f, err := os.CreateTemp("", "fanal-containerd-*")
 	if err != nil {
@@ -95,7 +115,7 @@ func ContainerdImage(ctx context.Context, imageName string) (Image, func(), erro
 		_ = os.Remove(f.Name())
 	}
 
-	insp, history, err := inspect(ctx, img, ref)
+	insp, history, ref, err := inspect(ctx, img, ref)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("inspect error: %w", err)
 	}
@@ -105,6 +125,47 @@ func ContainerdImage(ctx context.Context, imageName string) (Image, func(), erro
 		inspect: insp,
 		history: history,
 	}, cleanup, nil
+}
+
+func parseReference(imageName string) (refdocker.Reference, []string, error) {
+	ref, err := refdocker.ParseAnyReference(imageName)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("parse error: %w", err)
+	}
+
+	d, isDigested := ref.(refdocker.Digested)
+	n, isNamed := ref.(refdocker.Named)
+	nt, isNamedAndTagged := ref.(refdocker.NamedTagged)
+
+	// a name plus a digest
+	// example: name@sha256:41adb3ef...
+	if isDigested && isNamed {
+		digest := d.Digest()
+		// for the filters, each slice entry is logically or'd. each
+		// comma-separated filter is logically anded
+		return ref, []string{
+			fmt.Sprintf(`name~="^%s(:|@).*",target.digest=="%s"`, n.Name(), digest),
+			fmt.Sprintf(`name~="^%s(:|@).*",target.digest=="%s"`, refdocker.FamiliarName(n), digest),
+		}, nil
+	}
+
+	// digested, but not named. i.e. a plain digest
+	// example: sha256:41adb3ef...
+	if isDigested {
+		return ref, []string{fmt.Sprintf(`target.digest=="%s"`, d.Digest())}, nil
+	}
+
+	// a name plus a tag
+	// example: name:tag
+	if isNamedAndTagged {
+		tag := nt.Tag()
+		return familiarNamed(imageName), []string{
+			fmt.Sprintf(`name=="%s:%s"`, nt.Name(), tag),
+			fmt.Sprintf(`name=="%s:%s"`, refdocker.FamiliarName(nt), tag),
+		}, nil
+	}
+
+	return nil, nil, xerrors.Errorf("failed to parse image reference: %s", imageName)
 }
 
 // readImageConfig reads the config spec (`application/vnd.oci.image.config.v1+json`) for img.platform from content store.
@@ -127,16 +188,24 @@ func readImageConfig(ctx context.Context, img containerd.Image) (ocispec.Image, 
 }
 
 // ported from https://github.com/containerd/nerdctl/blob/d110fea18018f13c3f798fa6565e482f3ff03591/pkg/inspecttypes/dockercompat/dockercompat.go#L279-L321
-func inspect(ctx context.Context, img containerd.Image, ref docker.Named) (api.ImageInspect, []v1.History, error) {
+func inspect(ctx context.Context, img containerd.Image, ref docker.Reference) (api.ImageInspect, []v1.History, refdocker.Reference, error) {
+	if _, ok := ref.(refdocker.Digested); ok {
+		ref = familiarNamed(img.Name())
+	}
+
 	var tag string
 	if tagged, ok := ref.(refdocker.Tagged); ok {
 		tag = tagged.Tag()
 	}
-	repository := refdocker.FamiliarName(ref)
+
+	var repository string
+	if n, isNamed := ref.(docker.Named); isNamed {
+		repository = refdocker.FamiliarName(n)
+	}
 
 	imgConfig, imgConfigDesc, err := readImageConfig(ctx, img)
 	if err != nil {
-		return api.ImageInspect{}, nil, err
+		return api.ImageInspect{}, nil, nil, err
 	}
 
 	var lastHistory ocispec.History
@@ -185,5 +254,5 @@ func inspect(ctx context.Context, img containerd.Image, ref docker.Named) (api.I
 				return d.String()
 			}),
 		},
-	}, history, nil
+	}, history, ref, nil
 }

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -39,7 +39,12 @@ func (n familiarNamed) Name() string {
 }
 
 func (n familiarNamed) Tag() string {
-	return strings.Split(string(n), ":")[1]
+	s := strings.Split(string(n), ":")
+	if len(s) < 2 {
+		return ""
+	}
+
+	return s[1]
 }
 
 func (n familiarNamed) String() string {

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -167,12 +167,9 @@ func TestContainerd_SearchLocalStoreByNameOrDigest(t *testing.T) {
 		},
 	}
 
-	digestTests := []testInstance{}
-	_ = digestTests
-
-	ctx := namespaces.WithNamespace(context.Background(), "default")
-
-	tmpDir, socketPath := configureTestDataPaths(t)
+	namespace := "default"
+	ctx := namespaces.WithNamespace(context.Background(), namespace)
+	tmpDir, socketPath := configureTestDataPaths(t, namespace)
 	defer os.RemoveAll(tmpDir)
 
 	containerdC := startContainerd(t, ctx, tmpDir)


### PR DESCRIPTION
## Description
There are many ways to reference a container image. Because of the
history of the terms `reference`, `name`, `repo`, `tag`, I will refer to
any way of uniquely identifying an image as a `handle`. A handle can be
in any of the following formats:

```
repo.io/name:tag
repo.io/xyz/name:tag
name:tag
compound/name:tag
sha256:4dca0fd5f424a31b03ab807cbae77eb32bf2d089eed1cee154b3afed458de0dc
name@sha256:4dca0fd5f424a31b03ab807cbae77eb32bf2d089eed1cee154b3afed458de0dc
repo.io/name@4dca0fd5f424a31b03ab807cbae77eb32bf2d089eed1cee154b3afed458de0dc
```

To complicate matters, given Docker's conventions it is often customary
to prefix a "familiar name" (i.e a name with no registry component, in
the above example the familiar name of `name:tag` would be `name`) with
`docker.io/library/`. Following that convention, `name:tag` would become
`docker.io/library/name:tag`, and `compound/name:tag` would become 
`docker.io/compound/name:tag`.

The previous logic in `ContainerdImage()` would automatically prepend
familiar names with `docker.io/library` *before* searching the
containerd store. However, in the call to `containerd.Client.GetImage()`, 
containerd looks for an exact match between names. In this way, 
`trivy image hello:world` would turn into a search of the containerd 
store for `docker.io/library/hello:world`. However, if `hello:world` is in
 the containerd store, but not`docker.io/library/hello:world`, then the
search will fail even though the image is present.

This commit makes the containerd store searchable for images with
handles in any of the above formats, via the trivy command line.

## Related issues
- Close #3048 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed). **no documentation changes necessary**
- [x] I've added usage information (if the PR introduces new options) **no new options**
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
