### PR TITLE
fix: In alpine use Name to fetch advisories

### DIFF
--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -103,7 +103,11 @@ func (s *Scanner) Detect(osVer string, repo *ftypes.Repository, pkgs []ftypes.Pa
 
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
-		advisories, err := s.vs.Get(stream, pkg.SrcName)
+		srcName := pkg.SrcName
+		if srcName == "" {
+			srcName = pkg.Name
+		}
+		advisories, err := s.vs.Get(stream, srcName)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get alpine advisories: %w", err)
 		}

--- a/pkg/detector/ospkg/alpine/alpine_test.go
+++ b/pkg/detector/ospkg/alpine/alpine_test.go
@@ -197,6 +197,37 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			wantErr: "failed to get alpine advisories",
 		},
+		{
+			name:     "No src name",
+			fixtures: []string{"testdata/fixtures/alpine.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "3.9.3",
+				repo: &ftypes.Repository{
+					Family:  os.Alpine,
+					Release: "3.10",
+				},
+				pkgs: []ftypes.Package{
+					{
+						Name:       "jq",
+						Version:    "1.6-r0",
+						SrcVersion: "1.6-r0",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "jq",
+					VulnerabilityID:  "CVE-2020-1234",
+					InstalledVersion: "1.6-r0",
+					FixedVersion:     "1.6-r1",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Alpine,
+						Name: "Alpine Secdb",
+						URL:  "https://secdb.alpinelinux.org/",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

In few images like automation.azurecr.io/alpine_exploit:v1 we have no **o:** in **lib/apk/db/installed** path therefore analyzer is not sending SrcName. 

![Screenshot from 2022-10-26 11-47-08](https://user-images.githubusercontent.com/16453290/197971817-46a84b98-a2ab-4bfb-98bc-00231327a365.png)

But since SrcName is not available we are not getting advisories. 

![Screenshot from 2022-10-26 13-48-35](https://user-images.githubusercontent.com/16453290/197972872-5bce1bc8-3993-4f24-a242-06ce442eb7ad.png)

So I have modified code to check with Name for fetching advisories. I have also added a test case without SrcName for alpine.


## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
