### PR TITLE
perf(license): enable license classifier only with "--license-full"

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -527,6 +527,11 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			SecretScannerOption: analyzer.SecretScannerOption{
 				ConfigPath: opts.SecretConfigPath,
 			},
+
+			// For license scanning
+			LicenseScannerOption: analyzer.LicenseScannerOption{
+				Full: opts.LicenseFull,
+			},
 		},
 	}, scanOptions, nil
 }

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -39,14 +39,20 @@ var (
 
 // AnalyzerOptions is used to initialize analyzers
 type AnalyzerOptions struct {
-	Group               Group
-	FilePatterns        []string
-	DisabledAnalyzers   []Type
-	SecretScannerOption SecretScannerOption
+	Group                Group
+	FilePatterns         []string
+	DisabledAnalyzers    []Type
+	SecretScannerOption  SecretScannerOption
+	LicenseScannerOption LicenseScannerOption
 }
 
 type SecretScannerOption struct {
 	ConfigPath string
+}
+
+type LicenseScannerOption struct {
+	// Use license classifier to get better results though the classification is expensive.
+	Full bool
 }
 
 ////////////////

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -29,6 +29,7 @@ type Option struct {
 
 	MisconfScannerOption misconf.ScannerOption
 	SecretScannerOption  analyzer.SecretScannerOption
+	LicenseScannerOption analyzer.LicenseScannerOption
 }
 
 func (o *Option) Sort() {

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -51,10 +51,11 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, opt artifact.Option) (a
 	}
 
 	a, err := analyzer.NewAnalyzerGroup(analyzer.AnalyzerOptions{
-		Group:               opt.AnalyzerGroup,
-		FilePatterns:        opt.FilePatterns,
-		DisabledAnalyzers:   opt.DisabledAnalyzers,
-		SecretScannerOption: opt.SecretScannerOption,
+		Group:                opt.AnalyzerGroup,
+		FilePatterns:         opt.FilePatterns,
+		DisabledAnalyzers:    opt.DisabledAnalyzers,
+		SecretScannerOption:  opt.SecretScannerOption,
+		LicenseScannerOption: opt.LicenseScannerOption,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("analyzer group error: %w", err)

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -46,6 +46,9 @@ func TestArtifact_Inspect(t *testing.T) {
 		{
 			name:      "happy path",
 			imagePath: "../../test/testdata/alpine-311.tar.gz",
+			artifactOpt: artifact.Option{
+				LicenseScannerOption: analyzer.LicenseScannerOption{Full: true},
+			},
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
@@ -248,6 +251,9 @@ func TestArtifact_Inspect(t *testing.T) {
 		{
 			name:      "happy path: include lock files",
 			imagePath: "../../test/testdata/vuln-image.tar.gz",
+			artifactOpt: artifact.Option{
+				LicenseScannerOption: analyzer.LicenseScannerOption{Full: true},
+			},
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:a646bb11d39c149d4aaf9b888233048e0848304e5abd75667ea6f21d540d800c",
@@ -601,6 +607,7 @@ func TestArtifact_Inspect(t *testing.T) {
 					analyzer.TypeDebian, analyzer.TypeDpkg, analyzer.TypeDpkgLicense, analyzer.TypeComposer,
 					analyzer.TypeBundler, analyzer.TypeLicenseFile,
 				},
+				LicenseScannerOption: analyzer.LicenseScannerOption{Full: true},
 			},
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -42,10 +42,11 @@ func NewArtifact(rootPath string, c cache.ArtifactCache, opt artifact.Option) (a
 	}
 
 	a, err := analyzer.NewAnalyzerGroup(analyzer.AnalyzerOptions{
-		Group:               opt.AnalyzerGroup,
-		FilePatterns:        opt.FilePatterns,
-		DisabledAnalyzers:   opt.DisabledAnalyzers,
-		SecretScannerOption: opt.SecretScannerOption,
+		Group:                opt.AnalyzerGroup,
+		FilePatterns:         opt.FilePatterns,
+		DisabledAnalyzers:    opt.DisabledAnalyzers,
+		SecretScannerOption:  opt.SecretScannerOption,
+		LicenseScannerOption: opt.LicenseScannerOption,
 	})
 	if err != nil {
 		return nil, xerrors.Errorf("analyzer group error: %w", err)


### PR DESCRIPTION
## Description
Initializing license classifiers and performing license classification is expensive and it is disabled by default. However, it is used only when scanning Debian because Debian licenses are not stored in a machine-readable format. In other words, scanning Debian activates the license classification and leads to high CPU/memory utilization.
This PR changes it to try to detect licenses without license classifiers by default and enable classifies only when `--license-full` is specified.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
