### PR TITLE
fix: workdir command as empty layer

### DIFF
--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -241,7 +241,8 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		strings.HasPrefix(createdBy, "STOPSIGNAL") ||
 		strings.HasPrefix(createdBy, "SHELL") ||
 		strings.HasPrefix(createdBy, "ARG") ||
-		strings.HasPrefix(createdBy, "WORKDIR") {
+		// buildkit images with "WORKDIR /" command are empty
+		(createdBy == "WORKDIR /" && history.Comment == "buildkit.dockerfile.v0") {
 		return true
 	}
 	// commands here: 'ADD', COPY, RUN and WORKDIR != "/"

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -241,7 +241,7 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		strings.HasPrefix(createdBy, "STOPSIGNAL") ||
 		strings.HasPrefix(createdBy, "SHELL") ||
 		strings.HasPrefix(createdBy, "ARG") ||
-		createdBy == "WORKDIR /" { // only when workdir == "/" then layer is empty
+		strings.HasPrefix(createdBy, "WORKDIR") {
 		return true
 	}
 	// commands here: 'ADD', COPY, RUN and WORKDIR != "/"

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -244,8 +244,10 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		return true
 	}
 	// buildkit layers with "WORKDIR /" command are empty,
-	if strings.HasPrefix(history.Comment, "buildkit.dockerfile") && createdBy == "WORKDIR /" {
-		return true
+	if strings.HasPrefix(history.Comment, "buildkit.dockerfile") {
+		if createdBy == "WORKDIR /" {
+			return true
+		}
 	} else if strings.HasPrefix(createdBy, "WORKDIR") { // layers build with docker and podman, WORKDIR command is always empty layer.
 		return true
 	}

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -241,7 +241,7 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		strings.HasPrefix(createdBy, "STOPSIGNAL") ||
 		strings.HasPrefix(createdBy, "SHELL") ||
 		strings.HasPrefix(createdBy, "ARG") ||
-		// buildkit images with "WORKDIR /" command are empty
+		// buildkit image's layers with "WORKDIR /" command are empty
 		(createdBy == "WORKDIR /" && history.Comment == "buildkit.dockerfile.v0") {
 		return true
 	}

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -296,17 +296,17 @@ func Test_image_emptyLayer(t *testing.T) {
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop) WORKDIR /",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "WORKDIR != '/'",
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
 			},
-			want: false,
+			want: true,
 		},
 		{
-			name: "WORKDIR != '/' buildkit",
+			name: "WORKDIR =='/' buildkit",
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /",
 				Comment:   "buildkit.dockerfile.v0",
@@ -314,7 +314,7 @@ func Test_image_emptyLayer(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "WORKDIR != '/app' buildkit",
+			name: "WORKDIR == '/app' buildkit",
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
 				Comment:   "buildkit.dockerfile.v0",

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -303,7 +303,7 @@ func Test_image_emptyLayer(t *testing.T) {
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "without command",

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -296,14 +296,30 @@ func Test_image_emptyLayer(t *testing.T) {
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop) WORKDIR /",
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "WORKDIR != '/'",
 			history: dimage.HistoryResponseItem{
 				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
 			},
+			want: false,
+		},
+		{
+			name: "WORKDIR != '/' buildkit",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /",
+				Comment:   "buildkit.dockerfile.v0",
+			},
 			want: true,
+		},
+		{
+			name: "WORKDIR != '/app' buildkit",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c #(nop)  WORKDIR /app",
+				Comment:   "buildkit.dockerfile.v0",
+			},
+			want: false,
 		},
 		{
 			name: "without command",


### PR DESCRIPTION
## Description
WORKDIR command in docker file is actually empty layer. tested with podman and buildkit

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
