### PR TITLE
chore: handle GOPATH with several paths in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION := $(patsubst v%,%,$(shell git describe --tags --always)) #Strips the v prefix from the tag
 LDFLAGS := -ldflags "-s -w -X=main.version=$(VERSION)"
 
-GOPATH := $(shell go env GOPATH)
+GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 GOBIN := $(GOPATH)/bin
 GOSRC := $(GOPATH)/src
 


### PR DESCRIPTION
## Description
`GOPATH` variable can be composed of several paths.


Fix:
Extract and use first path from `GOPATH`.

## Related issues
- Close #3091


Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
