### PR TITLE
fix(spdx): rename describes field in spdx

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -46,7 +46,7 @@ const (
 	PropertyLayerDigest = "LayerDigest"
 
 	RelationShipContains  = "CONTAINS"
-	RelationShipDescribe  = "DESCRIBE"
+	RelationShipDescribe  = "DESCRIBES"
 	RelationShipDependsOn = "DEPENDS_ON"
 
 	ElementOperatingSystem = "OperatingSystem"

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -192,7 +192,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
 						RefB:         spdx.DocElementID{ElementRefID: "ContainerImage-9396d894cd0cb6cb"},
-						Relationship: "DESCRIBE",
+						Relationship: "DESCRIBES",
 					},
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "ContainerImage-9396d894cd0cb6cb"},
@@ -400,7 +400,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
 						RefB:         spdx.DocElementID{ElementRefID: "ContainerImage-413bfede37ad01fc"},
-						Relationship: "DESCRIBE",
+						Relationship: "DESCRIBES",
 					},
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "ContainerImage-413bfede37ad01fc"},
@@ -498,7 +498,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
 						RefB:         spdx.DocElementID{ElementRefID: "Filesystem-5af0f1f08c20909a"},
-						Relationship: "DESCRIBE",
+						Relationship: "DESCRIBES",
 					},
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "Filesystem-5af0f1f08c20909a"},
@@ -590,7 +590,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
 						RefB:         spdx.DocElementID{ElementRefID: "Repository-7cb7a269a391a798"},
-						Relationship: "DESCRIBE",
+						Relationship: "DESCRIBES",
 					},
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "Repository-7cb7a269a391a798"},
@@ -637,7 +637,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
 						RefB:         spdx.DocElementID{ElementRefID: "Filesystem-70f34983067dba86"},
-						Relationship: "DESCRIBE",
+						Relationship: "DESCRIBES",
 					},
 				},
 			},

--- a/pkg/sbom/spdx/testdata/happy/bom.json
+++ b/pkg/sbom/spdx/testdata/happy/bom.json
@@ -167,7 +167,7 @@
 	"relationships": [
 		{
 			"relatedSpdxElement": "SPDXRef-ContainerImage-b5d81cde5f95c8fc",
-			"relationshipType": "DESCRIBE",
+			"relationshipType": "DESCRIBES",
 			"spdxElementId": "SPDXRef-DOCUMENT"
 		},
 		{


### PR DESCRIPTION
## Description
There is mistake in `DESCRIBES` field in SPDX.
https://spdx.github.io/spdx-spec/relationships-between-SPDX-elements/#1111-description

## Related issues
- Close #3100

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
