### PR TITLE
docs: fix links on Built-in Policies page

### DIFF
--- a/docs/docs/misconfiguration/policy/builtin.md
+++ b/docs/docs/misconfiguration/policy/builtin.md
@@ -21,8 +21,8 @@ Helm Chart scanning will resolve the chart to Kubernetes manifests then run the 
 
 Ansible scanning is coming soon.
 
-[rego]: https://www.openpolicyagent.org/docs/latest/policy-language/
+[rego]: https://www.openpolicyagent.org/docs/latest/policy-language
 [defsec]: https://github.com/aquasecurity/defsec
-[kubernetes]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/kubernetes
-[kubernetes]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/rbac
-[docker]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/docker
+[kubernetes]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/kubernetes
+[docker]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/docker
+[rbac]: https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/rbac


### PR DESCRIPTION
## Description

The rego policies were moved to a different directory in the defsec project. See https://github.com/aquasecurity/defsec/pull/995. This caused a few of the links on https://aquasecurity.github.io/trivy/v0.34/docs/misconfiguration/policy/builtin/ to be broken. This PR updates the URLs and also fixes the misnamed link for `rbac`.

## Related issues
none

## Related PRs
none

## Before
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/8041246/199605117-7f627012-4458-4d7c-b257-741bcc72296d.png">

_Links that are relevant to this PR:_
| Config type | Hyperlink |
| --- | --- |
| Kubernetes | https://github.com/aquasecurity/defsec/tree/master/internal/rules/rbac |
| Dockerfile, Containerfile | https://github.com/aquasecurity/defsec/tree/master/internal/rules/docker |
| RBAC | https://github.com/aquasecurity/defsec |

## After
Notice that `[rbac]` no longer appears in the last row in the table.
<img width="1285" alt="image" src="https://user-images.githubusercontent.com/8041246/199604208-84680a28-e38f-4eac-92ea-13e3fe7a2595.png">

_Links that are relevant to this PR:_
| Config type | Hyperlink |
| --- | --- |
| Kubernetes | https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/kubernetes |
| Dockerfile, Containerfile | https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/docker |
| RBAC | https://github.com/aquasecurity/defsec/tree/master/internal/rules/policies/rbac |

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] _Not applicable_ ~I've added tests that prove my fix is effective or that my feature works.~
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] _Not applicable_ ~I've added usage information (if the PR introduces new options)~
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
