### PR TITLE
feat: support scan remote repository

### DIFF
--- a/pkg/commands/artifact/inject.go
+++ b/pkg/commands/artifact/inject.go
@@ -85,6 +85,14 @@ func initializeRemoteFilesystemScanner(ctx context.Context, path string, artifac
 	return scanner.Scanner{}, nil, nil
 }
 
+// initializeRemoteRepositoryScanner is for repository scanning in client/server mode
+func initializeRemoteRepositoryScanner(ctx context.Context, url string, artifactCache cache.ArtifactCache,
+	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (
+	scanner.Scanner, func(), error) {
+	wire.Build(scanner.RemoteRepositorySet)
+	return scanner.Scanner{}, nil, nil
+}
+
 // initializeRemoteSBOMScanner is for sbom scanning in client/server mode
 func initializeRemoteSBOMScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
 	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -208,7 +208,15 @@ func (r *runner) ScanRepository(ctx context.Context, opts flag.Options) (types.R
 	// Disable the OS analyzers and individual package analyzers
 	opts.DisabledAnalyzers = append(analyzer.TypeIndividualPkgs, analyzer.TypeOSes...)
 
-	return r.scanArtifact(ctx, opts, repositoryStandaloneScanner)
+	var s InitializeScanner
+	if opts.ServerAddr == "" {
+		// Scan repository in standalone mode
+		s = repositoryStandaloneScanner
+	} else {
+		// Scan repository in client/server mode
+		s = repositoryRemoteScanner
+	}
+	return r.scanArtifact(ctx, opts, s)
 }
 
 func (r *runner) ScanSBOM(ctx context.Context, opts flag.Options) (types.Report, error) {

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -83,12 +83,22 @@ func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 	return s, cleanup, nil
 }
 
-// filesystemStandaloneScanner initializes a repository scanner in standalone mode
+// repositoryStandaloneScanner initializes a repository scanner in standalone mode
 func repositoryStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
 		conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)
+		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a repository scanner: %w", err)
+	}
+	return s, cleanup, nil
+}
+
+// repositoryRemoteScanner initializes a repository scanner in client/server mode
+func repositoryRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
+	s, cleanup, err := initializeRemoteRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.RemoteOption,
+		conf.ArtifactOption)
+	if err != nil {
+		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a repository scanner: %w", err)
 	}
 	return s, cleanup, nil
 }

--- a/pkg/commands/artifact/wire_gen.go
+++ b/pkg/commands/artifact/wire_gen.go
@@ -8,7 +8,6 @@ package artifact
 
 import (
 	"context"
-
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
@@ -182,6 +181,20 @@ func initializeRemoteFilesystemScanner(ctx context.Context, path string, artifac
 	}
 	scannerScanner := scanner.NewScanner(clientScanner, artifactArtifact)
 	return scannerScanner, func() {
+	}, nil
+}
+
+// initializeRemoteRepositoryScanner is for repository scanning in client/server mode
+func initializeRemoteRepositoryScanner(ctx context.Context, url string, artifactCache cache.ArtifactCache, remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+	v := _wireValue3
+	clientScanner := client.NewScanner(remoteScanOptions, v...)
+	artifactArtifact, cleanup, err := remote.NewArtifact(url, artifactCache, artifactOption)
+	if err != nil {
+		return scanner.Scanner{}, nil, err
+	}
+	scannerScanner := scanner.NewScanner(clientScanner, artifactArtifact)
+	return scannerScanner, func() {
+		cleanup()
 	}, nil
 }
 

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -82,6 +82,12 @@ var RemoteFilesystemSet = wire.NewSet(
 	RemoteSuperSet,
 )
 
+// RemoteRepositorySet binds repository dependencies for client/server mode
+var RemoteRepositorySet = wire.NewSet(
+	remote.NewArtifact,
+	RemoteSuperSet,
+)
+
 // RemoteSBOMSet binds sbom dependencies for client/server mode
 var RemoteSBOMSet = wire.NewSet(
 	sbom.NewArtifact,


### PR DESCRIPTION
## Description
support scan remote repository through the deployed vulnerability database server. The detail see in #3121 .
## Related issues
- Close #3121 .

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
