### PR TITLE
docs(license): fix typo inside quick start

### DIFF
--- a/docs/docs/licenses/scanning.md
+++ b/docs/docs/licenses/scanning.md
@@ -47,7 +47,7 @@ License checking classifies the identified licenses and map the classification t
 This section shows how to scan license in container image and filesystem.
 
 ### Standard scanning
-Specify an image name with `--security-cheks license`.
+Specify an image name with `--security-checks license`.
 
 ``` shell
 $ trivy image --security-checks license --severity UNKNOWN,HIGH,CRITICAL alpine:3.15


### PR DESCRIPTION
## Description

Fix typo inside the license scanning quick start.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
