### PR TITLE
fix: Perform filepath.Clean first and then filepath.ToSlash for skipFile/skipDirs settings

### DIFF
--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -18,7 +18,7 @@ var (
 const ThresholdSize = int64(200) << 20
 
 type WalkFunc func(filePath string, info os.FileInfo, opener analyzer.Opener) error
-
+ 
 type walker struct {
 	skipFiles []string
 	skipDirs  []string
@@ -27,13 +27,13 @@ type walker struct {
 func newWalker(skipFiles, skipDirs []string) walker {
 	var cleanSkipFiles, cleanSkipDirs []string
 	for _, skipFile := range skipFiles {
-		skipFile = filepath.Clean(filepath.ToSlash(skipFile))
+		skipFile = filepath.ToSlash(filepath.Clean(skipFile))
 		skipFile = strings.TrimLeft(skipFile, "/")
 		cleanSkipFiles = append(cleanSkipFiles, skipFile)
 	}
 
 	for _, skipDir := range append(skipDirs, SystemDirs...) {
-		skipDir = filepath.Clean(filepath.ToSlash(skipDir))
+		skipDir = filepath.ToSlash(filepath.Clean(skipDir))
 		skipDir = strings.TrimLeft(skipDir, "/")
 		cleanSkipDirs = append(cleanSkipDirs, skipDir)
 	}


### PR DESCRIPTION
## Description
Perform filepath.Clean first and then filepath.ToSlash for skipFile/skipDirs settings

## Related issues
- Close #3132 
 
## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
