### PR TITLE
fix: remove `--security-checks none` from image help

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -247,7 +247,7 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
   $ trivy image --format json --output result.json alpine:3.15
 
   # Generate a report in the CycloneDX format
-  $ trivy image --format cyclonedx --output result.cdx --security-checks none alpine:3.15`,
+  $ trivy image --format cyclonedx --output result.cdx alpine:3.15`,
 
 		// 'Args' cannot be used since it is called before PreRunE and viper is not configured yet.
 		// cmd.Args     -> cannot validate args here


### PR DESCRIPTION
## Description
Example from `image` help contains wrong `--security-checks none` flag.
Fix this.

Before:
```
➜  trivy image --help
Scan a container image

Usage:
  trivy image [flags] IMAGE_NAME

...

  # Generate a report in the CycloneDX format
  $ trivy image --format cyclonedx --output result.cdx --security-checks none alpine:3.15
```

After:
```
➜  trivy git:(fix/cyclonedx-example) ✗ ./trivy image --help
Scan a container image

Usage:
  trivy image [flags] IMAGE_NAME

...

  # Generate a report in the CycloneDX format
  $ trivy image --format cyclonedx --output result.cdx alpine:3.15
```

## Related issues
- Close #3153

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
