### PR TITLE
docs(flag): add "rego" configuration file options

### DIFF
--- a/docs/docs/references/customization/config-file.md
+++ b/docs/docs/references/customization/config-file.md
@@ -194,6 +194,31 @@ secret:
   config: config/trivy/secret.yaml
 ```
 
+## Rego Options
+
+```yaml
+rego
+  # Same as '--trace'
+  # Default is false
+  trace: false
+
+  # Same as '--config-policy'
+  # Default is empty
+  policy:
+    - policy/repository
+    - policy/custom
+
+  # Same as '--config-data'
+  # Default is empty
+  data:
+    - data/
+
+  # Same as '--policy-namespaces'
+  # Default is empty
+  namespaces:
+    - opa.examples
+    - users
+```
 
 ## Misconfiguration Options
 Available with misconfiguration scanning
@@ -203,27 +228,6 @@ misconfiguration:
   # Same as '--include-non-failures'
   # Default is false
   include-non-failures: false
-  
-  # Same as '--trace'
-  # Default is false
-  trace: false
-  
-  # Same as '--config-policy'
-  # Default is empty
-  policy:
-    - policy/repository
-    - policy/custom
-    
-  # Same as '--config-data'
-  # Default is empty
-  data:
-    - data/
-    
-  # Same as '--policy-namespaces'
-  # Default is empty
-  namespaces:
-    - opa.examples
-    - users
 
   # helm value override configurations
   # set individual values


### PR DESCRIPTION
## Description

In #2994, some configuration flags were moved from the `misconfiguration` namespace setting into a new `rego` namespace setting.

This reflects the new configuration namespace.

## Related PRs

- [x] #2994


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
