### PR TITLE
chore: use newline for semantic pr

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -16,7 +16,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          types:
+          types: |
             feat
             fix
             docs
@@ -30,7 +30,7 @@ jobs:
             revert
             BREAKING
 
-          scopes:
+          scopes: |
             vuln
             misconf
             secret


### PR DESCRIPTION
## Description
amannn/action-semantic-pull-request v5 broke our workflow. This PR is a hotfix.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/3105

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
