### PR TITLE
docs(image): space issues during image scan

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -133,6 +133,23 @@ Try:
 $ TMPDIR=/my/custom/path trivy repo ...
 ```
 
+### Running out of space during image scans
+
+!!! error
+    ``` bash
+    image scan failed:
+    failed to copy the image:
+    write /tmp/fanal-3323732142: no space left on device
+    ```
+
+Trivy uses the `/tmp` directory during image scan, if the image is large or `/tmp` is of insufficient size then the scan fails You can set the `TMPDIR` environment variable to use redirect trivy to use a directory with adequate storage.
+
+Try:
+
+```
+$ TMPDIR=/my/custom/path trivy image ...
+```
+
 ## Homebrew
 ### Scope error
 !!! error


### PR DESCRIPTION
## Description

Troubleshoot space issues while scanning large images or with small /tmp.
/tmp initialisation: https://github.com/aquasecurity/trivy/blob/cb5744dcaf914fca954dc0f9327b093991c4ee42/pkg/fanal/image/daemon/docker.go#L45

## Related issues
- https://github.com/aquasecurity/trivy/issues/1796
- https://github.com/aquasecurity/trivy/issues/1834

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
