### PR TITLE
fix(suse): use package name to get advisories

### DIFF
--- a/integration/testdata/fixtures/db/opensuse.yaml
+++ b/integration/testdata/fixtures/db/opensuse.yaml
@@ -1,10 +1,12 @@
 - bucket: "openSUSE Leap 15.1"
   pairs:
+    - bucket: libopenssl1_1
+      pairs:
+        - key: "openSUSE-SU-2020:0062-1"
+          value:
+            FixedVersion: 1.1.0i-lp151.8.6.1
     - bucket: openssl-1_1
       pairs:
-        - key: "openSUSE-SU-2019:2158-1"
-          value:
-            FixedVersion: 1.1.0i-lp151.8.3.1
         - key: "openSUSE-SU-2020:0062-1"
           value:
             FixedVersion: 1.1.0i-lp151.8.6.1

--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -118,7 +118,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
-		advisories, err := s.vs.Get(osVer, pkg.SrcName)
+		advisories, err := s.vs.Get(osVer, pkg.Name)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get SUSE advisory: %w", err)
 		}


### PR DESCRIPTION
## Description
`SUSE cvrt` contains advisories for package names, not for source names.
False positive example(used actual Trivy version):
```
➜ trivy -q image registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1     


registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1 (suse linux enterprise server 15.4)

Total: 18 (UNKNOWN: 1, LOW: 0, MEDIUM: 8, HIGH: 7, CRITICAL: 2)
...
├───────────────────────┼─────────────────────┼──────────┼─────────────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ qemu-ipxe             │ SUSE-SU-2022:2260-1 │ HIGH     │ 1.0.0+-150400.37.8.2            │ 6.2.0-150400.37.5.3     │ Security update for qemu                                     │
│                       ├─────────────────────┼──────────┤                                 ├─────────────────────────┤                                                              │
│                       │ SUSE-SU-2022:3795-1 │ MEDIUM   │                                 │ 6.2.0-150400.37.8.2     │                                                              │
├───────────────────────┼─────────────────────┼──────────┼─────────────────────────────────┼─────────────────────────┤                                                              │
│ qemu-seabios          │ SUSE-SU-2022:2260-1 │ HIGH     │ 1.15.0_0_g2dd4b9b-150400.37.8.2 │ 6.2.0-150400.37.5.3     │                                                              │
│                       ├─────────────────────┼──────────┤                                 ├─────────────────────────┤                                                              │
│                       │ SUSE-SU-2022:3795-1 │ MEDIUM   │                                 │ 6.2.0-150400.37.8.2     │                                                              │
├───────────────────────┼─────────────────────┼──────────┤                                 ├─────────────────────────┤                                                              │
│ qemu-vgabios          │ SUSE-SU-2022:2260-1 │ HIGH     │                                 │ 6.2.0-150400.37.5.3     │                                                              │
│                       ├─────────────────────┼──────────┤                                 ├─────────────────────────┤                                                              │
│                       │ SUSE-SU-2022:3795-1 │ MEDIUM   │                                 │ 6.2.0-150400.37.8.2     │                                                              │
├───────────────────────┼─────────────────────┤          ├─────────────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
...

➜ docker run -it --rm --entrypoint /bin/bash registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1 
b28fe422ca0b:/ # rpm -qa --qf "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{SOURCERPM} %{ARCH}\n" qemu-ipxe
qemu-ipxe 0 1.0.0+ 150400.37.8.2 qemu-6.2.0-150400.37.8.2.src.rpm noarch
```
from [cvrf-suse-su-2022_2260-1.xml](https://ftp.suse.com/pub/projects/security/cvrf/cvrf-suse-su-2022%3A2260-1.xml):
* fixed version for `qemu` is `6.2.0-150400.37.5.3`
* fixed version for `qemu-ipxe` is `1.0.0+-150400.37.5.3`

Miss vulnerability example(used Trivy with this fix):
```
➜ ./trivy -q image registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1     


registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1 (suse linux enterprise server 15.4)
======================================================================================================
Total: 17 (UNKNOWN: 1, LOW: 0, MEDIUM: 7, HIGH: 6, CRITICAL: 3)

...
├───────────────────────┼─────────────────────┼──────────┼─────────────────────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┤
│ libX11-6              │ SUSE-SU-2022:3986-1 │ MEDIUM   │ 1.6.5-3.21.1            │ 1.6.5-150000.3.24.1     │ Security update for libX11                                   │
├───────────────────────┤                     │          │                         │                         │                                                              │
...
➜ docker run -it --rm --entrypoint /bin/bash registry.suse.com/suse/sles/15.4/virt-launcher:0.54.0-150400.3.5.1 
b28fe422ca0b:/ # rpm -qa --qf "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{SOURCERPM} %{ARCH}\n" libX11-6
libX11-6 0 1.6.5 3.21.1 libX11-1.6.5-3.21.1.src.rpm x86_64
```
from [cvrf-suse-su-2022_3986-1.xml](https://ftp.suse.com/pub/projects/security/cvrf/cvrf-suse-su-2022%3A3986-1.xml):
* `libX11` doesn't exist
* fixed version for `libX11-6` is `1.6.5-150000.3.24.1`


## Related issues
- Close #3193

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
