### PR TITLE
feat(helm): pass arbitrary env vars to trivy

### DIFF
--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
 | `trivy.existingSecret`                | existingSecret if an existing secret has been created outside the chart. Overrides gitHubToken, registryUsername, registryPassword, serverToken | `` |
 | `trivy.podAnnotations`                | Annotations for pods created by statefulset                             | `{}` |
+| `trivy.extraEnvVars`                  | extraEnvVars to be set on the container                                 | `{}` |
 | `service.name`                        | If specified, the name used for the Trivy service                       |     |
 | `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
 | `service.port`                        | Kubernetes service port                                                 | `4954`      |

--- a/helm/trivy/templates/configmap.yaml
+++ b/helm/trivy/templates/configmap.yaml
@@ -23,3 +23,6 @@ data:
 {{- if .Values.noProxy }}
   NO_PROXY: {{ .Values.noProxy | quote }}
 {{- end }}
+{{- with .Values.trivy.extraEnvVars }}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -124,6 +124,8 @@ trivy:
   # existingSecret if an existing secret has been created outside the chart.
   # Overrides gitHubToken, registryUsername, registryPassword, serverToken
   existingSecret: ""
+  # extraEnvVars to be set on the container
+  extraEnvVars: {}
 
 service:
   # If specified, the name used for the Trivy service.


### PR DESCRIPTION
## Description

fix #3206 

with the following values.yaml
```
trivy:
  extraEnvVars:
    FOO: bar
    TOTO: |
      titi
      multi
      line
``` 
the chart has the following diff in the configmap: 
``` 
@@ -47,6 +47,11 @@
   TRIVY_DEBUG: "false"
   TRIVY_SKIP_UPDATE: "false"
   TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db"
+  FOO: bar
+  TOTO: |
+    titi
+    multi
+    line
``` 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
