### PR TITLE
feat(report): add dependency locations to sarif format

### DIFF
--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -227,8 +227,9 @@ func (f *ReportFlagGroup) forceListAllPkgs(format string, listAllPkgs, dependenc
 		log.Logger.Debugf("%q automatically enables '--list-all-pkgs'.", report.SupportedSBOMFormats)
 		return true
 	}
+	// We need this flag to insert dependency locations into Sarif('Package' struct contains 'Locations')
 	if format == report.FormatSarif && !listAllPkgs {
-		log.Logger.Debugf("Sarif format automatically enables '--list-all-pkgs'. to get locations")
+		log.Logger.Debugf("Sarif format automatically enables '--list-all-pkgs' to get locations")
 		return true
 	}
 	if dependencyTree && !listAllPkgs {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -227,6 +227,10 @@ func (f *ReportFlagGroup) forceListAllPkgs(format string, listAllPkgs, dependenc
 		log.Logger.Debugf("%q automatically enables '--list-all-pkgs'.", report.SupportedSBOMFormats)
 		return true
 	}
+	if format == report.FormatSarif && !listAllPkgs {
+		log.Logger.Debugf("Sarif format automatically enables '--list-all-pkgs'. to get locations")
+		return true
+	}
 	if dependencyTree && !listAllPkgs {
 		log.Logger.Debugf("'--dependency-tree' enables '--list-all-pkgs'.")
 		return true

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -2,7 +2,7 @@ package report
 
 import (
 	"fmt"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+
 	"html"
 	"io"
 	"regexp"
@@ -12,6 +12,7 @@ import (
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"golang.org/x/xerrors"
 
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -126,6 +126,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 	sw.run = sarif.NewRunWithInformationURI("Trivy", "https://github.com/aquasecurity/trivy")
 	sw.run.Tool.Driver.WithVersion(sw.Version)
 	sw.run.Tool.Driver.WithFullName("Trivy Vulnerability Scanner")
+	sw.locationCache = map[string][]location{}
 
 	ruleIndexes := map[string]int{}
 	for _, res := range report.Results {

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -32,6 +32,22 @@ func TestReportWriter_Sarif(t *testing.T) {
 				{
 					Target: "library/test",
 					Class:  types.ClassOSPkg,
+					Packages: []ftypes.Package{
+						{
+							Name:    "foo",
+							Version: "1.2.3",
+							Locations: []ftypes.Location{
+								{
+									StartLine: 5,
+									EndLine:   10,
+								},
+								{
+									StartLine: 15,
+									EndLine:   20,
+								},
+							},
+						},
+					},
 					Vulnerabilities: []types.DetectedVulnerability{
 						{
 							VulnerabilityID:  "CVE-2020-0001",
@@ -103,8 +119,23 @@ func TestReportWriter_Sarif(t *testing.T) {
 									URIBaseId: toPtr("ROOTPATH"),
 								},
 								Region: &sarif.Region{
-									StartLine:   toPtr(1),
-									EndLine:     toPtr(1),
+									StartLine:   toPtr(5),
+									EndLine:     toPtr(10),
+									StartColumn: toPtr(1),
+									EndColumn:   toPtr(1),
+								},
+							},
+						},
+						{
+							Message: &sarif.Message{Text: toPtr("library/test: foo@1.2.3")},
+							PhysicalLocation: &sarif.PhysicalLocation{
+								ArtifactLocation: &sarif.ArtifactLocation{
+									URI:       toPtr("library/test"),
+									URIBaseId: toPtr("ROOTPATH"),
+								},
+								Region: &sarif.Region{
+									StartLine:   toPtr(15),
+									EndLine:     toPtr(20),
 									StartColumn: toPtr(1),
 									EndColumn:   toPtr(1),
 								},

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -82,7 +82,7 @@ func Write(report types.Report, option Option) error {
 		// We keep `sarif.tpl` template working for backward compatibility for a while.
 		if strings.HasPrefix(option.OutputTemplate, "@") && strings.HasSuffix(option.OutputTemplate, "sarif.tpl") {
 			log.Logger.Warn("Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571")
-			writer = SarifWriter{Output: option.Output, Version: option.AppVersion, locationCache: map[string][]location{}}
+			writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
 			break
 		}
 		var err error
@@ -90,7 +90,7 @@ func Write(report types.Report, option Option) error {
 			return xerrors.Errorf("failed to initialize template writer: %w", err)
 		}
 	case FormatSarif:
-		writer = SarifWriter{Output: option.Output, Version: option.AppVersion, locationCache: map[string][]location{}}
+		writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
 	case FormatCosignVuln:
 		writer = predicate.NewVulnWriter(option.Output, option.AppVersion)
 	default:

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -82,7 +82,7 @@ func Write(report types.Report, option Option) error {
 		// We keep `sarif.tpl` template working for backward compatibility for a while.
 		if strings.HasPrefix(option.OutputTemplate, "@") && strings.HasSuffix(option.OutputTemplate, "sarif.tpl") {
 			log.Logger.Warn("Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571")
-			writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
+			writer = SarifWriter{Output: option.Output, Version: option.AppVersion, locationCache: map[string][]location{}}
 			break
 		}
 		var err error
@@ -90,7 +90,7 @@ func Write(report types.Report, option Option) error {
 			return xerrors.Errorf("failed to initialize template writer: %w", err)
 		}
 	case FormatSarif:
-		writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
+		writer = SarifWriter{Output: option.Output, Version: option.AppVersion, locationCache: map[string][]location{}}
 	case FormatCosignVuln:
 		writer = predicate.NewVulnWriter(option.Output, option.AppVersion)
 	default:


### PR DESCRIPTION
## Description
We start support dependency locations for some languages (e.g. #3016, #3032...).
Use correct locations for these languages.

Before:
![изображение](https://user-images.githubusercontent.com/19297627/204908171-15598867-4123-42ee-9b0c-6a5723100b86.png)

After:
![Screenshot from 2022-11-28 11-54-31](https://user-images.githubusercontent.com/91113035/204204085-a35910e5-cd9b-4042-8b7b-a844b70f692d.png)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
