### PR TITLE
feat(dotnet): add dependency parsing for nuget lock files

### DIFF
--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -17,13 +17,12 @@ In some cases, vulnerable dependencies are not linked directly, and it requires 
 To make this task simpler Trivy can show a dependency origin tree with the `--dependency-tree` flag.
 This flag is only available with the `--format table` flag.
 
-!!! note
-    Only these packages/languages are currently supported:
+The following packages/languages are currently supported:
 
-    * OS packages 
-    * Node.js (package-lock.json) 
-    * Nuget lock files (packages.lock.json)
-    * Rust Binaries built with [cargo-auditable][cargo-auditable]
+- OS packages (apk, dpkg and rpm)
+- Node.js (package-lock.json) 
+- Nuget lock files (packages.lock.json)
+- Rust Binaries built with [cargo-auditable][cargo-auditable]
 
 This tree is the reverse of the npm list command.
 However, if you want to resolve a vulnerability in a particular indirect dependency, the reversed tree is useful to know where that dependency comes from and identify which package you actually need to update.

--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -18,7 +18,12 @@ To make this task simpler Trivy can show a dependency origin tree with the `--de
 This flag is only available with the `--format table` flag.
 
 !!! note
-    Only OS packages, Node.js (package-lock.json) and Rust Binaries built with [cargo-auditable][cargo-auditable] are supported at the moment.
+    Only these packages/languages are currently supported:
+
+    * OS packages 
+    * Node.js (package-lock.json) 
+    * Nuget lock files (packages.lock.json)
+    * Rust Binaries built with [cargo-auditable][cargo-auditable]
 
 This tree is the reverse of the npm list command.
 However, if you want to resolve a vulnerability in a particular indirect dependency, the reversed tree is useful to know where that dependency comes from and identify which package you actually need to update.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.82.0
-	github.com/aquasecurity/go-dep-parser v0.0.0-20221114145626-35ef808901e8
+	github.com/aquasecurity/go-dep-parser v0.0.0-20221115110529-0f27198c8fba
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.82.0 h1:WUpPZ6IR0NgZqDK7CGaY5fOI799FNlqGvGMSboHEHlI=
 github.com/aquasecurity/defsec v0.82.0/go.mod h1:4SMepRtX/F8bzTd8CucIpMiqpNOB6/BVPnRktDF5iN0=
-github.com/aquasecurity/go-dep-parser v0.0.0-20221114145626-35ef808901e8 h1:574FCPBKyseQXhlOfTFdbxfcynhXRWVlD3cpRK0reC4=
-github.com/aquasecurity/go-dep-parser v0.0.0-20221114145626-35ef808901e8/go.mod h1:ZCiGJgdQxCateSw3nPMwZvp9J/+nU8/3DcGY/NO71e4=
+github.com/aquasecurity/go-dep-parser v0.0.0-20221115110529-0f27198c8fba h1:YJTAuz/SimQCplNoqSYuzH3XZYmgmdfgoGdOkjCDceE=
+github.com/aquasecurity/go-dep-parser v0.0.0-20221115110529-0f27198c8fba/go.mod h1:ZCiGJgdQxCateSw3nPMwZvp9J/+nU8/3DcGY/NO71e4=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=

--- a/integration/testdata/fixtures/fs/nuget/packages.lock.json
+++ b/integration/testdata/fixtures/fs/nuget/packages.lock.json
@@ -12,7 +12,10 @@
                 "type": "Direct",
                 "requested": "[5.7.0, )",
                 "resolved": "5.7.0",
-                "contentHash": "7Q/wUoB3jCBcq9zoBOBGHFhe78C13jViPmvjvzTwthVV8DAjMfpXnqAYtgwdaRLJMkTXrtdLxfPBIFFhmlsnIQ=="
+                "contentHash": "7Q/wUoB3jCBcq9zoBOBGHFhe78C13jViPmvjvzTwthVV8DAjMfpXnqAYtgwdaRLJMkTXrtdLxfPBIFFhmlsnIQ==",
+                "dependencies": {
+                    "Newtonsoft.Json": "12.0.3"
+                }
             }
         }
     }

--- a/integration/testdata/nuget.json.golden
+++ b/integration/testdata/nuget.json.golden
@@ -21,6 +21,7 @@
       "Type": "nuget",
       "Packages": [
         {
+          "ID": "Newtonsoft.Json@12.0.3",
           "Name": "Newtonsoft.Json",
           "Version": "12.0.3",
           "Layer": {},
@@ -32,13 +33,17 @@
          ]
         },
         {
+          "ID": "NuGet.Frameworks@5.7.0",
           "Name": "NuGet.Frameworks",
           "Version": "5.7.0",
           "Layer": {},
+          "DependsOn": [
+            "Newtonsoft.Json@12.0.3"
+          ],
           "Locations": [
             {
               "StartLine": 11,
-              "EndLine": 16
+              "EndLine": 19
             }
          ]
         }
@@ -47,6 +52,7 @@
         {
           "VulnerabilityID": "GHSA-5crp-9r3c-p9vr",
           "PkgName": "Newtonsoft.Json",
+          "PkgID": "Newtonsoft.Json@12.0.3",
           "InstalledVersion": "12.0.3",
           "FixedVersion": "13.0.1",
           "Layer": {},

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
@@ -52,14 +52,17 @@ func Test_nugetibraryAnalyzer_Analyze(t *testing.T) {
 						FilePath: "testdata/packages.lock.json",
 						Libraries: []types.Package{
 							{
+								ID:        "Newtonsoft.Json@12.0.3",
 								Name:      "Newtonsoft.Json",
 								Version:   "12.0.3",
 								Locations: []types.Location{{StartLine: 5, EndLine: 10}},
 							},
 							{
+								ID:        "NuGet.Frameworks@5.7.0",
 								Name:      "NuGet.Frameworks",
 								Version:   "5.7.0",
-								Locations: []types.Location{{StartLine: 11, EndLine: 16}},
+								Locations: []types.Location{{StartLine: 11, EndLine: 19}},
+								DependsOn: []string{"Newtonsoft.Json@12.0.3"},
 							},
 						},
 					},

--- a/pkg/fanal/analyzer/language/dotnet/nuget/testdata/packages.lock.json
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/testdata/packages.lock.json
@@ -12,7 +12,10 @@
                 "type": "Direct",
                 "requested": "[5.7.0, )",
                 "resolved": "5.7.0",
-                "contentHash": "7Q/wUoB3jCBcq9zoBOBGHFhe78C13jViPmvjvzTwthVV8DAjMfpXnqAYtgwdaRLJMkTXrtdLxfPBIFFhmlsnIQ=="
+                "contentHash": "7Q/wUoB3jCBcq9zoBOBGHFhe78C13jViPmvjvzTwthVV8DAjMfpXnqAYtgwdaRLJMkTXrtdLxfPBIFFhmlsnIQ==",
+                "dependencies": {
+                    "Newtonsoft.Json": "12.0.3"
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
Add dependency parsing for nuget lock files

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/152

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
