### PR TITLE
fix: `slowSizeThreshold` should be less than `defaultSizeThreshold`

### DIFF
--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -17,7 +17,7 @@ var (
 
 const (
 	defaultSizeThreshold = int64(200) << 20 // 200MB
-	slowSizeThreshold    = int64(200) << 20 // 10KB
+	slowSizeThreshold    = int64(100) << 10 // 10KB
 )
 
 type WalkFunc func(filePath string, info os.FileInfo, opener analyzer.Opener) error


### PR DESCRIPTION
## Description
there is a mistake in `slowSizeThreshold`. it's equal `defaultSizeThreshold`.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
