### PR TITLE
fix(vm): turn warning message into debug message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/masahiro331/go-ext4-filesystem v0.0.0-20221016160854-4b40d7ee6193
 	github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08
 	github.com/masahiro331/go-vmdk-parser v0.0.0-20221124162251-5eeffd974e5a
-	github.com/masahiro331/go-xfs-filesystem v0.0.0-20221123035428-5c173df8b3f6
+	github.com/masahiro331/go-xfs-filesystem v0.0.0-20221127135739-051c25f1becd
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/open-policy-agent/opa v0.44.1-0.20220927105354-00e835a7cc15
 	github.com/owenrumney/go-sarif/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -1129,8 +1129,8 @@ github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08 h1:AevU
 github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08/go.mod h1:JOkBRrE1HvgTyjk6diFtNGgr8XJMtIfiBzkL5krqzVk=
 github.com/masahiro331/go-vmdk-parser v0.0.0-20221124162251-5eeffd974e5a h1:R2wjAgJt2IwTqKfSDc4mJ0SIz66lIslqmAjW/Dmi5fE=
 github.com/masahiro331/go-vmdk-parser v0.0.0-20221124162251-5eeffd974e5a/go.mod h1:5f7mCJGW9cJb8SDn3z8qodGxpMCOo8d/2nls/tiwRrw=
-github.com/masahiro331/go-xfs-filesystem v0.0.0-20221123035428-5c173df8b3f6 h1:UHo9uZWmmUVmYUJqTXPSHNUnPaO6ofKKdTWpEQtpxho=
-github.com/masahiro331/go-xfs-filesystem v0.0.0-20221123035428-5c173df8b3f6/go.mod h1:QKBZqdn6teT0LK3QhAf3K6xakItd1LonOShOEC44idQ=
+github.com/masahiro331/go-xfs-filesystem v0.0.0-20221127135739-051c25f1becd h1:jOFGJ9IFmR9jbm06nZzSR9xdd5clVbRcK55yGNhqMYM=
+github.com/masahiro331/go-xfs-filesystem v0.0.0-20221127135739-051c25f1becd/go.mod h1:QKBZqdn6teT0LK3QhAf3K6xakItd1LonOShOEC44idQ=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=


### PR DESCRIPTION
## Description
update go-xfs-filesystem.

change commit: https://github.com/masahiro331/go-xfs-filesystem/commit/051c25f1becd4b2f26cffb76a9b74cc3991740dc

## Related PRs
- [x] #2910

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
