### PR TITLE
fix: Handle RUN echo statements in images built with docker

### DIFF
--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -243,6 +243,12 @@ func emptyLayer(history dimage.HistoryResponseItem) bool {
 		strings.HasPrefix(createdBy, "ARG") {
 		return true
 	}
+	// For "echo" statements in the image creation (e.g. RUN echo "hello world"), docker treats the layer as empty,
+	// but podman and BUILDKIT mark it as non empty layer
+	// So this condition in the below conditional statement handles it for images built with docker
+	if strings.HasPrefix(strings.ToUpper(createdBy), "ECHO") {
+		return true
+	}
 	// buildkit layers with "WORKDIR /" command are empty,
 	if strings.HasPrefix(history.Comment, "buildkit.dockerfile") {
 		if createdBy == "WORKDIR /" {

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -328,6 +328,27 @@ func Test_image_emptyLayer(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "ECHO",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c ECHO \"hello world\"",
+			},
+			want: true,
+		},
+		{
+			name: "echo",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "/bin/sh -c echo \"hello world\"",
+			},
+			want: true,
+		},
+		{
+			name: "buildkit echo",
+			history: dimage.HistoryResponseItem{
+				CreatedBy: "RUN /bin/sh -c ECHO \"hello world\"",
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
RUN echo statements in image build steps are treated as empty layers by docker build tool 
So added condition to mark them as empty layers during scan analysis

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
