### PR TITLE
chore(go): updates wazero to 1.0.0-pre.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.1
 	github.com/testcontainers/testcontainers-go v0.15.0
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/twitchtv/twirp v8.1.2+incompatible
 	github.com/xlab/treeprint v1.1.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -1498,8 +1498,8 @@ github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BG
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/testcontainers/testcontainers-go v0.15.0 h1:3Ex7PUGFv0b2bBsdOv6R42+SK2qoZnWBd21LvZYhUtQ=
 github.com/testcontainers/testcontainers-go v0.15.0/go.mod h1:PkohMRH2X8Hib0IWtifVexDfLPVT+tb5E9hsf7cW12w=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -41,7 +41,7 @@ var (
 )
 
 // logDebug is defined as an api.GoModuleFunc for lower overhead vs reflection.
-func logDebug(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+func logDebug(ctx context.Context, mod api.Module, params []uint64) {
 	offset, size := uint32(params[0]), uint32(params[1])
 
 	buf := readMemory(ctx, mod, offset, size)
@@ -53,7 +53,7 @@ func logDebug(ctx context.Context, mod api.Module, params []uint64) (_ []uint64)
 }
 
 // logInfo is defined as an api.GoModuleFunc for lower overhead vs reflection.
-func logInfo(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+func logInfo(ctx context.Context, mod api.Module, params []uint64) {
 	offset, size := uint32(params[0]), uint32(params[1])
 
 	buf := readMemory(ctx, mod, offset, size)
@@ -65,7 +65,7 @@ func logInfo(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) 
 }
 
 // logWarn is defined as an api.GoModuleFunc for lower overhead vs reflection.
-func logWarn(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+func logWarn(ctx context.Context, mod api.Module, params []uint64) {
 	offset, size := uint32(params[0]), uint32(params[1])
 
 	buf := readMemory(ctx, mod, offset, size)
@@ -77,7 +77,7 @@ func logWarn(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) 
 }
 
 // logError is defined as an api.GoModuleFunc for lower overhead vs reflection.
-func logError(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+func logError(ctx context.Context, mod api.Module, params []uint64) {
 	offset, size := uint32(params[0]), uint32(params[1])
 
 	buf := readMemory(ctx, mod, offset, size)


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API