### PR TITLE
fix: change severity vendor priority for ghsa-ids and vulns from govuln

### DIFF
--- a/pkg/vulnerability/testdata/fixtures/vulnerability.yaml
+++ b/pkg/vulnerability/testdata/fixtures/vulnerability.yaml
@@ -55,3 +55,21 @@
         Description: dos vulnerability
         References:
           - http://example.com
+    - key: CVE-2022-0001
+      value:
+        Title: dos
+        Description: dos vulnerability
+        VendorSeverity:
+          nvd: 1
+          ghsa: 3
+        References:
+          - http://example.com
+    - key: GHSA-0000-aaaa-1111
+      value:
+        Title: dos
+        Description: dos vulnerability
+        VendorSeverity:
+          nvd: 1
+          ghsa: 3
+        References:
+          - http://example.com

--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -57,7 +57,7 @@ func (c Client) FillInfo(vulns []types.DetectedVulnerability) {
 		}
 
 		// Select the severity according to the detected source.
-		severity, severitySource := c.getVendorSeverity(&vuln, source)
+		severity, severitySource := c.getVendorSeverity(vulnID, &vuln, source)
 
 		// The vendor might provide package-specific severity like Debian.
 		// For example, CVE-2015-2328 in Debian has "unimportant" for mongodb and "low" for pcre3.
@@ -76,9 +76,17 @@ func (c Client) FillInfo(vulns []types.DetectedVulnerability) {
 	}
 }
 
-func (c Client) getVendorSeverity(vuln *dbTypes.Vulnerability, source dbTypes.SourceID) (string, dbTypes.SourceID) {
+func (c Client) getVendorSeverity(vulnID string, vuln *dbTypes.Vulnerability, source dbTypes.SourceID) (string, dbTypes.SourceID) {
 	if vs, ok := vuln.VendorSeverity[source]; ok {
 		return vs.String(), source
+	}
+
+	// use severity from GitHub for all GHSA-xxx vulnerabilities
+	// govuln doesn't have severity. Use severity from GitHub(for CVE-xxx vulns)
+	if strings.HasPrefix(vulnID, "GHSA-") || source == vulnerability.GoVulnDB {
+		if vs, ok := vuln.VendorSeverity[vulnerability.GHSA]; ok {
+			return vs.String(), vulnerability.GHSA
+		}
 	}
 
 	// Try NVD as a fallback if it exists

--- a/pkg/vulnerability/vulnerability_test.go
+++ b/pkg/vulnerability/vulnerability_test.go
@@ -223,6 +223,90 @@ func TestClient_FillInfo(t *testing.T) {
 			},
 		},
 		{
+			name:     "happy path. GHSA-xxx. Severity gets from ghsa",
+			fixtures: []string{"testdata/fixtures/vulnerability.yaml"},
+			vulns: []types.DetectedVulnerability{
+				{VulnerabilityID: "GHSA-0000-aaaa-1111"},
+			},
+			expectedVulnerabilities: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "GHSA-0000-aaaa-1111",
+					SeveritySource:  vulnerability.GHSA,
+					Vulnerability: dbTypes.Vulnerability{
+						Title:       "dos",
+						Description: "dos vulnerability",
+						Severity:    dbTypes.SeverityHigh.String(),
+						References:  []string{"http://example.com"},
+						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+							"nvd":  dbTypes.SeverityLow,
+							"ghsa": dbTypes.SeverityHigh,
+						},
+					},
+					PrimaryURL: "https://github.com/advisories/GHSA-0000-aaaa-1111",
+				},
+			},
+		},
+		{
+			name:     "happy path. CVE-xxx. Severity gets from nvd",
+			fixtures: []string{"testdata/fixtures/vulnerability.yaml"},
+			vulns: []types.DetectedVulnerability{
+				{VulnerabilityID: "CVE-2022-0001"},
+			},
+			expectedVulnerabilities: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-0001",
+					SeveritySource:  vulnerability.NVD,
+					Vulnerability: dbTypes.Vulnerability{
+						Title:       "dos",
+						Description: "dos vulnerability",
+						Severity:    dbTypes.SeverityLow.String(),
+						References:  []string{"http://example.com"},
+						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+							"nvd":  dbTypes.SeverityLow,
+							"ghsa": dbTypes.SeverityHigh,
+						},
+					},
+					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2022-0001",
+				},
+			},
+		},
+		{
+			name:     "happy path. CVE-xxx from govuln. Severity gets from ghsa",
+			fixtures: []string{"testdata/fixtures/vulnerability.yaml"},
+			vulns: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-0001",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.GoVulnDB,
+						Name: "The Go Vulnerability Database",
+						URL:  "https://github.com/golang/vulndb",
+					},
+				},
+			},
+			expectedVulnerabilities: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-0001",
+					SeveritySource:  vulnerability.GHSA,
+					Vulnerability: dbTypes.Vulnerability{
+						Title:       "dos",
+						Description: "dos vulnerability",
+						Severity:    dbTypes.SeverityHigh.String(),
+						References:  []string{"http://example.com"},
+						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+							"nvd":  dbTypes.SeverityLow,
+							"ghsa": dbTypes.SeverityHigh,
+						},
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.GoVulnDB,
+						Name: "The Go Vulnerability Database",
+						URL:  "https://github.com/golang/vulndb",
+					},
+					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2022-0001",
+				},
+			},
+		},
+		{
 			name:     "GetVulnerability returns an error",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			vulns: []types.DetectedVulnerability{


### PR DESCRIPTION
## Description
Vulnerabilities from `govuln` and `GHSA-xxx` will get severity from github first (if github has no severity then from NVD)

## Related PRs
- [ ] aquasecurity/trivy-db/pull/267

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
