### PR TITLE
fix(sbom): duplicate dependson

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -246,8 +246,8 @@ func (e *Marshaler) marshalComponents(r types.Report, bomRef string) (*[]cdx.Com
 			}
 		}
 
-		if result.Type == ftypes.NodePkg || result.Type == ftypes.PythonPkg || result.Type == ftypes.GoBinary ||
-			result.Type == ftypes.GemSpec || result.Type == ftypes.Jar || result.Type == ftypes.RustBinary {
+		if result.Type == ftypes.NodePkg || result.Type == ftypes.PythonPkg ||
+			result.Type == ftypes.GemSpec || result.Type == ftypes.Jar {
 			// If a package is language-specific package that isn't associated with a lock file,
 			// it will be a dependency of a component under "metadata".
 			// e.g.

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -205,6 +205,7 @@ func (e *Marshaler) marshalComponents(r types.Report, bomRef string) (*[]cdx.Com
 			pkgID := packageID(result.Target, pkg.Name, utils.FormatVersion(pkg), pkg.FilePath)
 			if _, ok := bomRefMap[pkgID]; !ok {
 				bomRefMap[pkgID] = pkgComponent.BOMRef
+				componentDependencies = append(componentDependencies, cdx.Dependency{Ref: pkgComponent.BOMRef})
 			}
 
 			// When multiple lock files have the same dependency with the same name and version,
@@ -227,8 +228,6 @@ func (e *Marshaler) marshalComponents(r types.Report, bomRef string) (*[]cdx.Com
 				// TODO: All packages are flattened at the moment. We should construct dependency tree.
 				components = append(components, pkgComponent)
 			}
-
-			componentDependencies = append(componentDependencies, cdx.Dependency{Ref: pkgComponent.BOMRef})
 		}
 
 		for _, vuln := range result.Vulnerabilities {

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -153,6 +153,17 @@ func TestMarshaler_Marshal(t *testing.T) {
 							},
 						},
 					},
+					{
+						Target: "usr/local/bin/tfsec",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.GoBinary,
+						Packages: []ftypes.Package{
+							{
+								Name:    "golang.org/x/crypto",
+								Version: "v0.0.0-20210421170649-83a5a9bb288b",
+							},
+						},
+					},
 				},
 			},
 			want: &cdx.BOM{
@@ -335,6 +346,35 @@ func TestMarshaler_Marshal(t *testing.T) {
 							},
 						},
 					},
+					{
+						BOMRef:     "pkg:golang/golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b",
+						Type:       cdx.ComponentTypeLibrary,
+						Name:       "golang.org/x/crypto",
+						Version:    "v0.0.0-20210421170649-83a5a9bb288b",
+						PackageURL: "pkg:golang/golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "gobinary",
+							},
+						},
+					},
+					{
+						BOMRef:  "3ff14136-e09f-4df9-80ea-000000000006",
+						Type:    cdx.ComponentTypeApplication,
+						Name:    "usr/local/bin/tfsec",
+						Version: "",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:Type",
+								Value: "gobinary",
+							},
+							{
+								Name:  "aquasecurity:trivy:Class",
+								Value: "lang-pkgs",
+							},
+						},
+					},
 				},
 				Dependencies: &[]cdx.Dependency{
 					{
@@ -373,6 +413,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
+						Ref: "3ff14136-e09f-4df9-80ea-000000000006",
+						Dependencies: &[]cdx.Dependency{
+							{
+								Ref: "pkg:golang/golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b",
+							},
+						},
+					},
+					{
 						Ref: "pkg:oci/rails@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177?repository_url=index.docker.io%2Flibrary%2Frails&arch=arm64",
 						Dependencies: &[]cdx.Dependency{
 							{
@@ -386,6 +434,9 @@ func TestMarshaler_Marshal(t *testing.T) {
 							},
 							{
 								Ref: "3ff14136-e09f-4df9-80ea-000000000005",
+							},
+							{
+								Ref: "3ff14136-e09f-4df9-80ea-000000000006",
 							},
 						},
 					},


### PR DESCRIPTION
## Description

* Changed to avoid duplicate dependsOn.
* Changed to create Application Component with RustBinary and GoBinary.

## Related issues
- Close #3260 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
