### PR TITLE
fix(vuln): include duplicate vulnerabilities with different package paths in the final report

### DIFF
--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -74,7 +74,7 @@ func filterVulnerabilities(vulns []types.DetectedVulnerability, severities []dbT
 			}
 
 			// Check if there is a duplicate vulnerability
-			key := fmt.Sprintf("%s/%s/%s", vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion)
+			key := fmt.Sprintf("%s/%s/%s/%s", vuln.VulnerabilityID, vuln.PkgName, vuln.InstalledVersion, vuln.PkgPath)
 			if old, ok := uniqVulns[key]; ok && !shouldOverwrite(old, vuln) {
 				continue
 			}

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -502,6 +502,139 @@ func TestClient_Filter(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "happy path with duplicates and different package paths",
+			args: args{
+				result: types.Result{
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID:  "CVE-2019-0001",
+							PkgPath:          "some/path/a.jar",
+							PkgName:          "bar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: dbTypes.SeverityCritical.String(),
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0001",
+							PkgPath:          "some/other/path/a.jar",
+							PkgName:          "bar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: dbTypes.SeverityCritical.String(),
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0002",
+							PkgName:          "baz",
+							PkgPath:          "some/path/b.jar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: dbTypes.SeverityHigh.String(),
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0002",
+							PkgPath:          "some/path/b.jar",
+							PkgName:          "baz",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: dbTypes.SeverityHigh.String(),
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0003",
+							PkgPath:          "some/path/c.jar",
+							PkgName:          "bar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: "",
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0003",
+							PkgName:          "bar",
+							PkgPath:          "some/path/c.jar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: "",
+							},
+						},
+						{
+							VulnerabilityID:  "CVE-2019-0003",
+							PkgName:          "bar",
+							PkgPath:          "some/other/path/c.jar",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: "",
+							},
+						},
+					},
+				},
+				severities:    []dbTypes.Severity{dbTypes.SeverityCritical, dbTypes.SeverityHigh, dbTypes.SeverityUnknown},
+				ignoreUnfixed: false,
+			},
+			wantVulns: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2019-0001",
+					PkgPath:          "some/other/path/a.jar",
+					PkgName:          "bar",
+					InstalledVersion: "1.2.3",
+					FixedVersion:     "1.2.4",
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityCritical.String(),
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2019-0001",
+					PkgPath:          "some/path/a.jar",
+					PkgName:          "bar",
+					InstalledVersion: "1.2.3",
+					FixedVersion:     "1.2.4",
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityCritical.String(),
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2019-0003",
+					PkgName:          "bar",
+					PkgPath:          "some/other/path/c.jar",
+					InstalledVersion: "1.2.3",
+					FixedVersion:     "",
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityUnknown.String(),
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2019-0003",
+					PkgName:          "bar",
+					PkgPath:          "some/path/c.jar",
+					InstalledVersion: "1.2.3",
+					FixedVersion:     "1.2.4",
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityUnknown.String(),
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2019-0002",
+					PkgPath:          "some/path/b.jar",
+					PkgName:          "baz",
+					InstalledVersion: "1.2.3",
+					FixedVersion:     "1.2.4",
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -40,7 +40,7 @@ type BySeverity []DetectedVulnerability
 // Len returns the length of DetectedVulnerabilities
 func (v BySeverity) Len() int { return len(v) }
 
-// Less compares 2 DetectedVulnerabilities based on package name, severity and vulnerabilityID
+// Less compares 2 DetectedVulnerabilities based on package name, severity, vulnerabilityID and package path
 func (v BySeverity) Less(i, j int) bool {
 	if v[i].PkgName != v[j].PkgName {
 		return v[i].PkgName < v[j].PkgName
@@ -53,7 +53,10 @@ func (v BySeverity) Less(i, j int) bool {
 	if ret != 0 {
 		return ret > 0
 	}
-	return v[i].VulnerabilityID < v[j].VulnerabilityID
+	if v[i].VulnerabilityID != v[j].VulnerabilityID {
+		return v[i].VulnerabilityID < v[j].VulnerabilityID
+	}
+	return v[i].PkgPath < v[j].PkgPath
 }
 
 // Swap swaps 2 vulnerability


### PR DESCRIPTION
## Description

DetectedVulnerability objects with identical VulnerabilityID, PkgName and InstalledVersion properties' values will only be included once in the final report of trivy, regardless of whether their respective PkgPath property values are different, due to the current [deduplication logic](https://github.com/aquasecurity/trivy/blob/7a6cf5a27c661f61a54669af7935c1389fef8453/pkg/result/filter.go#L56) for filtering unique DetectedVulnerability objects produced by different data sources. Thus, the final report is incomplete regarding the root cause of the corresponding vulnerability (i.e. which dependency files introduce it).

In order to mitigate this, our PR adds vuln.PkgPath to the [key](https://github.com/aquasecurity/trivy/blob/7a6cf5a27c661f61a54669af7935c1389fef8453/pkg/result/filter.go#L77) generated for the aforementioned deduplication, allowing for multiple DetectedVulnerability objects with identical vuln.VulnerabilityID, vuln.PkgName and vuln.InstalledVersion values to be included in the final report, as long as their respective vuln.PkgPath values are different. A more in-depth analysis of the bug can be found in the corresponding [issue](https://github.com/aquasecurity/trivy/issues/3274).

## Related issues
- Close #3274 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
