### PR TITLE
docs: fix broken "ecosystem" link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 [pronunciation]: #how-to-pronounce-the-name-trivy
 
 [Installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
-[Ecosystem]: https://aquasecurity.github.io/trivy/latestecosystem/tools
+[Ecosystem]: https://aquasecurity.github.io/trivy/latest/ecosystem/
 
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego


### PR DESCRIPTION
## Description

Fix link to Ecosystem page in Trivy docs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
