### PR TITLE
fix(sbom): use proper constants

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -42,6 +42,7 @@ jobs:
             sbom
             server
             k8s
+            aws
             vm
 
             alpine
@@ -86,6 +87,7 @@ jobs:
 
             cyclonedx
             spdx
+            purl
 
             helm
             report

--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -50,7 +50,10 @@ mode:
 - fs
 - repo
 - sbom
+- k8s
 - server
+- aws
+- vm
 
 os:
 
@@ -101,6 +104,12 @@ cli:
 
 - cli
 - flag
+
+SBOM:
+
+- cyclonedx
+- spdx
+- purl
 
 others:
 

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -99,21 +99,22 @@ func (p *PackageURL) AppType() string {
 	return p.Type
 }
 
-func (purl PackageURL) BOMRef() string {
+func (p *PackageURL) BOMRef() string {
 	// 'bom-ref' must be unique within BOM, but PURLs may conflict
 	// when the same packages are installed in an artifact.
 	// In that case, we prefer to make PURLs unique by adding file paths,
 	// rather than using UUIDs, even if it is not PURL technically.
 	// ref. https://cyclonedx.org/use-cases/#dependency-graph
-	if purl.FilePath != "" {
+	purl := p.PackageURL // so that it will not override the qualifiers below
+	if p.FilePath != "" {
 		purl.Qualifiers = append(purl.Qualifiers,
 			packageurl.Qualifier{
 				Key:   "file_path",
-				Value: purl.FilePath,
+				Value: p.FilePath,
 			},
 		)
 	}
-	return purl.PackageURL.String()
+	return purl.String()
 }
 
 // nolint: gocyclo

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -289,7 +289,7 @@ func parseNpm(pkgName string) (string, string) {
 
 func purlType(t string) string {
 	switch t {
-	case ftypes.Jar, ftypes.Pom:
+	case ftypes.Jar, ftypes.Pom, ftypes.Gradle:
 		return packageurl.TypeMaven
 	case ftypes.Bundler, ftypes.GemSpec:
 		return packageurl.TypeGem

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -80,21 +80,21 @@ func (p *PackageURL) Package() *ftypes.Package {
 func (p *PackageURL) AppType() string {
 	switch p.Type {
 	case packageurl.TypeComposer:
-		return string(analyzer.TypeComposer)
+		return ftypes.Composer
 	case packageurl.TypeMaven:
-		return string(analyzer.TypeJar)
+		return ftypes.Jar
 	case packageurl.TypeGem:
-		return string(analyzer.TypeGemSpec)
+		return ftypes.GemSpec
 	case packageurl.TypePyPi:
-		return string(analyzer.TypePythonPkg)
+		return ftypes.PythonPkg
 	case packageurl.TypeGolang:
-		return string(analyzer.TypeGoBinary)
+		return ftypes.GoBinary
 	case packageurl.TypeNPM:
-		return string(analyzer.TypeNodePkg)
+		return ftypes.NodePkg
 	case packageurl.TypeCargo:
-		return string(analyzer.TypeRustBinary)
+		return ftypes.Cargo
 	case packageurl.TypeNuget:
-		return string(analyzer.TypeNuget)
+		return ftypes.NuGet
 	}
 	return p.Type
 }
@@ -288,17 +288,17 @@ func parseNpm(pkgName string) (string, string) {
 
 func purlType(t string) string {
 	switch t {
-	case string(analyzer.TypeJar), string(analyzer.TypePom):
+	case ftypes.Jar, ftypes.Pom:
 		return packageurl.TypeMaven
-	case string(analyzer.TypeBundler), string(analyzer.TypeGemSpec):
+	case ftypes.Bundler, ftypes.GemSpec:
 		return packageurl.TypeGem
-	case string(analyzer.TypeNuget), string(analyzer.TypeDotNetCore):
+	case ftypes.NuGet, ftypes.DotNetCore:
 		return packageurl.TypeNuget
-	case string(analyzer.TypePythonPkg), string(analyzer.TypePip), string(analyzer.TypePipenv), string(analyzer.TypePoetry):
+	case ftypes.PythonPkg, ftypes.Pip, ftypes.Pipenv, ftypes.Poetry:
 		return packageurl.TypePyPi
-	case string(analyzer.TypeGoBinary), string(analyzer.TypeGoMod):
+	case ftypes.GoBinary, ftypes.GoModule:
 		return packageurl.TypeGolang
-	case string(analyzer.TypeNpmPkgLock), string(analyzer.TypeNodePkg), string(analyzer.TypeYarn), string(analyzer.TypePnpm):
+	case ftypes.Npm, ftypes.NodePkg, ftypes.Yarn, ftypes.Pnpm:
 		return packageurl.TypeNPM
 	case os.Alpine:
 		return string(analyzer.TypeApk)

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -27,7 +27,7 @@ func TestNewPackageURL(t *testing.T) {
 	}{
 		{
 			name: "maven package",
-			typ:  string(analyzer.TypeJar),
+			typ:  ftypes.Jar,
 			pkg: ftypes.Package{
 				Name:    "org.springframework:spring-core",
 				Version: "5.3.14",
@@ -59,7 +59,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "yarn package",
-			typ:  string(analyzer.TypeYarn),
+			typ:  ftypes.Yarn,
 			pkg: ftypes.Package{
 				Name:    "@xtuc/ieee754",
 				Version: "1.2.0",
@@ -75,7 +75,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "yarn package with non-namespace",
-			typ:  string(analyzer.TypeYarn),
+			typ:  ftypes.Yarn,
 			pkg: ftypes.Package{
 				Name:    "lodash",
 				Version: "4.17.21",
@@ -90,7 +90,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "pnpm package",
-			typ:  string(analyzer.TypePnpm),
+			typ:  ftypes.Pnpm,
 			pkg: ftypes.Package{
 				Name:    "@xtuc/ieee754",
 				Version: "1.2.0",
@@ -106,7 +106,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "pnpm package with non-namespace",
-			typ:  string(analyzer.TypePnpm),
+			typ:  ftypes.Pnpm,
 			pkg: ftypes.Package{
 				Name:    "lodash",
 				Version: "4.17.21",
@@ -121,7 +121,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "pypi package",
-			typ:  string(analyzer.TypePip),
+			typ:  ftypes.PythonPkg,
 			pkg: ftypes.Package{
 				Name:    "Django_test",
 				Version: "1.2.0",
@@ -136,7 +136,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "composer package",
-			typ:  string(analyzer.TypeComposer),
+			typ:  ftypes.Composer,
 			pkg: ftypes.Package{
 				Name:    "symfony/contracts",
 				Version: "v1.0.2",
@@ -152,7 +152,7 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "golang package",
-			typ:  string(analyzer.TypeGoMod),
+			typ:  ftypes.GoModule,
 			pkg: ftypes.Package{
 				Name:    "github.com/go-sql-driver/Mysql",
 				Version: "v1.5.0",

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -43,14 +43,14 @@ func TestNewPackageURL(t *testing.T) {
 		},
 		{
 			name: "gradle package",
-			typ:  string(ftypes.Gradle),
+			typ:  ftypes.Gradle,
 			pkg: ftypes.Package{
 				Name:    "org.springframework:spring-core",
 				Version: "5.3.14",
 			},
 			want: purl.PackageURL{
 				PackageURL: packageurl.PackageURL{
-					Type:      string(ftypes.Gradle),
+					Type:      packageurl.TypeMaven,
 					Namespace: "org.springframework",
 					Name:      "spring-core",
 					Version:   "5.3.14",


### PR DESCRIPTION
## Description
It currently uses constants for analyzers, but it should be constants for result types.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
