### PR TITLE
chore(go): remove experimental FS API usage in Wasm

### DIFF
--- a/pkg/module/memfs.go
+++ b/pkg/module/memfs.go
@@ -1,0 +1,43 @@
+package module
+
+import (
+	"io"
+	"io/fs"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	"github.com/aquasecurity/memoryfs"
+)
+
+// memFS is a wrapper of memoryfs.FS and can change its underlying file system
+// at runtime. This implements fs.FS.
+type memFS struct {
+	current *memoryfs.FS
+}
+
+// Open implements fs.FS.
+func (m *memFS) Open(name string) (fs.File, error) {
+	return m.current.Open(name)
+}
+
+// initialize changes the underlying memory file system with the given file path and contents.
+//
+// Note: it is always to safe swap the underlying ones as thia is called only at the beginning of Analyze
+// which is not concurrently called per module instance.
+func (m *memFS) initialize(filePath string, content dio.ReadSeekerAt) (err error) {
+	memfs := memoryfs.New()
+	if err = memfs.MkdirAll(filepath.Dir(filePath), fs.ModePerm); err != nil {
+		return xerrors.Errorf("memory fs mkdir error: %w", err)
+	}
+	err = memfs.WriteLazyFile(filePath, func() (io.Reader, error) {
+		return content, nil
+	}, fs.ModePerm)
+	if err != nil {
+		return xerrors.Errorf("memory fs write error: %w", err)
+	}
+
+	m.current = memfs
+	return
+}

--- a/pkg/module/memfs.go
+++ b/pkg/module/memfs.go
@@ -24,8 +24,8 @@ func (m *memFS) Open(name string) (fs.File, error) {
 
 // initialize changes the underlying memory file system with the given file path and contents.
 //
-// Note: it is always to safe swap the underlying ones as thia is called only at the beginning of Analyze
-// which is not concurrently called per module instance.
+// Note: it is always to safe swap the underlying FS with this API since this is called only at the beginning of
+// Analyze interface call, which is not concurrently called per module instance.
 func (m *memFS) initialize(filePath string, content dio.ReadSeekerAt) (err error) {
 	memfs := memoryfs.New()
 	if err = memfs.MkdirAll(filepath.Dir(filePath), fs.ModePerm); err != nil {

--- a/pkg/module/memfs_test.go
+++ b/pkg/module/memfs_test.go
@@ -1,0 +1,33 @@
+package module
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemFS(t *testing.T) {
+	m := &memFS{}
+	require.Nil(t, m.current)
+
+	const path, content = "/usr/foo/bar.txt", "my-content"
+	err := m.initialize(path, strings.NewReader(content))
+	require.NoError(t, err)
+	require.NotNil(t, m.current)
+
+	t.Run("happy", func(t *testing.T) {
+		f, err := m.Open(path)
+		require.NoError(t, err)
+		actual, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.Equal(t, content, string(actual))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err = m.Open(path + "tmp")
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

## Description

Previously, wazero introduced context-based FS (https://github.com/tetratelabs/wazero/pull/571) and used in Trivy to change the underlying file system anytime it calls Analyze API. But it came with the runtime overhead and there's actually an easy way to achieve the same thing without that experimental API.

This PR, hence, removes the usage of the experimental API by introducing the wrapper over memfs.FS which can change the underlying file system in response to the Analyze calls.

