### PR TITLE
feat(secret): Use .trivyignore for filtering secret scanning result

### DIFF
--- a/docs/docs/secret/examples.md
+++ b/docs/docs/secret/examples.md
@@ -35,6 +35,18 @@ Total: 1 (CRITICAL: 1)
 +----------+-------------------+----------+---------+--------------------------------+
 ```
 
+## Filter by RuleID
+
+Use `.trivyignore`.
+
+```bash
+$ cat .trivyignore
+
+# Ignore these rules
+generic-unwanted-rule
+aws-account-id
+```
+
 ## Disable secret scanning
 If you need vulnerability scanning only, you can disable secret scanning via the `--security-checks` flag.
 

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -293,6 +293,24 @@ func TestClient_Filter(t *testing.T) {
 							Status:   types.StatusFailure,
 						},
 					},
+					Secrets: []ftypes.SecretFinding{
+						{
+							RuleID:    "generic-wanted-rule",
+							Severity:  dbTypes.SeverityLow.String(),
+							Title:     "Secret that should pass filter on rule id",
+							StartLine: 1,
+							EndLine:   2,
+							Match:     "*****",
+						},
+						{
+							RuleID:    "generic-unwanted-rule",
+							Severity:  dbTypes.SeverityLow.String(),
+							Title:     "Secret that should not pass filter on rule id",
+							StartLine: 3,
+							EndLine:   4,
+							Match:     "*****",
+						},
+					},
 				},
 				severities:    []dbTypes.Severity{dbTypes.SeverityLow},
 				ignoreUnfixed: false,
@@ -317,6 +335,16 @@ func TestClient_Filter(t *testing.T) {
 					Vulnerability: dbTypes.Vulnerability{
 						Severity: dbTypes.SeverityLow.String(),
 					},
+				},
+			},
+			wantSecrets: []ftypes.SecretFinding{
+				{
+					RuleID:    "generic-wanted-rule",
+					Severity:  dbTypes.SeverityLow.String(),
+					Title:     "Secret that should pass filter on rule id",
+					StartLine: 1,
+					EndLine:   2,
+					Match:     "*****",
 				},
 			},
 		},

--- a/pkg/result/testdata/.trivyignore
+++ b/pkg/result/testdata/.trivyignore
@@ -7,3 +7,6 @@ CVE-2022-0003 exp:9999-01-01 key2:value2
 
 # misconfigurations
 ID100
+
+# secrets
+generic-unwanted-rule


### PR DESCRIPTION
## Description

This allows the filtering of secret scan results by RuleID using .trivyignore as it's possible for Misconfiguration or Vulnerability.

## Related issues
- Close #3311 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
