### PR TITLE
fix(sbom): support for the detection of old CycloneDX predicate type

### DIFF
--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -26,6 +26,11 @@ const (
 	FormatSPDXXML             Format = "spdx-xml"
 	FormatAttestCycloneDXJSON Format = "attest-cyclonedx-json"
 	FormatUnknown             Format = "unknown"
+
+	// PredicateCycloneDXBeforeV05 is the PredicateCycloneDX value defined in in-toto-golang before v0.5.0.
+	// This is necessary for backward-compatible SBOM detection.
+	// ref. https://github.com/in-toto/in-toto-golang/pull/188
+	PredicateCycloneDXBeforeV05 = "https://cyclonedx.org/schema"
 )
 
 var ErrUnknownFormat = xerrors.New("Unknown SBOM format")
@@ -97,7 +102,7 @@ func DetectFormat(r io.ReadSeeker) (Format, error) {
 	// Try in-toto attestation
 	var s attestation.Statement
 	if err := json.NewDecoder(r).Decode(&s); err == nil {
-		if s.PredicateType == in_toto.PredicateCycloneDX {
+		if s.PredicateType == in_toto.PredicateCycloneDX || s.PredicateType == PredicateCycloneDXBeforeV05 {
 			return FormatAttestCycloneDXJSON, nil
 		}
 	}


### PR DESCRIPTION
## Description
Add support for the detection of old CycloneDX predicate type.

I tested scanning sbom attestation created by Cosign v1.13.1, which has cyclonedx attestation with the old predicate type( `https://cyclonedx.org/schema` ).


before
```bash
$ trivy image --format cyclonedx -o sbom.cdx.json otms61/my-alpine:latest

$ cosign verify-attestation --key cosign.pub --type cyclonedx otms61/my-alpine:latest > sbom.cdx.intoto.jsonl

Verification for otms61/my-alpine:latest --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The signatures were verified against the specified public key

$ cat sbom.cdx.intoto.jsonl | jq '.payload | @base64d | fromjson | .predicateType'
"https://cyclonedx.org/schema"

$ trivy sbom --debug ./sbom.cdx.intoto.jsonl
2022-12-19T00:07:19.939+0900    DEBUG   Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2022-12-19T00:07:19.949+0900    DEBUG   cache dir:  /Users/saso/Library/Caches/trivy
2022-12-19T00:07:19.949+0900    DEBUG   DB update was skipped because the local DB is the latest
2022-12-19T00:07:19.949+0900    DEBUG   DB Schema: 2, UpdatedAt: 2022-12-18 12:07:10.0932724 +0000 UTC, NextUpdate: 2022-12-18 18:07:10.093272 +0000 UTC, DownloadedAt: 2022-12-18 15:04:54.336853 +0000 UTC
2022-12-19T00:07:19.949+0900    INFO    Vulnerability scanning is enabled
2022-12-19T00:07:19.949+0900    DEBUG   Vulnerability type:  [os library]
2022-12-19T00:07:19.950+0900    INFO    Detected SBOM format: unknown
2022-12-19T00:07:19.950+0900    FATAL   sbom scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.Run
        github.com/aquasecurity/trivy/pkg/commands/artifact/run.go:405
  - scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact
        github.com/aquasecurity/trivy/pkg/commands/artifact/run.go:249
  - scan failed:
    github.com/aquasecurity/trivy/pkg/commands/artifact.scan
        github.com/aquasecurity/trivy/pkg/commands/artifact/run.go:579
  - failed analysis:
    github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact
        github.com/aquasecurity/trivy/pkg/scanner/scan.go:140
  - SBOM decode error:
    github.com/aquasecurity/trivy/pkg/fanal/artifact/sbom.Artifact.Inspect
        github.com/aquasecurity/trivy/pkg/fanal/artifact/sbom/sbom.go:55
  - unknown scanning is not yet supported:
    github.com/aquasecurity/trivy/pkg/sbom.Decode
        github.com/aquasecurity/trivy/pkg/sbom/sbom.go:138
```
after

```bash
> ./trivy sbom --debug ./sbom.cdx.intoto.jsonl
2022-12-19T00:08:09.428+0900    DEBUG   Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2022-12-19T00:08:09.440+0900    DEBUG   cache dir:  /Users/saso/Library/Caches/trivy
2022-12-19T00:08:09.441+0900    DEBUG   DB update was skipped because the local DB is the latest
2022-12-19T00:08:09.441+0900    DEBUG   DB Schema: 2, UpdatedAt: 2022-12-18 12:07:10.0932724 +0000 UTC, NextUpdate: 2022-12-18 18:07:10.093272 +0000 UTC, DownloadedAt: 2022-12-18 15:04:54.336853 +0000 UTC
2022-12-19T00:08:09.441+0900    INFO    Vulnerability scanning is enabled
2022-12-19T00:08:09.441+0900    DEBUG   Vulnerability type:  [os library]
2022-12-19T00:08:09.441+0900    INFO    Detected SBOM format: attest-cyclonedx-json
2022-12-19T00:08:09.442+0900    DEBUG   Unmarshaling CycloneDX JSON...
2022-12-19T00:08:09.455+0900    INFO    Detected OS: alpine
2022-12-19T00:08:09.455+0900    INFO    Detecting Alpine vulnerabilities...
2022-12-19T00:08:09.455+0900    DEBUG   alpine: os version: 3.15
2022-12-19T00:08:09.455+0900    DEBUG   alpine: package repository:
2022-12-19T00:08:09.455+0900    DEBUG   alpine: the number of packages: 14
2022-12-19T00:08:09.455+0900    INFO    Number of language-specific files: 0

sbom.cdx.intoto.jsonl (alpine 3.15.6)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3281


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
