### PR TITLE
fix(image): parsePlatform is failing with UNAUTHORIZED error

### DIFF
--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -45,7 +45,9 @@ func tryRemote(ctx context.Context, imageName string, ref name.Reference, option
 		if err != nil {
 			return nil, err
 		}
-		remoteOpts = append(remoteOpts, remote.WithPlatform(*s))
+		if s != nil {
+			remoteOpts = append(remoteOpts, remote.WithPlatform(*s))
+		}
 	}
 
 	desc, err := remote.Get(ref, remoteOpts...)

--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -43,9 +43,9 @@ func tryRemote(ctx context.Context, imageName string, ref name.Reference, option
 	if option.Platform != "" {
 		s, err := parsePlatform(ref, option.Platform, remoteOpts)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("platform error: %w", err)
 		}
-		//Ignored --platform should skip adding platform remoteOpts
+		// Don't pass platform when the specified image is single-arch.
 		if s != nil {
 			remoteOpts = append(remoteOpts, remote.WithPlatform(*s))
 		}

--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -73,7 +73,7 @@ func parsePlatform(ref name.Reference, options []remote.Option, p string) (*v1.P
 	if strings.HasPrefix(p, "*/") {
 		index, err := remote.Index(ref, options...)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("remote index error: %w", err)
 		}
 		m, err := index.IndexManifest()
 		if err != nil {
@@ -81,7 +81,7 @@ func parsePlatform(ref name.Reference, options []remote.Option, p string) (*v1.P
 		}
 		if len(m.Manifests) == 0 {
 			log.Logger.Debug("Ignored --platform as the image is not multi-arch")
-			return nil, xerrors.New("ignored --platform as the image is not multi-arch")
+			return nil, nil
 		}
 		if m.Manifests[0].Platform != nil {
 			// Replace with the detected OS

--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -73,12 +73,7 @@ func parsePlatform(ref name.Reference, options []remote.Option, p string) (*v1.P
 	if strings.HasPrefix(p, "*/") {
 		index, err := remote.Index(ref, options...)
 		if err != nil {
-			// Not a multi-arch image
-			if _, ok := err.(*remote.ErrSchema1); ok {
-				log.Logger.Debug("Ignored --platform as the image is not multi-arch")
-				return nil, err
-			}
-			return nil, xerrors.Errorf("remote index error: %w", err)
+			return nil, err
 		}
 		m, err := index.IndexManifest()
 		if err != nil {

--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -45,6 +45,7 @@ func tryRemote(ctx context.Context, imageName string, ref name.Reference, option
 		if err != nil {
 			return nil, err
 		}
+		//Ignored --platform should skip adding platform remoteOpts
 		if s != nil {
 			remoteOpts = append(remoteOpts, remote.WithPlatform(*s))
 		}


### PR DESCRIPTION
## Description
fix parsePlatform is failing with UNAUTHORIZED error by Plugging in the **auth** to the **parsePlatform**

## Related issues
- Close #3304

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
