### PR TITLE
fix: change logic to build relative paths for skip-dirs and skip-files

### DIFF
--- a/integration/fs_test.go
+++ b/integration/fs_test.go
@@ -47,7 +47,7 @@ func TestFilesystem(t *testing.T) {
 			args: args{
 				securityChecks: "vuln",
 				input:          "testdata/fixtures/fs/gomod",
-				skipFiles:      []string{"/testdata/fixtures/fs/gomod/submod2/go.mod"},
+				skipFiles:      []string{"testdata/fixtures/fs/gomod/submod2/go.mod"},
 			},
 			golden: "testdata/gomod-skip.json.golden",
 		},
@@ -56,7 +56,7 @@ func TestFilesystem(t *testing.T) {
 			args: args{
 				securityChecks: "vuln",
 				input:          "testdata/fixtures/fs/gomod",
-				skipDirs:       []string{"/testdata/fixtures/fs/gomod/submod2"},
+				skipDirs:       []string{"testdata/fixtures/fs/gomod/submod2"},
 			},
 			golden: "testdata/gomod-skip.json.golden",
 		},

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"github.com/aquasecurity/trivy/pkg/log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/handler"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/semaphore"
 )
 

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -239,22 +240,29 @@ func TestArtifact_Inspect(t *testing.T) {
 func TestBuildPathsToSkip(t *testing.T) {
 	tests := []struct {
 		name  string
+		os    string
 		paths []string
 		base  string
 		want  []string
 	}{
-		{"path - abs, base - abs. Skip common prefix", []string{"/foo/bar"}, "/foo", []string{"/foo/bar"}},
+		// linux/mac
+		{"path - abs, base - abs. Skip common prefix", "linux/mac", []string{"/foo/bar"}, "/foo", []string{"/foo/bar"}},
 		//{"path - abs, base - rel.", nil, "", nil}, - impossible to check. absPath for each PC will be different. Checked manual mode.
-		{"path - rel, base - abs", []string{"bar"}, "/foo", []string{"/foo/bar"}},
-		{"path - rel, base - rel. Skip common prefix", []string{"foo/bar/bar"}, "foo", []string{"foo/bar/bar"}},
-		{"path - rel with dot, base - rel. Skip common prefix", []string{"./foo/bar"}, "foo", []string{"foo/bar"}},
-		{"path - rel, base - dot", []string{"foo/bar"}, ".", []string{"foo/bar"}},
+		{"path - rel, base - abs", "linux/mac", []string{"bar"}, "/foo", []string{"/foo/bar"}},
+		{"path - rel, base - rel. Skip common prefix", "linux/mac", []string{"foo/bar/bar"}, "foo", []string{"foo/bar/bar"}},
+		{"path - rel with dot, base - rel. Skip common prefix", "linux/mac", []string{"./foo/bar"}, "foo", []string{"foo/bar"}},
+		{"path - rel, base - dot", "linux/mac", []string{"foo/bar"}, ".", []string{"foo/bar"}},
+		// windows
+		{"path - rel, base - rel. Skip common prefix", "windows", []string{"foo\\bar\\bar"}, "foo", []string{"foo\\bar\\bar"}},
+		{"path - rel, base - dot", "windows", []string{"foo\\bar"}, ".", []string{"foo\\bar"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPathsToSkip(tt.base, tt.paths)
-			assert.Equal(t, tt.want, got)
+			if runtime.GOOS == tt.os {
+				got := buildPathsToSkip(tt.base, tt.paths)
+				assert.Equal(t, tt.want, got)
+			}
 		})
 	}
 }

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -237,34 +237,27 @@ func TestArtifact_Inspect(t *testing.T) {
 }
 
 // TODO: fix the logic in the first place
-//func TestBuildAbsPath(t *testing.T) {
-//	tests := []struct {
-//		name          string
-//		base          string
-//		paths         []string
-//		expectedPaths []string
-//	}{
-//		{"absolute path", "/testBase", []string{"/testPath"}, []string{"/testPath"}},
-//		{"relative path", "/testBase", []string{"testPath"}, []string{"/testBase/testPath"}},
-//		{"path have '.'", "/testBase", []string{"./testPath"}, []string{"/testBase/testPath"}},
-//		{"path have '..'", "/testBase", []string{"../testPath/"}, []string{"/testPath"}},
-//	}
-//
-//	for _, test := range tests {
-//		t.Run(test.name, func(t *testing.T) {
-//			got := buildAbsPaths(test.base, test.paths)
-//			if len(test.paths) != len(got) {
-//				t.Errorf("paths not equals, expected: %s, got: %s", test.expectedPaths, got)
-//			} else {
-//				for i, path := range test.expectedPaths {
-//					if path != got[i] {
-//						t.Errorf("paths not equals, expected: %s, got: %s", test.expectedPaths, got)
-//					}
-//				}
-//			}
-//		})
-//	}
-//}
+func TestBuildRelativePath(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		base  string
+		want  []string
+	}{
+		{"path - abs, base - abs", []string{"/bar"}, "/foo", []string{"../bar"}},
+		{"path - abs, base - abs. Skip common prefix", []string{"/foo/bar"}, "/foo", []string{"bar"}},
+		{"path - rel, base - rel. Skip common prefix", []string{"foo/bar"}, "foo", []string{"bar"}},
+		{"path - rel with dot, base - rel. Skip common prefix", []string{"./foo/bar"}, "foo", []string{"bar"}},
+		{"path - rel, base - dot", []string{"foo/bar"}, ".", []string{"foo/bar"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRelativePaths(tt.base, tt.paths)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestTerraformMisconfigurationScan(t *testing.T) {
 	type fields struct {

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -236,24 +236,24 @@ func TestArtifact_Inspect(t *testing.T) {
 	}
 }
 
-// TODO: fix the logic in the first place
-func TestBuildRelativePath(t *testing.T) {
+func TestBuildPathsToSkip(t *testing.T) {
 	tests := []struct {
 		name  string
 		paths []string
 		base  string
 		want  []string
 	}{
-		{"path - abs, base - abs", []string{"/bar"}, "/foo", []string{"../bar"}},
-		{"path - abs, base - abs. Skip common prefix", []string{"/foo/bar"}, "/foo", []string{"bar"}},
-		{"path - rel, base - rel. Skip common prefix", []string{"foo/bar"}, "foo", []string{"bar"}},
-		{"path - rel with dot, base - rel. Skip common prefix", []string{"./foo/bar"}, "foo", []string{"bar"}},
+		{"path - abs, base - abs. Skip common prefix", []string{"/foo/bar"}, "/foo", []string{"/foo/bar"}},
+		//{"path - abs, base - rel.", nil, "", nil}, - impossible to check. absPath for each PC will be different. Checked manual mode.
+		{"path - rel, base - abs", []string{"bar"}, "/foo", []string{"/foo/bar"}},
+		{"path - rel, base - rel. Skip common prefix", []string{"foo/bar/bar"}, "foo", []string{"foo/bar/bar"}},
+		{"path - rel with dot, base - rel. Skip common prefix", []string{"./foo/bar"}, "foo", []string{"foo/bar"}},
 		{"path - rel, base - dot", []string{"foo/bar"}, ".", []string{"foo/bar"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildRelativePaths(tt.base, tt.paths)
+			got := buildPathsToSkip(tt.base, tt.paths)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -303,11 +303,11 @@ func TestBuildPathsToSkip(t *testing.T) {
 			want:  []string{"bar/bar"},
 		},
 		{
-			name:  "path - rel, base - dot",
+			name:  "path - rel, base - dot, windows",
 			oses:  []string{"windows"},
 			base:  ".",
 			paths: []string{"foo\\bar"},
-			want:  []string{"bar"},
+			want:  []string{"foo/bar"},
 		},
 	}
 

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -28,19 +28,26 @@ func (w FS) Walk(root string, fn WalkFunc) error {
 	// walk function called for every path found
 	walkFn := func(pathname string, fi os.FileInfo) error {
 		pathname = filepath.Clean(pathname)
+		pathname = filepath.ToSlash(pathname)
+
+		// For exported rootfs (e.g. images/alpine/etc/alpine-release)
+		relPath, err := filepath.Rel(root, pathname)
+		if err != nil {
+			return xerrors.Errorf("filepath rel (%s): %w", relPath, err)
+		}
 
 		if fi.IsDir() {
-			if w.shouldSkipDir(pathname) {
+			if w.shouldSkipDir(relPath) {
 				return filepath.SkipDir
 			}
 			return nil
 		} else if !fi.Mode().IsRegular() {
 			return nil
-		} else if w.shouldSkipFile(pathname) {
+		} else if w.shouldSkipFile(relPath) {
 			return nil
 		}
 
-		if err := fn(pathname, fi, w.fileOpener(pathname)); err != nil {
+		if err := fn(relPath, fi, w.fileOpener(pathname)); err != nil {
 			return xerrors.Errorf("failed to analyze file: %w", err)
 		}
 		return nil

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -28,13 +28,13 @@ func (w FS) Walk(root string, fn WalkFunc) error {
 	// walk function called for every path found
 	walkFn := func(pathname string, fi os.FileInfo) error {
 		pathname = filepath.Clean(pathname)
-		pathname = filepath.ToSlash(pathname)
 
 		// For exported rootfs (e.g. images/alpine/etc/alpine-release)
 		relPath, err := filepath.Rel(root, pathname)
 		if err != nil {
 			return xerrors.Errorf("filepath rel (%s): %w", relPath, err)
 		}
+		relPath = filepath.ToSlash(relPath)
 
 		if fi.IsDir() {
 			if w.shouldSkipDir(relPath) {

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -50,7 +50,6 @@ func newWalker(skipFiles, skipDirs []string, slow bool) walker {
 }
 
 func (w *walker) shouldSkipFile(filePath string) bool {
-	filePath = filepath.ToSlash(filePath)
 	filePath = strings.TrimLeft(filePath, "/")
 
 	// skip files
@@ -58,7 +57,6 @@ func (w *walker) shouldSkipFile(filePath string) bool {
 }
 
 func (w *walker) shouldSkipDir(dir string) bool {
-	dir = filepath.ToSlash(dir)
 	dir = strings.TrimLeft(dir, "/")
 
 	// Skip application dirs (relative path)


### PR DESCRIPTION
## Description
Change logic to build relative paths for skip-dirs and skip-files

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
