### PR TITLE
docs: improve compliance docs

### DIFF
--- a/docs/docs/cloud/aws/compliance.md
+++ b/docs/docs/cloud/aws/compliance.md
@@ -1,299 +1,23 @@
 # AWS Compliance
 
-## CIS Compliance Report
+# Kubernetes Compliance
 
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.
 
-The Trivy AWS CLI allows you to scan your AWS account resources and generate the `AWS CIS Foundations Benchmark` report
+This page describes AWS specific compliance reports. For an overview of Trivy's Compliance feature, including working with custom compliance, check out the [Compliance documentation](../../compliance/compliance.md).
 
-[AWS CIS Foundations Benchmark v1.2](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf) validates the following control checks:
-
-```shell
-+--------------------------------------------+--------------------------------+
-|                    NAME                    |          DESCRIPTION           |
-+--------------------------------------------+--------------------------------+
-| limit-root-account-usage                   | The "root" account has         |
-|                                            | unrestricted access to all     |
-|                                            | resources in the AWS account.  |
-|                                            | It is highly recommended that  |
-|                                            | the use of this account be     |
-|                                            | avoided.                       |
-| no-password-reuse                          | IAM Password policy should     |
-|                                            | prevent password reuse.        |
-| set-max-password-age                       | IAM Password policy should     |
-|                                            | have expiry less than or equal |
-|                                            | to 90 days.                    |
-| no-root-access-keys                        | The root user has complete     |
-|                                            | access to all services and     |
-|                                            | resources in an AWS account.   |
-|                                            | AWS Access Keys provide        |
-|                                            | programmatic access to a given |
-|                                            | account.                       |
-| enforce-root-mfa                           | The "root" account has         |
-|                                            | unrestricted access to all     |
-|                                            | resources in the AWS account.  |
-|                                            | It is highly recommended that  |
-|                                            | this account have MFA enabled. |
-| no-user-attached-policies                  | IAM policies should not be     |
-|                                            | granted directly to users.     |
-| enforce-user-mfa                           | IAM Users should have MFA      |
-|                                            | enforcement activated.         |
-| disable-unused-credentials                 | Credentials which are          |
-|                                            | no longer used should be       |
-|                                            | disabled.                      |
-| rotate-access-keys                         | Access keys should be rotated  |
-|                                            | at least every 90 days         |
-| require-uppercase-in-passwords             | IAM Password policy should     |
-|                                            | have requirement for at least  |
-|                                            | one uppercase character.       |
-| require-lowercase-in-passwords             | IAM Password policy should     |
-|                                            | have requirement for at least  |
-|                                            | one lowercase character.       |
-| require-symbols-in-passwords               | IAM Password policy should     |
-|                                            | have requirement for at least  |
-|                                            | one symbol in the password.    |
-| require-numbers-in-passwords               | IAM Password policy should     |
-|                                            | have requirement for at least  |
-|                                            | one number in the password.    |
-| set-minimum-password-length                | IAM Password policy should     |
-|                                            | have minimum password length   |
-|                                            | of 14 or more characters.      |
-| no-public-log-access                       | The S3 Bucket backing          |
-|                                            | Cloudtrail should be private   |
-| ensure-cloudwatch-integration              | CloudTrail logs should be      |
-|                                            | stored in S3 and also sent to  |
-|                                            | CloudWatch Logs                |
-| enable-all-regions                         | Cloudtrail should be enabled   |
-|                                            | in all regions regardless of   |
-|                                            | where your AWS resources are   |
-|                                            | generally homed                |
-| require-bucket-access-logging              | You should enable bucket       |
-|                                            | access logging on the          |
-|                                            | CloudTrail S3 bucket.          |
-| require-unauthorised-api-call-alarm        | Ensure a log metric filter and |
-|                                            | alarm exist for unauthorized   |
-|                                            | API calls                      |
-| require-sg-change-alarms                   | Ensure a log metric filter and |
-|                                            | alarm exist for security group |
-|                                            | changes                        |
-| require-nacl-changes-alarm                 | Ensure a log metric filter     |
-|                                            | and alarm exist for changes to |
-|                                            | Network Access Control Lists   |
-|                                            | (NACL)                         |
-| require-network-gateway-changes-alarm      | Ensure a log metric filter     |
-|                                            | and alarm exist for changes to |
-|                                            | network gateways               |
-| require-network-gateway-changes-alarm      | Ensure a log metric filter and |
-|                                            | alarm exist for route table    |
-|                                            | changes                        |
-| require-vpc-changes-alarm                  | Ensure a log metric filter and |
-|                                            | alarm exist for VPC changes    |
-| require-non-mfa-login-alarm                | Ensure a log metric filter and |
-|                                            | alarm exist for AWS Management |
-|                                            | Console sign-in without MFA    |
-| require-root-user-usage-alarm              | Ensure a log metric filter and |
-|                                            | alarm exist for usage of root  |
-|                                            | user                           |
-| require-iam-policy-change-alarm            | Ensure a log metric filter     |
-|                                            | and alarm exist for IAM policy |
-|                                            | changes                        |
-| require-cloud-trail-change-alarm           | Ensure a log metric filter     |
-|                                            | and alarm exist for CloudTrail |
-|                                            | configuration changes          |
-| require-console-login-failures-alarm       | Ensure a log metric filter and |
-|                                            | alarm exist for AWS Management |
-|                                            | Console authentication         |
-|                                            | failures                       |
-| require-cmk-disabled-alarm                 | Ensure a log metric filter and |
-|                                            | alarm exist for disabling or   |
-|                                            | scheduled deletion of customer |
-|                                            | managed keys                   |
-| require-s3-bucket-policy-change-alarm      | Ensure a log metric filter     |
-|                                            | and alarm exist for S3 bucket  |
-|                                            | policy changes                 |
-| require-config-configuration-changes-alarm | Ensure a log metric filter     |
-|                                            | and alarm exist for AWS Config |
-|                                            | configuration changes          |
-| no-public-ingress-sgr                      | An ingress security group rule |
-|                                            | allows traffic from /0.        |
-+--------------------------------------------+--------------------------------+
-```
-
-
-[AWS CIS Foundations Benchmark v1.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html) validates the following control checks:
-```shell
-+--------------------------------------------+--------------------------------+
-|                    NAME                    |          DESCRIPTION           |
-+--------------------------------------------+--------------------------------+
-| require-mfa-delete                         | Buckets should have MFA        |
-|                                            | deletion protection enabled.   |
-| disable-unused-credentials-45-days         | AWS IAM users can access AWS   |
-|                                            | resources using different      |
-|                                            | types of credentials, such     |
-|                                            | as passwords or access keys.   |
-|                                            | It is recommended that all     |
-|                                            | credentials that have been     |
-|                                            | unused in 45 or greater days   |
-|                                            | be deactivated or removed.     |
-| limit-user-access-keys                     | No user should have more than  |
-|                                            | one active access key.         |
-| rotate-access-keys                         | Access keys should be rotated  |
-|                                            | at least every 90 days         |
-| no-user-attached-policies                  | IAM policies should not be     |
-|                                            | granted directly to users.     |
-| no-policy-wildcards                        | IAM policy should avoid use    |
-|                                            | of wildcards and instead       |
-|                                            | apply the principle of least   |
-|                                            | privilege                      |
-| require-support-role                       | Missing IAM Role to allow      |
-|                                            | authorized users to manage     |
-|                                            | incidents with AWS Support.    |
-| remove-expired-certificates                | Delete expired TLS             |
-|                                            | certificates                   |
-| enable-access-analyzer                     | Enable IAM Access analyzer     |
-|                                            | for IAM policies about all     |
-|                                            | resources in each region.      |
-| enforce-user-mfa                           | IAM Users should have MFA      |
-|                                            | enforcement activated.         |
-| no-root-access-keys                        | The root user has complete     |
-|                                            | access to all services and     |
-|                                            | resources in an AWS account.   |
-|                                            | AWS Access Keys provide        |
-|                                            | programmatic access to a given |
-|                                            | account.                       |
-| enforce-root-mfa                           | The "root" account has         |
-|                                            | unrestricted access to all     |
-|                                            | resources in the AWS account.  |
-|                                            | It is highly recommended that  |
-|                                            | this account have MFA enabled. |
-| enforce-root-hardware-mfa                  | The "root" account has         |
-|                                            | unrestricted access to all     |
-|                                            | resources in the AWS account.  |
-|                                            | It is highly recommended that  |
-|                                            | this account have hardware MFA |
-|                                            | enabled.                       |
-| limit-root-account-usage                   | The "root" account has         |
-|                                            | unrestricted access to all     |
-|                                            | resources in the AWS account.  |
-|                                            | It is highly recommended that  |
-|                                            | the use of this account be     |
-|                                            | avoided.                       |
-| set-minimum-password-length                | IAM Password policy should     |
-|                                            | have minimum password length   |
-|                                            | of 14 or more characters.      |
-| no-password-reuse                          | IAM Password policy should     |
-|                                            | prevent password reuse.        |
-| enable-object-write-logging                | S3 object-level API            |
-|                                            | operations such as GetObject,  |
-|                                            | DeleteObject, and PutObject    |
-|                                            | are called data events. By     |
-|                                            | default, CloudTrail trails     |
-|                                            | don't log data events and so   |
-|                                            | it is recommended to enable    |
-|                                            | Object-level logging for S3    |
-|                                            | buckets.                       |
-| enable-object-read-logging                 | S3 object-level API            |
-|                                            | operations such as GetObject,  |
-|                                            | DeleteObject, and PutObject    |
-|                                            | are called data events. By     |
-|                                            | default, CloudTrail trails     |
-|                                            | don't log data events and so   |
-|                                            | it is recommended to enable    |
-|                                            | Object-level logging for S3    |
-|                                            | buckets.                       |
-| no-public-log-access                       | The S3 Bucket backing          |
-|                                            | Cloudtrail should be private   |
-| ensure-cloudwatch-integration              | CloudTrail logs should be      |
-|                                            | stored in S3 and also sent to  |
-|                                            | CloudWatch Logs                |
-| require-bucket-access-logging              | You should enable bucket       |
-|                                            | access logging on the          |
-|                                            | CloudTrail S3 bucket.          |
-| require-sg-change-alarms                   | Ensure a log metric filter and |
-|                                            | alarm exist for security group |
-|                                            | changes                        |
-| require-unauthorised-api-call-alarm        | Ensure a log metric filter and |
-|                                            | alarm exist for unauthorized   |
-|                                            | API calls                      |
-| require-nacl-changes-alarm                 | Ensure a log metric filter     |
-|                                            | and alarm exist for changes to |
-|                                            | Network Access Control Lists   |
-|                                            | (NACL)                         |
-| require-network-gateway-changes-alarm      | Ensure a log metric filter     |
-|                                            | and alarm exist for changes to |
-|                                            | network gateways               |
-| require-network-gateway-changes-alarm      | Ensure a log metric filter and |
-|                                            | alarm exist for route table    |
-|                                            | changes                        |
-| require-vpc-changes-alarm                  | Ensure a log metric filter and |
-|                                            | alarm exist for VPC changes    |
-| require-org-changes-alarm                  | Ensure a log metric filter and |
-|                                            | alarm exist for organisation   |
-|                                            | changes                        |
-| require-non-mfa-login-alarm                | Ensure a log metric filter and |
-|                                            | alarm exist for AWS Management |
-|                                            | Console sign-in without MFA    |
-| require-root-user-usage-alarm              | Ensure a log metric filter and |
-|                                            | alarm exist for usage of root  |
-|                                            | user                           |
-| require-iam-policy-change-alarm            | Ensure a log metric filter     |
-|                                            | and alarm exist for IAM policy |
-|                                            | changes                        |
-| require-cloud-trail-change-alarm           | Ensure a log metric filter     |
-|                                            | and alarm exist for CloudTrail |
-|                                            | configuration changes          |
-| require-console-login-failures-alarm       | Ensure a log metric filter and |
-|                                            | alarm exist for AWS Management |
-|                                            | Console authentication         |
-|                                            | failures                       |
-| require-cmk-disabled-alarm                 | Ensure a log metric filter and |
-|                                            | alarm exist for disabling or   |
-|                                            | scheduled deletion of customer |
-|                                            | managed keys                   |
-| require-s3-bucket-policy-change-alarm      | Ensure a log metric filter     |
-|                                            | and alarm exist for S3 bucket  |
-|                                            | policy changes                 |
-| require-config-configuration-changes-alarm | Ensure a log metric filter     |
-|                                            | and alarm exist for AWS Config |
-|                                            | configuration changes          |
-| restrict-all-in-default-sg                 | Default security group should  |
-|                                            | restrict all traffic           |
-+--------------------------------------------+--------------------------------+
-```
-
-[Differences between v1.2 and v1.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-cis1.4-vs-cis1.2.html)
 
 ## CLI Commands
 
-Scan for misconfigurations in an AWS account based on AWS CIS 1.2 benchmark:
-
-```shell
-$ trivy aws --compliance=aws-cis-1.2
-
-arn:aws:iam::123456789:user/DummyRoleManager (cloud)
-
-Tests: 1 (SUCCESSES: 0, FAILURES: 1, EXCEPTIONS: 0)
-
-LOW: One or more policies are attached directly to a user
-══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-CIS recommends that you apply IAM policies directly to groups and roles but not users. Assigning privileges at the group or role level reduces the complexity of access management as the number of users grow. Reducing access management complexity might in turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.
-
-See https://avd.aquasec.com/misconfig/avd-aws-0143
-──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
+Scan a cloud accoung and generate a compliance summary report:
 
 ```
-
-
-
-You can also summarize the report to get a full compliance report with all the included checks.
-```shell
-$ trivy aws --compliance=aws-cis-1.2 --report=summary
+$ trivy aws --compliance=awscis1.2 --report=summary
 ```
 
-```shell
-Summary Report for compliance: AWS CIS Foundations v1.2
+```
+Summary Report for compliance: awscis1.2
 ┌──────┬──────────┬────────────────────────────────────────────┬────────┬────────┐
 │  ID  │ Severity │                Control Name                │ Status │ Issues │
 ├──────┼──────────┼────────────────────────────────────────────┼────────┼────────┤
@@ -333,6 +57,7 @@ Summary Report for compliance: AWS CIS Foundations v1.2
 └──────┴──────────┴────────────────────────────────────────────┴────────┴────────┘
 ```
 
+<<<<<<< HEAD
 
 Furthermore, you can also get the report in a JSON format.
 ```shell
@@ -396,8 +121,32 @@ spec:
 ## Custom report CLI Commands
 
 To use a custom spec, the file path should be passed to the `--compliance` flag with `@` prefix as follows:
+=======
+***Note*** : The `Issues` column represent the total number of failed checks for this control.
+
+
+Get all of the detailed output for checks:
+>>>>>>> 499209ca8 (docs: improve compliance docs)
 
 ```
-$ trivy aws --compliance=@/spec/my_compliance.yaml
+$ trivy aws --compliance=awscis1.2 --report all
 ```
 
+Report result in JSON format:
+
+```
+$ trivy aws --compliance=awscis1.2 --report all --format json
+```
+
+```
+$ trivy k8s cluster --compliance=nsa --report all --format json
+```
+
+## Built in reports
+
+the following reports out of the box:
+
+| Compliance | Name for command | More info
+--- | --- | ---
+AWS CIS Foundations Benchmark v1.2 | `awscis1.2` | [link](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf)
+AWS CIS Foundations Benchmark v1.4 | `awscis1.4` | [link](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html)

--- a/docs/docs/cloud/aws/compliance.md
+++ b/docs/docs/cloud/aws/compliance.md
@@ -1,7 +1,5 @@
 # AWS Compliance
 
-# Kubernetes Compliance
-
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.
 

--- a/docs/docs/cloud/aws/compliance.md
+++ b/docs/docs/cloud/aws/compliance.md
@@ -8,136 +8,25 @@ This page describes AWS specific compliance reports. For an overview of Trivy's 
 
 ## CLI Commands
 
-Scan a cloud accoung and generate a compliance summary report:
+Scan a cloud account and generate a compliance summary report:
 
 ```
-$ trivy aws --compliance=awscis1.2 --report=summary
+$ trivy aws --compliance=<compliance_id> --report=summary
 ```
 
-```
-Summary Report for compliance: awscis1.2
-┌──────┬──────────┬────────────────────────────────────────────┬────────┬────────┐
-│  ID  │ Severity │                Control Name                │ Status │ Issues │
-├──────┼──────────┼────────────────────────────────────────────┼────────┼────────┤
-│ 1.1  │ LOW      │          limit-root-account-usage          │  PASS  │   0    │
-│ 1.10 │ MEDIUM   │             no-password-reuse              │  PASS  │   0    │
-│ 1.11 │ MEDIUM   │            set-max-password-age            │  PASS  │   0    │
-│ 1.12 │ CRITICAL │            no-root-access-keys             │  PASS  │   0    │
-│ 1.13 │ CRITICAL │              enforce-root-mfa              │  PASS  │   0    │
-│ 1.16 │ LOW      │         no-user-attached-policies          │  FAIL  │   5    │
-│ 1.2  │ MEDIUM   │              enforce-user-mfa              │  PASS  │   0    │
-│ 1.3  │ MEDIUM   │         disable-unused-credentials         │  FAIL  │   2    │
-│ 1.4  │ LOW      │             rotate-access-keys             │  FAIL  │   7    │
-│ 1.5  │ MEDIUM   │       require-uppercase-in-passwords       │  PASS  │   0    │
-│ 1.6  │ MEDIUM   │       require-lowercase-in-passwords       │  PASS  │   0    │
-│ 1.7  │ MEDIUM   │        require-symbols-in-passwords        │  PASS  │   0    │
-│ 1.8  │ MEDIUM   │        require-numbers-in-passwords        │  PASS  │   0    │
-│ 1.9  │ MEDIUM   │        set-minimum-password-length         │  FAIL  │   1    │
-│ 2.3  │ CRITICAL │            no-public-log-access            │  PASS  │   0    │
-│ 2.4  │ LOW      │       ensure-cloudwatch-integration        │  PASS  │   0    │
-│ 2.5  │ MEDIUM   │             enable-all-regions             │  PASS  │   0    │
-│ 2.6  │ LOW      │       require-bucket-access-logging        │  PASS  │   0    │
-│ 3.1  │ LOW      │    require-unauthorised-api-call-alarm     │  PASS  │   0    │
-│ 3.10 │ LOW      │          require-sg-change-alarms          │  PASS  │   0    │
-│ 3.11 │ LOW      │         require-nacl-changes-alarm         │  PASS  │   0    │
-│ 3.12 │ LOW      │   require-network-gateway-changes-alarm    │  PASS  │   0    │
-│ 3.13 │ LOW      │   require-network-gateway-changes-alarm    │  PASS  │   0    │
-│ 3.14 │ LOW      │         require-vpc-changes-alarm          │  PASS  │   0    │
-│ 3.2  │ LOW      │        require-non-mfa-login-alarm         │  PASS  │   0    │
-│ 3.3  │ LOW      │       require-root-user-usage-alarm        │  PASS  │   0    │
-│ 3.4  │ LOW      │      require-iam-policy-change-alarm       │  PASS  │   0    │
-│ 3.5  │ LOW      │      require-cloud-trail-change-alarm      │  PASS  │   0    │
-│ 3.6  │ LOW      │    require-console-login-failures-alarm    │  PASS  │   0    │
-│ 3.7  │ LOW      │         require-cmk-disabled-alarm         │  PASS  │   0    │
-│ 3.8  │ LOW      │   require-s3-bucket-policy-change-alarm    │  PASS  │   0    │
-│ 3.9  │ LOW      │ require-config-configuration-changes-alarm │  PASS  │   0    │
-│ 4.1  │ CRITICAL │           no-public-ingress-sgr            │  PASS  │   0    │
-└──────┴──────────┴────────────────────────────────────────────┴────────┴────────┘
-```
-
-<<<<<<< HEAD
-
-Furthermore, you can also get the report in a JSON format.
-```shell
-$ trivy aws --compliance=aws-cis-1.2 --report=summary --format=json
-```
-
-```json
-{
-  "ID": "aws-cis-1.2",
-  "Title": "AWS CIS Foundations",
-  "SummaryControls": [
-    {
-      "ID": "1.1",
-      "Name": "limit-root-account-usage",
-      "Severity": "LOW",
-      "TotalFail": 5
-    },
-    {
-      "ID": "1.10",
-      "Name": "no-password-reuse",
-      "Severity": "MEDIUM",
-      "TotalFail": 1
-    }
-  ]
-}
-```
-
-
-## Custom compliance report
-
-The Trivy AWS CLI allows you to create a custom compliance specification and pass it to trivy for generating scan report.
-
-The report is generated based on scanning result mapping between users define controls and trivy checks ID.
-The supported checks are from two types and can be found at [Aqua vulnerability DB](https://avd.aquasec.com/):
-- [misconfiguration](https://avd.aquasec.com/misconfig/)
-
-### Compliance spec format
-The compliance spec file format should be as follows:
-
-
-```yaml
----
-spec:
-  id: aws-cis-1.2
-  title: AWS CIS Foundations
-  description: AWS CIS Foundations
-  version: "1.2"
-  relatedResources:
-  - https://www.cisecurity.org/benchmark/amazon_web_services
-  controls:
-  - id: "1.1"
-    name: limit-root-account-usage
-    description: |-
-      The "root" account has unrestricted access to all resources in the AWS account. It is highly
-      recommended that the use of this account be avoided.
-    checks:
-    - id: AVD-AWS-0140
-    severity: LOW
-```
-
-## Custom report CLI Commands
-
-To use a custom spec, the file path should be passed to the `--compliance` flag with `@` prefix as follows:
-=======
 ***Note*** : The `Issues` column represent the total number of failed checks for this control.
 
 
 Get all of the detailed output for checks:
->>>>>>> 499209ca8 (docs: improve compliance docs)
 
 ```
-$ trivy aws --compliance=awscis1.2 --report all
+$ trivy aws --compliance=<compliance_id> --report all
 ```
 
 Report result in JSON format:
 
 ```
-$ trivy aws --compliance=awscis1.2 --report all --format json
-```
-
-```
-$ trivy k8s cluster --compliance=nsa --report all --format json
+$ trivy aws --compliance=<compliance_id> --report all --format json
 ```
 
 ## Built in reports
@@ -146,5 +35,5 @@ the following reports out of the box:
 
 | Compliance | Name for command | More info
 --- | --- | ---
-AWS CIS Foundations Benchmark v1.2 | `awscis1.2` | [link](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf)
-AWS CIS Foundations Benchmark v1.4 | `awscis1.4` | [link](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html)
+AWS CIS Foundations Benchmark v1.2 | `aws-cis-1.2` | [link](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf)
+AWS CIS Foundations Benchmark v1.4 | `aws-cis-1.4` | [link](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html)

--- a/docs/docs/cloud/aws/compliance.md
+++ b/docs/docs/cloud/aws/compliance.md
@@ -5,8 +5,16 @@
 
 This page describes AWS specific compliance reports. For an overview of Trivy's Compliance feature, including working with custom compliance, check out the [Compliance documentation](../../compliance/compliance.md).
 
+## Built in reports
 
-## CLI Commands
+the following reports are available out of the box:
+
+| Compliance | Name for command | More info
+--- | --- | ---
+AWS CIS Foundations Benchmark v1.2 | `aws-cis-1.2` | [link](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf)
+AWS CIS Foundations Benchmark v1.4 | `aws-cis-1.4` | [link](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html)
+
+## Examples
 
 Scan a cloud account and generate a compliance summary report:
 
@@ -29,11 +37,3 @@ Report result in JSON format:
 $ trivy aws --compliance=<compliance_id> --report all --format json
 ```
 
-## Built in reports
-
-the following reports out of the box:
-
-| Compliance | Name for command | More info
---- | --- | ---
-AWS CIS Foundations Benchmark v1.2 | `aws-cis-1.2` | [link](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf)
-AWS CIS Foundations Benchmark v1.4 | `aws-cis-1.4` | [link](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html)

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -5,6 +5,26 @@
 
 Trivy’s compliance flag lets you curate a specific set of checks into a report. In a typical Trivy scan, there are hundreds of different checks for many different components and configurations, but sometimes you already know which specific checks you are interested in. Often this would be an industry accepted set of checks such as CIS, or some vendor specific guideline, or your own organization policy that you want to comply with. These are all possible using the flexible compliance infrastructure that's built into Trivy. Compliance reports are defined as simple YAML documents that select checks to include in the report.
 
+## Usage
+
+Compliance report is currently supported in the following targets (trivy sub-commands):
+
+- `trivy aws`
+- `trivy k8s`
+
+Add the `--compliance` flag to the command line, and set it's value to desired report. For example: `trivy k8s cluster --compliance k8s-nsa` (see below for built-in and custom reports)
+
+### Options
+
+The following flags are compatible with `--compliance` flag and allows customizing it's output:
+
+flag | effect
+--- | ---
+`--report summary` | shows a summary of the results. for every control shows the number of failed checks.
+`--report all` | shows fully detailed results. for every control shows where it failed and why.
+`--format table` | shows results in textual table format (good for human readability).
+`--reoirt json` | shows results in json format (good for machine readability).
+
 ## Built-in compliance
 
 Trivy has a number of built-in compliance reports that you can asses right out of the box.

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -23,7 +23,7 @@ flag | effect
 `--report summary` | shows a summary of the results. for every control shows the number of failed checks.
 `--report all` | shows fully detailed results. for every control shows where it failed and why.
 `--format table` | shows results in textual table format (good for human readability).
-`--reoirt json` | shows results in json format (good for machine readability).
+`--format json` | shows results in json format (good for machine readability).
 
 ## Built-in compliance
 

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -3,38 +3,37 @@
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.
 
-Trivy’s compliance flag lets you curate a specific set of checks into one report. In a typical Trivy scan, we make hundreds of different checks for many different components and configurations, but sometimes you already know which specific set of checks that you want to verify. Often this would be an industry accepted set of checks such as CIS, or some vendor specific guideline, or your own organization policy that you want to comply with. These are all possible using the flexible compliance infrastructure that's built into Trivy. Compliance reports are defined as simple YAML documents that select checks to add to the report.
+Trivy’s compliance flag lets you curate a specific set of checks into a report. In a typical Trivy scan, there are hundreds of different checks for many different components and configurations, but sometimes you already know which specific checks you are interested in. Often this would be an industry accepted set of checks such as CIS, or some vendor specific guideline, or your own organization policy that you want to comply with. These are all possible using the flexible compliance infrastructure that's built into Trivy. Compliance reports are defined as simple YAML documents that select checks to include in the report.
 
 ## Built-in compliance
 
 Trivy has a number of built-in compliance reports that you can asses right out of the box.
-to specify a built-in compliance report, select it by name like `trivy --compliance <compliance_name>`.
-These are described under each specific target, for example:
+to specify a built-in compliance report, select it by ID like `trivy --compliance <compliance_id>`.
+
+For the list of built-in compliance reports, please see the relevant section:
 
 - [Kubernetes compliance](../kubernetes/cli/compliance.md) 
 - [AWS compliance](../cloud/aws/compliance.md)
 
 ## Custom compliance
 
-You can create custom compliance specification. Create a compliance spec, and select it by file path like `trivy --compliance @</path/to/compliance.yaml>` (note the `@` indicating file path instead of report name).
-
-### Compliance spec format
+You can create your own custom compliance report. A compliance report is a simple YAML document in the following format:
 
 ```yaml
 spec:
-  id: "0001" # report unique identifier
-  title: nsa # report title 
-  description: "National Security Agency - Kubernetes Hardening Guidance" # description of the report
+  id: "k8s-myreport" # report unique identifier. this should not container spaces.
+  title: "My custom Kubernetes report" # report title. Any one-line title.
+  description: "Describe your report" # description of the report. Any text.
   relatedResources :
-    - https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/ # reference is related to public or internal spec
-  version: "1.0" # spec version
+    - https://some.url # useful references. URLs only.
+  version: "1.0" # spec version (string)
   controls:
-    - name: "Non-root containers" # short control naming
-      description: 'Check that container is not running as root' # long control description
-      id: "1.0" # control identifier 
-      checks:   # list of trivy checks which associated to control
-        - id: AVD-KSV-0012 # check ID (midconfiguration ot vulnerability) must start with `AVD-` or `CVE-` 
-      severity: "MEDIUM" # control severity
+    - name: "Non-root containers" # Name for the control (appears in the report as is). Any one-line name.
+      description: 'Check that container is not running as root' # Description (appears in the report as is). Any text.
+      id: "1.0" # control identifier (string)
+      checks:   # list of existing Trivy checks that define the control
+        - id: AVD-KSV-0012 # check ID. Must start with `AVD-` or `CVE-` 
+      severity: "MEDIUM" # Severity for the control (note that checks severity isn't used)
     - name: "Immutable container file systems"
       description: 'Check that container root file system is immutable'
       id: "1.1"
@@ -43,4 +42,6 @@ spec:
       severity: "LOW"
 ```
 
-The check id field (`controls[].checks[].id`) is referencing an existing check by it's "AVD ID". This is easily located in the check's source code metadata header, or by browsing checks in [Aqua vulnerability DB](https://avd.aquasec.com/), specifically in the [Misconfigurations](https://avd.aquasec.com/misconfig/) and [Vulnerabilities](https://avd.aquasec.com/nvd) sections.
+The check id field (`controls[].checks[].id`) is referring to existing check by it's "AVD ID". This AVD ID is easily located in the check's source code metadata header, or by browsing [Aqua vulnerability DB](https://avd.aquasec.com/), specifically in the [Misconfigurations](https://avd.aquasec.com/misconfig/) and [Vulnerabilities](https://avd.aquasec.com/nvd) sections.
+
+Once you have a compliance spec, you can select it by file path: `trivy --compliance @</path/to/compliance.yaml>` (note the `@` indicating file path instead of report id).

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -1,9 +1,46 @@
 # Compliance Reports
 
-Trivy supports producing compliance reports.
+!!! warning "EXPERIMENTAL"
+    This feature might change without preserving backwards compatibility.
 
-## Supported reports
+Trivy’s compliance flag lets you curate a specific set of checks into one report. In a typical Trivy scan, we make hundreds of different checks for many different components and configurations, but sometimes you already know which specific set of checks that you want to verify. Often this would be an industry accepted set of checks such as CIS, or some vendor specific guideline, or your own organization policy that you want to comply with. These are all possible using the flexible compliance infrastructure that's built into Trivy. Compliance reports are defined as simple YAML documents that select checks to add to the report.
 
-- [NSA, CISA Kubernetes Hardening Guidance v1.0](../kubernetes/cli/compliance.md)
-- [CIS Benchmark for Kubernetes v1.23](../kubernetes/cli/compliance.md)
-- [AWS CIS v1.2 and v1.4](../cloud/aws/compliance.md)
+## Built-in compliance
+
+Trivy has a number of built-in compliance reports that you can asses right out of the box.
+to specify a built-in compliance report, select it by name like `trivy --compliance <compliance_name>`.
+These are described under each specific target, for example:
+
+- [Kubernetes compliance](../kubernetes/cli/compliance.md) 
+- [AWS compliance](../cloud/aws/compliance.md)
+
+## Custom compliance
+
+You can create custom compliance specification. Create a compliance spec, and select it by file path like `trivy --compliance @</path/to/compliance.yaml>` (note the `@` indicating file path instead of report name).
+
+### Compliance spec format
+
+```yaml
+spec:
+  id: "0001" # report unique identifier
+  title: nsa # report title 
+  description: "National Security Agency - Kubernetes Hardening Guidance" # description of the report
+  relatedResources :
+    - https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/ # reference is related to public or internal spec
+  version: "1.0" # spec version
+  controls:
+    - name: "Non-root containers" # short control naming
+      description: 'Check that container is not running as root' # long control description
+      id: "1.0" # control identifier 
+      checks:   # list of trivy checks which associated to control
+        - id: AVD-KSV-0012 # check ID (midconfiguration ot vulnerability) must start with `AVD-` or `CVE-` 
+      severity: "MEDIUM" # control severity
+    - name: "Immutable container file systems"
+      description: 'Check that container root file system is immutable'
+      id: "1.1"
+      checks:
+        - id: AVD-KSV-0014
+      severity: "LOW"
+```
+
+The check id field (`controls[].checks[].id`) is referencing an existing check by it's "AVD ID". This is easily located in the check's source code metadata header, or by browsing checks in [Aqua vulnerability DB](https://avd.aquasec.com/), specifically in the [Misconfigurations](https://avd.aquasec.com/misconfig/) and [Vulnerabilities](https://avd.aquasec.com/nvd) sections.

--- a/docs/docs/kubernetes/cli/compliance.md
+++ b/docs/docs/kubernetes/cli/compliance.md
@@ -40,5 +40,3 @@ trivy k8s cluster --compliance=<compliance_id> --report summary --format json
 ```
 trivy k8s cluster --compliance=<compliance_id> --report all --format json
 ```
-
-

--- a/docs/docs/kubernetes/cli/compliance.md
+++ b/docs/docs/kubernetes/cli/compliance.md
@@ -5,8 +5,16 @@
 
 This page describes Kubernetes specific compliance reports. For an overview of Trivy's Compliance feature, including working with custom compliance, check out the [Compliance documentation](../../compliance/compliance.md).
 
+## Built in reports
 
-## CLI Commands
+The following reports are available out of the box:
+
+| Compliance | Name for command | More info
+--- | --- | ---
+NSA, CISA Kubernetes Hardening Guidance v1.2 | `k8s-nsa` | [Link](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)
+CIS Benchmark for Kubernetes v1.23 | `k8s-cis` | [Link](https://www.cisecurity.org/benchmark/kubernetes)
+
+## Examples
 
 Scan a full cluster and generate a compliance summary report:
 
@@ -33,11 +41,4 @@ trivy k8s cluster --compliance=<compliance_id> --report summary --format json
 trivy k8s cluster --compliance=<compliance_id> --report all --format json
 ```
 
-## Built in reports
 
-the following reports out of the box:
-
-| Compliance | Name for command | More info
---- | --- | ---
-NSA, CISA Kubernetes Hardening Guidance v1.2 | `k8s-nsa` | [Link](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)
-CIS Benchmark for Kubernetes v1.23 | `k8s-cis` | [Link](https://www.cisecurity.org/benchmark/kubernetes)

--- a/docs/docs/kubernetes/cli/compliance.md
+++ b/docs/docs/kubernetes/cli/compliance.md
@@ -11,7 +11,7 @@ This page describes Kubernetes specific compliance reports. For an overview of T
 Scan a full cluster and generate a compliance summary report:
 
 ```
-$ trivy k8s cluster --compliance=<compliance_name> --report summary
+$ trivy k8s cluster --compliance=<compliance_id> --report summary
 ```
 
 ***Note*** : The `Issues` column represent the total number of failed checks for this control.
@@ -20,17 +20,17 @@ $ trivy k8s cluster --compliance=<compliance_name> --report summary
 Get all of the detailed output for checks:
 
 ```
-trivy k8s cluster --compliance=k8s-cis --report all
+trivy k8s cluster --compliance=<compliance_id> --report all
 ```
 
 Report result in JSON format:
 
 ```
-trivy k8s cluster --compliance=k8s-nsa --report summary --format json
+trivy k8s cluster --compliance=<compliance_id> --report summary --format json
 ```
 
 ```
-trivy k8s cluster --compliance=k8s-cis --report all --format json
+trivy k8s cluster --compliance=<compliance_id> --report all --format json
 ```
 
 ## Built in reports
@@ -39,5 +39,5 @@ the following reports out of the box:
 
 | Compliance | Name for command | More info
 --- | --- | ---
-NSA, CISA Kubernetes Hardening Guidance v1.2 | `nsa` | [Link](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)
-CIS Benchmark for Kubernetes v1.23 | `cis` | [Link](https://www.cisecurity.org/benchmark/kubernetes)
+NSA, CISA Kubernetes Hardening Guidance v1.2 | `k8s-nsa` | [Link](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)
+CIS Benchmark for Kubernetes v1.23 | `k8s-cis` | [Link](https://www.cisecurity.org/benchmark/kubernetes)

--- a/docs/docs/kubernetes/cli/compliance.md
+++ b/docs/docs/kubernetes/cli/compliance.md
@@ -3,23 +3,27 @@
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.
 
-</details>
+This page describes Kubernetes specific compliance reports. For an overview of Trivy's Compliance feature, including working with custom compliance, check out the [Compliance documentation](../../compliance/compliance.md).
+
+
 ## CLI Commands
-Scan a full cluster and generate a complliance NSA / CIS Kubernetes Benchmark summary report:
-Supported spec IDs: `k8s-nsa` , `k8s-cis`
+
+Scan a full cluster and generate a compliance summary report:
+
 ```
-trivy k8s cluster --compliance=k8s-nsa --report summary
+$ trivy k8s cluster --compliance=<compliance_name> --report summary
 ```
 
 ***Note*** : The `Issues` column represent the total number of failed checks for this control.
 
-An additional report is supported to get all of the detail the output contains, use `--report all`
+
+Get all of the detailed output for checks:
 
 ```
 trivy k8s cluster --compliance=k8s-cis --report all
 ```
 
-Report also supported in json format examples :
+Report result in JSON format:
 
 ```
 trivy k8s cluster --compliance=k8s-nsa --report summary --format json
@@ -29,173 +33,11 @@ trivy k8s cluster --compliance=k8s-nsa --report summary --format json
 trivy k8s cluster --compliance=k8s-cis --report all --format json
 ```
 
-## Custom compliance report
-The Trivy K8s CLI allows you to create a custom compliance specification and pass it to trivy for generating scan report .
+## Built in reports
 
-The supported checks are from two types and can be found at [Aqua vulnerability DB](https://avd.aquasec.com/):
+the following reports out of the box:
 
-- [misconfiguration](https://avd.aquasec.com/misconfig/)
-- [vulnerabilities](https://avd.aquasec.com/nvd)
-
-### Compliance spec format
-
-The compliance spec file format should look as follow :
-
-```yaml
----
-spec:
-  id: "0001" # report unique identifier
-  title: nsa # report title 
-  description: National Security Agency - Kubernetes Hardening Guidance # description of the report
-  relatedResources :
-    - https://www.nsa.gov/Press-Room/News-Highlights/Article/Article/2716980/nsa-cisa-release-kubernetes-hardening-guidance/ # reference is related to public or internal spec
-  version: "1.0" # spec version
-  controls:
-    - name: Non-root containers # short control naming
-      description: 'Check that container is not running as root' # long control description
-      id: '1.0' # control identifier 
-      checks:   # list of trivy checks which associated to control
-        - id: AVD-KSV-0012 # check ID (midconfiguration ot vulnerability) must start with `AVD-` or `CVE-` 
-      severity: 'MEDIUM' # control severity
-    - name: Immutable container file systems
-      description: 'Check that container root file system is immutable'
-      id: '1.1'
-      checks:
-        - id: AVD-KSV-0014
-      severity: 'LOW'
-```
-
-## Custom report CLI Commands
-
-To generate the custom report, an custom spec file path should be passed to the `--compliance` flag with `@` prefix as follow:
-
-```
-trivy k8s cluster --compliance=@/spec/my_complaince.yaml --report summary
-```
-
-The Trivy K8s CLI allows you to scan your Kubernetes cluster resources and generate the `NSA, CISA Kubernetes Hardening Guidance` report
-
-## NSA Compliance Report
-
-[NSA, CISA Kubernetes Hardening Guidance v1.2](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF) cybersecurity technical report is produced by trivy and validate the following control checks :
-
-<details>
-<summary>NSA Control Checks</summary>
-```
-| ID    | Name                                                                                                    |
-|-------|---------------------------------------------------------------------------------------------------------|
-| 1.0   | Check that container is not running as root                                                             |
-| 1.1   | Check that container root file system is immutable                                                      |
-| 1.2   | Controls whether Pods can run privileged containers                                                     |
-| 1.3   | Controls whether containers can share process namespaces                                                |
-| 1.4   | Controls whether share host process namespaces                                                          |
-| 1.5   | Controls whether containers can use the host network                                                    |
-| 1.6   | Controls whether container applications can run with <br/>root privileges or with root group membership |
-| 1.7   | Control check restrictions escalation to root privileges                                                |
-| 1.8   | Control checks if pod sets the SELinux context of the container                                         |
-| 1.9   | Control checks the restriction of containers access to resources with AppArmor                          |
-| 1.10  | Control checks the sets the seccomp profile used to sandbox containers                                  |
-| 1.11  | Control check whether disable secret token been mount ,automountServiceAccountToken: false              |
-| 1.12  | Control check whether Namespace kube-system is not be used by users                                     |
-| 2.0   | Control check validate the pod and/or namespace Selectors usage                                         |
-| 3.0   | Control check whether check cni plugin installed                                                        |
-| 4.0   | Control check the use of ResourceQuota policy to limit aggregate resource usage within namespace        |
-| 4.1   | Control check the use of LimitRange policy limit resource usage for namespaces or nodes                 |
-| 5.0   | Control check whether control plan disable insecure port                                                |
-| 5.1   | Control check whether etcd communication is encrypted                                                   |
-| 6.0   | Control check whether kube config file permissions                                                      |
-| 6.1   | Control checks whether encryption resource has been set                                                 |
-| 6.2   | Control checks whether encryption provider has been set                                                 |
-| 7.0   | Control checks whether anonymous-auth is unset                                                          |
-| 7.1   | Control check whether RBAC permission is in use                                                         |
-| 8.0   | Control check whether audit policy is configure                                                         |
-| 8.1   | Control check whether audit log path is configure                                                       |
-| 8.2   | Control check whether audit log aging is configure                                                      |
-```
-</details>
-
-## CIS Bebchmark Report
-
-The Trivy K8s CLI allows you to scan your Kubernetes cluster resources and generate the `CIS Kubernetes Benchmark` report
-
-[CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) report is produced by trivy and validate the following control checks :
-
-<details>
-<summary>CIS Benchmark Control Checks</summary>
-```
-| ID     | Name                                                                                                   |
-| ------ | ------------------------------------------------------------------------------------------------------ |
-| 1.2.1  | Ensure that the --anonymous-auth argument is set to false                                              | server                                                                                                            |
-| 1.2.2  | Ensure that the --token-auth-file parameter is not set                                                 |
-| 1.2.3  | Ensure that the --DenyServiceExternalIPs is not set                                                    |
-| 1.2.4  | Ensure that the --kubelet-https argument is set to true                                                |
-| 1.2.5  | Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set                |
-| 1.2.6  | Ensure that the --kubelet-certificate-authority argument is set as appropriate                         |
-| 1.2.7  | Ensure that the --authorization-mode argument is not set to AlwaysAllow                                |
-| 1.2.8  | Ensure that the --authorization-mode argument includes Node                                            |
-| 1.2.9  | Ensure that the --authorization-mode argument includes RBAC                                            |
-| 1.2.10 | Ensure that the admission control plugin EventRateLimit is set                                         |
-| 1.2.11 | Ensure that the admission control plugin AlwaysAdmit is not set                                        |
-| 1.2.12 | Ensure that the admission control plugin AlwaysPullImages is set                                       |
-| 1.2.13 | Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used   |
-| 1.2.14 | Ensure that the admission control plugin ServiceAccount is set                                         |
-| 1.2.15 | Ensure that the admission control plugin NamespaceLifecycle is set                                     |
-| 1.2.16 | Ensure that the admission control plugin NodeRestriction is set                                        |
-| 1.2.17 | Ensure that the --secure-port argument is not set to 0                                                 |
-| 1.2.18 | Ensure that the --profiling argument is set to false                                                   |
-| 1.2.19 | Ensure that the --audit-log-path argument is set                                                       |
-| 1.2.20 | Ensure that the --audit-log-maxage argument is set to 30 or as appropriate                             |
-| 1.2.21 | Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate                          |
-| 1.2.22 | Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate                           |
-| 1.2.24 | Ensure that the --service-account-lookup argument is set to true                                       |
-| 1.2.25 | Ensure that the --service-account-key-file argument is set as appropriate                              |
-| 1.2.26 | Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate                    |
-| 1.2.27 | Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as                        |
-| 1.2.28 | Ensure that the --client-ca-file argument is set appropriate                                           |
-| 1.2.29 | Ensure that the --etcd-cafile argument is set as appropriate                                           |
-| 1.2.30 | Ensure that the --encryption-provider-config argument is set as appropriate                            |
-| 1.3.1  | Ensure that the --terminated-pod-gc-threshold argument is set as appropriate                           |
-| 1.3.3  | Ensure that the --use-service-account-credentials argument is set to true                              |
-| 1.3.4  | Ensure that the --service-account-private-key-file argument is set as appropriate                      |
-| 1.3.5  | Ensure that the --root-ca-file argument is set as appropriate                                          |
-| 1.3.6  | Ensure that the RotateKubeletServerCertificate argument is set                                         |
-| 1.3.7  | Ensure that the --bind-address argument is set to 127.0.0.1                                            |
-| 1.4.1  | Ensure that the --profiling argument is set to false                                                   |
-| 1.4.2  | Ensure that the --bind-address argument is set to 127.0.0.1                                            |
-| 2.1    | Ensure that the --cert-file and --key-file arguments are set as appropriate                            |
-| 2.2    | Ensure that the --client-cert-auth argument is set to true                                             |
-| 2.3    | Ensure that the --auto-tls argument is not set to true                                                 |
-| 2.4    | Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate                  |
-| 2.5    | Ensure that the --peer-client-cert-auth argument is set to true                                        |
-| 2.6    | Ensure that the --peer-auto-tls argument is not set to true                                            |
-| 3.1.1  | Client certificate authentication should not be used for users (Manual)                                |
-| 3.2.1  | Ensure that a minimal audit policy is created (Manual)                                                 |
-| 3.2.2  | Ensure that the audit policy covers key security concerns (Manual)                                     |
-| 5.1.1  | Ensure that the cluster-admin role is only used where required                                         |
-| 5.1.2  | Minimize access to secrets                                                                             |
-| 5.1.3  | Minimize wildcard use in Roles and ClusterRoles                                                        |
-| 5.1.6  | Ensure that Service Account Tokens are only mounted where necessary                                    |
-| 5.1.8  | Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster                  |
-| 5.2.2  | Minimize the admission of privileged containers                                                        |
-| 5.2.3  | Minimize the admission of containers wishing to share the host process ID namespace                    |
-| 5.2.4  | Minimize the admission of containers wishing to share the host IPC namespace                           |
-| 5.2.5  | Minimize the admission of containers wishing to share the host network namespace                       |
-| 5.2.6  | Minimize the admission of containers with allowPrivilegeEscalation                                     |
-| 5.2.7  | Minimize the admission of root containers                                                              |
-| 5.2.8  | Minimize the admission of containers with the NET_RAW capability                                       |
-| 5.2.9  | Minimize the admission of containers with added capabilities                                           |
-| 5.2.10 | Minimize the admission of containers with capabilities assigned                                        |
-| 5.2.11 | Minimize the admission of containers with capabilities assigned                                        |
-| 5.2.12 | Minimize the admission of HostPath volumes                                                             |
-| 5.2.13 | Minimize the admission of containers which use HostPorts                                               |
-| 5.3.1  | Ensure that the CNI in use supports Network Policies (Manual)                                          |
-| 5.3.2  | Ensure that all Namespaces have Network Policies defined                                               |
-| 5.4.1  | Prefer using secrets as files over secrets as environment variables (Manual)                           |
-| 5.4.2  | Consider external secret storage (Manual)                                                              |
-| 5.5.1  | Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)                      |
-| 5.7.1  | Create administrative boundaries between resources using namespaces (Manual)                           |
-| 5.7.2  | Ensure that the seccomp profile is set to docker/default in your pod definitions                       |
-| 5.7.3  | Apply Security Context to Your Pods and Containers                                                     |
-| 5.7.4  | The default namespace should not be used                                                               |
-```
-</details>
+| Compliance | Name for command | More info
+--- | --- | ---
+NSA, CISA Kubernetes Hardening Guidance v1.2 | `nsa` | [Link](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF)
+CIS Benchmark for Kubernetes v1.23 | `cis` | [Link](https://www.cisecurity.org/benchmark/kubernetes)


### PR DESCRIPTION
## Description
Added most of the general description to the compliance page, including custom compliance docs. 
the k8s and aws pages repeated the same content, so I restructured them (note that I've removed the table with all the checks because it made it hard to read the page, if we need it it should probably be in avd). This change will also help when we add compliance in the fs command

## Related issues
- related https://github.com/aquasecurity/trivy/issues/3339


## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
