### PR TITLE
feat: add git submodule analyzer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.17.0
 	github.com/tetratelabs/wazero v1.0.0
 	github.com/twitchtv/twirp v8.1.2+incompatible
+	github.com/whilp/git-urls v1.0.0
 	github.com/xlab/treeprint v1.1.0
 	go.etcd.io/bbolt v1.3.7
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -1649,6 +1649,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -62,8 +62,8 @@ func NewDriver(libType string) (Driver, error) {
 		// Only semver can be used for version ranges
 		// https://docs.conan.io/en/latest/versioning/version_ranges.html
 		comparer = compare.GenericComparer{}
-	case ftypes.Cocoapods:
-		log.Logger.Warn("CocoaPods is supported for SBOM, not for vulnerability scanning")
+	case ftypes.Cocoapods, ftypes.GitSubmodule:
+		log.Logger.Warnf("%s is supported for SBOM, not for vulnerability scanning", libType)
 		return Driver{}, ErrSBOMSupportOnly
 	case ftypes.CondaPkg:
 		log.Logger.Warn("Conda package is supported for SBOM, not for vulnerability scanning")

--- a/pkg/fanal/analyzer/all/import.go
+++ b/pkg/fanal/analyzer/all/import.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/buildinfo"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/config/all"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/executable"
+	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/git/submodule"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/imgconf/apk"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/imgconf/dockerfile"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/imgconf/secret"

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -90,7 +90,8 @@ const (
 	// ============
 	// Non-packaged
 	// ============
-	TypeExecutable Type = "executable"
+	TypeExecutable   Type = "executable"
+	TypeGitSubmodule Type = "git-submodule"
 
 	// ============
 	// Image Config

--- a/pkg/fanal/analyzer/git/submodule/submodule.go
+++ b/pkg/fanal/analyzer/git/submodule/submodule.go
@@ -1,0 +1,108 @@
+package submodule
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	godeptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/language"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+
+	"github.com/go-git/go-git/v5"
+	giturls "github.com/whilp/git-urls"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	analyzer.RegisterAnalyzer(&gitSubmoduleAnalyzer{})
+}
+
+const version = 1
+
+type gitSubmoduleAnalyzer struct{}
+
+func (a gitSubmoduleAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	libs, deps, err := parseGitmodules(input.Dir)
+	if err != nil {
+		return nil, xerrors.Errorf("git repo parse error: %w", err)
+	}
+
+	return language.ToAnalysisResult(types.GitSubmodule, input.FilePath, "", libs, deps), nil
+}
+
+func (a gitSubmoduleAnalyzer) Required(_ string, fileInfo os.FileInfo) bool {
+	return fileInfo.Name() == types.GitModules
+}
+
+func (a gitSubmoduleAnalyzer) Type() analyzer.Type {
+	return analyzer.TypeGitSubmodule
+}
+
+func (a gitSubmoduleAnalyzer) Version() int {
+	return version
+}
+
+func parseGitmodules(inputDir string) ([]godeptypes.Library, []godeptypes.Dependency, error) {
+	repo, err := git.PlainOpen(inputDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	submodules, err := w.Submodules()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	libs, _ := parseSubmodules(repo, &submodules)
+	return libs, nil, nil
+}
+
+func parseSubmodules(repo *git.Repository, submodules *git.Submodules) ([]godeptypes.Library, []godeptypes.Dependency) {
+	var libs []godeptypes.Library
+	var name *url.URL
+
+	for _, submodule := range *submodules {
+		remote := submodule.Config().URL
+
+		if strings.HasPrefix(remote, "../") {
+			// resolve relative URLs via root remote
+			rootRemote, err := getRemoteUrl(repo)
+			if err != nil {
+				return nil, nil
+			}
+
+			baseUrl, _ := giturls.Parse(fmt.Sprintf("%s/", rootRemote))
+			name, _ = baseUrl.Parse(remote)
+		} else {
+			name, _ = giturls.Parse(remote)
+		}
+
+		status, _ := submodule.Status()
+		version := status.Expected.String()
+
+		libs = append(libs, godeptypes.Library{
+			Name:    name.String(),
+			Version: version,
+		})
+	}
+
+	return libs, nil
+}
+
+func getRemoteUrl(repo *git.Repository) (string, error) {
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		return "", err
+	}
+
+	return remote.Config().URLs[0], nil
+}

--- a/pkg/fanal/analyzer/git/submodule/submodule_test.go
+++ b/pkg/fanal/analyzer/git/submodule/submodule_test.go
@@ -1,0 +1,162 @@
+package submodule
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/utils"
+)
+
+func Test_gitSubmoduleAnalyzer_Analyze(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     *analyzer.AnalysisResult
+	}{
+		{
+			name:     "https-url",
+			filePath: "testdata/https-url.gitmodules",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GitSubmodule,
+						FilePath: types.GitModules,
+						Libraries: []types.Package{
+							{
+								Name:    "https://github.com/org/repository.git",
+								Version: "ca82a6dff817ec66f44342007202690a93763949",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "git-url",
+			filePath: "testdata/git-url.gitmodules",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GitSubmodule,
+						FilePath: types.GitModules,
+						Libraries: []types.Package{
+							{
+								Name:    "ssh://git@github.com/org/repository.git",
+								Version: "ca82a6dff817ec66f44342007202690a93763949",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "ssh-url",
+			filePath: "testdata/ssh-url.gitmodules",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GitSubmodule,
+						FilePath: types.GitModules,
+						Libraries: []types.Package{
+							{
+								Name:    "ssh://git@github.com/org/repository.git",
+								Version: "ca82a6dff817ec66f44342007202690a93763949",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "relative-url",
+			filePath: "testdata/relative-url.gitmodules",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GitSubmodule,
+						FilePath: types.GitModules,
+						Libraries: []types.Package{
+							{
+								Name:    "https://github.com/org/repository.git",
+								Version: "ca82a6dff817ec66f44342007202690a93763949",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "missing-submodule",
+			filePath: "testdata/missing-submodule.gitmodules",
+			want:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentDir, err := os.Getwd()
+			require.NoError(t, err)
+
+			dir := t.TempDir()
+			destFilePath := filepath.Join(dir, types.GitModules)
+
+			_, err = utils.CopyFile(tt.filePath, destFilePath)
+			require.NoError(t, err)
+
+			err = initRepoWithSubmodules(dir)
+			require.NoError(t, err)
+
+			err = os.Chdir(dir)
+			require.NoError(t, err)
+			defer os.Chdir(currentDir)
+
+			a := gitSubmoduleAnalyzer{}
+			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+				Dir:      dir,
+				FilePath: types.GitModules,
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func initRepoWithSubmodules(dir string) error {
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/org/repository.git"},
+	})
+	if err != nil {
+		return err
+	}
+
+	updateIndexCmd := exec.Command(
+		"git",
+		"update-index",
+		"--add",
+		"--cacheinfo",
+		"160000",
+		"ca82a6dff817ec66f44342007202690a93763949",
+		"submodule",
+	)
+	updateIndexCmd.Dir = dir
+	updateIndexCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fanal/analyzer/git/submodule/testdata/README.md
+++ b/pkg/fanal/analyzer/git/submodule/testdata/README.md
@@ -1,0 +1,11 @@
+# Git submodule testdata
+
+The examples in this testdata directory test a few common Git URL formats. For a full
+list of supported Git URL formats, see:
+https://stackoverflow.com/questions/31801271/what-are-the-supported-git-url-formats
+
+For the git plumbing commands involved in the faked remote submodule test setup, see
+https://stackoverflow.com/questions/34562333/is-there-a-way-to-git-submodule-add-a-repo-without-cloning-it.
+
+Files here are not valid Git submodule configuration filenames. They are copied in each test case
+to `t.TempDir` as `.gitmodules`.

--- a/pkg/fanal/analyzer/git/submodule/testdata/git-url.gitmodules
+++ b/pkg/fanal/analyzer/git/submodule/testdata/git-url.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = git@github.com:org/repository.git

--- a/pkg/fanal/analyzer/git/submodule/testdata/https-url.gitmodules
+++ b/pkg/fanal/analyzer/git/submodule/testdata/https-url.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = https://github.com/org/repository.git

--- a/pkg/fanal/analyzer/git/submodule/testdata/missing-submodule.gitmodules
+++ b/pkg/fanal/analyzer/git/submodule/testdata/missing-submodule.gitmodules
@@ -1,0 +1,1 @@
+# This repository includes a valid entry in .git/index but no .gitmodules entry

--- a/pkg/fanal/analyzer/git/submodule/testdata/relative-url.gitmodules
+++ b/pkg/fanal/analyzer/git/submodule/testdata/relative-url.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = ../repository.git

--- a/pkg/fanal/analyzer/git/submodule/testdata/ssh-url.gitmodules
+++ b/pkg/fanal/analyzer/git/submodule/testdata/ssh-url.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodule"]
+	path = submodule
+	url = ssh://git@github.com/org/repository.git

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -34,6 +34,9 @@ const (
 	Pub        = "pub"
 	Hex        = "hex"
 
+	// Non-packaged dependencies
+	GitSubmodule = "git-submodule"
+
 	// Config files
 	YAML           = "yaml"
 	JSON           = "json"
@@ -83,4 +86,7 @@ const (
 	PubSpecLock = "pubspec.lock"
 
 	MixLock = "mix.lock"
+
+	// Non-packaged file names
+	GitModules = ".gitmodules"
 )


### PR DESCRIPTION
## Description

Provides a git submodule analyzer, currently mainly for SBOM generation. A future use case for vulnerability scanning (if feasible) would be for people who build their dependencies from source rather than packages (very common in C/C++ and the embedded ecosystem).

This is an initial PR to get feedback. We discussed with @DmitriyLewen in https://github.com/aquasecurity/go-dep-parser/pull/144 (which adds a similar feature) it might be better to start here with a draft for these non-packaged dependencies.

The full parser is here in trivy rather than in go-dep-parser because we only use `.gitmodules` to discover if submodules are present, but the actual parsing needs to be done in the git index (git commands via go-git in this case).

The testing set up is a bit more involved because I couldn't find a good way to mock all submodule-related plumbing. However, it's still quite performant, and it tests against real git behavior:

```
go test -run ^Test_gitSubmoduleAnalyzer_Analyze$ github.com/aquasecurity/trivy/pkg/fanal/analyzer/git/submodule

ok  	github.com/aquasecurity/trivy/pkg/fanal/analyzer/git/submodule	0.075s
``` 

Result for https://github.com/git-fixtures/submodule:
<details>
<pre>
make build
./trivy repo --format cyclonedx https://github.com/git-fixtures/submodule.git
2022-12-27T12:32:45.043+0100    INFO    "--format cyclonedx" disables security checks. Specify "--security-checks vuln" explicitly if you want to include vulnerabilities in the CycloneDX report.
Enumerating objects: 4, done.
Counting objects: 100% (4/4), done.
Compressing objects: 100% (3/3), done.
Total 4 (delta 0), reused 4 (delta 0), pack-reused 0
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:59c26bf6-a0f0-4668-a6eb-37755c29272a",
  "version": 1,
  "metadata": {
    "timestamp": "2022-12-27T11:32:45+00:00",
    "tools": [
      {
        "vendor": "aquasecurity",
        "name": "trivy",
        "version": "0.35.0-43-g52c1fb4f"
      }
    ],
    "component": {
      "bom-ref": "9f318aaf-e2a4-4a08-9a40-dab75d22d767",
      "type": "application",
      "name": "https://github.com/git-fixtures/submodule.git",
      "properties": [
        {
          "name": "aquasecurity:trivy:SchemaVersion",
          "value": "2"
        }
      ]
    }
  },
  "components": [
    {
      "bom-ref": "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fbasic.git@6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
      "type": "library",
      "name": "https://github.com/git-fixtures/basic.git",
      "version": "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
      "purl": "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fbasic.git@6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
      "properties": [
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "git-submodule"
        }
      ]
    },
    {
      "bom-ref": "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fsubmodule.git@47770b26e71b0f69c0ecd494b1066f8d1da4fc03",
      "type": "library",
      "name": "https://github.com/git-fixtures/submodule.git",
      "version": "47770b26e71b0f69c0ecd494b1066f8d1da4fc03",
      "purl": "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fsubmodule.git@47770b26e71b0f69c0ecd494b1066f8d1da4fc03",
      "properties": [
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "git-submodule"
        }
      ]
    },
    {
      "bom-ref": "f73aab6d-1d44-4025-bf3a-ec253b31dfcf",
      "type": "application",
      "name": ".gitmodules",
      "properties": [
        {
          "name": "aquasecurity:trivy:Type",
          "value": "git-submodule"
        },
        {
          "name": "aquasecurity:trivy:Class",
          "value": "lang-pkgs"
        }
      ]
    }
  ],
  "dependencies": [
    {
      "ref": "f73aab6d-1d44-4025-bf3a-ec253b31dfcf",
      "dependsOn": [
        "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fbasic.git@6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
        "pkg:git-submodule/https:%2F%2Fgithub.com%2Fgit-fixtures%2Fsubmodule.git@47770b26e71b0f69c0ecd494b1066f8d1da4fc03"
      ]
    },
    {
      "ref": "9f318aaf-e2a4-4a08-9a40-dab75d22d767",
      "dependsOn": [
        "f73aab6d-1d44-4025-bf3a-ec253b31dfcf"
      ]
    }
  ],
  "vulnerabilities": []
}
</pre>
</details>

Time on the boost library with 161 submodules:

```
make build
git clone https://github.com/boostorg/boost.git ../boost/
time ./trivy fs --format cyclonedx ../boost/
# ...
real    0m0.332s
user    0m0.447s
sys     0m0.035s
```


## Related issues
- Part 1 of https://github.com/aquasecurity/trivy/issues/3067

## Related PRs
- [ ] https://github.com/aquasecurity/go-dep-parser/pull/143 (another git-based dependency parser)
- [ ] https://github.com/aquasecurity/go-dep-parser/pull/144 (another git-based dependency parser)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
