### PR TITLE
chore(go): updates wazero to 1.0.0-pre.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	github.com/testcontainers/testcontainers-go v0.15.0
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.7
 	github.com/twitchtv/twirp v8.1.2+incompatible
 	github.com/xlab/treeprint v1.1.0
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -1502,8 +1502,8 @@ github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BG
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/testcontainers/testcontainers-go v0.15.0 h1:3Ex7PUGFv0b2bBsdOv6R42+SK2qoZnWBd21LvZYhUtQ=
 github.com/testcontainers/testcontainers-go v0.15.0/go.mod h1:PkohMRH2X8Hib0IWtifVexDfLPVT+tb5E9hsf7cW12w=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
+github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/pkg/module/memfs.go
+++ b/pkg/module/memfs.go
@@ -19,6 +19,9 @@ type memFS struct {
 
 // Open implements fs.FS.
 func (m *memFS) Open(name string) (fs.File, error) {
+	if m.current == nil {
+		return nil, fs.ErrNotExist
+	}
 	return m.current.Open(name)
 }
 


### PR DESCRIPTION
## Description

This updates to wazero v1.0.0-pre.7 which fixes a `GOARCH=386` compilation problem in v1.0.0-pre.6.

[wazero](https://wazero.io/) [1.0.0-pre.6](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.6) includes the following notable changes:
* improves module compilation and initialization performance

The following features are new and not currently used in Trivy, but might be relevant for future work:
* adds `writefs.NewDirFS` which lets you add new files.
  * `path_open` `O_CREAT` flags, `path_remove_directory` `path_rename` `path_unlink_file`
* adds `NewFilesystemLoggingListenerFactory` with dramatically improved logging.

This also includes changes described in [1.0.0-pre.5](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.5). Notably, context param was removed from memory functions as it was never used due to the scope being very narrow, and adds overhead to propagate.