### PR TITLE
feat(flag): early fail when the format is invalid

### DIFF
--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -155,8 +155,8 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 	listAllPkgs := getBool(f.ListAllPkgs)
 	output := getString(f.Output)
 
-	if err := report.ValidateFormat(format); err != nil {
-		return ReportOptions{}, err
+	if format != "" && !slices.Contains(report.SupportedFormats, format) {
+		return ReportOptions{}, xerrors.Errorf("unknown format: %v", format)
 	}
 
 	if template != "" {

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -155,6 +155,10 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 	listAllPkgs := getBool(f.ListAllPkgs)
 	output := getString(f.Output)
 
+	if err := report.ValidateFormat(format); err != nil {
+		return ReportOptions{}, err
+	}
+
 	if template != "" {
 		if format == "" {
 			log.Logger.Warn("'--template' is ignored because '--format template' is not specified. Use '--template' option with '--format template' option.")

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -26,7 +26,7 @@ var (
 		ConfigName: "format",
 		Shorthand:  "f",
 		Value:      report.FormatTable,
-		Usage:      "format (table, json, sarif, template, cyclonedx, spdx, spdx-json, github, cosign-vuln)",
+		Usage:      "format (" + strings.Join(report.SupportedFormats, ", ") + ")",
 	}
 	ReportFormatFlag = Flag{
 		Name:       "report",

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -33,6 +33,10 @@ const (
 )
 
 var (
+	SupportedFormats = []string{FormatTable, FormatJSON, FormatTemplate, FormatSarif, FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatGitHub, FormatCosignVuln}
+)
+
+var (
 	SupportedSBOMFormats = []string{FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatGitHub}
 )
 
@@ -101,15 +105,6 @@ func Write(report types.Report, option Option) error {
 		return xerrors.Errorf("failed to write results: %w", err)
 	}
 	return nil
-}
-
-func ValidateFormat(format string) error {
-	switch format {
-	case FormatTable, FormatJSON, FormatGitHub, FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatTemplate, FormatSarif, FormatCosignVuln:
-		return nil
-	default:
-		return xerrors.Errorf("unknown format: %v", format)
-	}
 }
 
 // Writer defines the result write operation

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -103,6 +103,15 @@ func Write(report types.Report, option Option) error {
 	return nil
 }
 
+func ValidateFormat(format string) error {
+	switch format {
+	case FormatTable, FormatJSON, FormatGitHub, FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatTemplate, FormatSarif, FormatCosignVuln:
+		return nil
+	default:
+		return xerrors.Errorf("unknown format: %v", format)
+	}
+}
+
 // Writer defines the result write operation
 type Writer interface {
 	Write(types.Report) error


### PR DESCRIPTION
## Description

This PR will make trivy fail earlier when the format is wrong.

## Related issues
- Close #3244

Before:
```
$ ./trivy image alpine:latest --format foo
2023-01-02T19:00:26.902+0800    INFO    Vulnerability scanning is enabled
2023-01-02T19:00:26.902+0800    INFO    Secret scanning is enabled
2023-01-02T19:00:26.902+0800    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-01-02T19:00:26.902+0800    INFO    Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2023-01-02T19:00:29.062+0800    INFO    Detected OS: alpine
2023-01-02T19:00:29.062+0800    INFO    This OS version is not on the EOL list: alpine 3.17
2023-01-02T19:00:29.062+0800    INFO    Detecting Alpine vulnerabilities...
2023-01-02T19:00:29.065+0800    INFO    Number of language-specific files: 0
2023-01-02T19:00:29.065+0800    FATAL   report error: unable to write results: unknown format: foo
```
After:
```
$ ./trivy image alpine:latest --format foo
2023-01-02T19:00:20.617+0800    FATAL   flag error: report flag error: unknown format: foo
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example in the description (if the PR is a user interface change).
