### PR TITLE
docs(aws): fix broken links

### DIFF
--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -280,6 +280,6 @@ $ trivy image --format template --template "@/usr/local/share/trivy/templates/ht
 [cargo-auditable]: https://github.com/rust-secure-code/cargo-auditable/
 [new-json]: https://github.com/aquasecurity/trivy/discussions/1050
 [action]: https://github.com/aquasecurity/trivy-action
-[asff]: https://github.com/aquasecurity/trivy/blob/main/docs/docs/integrations/aws-security-hub.md
+[asff]: ../../../tutorials/integrations/aws-security-hub.md
 [sarif]: https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/managing-results-from-code-scanning
 [sprig]: http://masterminds.github.io/sprig/

--- a/docs/tutorials/integrations/aws-security-hub.md
+++ b/docs/tutorials/integrations/aws-security-hub.md
@@ -1,6 +1,6 @@
 # AWS Security Hub
 
-<img src="../../imgs/Security-Hub.jpeg" alt="security-hub" width=50 height=50 />
+![Amazon Security Hub](../../imgs/Security-Hub.jpeg){ width=50 }
 
 ## Upload findings to Security Hub
 
@@ -59,7 +59,7 @@ $ trivy image --format template --template "@your-asff.tpl" -o report.asff golan
 ```
 
 ## Reference
-https://aws.amazon.com/blogs/security/how-to-build-ci-cd-pipeline-container-vulnerability-scanning-trivy-and-aws-security-hub/
+[aws.amazon.com/blogs/security/how-to-build-ci-cd-pipeline-container-vulnerability-scanning-trivy-and-aws-security-hub/](https://aws.amazon.com/blogs/security/how-to-build-ci-cd-pipeline-container-vulnerability-scanning-trivy-and-aws-security-hub/)
 
 [asff]: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html
 [asff-syntax]: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format-syntax.html


### PR DESCRIPTION
## Description

Fix broken links for Amazon Security Hub:

- In `report.md`, link to ASFF  / Security Hub tutorial
- In `aws-security-hub.md` tutorial, fix image link and resizing thanks to `attr_list`
- In `aws-security-hub.md` tutorial, make link to AWS blog clickable

Before:
![image](https://user-images.githubusercontent.com/5385290/210381160-ddfa1f5d-5d5d-433b-9c43-ac51836b6300.png)

After:
![image](https://user-images.githubusercontent.com/5385290/210381077-2734a01d-a1cb-45e0-9d38-386d9105659b.png)


## Related issues
- Not applicable: simple doc fix.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
