### PR TITLE
fix(image): handle wrong empty layer detection

### DIFF
--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -27,10 +27,6 @@ func (f fakeImage) ID() (string, error) {
 	return "", nil
 }
 
-func (f fakeImage) LayerIDs() ([]string, error) {
-	return nil, nil
-}
-
 func (f fakeImage) Name() string {
 	return f.name
 }

--- a/pkg/fanal/image/archive.go
+++ b/pkg/fanal/image/archive.go
@@ -53,11 +53,6 @@ func (img archiveImage) ID() (string, error) {
 	return ID(img)
 }
 
-// LayerIDs returns a list of uncompressed layer IDs
-func (img archiveImage) LayerIDs() ([]string, error) {
-	return LayerIDs(img)
-}
-
 // RepoTags returns empty as an archive doesn't support RepoTags
 func (archiveImage) RepoTags() []string {
 	return nil

--- a/pkg/fanal/image/daemon.go
+++ b/pkg/fanal/image/daemon.go
@@ -56,7 +56,3 @@ func (d daemonImage) Name() string {
 func (d daemonImage) ID() (string, error) {
 	return ID(d)
 }
-
-func (d daemonImage) LayerIDs() ([]string, error) {
-	return LayerIDs(d)
-}

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -13,7 +13,10 @@ import (
 	dimage "github.com/docker/docker/api/types/image"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 type Image interface {
@@ -89,10 +92,17 @@ func (img *image) ConfigName() (v1.Hash, error) {
 func (img *image) ConfigFile() (*v1.ConfigFile, error) {
 	if len(img.inspect.RootFS.Layers) == 0 {
 		// Podman doesn't return RootFS...
-		if err := img.populateImage(); err != nil {
-			return nil, xerrors.Errorf("unable to populate: %w", err)
-		}
-		return img.Image.ConfigFile()
+		return img.configFile()
+	}
+
+	nonEmptyLayerCount := lo.CountBy(img.history, func(history v1.History) bool {
+		return !history.EmptyLayer
+	})
+
+	if len(img.inspect.RootFS.Layers) != nonEmptyLayerCount {
+		// In cases where empty layers are not correctly determined from the history API.
+		// There are some edge cases where we cannot guess empty layers well.
+		return img.configFile()
 	}
 
 	diffIDs, err := img.diffIDs()
@@ -119,6 +129,17 @@ func (img *image) ConfigFile() (*v1.ConfigFile, error) {
 			DiffIDs: diffIDs,
 		},
 	}, nil
+}
+
+func (img *image) configFile() (*v1.ConfigFile, error) {
+	log.Logger.Debug("Saving the container image to a local file to obtain the image config...")
+
+	// Need to fall back into expensive operations like "docker save"
+	// because the config file cannot be generated properly from container engine API for some reason.
+	if err := img.populateImage(); err != nil {
+		return nil, xerrors.Errorf("unable to populate: %w", err)
+	}
+	return img.Image.ConfigFile()
 }
 
 func (img *image) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
@@ -223,6 +244,8 @@ func configHistory(dhistory []dimage.HistoryResponseItem) []v1.History {
 	return history
 }
 
+// emptyLayer tries to determine if the layer is empty from the history API, but may return a wrong result.
+// The non-empty layers will be compared to diffIDs later so that results can be validated.
 func emptyLayer(history dimage.HistoryResponseItem) bool {
 	if history.Size != 0 {
 		return false

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -60,7 +60,6 @@ func TestNewDockerImage(t *testing.T) {
 		name            string
 		args            args
 		wantID          string
-		wantLayerIDs    []string
 		wantConfigFile  *v1.ConfigFile
 		wantRepoTags    []string
 		wantRepoDigests []string
@@ -72,7 +71,6 @@ func TestNewDockerImage(t *testing.T) {
 				imageName: "alpine:3.11",
 			},
 			wantID:       "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
-			wantLayerIDs: []string{"sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203"},
 			wantRepoTags: []string{"alpine:3.11"},
 			wantConfigFile: &v1.ConfigFile{
 				Architecture:  "amd64",
@@ -117,7 +115,6 @@ func TestNewDockerImage(t *testing.T) {
 				imageName: "a187dde48cd2",
 			},
 			wantID:       "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
-			wantLayerIDs: []string{"sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203"},
 			wantRepoTags: []string{"alpine:3.11"},
 			wantConfigFile: &v1.ConfigFile{
 				Architecture:  "amd64",
@@ -162,7 +159,6 @@ func TestNewDockerImage(t *testing.T) {
 				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
 			},
 			wantID:       "sha256:af341ccd2df8b0e2d67cf8dd32e087bfda4e5756ebd1c76bbf3efa0dc246590e",
-			wantLayerIDs: []string{"sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
 			wantRepoTags: []string{serverAddr + "/library/alpine:3.10"},
 			wantRepoDigests: []string{
 				serverAddr + "/library/alpine@sha256:e10ea963554297215478627d985466ada334ed15c56d3d6bb808ceab98374d91",
@@ -215,7 +211,6 @@ func TestNewDockerImage(t *testing.T) {
 				},
 			},
 			wantID:       "sha256:af341ccd2df8b0e2d67cf8dd32e087bfda4e5756ebd1c76bbf3efa0dc246590e",
-			wantLayerIDs: []string{"sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
 			wantRepoTags: []string{serverAddr + "/library/alpine:3.10"},
 			wantRepoDigests: []string{
 				serverAddr + "/library/alpine@sha256:e10ea963554297215478627d985466ada334ed15c56d3d6bb808ceab98374d91",
@@ -288,10 +283,6 @@ func TestNewDockerImage(t *testing.T) {
 			gotConfigFile, err := img.ConfigFile()
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantConfigFile, gotConfigFile)
-
-			gotLayerIDs, err := img.LayerIDs()
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantLayerIDs, gotLayerIDs)
 
 			gotRepoTags := img.RepoTags()
 			assert.Equal(t, tt.wantRepoTags, gotRepoTags)

--- a/pkg/fanal/image/remote.go
+++ b/pkg/fanal/image/remote.go
@@ -116,10 +116,6 @@ func (img remoteImage) ID() (string, error) {
 	return ID(img)
 }
 
-func (img remoteImage) LayerIDs() ([]string, error) {
-	return LayerIDs(img)
-}
-
 func (img remoteImage) RepoTags() []string {
 	tag := img.ref.TagName()
 	if tag == "" {

--- a/pkg/fanal/types/image.go
+++ b/pkg/fanal/types/image.go
@@ -10,7 +10,6 @@ type Image interface {
 type ImageExtension interface {
 	Name() string
 	ID() (string, error)
-	LayerIDs() ([]string, error)
 	RepoTags() []string
 	RepoDigests() []string
 }


### PR DESCRIPTION
## Description
Trivy needs to determine which layers are empty because the history API of container engines doesn't return the `emptyLayer` field. However, we recently found out that the implementation of `emptyLayer` differs depending on container engine. It seems to be challenging to handle all edge cases where empty layers cannot be properly determined.
This PR implements fallback into `docker save` in that case. It falls back only when empty layer detection is wrong as `docker save` is expensive.

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/3235

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
