### PR TITLE
docs: use the formula maintained by Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Trivy is available in most common distribution methods. The full list of install
 
 - `apt-get install trivy`
 - `yum install trivy`
-- `brew install aquasecurity/trivy/trivy`
+- `brew install trivy`
 - `docker run aquasec/trivy`
 - Download binary from <https://github.com/aquasecurity/trivy/releases/latest/>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Trivy is available in most common distribution methods. The full list of install
 
 - `apt-get install trivy`
 - `yum install trivy`
-- `brew install aquasecurity/trivy/trivy`
+- `brew install trivy`
 - `docker run aquasec/trivy`
 - Download binary from <https://github.com/aquasecurity/trivy/releases/latest/>
 


### PR DESCRIPTION
## Description
Homebrew currently maintains the Trivy formula. It is better to use it rather than our formula.
https://github.com/Porkepix/homebrew-core/blob/master/Formula/trivy.rb

Homebrew didn't use to have `trivy` and we needed to maintain our tap. We no longer have to maintain that, but keep it for compatibility.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3388
- Close https://github.com/aquasecurity/trivy/issues/3387

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
