### PR TITLE
feat(server): log errors on server side

### DIFF
--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -34,10 +34,9 @@ func NewScanServer(s scanner.Driver) *ScanServer {
 	return &ScanServer{localScanner: s}
 }
 
-// Log warning message on server side and return an error
-func WarnAndError(format string, args ...interface{}) error {
-	err := xerrors.Errorf(format, args...)
-	log.Logger.Warnf("%v", err)
+// Log and return an error
+func teeError(err error) error {
+	log.Logger.Errorf("%v", err)
 	return err
 }
 
@@ -50,7 +49,7 @@ func (s *ScanServer) Scan(ctx context.Context, in *rpcScanner.ScanRequest) (*rpc
 	}
 	results, os, err := s.localScanner.Scan(ctx, in.Target, in.ArtifactId, in.BlobIds, options)
 	if err != nil {
-		return nil, WarnAndError("failed scan, %s: %w", in.Target, err)
+		return nil, teeError(xerrors.Errorf("failed scan, %s: %w", in.Target, err))
 	}
 
 	return rpc.ConvertToRPCScanResponse(results, os), nil
@@ -69,11 +68,11 @@ func NewCacheServer(c cache.Cache) *CacheServer {
 // PutArtifact puts the artifacts in cache
 func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
 	if in.ArtifactInfo == nil {
-		return nil, WarnAndError("empty image info")
+		return nil, teeError(xerrors.Errorf("empty image info"))
 	}
 	imageInfo := rpc.ConvertFromRPCPutArtifactRequest(in)
 	if err := s.cache.PutArtifact(in.ArtifactId, imageInfo); err != nil {
-		return nil, WarnAndError("unable to store image info in cache: %w", err)
+		return nil, teeError(xerrors.Errorf("unable to store image info in cache: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -81,11 +80,11 @@ func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactReq
 // PutBlob puts the blobs in cache
 func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
 	if in.BlobInfo == nil {
-		return nil, WarnAndError("empty layer info")
+		return nil, teeError(xerrors.Errorf("empty layer info"))
 	}
 	layerInfo := rpc.ConvertFromRPCPutBlobRequest(in)
 	if err := s.cache.PutBlob(in.DiffId, layerInfo); err != nil {
-		return nil, WarnAndError("unable to store layer info in cache: %w", err)
+		return nil, teeError(xerrors.Errorf("unable to store layer info in cache: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -94,7 +93,7 @@ func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*
 func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsRequest) (*rpcCache.MissingBlobsResponse, error) {
 	missingArtifact, blobIDs, err := s.cache.MissingBlobs(in.ArtifactId, in.BlobIds)
 	if err != nil {
-		return nil, WarnAndError("failed to get missing blobs: %w", err)
+		return nil, teeError(xerrors.Errorf("failed to get missing blobs: %w", err))
 	}
 	return &rpcCache.MissingBlobsResponse{MissingArtifact: missingArtifact, MissingBlobIds: blobIDs}, nil
 }
@@ -103,7 +102,7 @@ func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsR
 func (s *CacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
 	blobIDs := rpc.ConvertFromDeleteBlobsRequest(in)
 	if err := s.cache.DeleteBlobs(blobIDs); err != nil {
-		return nil, WarnAndError("failed to remove a blobs: %w", err)
+		return nil, teeError(xerrors.Errorf("failed to remove a blobs: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -36,7 +36,7 @@ func NewScanServer(s scanner.Driver) *ScanServer {
 
 // Log and return an error
 func teeError(err error) error {
-	log.Logger.Errorf("%v", err)
+	log.Logger.Errorf("%+v", err)
 	return err
 }
 

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/rpc"
 	"github.com/aquasecurity/trivy/pkg/scanner"
 	"github.com/aquasecurity/trivy/pkg/scanner/local"
@@ -33,6 +34,13 @@ func NewScanServer(s scanner.Driver) *ScanServer {
 	return &ScanServer{localScanner: s}
 }
 
+// Log warning message on server side and return an error
+func WarnAndError(format string, args ...interface{}) error {
+	err := xerrors.Errorf(format, args...)
+	log.Logger.Warnf("%v", err)
+	return err
+}
+
 // Scan scans and return response
 func (s *ScanServer) Scan(ctx context.Context, in *rpcScanner.ScanRequest) (*rpcScanner.ScanResponse, error) {
 	options := types.ScanOptions{
@@ -42,7 +50,7 @@ func (s *ScanServer) Scan(ctx context.Context, in *rpcScanner.ScanRequest) (*rpc
 	}
 	results, os, err := s.localScanner.Scan(ctx, in.Target, in.ArtifactId, in.BlobIds, options)
 	if err != nil {
-		return nil, xerrors.Errorf("failed scan, %s: %w", in.Target, err)
+		return nil, WarnAndError("failed scan, %s: %w", in.Target, err)
 	}
 
 	return rpc.ConvertToRPCScanResponse(results, os), nil
@@ -61,11 +69,11 @@ func NewCacheServer(c cache.Cache) *CacheServer {
 // PutArtifact puts the artifacts in cache
 func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
 	if in.ArtifactInfo == nil {
-		return nil, xerrors.Errorf("empty image info")
+		return nil, WarnAndError("empty image info")
 	}
 	imageInfo := rpc.ConvertFromRPCPutArtifactRequest(in)
 	if err := s.cache.PutArtifact(in.ArtifactId, imageInfo); err != nil {
-		return nil, xerrors.Errorf("unable to store image info in cache: %w", err)
+		return nil, WarnAndError("unable to store image info in cache: %w", err)
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -73,11 +81,11 @@ func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactReq
 // PutBlob puts the blobs in cache
 func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
 	if in.BlobInfo == nil {
-		return nil, xerrors.Errorf("empty layer info")
+		return nil, WarnAndError("empty layer info")
 	}
 	layerInfo := rpc.ConvertFromRPCPutBlobRequest(in)
 	if err := s.cache.PutBlob(in.DiffId, layerInfo); err != nil {
-		return nil, xerrors.Errorf("unable to store layer info in cache: %w", err)
+		return nil, WarnAndError("unable to store layer info in cache: %w", err)
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -86,7 +94,7 @@ func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*
 func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsRequest) (*rpcCache.MissingBlobsResponse, error) {
 	missingArtifact, blobIDs, err := s.cache.MissingBlobs(in.ArtifactId, in.BlobIds)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get missing blobs: %w", err)
+		return nil, WarnAndError("failed to get missing blobs: %w", err)
 	}
 	return &rpcCache.MissingBlobsResponse{MissingArtifact: missingArtifact, MissingBlobIds: blobIDs}, nil
 }
@@ -95,7 +103,7 @@ func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsR
 func (s *CacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
 	blobIDs := rpc.ConvertFromDeleteBlobsRequest(in)
 	if err := s.cache.DeleteBlobs(blobIDs); err != nil {
-		return nil, xerrors.Errorf("failed to remove a blobs: %w", err)
+		return nil, WarnAndError("failed to remove a blobs: %w", err)
 	}
 	return &google_protobuf.Empty{}, nil
 }


### PR DESCRIPTION
## Description
Log rpc errors in warn level on server.

## Related issues
- Close #3310

## Before
Open two terminals and run the following commands (please turn off redis server for testing purpose):
```bash
# Trivy server
trivy server --cache-backend redis://localhost:6379 --cache-ttl 1h --listen localhost:4954 --debug

# Trivy client
trivy image --server http://localhost:4954 busybox:latest --debug
```
Output on the server-side:
```
2023-01-08T12:46:49.683+0800	INFO	Redis cache: redis://localhost:6379
2023-01-08T12:46:49.683+0800	DEBUG	cache dir:  /home/lin/.cache/trivy
2023-01-08T12:46:49.683+0800	DEBUG	DB update was skipped because the local DB is the latest
2023-01-08T12:46:49.683+0800	DEBUG	DB Schema: 2, UpdatedAt: 2023-01-08 00:11:47.038838827 +0000 UTC, NextUpdate: 2023-01-08 06:11:47.038838527 +0000 UTC, DownloadedAt: 2023-01-08 04:46:15.748637321 +0000 UTC
2023-01-08T12:46:49.684+0800	INFO	Listening localhost:4954...
```
Output on the client-side:
```
2023-01-08T12:50:51.118+0800	DEBUG	Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2023-01-08T12:50:51.119+0800	INFO	Vulnerability scanning is enabled
2023-01-08T12:50:51.119+0800	DEBUG	Vulnerability type:  [os library]
2023-01-08T12:50:51.119+0800	INFO	Secret scanning is enabled
2023-01-08T12:50:51.119+0800	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-01-08T12:50:51.119+0800	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2023-01-08T12:50:52.830+0800	DEBUG	No secret config detected: trivy-secret.yaml
2023-01-08T12:50:53.067+0800	DEBUG	Image ID: sha256:49176f190c7e9cdb51ac85ab6c6d5e4512352218190cd69b08e6fd803ffbf3da
2023-01-08T12:50:53.067+0800	DEBUG	Diff IDs: [sha256:ded7a220bb058e28ee3254fbba04ca90b679070424424761a53a043b93b612bf]
2023-01-08T12:50:53.067+0800	DEBUG	Base Layers: []
2023-01-08T12:50:53.264+0800	DEBUG	Missing image ID in cache: sha256:49176f190c7e9cdb51ac85ab6c6d5e4512352218190cd69b08e6fd803ffbf3da
2023-01-08T12:50:53.264+0800	DEBUG	Missing diff ID in cache: sha256:ded7a220bb058e28ee3254fbba04ca90b679070424424761a53a043b93b612bf
2023-01-08T12:50:53.757+0800	FATAL	image scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.Run
        /home/lin/Desktop/trivy/pkg/commands/artifact/run.go:397
  - scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact
        /home/lin/Desktop/trivy/pkg/commands/artifact/run.go:257
  - scan failed:
    github.com/aquasecurity/trivy/pkg/commands/artifact.scan
        /home/lin/Desktop/trivy/pkg/commands/artifact/run.go:588
  - failed analysis:
    github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact
        /home/lin/Desktop/trivy/pkg/scanner/scan.go:146
  - analyze error:
    github.com/aquasecurity/trivy/pkg/fanal/artifact/image.Artifact.Inspect
        /home/lin/Desktop/trivy/pkg/fanal/artifact/image/image.go:127
  - failed to store layer: sha256:8ebabdc9bfff05e21d43b53f1565d84d770aaedb0a28950fcf4b3af23aae67d0 in cache:
    github.com/aquasecurity/trivy/pkg/fanal/artifact/image.Artifact.inspect.func1
        /home/lin/Desktop/trivy/pkg/fanal/artifact/image/image.go:233
  - unable to store cache on the server:
    github.com/aquasecurity/trivy/pkg/cache.RemoteCache.PutBlob
        /home/lin/Desktop/trivy/pkg/cache/remote.go:52
  - twirp error internal: unable to store layer info in cache: unable to store blob information in Redis cache (sha256:8ebabdc9bfff05e21d43b53f1565d84d770aaedb0a28950fcf4b3af23aae67d0): dial tcp 127.0.0.1:6379: connect: connection refused
```
## After

There shows up a warning of scanning failure at the last line on the server-side:
```
2023-01-10T13:33:03.230+0800	INFO	Redis cache: redis://localhost:6379
2023-01-10T13:33:03.230+0800	DEBUG	cache dir:  /home/lin/.cache/trivy
2023-01-10T13:33:03.230+0800	DEBUG	DB update was skipped because the local DB is the latest
2023-01-10T13:33:03.230+0800	DEBUG	DB Schema: 2, UpdatedAt: 2023-01-10 00:12:47.949419909 +0000 UTC, NextUpdate: 2023-01-10 06:12:47.949419709 +0000 UTC, DownloadedAt: 2023-01-10 05:27:07.388632207 +0000 UTC
2023-01-10T13:33:03.230+0800	INFO	Listening localhost:4954...
2023-01-10T13:33:08.216+0800	ERROR	unable to store layer info in cache:
    github.com/aquasecurity/trivy/pkg/rpc/server.(*CacheServer).PutBlob
        /home/lin/Desktop/trivy/pkg/rpc/server/server.go:87
  - unable to store blob information in Redis cache (sha256:609bcddd712e23c01b20afc4be7931e51fcf83ccc4769befaf8d66ba1741c3f3):
    github.com/aquasecurity/trivy/pkg/fanal/cache.RedisCache.PutBlob
        /home/lin/Desktop/trivy/pkg/fanal/cache/redis.go:53
  - dial tcp 127.0.0.1:6379: connect: connection refused
```
Output on the client-side remains the same.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
