### PR TITLE
fix(license): change normalize for GPL-3+-WITH-BISON-EXCEPTION

### DIFF
--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -19,6 +19,7 @@ var mapping = map[string]string{
 	"GPL-2.0+":                       GPL20,
 	"GPL-2.0-OR-LATER":               GPL20,
 	"GPL-2+ WITH AUTOCONF EXCEPTION": GPL20withautoconfexception,
+	"GPL-2+-WITH-BISON-EXCEPTION":    GPL20withbisonexception,
 	"GPL3":                           GPL30,
 	"GPL 3.0":                        GPL30,
 	"GPL 3":                          GPL30,
@@ -28,7 +29,6 @@ var mapping = map[string]string{
 	"GPL3+":                          GPL30,
 	"GPL-3+":                         GPL30,
 	"GPL-3.0-OR-LATER":               GPL30,
-	"GPL-3+-WITH-BISON-EXCEPTION":    GPL20withbisonexception,
 	"GPL":                            GPL30, // 2? 3?
 
 	// LGPL

--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -19,7 +19,7 @@ var mapping = map[string]string{
 	"GPL-2.0+":                       GPL20,
 	"GPL-2.0-OR-LATER":               GPL20,
 	"GPL-2+ WITH AUTOCONF EXCEPTION": GPL20withautoconfexception,
-	"GPL-2+-WITH-BISON-EXCEPTION":    GPL20withbisonexception,
+	"GPL-2+-with-bison-exception":    GPL20withbisonexception,
 	"GPL3":                           GPL30,
 	"GPL 3.0":                        GPL30,
 	"GPL 3":                          GPL30,


### PR DESCRIPTION
## Description
Fix mistake when GPL-3+-WITH-BISON-EXCEPTION normalize to GPL-2.0-with-bison-exception

## Related issues
- Close #3404

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
