### PR TITLE
ci: store URLs to Github Releases in RPM repository

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
+TRIVY_VERSION=$(find ../dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+
 function create_rpm_repo () {
         version=$1
         rpm_path=rpm/releases/${version}/x86_64
 
-        RPM_EL=$(find ../dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -e "s/_/-/g" -e "s/-Linux/.el$version/" -e "s/-64bit/.x86_64/")
-        echo $RPM_EL
-
         mkdir -p $rpm_path
-        cp ../dist/*64bit.rpm ${rpm_path}/${RPM_EL}
+        cp ../dist/*64bit.rpm ${rpm_path}/
 
-        createrepo_c --update $rpm_path
+        createrepo_c -u https://github.com/aquasecurity/trivy/releases/download/ --location-prefix="v"$TRIVY_VERSION --update $rpm_path
+
+        rm ${rpm_path}/*64bit.rpm
 }
+
+echo "Create RPM releases for Trivy v$TRIVY_VERSION"
 
 cd trivy-repo
 
@@ -22,6 +25,5 @@ for version in ${VERSIONS[@]}; do
 done
 
 git add .
-git commit -m "Update rpm packages"
+git commit -m "Update rpm packages for Trivy v$TRIVY_VERSION"
 git push origin main
-


### PR DESCRIPTION
## Description
[aquasecurity/trivy-repo](https://github.com/aquasecurity/trivy-repo) has a large size - more than 4.5Gb.
It leads to timeout aborting in deploy Github Pages, ex: https://github.com/aquasecurity/trivy-repo/actions/runs/3360429639
the reason is that rpm folder contains all built rpm releases, it's about 4.37 Gb. for comparison, deb folder has about 237 Mb.

Now Trivy RPM repository stores only a link to Github Release.

## Related issues
- Close https://github.com/aquasecurity/trivy-repo/issues/21

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
