### PR TITLE
feat(server): add support of `skip-db-update` flag for hot db update

### DIFF
--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -55,5 +55,5 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	m.Register()
 
 	server := rpcServer.NewServer(opts.AppVersion, opts.Listen, opts.CacheDir, opts.Token, opts.TokenHeader, opts.DBRepository)
-	return server.ListenAndServe(cache, opts.Insecure)
+	return server.ListenAndServe(cache, opts.Insecure, opts.SkipDBUpdate)
 }

--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -121,13 +121,9 @@ func newDBWorker(dbClient dbFile.Operation) dbWorker {
 }
 
 func (w dbWorker) update(ctx context.Context, appVersion, cacheDir string,
-	skipDbUpdate bool, dbUpdateWg, requestWg *sync.WaitGroup) error {
-	if skipDbUpdate { // don't update db if `skip-db-update` flag is enabled
-		log.Logger.Debug("Skip db update because `skip-db-update` flag is enabled")
-		return nil
-	}
+	skipDBUpdate bool, dbUpdateWg, requestWg *sync.WaitGroup) error {
 	log.Logger.Debug("Check for DB update...")
-	needsUpdate, err := w.dbClient.NeedsUpdate(appVersion, false)
+	needsUpdate, err := w.dbClient.NeedsUpdate(appVersion, skipDBUpdate)
 	if err != nil {
 		return xerrors.Errorf("failed to check if db needs an update")
 	} else if !needsUpdate {

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -84,7 +84,7 @@ func Test_dbWorker_update(t *testing.T) {
 			name: "skip update",
 			needsUpdate: needsUpdate{
 				input:  needsUpdateInput{appVersion: "1", skip: true},
-				output: needsUpdateOutput{needsUpdate: true},
+				output: needsUpdateOutput{needsUpdate: false},
 			},
 			args: args{appVersion: "1"},
 		},

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -81,6 +81,14 @@ func Test_dbWorker_update(t *testing.T) {
 			args: args{appVersion: "1"},
 		},
 		{
+			name: "skip update",
+			needsUpdate: needsUpdate{
+				input:  needsUpdateInput{appVersion: "1", skip: true},
+				output: needsUpdateOutput{needsUpdate: true},
+			},
+			args: args{appVersion: "1"},
+		},
+		{
 			name: "NeedsUpdate returns an error",
 			needsUpdate: needsUpdate{
 				input:  needsUpdateInput{appVersion: "1", skip: false},
@@ -137,7 +145,7 @@ func Test_dbWorker_update(t *testing.T) {
 
 			var dbUpdateWg, requestWg sync.WaitGroup
 			err := w.update(context.Background(), tt.args.appVersion, cacheDir,
-				&dbUpdateWg, &requestWg)
+				tt.needsUpdate.input.skip, &dbUpdateWg, &requestWg)
 			if tt.wantErr != "" {
 				require.NotNil(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)


### PR DESCRIPTION
## Description
add support of `skip-db-update` flag for hot db update in server mode

## Related issues
- #3408

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
