### PR TITLE
fix: docker local image does not have digest id for vul report's…

### DIFF
--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -349,6 +349,13 @@ func (a Artifact) uncompressedLayer(diffID string) (string, io.Reader, error) {
 	if err != nil {
 		return "", nil, xerrors.Errorf("failed to get the layer content (%s): %w", diffID, err)
 	}
+	if digest == "" {
+		d, err := layer.Digest()
+		if err != nil {
+			return "", nil, xerrors.Errorf("failed to get the digest (%s): %w", diffID, err)
+		}
+		digest = d.String()
+	}
 	return digest, r, nil
 }
 


### PR DESCRIPTION
issue 3417