### PR TITLE
fix(db): check proxy settings when using insecure flag

### DIFF
--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -60,6 +60,7 @@ func NewArtifact(repo, mediaType string, quiet, insecure bool, opts ...Option) (
 		if insecure {
 			t := &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				Proxy:           http.ProxyFromEnvironment,
 			}
 			remoteOpts = append(remoteOpts, remote.WithTransport(t))
 		}


### PR DESCRIPTION
## Description
When we download DB with `insecure` flag - we don't check proxy settings.
Fix this.

## Related issues
- Close #3396

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
