### PR TITLE
ci: set paths triggering VM tests in PR

### DIFF
--- a/.github/workflows/vm-test.yaml
+++ b/.github/workflows/vm-test.yaml
@@ -9,6 +9,11 @@ on:
       - 'pkg/fanal/artifact/vm/**'
       - 'integration/vm_test.go'
   pull_request:
+    paths:
+      - 'pkg/fanal/vm/**'
+      - 'pkg/fanal/walker/vm.go'
+      - 'pkg/fanal/artifact/vm/**'
+      - 'integration/vm_test.go'
 
 jobs:
   vm-test:


### PR DESCRIPTION
## Description
The VM test is triggered by all PRs now. This PR changes it to trigger the test only when needed.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
