### PR TITLE
docs(secret): typo in --skip-files

### DIFF
--- a/docs/docs/secret/examples.md
+++ b/docs/docs/secret/examples.md
@@ -15,7 +15,7 @@ $ trivy image --skip-dirs /var/lib --skip-dirs /var/log YOUR_IMAGE
 $ trivy fs --skip-dirs ./my-test-dir --skip-dirs ./my-testing-cert/ /path/to/your_project
 ```
 
-`--skip-fles` also works similarly.
+`--skip-files` also works similarly.
 
 ## Filter by severity
 


### PR DESCRIPTION
## Description
Typo in docs -> secret/examples

before - 
"`--skip-fles` also works similarly."
after - 
"`--skip-files` also works similarly."

Fix screenshot - 
![image](https://user-images.githubusercontent.com/58729960/213135150-8ab050e3-d1ef-4d21-a53b-a1fbc14afb2e.png)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

