### PR TITLE
docs: yaml tabs to spaces, auto create namespace

### DIFF
--- a/docs/tutorials/kubernetes/gitops.md
+++ b/docs/tutorials/kubernetes/gitops.md
@@ -106,9 +106,15 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: trivy-operator
-		namespace: flux-system
-      version: 0.0.5
+        namespace: flux-system
+      version: 0.10.1
   interval: 60m
+  values:
+    trivy:
+      ignoreUnfixed: true
+  install:
+    crds: CreateReplace
+    createNamespace: true
 ```
 
 You can then apply the file to your Kubernetes cluster:


### PR DESCRIPTION
## Description
Fixes tabs FluxCD yaml example, updates example to auto create the namespace, bumps version to current and gives example for setting values to be more in line with the "normal" helm install docs.
