### PR TITLE
chore: display the troubleshooting URL for the DB denial error

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -91,23 +91,6 @@ Reference : [boltdb: Opening a database][boltdb].
 
 [boltdb]: https://github.com/boltdb/bolt#opening-a-database
 
-### Error downloading vulnerability DB
-
-!!! error
-    FATAL failed to download vulnerability DB
-
-If trivy is running behind corporate firewall, you have to add the following urls to your allowlist.
-
-- ghcr.io
-- pkg-containers.githubusercontent.com
-
-### Old DB schema
-
-!!! error
-    --skip-update cannot be specified with the old DB schema.
-
-Trivy v0.23.0 or later requires Trivy DB v2. Please update your local database or follow [the instruction of air-gapped environment][air-gapped].
-
 ### Multiple Trivy servers
 
 !!! error
@@ -149,6 +132,37 @@ Try:
 ```
 $ TMPDIR=/my/custom/path trivy image ...
 ```
+
+## DB
+### Old DB schema
+
+!!! error
+    --skip-update cannot be specified with the old DB schema.
+
+Trivy v0.23.0 or later requires Trivy DB v2. Please update your local database or follow [the instruction of air-gapped environment][air-gapped].
+
+### Error downloading vulnerability DB
+
+!!! error
+    FATAL failed to download vulnerability DB
+
+If trivy is running behind corporate firewall, you have to add the following urls to your allowlist.
+
+- ghcr.io
+- pkg-containers.githubusercontent.com
+
+### Denied
+
+!!! error
+    GET https://ghcr.io/token?scope=repository%3Aaquasecurity%2Ftrivy-db%3Apull&service=ghcr.io: DENIED: denied
+
+Your local GHCR (GitHub Container Registry) token might be expired.
+Please remove the token and try downloading the DB again.
+
+```shell
+docker logout ghcr.io
+```
+
 
 ## Homebrew
 ### Scope error


### PR DESCRIPTION
## Description
The expired GHCR token configured locally like `docker login ghcr.io` leads to the following error.

```
2023-01-23T14:50:36.108+0200    FATAL   init error: DB error: failed to download vulnerability DB: OCI artifact error: OCI artifact error: OCI repository error: GET https://ghcr.io/token?scope=repository%3Aaquasecurity%2Ftrivy-db%3Apull&service=ghcr.io: DENIED: denied
```

- [x] Add a new section about DB downloading denied
- [x] Display a link to the troubleshooting page

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3472

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
