### PR TITLE
docs: add note about the limitation in Rekor

### DIFF
--- a/docs/docs/attestation/rekor.md
+++ b/docs/docs/attestation/rekor.md
@@ -80,6 +80,8 @@ $ trivy plugin install github.com/aquasecurity/trivy-plugin-attest
 $ trivy attest --predicate ./bat.cdx --type cyclonedx ./bat-v0.20.0-x86_64-apple-darwin/bat
 ```
 
+> An important note about the public instance of the Rekor maintained by the Sigstore team is that the attestation size is limited to 100KB. If you are using the public instance, please make sure that your SBOM is smaller than 100KB. To get more detail, please refer to the Rekor project's [documentation](https://github.com/sigstore/rekor#public-instance).
+
 ### Scan a non-packaged binary
 Trivy calculates the digest of the `bat` binary and searches for the SBOM attestation by the digest in Rekor.
 If it is found, Trivy uses that for vulnerability scanning.

--- a/docs/docs/attestation/rekor.md
+++ b/docs/docs/attestation/rekor.md
@@ -80,7 +80,10 @@ $ trivy plugin install github.com/aquasecurity/trivy-plugin-attest
 $ trivy attest --predicate ./bat.cdx --type cyclonedx ./bat-v0.20.0-x86_64-apple-darwin/bat
 ```
 
-> An important note about the public instance of the Rekor maintained by the Sigstore team is that the attestation size is limited to 100KB. If you are using the public instance, please make sure that your SBOM is smaller than 100KB. To get more detail, please refer to the Rekor project's [documentation](https://github.com/sigstore/rekor#public-instance).
+!!! note
+    The public instance of the Rekor maintained by the Sigstore team limits the attestation size.
+    If you are using the public instance, please make sure that your SBOM is small enough.
+    To get more detail, please refer to the Rekor project's [documentation](https://github.com/sigstore/rekor#public-instance).
 
 ### Scan a non-packaged binary
 Trivy calculates the digest of the `bat` binary and searches for the SBOM attestation by the digest in Rekor.


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

## Description
This PR aims to add information about the limitation in Rekor about the attestation size.

## Related issues
- Close #XXX

## Related PRs
https://github.com/sigstore/rekor/pull/1313
https://github.com/aquasecurity/trivy-plugin-attest/pull/6

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
