### PR TITLE
feat(image): add support for Docker CIS Benchmark

### DIFF
--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -9,10 +9,12 @@ Trivy’s compliance flag lets you curate a specific set of checks into a report
 
 Compliance report is currently supported in the following targets (trivy sub-commands):
 
+- `trivy image`
 - `trivy aws`
 - `trivy k8s`
 
-Add the `--compliance` flag to the command line, and set it's value to desired report. For example: `trivy k8s cluster --compliance k8s-nsa` (see below for built-in and custom reports)
+Add the `--compliance` flag to the command line, and set it's value to desired report.
+For example: `trivy k8s cluster --compliance k8s-nsa` (see below for built-in and custom reports)
 
 ### Options
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/defsec v0.82.8
+	github.com/aquasecurity/defsec v0.82.9-0.20230130071923-197035f687cb
 	github.com/aquasecurity/go-dep-parser v0.0.0-20230123091557-6a4a819ab8da
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.82.8 h1:qQmpbIYXHYykTBqcwjYV5LEGU2tnbn2Pbz9P3CY10xg=
-github.com/aquasecurity/defsec v0.82.8/go.mod h1:f/acz2sBQzfTcnaPxSjVnkRhCQ9hUbC6qwQCaHQwrFc=
+github.com/aquasecurity/defsec v0.82.9-0.20230130071923-197035f687cb h1:bq0WzKdisulgz3EVXVGQlL8uOIn5i25BYegJgLBvxJM=
+github.com/aquasecurity/defsec v0.82.9-0.20230130071923-197035f687cb/go.mod h1:f/acz2sBQzfTcnaPxSjVnkRhCQ9hUbC6qwQCaHQwrFc=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230123091557-6a4a819ab8da h1:dQ9R41jz6tAZCw6NNJQCkdNYfEzRUxK1ZmuChldWcbc=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230123091557-6a4a819ab8da/go.mod h1:Cj+0xDZFgXGQin2fo40aH2a9srUKMOCFPw50NHsfVEk=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/compliance/spec"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -646,7 +647,30 @@ deny[res] {
 				CloudOptions: flag.CloudOptions{
 					MaxCacheAge: time.Hour * 24 * 365 * 100,
 				},
-				ReportOptions: flag.ReportOptions{Compliance: "@./testdata/example-spec.yaml", Format: "table", ReportFormat: "summary"},
+				ReportOptions: flag.ReportOptions{
+					Compliance: spec.ComplianceSpec{
+						Spec: spec.Spec{
+							// TODO: refactor defsec so that the parsed spec can be passed
+							ID:          "@testdata/example-spec.yaml",
+							Title:       "my-custom-spec",
+							Description: "My fancy spec",
+							Version:     "1.2",
+							Controls: []spec.Control{
+								{
+									ID:          "1.1",
+									Name:        "Unencrypted S3 bucket",
+									Description: "S3 Buckets should be encrypted to protect the data that is stored within them if access is compromised.",
+									Checks: []spec.SpecCheck{
+										{ID: "AVD-AWS-0088"},
+									},
+									Severity: "HIGH",
+								},
+							},
+						},
+					},
+					Format:       "table",
+					ReportFormat: "summary",
+				},
 			},
 			cacheContent: exampleS3Cache,
 			want: `
@@ -654,27 +678,9 @@ Summary Report for compliance: my-custom-spec
 ┌─────┬──────────┬───────────────────────┬────────┬────────┐
 │ ID  │ Severity │     Control Name      │ Status │ Issues │
 ├─────┼──────────┼───────────────────────┼────────┼────────┤
-│ 1.1 │ HIGH     │ Unencrypted S3 bucket │  FAIL  │   1    │
+│ 1.1 │   HIGH   │ Unencrypted S3 bucket │  FAIL  │   1    │
 └─────┴──────────┴───────────────────────┴────────┴────────┘
-
-
 `,
-		},
-		{
-			name:      "error loading compliance report",
-			expectErr: true,
-			options: flag.Options{
-				AWSOptions: flag.AWSOptions{
-					Region:   "us-east-1",
-					Services: []string{"s3"},
-					Account:  "12345678",
-				},
-				CloudOptions: flag.CloudOptions{
-					MaxCacheAge: time.Hour * 24 * 365 * 100,
-				},
-				ReportOptions: flag.ReportOptions{Compliance: "@./testdata/nosuchspec.yaml", Format: "table", ReportFormat: "summary"},
-			},
-			cacheContent: exampleS3Cache,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -85,8 +85,8 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 		)
 	}
 
-	if len(option.Compliance) > 0 {
-		scannerOpts = append(scannerOpts, options.ScannerWithSpec(option.Compliance))
+	if option.Compliance.Spec.ID != "" {
+		scannerOpts = append(scannerOpts, options.ScannerWithSpec(option.Compliance.Spec.ID))
 	} else {
 		scannerOpts = append(scannerOpts, options.ScannerWithFrameworks(
 			framework.Default,

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -209,8 +209,10 @@ func NewRootCommand(version string, globalFlags *flag.GlobalFlagGroup) *cobra.Co
 
 func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup := flag.NewReportFlagGroup()
-	reportFlagGroup.ReportFormat = nil // TODO: support --report summary
-	reportFlagGroup.Compliance = nil   // disable '--compliance'
+
+	compliance := flag.ComplianceFlag
+	compliance.Usage += fmt.Sprintf(" (%s)", types.ComplianceDockerCIS)
+	reportFlagGroup.Compliance = &compliance // override usage as the accepted values differ for each subcommand.
 
 	imageFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -210,6 +210,11 @@ func NewRootCommand(version string, globalFlags *flag.GlobalFlagGroup) *cobra.Co
 func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup := flag.NewReportFlagGroup()
 
+	report := flag.ReportFormatFlag
+	report.Value = "summary"                                     // override the default value as the summary is preferred for the compliance report
+	report.Usage = "specify a format for the compliance report." // "--report" works only with "--compliance"
+	reportFlagGroup.ReportFormat = &report
+
 	compliance := flag.ComplianceFlag
 	compliance.Usage += fmt.Sprintf(" (%s)", types.ComplianceDockerCIS)
 	reportFlagGroup.Compliance = &compliance // override usage as the accepted values differ for each subcommand.

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -484,13 +484,14 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		if err != nil {
 			return ScannerConfig{}, types.ScanOptions{}, xerrors.Errorf("scanner error: %w", err)
 		}
+
 		opts.Scanners = scanners
 		opts.ImageConfigScanners = nil
 		// TODO: define image-config-scanners in the spec
 		if opts.Compliance.Spec.ID == "docker-cis" {
 			opts.Scanners = nil
 			opts.ImageConfigScanners = scanners
-		} 
+		}
 	}
 
 	scanOptions := types.ScanOptions{

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -484,14 +484,13 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		if err != nil {
 			return ScannerConfig{}, types.ScanOptions{}, xerrors.Errorf("scanner error: %w", err)
 		}
+		opts.Scanners = scanners
+		opts.ImageConfigScanners = nil
 		// TODO: define image-config-scanners in the spec
 		if opts.Compliance.Spec.ID == "docker-cis" {
 			opts.Scanners = nil
 			opts.ImageConfigScanners = scanners
-		} else {
-			opts.Scanners = scanners
-			opts.ImageConfigScanners = nil
-		}
+		} 
 	}
 
 	scanOptions := types.ScanOptions{

--- a/pkg/compliance/report/table.go
+++ b/pkg/compliance/report/table.go
@@ -26,14 +26,14 @@ const (
 	IssuesColumn      = "Issues"
 )
 
-func (tw TableWriter) columns() []string {
-	return []string{ControlIDColumn, SeverityColumn, ControlNameColumn, StatusColumn, IssuesColumn}
-}
-
 func (tw TableWriter) Write(report *ComplianceReport) error {
 	switch tw.Report {
 	case allReport:
-		t := pkgReport.Writer{Output: tw.Output, Severities: tw.Severities, ShowMessageOnce: &sync.Once{}}
+		t := pkgReport.Writer{
+			Output:          tw.Output,
+			Severities:      tw.Severities,
+			ShowMessageOnce: &sync.Once{},
+		}
 		for _, cr := range report.Results {
 			r := types.Report{Results: cr.Results}
 			err := t.Write(r)
@@ -42,7 +42,7 @@ func (tw TableWriter) Write(report *ComplianceReport) error {
 			}
 		}
 	case summaryReport:
-		writer := NewSummaryWriter(tw.Output, tw.Severities, tw.columns())
+		writer := NewSummaryWriter(tw.Output)
 		return writer.Write(report)
 	default:
 		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)

--- a/pkg/compliance/report/testdata/table_summary.txt
+++ b/pkg/compliance/report/testdata/table_summary.txt
@@ -3,8 +3,6 @@ Summary Report for compliance: NSA
 ┌─────┬──────────┬──────────────────────────────────┬────────┬────────┐
 │ ID  │ Severity │           Control Name           │ Status │ Issues │
 ├─────┼──────────┼──────────────────────────────────┼────────┼────────┤
-│ 1.0 │ MEDIUM   │       Non-root containers        │  FAIL  │   1    │
-│ 1.1 │ LOW      │ Immutable container file systems │  FAIL  │   1    │
+│ 1.0 │  MEDIUM  │ Non-root containers              │  FAIL  │   1    │
+│ 1.1 │   LOW    │ Immutable container file systems │  FAIL  │   1    │
 └─────┴──────────┴──────────────────────────────────┴────────┴────────┘
-
-

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/compliance/spec"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/report"
@@ -174,12 +175,30 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "happy path with compliance",
 			fields: fields{
-				compliane:  "k8s-nsa",
+				compliane:  "@testdata/example-spec.yaml",
 				severities: "low",
 			},
 			want: flag.ReportOptions{
-				Output:     os.Stdout,
-				Compliance: "k8s-nsa",
+				Output: os.Stdout,
+				Compliance: spec.ComplianceSpec{
+					Spec: spec.Spec{
+						ID:          "0001",
+						Title:       "my-custom-spec",
+						Description: "My fancy spec",
+						Version:     "1.2",
+						Controls: []spec.Control{
+							{
+								ID:          "1.1",
+								Name:        "Unencrypted S3 bucket",
+								Description: "S3 Buckets should be encrypted to protect the data that is stored within them if access is compromised.",
+								Checks: []spec.SpecCheck{
+									{ID: "AVD-AWS-0088"},
+								},
+								Severity: "HIGH",
+							},
+						},
+					},
+				},
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 			},
 		},

--- a/pkg/flag/testdata/example-spec.yaml
+++ b/pkg/flag/testdata/example-spec.yaml
@@ -1,0 +1,13 @@
+spec:
+  id: "0001"
+  title: my-custom-spec
+  description: My fancy spec
+  version: "1.2"
+  controls:
+  - id: "1.1"
+    name: Unencrypted S3 bucket
+    description: |-
+      S3 Buckets should be encrypted to protect the data that is stored within them if access is compromised.
+    checks:
+    - id: AVD-AWS-0088
+    severity: HIGH

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,16 +5,17 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aquasecurity/trivy/pkg/report/predicate"
-	"github.com/aquasecurity/trivy/pkg/report/table"
-
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	cr "github.com/aquasecurity/trivy/pkg/compliance/report"
+	"github.com/aquasecurity/trivy/pkg/compliance/spec"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/report/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/report/github"
+	"github.com/aquasecurity/trivy/pkg/report/predicate"
 	"github.com/aquasecurity/trivy/pkg/report/spdx"
+	"github.com/aquasecurity/trivy/pkg/report/table"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -33,21 +34,38 @@ const (
 )
 
 var (
-	SupportedFormats = []string{FormatTable, FormatJSON, FormatTemplate, FormatSarif, FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatGitHub, FormatCosignVuln}
+	SupportedFormats = []string{
+		FormatTable,
+		FormatJSON,
+		FormatTemplate,
+		FormatSarif,
+		FormatCycloneDX,
+		FormatSPDX,
+		FormatSPDXJSON,
+		FormatGitHub,
+		FormatCosignVuln,
+	}
 )
 
 var (
-	SupportedSBOMFormats = []string{FormatCycloneDX, FormatSPDX, FormatSPDXJSON, FormatGitHub}
+	SupportedSBOMFormats = []string{
+		FormatCycloneDX,
+		FormatSPDX,
+		FormatSPDXJSON,
+		FormatGitHub,
+	}
 )
 
 type Option struct {
 	AppVersion string
 
 	Format         string
+	Report         string
 	Output         io.Writer
 	Tree           bool
 	Severities     []dbTypes.Severity
 	OutputTemplate string
+	Compliance     spec.ComplianceSpec
 
 	// For misconfigurations
 	IncludeNonFailures bool
@@ -60,6 +78,11 @@ type Option struct {
 
 // Write writes the result to output, format as passed in argument
 func Write(report types.Report, option Option) error {
+	// Compliance report
+	if option.Compliance.Spec.ID != "" {
+		return complianceWrite(report, option)
+	}
+
 	var writer Writer
 	switch option.Format {
 	case FormatTable:
@@ -76,7 +99,10 @@ func Write(report types.Report, option Option) error {
 	case FormatJSON:
 		writer = &JSONWriter{Output: option.Output}
 	case FormatGitHub:
-		writer = &github.Writer{Output: option.Output, Version: option.AppVersion}
+		writer = &github.Writer{
+			Output:  option.Output,
+			Version: option.AppVersion,
+		}
 	case FormatCycloneDX:
 		// TODO: support xml format option with cyclonedx writer
 		writer = cyclonedx.NewWriter(option.Output, option.AppVersion)
@@ -86,7 +112,10 @@ func Write(report types.Report, option Option) error {
 		// We keep `sarif.tpl` template working for backward compatibility for a while.
 		if strings.HasPrefix(option.OutputTemplate, "@") && strings.HasSuffix(option.OutputTemplate, "sarif.tpl") {
 			log.Logger.Warn("Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571")
-			writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
+			writer = SarifWriter{
+				Output:  option.Output,
+				Version: option.AppVersion,
+			}
 			break
 		}
 		var err error
@@ -94,7 +123,10 @@ func Write(report types.Report, option Option) error {
 			return xerrors.Errorf("failed to initialize template writer: %w", err)
 		}
 	case FormatSarif:
-		writer = SarifWriter{Output: option.Output, Version: option.AppVersion}
+		writer = SarifWriter{
+			Output:  option.Output,
+			Version: option.AppVersion,
+		}
 	case FormatCosignVuln:
 		writer = predicate.NewVulnWriter(option.Output, option.AppVersion)
 	default:
@@ -105,6 +137,19 @@ func Write(report types.Report, option Option) error {
 		return xerrors.Errorf("failed to write results: %w", err)
 	}
 	return nil
+}
+
+func complianceWrite(report types.Report, opt Option) error {
+	complianceReport, err := cr.BuildComplianceReport([]types.Results{report.Results}, opt.Compliance)
+	if err != nil {
+		return xerrors.Errorf("compliance report build error: %w", err)
+	}
+	return cr.Write(complianceReport, cr.Option{
+		Format:     opt.Format,
+		Report:     opt.Report,
+		Output:     opt.Output,
+		Severities: opt.Severities,
+	})
 }
 
 // Writer defines the result write operation

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -8,7 +8,13 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
-var Compliances = []string{ComplianceK8sNsa, ComplianceK8sCIS, ComplianceAWSCIS12, ComplianceAWSCIS14}
+var Compliances = []string{
+	ComplianceK8sNsa,
+	ComplianceK8sCIS,
+	ComplianceAWSCIS12,
+	ComplianceAWSCIS14,
+	ComplianceDockerCIS,
+}
 
 // Report represents a scan result
 type Report struct {
@@ -51,10 +57,11 @@ const (
 	ClassCustom      = "custom"
 
 	// ComplianceNsa is the compliance checks for nsa
-	ComplianceK8sNsa   = Compliance("k8s-nsa")
-	ComplianceK8sCIS   = Compliance("k8s-cis")
-	ComplianceAWSCIS12 = Compliance("aws-cis-1.2")
-	ComplianceAWSCIS14 = Compliance("aws-cis-1.4")
+	ComplianceK8sNsa    = Compliance("k8s-nsa")
+	ComplianceK8sCIS    = Compliance("k8s-cis")
+	ComplianceAWSCIS12  = Compliance("aws-cis-1.2")
+	ComplianceAWSCIS14  = Compliance("aws-cis-1.4")
+	ComplianceDockerCIS = Compliance("docker-cis")
 )
 
 // Result holds a target and detected vulnerabilities


### PR DESCRIPTION
## Description
This PR adds support for [Docker CIS Benchmark](https://www.aquasec.com/cloud-native-academy/docker-container/docker-cis-benchmark/).

Docker CIS Benchmark has checks for vulnerabilities, misconfigurations and secrets. This PR supports only misconfigurations. Vulnerabilities and secrets will be supported later.

- [ ] Vulnerabilities
- [x] Misconfigurations
- [ ] Secrets

I'll update the documentation in another PR since we need to restructure the doc.

### Example

```
$ trivy image --compliance docker-cis my-image
2023-01-30T16:59:31.454+0900    INFO    Container image config scanners: ["config"]
2023-01-30T16:59:31.454+0900    INFO    Misconfiguration scanning is enabled
2023-01-30T16:59:31.511+0900    INFO    Detected config files: 1

Summary Report for compliance: CIS Docker Community Edition Benchmark v1.1.0
┌──────┬──────────┬────────────────────────────────────────────────────────────────────────────┬────────┬────────┐
│  ID  │ Severity │                                Control Name                                │ Status │ Issues │
├──────┼──────────┼────────────────────────────────────────────────────────────────────────────┼────────┼────────┤
│ 4.1  │   HIGH   │ Ensure a user for the container has been created                           │  FAIL  │   1    │
│ 4.2  │   HIGH   │ Ensure that containers use trusted base images (Manual)                    │   -    │   -    │
│ 4.3  │   HIGH   │ Ensure unnecessary packages are not installed in the container (Manual)    │   -    │   -    │
│ 4.4  │ CRITICAL │ Ensure images are scanned and rebuilt to include security patches (Manual) │   -    │   -    │
│ 4.5  │   LOW    │ Ensure Content trust for Docker is Enabled (Manual)                        │   -    │   -    │
│ 4.6  │   LOW    │ Ensure HEALTHCHECK instructions have been added to the container image     │  FAIL  │   1    │
│ 4.7  │   HIGH   │ Ensure update instructions are not use alone in the Dockerfile             │  PASS  │   0    │
│ 4.8  │   HIGH   │ Ensure setuid and setgid permissions are removed in the images (Manual)    │   -    │   -    │
│ 4.9  │   LOW    │ Ensure COPY is used instead of ADD in Dockerfile                           │  FAIL  │   1    │
│ 4.10 │ CRITICAL │ Ensure secrets are not stored in Dockerfiles (Manual)                      │   -    │   -    │
│ 4.11 │  MEDIUM  │ Ensure verified packages are only Installed (Manual)                       │   -    │   -    │
└──────┴──────────┴────────────────────────────────────────────────────────────────────────────┴────────┴────────┘
```

## Related issues
- https://github.com/aquasecurity/trivy/issues/2676

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/3437
- [ ] https://github.com/aquasecurity/trivy/pull/3495
- [x] https://github.com/aquasecurity/defsec/pull/1144

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
