### PR TITLE
feat(vuln): Pass Type,Class,Target to open policy agent

### DIFF
--- a/contrib/example_policy/advanced.rego
+++ b/contrib/example_policy/advanced.rego
@@ -104,3 +104,7 @@ ignore {
 	deny_cwe_ids := {"CWE-79"} # XSS
 	count({x | x := input.CweIDs[_]; x == deny_cwe_ids[_]}) == 0
 }
+
+ignore {
+	input.Type != "gobinary"
+}

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -349,7 +349,7 @@ func TestClient_Filter(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path with a policy file",
+			name: "happy path with a policy file (by detected vulnerabilty)",
 			args: args{
 				result: types.Result{
 					Vulnerabilities: []types.DetectedVulnerability{
@@ -399,6 +399,30 @@ func TestClient_Filter(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "happy path with a policy file (by detected vulnerabilty extended)",
+			args: args{
+				result: types.Result{
+					Target: "foobar",
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							// this vulnerability is ignored
+							VulnerabilityID:  "CVE-2019-0001",
+							PkgName:          "foo",
+							InstalledVersion: "1.2.3",
+							FixedVersion:     "1.2.4",
+							Vulnerability: dbTypes.Vulnerability{
+								Severity: dbTypes.SeverityLow.String(),
+							},
+						},
+					},
+				},
+				severities:    []dbTypes.Severity{dbTypes.SeverityLow},
+				ignoreUnfixed: false,
+				policyFile:    "./testdata/test2.rego",
+			},
+			wantVulns: []types.DetectedVulnerability{},
 		},
 		{
 			name: "happy path with duplicates, one with empty fixed version",

--- a/pkg/result/testdata/test2.rego
+++ b/pkg/result/testdata/test2.rego
@@ -1,0 +1,5 @@
+package trivy
+
+ignore {
+	input.Target == "foobar"
+}


### PR DESCRIPTION
## Description

1. As preparation, the filtering code has been streamlined. Before there was a first step to filter by ignore file and a second step to filter by policy. This has been unified into a single filter function (for both vulns and misconfs).
2. Adds `Type`, `Class` and `Target` to OPA input so that one can also filter by `input.Type != "gobinary"`.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
