### PR TITLE
docs: add AlmaLinux 9 and Rocky Linux 9 to supported OS

### DIFF
--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -9,8 +9,8 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 | Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |
 | Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
 | CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
-| AlmaLinux                        | 8                                         | Installed by yum/rpm          |                  NO                  |
-| Rocky Linux                      | 8                                         | Installed by yum/rpm          |                  NO                  |
+| AlmaLinux                        | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
+| Rocky Linux                      | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
 | Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
 | CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
 | Amazon Linux                     | 1, 2, 2022                                | Installed by yum/rpm          |                  NO                  |


### PR DESCRIPTION
## Description
Trivy supports `AlmaLinux 9` and `Rocky Linux 9`, but there is no information about this in the documentation.

## Related issues
- Close #2520

## Related PRs
- [x] #2653
- [x] #2543

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
