### PR TITLE
ci: fix path to dist folder

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TRIVY_VERSION=$(find ../dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+TRIVY_VERSION=$(find dist/ -type f -name "*64bit.rpm" -printf "%f\n" | head -n1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
 
 function create_rpm_repo () {
         version=$1


### PR DESCRIPTION
## Description
`deploy-rpm.sh` calculated `TRIVY_VERSION` from the main folder, not from `trivy-repo` 
so path `../dist/` was wrong and `TRIVY_VERSION` was empty

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
