### PR TITLE
fix(misconf): handle dot files better

### DIFF
--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -205,8 +205,7 @@ func createPolicyFS(policyPaths []string) (fs.FS, []string, error) {
 		}
 		var cleanPaths []string
 		for _, path := range policyPaths {
-			path = strings.TrimPrefix(path, "/")
-			cleanPaths = append(cleanPaths, path)
+			cleanPaths = append(cleanPaths, filepath.Clean(path))
 		}
 		return os.DirFS(cwd), cleanPaths, nil
 	}

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -205,7 +205,6 @@ func createPolicyFS(policyPaths []string) (fs.FS, []string, error) {
 		}
 		var cleanPaths []string
 		for _, path := range policyPaths {
-			path = strings.TrimPrefix(path, ".")
 			path = strings.TrimPrefix(path, "/")
 			cleanPaths = append(cleanPaths, path)
 		}


### PR DESCRIPTION
Signed-off-by: Simar <simar@linux.com>

## Description
We shouldn't trim out dot prefixes as they are valid usable directories.


## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3549

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
