### PR TITLE
feat(report): add slack template

### DIFF
--- a/contrib/slack.tpl
+++ b/contrib/slack.tpl
@@ -21,7 +21,7 @@
                 "type": "section",
                     "text": {
                     "type": "mrkdwn",
-                    "text": ":scream: *{{ (len .Vulnerabilities) | toString }} vulnerabilities found!* \nThis is too many for Slack to render!\nPlease <https://aquasecurity.github.io/trivy/latest/getting-started/installation/|install> & <https://aquasecurity.github.io/trivy/v0.37/docs/target/container_image/|run> trivy locally to see the full list."
+                    "text": ":scream: *{{ (len .Vulnerabilities) | toString }} vulnerabilities found!* \nThis is too many for Slack to render!\nPlease <https://aquasecurity.github.io/trivy/latest/getting-started/installation/|install> & <https://aquasecurity.github.io/trivy/latest/docs/target/container_image/|run> trivy locally to see the full list."
                 }
             },
             {{- else if (eq (len .Vulnerabilities) 0) }}

--- a/contrib/slack.tpl
+++ b/contrib/slack.tpl
@@ -21,7 +21,7 @@
                 "type": "section",
                     "text": {
                     "type": "mrkdwn",
-                    "text": ":scream: *{{ (len .Vulnerabilities) | toString }} vulnerabilities found!* \nThis is too many for Slack to render!\nPlease <https://aquasecurity.github.io/trivy/v0.37/getting-started/installation/|install> & <https://aquasecurity.github.io/trivy/v0.37/docs/target/container_image/|run> trivy locally to see the full list."
+                    "text": ":scream: *{{ (len .Vulnerabilities) | toString }} vulnerabilities found!* \nThis is too many for Slack to render!\nPlease <https://aquasecurity.github.io/trivy/latest/getting-started/installation/|install> & <https://aquasecurity.github.io/trivy/v0.37/docs/target/container_image/|run> trivy locally to see the full list."
                 }
             },
             {{- else if (eq (len .Vulnerabilities) 0) }}

--- a/contrib/slack.tpl
+++ b/contrib/slack.tpl
@@ -1,0 +1,49 @@
+{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":rotating_light: VULNERABILITIES FOUND:\n{{ escapeXML ( index . 0 ).Target }}",
+                "emoji": true
+            }
+        },
+        {{- range . }}
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Scan type: {{ escapeXML .Type }}*",
+                }
+            },
+            {{- if (gt (len .Vulnerabilities) 40) }}
+                {
+                "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": ":scream: *{{ (len .Vulnerabilities) | toString }} vulnerabilities found!* \nThis is too many for Slack to render!\nPlease <https://aquasecurity.github.io/trivy/v0.37/getting-started/installation/|install> & <https://aquasecurity.github.io/trivy/v0.37/docs/target/container_image/|run> trivy locally to see the full list."
+                }
+            },
+            {{- else if (eq (len .Vulnerabilities) 0) }}
+                {
+                "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "- none"
+                }
+            },
+            {{- else }}
+            {{- range .Vulnerabilities }}
+            {
+                "type": "section",
+                    "text": {
+                    "type": "mrkdwn",
+                    "text": "- *{{ escapeXML .Vulnerability.Severity }}:* <https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ escapeXML .VulnerabilityID }}|{{ escapeXML .VulnerabilityID }}> `{{ escapeXML .PkgName }} v{{ escapeXML .InstalledVersion }}` (upgrade to: {{ escapeXML .FixedVersion }})"
+                }
+            },
+            {{- end }}
+            
+            {{- end }}
+        {{- end }}
+    ]
+}

--- a/docs/docs/vulnerability/examples/report.md
+++ b/docs/docs/vulnerability/examples/report.md
@@ -277,6 +277,20 @@ The following example shows use of default HTML template when Trivy is installed
 $ trivy image --format template --template "@/usr/local/share/trivy/templates/html.tpl" -o report.html golang:1.12-alpine
 ```
 
+#### Slack
+
+In the following example a Slack payload is created if there are any findings from Trivy
+
+```
+trivy image --format template --template "@contrib/slack.tpl" --output=payload.json golang:1.12-alpine
+```
+
+You can then send the payload to a Slack webhook with a simple curl command such as:
+
+```
+curl -X POST -H 'Content-type: application/json' \ --data @payload.json \ "$SLACK_WEBHOOK"
+```
+
 [cargo-auditable]: https://github.com/rust-secure-code/cargo-auditable/
 [new-json]: https://github.com/aquasecurity/trivy/discussions/1050
 [action]: https://github.com/aquasecurity/trivy-action


### PR DESCRIPTION
## Description

Provides a slack template that builds a block-kit payload with a summary of results. Useful for CI and scheduled scans where you would want to send the results to slack via a webhook.

There is a Slack enforced limit of 50 blocks in a payload, so the template also handles that case where the message wouldn't be able to be rendered (triggers at 40 vulnerabilities to be on the safe side)

## Examples:

### Usage

`trivy ... --format=template --template="@contrib/slack.tpl" --output=payload.json`

A user can send the payload to a webhook with a simple curl POST request

`curl -X POST -H 'Content-type: application/json' \
    --data @payload.json \
    "$SLACK_WEBHOOK"`

### Normal:
![image](https://user-images.githubusercontent.com/58994586/216718088-45bc5bb6-976d-4784-9561-c2300dafe1e7.png)

### Way too many vulnerabilities

![image](https://user-images.githubusercontent.com/58994586/216718405-41a43965-b7f1-4cf9-b505-42b03a329ce2.png)


## Related issues
- None

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
