### PR TITLE
docs: java-db air-gap doc tweaks

### DIFF
--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -52,7 +52,7 @@ Java users also need to download the Java index database for use in air-gapped e
 === "oras >= v0.13.0"
     Please follow [oras installation instruction][oras].
 
-    Download `db.tar.gz`:
+    Download `javadb.tar.gz`:
 
     ```
     $ oras pull ghcr.io/aquasecurity/trivy-java-db:1
@@ -61,7 +61,7 @@ Java users also need to download the Java index database for use in air-gapped e
 === "oras < v0.13.0"
     Please follow [oras installation instruction][oras].
 
-    Download `db.tar.gz`:
+    Download `javadb.tar.gz`:
 
     ```
     $ oras pull -a ghcr.io/aquasecurity/trivy-java-db:1
@@ -122,7 +122,7 @@ In an air-gapped environment, you have to specify `--skip-db-update` and `--skip
 In addition, if you want to scan `pom.xml` dependencies, you need to specify `--offline-scan` since Trivy tries to issue API requests for scanning Java applications by default.
 
 ```
-$ trivy image --skip-update --skip-java-db-update --offline-scan alpine:3.12
+$ trivy image --skip-db-update --skip-java-db-update --offline-scan alpine:3.12
 ```
 
 ## Air-Gapped Environment for misconfigurations


### PR DESCRIPTION
## Description
Downloaded file name is `javadb.tar.gz` rather than `db.tar.gz`. Also `--skip-update` is deprecated in favor of `--skip-db-update` and `--skip-java-db-update`.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
