### PR TITLE
feat: Adding a global flag which accepts an array of input WASM files

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -131,7 +131,7 @@ func NewRunner(ctx context.Context, cliOptions flag.Options, opts ...runnerOptio
 	}
 
 	// Initialize WASM modules
-	m, err := module.NewManager(ctx)
+	m, err := module.NewManager(ctx, cliOptions.ModuleFiles...)
 	if err != nil {
 		return nil, xerrors.Errorf("WASM module error: %w", err)
 	}

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -48,7 +48,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	}
 
 	// Initialize WASM modules
-	m, err := module.NewManager(ctx)
+	m, err := module.NewManager(ctx, opts.ModuleFiles...)
 	if err != nil {
 		return xerrors.Errorf("WASM module error: %w", err)
 	}

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -69,6 +69,13 @@ var (
 		Usage:      "write the default config to trivy-default.yaml",
 		Persistent: true,
 	}
+	ModuleFilesFlag = Flag{
+		Name:       "module-files",
+		ConfigName: "module.files",
+		Value:      []string{},
+		Usage:      "specify files to the wasm modules that can be loaded for module scan",
+		Persistent: true,
+	}
 )
 
 // GlobalFlagGroup composes global flags
@@ -81,6 +88,7 @@ type GlobalFlagGroup struct {
 	Timeout               *Flag
 	CacheDir              *Flag
 	GenerateDefaultConfig *Flag
+	ModuleFiles           *Flag
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -93,6 +101,7 @@ type GlobalOptions struct {
 	Timeout               time.Duration
 	CacheDir              string
 	GenerateDefaultConfig bool
+	ModuleFiles           []string
 }
 
 func NewGlobalFlagGroup() *GlobalFlagGroup {
@@ -105,11 +114,12 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		Timeout:               &TimeoutFlag,
 		CacheDir:              &CacheDirFlag,
 		GenerateDefaultConfig: &GenerateDefaultConfigFlag,
+		ModuleFiles:           &ModuleFilesFlag,
 	}
 }
 
 func (f *GlobalFlagGroup) flags() []*Flag {
-	return []*Flag{f.ConfigFile, f.ShowVersion, f.Quiet, f.Debug, f.Insecure, f.Timeout, f.CacheDir, f.GenerateDefaultConfig}
+	return []*Flag{f.ConfigFile, f.ShowVersion, f.Quiet, f.Debug, f.Insecure, f.Timeout, f.CacheDir, f.GenerateDefaultConfig, f.ModuleFiles}
 }
 
 func (f *GlobalFlagGroup) AddFlags(cmd *cobra.Command) {
@@ -137,5 +147,6 @@ func (f *GlobalFlagGroup) ToOptions() GlobalOptions {
 		Timeout:               getDuration(f.Timeout),
 		CacheDir:              getString(f.CacheDir),
 		GenerateDefaultConfig: getBool(f.GenerateDefaultConfig),
+		ModuleFiles:           getStringSlice(f.ModuleFiles),
 	}
 }

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -109,3 +109,100 @@ func TestManager_Register(t *testing.T) {
 		})
 	}
 }
+
+func TestManager_CustomModuleRegister(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// WASM tests difficult on Windows
+		t.Skip("Test satisfied adequately by Linux tests")
+	}
+	tests := []struct {
+		name                    string
+		noModuleDir             bool
+		moduleName              string
+		wantAnalyzerVersions    map[string]int
+		wantPostScannerVersions map[string]int
+		wantErr                 bool
+	}{
+		{
+			name:       "happy path",
+			moduleName: "happy",
+			wantAnalyzerVersions: map[string]int{
+				"happy": 1,
+			},
+			wantPostScannerVersions: map[string]int{
+				"happy": 1,
+			},
+		},
+		{
+			name:       "only analyzer",
+			moduleName: "analyzer",
+			wantAnalyzerVersions: map[string]int{
+				"analyzer": 1,
+			},
+			wantPostScannerVersions: map[string]int{},
+		},
+		{
+			name:                 "only post scanner",
+			moduleName:           "scanner",
+			wantAnalyzerVersions: map[string]int{},
+			wantPostScannerVersions: map[string]int{
+				"scanner": 2,
+			},
+		},
+		{
+			name:                    "no module dir",
+			noModuleDir:             true,
+			moduleName:              "happy",
+			wantAnalyzerVersions:    map[string]int{},
+			wantPostScannerVersions: map[string]int{},
+		},
+	}
+
+	// Loading and registering WASM file(s) via --module-files flag
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modulePath := filepath.Join("testdata", tt.moduleName, tt.moduleName+".wasm")
+
+			// WASM modules must be generated before running this test.
+			if _, err := os.Stat(modulePath); os.IsNotExist(err) {
+				require.Fail(t, "missing WASM modules, try 'make test' or 'make generate-test-modules'")
+			}
+
+			// Set up a temp dir for modules
+			tmpDir := t.TempDir()
+			t.Setenv("XDG_DATA_HOME", tmpDir)
+			moduleDir := filepath.Join(tmpDir, module.RelativeDir)
+
+			if !tt.noModuleDir {
+				err := os.MkdirAll(moduleDir, 0777)
+				require.NoError(t, err)
+
+				// Copy the wasm module for testing
+				_, err = utils.CopyFile(modulePath, filepath.Join(moduleDir, filepath.Base(modulePath)))
+				require.NoError(t, err)
+			}
+
+			modulePaths := []string{filepath.Join(moduleDir, tt.moduleName+".wasm")}
+			m, err := module.NewManager(context.Background(), modulePaths...)
+			require.NoError(t, err)
+
+			// Register analyzer and post scanner from WASM module
+			m.Register()
+			defer func() {
+				analyzer.DeregisterAnalyzer(analyzer.Type(tt.moduleName))
+				post.DeregisterPostScanner(tt.moduleName)
+			}()
+
+			// Confirm the analyzer is registered
+			a, err := analyzer.NewAnalyzerGroup(analyzer.AnalyzerOptions{})
+			require.NoError(t, err)
+
+			got := a.AnalyzerVersions()
+			assert.Equal(t, tt.wantAnalyzerVersions, got)
+
+			// Confirm the post scanner is registered
+			got = post.ScannerVersions()
+			assert.Equal(t, tt.wantPostScannerVersions, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Adding a global flag which accepts an array of input WASM files
- Passing in the input string array of files to be loaded / registered as WASM modules
- Modularisation of loading of wasmPlugin  by call this common code from custom Module files loading and file.Walk from default relative directory ".trivy/modules"

Note: Tested on Windows environment as well.

## Related feature(s)
- Implement #3406

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
