### PR TITLE
fix(cli): make java db repository configurable

### DIFF
--- a/docs/docs/references/cli/client.md
+++ b/docs/docs/references/cli/client.md
@@ -37,6 +37,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/cli/fs.md
+++ b/docs/docs/references/cli/fs.md
@@ -45,6 +45,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/cli/image.md
+++ b/docs/docs/references/cli/image.md
@@ -59,6 +59,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/cli/repo.md
+++ b/docs/docs/references/cli/repo.md
@@ -42,6 +42,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/cli/rootfs.md
+++ b/docs/docs/references/cli/rootfs.md
@@ -48,6 +48,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/cli/sbom.md
+++ b/docs/docs/references/cli/sbom.md
@@ -45,6 +45,7 @@ DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
       --download-db-only       download/update vulnerability database but don't run a scan
       --download-java-db-only  download/update java indexes database but don't run a scan
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --no-progress            suppress progress bar
       --reset                  remove all caches and database
       --skip-db-update         skip updating vulnerability database

--- a/docs/docs/references/customization/config-file.md
+++ b/docs/docs/references/customization/config-file.md
@@ -41,7 +41,7 @@ report: all
 
 # Same as '--template'
 # Default is empty
-template: 
+template:
 
 # Same as '--dependency-tree'
 # Default is false
@@ -92,16 +92,16 @@ scan:
   skip-dirs:
     - usr/local/
     - etc/
-  
+
   # Same as '--skip-files'
   # Default is empty
   skip-files:
     - package-dev.json
-  
+
   # Same as '--offline-scan'
   # Default is false
   offline-scan: false
-  
+
   # Same as '--scanners'
   # Default depends on subcommand
   scanners:
@@ -115,23 +115,23 @@ scan:
 ```yaml
 cache:
   # Same as '--cache-backend'
-  # Default is 'fs' 
+  # Default is 'fs'
   backend: 'fs'
-  
+
   # Same as '--cache-ttl'
-  # Default is 0 (no ttl) 
+  # Default is 0 (no ttl)
   ttl: 0
-  
+
   # Redis options
   redis:
     # Same as '--redis-ca'
     # Default is empty
     ca:
-    
+
     # Same as '--redis-cert'
     # Default is empty
     cert:
-    
+
     # Same as '--redis-key'
     # Default is empty
     key:
@@ -144,14 +144,18 @@ db:
   # Same as '--skip-db-update'
   # Default is false
   skip-update: false
-  
+
   # Same as '--no-progress'
   # Default is false
   no-progress: false
-  
+
   # Same as '--db-repository'
-  # Default is 'github.com/aquasecurity-trivy-repo'
-  repository: github.com/aquasecurity-trivy-repo
+  # Default is 'ghcr.io/aquasecurity/trivy-db'
+  repository: ghcr.io/aquasecurity/trivy-db
+
+  # Same as '--java-db-repository'
+  # Default is 'ghcr.io/aquasecurity/trivy-java-db'
+  java-repository: ghcr.io/aquasecurity/trivy-java-db
 ```
 
 ## Image Options
@@ -162,7 +166,7 @@ image:
   # Same as '--input' (available with 'trivy image')
   # Default is empty
   input:
-  
+
   # Same as '--removed-pkgs'
   # Default is false
   removed-pkgs: false
@@ -178,7 +182,7 @@ vulnerability:
   type:
     - os
     - library
-  
+
   # Same as '--ignore-unfixed'
   # Default is false
   ignore-unfixed: false
@@ -265,25 +269,25 @@ kubernetes:
   # Same as '--context'
   # Default is empty
   context:
-  
+
   # Same as '--namespace'
   # Default is empty
   namespace:
 ```
 
 ## Repository Options
-Available with git repository scanning (`trivy repo`) 
+Available with git repository scanning (`trivy repo`)
 
 ```yaml
 repository:
   # Same as '--branch'
   # Default is empty
   branch:
-  
+
   # Same as '--commit'
   # Default is empty
   commit:
-  
+
   # Same as '--tag'
   # Default is empty
   tag:
@@ -297,21 +301,21 @@ server:
   # Same as '--server' (available in client mode)
   # Default is empty
   addr: http://localhost:4954
-  
+
   # Same as '--token'
   # Default is empty
   token: "something-secret"
-  
+
   # Same as '--token-header'
   # Default is 'Trivy-Token'
   token-header: 'My-Token-Header'
-  
+
   # Same as '--custom-headers'
   # Default is empty
   custom-headers:
     - scanner: trivy
     - x-api-token: xxx
-    
+
   # Same as '--listen' (available in server mode)
   # Default is 'localhost:4954'
   listen: 0.0.0.0:10000
@@ -325,18 +329,18 @@ Available for cloud scanning (currently only `trivy aws`)
 cloud:
   # whether to force a cache update for every scan
   update-cache: false
-  
+
   # how old cached results can be before being invalidated
   max-cache-age: 24h
-  
+
   # aws-specific cloud settings
   aws:
     # the aws region to use
     region: us-east-1
-    
+
     # the aws endpoint to use (not required for general use)
     endpoint: https://my.custom.aws.endpoint
-    
+
     # the aws account to use (this will be determined from your environment when not set)
     account: 123456789012
 ```

--- a/docs/docs/vulnerability/examples/db.md
+++ b/docs/docs/vulnerability/examples/db.md
@@ -43,3 +43,13 @@ $ trivy image --download-db-only
 ```
 $ trivy image --db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-db
 ```
+
+## Java Vulnerability DB
+
+The same options are also available for the Java vulnerability DB, which is used for scanning Java applications. Skipping an update can be done by using the `--skip-java-db-update` option, while `--download-java-db-only` can be used to only download the Java vulnerability DB.
+
+Downloading the Java vulnerability DB from an external OCI registry can be done by using the `--java-db-repository` option.
+
+```
+$ trivy image --java-db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-java-db --download-java-db-only
+```

--- a/docs/docs/vulnerability/examples/db.md
+++ b/docs/docs/vulnerability/examples/db.md
@@ -45,10 +45,10 @@ $ trivy image --db-repository registry.gitlab.com/gitlab-org/security-products/d
 ```
 
 ## Java Vulnerability DB
+The same options are also available for the Java index DB, which is used for scanning Java applications.
+Skipping an update can be done by using the `--skip-java-db-update` option, while `--download-java-db-only` can be used to only download the Java index DB.
 
-The same options are also available for the Java vulnerability DB, which is used for scanning Java applications. Skipping an update can be done by using the `--skip-java-db-update` option, while `--download-java-db-only` can be used to only download the Java vulnerability DB.
-
-Downloading the Java vulnerability DB from an external OCI registry can be done by using the `--java-db-repository` option.
+Downloading the Java index DB from an external OCI registry can be done by using the `--java-db-repository` option.
 
 ```
 $ trivy image --java-db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-java-db --download-java-db-only

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -341,7 +341,7 @@ func (r *runner) initJavaDB(opts flag.Options) error {
 
 	// Update the Java DB
 	noProgress := opts.Quiet || opts.NoProgress
-	javadb.Init(opts.CacheDir, opts.SkipJavaDBUpdate, noProgress, opts.Insecure)
+	javadb.Init(opts.CacheDir, opts.JavaDBRepository, opts.SkipJavaDBUpdate, noProgress, opts.Insecure)
 	if opts.DownloadJavaDBOnly {
 		if err := javadb.Update(); err != nil {
 			return xerrors.Errorf("Java DB error: %w", err)

--- a/pkg/fanal/analyzer/language/java/jar/jar_test.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar_test.go
@@ -15,6 +15,10 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+const (
+	defaultJavaDBRepository = "ghcr.io/aquasecurity/trivy-java-db"
+)
+
 func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -130,7 +134,7 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			// init java-trivy-db with skip update
-			javadb.Init("testdata", true, false, false)
+			javadb.Init("testdata", defaultJavaDBRepository, true, false, false)
 
 			a := javaLibraryAnalyzer{}
 			ctx := context.Background()

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -7,6 +7,7 @@ import (
 )
 
 const defaultDBRepository = "ghcr.io/aquasecurity/trivy-db"
+const defaultJavaDBRepository = "ghcr.io/aquasecurity/trivy-java-db"
 
 var (
 	ResetFlag = Flag{
@@ -57,6 +58,12 @@ var (
 		Value:      defaultDBRepository,
 		Usage:      "OCI repository to retrieve trivy-db from",
 	}
+	JavaDBRepositoryFlag = Flag{
+		Name:       "java-db-repository",
+		ConfigName: "db.java-repository",
+		Value:      defaultJavaDBRepository,
+		Usage:      "OCI repository to retrieve trivy-java-db from",
+	}
 	LightFlag = Flag{
 		Name:       "light",
 		ConfigName: "db.light",
@@ -75,6 +82,7 @@ type DBFlagGroup struct {
 	SkipJavaDBUpdate   *Flag
 	NoProgress         *Flag
 	DBRepository       *Flag
+	JavaDBRepository   *Flag
 	Light              *Flag // deprecated
 }
 
@@ -86,6 +94,7 @@ type DBOptions struct {
 	SkipJavaDBUpdate   bool
 	NoProgress         bool
 	DBRepository       string
+	JavaDBRepository   string
 	Light              bool // deprecated
 }
 
@@ -100,6 +109,7 @@ func NewDBFlagGroup() *DBFlagGroup {
 		Light:              &LightFlag,
 		NoProgress:         &NoProgressFlag,
 		DBRepository:       &DBRepositoryFlag,
+		JavaDBRepository:   &JavaDBRepositoryFlag,
 	}
 }
 
@@ -116,6 +126,7 @@ func (f *DBFlagGroup) Flags() []*Flag {
 		f.SkipJavaDBUpdate,
 		f.NoProgress,
 		f.DBRepository,
+		f.JavaDBRepository,
 		f.Light,
 	}
 }
@@ -146,5 +157,6 @@ func (f *DBFlagGroup) ToOptions() (DBOptions, error) {
 		Light:              light,
 		NoProgress:         getBool(f.NoProgress),
 		DBRepository:       getString(f.DBRepository),
+		JavaDBRepository:   getString(f.JavaDBRepository),
 	}, nil
 }

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	defaultJavaDBRepository = "ghcr.io/aquasecurity/trivy-java-db"
-	mediaType               = "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+	mediaType = "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
 )
 
 var updater *Updater
@@ -48,6 +47,7 @@ func (u *Updater) Update() error {
 
 	if (meta.Version != db.SchemaVersion || meta.NextUpdate.Before(time.Now().UTC())) && !u.skip {
 		// Download DB
+		log.Logger.Infof("Java DB Repository: %s", u.repo)
 		log.Logger.Info("Downloading the Java DB...")
 
 		var a *oci.Artifact
@@ -76,9 +76,9 @@ func (u *Updater) Update() error {
 	return nil
 }
 
-func Init(cacheDir string, skip, quiet, insecure bool) {
+func Init(cacheDir string, javaDBRepository string, skip, quiet, insecure bool) {
 	updater = &Updater{
-		repo:     fmt.Sprintf("%s:%d", defaultJavaDBRepository, db.SchemaVersion), // TODO: make it configurable
+		repo:     fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion),
 		dbDir:    filepath.Join(cacheDir, "java-db"),
 		skip:     skip,
 		quiet:    quiet,


### PR DESCRIPTION
## Description

This implements an additional `--java-db-repository` option to allow users to specify a custom Java DB repository. This is useful for users who want to use a custom Java DB repository, such as a private repository mirror like Artifactory or other private registries. It will also print the Java DB repository - even if it's the default - to make it clear to the user which Java DB repository is being used.

I've updated the documentation to reflect this new option, as well as the existing tests for the JAR file scanner.

### Before

Scanning an image containing JAR files will print the following:

```bash
$ trivy image tomcat:9.0.71-jdk8        
2023-02-11T15:12:30.064+0100    INFO    Need to update DB
2023-02-11T15:12:30.064+0100    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-02-11T15:12:30.064+0100    INFO    Downloading DB...
...
2023-02-11T15:12:33.442+0100    INFO    Vulnerability scanning is enabled
2023-02-11T15:12:33.442+0100    INFO    Secret scanning is enabled
2023-02-11T15:12:33.442+0100    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-02-11T15:12:33.442+0100    INFO    Please see also https://aquasecurity.github.io/trivy/v0.37/docs/secret/scanning/#recommendation for faster secret detection
2023-02-11T15:12:37.627+0100    INFO    JAR files found
2023-02-11T15:12:37.627+0100    INFO    Downloading the Java DB...
...
```

### After

Scanning the same image with a custom Java DB repository will print the following:

```bash
$ trivy image --java-db-repository ghcr.io/nobbs/trivy-java-db tomcat:9.0.71-jdk8               
2023-02-11T15:10:16.681+0100    INFO    Need to update DB
2023-02-11T15:10:16.682+0100    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-02-11T15:10:16.682+0100    INFO    Downloading DB...
...
2023-02-11T15:10:19.858+0100    INFO    Vulnerability scanning is enabled
2023-02-11T15:10:19.858+0100    INFO    Secret scanning is enabled
2023-02-11T15:10:19.858+0100    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-02-11T15:10:19.858+0100    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2023-02-11T15:10:23.631+0100    INFO    JAR files found
2023-02-11T15:10:23.632+0100    INFO    Java DB Repository: ghcr.io/nobbs/trivy-java-db:1
2023-02-11T15:10:23.632+0100    INFO    Downloading the Java DB...
...
```

The help text for scans supporting the `--java-db-repository` option will now print the following:

```bash
$ trivy image --help
...
DB Flags
      --db-repository string        OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
      --download-db-only            download/update vulnerability database but don't run a scan
      --download-java-db-only       download/update Java index database but don't run a scan
      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
      --no-progress                 suppress progress bar
      --reset                       remove all caches and database
      --skip-db-update              skip updating vulnerability database
      --skip-java-db-update         skip updating Java index database
... 
```

## Related issues
- Close #3545
  Partially, this does not implement any authentication functionality mentioned in that issue.

## Related PRs
None

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
