### PR TITLE
ci: add gpg signing for RPM packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,5 +50,8 @@ jobs:
       - name: Create rpm repository
         run: ci/deploy-rpm.sh
 
+      - name: Import GPG key
+        run: echo -e "${{ secrets.GPG_KEY }}" | gpg --import
+
       - name: Create deb repository
         run: ci/deploy-deb.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,5 @@ jobs:
       - name: Create rpm repository
         run: ci/deploy-rpm.sh
 
-      - name: Import GPG key
-        run: echo -e "${{ secrets.GPG_KEY }}" | gpg --import
-
       - name: Create deb repository
         run: ci/deploy-deb.sh

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: AQUA_ENVIRONMENT
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     permissions:

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -91,6 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       ## push images to registries
       ## only for canary build

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -19,7 +19,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    environment: AQUA_ENVIRONMENT
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     permissions:

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -83,6 +83,12 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: "save gpg key"
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+        run: |
+          echo "$GPG_KEY" > gpg.txt
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -92,6 +98,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_FILE: "gpg.txt"
+
+      - name: "remove gpg key"
+        run: |
+          rm gpg.txt
 
       ## push images to registries
       ## only for canary build

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -75,13 +75,6 @@ jobs:
           args: mod -licenses -json -output bom.json
           version: ^v1
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
       - name: "save gpg key"
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
@@ -95,8 +88,6 @@ jobs:
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FILE: "gpg.txt"
 

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -75,6 +75,13 @@ jobs:
           args: mod -licenses -json -output bom.json
           version: ^v1
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -82,6 +89,7 @@ jobs:
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
       ## push images to registries
       ## only for canary build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,4 +120,5 @@ jobs:
       with:
         version: v1.4.1
         args: release --skip-sign --snapshot --rm-dist --skip-publish --timeout 90m
-
+      env:
+        GPG_FILE: "nofile"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,8 +15,9 @@ In this section you will find an aggregation of the different ways to install Tr
     [trivy]
     name=Trivy repository
     baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$RELEASE_VERSION/\$basearch/
-    gpgcheck=0
+    gpgcheck=1
     enabled=1
+    gpgkey=https://aquasecurity.github.io/trivy-repo/deb/public.key
     EOF
     sudo yum -y update
     sudo yum -y install trivy

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ In this section you will find an aggregation of the different ways to install Tr
     baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$RELEASE_VERSION/\$basearch/
     gpgcheck=1
     enabled=1
-    gpgkey=https://aquasecurity.github.io/trivy-repo/deb/public.key
+    gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
     EOF
     sudo yum -y update
     sudo yum -y install trivy

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -254,19 +254,6 @@ docker_manifests:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
 
 signs:
-- id: "gpg signing"
-  artifacts: all
-  signature: "${artifact}.gpg.sig"
-  args:
-    - "--batch"
-    - "-u"
-    - "{{ .Env.GPG_FINGERPRINT }}"
-    - "--output"
-    - "${signature}"
-    - "--detach-sign"
-    - "${artifact}"
-  output: true
-  stdin: '{{ .Env.GPG_PASSPHRASE }}'
 - cmd: cosign
   env:
   - COSIGN_EXPERIMENTAL=1

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -266,6 +266,7 @@ signs:
   output: true
 - id: "gpg signing"
   artifacts: package
+  signature: "${artifact}.gpg.sig"
   args:
     - "--batch"
     - "--local-user"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -264,6 +264,16 @@ signs:
     - "${artifact}"
   artifacts: all
   output: true
+- id: "gpg signing"
+  artifacts: package
+  args:
+    - "--batch"
+    - "--local-user"
+    - "{{ .Env.GPG_FINGERPRINT }}"
+    - "--output"
+    - "${signature}"
+    - "--detach-sign"
+    - "${artifact}"
 
 docker_signs:
 - cmd: cosign

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -275,6 +275,8 @@ signs:
     - "${signature}"
     - "--detach-sign"
     - "${artifact}"
+  output: true
+  stdin: '{{ .Env.GPG_PASSPHRASE }}'
 
 docker_signs:
 - cmd: cosign

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -74,6 +74,9 @@ nfpms:
     contents:
      - src: contrib/*.tpl
        dst: /usr/local/share/trivy/templates
+    rpm:
+      signature:
+         key_file: '{{ .Env.GPG_FILE }}'
 
 archives:
   -
@@ -251,6 +254,19 @@ docker_manifests:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
 
 signs:
+- id: "gpg signing"
+  artifacts: all
+  signature: "${artifact}.gpg.sig"
+  args:
+    - "--batch"
+    - "-u"
+    - "{{ .Env.GPG_FINGERPRINT }}"
+    - "--output"
+    - "${signature}"
+    - "--detach-sign"
+    - "${artifact}"
+  output: true
+  stdin: '{{ .Env.GPG_PASSPHRASE }}'
 - cmd: cosign
   env:
   - COSIGN_EXPERIMENTAL=1
@@ -264,19 +280,6 @@ signs:
     - "${artifact}"
   artifacts: all
   output: true
-- id: "gpg signing"
-  artifacts: package
-  signature: "${artifact}.gpg.sig"
-  args:
-    - "--batch"
-    - "--local-user"
-    - "{{ .Env.GPG_FINGERPRINT }}"
-    - "--output"
-    - "${signature}"
-    - "--detach-sign"
-    - "${artifact}"
-  output: true
-  stdin: '{{ .Env.GPG_PASSPHRASE }}'
 
 docker_signs:
 - cmd: cosign


### PR DESCRIPTION
## Description

Added inline signatures for `RPM` packages.

we use custom configuration [GoReleaser's nFPM](https://goreleaser.com/customization/nfpm/?h=rpm), so we need to set `$NFPM_ID_RPM_PASSPHRASE` and `$GPG_FILE`.

## Related issues
Closes #1384 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
