### PR TITLE
fix(aws): Adding a fix for update-cache flag that is not applied on AWS scans.

### DIFF
--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -93,10 +93,14 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 			framework.CIS_AWS_1_2))
 	}
 
+	if option.CloudOptions.UpdateCache {
+		scannerOpts = append(scannerOpts, options.ScannerWithSpec(option.Compliance))
+	}
+
 	scanner := aws.New(scannerOpts...)
 
 	var freshState *state.State
-	if len(missing) > 0 {
+	if len(missing) > 0 || option.CloudOptions.UpdateCache {
 		var err error
 		freshState, err = scanner.CreateState(ctx)
 		if err != nil {

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -93,10 +93,6 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 			framework.CIS_AWS_1_2))
 	}
 
-	if option.CloudOptions.UpdateCache {
-		scannerOpts = append(scannerOpts, options.ScannerWithSpec(option.Compliance))
-	}
-
 	scanner := aws.New(scannerOpts...)
 
 	var freshState *state.State


### PR DESCRIPTION
## Description
Fixes a bug where update-cache flag is not being properly applied.

## Related issues
- Close #3618 

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
