### PR TITLE
feat: add support for Chainguard's commercial distro

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -47,6 +47,7 @@ jobs:
 
             alpine
             wolfi
+            chainguard
             redhat
             alma
             rocky

--- a/docs/docs/vulnerability/detection/data-source.md
+++ b/docs/docs/vulnerability/detection/data-source.md
@@ -5,6 +5,7 @@
 | Arch Linux    | [Vulnerable Issues][arch]              |
 | Alpine Linux  | [secdb][alpine]                        |
 | Wolfi Linux   | [secdb][wolfi]                         |
+| Chainguard    | [secdb][chainguard]                    |
 | Amazon Linux  | [Amazon Linux Security Center][amazon] |
 | Debian        | [Security Bug Tracker][debian-tracker] |
 |               | [OVAL][debian-oval]                    |
@@ -61,6 +62,7 @@ The severity is from the selected data source. If the data source does not provi
 [arch]: https://security.archlinux.org/
 [alpine]: https://secdb.alpinelinux.org/
 [wolfi]: https://packages.wolfi.dev/os/security.json
+[chainguard]: https://packages.cgr.dev/chainguard/security.json
 [amazon]: https://alas.aws.amazon.com/
 [debian-tracker]: https://security-tracker.debian.org/tracker/
 [debian-oval]: https://www.debian.org/security/oval/

--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -6,6 +6,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 |----------------------------------|-------------------------------------------|-------------------------------|:------------------------------------:|
 | Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.17, edge               | Installed by apk              |                  NO                  |
 | Wolfi Linux                      | (n/a)                                     | Installed by apk              |                  NO                  |
+| Chainguard                       | (n/a)                                     | Installed by apk              |                  NO                  |
 | Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |
 | Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
 | CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/aquasecurity/table v1.8.0
 	github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da
 	github.com/aquasecurity/tml v0.6.1
-	github.com/aquasecurity/trivy-db v0.0.0-20230116084806-4bcdf1c414d0
+	github.com/aquasecurity/trivy-db v0.0.0-20230411140759-3c2ee2168575
 	github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728
 	github.com/aquasecurity/trivy-kubernetes v0.4.1-0.20230329141338-410c58d31395
 	github.com/aws/aws-sdk-go v1.44.234
@@ -96,7 +96,7 @@ require (
 	golang.org/x/mod v0.9.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.6.0
-	golang.org/x/text v0.8.0
+	golang.org/x/text v0.9.0
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -190,7 +190,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/briandowns/spinner v1.19.0 // indirect
+	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gw
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
 github.com/aquasecurity/trivy-db v0.0.0-20230116084806-4bcdf1c414d0 h1:FI5qaSoJEH47SZVvRVtTPvOmlECG2IRN92deZ/oXHis=
 github.com/aquasecurity/trivy-db v0.0.0-20230116084806-4bcdf1c414d0/go.mod h1:l3BWhRS80Mkeb++dgXij/6BmZIxLb9IpZCSAZHeI6Zk=
+github.com/aquasecurity/trivy-db v0.0.0-20230411140759-3c2ee2168575 h1:8Y/qLPXGFYGGetDo0uhMRnqF8696tWBVis5scJ42q3w=
+github.com/aquasecurity/trivy-db v0.0.0-20230411140759-3c2ee2168575/go.mod h1:zn8GepvD5wBkCmmtBDwh0BWfiMUxS6xfGRcTPmXRVXo=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728 h1:0eS+V7SXHgqoT99tV1mtMW6HL4HdoB9qGLMCb1fZp8A=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728/go.mod h1:Ldya37FLi0e/5Cjq2T5Bty7cFkzUDwTcPeQua+2M8i8=
 github.com/aquasecurity/trivy-kubernetes v0.4.1-0.20230329141338-410c58d31395 h1:KDr8EyCLZHsM7KBB9XqIAtYzBvbfZoGBj3kWKT6k8y4=
@@ -507,6 +509,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
 github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
+github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
+github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
@@ -2087,6 +2091,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
+golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,6 @@ github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da h1:pj/adfN
 github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da/go.mod h1:852lbQLpK2nCwlR4ZLYIccxYCfoQao6q9Nl6tjz54v8=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy-db v0.0.0-20230116084806-4bcdf1c414d0 h1:FI5qaSoJEH47SZVvRVtTPvOmlECG2IRN92deZ/oXHis=
-github.com/aquasecurity/trivy-db v0.0.0-20230116084806-4bcdf1c414d0/go.mod h1:l3BWhRS80Mkeb++dgXij/6BmZIxLb9IpZCSAZHeI6Zk=
 github.com/aquasecurity/trivy-db v0.0.0-20230411140759-3c2ee2168575 h1:8Y/qLPXGFYGGetDo0uhMRnqF8696tWBVis5scJ42q3w=
 github.com/aquasecurity/trivy-db v0.0.0-20230411140759-3c2ee2168575/go.mod h1:zn8GepvD5wBkCmmtBDwh0BWfiMUxS6xfGRcTPmXRVXo=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728 h1:0eS+V7SXHgqoT99tV1mtMW6HL4HdoB9qGLMCb1fZp8A=
@@ -507,8 +505,6 @@ github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQ
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
-github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
-github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
@@ -1270,7 +1266,6 @@ github.com/masahiro331/go-xfs-filesystem v0.0.0-20221225060805-c02764233454/go.m
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -2089,8 +2084,6 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
-golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/detector/ospkg/chainguard/chainguard.go
+++ b/pkg/detector/ospkg/chainguard/chainguard.go
@@ -1,0 +1,112 @@
+package chainguard
+
+import (
+	version "github.com/knqyf263/go-apk-version"
+	"golang.org/x/xerrors"
+	"k8s.io/utils/clock"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/chainguard"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scanner/utils"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+type options struct {
+	clock clock.Clock
+}
+
+type option func(*options)
+
+func WithClock(clock clock.Clock) option {
+	return func(opts *options) {
+		opts.clock = clock
+	}
+}
+
+// Scanner implements the Chainguard scanner
+type Scanner struct {
+	vs chainguard.VulnSrc
+	*options
+}
+
+// NewScanner is the factory method for Scanner
+func NewScanner(opts ...option) *Scanner {
+	o := &options{
+		clock: clock.RealClock{},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Scanner{
+		vs:      chainguard.NewVulnSrc(),
+		options: o,
+	}
+}
+
+// Detect vulnerabilities in package using Chainguard scanner
+func (s *Scanner) Detect(_ string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	log.Logger.Info("Detecting Chainguard vulnerabilities...")
+
+	log.Logger.Debugf("chainguard: the number of packages: %d", len(pkgs))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		srcName := pkg.SrcName
+		if srcName == "" {
+			srcName = pkg.Name
+		}
+		advisories, err := s.vs.Get("", srcName)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get Chainguard advisories: %w", err)
+		}
+
+		installed := utils.FormatVersion(pkg)
+		installedVersion, err := version.NewVersion(installed)
+		if err != nil {
+			log.Logger.Debugf("failed to parse Chainguard installed package version: %s", err)
+			continue
+		}
+
+		for _, adv := range advisories {
+			if !s.isVulnerable(installedVersion, adv) {
+				continue
+			}
+			vulns = append(vulns, types.DetectedVulnerability{
+				VulnerabilityID:  adv.VulnerabilityID,
+				PkgID:            pkg.ID,
+				PkgName:          pkg.Name,
+				InstalledVersion: installed,
+				FixedVersion:     adv.FixedVersion,
+				Layer:            pkg.Layer,
+				Ref:              pkg.Ref,
+				Custom:           adv.Custom,
+				DataSource:       adv.DataSource,
+			})
+		}
+	}
+	return vulns, nil
+}
+
+func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Advisory) bool {
+	// Compare versions for fixed vulnerabilities
+	fixedVersion, err := version.NewVersion(adv.FixedVersion)
+	if err != nil {
+		log.Logger.Debugf("failed to parse Chainguard fixed version: %s", err)
+		return false
+	}
+
+	// It means the fixed vulnerability
+	return installedVersion.LessThan(fixedVersion)
+}
+
+// IsSupportedVersion checks the OSFamily can be scanned using Chainguard scanner
+func (s *Scanner) IsSupportedVersion(_, _ string) bool {
+	// Chainguard doesn't have versions, so there is no case where a given input yields a
+	// result of an unsupported Chainguard version.
+
+	return true
+}

--- a/pkg/detector/ospkg/chainguard/chainguard_test.go
+++ b/pkg/detector/ospkg/chainguard/chainguard_test.go
@@ -1,0 +1,197 @@
+package chainguard_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/chainguard"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy/pkg/dbtest"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanner_Detect(t *testing.T) {
+	type args struct {
+		repo *ftypes.Repository
+		pkgs []ftypes.Package
+	}
+	tests := []struct {
+		name     string
+		args     args
+		fixtures []string
+		want     []types.DetectedVulnerability
+		wantErr  string
+	}{
+		{
+			name:     "happy path",
+			fixtures: []string{"testdata/fixtures/chainguard.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "ansible",
+						Version:    "2.6.4",
+						SrcName:    "ansible",
+						SrcVersion: "2.6.4",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+					{
+						Name:       "invalid",
+						Version:    "invalid", // skipped
+						SrcName:    "invalid",
+						SrcVersion: "invalid",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "ansible",
+					VulnerabilityID:  "CVE-2019-10217",
+					InstalledVersion: "2.6.4",
+					FixedVersion:     "2.8.4-r0",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Chainguard,
+						Name: "Chainguard Secdb",
+						URL:  "https://packages.cgr.dev/chainguard/security.json",
+					},
+				},
+			},
+		},
+		{
+			name:     "contain rc",
+			fixtures: []string{"testdata/fixtures/chainguard.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "jq",
+						Version:    "1.6-r0",
+						SrcName:    "jq",
+						SrcVersion: "1.6-r0",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "jq",
+					VulnerabilityID:  "CVE-2020-1234",
+					InstalledVersion: "1.6-r0",
+					FixedVersion:     "1.6-r1",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Chainguard,
+						Name: "Chainguard Secdb",
+						URL:  "https://packages.cgr.dev/chainguard/security.json",
+					},
+				},
+			},
+		},
+		{
+			name:     "contain pre",
+			fixtures: []string{"testdata/fixtures/chainguard.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "test",
+						Version:    "0.1.0_alpha",
+						SrcName:    "test-src",
+						SrcVersion: "0.1.0_alpha",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2030-0002",
+					PkgName:          "test",
+					InstalledVersion: "0.1.0_alpha",
+					FixedVersion:     "0.1.0_alpha2",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Chainguard,
+						Name: "Chainguard Secdb",
+						URL:  "https://packages.cgr.dev/chainguard/security.json",
+					},
+				},
+			},
+		},
+		{
+			name:     "Get returns an error",
+			fixtures: []string{"testdata/fixtures/invalid.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "jq",
+						Version:    "1.6-r0",
+						SrcName:    "jq",
+						SrcVersion: "1.6-r0",
+					},
+				},
+			},
+			wantErr: "failed to get Chainguard advisories",
+		},
+		{
+			name:     "No src name",
+			fixtures: []string{"testdata/fixtures/chainguard.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				repo: &ftypes.Repository{
+					Family:  os.Chainguard,
+					Release: "3.10",
+				},
+				pkgs: []ftypes.Package{
+					{
+						Name:       "jq",
+						Version:    "1.6-r0",
+						SrcVersion: "1.6-r0",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "jq",
+					VulnerabilityID:  "CVE-2020-1234",
+					InstalledVersion: "1.6-r0",
+					FixedVersion:     "1.6-r1",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Chainguard,
+						Name: "Chainguard Secdb",
+						URL:  "https://packages.cgr.dev/chainguard/security.json",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = dbtest.InitDB(t, tt.fixtures)
+			defer db.Close()
+
+			s := chainguard.NewScanner()
+			got, err := s.Detect("", tt.args.repo, tt.args.pkgs)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].VulnerabilityID < got[j].VulnerabilityID
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/ospkg/chainguard/testdata/fixtures/chainguard.yaml
+++ b/pkg/detector/ospkg/chainguard/testdata/fixtures/chainguard.yaml
@@ -1,0 +1,39 @@
+- bucket: chainguard
+  pairs:
+    - bucket: ansible
+      pairs:
+        - key: CVE-2018-10875
+          value:
+            FixedVersion: "2.6.3-r0"
+        - key: CVE-2019-10217
+          value:
+            FixedVersion: "2.8.4-r0"
+        - key: CVE-2020-1740
+          value:
+            FixedVersion: ""
+            AffectedVersion: "2.6.5"
+        - key: CVE-2021-20191
+          value:
+            FixedVersion: ""
+        - key: CVE-2019-INVALID
+          value:
+            FixedVersion: "invalid"
+    - bucket: jq
+      pairs:
+        - key: CVE-2016-4074
+          value:
+            FixedVersion: "1.6_rc1-r0"
+        - key: CVE-2019-9999
+          value:
+            FixedVersion: "1.6_rc2"
+        - key: CVE-2020-1234
+          value:
+            FixedVersion: "1.6-r1"
+    - bucket: test-src
+      pairs:
+        - key: CVE-2030-0001
+          value:
+            FixedVersion: "0.1.0_alpha_pre2"
+        - key: CVE-2030-0002
+          value:
+            FixedVersion: "0.1.0_alpha2"

--- a/pkg/detector/ospkg/chainguard/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/chainguard/testdata/fixtures/data-source.yaml
@@ -1,0 +1,7 @@
+- bucket: data-source
+  pairs:
+    - key: chainguard
+      value:
+        ID: "chainguard"
+        Name: "Chainguard Secdb"
+        URL: "https://packages.cgr.dev/chainguard/security.json"

--- a/pkg/detector/ospkg/chainguard/testdata/fixtures/invalid.yaml
+++ b/pkg/detector/ospkg/chainguard/testdata/fixtures/invalid.yaml
@@ -1,0 +1,9 @@
+- bucket: chainguard
+  pairs:
+    - bucket: jq
+      pairs:
+        - key: CVE-2020-8177
+          value:
+            FixedVersion:
+              - foo
+              - bar

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alma"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alpine"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/amazon"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/chainguard"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/mariner"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/oracle"
@@ -42,6 +43,7 @@ var (
 		fos.SLES:         suse.NewScanner(suse.SUSEEnterpriseLinux),
 		fos.Photon:       photon.NewScanner(),
 		fos.Wolfi:        wolfi.NewScanner(),
+		fos.Chainguard:   chainguard.NewScanner(),
 	}
 )
 

--- a/pkg/detector/ospkg/wolfi/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/wolfi/testdata/fixtures/data-source.yaml
@@ -4,4 +4,4 @@
       value:
         ID: "wolfi"
         Name: "Wolfi Secdb"
-        URL: "https://packages.wolfi.dev/os/security.json/"
+        URL: "https://packages.wolfi.dev/os/security.json"

--- a/pkg/detector/ospkg/wolfi/wolfi_test.go
+++ b/pkg/detector/ospkg/wolfi/wolfi_test.go
@@ -63,7 +63,7 @@ func TestScanner_Detect(t *testing.T) {
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Wolfi,
 						Name: "Wolfi Secdb",
-						URL:  "https://packages.wolfi.dev/os/security.json/",
+						URL:  "https://packages.wolfi.dev/os/security.json",
 					},
 				},
 			},
@@ -90,7 +90,7 @@ func TestScanner_Detect(t *testing.T) {
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Wolfi,
 						Name: "Wolfi Secdb",
-						URL:  "https://packages.wolfi.dev/os/security.json/",
+						URL:  "https://packages.wolfi.dev/os/security.json",
 					},
 				},
 			},
@@ -123,7 +123,7 @@ func TestScanner_Detect(t *testing.T) {
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Wolfi,
 						Name: "Wolfi Secdb",
-						URL:  "https://packages.wolfi.dev/os/security.json/",
+						URL:  "https://packages.wolfi.dev/os/security.json",
 					},
 				},
 			},
@@ -168,7 +168,7 @@ func TestScanner_Detect(t *testing.T) {
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Wolfi,
 						Name: "Wolfi Secdb",
-						URL:  "https://packages.wolfi.dev/os/security.json/",
+						URL:  "https://packages.wolfi.dev/os/security.json",
 					},
 				},
 			},

--- a/pkg/fanal/analyzer/os/const.go
+++ b/pkg/fanal/analyzer/os/const.go
@@ -60,6 +60,9 @@ const (
 
 	// Wolfi is done
 	Wolfi = "wolfi"
+
+	// Chainguard is done
+	Chainguard = "chainguard"
 )
 
 var AnalyzeOSError = xerrors.New("unable to analyze OS information")

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -61,6 +61,8 @@ func (a osReleaseAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInp
 			family = aos.Photon
 		case "wolfi":
 			family = aos.Wolfi
+		case "chainguard":
+			family = aos.Chainguard
 		}
 
 		if family != "" && versionID != "" {


### PR DESCRIPTION
## Description

This PR adds support for Chainguard's commercial Linux distribution, which is based on [Wolfi](https://github.com/wolfi-dev/).

### Before

```console
$ trivy i ghcr.io/luhring/trivy-chainguard:latest
2023-02-16T16:37:55.851-0500	INFO	Vulnerability scanning is enabled
2023-02-16T16:37:55.851-0500	INFO	Secret scanning is enabled
2023-02-16T16:37:55.851-0500	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-02-16T16:37:55.851-0500	INFO	Please see also https://aquasecurity.github.io/trivy/v0.37/docs/secret/scanning/#recommendation for faster secret detection
2023-02-16T16:37:55.860-0500	INFO	Detected OS: none
2023-02-16T16:37:55.860-0500	WARN	unsupported os : none
2023-02-16T16:37:55.860-0500	INFO	Number of language-specific files: 0
```

### After

```console
$ go run ./cmd/trivy --cache-dir '../trivy-db/cache' i --skip-db-update ghcr.io/luhring/trivy-chainguard:latest
2023-02-16T16:38:28.870-0500	INFO	Vulnerability scanning is enabled
2023-02-16T16:38:28.870-0500	INFO	Secret scanning is enabled
2023-02-16T16:38:28.870-0500	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-02-16T16:38:28.870-0500	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2023-02-16T16:38:28.875-0500	INFO	Detected OS: chainguard
2023-02-16T16:38:28.875-0500	INFO	Detecting Chainguard vulnerabilities...
2023-02-16T16:38:28.876-0500	INFO	Number of language-specific files: 0

ghcr.io/luhring/trivy-chainguard:latest (chainguard 20230214)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

### Notes

- Depends on `trivy-db` version bump once https://github.com/aquasecurity/trivy-db/pull/281 is merged
- See related re: Wolfi support: https://github.com/aquasecurity/trivy/pull/3215

## Related issues
- Close #3630 

## Related PRs
- [ ] https://github.com/aquasecurity/vuln-list-update/pull/190
- [ ] https://github.com/aquasecurity/trivy-db/pull/281

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
