### PR TITLE
feat: add support for virtual files in mapfs

### DIFF
--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -88,7 +88,7 @@ func (m *FS) Stat(name string) (fs.FileInfo, error) {
 			Err:  err,
 		}
 	}
-	if f.stat.IsDir() {
+	if f.isVirtual() {
 		return &f.stat, nil
 	}
 	return os.Stat(f.path)
@@ -105,9 +105,14 @@ func (m *FS) Open(name string) (fs.File, error) {
 	return m.root.Open(cleanPath(name))
 }
 
-// WriteFile writes the specified bytes to the named file. If the file exists, it will be overwritten.
+// WriteFile creates a mapping between path and underlyingPath.
 func (m *FS) WriteFile(path, underlyingPath string) error {
 	return m.root.WriteFile(cleanPath(path), underlyingPath)
+}
+
+// WriteVirtualFile writes the specified bytes to the named file. If the file exists, it will be overwritten.
+func (m *FS) WriteVirtualFile(path string, data []byte, mode fs.FileMode) error {
+	return m.root.WriteVirtualFile(cleanPath(path), data, mode)
 }
 
 // MkdirAll creates a directory named path,


### PR DESCRIPTION
## Description
This PR adds support for virtual files in `mapfs`.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
