### PR TITLE
chore(helm): update skip-db-update environment variable

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trivy
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.37.2
 description: Trivy helm chart
 keywords:

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -68,7 +68,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
 | `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
 | `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
-| `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
+| `trivy.skipDBUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
 | `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from        | `ghcr.io/aquasecurity/trivy-db`        |
 | `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
 | `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |

--- a/helm/trivy/templates/configmap.yaml
+++ b/helm/trivy/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   TRIVY_CACHE_TTL: {{ .Values.trivy.cache.redis.ttl | quote }}
 {{- end }}
   TRIVY_DEBUG: {{ .Values.trivy.debugMode | quote }}
-  TRIVY_SKIP_UPDATE: {{ .Values.trivy.skipUpdate | quote }}
+  TRIVY_SKIP_DB_UPDATE: {{ .Values.trivy.skipDBUpdate | quote }}
   TRIVY_DB_REPOSITORY: {{ .Values.trivy.dbRepository | quote }}
 {{- if .Values.httpProxy }}
   HTTP_PROXY: {{ .Values.httpProxy | quote }}

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -93,12 +93,12 @@ trivy:
   # NOTE: When this is set the previous parameters are ignored.
   #
   # registryCredentialsExistingSecret: name-of-existing-secret
-  # skipUpdate the flag to enable or disable Trivy DB downloads from GitHub
+  # skipDBUpdate the flag to enable or disable Trivy DB downloads from GitHub
   #
   # You might want to enable this flag in test or CI/CD environments to avoid GitHub rate limiting issues.
   # If the flag is enabled you have to manually download the `trivy.db` file and mount it in the
   # `/home/scanner/.cache/trivy/db/trivy.db` path (see `cacheDir`).
-  skipUpdate: false
+  skipDBUpdate: false
   # OCI repository to retrieve the trivy vulnerability database from
   dbRepository: ghcr.io/aquasecurity/trivy-db
   # Trivy supports filesystem and redis as caching backend


### PR DESCRIPTION
## Description

Use `TRIVY_SKIP_DB_UPDATE` instead of `TRIVY_SKIP_UPDATE`.

## Related issues
- Close #3656

## Before

```
2023-02-20T16:59:57.928Z        WARN    'TRIVY_SKIP_UPDATE' is deprecated. Use 'TRIVY_SKIP_DB_UPDATE' instead.
2023-02-20T16:59:57.931Z        INFO    Listening 0.0.0.0:4954...
```

## After

```
2023-02-20T16:59:57.931Z        INFO    Listening 0.0.0.0:4954...
```

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
