### PR TITLE
fix(spdx): change CreationInfo timestamp format RFC3336Nano to RFC3336

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -150,7 +150,7 @@ func (m *Marshaler) Marshal(r types.Report) (*spdx.Document2_2, error) {
 			DocumentNamespace:    getDocumentNamespace(r, m),
 			CreatorOrganizations: []string{CreatorOrganization},
 			CreatorTools:         []string{CreatorTool},
-			Created:              m.clock.Now().UTC().Format(time.RFC3339Nano),
+			Created:              m.clock.Now().UTC().Format(time.RFC3339),
 		},
 		Packages:      packages,
 		Relationships: relationShips,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -106,7 +106,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
 					CreatorTools:         []string{"trivy"},
-					Created:              "2021-08-25T12:20:30.000000005Z",
+					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("ContainerImage-9396d894cd0cb6cb"): {
@@ -311,7 +311,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
 					CreatorTools:         []string{"trivy"},
-					Created:              "2021-08-25T12:20:30.000000005Z",
+					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("ContainerImage-413bfede37ad01fc"): {
@@ -464,7 +464,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
 					CreatorTools:         []string{"trivy"},
-					Created:              "2021-08-25T12:20:30.000000005Z",
+					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("Filesystem-5af0f1f08c20909a"): {
@@ -547,7 +547,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
 					CreatorTools:         []string{"trivy"},
-					Created:              "2021-08-25T12:20:30.000000005Z",
+					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("Repository-7cb7a269a391a798"): {
@@ -622,7 +622,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
 					CreatorTools:         []string{"trivy"},
-					Created:              "2021-08-25T12:20:30.000000005Z",
+					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
 					spdx.ElementID("Filesystem-70f34983067dba86"): {


### PR DESCRIPTION
## Description

Change CreationInfo timestamp format.
Before: Use RFC3336Nano format
After: Use RFC3336 format

Ref: https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#69-created-field

## Related issues
- Close #3600 


Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
