### PR TITLE
fix(sbom): fix fillPkgsInVulns's found conditions

### DIFF
--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -341,7 +341,7 @@ func (s Scanner) fillPkgsInVulns(pkgResults, vulnResults types.Results) types.Re
 	}
 	for _, result := range pkgResults {
 		if r, found := lo.Find(vulnResults, func(r types.Result) bool {
-			return r.Class == result.Class && r.Target == result.Target
+			return r.Class == result.Class && r.Target == result.Target && r.Type == result.Type
 		}); found {
 			r.Packages = result.Packages
 			results = append(results, r)


### PR DESCRIPTION
## Description

The fillPkgsInVulns function in pkg/scanner/local/scan.go pollutes the results.

```
if r, found := lo.Find(vulnResults, func(r types.Result) bool {
			return r.Class == result.Class && r.Target == result.Target
		});
```

It affects the following conditions.

* result.Class is lang-pkgs
* result.Target is empty string

This Pull Request fix the conditions. 

### debug pkg/scanner/local/scan.go fillPkgsInVulns function

```
func (s Scanner) fillPkgsInVulns(pkgResults, vulnResults types.Results) types.Results {
	var results types.Results
	if len(pkgResults) == 0 { // '--list-all-pkgs' == false or packages not found
		return vulnResults
	}
+	fmt.Println("====== pkg results")
+	for _, r := range pkgResults {
+		fmt.Println(r.Type)
+	}
	for _, result := range pkgResults {
		if r, found := lo.Find(vulnResults, func(r types.Result) bool {
			return r.Class == result.Class && r.Target == result.Target
		}); found {
			r.Packages = result.Packages
			results = append(results, r)
		} else { // when package result has no vulnerabilities we still need to add it to result(for 'list-all-pkgs')
			results = append(results, result)
		}
	}
+	fmt.Println("====== results")
+	for _, r := range results {
+		fmt.Println(r.Type)
+	}
	return results
}
```

Input:

```
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "version": 1,
  "components": [
    {
      "type": "library",
      "bom-ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.44.171",
      "name": "github.com/aws/aws-sdk-go",
      "version": "v1.44.171",
      "scope": "required",
      "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.44.171"
    },
    {
      "type": "library",
      "bom-ref": "pkg:pip/hoge@0.42.0",
      "name": "hoge",
      "version": "0.42.0",
      "scope": "required",
      "purl": "pkg:pip/hoge@0.42.0"
    },
    {
      "type": "library",
      "bom-ref": "pkg:cargo/hoge@0.42.0",
      "name": "hoge",
      "version": "0.42.0",
      "scope": "required",
      "purl": "pkg:cargo/hoge@0.42.0"
    }
  ]
}
```

Output: 

```
$ ./trivy sbom -f cyclonedx sbom.json

====== pkg results
cargo
gobinary
pip
====== results
gobinary
gobinary
gobinary
```


## Related issues
- Close #3492 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
