### PR TITLE
docs: adding a terraform tutorial to the docs

### DIFF
--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -1,0 +1,113 @@
+# Trivy Terraform Scan 
+
+This tutorial is focused on ways Trivy can scan Terraform IaC configuration files. 
+
+**A note to tfsec users** 
+We have been consolidating all of our scanning-related efforts in one place, and that is Trivy. Over the past year, tfsec has laid the foundations to Trivy's IaC & misconfigurations scanning capabilities, including Terraform scanning, which has been natively supported in Trivy for a long time now. 
+Going forward we want to encourage the tfsec community to transition over to Trivy. Moving to Trivy gives you the same excellent Terraform scanning engine, with some extra benefits: 
+
+- Access to more languages and features in the same tool. 
+- Access to more integrations with tools and services through the rich ecosystem around Trivy. 
+- Commercially supported by Aqua as well as by a the passionate Trivy community. 
+
+Furthermore, Trivy can already check [AWS services for misconfiguration](https://aquasecurity.github.io/trivy/latest/docs/target/aws/). We are currently in the process of merging [Cloudsploit](https://github.com/aquasecurity/cloudsploit) checks into Trivy so that Trivy will be able to perform more checks on cloud provider resources. 
+
+## Trivy Config Command 
+
+Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues.  
+
+Command structure: 
+``` 
+trivy config <any flags you want to use> <file or directory that you would like to scan> 
+``` 
+
+The `trivy config` command can scan Terraform configuration, CloudFormation, Dockerfile, Kubernetes manifests, and Helm Charts for misconfiguration. Trivy will compare the configuration found in the file with a set of best practices.  
+
+- If the configuration is following best practices, the check will pass,  
+- If the configuration does not define some configuration according to best practices, the default is used, 
+- If the configuration does not follow best practices, the check will fail.  
+
+## Using the `trivy config` command 
+
+The `trivy config` command is used like any other Trivy command. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/scanning/) 
+
+### Prerequisites 
+Install Trivy on your local machines. The documentation provides several [different installation options.](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) 
+This tutorial will use this example [Terraform tutorial]() for terraform misconfiguration scanning with Trivy. 
+Git clone the tutorial and cd into the directory: 
+``` 
+git clone https://github.com/Cloud-Native-Security/terraform-and-argocd 
+cd terraform-and-argocd 
+``` 
+In this case, the folder only containes Terraform configuration files. However, you could scan a directory that contains several different configurations e.g. Kubernetes YAML manifests, Dockerfile, and Terraform. In this case, Trivy detects the different configuration files and applies the right rules automatically. 
+
+## Different types of `trivy config` scans 
+
+Below are several examples of how the trivy config scan can be used. 
+
+General Terraform scan with trivy: 
+``` 
+trivy config <specify the directory> 
+``` 
+So if we are already in the directory that we want to scan: 
+``` 
+trivy config terraform-infra 
+``` 
+### Specify the scan format 
+The `--format` flag changes the way that Trivy displays the scan result: 
+
+JSON: 
+```
+trivy config -f json terraform-infra 
+``` 
+Sarif: 
+``` 
+trivy config -f sarif terraform-infra 
+``` 
+### Specifying the output location 
+
+The `--output` flag specifies the file location in which the scan result should be saved to: 
+
+JSON: 
+``` 
+trivy config -f json -o example.json terraform-infra 
+``` 
+
+Sarif: 
+``` 
+trivy config -f sarif-o example.sarif terraform-infra 
+``` 
+
+### Defining the severity of misconfiguration 
+
+If you are presented with lots and lots of misconfiguration across different files, you might want to filter or the misconfiguration with the highest severity: 
+
+``` 
+trivy config --severity CRITICAL, MEDIUM terraform-infra 
+``` 
+
+### Passing tf.vars files into `trivy config` scans 
+
+You can pass tf-vars files to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/options/values/) 
+
+``` 
+trivy conf --tf-vars dev.terraform.tfvars ./terraform-infra 
+``` 
+### Custom Policy 
+
+We have lots of example in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
+
+## Secret scans and vulnerability scans as part of misconfiguration scans 
+
+The trivy config` command does not perform secrete and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets through an additional flag: 
+
+```
+trivy fs --scanners secret ./terraform-infra 
+```
+
+The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/) 
+
+## Using Trivy in your CI/CD pipeline 
+Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://aquasecurity.github.io/trivy/latest/tutorials/integrations/ ](https://aquasecurity.github.io/trivy/latest/tutorials/integrations/) 
+
+ 

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -92,7 +92,7 @@ trivy conf --tf-vars terraform.tfvars ./
 
 We have lots of examples in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
 
-## Secret scans and vulnerability scans as part of misconfiguration scans 
+## Secret and vulnerability scans
 
 The `trivy config` command does not perform secrete and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets and misconfiguraction through the following flags: 
 
@@ -104,7 +104,7 @@ The `trivy config` command is a sub-command of the `trivy fs` command. You can l
 
 ## Scanning Terraform Plan files
 
-Instead of scanning your different Terraform resources individually, you could also scan your terraform plan output for misconfiguration. [Here](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/examples/#terraform-plan) is the link to the documentation.
+Instead of scanning your different Terraform resources individually, you could also scan your terraform plan output before it is deployed for misconfiguration. This will give you insights into any misconfiguration of your resources as they would become deployed. [Here](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/examples/#terraform-plan) is the link to the documentation.
 
 First, create a terraform plan and save it to a file:
 ```

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -1,4 +1,4 @@
-# Trivy Terraform Scan 
+# Scanning Terraform files with Trivy
 
 This tutorial is focused on ways Trivy can scan Terraform IaC configuration files. 
 
@@ -9,7 +9,7 @@ We have been consolidating all of our scanning-related efforts in one place, and
 
 ## Trivy Config Command 
 
-Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues.  
+Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/scanning/) 
 
 Command structure: 
 ``` 
@@ -19,12 +19,8 @@ trivy config <any flags you want to use> <file or directory that you would like 
 The `trivy config` command can scan Terraform configuration, CloudFormation, Dockerfile, Kubernetes manifests, and Helm Charts for misconfiguration. Trivy will compare the configuration found in the file with a set of best practices.  
 
 - If the configuration is following best practices, the check will pass,  
-- If the configuration does not define some configuration according to best practices, the default is used, 
-- If the configuration does not follow best practices, the check will fail.  
-
-## Using the `trivy config` command 
-
-The `trivy config` command is used like any other Trivy command. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/scanning/) 
+- If the configuration does not define the resource of some configuration, Trivy will assume the default configuration for the resource creation is used. In this case, the check might fail.
+- If the configuration that has been defined does not follow best practices, the check will fail.  
 
 ### Prerequisites 
 Install Trivy on your local machines. The documentation provides several [different installation options.](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) 
@@ -77,7 +73,7 @@ Sarif:
 trivy config -f sarif -o example.sarif terraform-infra 
 ``` 
 
-### Defining the severity of misconfiguration 
+### Filtering by severity 
 
 If you are presented with lots and lots of misconfiguration across different files, you might want to filter or the misconfiguration with the highest severity: 
 
@@ -85,16 +81,16 @@ If you are presented with lots and lots of misconfiguration across different fil
 trivy config --severity CRITICAL, MEDIUM terraform-infra 
 ``` 
 
-### Passing tf.vars files into `trivy config` scans 
+### Passing tf.tfvars files into `trivy config` scans 
 
-You can pass tf-vars files to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/options/values/) 
+You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/options/values/) 
 
 ``` 
 trivy conf --tf-vars terraform.tfvars ./
 ``` 
-### Custom Policy 
+### Custom Checks 
 
-We have lots of example in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
+We have lots of examples in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
 
 ## Secret scans and vulnerability scans as part of misconfiguration scans 
 
@@ -106,7 +102,7 @@ trivy fs --scanners secret,config ./
 
 The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/) 
 
-## Scan the Terraform Plan file
+## Scanning Terraform Plan files
 
 Instead of scanning your different Terraform resources individually, you could also scan your terraform plan output for misconfiguration. [Here](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/examples/#terraform-plan) is the link to the documentation.
 
@@ -128,6 +124,6 @@ trivy config ./tfplan.json
 Note that you need to be able to create a terraform init and plan without any errors. 
 
 ## Using Trivy in your CI/CD pipeline 
-Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://aquasecurity.github.io/trivy/latest/tutorials/integrations/ ](https://aquasecurity.github.io/trivy/latest/tutorials/integrations/) 
+Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://aquasecurity.github.io/trivy/latest/tutorials/integrations/](https://aquasecurity.github.io/trivy/latest/tutorials/integrations/) 
 
  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ nav:
           - Cluster Scanning: tutorials/kubernetes/cluster-scanning.md
           - Kyverno: tutorials/kubernetes/kyverno.md
           - GitOps: tutorials/kubernetes/gitops.md
+      - Misconfiguration:
+          - Terraform scanning: tutorials/misconfiguration/terraform.md
       - Signing:
           - Vulnerability Scan Record Attestation: tutorials/signing/vuln-attestation.md
       - Shell:


### PR DESCRIPTION
We received a lot of questions by the tfsec community on how to move over to Trivy, how different Trivy for terraform scanning is and similar. 