### PR TITLE
fix(sbom): add trivy version to spdx creators tool field

### DIFF
--- a/docs/docs/sbom/spdx.md
+++ b/docs/docs/sbom/spdx.md
@@ -19,7 +19,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: alpine:3.15
 DocumentNamespace: http://aquasecurity.github.io/trivy/container_image/alpine:3.15-bebf6b19-a94c-4e2c-af44-065f63923f48
 Creator: Organization: aquasecurity
-Creator: Tool: trivy
+Creator: Tool: trivy-0.38.1
 Created: 2022-04-28T07:32:57.142806Z
 
 ##### Package: zlib
@@ -167,7 +167,7 @@ $ cat result.spdx.json | jq .
 	"creationInfo": {
 		"created": "2022-04-28T08:16:55.328255Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-0.38.1",
 			"Organization: aquasecurity"
 		]
 	},

--- a/integration/testdata/conda-spdx.json.golden
+++ b/integration/testdata/conda-spdx.json.golden
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2023-01-08T23:58:16.700785648Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/integration/testdata/fixtures/sbom/centos-7-spdx.json
+++ b/integration/testdata/fixtures/sbom/centos-7-spdx.json
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2022-09-13T13:27:55.874784Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/integration/testdata/fixtures/sbom/centos-7-spdx.txt
+++ b/integration/testdata/fixtures/sbom/centos-7-spdx.txt
@@ -4,7 +4,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: integration/testdata/fixtures/images/centos-7.tar.gz
 DocumentNamespace: http://aquasecurity.github.io/trivy/container_image/integration/testdata/fixtures/images/centos-7.tar.gz-6a2c050f-bc12-46dc-b2df-1f4e3e0b5e1d
 Creator: Organization: aquasecurity
-Creator: Tool: trivy
+Creator: Tool: trivy-dev
 Created: 2022-09-13T13:24:58.796907Z
 
 ##### Package: integration/testdata/fixtures/images/centos-7.tar.gz

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -23,7 +23,7 @@ func NewWriter(output io.Writer, version string, spdxFormat string) Writer {
 		output:    output,
 		version:   version,
 		format:    spdxFormat,
-		marshaler: spdx.NewMarshaler(),
+		marshaler: spdx.NewMarshaler(version),
 	}
 }
 

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -60,10 +60,11 @@ var (
 )
 
 type Marshaler struct {
-	format  spdx.Document2_1
-	clock   clock.Clock
-	newUUID newUUID
-	hasher  Hash
+	format     spdx.Document2_1
+	clock      clock.Clock
+	newUUID    newUUID
+	hasher     Hash
+	appVersion string // Trivy version. It needed for `creator` field
 }
 
 type Hash func(v interface{}, format hashstructure.Format, opts *hashstructure.HashOptions) (uint64, error)
@@ -90,12 +91,13 @@ func WithHasher(hasher Hash) marshalOption {
 	}
 }
 
-func NewMarshaler(opts ...marshalOption) *Marshaler {
+func NewMarshaler(version string, opts ...marshalOption) *Marshaler {
 	m := &Marshaler{
-		format:  spdx.Document2_1{},
-		clock:   clock.RealClock{},
-		newUUID: uuid.New,
-		hasher:  hashstructure.Hash,
+		format:     spdx.Document2_1{},
+		clock:      clock.RealClock{},
+		newUUID:    uuid.New,
+		hasher:     hashstructure.Hash,
+		appVersion: version,
 	}
 
 	for _, opt := range opts {
@@ -149,7 +151,7 @@ func (m *Marshaler) Marshal(r types.Report) (*spdx.Document2_2, error) {
 			DocumentName:         r.ArtifactName,
 			DocumentNamespace:    getDocumentNamespace(r, m),
 			CreatorOrganizations: []string{CreatorOrganization},
-			CreatorTools:         []string{CreatorTool},
+			CreatorTools:         []string{fmt.Sprintf("%s-%s", CreatorTool, m.appVersion)},
 			Created:              m.clock.Now().UTC().Format(time.RFC3339),
 		},
 		Packages:      packages,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -105,7 +105,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "rails:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy-v0.0.0"},
+					CreatorTools:         []string{"trivy-0.38.1"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -310,7 +310,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "centos:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy-v0.0.0"},
+					CreatorTools:         []string{"trivy-0.38.1"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -463,7 +463,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "masahiro331/CVE-2021-41098",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy-v0.0.0"},
+					CreatorTools:         []string{"trivy-0.38.1"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -546,7 +546,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "test-aggregate",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy-v0.0.0"},
+					CreatorTools:         []string{"trivy-0.38.1"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -621,7 +621,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "empty/path",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy-v0.0.0"},
+					CreatorTools:         []string{"trivy-0.38.1"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -678,7 +678,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			marshaler := tspdx.NewMarshaler("v0.0.0", tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
+			marshaler := tspdx.NewMarshaler("0.38.1", tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
 			spdxDoc, err := marshaler.Marshal(tc.inputReport)
 			require.NoError(t, err)
 

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -105,7 +105,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "rails:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-v0.0.0"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -310,7 +310,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "centos:latest",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-v0.0.0"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -463,7 +463,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "masahiro331/CVE-2021-41098",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-v0.0.0"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -546,7 +546,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "test-aggregate",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-v0.0.0"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -621,7 +621,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					DocumentName:         "empty/path",
 					DocumentNamespace:    "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000001",
 					CreatorOrganizations: []string{"aquasecurity"},
-					CreatorTools:         []string{"trivy"},
+					CreatorTools:         []string{"trivy-v0.0.0"},
 					Created:              "2021-08-25T12:20:30Z",
 				},
 				Packages: map[spdx.ElementID]*spdx.Package2_2{
@@ -678,7 +678,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			marshaler := tspdx.NewMarshaler(tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
+			marshaler := tspdx.NewMarshaler("v0.0.0", tspdx.WithClock(clock), tspdx.WithNewUUID(newUUID), tspdx.WithHasher(hasher))
 			spdxDoc, err := marshaler.Marshal(tc.inputReport)
 			require.NoError(t, err)
 

--- a/pkg/sbom/spdx/testdata/happy/bom.json
+++ b/pkg/sbom/spdx/testdata/happy/bom.json
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2022-09-12T17:02:46.826609Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/pkg/sbom/spdx/testdata/happy/empty-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/empty-bom.json
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2022-09-12T17:03:35.840861Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/pkg/sbom/spdx/testdata/happy/os-only-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/os-only-bom.json
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2022-09-12T17:04:09.262672Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/pkg/sbom/spdx/testdata/happy/unrelated-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/unrelated-bom.json
@@ -3,7 +3,7 @@
 	"creationInfo": {
 		"created": "2022-09-12T17:04:28.43059Z",
 		"creators": [
-			"Tool: trivy",
+			"Tool: trivy-dev",
 			"Organization: aquasecurity"
 		]
 	},

--- a/pkg/sbom/spdx/testdata/sad/invalid-source-info.json
+++ b/pkg/sbom/spdx/testdata/sad/invalid-source-info.json
@@ -3,7 +3,7 @@
   "creationInfo": {
     "created": "2022-09-12T17:02:46.826609Z",
     "creators": [
-      "Tool: trivy",
+      "Tool: trivy-dev",
       "Organization: aquasecurity"
     ]
   },


### PR DESCRIPTION
## Description
`Creator.Tool` field should contain `Trivy` version: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#68-creator-field.

### spdx:
before:
```
Creator: Organization: aquasecurity
Creator: Tool: trivy
```
after:
```
Creator: Organization: aquasecurity
Creator: Tool: trivy-0.38.1
```
### spdx-json:
before:
``` json
	"creationInfo": {
		"created": "2023-03-03T04:46:04.859719101Z",
		"creators": [
			"Tool: trivy",
			"Organization: aquasecurity"
		]
	},
```
after:
```json
	"creationInfo": {
		"created": "2023-03-03T04:45:57Z",
		"creators": [
			"Tool: trivy-0.38.1",
			"Organization: aquasecurity"
		]
	},
```


## Related issues
- Close #3707

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
