### PR TITLE
fix: exclude node collector scanning

### DIFF
--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -3,14 +3,15 @@ package commands
 import (
 	"context"
 
+	"golang.org/x/exp/slices"
+	"golang.org/x/xerrors"
+
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
-
-	"golang.org/x/xerrors"
 )
 
 // clusterRun runs scan on kubernetes cluster
@@ -20,7 +21,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	}
 	var artifacts []*artifacts.Artifact
 	var err error
-	if opts.Scanners.AnyEnabled(types.MisconfigScanner) {
+	if opts.Scanners.AnyEnabled(types.MisconfigScanner) && slices.Contains(opts.Components, "infra") {
 		artifacts, err = trivyk8s.New(cluster, log.Logger).ListArtifactAndNodeInfo(ctx)
 		if err != nil {
 			return xerrors.Errorf("get k8s artifacts with node info error: %w", err)

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"context"
 
+	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
 
 	"golang.org/x/xerrors"
 )
@@ -16,10 +18,18 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	if err := validateReportArguments(opts); err != nil {
 		return err
 	}
-
-	artifacts, err := trivyk8s.New(cluster, log.Logger).ListArtifactAndNodeInfo(ctx)
-	if err != nil {
-		return xerrors.Errorf("get k8s artifacts error: %w", err)
+	var artifacts []*artifacts.Artifact
+	var err error
+	if opts.Scanners.AnyEnabled(types.MisconfigScanner) {
+		artifacts, err = trivyk8s.New(cluster, log.Logger).ListArtifactAndNodeInfo(ctx)
+		if err != nil {
+			return xerrors.Errorf("get k8s artifacts with node info error: %w", err)
+		}
+	} else {
+		artifacts, err = trivyk8s.New(cluster, log.Logger).ListArtifacts(ctx)
+		if err != nil {
+			return xerrors.Errorf("get k8s artifacts error: %w", err)
+		}
 	}
 
 	runner := newRunner(opts, cluster.GetCurrentContext())


### PR DESCRIPTION
## Description
exclude node collector scanning if misconfig scanner is not enable
## Related issues
- Close #3769 
- Related #3776
## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
