### PR TITLE
fix: skip checking dirs for required post-analyzers

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -456,7 +456,7 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, wg *sync.WaitGroup, lim
 func (ag AnalyzerGroup) RequiredPostAnalyzers(filePath string, info os.FileInfo) []Type {
 	var postAnalyzerTypes []Type
 	for _, a := range ag.postAnalyzers {
-		if a.Required(filePath, info) {
+		if !info.IsDir() && a.Required(filePath, info) {
 			postAnalyzerTypes = append(postAnalyzerTypes, a.Type())
 		}
 	}

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -454,9 +454,12 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, wg *sync.WaitGroup, lim
 }
 
 func (ag AnalyzerGroup) RequiredPostAnalyzers(filePath string, info os.FileInfo) []Type {
+	if info.IsDir() {
+		return nil
+	}
 	var postAnalyzerTypes []Type
 	for _, a := range ag.postAnalyzers {
-		if !info.IsDir() && a.Required(filePath, info) {
+		if a.Required(filePath, info) {
 			postAnalyzerTypes = append(postAnalyzerTypes, a.Type())
 		}
 	}

--- a/pkg/fanal/analyzer/language/java/jar/jar.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar.go
@@ -72,7 +72,7 @@ func (a *javaLibraryAnalyzer) PostAnalyze(ctx context.Context, input analyzer.Po
 		p := jar.NewParser(a.client, jar.WithSize(info.Size()), jar.WithFilePath(path))
 		libs, deps, err := p.Parse(r)
 		if err != nil {
-			return nil, xerrors.Errorf("jar/war/ear/par parse error: %w", err)
+			return nil, xerrors.Errorf("%q parse error: %w", path, err)
 		}
 
 		return language.ToApplication(types.Jar, path, path, libs, deps), nil


### PR DESCRIPTION
## Description
There are cases when dir has same name as required file.
e.g.
```
➜  docker run -it --rm  --entrypoint /bin/bash docker.io/consensys/teku:develop-jdk16

teku@6636da39406f:~$ ls -hl ./licenses/
total 604K
drwxr-xr-x 3 teku teku 4.0K Mar  6 05:43 apiguardian-api-1.1.2.jar
drwxr-xr-x 3 teku teku 4.0K Mar  6 05:43 attoparser-2.0.6.RELEASE.jar
drwxr-xr-x 3 teku teku 4.0K Mar  6 05:43 byte-buddy-1.12.21.jar
...
```

We should skip these dirs.

## Related issues
- Close #3760

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
