### PR TITLE
fix(license): disable jar analyzer for licence scan only

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -494,11 +494,13 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 		analyzers = append(analyzers, analyzer.TypeLicenseFile)
 	}
 
-	// Some language files contain license information
-	// We don't need to parse other languages if we don't analyze vulnerabilities or use sbom format
+	// Parsing jar files requires Java-db client
+	// But we don't create client if vulnerability analysis is disabled and sbom format is not used
+	// We need to disable jar analyzer to avoid errors
+	// TODO disable all languages that don't contains license information for this case
 	if opts.Scanners.Enabled(types.LicenseScanner) && !opts.Scanners.Enabled(types.VulnerabilityScanner) &&
 		!slices.Contains(report.SupportedSBOMFormats, opts.Format) {
-		analyzers = append(analyzers, analyzer.TypeLanguagesWithoutLicenses...)
+		analyzers = append(analyzers, analyzer.TypeJar)
 	}
 
 	// Do not perform misconfiguration scanning on container image config

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -495,9 +495,9 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 	}
 
 	// Parsing jar files requires Java-db client
-	// But we don't create client if vulnerability analysis is disabled and sbom format is not used
+	// But we don't create client if vulnerability analysis is disabled and SBOM format is not used
 	// We need to disable jar analyzer to avoid errors
-	// TODO disable all languages that don't contains license information for this case
+	// TODO disable all languages that don't contain license information for this case
 	if opts.Scanners.Enabled(types.LicenseScanner) && !opts.Scanners.Enabled(types.VulnerabilityScanner) &&
 		!slices.Contains(report.SupportedSBOMFormats, opts.Format) {
 		analyzers = append(analyzers, analyzer.TypeJar)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -495,8 +495,9 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 	}
 
 	// Some language files contain license information
-	// We don't need to parse other languages if we don't analyze vulnerabilities
-	if opts.Scanners.Enabled(types.LicenseScanner) && !opts.Scanners.Enabled(types.VulnerabilityScanner) {
+	// We don't need to parse other languages if we don't analyze vulnerabilities or use sbom format
+	if opts.Scanners.Enabled(types.LicenseScanner) && !opts.Scanners.Enabled(types.VulnerabilityScanner) &&
+		!slices.Contains(report.SupportedSBOMFormats, opts.Format) {
 		analyzers = append(analyzers, analyzer.TypeLanguagesWithoutLicenses...)
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -494,6 +494,12 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 		analyzers = append(analyzers, analyzer.TypeLicenseFile)
 	}
 
+	// Some language files contain license information
+	// We don't need to parse other languages if we don't analyze vulnerabilities
+	if opts.Scanners.Enabled(types.LicenseScanner) && !opts.Scanners.Enabled(types.VulnerabilityScanner) {
+		analyzers = append(analyzers, analyzer.TypeLanguagesWithoutLicenses...)
+	}
+
 	// Do not perform misconfiguration scanning on container image config
 	// when it is not specified.
 	if !opts.ImageConfigScanners.Enabled(types.MisconfigScanner) {

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -218,28 +218,4 @@ var (
 		TypeCloudFormation,
 		TypeHelm,
 	}
-
-	// TypeLanguagesWithoutLicenses has all language analyzers which don't have licenses
-	TypeLanguagesWithoutLicenses = []Type{
-		TypeBundler,
-		TypeCargo,
-		TypeComposer,
-		TypeJar,
-		TypePom,
-		TypeGradleLock,
-		TypeNpmPkgLock,
-		TypeYarn,
-		TypePnpm,
-		TypeNuget,
-		TypeDotNetCore,
-		TypePip,
-		TypePipenv,
-		TypePoetry,
-		TypeGoBinary,
-		TypeRustBinary,
-		TypeConanLock,
-		TypeCocoaPods,
-		TypePubSpecLock,
-		TypeMixLock,
-	}
 )

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -218,4 +218,28 @@ var (
 		TypeCloudFormation,
 		TypeHelm,
 	}
+
+	// TypeLanguagesWithoutLicenses has all language analyzers which don't have licenses
+	TypeLanguagesWithoutLicenses = []Type{
+		TypeBundler,
+		TypeCargo,
+		TypeComposer,
+		TypeJar,
+		TypePom,
+		TypeGradleLock,
+		TypeNpmPkgLock,
+		TypeYarn,
+		TypePnpm,
+		TypeNuget,
+		TypeDotNetCore,
+		TypePip,
+		TypePipenv,
+		TypePoetry,
+		TypeGoBinary,
+		TypeRustBinary,
+		TypeConanLock,
+		TypeCocoaPods,
+		TypePubSpecLock,
+		TypeMixLock,
+	}
 )


### PR DESCRIPTION
## Description
We don't need to parse jar files if we don't analyze vulnerabilities or use sbom format

## Related issues
- Close #3699

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
