### PR TITLE
docs: add canary build info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Trivy is integrated with many popular platforms and applications. The complete l
 - See [Ecosystem] for more
 
 ### Canary builds
-There are canary builds ([Docker Hub image](https://hub.docker.com/r/aquasec/trivy/tags?page=1&name=canary), [ghcr image](https://github.com/aquasecurity/trivy/pkgs/container/trivy/75776514?tag=canary) and [binaries](https://github.com/aquasecurity/trivy/actions/workflows/canary.yaml)) as generated every push to main branch.
+There are canary builds ([Docker Hub](https://hub.docker.com/r/aquasec/trivy/tags?page=1&name=canary), [GitHub](https://github.com/aquasecurity/trivy/pkgs/container/trivy/75776514?tag=canary), [ECR](https://gallery.ecr.aws/aquasecurity/trivy#canary) images and [binaries](https://github.com/aquasecurity/trivy/actions/workflows/canary.yaml)) as generated every push to main branch.
 
 Please be aware: canary builds might have critical bugs, it's not recommended for use in production.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Trivy is integrated with many popular platforms and applications. The complete l
 - [VS Code plugin](https://github.com/aquasecurity/trivy-vscode-extension)
 - See [Ecosystem] for more
 
+### Canary builds
+There are canary builds ([Docker Hub image](https://hub.docker.com/r/aquasec/trivy/tags?page=1&name=canary), [ghcr image](https://github.com/aquasecurity/trivy/pkgs/container/trivy/75776514?tag=canary) and [binaries](https://github.com/aquasecurity/trivy/actions/workflows/canary.yaml)) as generated every push to main branch.
+
+Please be aware: canary builds might have critical bugs, it's not recommended for use in production.
+
 ### General usage
 
 ```bash


### PR DESCRIPTION
## Description
Add canary build info to `README.md`

## Related issues
- Close #3782

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
