### PR TITLE
fix: display correct flag in error message when skipping java db update

### DIFF
--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -42,7 +42,7 @@ func (u *Updater) Update() error {
 			return xerrors.Errorf("Java DB metadata error: %w", err)
 		} else if u.skip {
 			log.Logger.Error("The first run cannot skip downloading Java DB")
-			return xerrors.New("'--skip-java-update' cannot be specified on the first run")
+			return xerrors.New("'--skip-java-db-update' cannot be specified on the first run")
 		}
 	}
 


### PR DESCRIPTION
## Description

Error message when running `trivy image --skip-java-db-update ...` on a first run yields the following error:
```
ERROR   Unable to initialize the Java DB: Java DB update failed: Java DB update error: '--skip-java-update' cannot be specified on the first run
```

The error message should specify the `--skip-java-db-update` instead. 

Version: 0.38.2

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
