### PR TITLE
feat: s3 cache backend

### DIFF
--- a/docs/docs/references/cli/client.md
+++ b/docs/docs/references/cli/client.md
@@ -27,12 +27,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/config.md
+++ b/docs/docs/references/cli/config.md
@@ -22,12 +22,14 @@ Report Flags
   -t, --template string     output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 Misconfiguration Flags
       --config-data strings         specify paths from which data for the Rego policies will be recursively loaded

--- a/docs/docs/references/cli/fs.md
+++ b/docs/docs/references/cli/fs.md
@@ -34,12 +34,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/image.md
+++ b/docs/docs/references/cli/image.md
@@ -49,12 +49,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/repo.md
+++ b/docs/docs/references/cli/repo.md
@@ -31,12 +31,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/rootfs.md
+++ b/docs/docs/references/cli/rootfs.md
@@ -37,12 +37,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/sbom.md
+++ b/docs/docs/references/cli/sbom.md
@@ -34,12 +34,14 @@ Report Flags
   -t, --template string        output template
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/cli/server.md
+++ b/docs/docs/references/cli/server.md
@@ -18,12 +18,14 @@ Examples:
 
 
 Cache Flags
-      --cache-backend string   cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-backend string   cache backend (e.g. redis://localhost:6379 or s3://yourbucket) (default "fs")
       --cache-ttl duration     cache TTL when using redis as cache backend
       --clear-cache            clear image caches without scanning
       --redis-ca string        redis ca file location, if using redis as cache backend
       --redis-cert string      redis certificate file location, if using redis as cache backend
       --redis-key string       redis key file location, if using redis as cache backend
+      --s3-endpoint string     s3 endpoint url (optional), if using s3 as cache backend
+      --s3-prefix string       s3 prefix name, if using s3 as cache backend
 
 DB Flags
       --db-repository string   OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")

--- a/docs/docs/references/customization/config-file.md
+++ b/docs/docs/references/customization/config-file.md
@@ -139,6 +139,17 @@ cache:
     # Same as '--redis-key'
     # Default is empty
     key:
+
+  # S3 options
+  s3:
+    # Same as '--s3-endpoint'
+    # Default is empty
+    endpoint:
+
+    # Same as '--s3-prefix'
+    # Default is 'trivy'
+    prefix:
+  
 ```
 
 ## DB Options

--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -73,7 +73,7 @@ Reference : [boltdb: Opening a database][boltdb].
     ...
     - twirp error internal: failed scan, test-image: failed to apply layers: layer cache missing: sha256:*****
     ```
-To run multiple Trivy servers, you need to use Redis as the cache backend so that those servers can share the cache. 
+To run multiple Trivy servers, you need to use Redis or S3 as the cache backend so that those servers can share the cache. 
 Follow [this instruction][redis-cache] to do so.
 
 

--- a/docs/docs/vulnerability/examples/cache.md
+++ b/docs/docs/vulnerability/examples/cache.md
@@ -30,15 +30,18 @@ $ trivy --cache-dir /tmp/trivy/ image python:3.4-alpine3.9
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.
 
-Trivy supports local filesystem and Redis as the cache backend. This option is useful especially for client/server mode.
+Trivy supports local filesystem, Redis and S3 as the cache backend. This option is useful especially for client/server mode.
 
-Two options:
+Three options:
 
 - `fs`
     - the cache path can be specified by `--cache-dir`
 - `redis://`
     - `redis://[HOST]:[PORT]`
     - TTL can be configured via `--cache-ttl`
+- `s3://`
+    - `s3://[bucket name]`
+    - Custom S3 endpoint can be configured via `--s3-endpoint`
 
 ```
 $ trivy server --cache-backend redis://localhost:6379
@@ -54,3 +57,19 @@ $ trivy server --cache-backend redis://localhost:6379 \
 ```
 
 TLS option for redis is hidden from Trivy command-line flag, but you still can use it.
+
+
+Using On-premise S3 storage:
+
+```
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=keyid
+export AWS_SECRET_ACCESS_KEY=accesskey
+trivy server --cache-backend=s3://trivy-onprem --s3-endpoint=https://obj.toosecret.com
+```
+
+Using AWS default credential loader (credentials can be in environment variables or AWS metadata): 
+
+```
+trivy server --cache-backend=s3://trivy
+```

--- a/pkg/fanal/cache/s3_test.go
+++ b/pkg/fanal/cache/s3_test.go
@@ -30,9 +30,9 @@ func (m *mockS3Client) HeadObject(*s3.HeadObjectInput) (*s3.HeadObjectOutput, er
 	return &s3.HeadObjectOutput{}, nil
 }
 
-func (m *mockS3Client) DeleteBucket(in *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
-	if in != nil && *in.Bucket == blobBucket+"/prefix/"+correctHash {
-		return &s3.DeleteBucketOutput{}, nil
+func (m *mockS3Client) DeleteObjects(in *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
+	if in != nil && in.Delete != nil && len(in.Delete.Objects) == 1 && *in.Delete.Objects[0].Key == blobBucket+"/prefix/"+correctHash {
+		return &s3.DeleteObjectsOutput{}, nil
 	}
 	return nil, errors.New("unknown bucket")
 }

--- a/pkg/flag/cache_flags_test.go
+++ b/pkg/flag/cache_flags_test.go
@@ -19,6 +19,8 @@ func TestCacheFlagGroup_ToOptions(t *testing.T) {
 		RedisCACert  string
 		RedisCert    string
 		RedisKey     string
+		S3Endpoint   string
+		S3Prefix     string
 	}
 	tests := []struct {
 		name      string
@@ -65,6 +67,37 @@ func TestCacheFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
+			name: "s3",
+			fields: fields{
+				CacheBackend: "s3://foobar",
+				S3Prefix:     "trivy",
+			},
+			want: flag.CacheOptions{
+				CacheBackend: "s3://foobar",
+				S3Options: flag.S3Options{
+					S3Endpoint: "",
+					S3Prefix:   "trivy",
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "s3 custom endpoint",
+			fields: fields{
+				CacheBackend: "s3://foobar2",
+				S3Endpoint:   "https://obj.mycompany.com",
+				S3Prefix:     "anotherprefix",
+			},
+			want: flag.CacheOptions{
+				CacheBackend: "s3://foobar2",
+				S3Options: flag.S3Options{
+					S3Endpoint: "https://obj.mycompany.com",
+					S3Prefix:   "anotherprefix",
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
 			name: "unknown backend",
 			fields: fields{
 				CacheBackend: "unknown",
@@ -92,6 +125,8 @@ func TestCacheFlagGroup_ToOptions(t *testing.T) {
 			viper.Set(flag.RedisCACertFlag.ConfigName, tt.fields.RedisCACert)
 			viper.Set(flag.RedisCertFlag.ConfigName, tt.fields.RedisCert)
 			viper.Set(flag.RedisKeyFlag.ConfigName, tt.fields.RedisKey)
+			viper.Set(flag.S3EndpointFlag.ConfigName, tt.fields.S3Endpoint)
+			viper.Set(flag.S3PrefixFlag.ConfigName, tt.fields.S3Prefix)
 
 			f := &flag.CacheFlagGroup{
 				ClearCache:   &flag.ClearCacheFlag,
@@ -100,6 +135,8 @@ func TestCacheFlagGroup_ToOptions(t *testing.T) {
 				RedisCACert:  &flag.RedisCACertFlag,
 				RedisCert:    &flag.RedisCertFlag,
 				RedisKey:     &flag.RedisKeyFlag,
+				S3Endpoint:   &flag.S3EndpointFlag,
+				S3Prefix:     &flag.S3PrefixFlag,
 			}
 
 			got, err := f.ToOptions()


### PR DESCRIPTION
## Description

S3 cache backend is already included in trivy code. However, it is impossible to use because it cannot be defined with envs / startup flags.

This PR will add support to use S3 as cache backend for trivy. It will store artifact and blob information to S3. It will also support custom S3 endpoints.

Examples:

`trivy --cache-backend=s3://trivy-test image registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.0-alpha.0`

This will load AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY from environment or use AWS metadata.


`trivy --cache-backend=s3://trivy-onprem --s3-endpoint=https://obj.toosecret.com image registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.0-alpha.0`

This example uses on-premise S3 bucket (for instance ceph or similar). In order to use this solution you need to have env variables defined:

```
export AWS_REGION=us-east-1
export AWS_ACCESS_KEY_ID=keyid
export AWS_SECRET_ACCESS_KEY=accesskey
```

## Related issues
- https://github.com/aquasecurity/trivy/issues/3820

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
