### PR TITLE
feat(nodejs): Add v3 npm lock file support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -394,3 +394,5 @@ replace oras.land/oras-go => oras.land/oras-go v1.1.1
 // v0.3.1-0.20230104082527-d6f58551be3f is taken from github.com/moby/buildkit v0.11.0
 // spdx logic write on v0.3.0 and incompatible with v0.3.1-0.20230104082527-d6f58551be3f
 replace github.com/spdx/tools-golang => github.com/spdx/tools-golang v0.3.0
+
+replace github.com/aquasecurity/go-dep-parser => github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.84.0
-	github.com/aquasecurity/go-dep-parser v0.0.0-20230309121549-fcc0deb06781
+	github.com/aquasecurity/go-dep-parser v0.0.0-20230315140444-2c62bb5726f4
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
@@ -394,5 +394,3 @@ replace oras.land/oras-go => oras.land/oras-go v1.1.1
 // v0.3.1-0.20230104082527-d6f58551be3f is taken from github.com/moby/buildkit v0.11.0
 // spdx logic write on v0.3.0 and incompatible with v0.3.1-0.20230104082527-d6f58551be3f
 replace github.com/spdx/tools-golang => github.com/spdx/tools-golang v0.3.0
-
-replace github.com/aquasecurity/go-dep-parser => github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82 h1:yP/WKCeuciEzUjGgzLjjJgcj4xIISoPquR5OfYYlB6Y=
-github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82/go.mod h1:tr2q/pzZLXvQEnhPNnyOZjVolQi0UOx0DVphSmxo6uU=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible h1:juIaKLLVhqzP55d8x4cSVgwyQv76Z55/fRv/UBr2KkQ=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
@@ -316,6 +314,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.84.0 h1:31HunilGj3xcgze5AqB7dtdiYwMXzXzDXEqYwx/OUhg=
 github.com/aquasecurity/defsec v0.84.0/go.mod h1:qrD/P88T3puVWDAHM/daPfgvJaVzBprdmROxtRpCT4A=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230315140444-2c62bb5726f4 h1:L9ogxesMkRaH3ct2bn2whA6nEJU7ZUMcaKjGDU9TwX8=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230315140444-2c62bb5726f4/go.mod h1:sG02b+zain+8EkcKAVnggE1X1+OrXRjkTzUmFNk7/Lc=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9QoSmhK/zg=
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82 h1:yP/WKCeuciEzUjGgzLjjJgcj4xIISoPquR5OfYYlB6Y=
+github.com/DmitriyLewen/go-dep-parser v0.0.0-20230313082850-fd7cd4355d82/go.mod h1:tr2q/pzZLXvQEnhPNnyOZjVolQi0UOx0DVphSmxo6uU=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible h1:juIaKLLVhqzP55d8x4cSVgwyQv76Z55/fRv/UBr2KkQ=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
@@ -314,8 +316,6 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.84.0 h1:31HunilGj3xcgze5AqB7dtdiYwMXzXzDXEqYwx/OUhg=
 github.com/aquasecurity/defsec v0.84.0/go.mod h1:qrD/P88T3puVWDAHM/daPfgvJaVzBprdmROxtRpCT4A=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230309121549-fcc0deb06781 h1:OG7Z7FV8ypNbLlUcK4l1SDdJItlWQQcArV9dbmJ0yOU=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230309121549-fcc0deb06781/go.mod h1:sG02b+zain+8EkcKAVnggE1X1+OrXRjkTzUmFNk7/Lc=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20220726154943-99847deb62b0 h1:tihCUjLWkF0b1SAjAKcFltUs3SpsqGrLtI+Frye0D10=


### PR DESCRIPTION
## Description
Add v3 lock file support - https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json?v=true#lockfileversion

## Related issues
- Close #3777

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/191

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
