### PR TITLE
fix(docker): build healthcheck command when building dockerfile from image config

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -3,6 +3,7 @@ package dockerfile
 import (
 	"context"
 	"testing"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
@@ -23,13 +24,20 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 			name: "happy",
 			input: analyzer.ConfigAnalysisInput{
 				Config: &v1.ConfigFile{
+					Config: v1.Config{
+						Healthcheck: &v1.HealthConfig{
+							Test:     []string{"CMD-SHELL", "curl --fail http://localhost:3000 || exit 1"},
+							Interval: time.Second * 10,
+							Timeout:  time.Second * 3,
+						},
+					},
 					History: []v1.History{
 						{
 							CreatedBy:  "/bin/sh -c #(nop) ADD file:e4d600fc4c9c293efe360be7b30ee96579925d1b4634c94332e2ec73f7d8eca1 in /",
 							EmptyLayer: false,
 						},
 						{
-							CreatedBy:  "/bin/sh -c #(nop) HEALTHCHECK NONE",
+							CreatedBy:  `HEALTHCHECK &{["CMD-SHELL" "curl --fail http://localhost:3000 || exit 1"] "10s" "3s" "0s" '\x00'}`,
 							EmptyLayer: false,
 						},
 						{


### PR DESCRIPTION
## Description
There are cases when `HEALTHCHECK` in image config doesn't have `/bin/sh` prefix.
e.g.
Dockerfile:
```Dockerfile
FROM alpine

HEALTHCHECK --interval=10s --timeout=3s CMD curl --fail http://localhost:3000 || exit 1 
```
Image history:
```
➜ docker history 3814 
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
b3bcbd9f64be   7 months ago   HEALTHCHECK &{["CMD-SHELL" "curl --fail http…   0B        buildkit.dockerfile.v0
<missing>      7 months ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B        
<missing>      7 months ago   /bin/sh -c #(nop) ADD file:2a949686d9886ac7c…   5.54MB  
```
We are currently skipping this line and getting a false positive.

## Related issues
- Close #3814


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
