### PR TITLE
fix(java): skip empty files for jar post analyzer

### DIFF
--- a/pkg/parallel/walk.go
+++ b/pkg/parallel/walk.go
@@ -2,6 +2,7 @@ package parallel
 
 import (
 	"context"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"io/fs"
 
 	"golang.org/x/sync/errgroup"
@@ -25,6 +26,15 @@ func WalkDir[T any](ctx context.Context, fsys fs.FS, root string, slow bool,
 			if err != nil {
 				return err
 			} else if !d.Type().IsRegular() {
+				return nil
+			}
+
+			// check if file is empty
+			info, err := d.Info()
+			if err != nil {
+				return err
+			} else if info.Size() == 0 {
+				log.Logger.Debugf("%s is empty, skip this file", path)
 				return nil
 			}
 

--- a/pkg/parallel/walk.go
+++ b/pkg/parallel/walk.go
@@ -2,13 +2,13 @@ package parallel
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/log"
 	"io/fs"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 type onFile[T any] func(string, fs.FileInfo, dio.ReadSeekerAt) (T, error)


### PR DESCRIPTION
## Description
Skip empty files for jar post analyzer to avoid error when unzip empty archive.

## Related issues
- Close #3818

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
