### PR TITLE
fix(report): update uri only for os class targets

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -130,7 +130,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 
 	ruleIndexes := map[string]int{}
 	for _, res := range report.Results {
-		target := ToPathUri(res.Target)
+		target := ToPathUri(res.Target, res.Class)
 
 		for _, vuln := range res.Vulnerabilities {
 			fullDescription := vuln.Description
@@ -139,7 +139,7 @@ func (sw SarifWriter) Write(report types.Report) error {
 			}
 			path := target
 			if vuln.PkgPath != "" {
-				path = ToPathUri(vuln.PkgPath)
+				path = ToPathUri(vuln.PkgPath, res.Class)
 			}
 			sw.addSarifResult(&sarifData{
 				title:            "vulnerability",
@@ -270,7 +270,12 @@ func toSarifErrorLevel(severity string) string {
 	}
 }
 
-func ToPathUri(input string) string {
+func ToPathUri(input string, resultClass types.ResultClass) string {
+	// we only need to convert OS input
+	// e.g. image names, digests, etc...
+	if resultClass != types.ClassOSPkg {
+		return input
+	}
 	var matches = pathRegex.FindStringSubmatch(input)
 	if matches != nil {
 		input = matches[pathRegex.SubexpIndex("path")]

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -367,25 +367,39 @@ func TestReportWriter_Sarif(t *testing.T) {
 
 func TestToPathUri(t *testing.T) {
 	tests := []struct {
-		input  string
-		output string
+		input       string
+		resultClass types.ResultClass
+		output      string
 	}{
 		{
-			input:  "almalinux@sha256:08042694fffd61e6a0b3a22dadba207c8937977915ff6b1879ad744fd6638837",
-			output: "library/almalinux",
+			input:       "almalinux@sha256:08042694fffd61e6a0b3a22dadba207c8937977915ff6b1879ad744fd6638837",
+			resultClass: types.ClassOSPkg,
+			output:      "library/almalinux",
 		},
 		{
-			input:  "alpine:latest (alpine 3.13.4)",
-			output: "library/alpine",
+			input:       "alpine:latest (alpine 3.13.4)",
+			resultClass: types.ClassOSPkg,
+			output:      "library/alpine",
 		},
 		{
-			input:  "docker.io/my-organization/my-app:2c6912aee7bde44b84d810aed106ca84f40e2e29",
-			output: "my-organization/my-app",
+			input:       "docker.io/my-organization/my-app:2c6912aee7bde44b84d810aed106ca84f40e2e29",
+			resultClass: types.ClassOSPkg,
+			output:      "my-organization/my-app",
+		},
+		{
+			input:       "lib/test",
+			resultClass: types.ClassLangPkg,
+			output:      "lib/test",
+		},
+		{
+			input:       "lib(2)/test",
+			resultClass: types.ClassSecret,
+			output:      "lib(2)/test",
 		},
 	}
 
 	for _, test := range tests {
-		got := report.ToPathUri(test.input)
+		got := report.ToPathUri(test.input, test.resultClass)
 		if got != test.output {
 			t.Errorf("toPathUri(%q) got %q, wanted %q", test.input, got, test.output)
 		}


### PR DESCRIPTION
## Description
We only need to update uri for OS class to avoid errors with folder names(e.g. `lib(2)/test`).

## Related issues
- Close #3839
- Close #2960

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
