### PR TITLE
feat(sbom): add support for CycloneDX JSON Attestation of the correct specification

### DIFF
--- a/pkg/fanal/artifact/sbom/sbom.go
+++ b/pkg/fanal/artifact/sbom/sbom.go
@@ -73,7 +73,7 @@ func (a Artifact) Inspect(_ context.Context) (types.ArtifactReference, error) {
 
 	var artifactType types.ArtifactType
 	switch format {
-	case sbom.FormatCycloneDXJSON, sbom.FormatCycloneDXXML, sbom.FormatAttestCycloneDXJSON:
+	case sbom.FormatCycloneDXJSON, sbom.FormatCycloneDXXML, sbom.FormatAttestCycloneDXJSON, sbom.FormatLegacyCosignAttestCycloneDXJSON:
 		artifactType = types.ArtifactCycloneDX
 	case sbom.FormatSPDXTV, sbom.FormatSPDXJSON:
 		artifactType = types.ArtifactSPDX


### PR DESCRIPTION
## Description

Add support for CycloneDX JSON attestations generated by Cosign V2. While Cosign V1 produced a format that differed from the in-toto-defined specification, Cosign V2 generated the attestation in the correct format(https://github.com/sigstore/cosign/pull/2718).

This PR adds support for the correct format and keeps backward compatibility by continuing to support the attestations generated by Cosign V1.

The following tests have been done.

```
> cosign version
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    v2.0.0
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.19.5
Compiler:      gc
Platform:      darwin/arm64

> cosign attest --key ./cosign.key --type cyclonedx --predicate sbom.cdx.json otms61/distroless-java17-debian11

> cosign verify-attestation --key ./cosign.pub --type cyclonedx otms61/distroless-java17-debian11 > sbom.cdx.intoto.jsonl

> ./trivy sbom sbom.cdx.intoto.jsonl
2023-03-16T00:15:45.342+0900	INFO	Vulnerability scanning is enabled
2023-03-16T00:15:45.345+0900	INFO	Detected SBOM format: attest-cyclonedx-json
2023-03-16T00:15:45.358+0900	INFO	Detected OS: debian
2023-03-16T00:15:45.358+0900	INFO	Detecting Debian vulnerabilities...
2023-03-16T00:15:45.363+0900	INFO	Number of language-specific files: 0

sbom.cdx.intoto.jsonl (debian 11.6)

Total: 25 (UNKNOWN: 0, LOW: 22, MEDIUM: 2, HIGH: 1, CRITICAL: 0)
・・・

```

```
> cosign1.13.1 attest --key ./cosign.key --type cyclonedx --predicate sbom.cdx.json otms61/distroless-java17-debian11

> cosign1.13.1 verify-attestation --key ./cosign.pub --type cyclonedx otms61/distroless-java17-debian11 > sbom.cdx.intoto.jsonl

> ./trivy sbom sbom.cdx.intoto.jsonl
2023-03-15T20:14:39.457+0900	INFO	Vulnerability scanning is enabled
2023-03-15T20:14:39.458+0900	INFO	Detected SBOM format: attest-cyclonedx-json
2023-03-15T20:14:39.469+0900	INFO	Detected OS: debian
2023-03-15T20:14:39.469+0900	INFO	Detecting Debian vulnerabilities...
2023-03-15T20:14:39.474+0900	INFO	Number of language-specific files: 0

sbom.cdx.intoto.jsonl (debian 11.6)

Total: 25 (UNKNOWN: 0, LOW: 22, MEDIUM: 2, HIGH: 1, CRITICAL: 0)
・・・
```


## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3817


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
