### PR TITLE
fix(report): try to guess direct deps for dependency tree

### DIFF
--- a/pkg/report/table/table_test.go
+++ b/pkg/report/table/table_test.go
@@ -162,7 +162,7 @@ Total: 1 (MEDIUM: 0, HIGH: 1)
 			expectedOutput: ``,
 		},
 		{
-			name: "happy path with vulnerability origin graph",
+			name: "happy path with vulnerability origin graph with",
 			results: types.Results{
 				{
 					Target: "package-lock.json",
@@ -202,6 +202,104 @@ Total: 1 (MEDIUM: 0, HIGH: 1)
 							ID:      "styled-components@3.1.3",
 							Name:    "styled-components",
 							Version: "3.1.3",
+							DependsOn: []string{
+								"fbjs@0.8.18",
+							},
+						},
+					},
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID: "CVE-2022-0235",
+							PkgID:           "node-fetch@1.7.3",
+							PkgName:         "node-fetch",
+							Vulnerability: dbTypes.Vulnerability{
+								Title:       "foobar",
+								Description: "baz",
+								Severity:    "HIGH",
+							},
+							InstalledVersion: "1.7.3",
+							FixedVersion:     "2.6.7, 3.1.1",
+						},
+						{
+							VulnerabilityID: "CVE-2021-26539",
+							PkgID:           "sanitize-html@1.20.0",
+							PkgName:         "sanitize-html",
+							Vulnerability: dbTypes.Vulnerability{
+								Title:       "foobar",
+								Description: "baz",
+								Severity:    "MEDIUM",
+							},
+							InstalledVersion: "1.20.0",
+							FixedVersion:     "2.3.1",
+						},
+					},
+				},
+			},
+			expectedOutput: `
+package-lock.json (npm)
+=======================
+Total: 2 (MEDIUM: 1, HIGH: 1)
+
+┌───────────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────┐
+│    Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │ Title  │
+├───────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────┤
+│ node-fetch    │ CVE-2022-0235  │ HIGH     │ 1.7.3             │ 2.6.7, 3.1.1  │ foobar │
+├───────────────┼────────────────┼──────────┼───────────────────┼───────────────┤        │
+│ sanitize-html │ CVE-2021-26539 │ MEDIUM   │ 1.20.0            │ 2.3.1         │        │
+└───────────────┴────────────────┴──────────┴───────────────────┴───────────────┴────────┘
+
+Dependency Origin Tree (Reversed)
+=================================
+package-lock.json
+├── node-fetch@1.7.3, (MEDIUM: 0, HIGH: 1)
+│   └── ...(omitted)...
+│       └── styled-components@3.1.3
+└── sanitize-html@1.20.0, (MEDIUM: 1, HIGH: 0)
+`,
+		},
+		{
+			name: "happy path with vulnerability origin graph(no info about direct deps)",
+			results: types.Results{
+				{
+					Target: "package-lock.json",
+					Class:  types.ClassLangPkg,
+					Type:   "npm",
+					Packages: []ftypes.Package{
+						{
+							ID:       "node-fetch@1.7.3",
+							Name:     "node-fetch",
+							Version:  "1.7.3",
+							Indirect: true,
+						},
+						{
+							ID:       "isomorphic-fetch@2.2.1",
+							Name:     "isomorphic-fetch",
+							Version:  "2.2.1",
+							Indirect: true,
+							DependsOn: []string{
+								"node-fetch@1.7.3",
+							},
+						},
+						{
+							ID:       "fbjs@0.8.18",
+							Name:     "fbjs",
+							Version:  "0.8.18",
+							Indirect: true,
+							DependsOn: []string{
+								"isomorphic-fetch@2.2.1",
+							},
+						},
+						{
+							ID:       "sanitize-html@1.20.0",
+							Name:     "sanitize-html",
+							Version:  "1.20.0",
+							Indirect: true,
+						},
+						{
+							ID:       "styled-components@3.1.3",
+							Name:     "styled-components",
+							Version:  "3.1.3",
+							Indirect: true,
 							DependsOn: []string{
 								"fbjs@0.8.18",
 							},

--- a/pkg/report/table/vulnerability.go
+++ b/pkg/report/table/vulnerability.go
@@ -266,7 +266,17 @@ func findAncestor(pkgID string, parentMap map[string]ftypes.Packages, seen map[s
 		if !parent.Indirect {
 			ancestors[parent.ID] = struct{}{}
 		} else {
-			for _, a := range findAncestor(parent.ID, parentMap, seen) {
+			foundAncestors := findAncestor(parent.ID, parentMap, seen)
+			// if we checked graph, but didn't find Direct dependency - let's try to guess direct dependency:
+			// this means that last dependency in chain must be direct dependency
+			// e.g. `node-fetch` -> `isomorphic-fetch` -> `fbjs` -> `styled-components`
+			// if `styled-components` is not mark as !Indirect dependency:
+			// `styled-components` will have no child dependencies, and we think it is a direct dependency
+			if len(foundAncestors) == 0 {
+				ancestors[parent.ID] = struct{}{}
+				continue
+			}
+			for _, a := range foundAncestors {
 				ancestors[a] = struct{}{}
 			}
 		}


### PR DESCRIPTION
## Description
We are using `Indirect` field to build short graph(changes #3691).
But there are languages which don't have info about Direct deps(e.g. `package-lock.json` with lockfile version == 1).
But we have chains of dependencies and we can try to guess direct dependencies.

## Related issues
- Close #3840

## Related PRs
- [ ] #3691

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
