### PR TITLE
feat(amazon): add al2023 support

### DIFF
--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -13,7 +13,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 | Rocky Linux                      | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
 | Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
 | CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
-| Amazon Linux                     | 1, 2, 2022                                | Installed by yum/rpm          |                  NO                  |
+| Amazon Linux                     | 1, 2, 2022, 2023                          | Installed by yum/rpm          |                  NO                  |
 | openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |
 | SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |
 | Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -23,6 +23,7 @@ var (
 		"2": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		// N/A
 		"2022": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"2023": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}
 )
 
@@ -66,7 +67,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	log.Logger.Info("Detecting Amazon Linux vulnerabilities...")
 
 	osVer = strings.Fields(osVer)[0]
-	if osVer != "2" && osVer != "2022" {
+	if osVer != "2" && osVer != "2022" && osVer != "2023" {
 		osVer = "1"
 	}
 	log.Logger.Debugf("amazon: os version: %s", osVer)

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -23,7 +23,7 @@ var (
 		"2": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		// N/A
 		"2022": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
-		"2023": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"2023": time.Date(2028, 3, 15, 23, 59, 59, 0, time.UTC),
 	}
 )
 

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -128,6 +128,38 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "amazon linux 2023",
+			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "2023",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "protobuf",
+						Version: "3.14.0-7.amzn2023.0.3",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "protobuf",
+					VulnerabilityID:  "CVE-2022-1941",
+					InstalledVersion: "3.14.0-7.amzn2023.0.3",
+					FixedVersion:     "3.19.6-1.amzn2023.0.1",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Amazon,
+						Name: "Amazon Linux Security Center",
+						URL:  "https://alas.aws.amazon.com/",
+					},
+				},
+			},
+		},
+		{
 			name:     "empty version",
 			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/amazon/testdata/fixtures/amazon.yaml
+++ b/pkg/detector/ospkg/amazon/testdata/fixtures/amazon.yaml
@@ -19,3 +19,10 @@
         - key: CVE-2021-44228
           value:
             FixedVersion: "2.15.0-1.amzn2022.0.1"
+- bucket: amazon linux 2023
+  pairs:
+    - bucket: protobuf
+      pairs:
+        - key: CVE-2022-1941
+          value:
+            FixedVersion: "3.19.6-1.amzn2023.0.1"

--- a/pkg/detector/ospkg/amazon/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/amazon/testdata/fixtures/data-source.yaml
@@ -15,3 +15,8 @@
         ID: "amazon"
         Name: "Amazon Linux Security Center"
         URL: "https://alas.aws.amazon.com/"
+    - key: amazon linux 2023
+      value:
+        ID: "amazon"
+        Name: "Amazon Linux Security Center"
+        URL: "https://alas.aws.amazon.com/"

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
@@ -26,7 +26,7 @@ const version = 1
 
 var requiredFiles = []string{
 	"etc/system-release",     // for 1 and 2 versions
-	"usr/lib/system-release", // for 2022 version
+	"usr/lib/system-release", // for 2022, 2023 version
 }
 
 type amazonlinuxOSAnalyzer struct{}

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -61,6 +61,19 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path amazon linux 2023",
+			input: analyzer.AnalysisInput{
+				FilePath: "usr/lib/system-release",
+				Content:  strings.NewReader(`Amazon Linux release 2023 (Amazon Linux)`),
+			},
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: aos.Amazon,
+					Name:   "2023 (Amazon Linux)",
+				},
+			},
+		},
+		{
 			name: "sad path amazon linux 2 without code name",
 			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",


### PR DESCRIPTION
## Description
Add `Amazon Linux 2023` support


## Related PRs
- [x] #aquasecurity/vuln-list-update/pull/199
merge this PR first!
- [x] #aquasecurity/trivy-db/pull/293
merge this PR first!

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
