### PR TITLE
fix(docker): check that dockerfile healthcheck is not nil

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -49,23 +49,25 @@ func (a *historyAnalyzer) Analyze(ctx context.Context, input analyzer.ConfigAnal
 			// RUN instruction
 			createdBy = strings.ReplaceAll(h.CreatedBy, "/bin/sh -c", "RUN")
 		case strings.HasPrefix(h.CreatedBy, "HEALTHCHECK"):
-			// HEALTHCHECK instruction
-			var interval, timeout, startPeriod, retries, command string
-			if input.Config.Config.Healthcheck.Interval != 0 {
-				interval = fmt.Sprintf("--interval=%s ", input.Config.Config.Healthcheck.Interval)
+			if input.Config.Config.Healthcheck != nil {
+				// HEALTHCHECK instruction
+				var interval, timeout, startPeriod, retries, command string
+				if input.Config.Config.Healthcheck.Interval != 0 {
+					interval = fmt.Sprintf("--interval=%s ", input.Config.Config.Healthcheck.Interval)
+				}
+				if input.Config.Config.Healthcheck.Timeout != 0 {
+					timeout = fmt.Sprintf("--timeout=%s ", input.Config.Config.Healthcheck.Timeout)
+				}
+				if input.Config.Config.Healthcheck.StartPeriod != 0 {
+					startPeriod = fmt.Sprintf("--startPeriod=%s ", input.Config.Config.Healthcheck.StartPeriod)
+				}
+				if input.Config.Config.Healthcheck.Retries != 0 {
+					retries = fmt.Sprintf("--retries=%d ", input.Config.Config.Healthcheck.Retries)
+				}
+				command = strings.Join(input.Config.Config.Healthcheck.Test, " ")
+				command = strings.ReplaceAll(command, "CMD-SHELL", "CMD")
+				createdBy = fmt.Sprintf("HEALTHCHECK %s%s%s%s%s", interval, timeout, startPeriod, retries, command)
 			}
-			if input.Config.Config.Healthcheck.Timeout != 0 {
-				timeout = fmt.Sprintf("--timeout=%s ", input.Config.Config.Healthcheck.Timeout)
-			}
-			if input.Config.Config.Healthcheck.StartPeriod != 0 {
-				startPeriod = fmt.Sprintf("--startPeriod=%s ", input.Config.Config.Healthcheck.StartPeriod)
-			}
-			if input.Config.Config.Healthcheck.Retries != 0 {
-				retries = fmt.Sprintf("--retries=%d ", input.Config.Config.Healthcheck.Retries)
-			}
-			command = strings.Join(input.Config.Config.Healthcheck.Test, " ")
-			command = strings.ReplaceAll(command, "CMD-SHELL", "CMD")
-			createdBy = fmt.Sprintf("HEALTHCHECK %s%s%s%s%s", interval, timeout, startPeriod, retries, command)
 		}
 		dockerfile.WriteString(strings.TrimSpace(createdBy) + "\n")
 	}


### PR DESCRIPTION
## Description

Checks that the healthcheck is not nil when trying to read variables

## Related issues
- Close #3857

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
