### PR TITLE
docs: add general coverage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Scanners (what Trivy can find there):
 - Sensitive information and secrets
 - Software licenses
 
+Trivy supports most popular programming languages, operating systems, and platforms. For a complete list, see the [Scanning Coverage] page.
+
 To learn more, go to the [Trivy homepage][homepage] for feature highlights, or to the [Documentation site][docs] for detailed information.
 
 ## Quick Start
@@ -125,6 +127,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 
 [Installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [Ecosystem]: https://aquasecurity.github.io/trivy/latest/ecosystem/
+[Scanning Coverage]: https://aquasecurity.github.io/trivy/latest/getting-started/coverage/
 
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego

--- a/docs/getting-started/coverage.md
+++ b/docs/getting-started/coverage.md
@@ -1,6 +1,10 @@
 # Scanning Coverage
 
-## Programming languages
+Trivy can detect security issues in many different platforms and languages. This page gives a general overview of that coverage, and can help answer the frequently asked question "Does Trivy support X?". For more detailed information about the specific features and options, check the relevant scanner documentation.
+
+## Vulnerabilities & SBOM
+
+### Programming languages
 Trivy detects code dependencies for the purpose of SBOM generation and vulnerability detection. The following programming languages have some level of support:
 
 - Ruby
@@ -18,7 +22,7 @@ Trivy detects code dependencies for the purpose of SBOM generation and vulnerabi
 
 Some features might be not be universally supported. For a full supportability matrix, [see here](../docs/scanner/vulnerability/language/index.md).
 
-## OS
+### OS
 Trivy detects installed packages for the purpose of vulnerability detection. The following package managers are supported:
 
 - Alpine Linux

--- a/docs/getting-started/coverage.md
+++ b/docs/getting-started/coverage.md
@@ -1,0 +1,54 @@
+# Scanning Coverage
+
+## Programming languages
+Trivy detects code dependencies for the purpose of SBOM generation and vulnerability detection. The following programming languages have some level of support:
+
+- Ruby
+- Python
+- PHP
+- Node.js
+- .NET
+- Java
+- Go
+- Rust
+- C/C++
+- Elixir
+- Dart
+- Swift
+
+Some features might be not be universally supported. For a full supportability matrix, [see here](../docs/scanner/vulnerability/language/index.md).
+
+## OS
+Trivy detects installed packages for the purpose of vulnerability detection. The following package managers are supported:
+
+- Alpine Linux
+- Wolfi Linux
+- Chainguard
+- Red Hat Universal Base Image
+- Red Hat Enterprise Linux
+- CentOS
+- AlmaLinux
+- Rocky Linux
+- Oracle Linux
+- CBL-Mariner
+- Amazon Linux
+- openSUSE Leap
+- SUSE Enterprise Linux
+- Photon OS
+- Debian GNU/Linux
+- Ubuntu
+- Distroless
+
+Some features might be not be universally supported. For a full supportability matrix, [see here](../docs/scanner/vulnerability/os.md).
+
+## IaC & configuration
+Trivy reads IaC & configuration languages for the purpose of misconfiguration detection and custom checks.
+
+- Kubernetes
+- Dockerfile, Containerfile
+- Terraform 
+- CloudFormation
+- Azure ARM Template
+- Helm Chart
+
+For more information about checks [see here](../docs/misconfiguration/policy/builtin.md).

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -4,8 +4,13 @@
 
 `tri` is pronounced like **tri**gger, `vy` is pronounced like en**vy**.
 
+### Does Trivy support X?
+
+Check out the [Scanning coverage page](./coverage.md)
+
 ### How to generate multiple reports?
 See [here](../docs/configuration/reporting.md#converting).
 
 ### How to run Trivy under air-gapped environment?
 See [here](../docs/advanced/air-gap.md).
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ Scanners (what Trivy can find there):
 - Sensitive information and secrets
 - Software licenses
 
+Trivy supports most popular programming languages, operating systems, and platforms. For a complete list, see the [Scanning Coverage] page.
+
 To learn more, go to the [Trivy homepage][homepage] for feature highlights, or to the [Documentation site][Docs] for detailed information.
 
 ## Quick Start
@@ -117,6 +119,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 [Ecosystem]: ./ecosystem/index.md
 [Installation]: getting-started/installation.md
 [pronunciation]: #how-to-pronounce-the-name-trivy
+[Scanning Coverage]: getting-started/coverage.md
 
 [aquasec]: https://aquasec.com
 [oss]: https://www.aquasec.com/products/open-source-projects/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Getting Started: 
       - Overview: index.md
       - Installation: getting-started/installation.md
+      - Scanning coverage: getting-started/coverage.md
       - FAQ: getting-started/faq.md
   - Tutorials:
       - Overview: tutorials/overview.md   


### PR DESCRIPTION
## Description
added a high-level doc that shows a growing list of supported languages and platforms. This is not supposed to be the complete supportability matrix, but a landing page that can give a quick hint if we support X or not, and if so, where to find the full details.

Let me know if you think it's helpful