### PR TITLE
fix: allow mapfs to open dirs

### DIFF
--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/exp/slices"
@@ -188,5 +189,6 @@ func (m *FS) RemoveAll(path string) error {
 func cleanPath(path string) string {
 	path = filepath.Clean(path)
 	path = filepath.ToSlash(path)
+	path = strings.TrimLeft(path, "/") // Remove the leading slash
 	return path
 }

--- a/pkg/mapfs/fs_test.go
+++ b/pkg/mapfs/fs_test.go
@@ -281,7 +281,10 @@ func TestFS_Open(t *testing.T) {
 		{
 			name:     "dir",
 			filePath: "a/b/c",
-			wantErr:  assert.Error,
+			want: file{
+				fileInfo: cdirFileInfo,
+			},
+			wantErr: assert.NoError,
 		},
 		{
 			name:     "no such file",
@@ -306,9 +309,11 @@ func TestFS_Open(t *testing.T) {
 			require.NoError(t, err)
 			assertFileInfo(t, tt.want.fileInfo, fi)
 
-			b, err := io.ReadAll(f)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want.body, string(b))
+			if tt.want.body != "" {
+				b, err := io.ReadAll(f)
+				require.NoError(t, err)
+				assert.Equal(t, tt.want.body, string(b))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description
mapfs.Open() should work with directories.

>A File provides access to a single file. The File interface is the minimum implementation required of the file. Directory files should also implement ReadDirFile. A file may implement io.ReaderAt or io.Seeker as optimizations.

https://pkg.go.dev/io/fs#File

This is a leftover task from https://github.com/aquasecurity/trivy/pull/3654. This PR adds support for directories that implement ReadDirFile.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
