### PR TITLE
docs: add DefectDojo in the Security Management section

### DIFF
--- a/docs/ecosystem/security.md
+++ b/docs/ecosystem/security.md
@@ -4,3 +4,8 @@
 A Trivy plugin that converts JSON report to SonarQube [generic issues format](https://docs.sonarqube.org/9.6/analyzing-source-code/importing-external-issues/generic-issue-import-format/).
 
 👉 Get it at: <https://github.com/umax/trivy-plugin-sonarqube>
+
+## DefectDojo (Community)
+DefectDojo can parse Trivy JSON reports. The parser supports deduplication and auto-close features.
+
+👉 Get it at: <https://github.com/DefectDojo/django-DefectDojo>


### PR DESCRIPTION
## Description
Add [DefectDojo](https://github.com/defectdojo/django-defectdojo) to the Security Management section of the Trivy documentation.

## Related issues
- Close #3870

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
