### PR TITLE
refactor(misconf): simplify policy filesystem

### DIFF
--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -187,8 +187,13 @@ func (m *FS) RemoveAll(path string) error {
 }
 
 func cleanPath(path string) string {
+	// Return if the file path is a volume name only.
+	// Otherwise, `filepath.Clean` changes "C:" to "C:." and
+	// it will no longer match the pathname held by mapfs.
+	if path == filepath.VolumeName(path) {
+		return path
+	}
 	path = filepath.Clean(path)
-	path = strings.TrimPrefix(path, filepath.VolumeName(path)) // Remove the volume name
 	path = filepath.ToSlash(path)
 	path = strings.TrimLeft(path, "/") // Remove the leading slash
 	return path

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -188,6 +188,7 @@ func (m *FS) RemoveAll(path string) error {
 
 func cleanPath(path string) string {
 	path = filepath.Clean(path)
+	path = strings.TrimPrefix(path, filepath.VolumeName(path)) // Remove the volume name
 	path = filepath.ToSlash(path)
 	path = strings.TrimLeft(path, "/") // Remove the leading slash
 	return path

--- a/pkg/misconf/scanner_test.go
+++ b/pkg/misconf/scanner_test.go
@@ -2,10 +2,8 @@ package misconf
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,111 +61,18 @@ func TestScanner_Scan(t *testing.T) {
 	}
 }
 
-func Test_FindingFSTarget(t *testing.T) {
-	tests := []struct {
-		input      []string
-		wantTarget string
-		wantPaths  []string
-		wantErr    bool
-	}{
-		{
-			input:   nil,
-			wantErr: true,
-		},
-		{
-			input:      []string{string(os.PathSeparator)},
-			wantTarget: string(os.PathSeparator),
-			wantPaths:  []string{"."},
-		},
-		{
-			input:      []string{filepath.Join(string(os.PathSeparator), "home", "user")},
-			wantTarget: filepath.Join(string(os.PathSeparator), "home", "user"),
-			wantPaths:  []string{"."},
-		},
-		{
-			input: []string{
-				filepath.Join(string(os.PathSeparator), "home", "user"),
-				filepath.Join(string(os.PathSeparator), "home", "user", "something"),
-			},
-			wantTarget: filepath.Join(string(os.PathSeparator), "home", "user"),
-			wantPaths:  []string{".", "something"},
-		},
-		{
-			input: []string{
-				filepath.Join(string(os.PathSeparator), "home", "user"),
-				filepath.Join(string(os.PathSeparator), "home", "user", "something", "else"),
-			},
-			wantTarget: filepath.Join(string(os.PathSeparator), "home", "user"),
-			wantPaths:  []string{".", "something/else"},
-		},
-		{
-			input: []string{
-				filepath.Join(string(os.PathSeparator), "home", "user"),
-				filepath.Join(string(os.PathSeparator), "home", "user2", "something", "else"),
-			},
-			wantTarget: filepath.Join(string(os.PathSeparator), "home"),
-			wantPaths:  []string{"user", "user2/something/else"},
-		},
-		{
-			input: []string{
-				filepath.Join(string(os.PathSeparator), "foo"),
-				filepath.Join(string(os.PathSeparator), "bar"),
-			},
-			wantTarget: string(os.PathSeparator),
-			wantPaths:  []string{"foo", "bar"},
-		},
-		{
-			input:      []string{string(os.PathSeparator), filepath.Join(string(os.PathSeparator), "bar")},
-			wantTarget: string(os.PathSeparator),
-			wantPaths:  []string{".", "bar"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%#v", test.input), func(t *testing.T) {
-			if runtime.GOOS == "windows" {
-				wantTarget, err := filepath.Abs(test.wantTarget)
-				require.NoError(t, err)
-				test.wantTarget = filepath.Clean(wantTarget)
-			}
-
-			target, paths, err := findFSTarget(test.input)
-			if test.wantErr {
-				require.Error(t, err)
-			} else {
-				assert.Equal(t, test.wantTarget, target)
-				assert.Equal(t, test.wantPaths, paths)
-			}
-		})
-	}
-}
-
 func Test_createPolicyFS(t *testing.T) {
-	t.Run("inside cwd", func(t *testing.T) {
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		require.NoError(t, os.MkdirAll(filepath.Join(cwd, "testdir"), 0750))
-		require.NoError(t, os.MkdirAll(filepath.Join(cwd, ".testdir"), 0750))
-		defer func() {
-			os.RemoveAll(filepath.Join(cwd, "testdir"))
-			os.RemoveAll(filepath.Join(cwd, ".testdir"))
-		}()
-
-		_, got1, err := createPolicyFS([]string{"testdir"})
-		require.NoError(t, err)
-
-		_, got2, err := createPolicyFS([]string{".testdir"})
-		require.NoError(t, err)
-
-		assert.NotEqual(t, got1, got2, "testdir and .testdir are different dirs and should not be equal")
-	})
-
-	t.Run("outside cwd", func(t *testing.T) {
+	t.Run("outside pwd", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "subdir/testdir"), 0750))
 		f, got, err := createPolicyFS([]string{filepath.Join(tmpDir, "subdir/testdir")})
 		require.NoError(t, err)
 		assert.Equal(t, []string{"."}, got)
-		assert.Contains(t, f, "testdir")
+
+		d, err := f.Open(tmpDir)
+		require.NoError(t, err)
+		stat, err := d.Stat()
+		require.NoError(t, err)
+		assert.True(t, stat.IsDir())
 	})
 }


### PR DESCRIPTION
## Description
If I understand correctly, we no longer need the complicated logic for creating the policy filesystem.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
