### PR TITLE
chore(amazon): update EOL

### DIFF
--- a/docs/docs/vulnerability/detection/os.md
+++ b/docs/docs/vulnerability/detection/os.md
@@ -13,7 +13,7 @@ The unfixed/unfixable vulnerabilities mean that the patch has not yet been provi
 | Rocky Linux                      | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
 | Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
 | CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
-| Amazon Linux                     | 1, 2, 2022, 2023                          | Installed by yum/rpm          |                  NO                  |
+| Amazon Linux                     | 1, 2, 2023                                | Installed by yum/rpm          |                  NO                  |
 | openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |
 | SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |
 | Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -120,7 +120,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 // IsSupportedVersion checks if os can be scanned using amazon scanner
 func (s *Scanner) IsSupportedVersion(osFamily, osVer string) bool {
 	osVer = strings.Fields(osVer)[0]
-	if osVer != "2" {
+	if osVer != "2" && osVer != "2022" && osVer != "2023" {
 		osVer = "1"
 	}
 	eol, ok := eolDates[osVer]

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -20,9 +20,9 @@ import (
 var (
 	eolDates = map[string]time.Time{
 		"1": time.Date(2023, 6, 30, 23, 59, 59, 0, time.UTC),
-		"2": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
-		// N/A
-		"2022": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		// https://aws.amazon.com/amazon-linux-2/faqs/?nc1=h_ls
+		"2": time.Date(2025, 6, 30, 23, 59, 59, 0, time.UTC),
+		// Amazon Linux 2022 was renamed to 2023. AL2022 is not currently supported.
 		"2023": time.Date(2028, 3, 15, 23, 59, 59, 0, time.UTC),
 	}
 )

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -96,38 +96,6 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
-			name:     "amazon linux 2022",
-			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
-			args: args{
-				osVer: "2022",
-				pkgs: []ftypes.Package{
-					{
-						Name:    "log4j",
-						Version: "2.14.0",
-						Layer: ftypes.Layer{
-							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
-						},
-					},
-				},
-			},
-			want: []types.DetectedVulnerability{
-				{
-					PkgName:          "log4j",
-					VulnerabilityID:  "CVE-2021-44228",
-					InstalledVersion: "2.14.0",
-					FixedVersion:     "2.15.0-1.amzn2022.0.1",
-					Layer: ftypes.Layer{
-						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
-					},
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.Amazon,
-						Name: "Amazon Linux Security Center",
-						URL:  "https://alas.aws.amazon.com/",
-					},
-				},
-			},
-		},
-		{
 			name:     "amazon linux 2023",
 			fixtures: []string{"testdata/fixtures/amazon.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -219,6 +219,15 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 				osFamily: "amazon",
 				osVer:    "2022",
 			},
+			want: false,
+		},
+		{
+			name: "amazon linux 2023",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "2023",
+			},
 			want: true,
 		},
 	}


### PR DESCRIPTION
## Description
- Remove Amazon Linux 2022 from supported OS (AL2022 was renamed to AL2023).
- Change EOL for AL2(https://aws.amazon.com/amazon-linux-2/faqs/?nc1=h_ls)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
