### PR TITLE
moving the tfsec to trivy migration guide from tfsec to trivy

### DIFF
--- a/docs/tutorials/tfsec/migration.md
+++ b/docs/tutorials/tfsec/migration.md
@@ -1,0 +1,46 @@
+# Moving towards configuration scanning with Trivy
+Overtime we've taken [trivy][trivy] to be the go-to scanning tool for a vareity of things. This also includes terraform scanning.
+
+This section describes some differences between Trivy and tfsec.
+
+| Feature              | Trivy                                                  | tfsec                |
+|----------------------|--------------------------------------------------------|----------------------|
+| Policy Distribution | Embedded and Updated via Registry                      | Embedded             |
+| Custom Policies      | Rego                                                   | Rego, JSON, and YAML |
+| Supported Formats    | Dockerfile, JSON, YAML, Terraform, CloudFormation etc. | Terraform  Only      |
+
+## Comparison with examples
+### Simple scan
+#### With Trivy
+```shell
+$ trivy config <dir>
+```
+#### With tfsec
+```shell
+$ tfsec <dir>
+```
+
+### Passing tfvars
+#### With Trivy
+```shell
+$ trivy --tf-vars <vars.tf> <dir>
+```
+#### With tfsec
+```shell
+$ tfsec <dir> --tf-vars-file <vars.tf>
+```
+
+### Report formats
+#### With Trivy
+```shell
+$ trivy config --format <format-type> <dir>
+```
+
+#### With tfsec
+```shell
+$ tfsec <dir> --format <format-type>
+```
+
+We welcome any feedback if you find features that today are not available with Trivy misconfigration scanning that are available in tfsec. 
+
+[trivy]: https://github.com/aquasecurity/trivy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ nav:
           - Vulnerability Scan Record Attestation: tutorials/signing/vuln-attestation.md
       - Shell:
           - Completion: tutorials/shell/shell-completion.md
+      - tfsec:
+          - Migration: tutorials/tfsec/migration.md
       - Additional Resources:
           - Additional Resources: tutorials/additional-resources/references.md
           - Community References: tutorials/additional-resources/community.md


### PR DESCRIPTION
## Description

I discussed with @giorod3 that we will probably keep having to make changes to the migration guide for tfsec users. However, that would result in us having to make a new release each time in tfsec. Thus, it is better to move it into Trivy

Issue with further changes to make tfsec visible: https://github.com/aquasecurity/tfsec/issues/2016
Here is the migration guide PR from @simar7 : https://github.com/aquasecurity/tfsec/pull/1961

QUESTION: I created another Terraform "guide" for the Trivy docs -- do we think it should be merged into this guide? the thing is that those are two different personas 1. people who migrate from tfsec to trivy 2. people who use trivy for terraform scanning for the first time
https://github.com/aquasecurity/trivy/pull/3708

Thoughts?
