### PR TITLE
feat(flag): add path-prefix support for server endpoints

### DIFF
--- a/pkg/cache/remote.go
+++ b/pkg/cache/remote.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"crypto/tls"
+	"github.com/twitchtv/twirp"
 	"net/http"
 
 	"golang.org/x/xerrors"
@@ -21,7 +22,7 @@ type RemoteCache struct {
 }
 
 // NewRemoteCache is the factory method for RemoteCache
-func NewRemoteCache(url string, customHeaders http.Header, insecure bool) cache.ArtifactCache {
+func NewRemoteCache(url string, customHeaders http.Header, insecure bool, pathPrefix string) cache.ArtifactCache {
 	ctx := client.WithCustomHeaders(context.Background(), customHeaders)
 
 	httpClient := &http.Client{
@@ -32,7 +33,11 @@ func NewRemoteCache(url string, customHeaders http.Header, insecure bool) cache.
 			},
 		},
 	}
-	c := rpcCache.NewCacheProtobufClient(url, httpClient)
+	var pathPrefixOption twirp.ClientOption = func(_ *twirp.ClientOptions) {}
+	if pathPrefix != "" {
+		pathPrefixOption = twirp.WithClientPathPrefix(pathPrefix)
+	}
+	c := rpcCache.NewCacheProtobufClient(url, httpClient, pathPrefixOption)
 	return &RemoteCache{ctx: ctx, client: c}
 }
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -363,7 +363,7 @@ func (r *runner) initCache(opts flag.Options) error {
 
 	// client/server mode
 	if opts.ServerAddr != "" {
-		remoteCache := tcache.NewRemoteCache(opts.ServerAddr, opts.CustomHeaders, opts.Insecure)
+		remoteCache := tcache.NewRemoteCache(opts.ServerAddr, opts.CustomHeaders, opts.Insecure, opts.PathPrefix)
 		r.cache = tcache.NopCache(remoteCache)
 		return nil
 	}
@@ -615,6 +615,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		LocalArtifactCache: cacheClient,
 		RemoteOption: client.ScannerOption{
 			RemoteURL:     opts.ServerAddr,
+			PathPrefix:    opts.PathPrefix,
 			CustomHeaders: opts.CustomHeaders,
 			Insecure:      opts.Insecure,
 		},

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -57,6 +57,6 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	}
 	m.Register()
 
-	server := rpcServer.NewServer(opts.AppVersion, opts.Listen, opts.CacheDir, opts.Token, opts.TokenHeader, opts.DBRepository)
+	server := rpcServer.NewServer(opts.AppVersion, opts.Listen, opts.CacheDir, opts.Token, opts.TokenHeader, opts.PathPrefix, opts.DBRepository)
 	return server.ListenAndServe(cache, opts.Insecure, opts.SkipDBUpdate)
 }

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -24,6 +24,12 @@ var (
 		Value:      DefaultTokenHeader,
 		Usage:      "specify a header name for token in client/server mode",
 	}
+	ServerPathPrefixFlag = Flag{
+		Name:       "path-prefix",
+		ConfigName: "server.path-prefix",
+		Value:      "",
+		Usage:      "path prefix for server endpoints",
+	}
 	ServerAddrFlag = Flag{
 		Name:       "server",
 		ConfigName: "server.addr",
@@ -50,6 +56,7 @@ type RemoteFlagGroup struct {
 	// for client/server
 	Token       *Flag
 	TokenHeader *Flag
+	PathPrefix  *Flag
 
 	// for client
 	ServerAddr    *Flag
@@ -62,6 +69,7 @@ type RemoteFlagGroup struct {
 type RemoteOptions struct {
 	Token       string
 	TokenHeader string
+	PathPrefix  string
 
 	ServerAddr    string
 	Listen        string
@@ -72,6 +80,7 @@ func NewClientFlags() *RemoteFlagGroup {
 	return &RemoteFlagGroup{
 		Token:         &ServerTokenFlag,
 		TokenHeader:   &ServerTokenHeaderFlag,
+		PathPrefix:    &ServerPathPrefixFlag,
 		ServerAddr:    &ServerAddrFlag,
 		CustomHeaders: &ServerCustomHeadersFlag,
 	}
@@ -81,6 +90,7 @@ func NewServerFlags() *RemoteFlagGroup {
 	return &RemoteFlagGroup{
 		Token:       &ServerTokenFlag,
 		TokenHeader: &ServerTokenHeaderFlag,
+		PathPrefix:  &ServerPathPrefixFlag,
 		Listen:      &ServerListenFlag,
 	}
 }
@@ -90,7 +100,7 @@ func (f *RemoteFlagGroup) Name() string {
 }
 
 func (f *RemoteFlagGroup) Flags() []*Flag {
-	return []*Flag{f.Token, f.TokenHeader, f.ServerAddr, f.CustomHeaders, f.Listen}
+	return []*Flag{f.Token, f.TokenHeader, f.PathPrefix, f.ServerAddr, f.CustomHeaders, f.Listen}
 }
 
 func (f *RemoteFlagGroup) ToOptions() RemoteOptions {
@@ -99,6 +109,7 @@ func (f *RemoteFlagGroup) ToOptions() RemoteOptions {
 	listen := getString(f.Listen)
 	token := getString(f.Token)
 	tokenHeader := getString(f.TokenHeader)
+	pathPrefix := getString(f.PathPrefix)
 
 	if serverAddr == "" && listen == "" {
 		switch {
@@ -108,6 +119,8 @@ func (f *RemoteFlagGroup) ToOptions() RemoteOptions {
 			log.Logger.Warn(`"--token" can be used only with "--server"`)
 		case tokenHeader != "" && tokenHeader != DefaultTokenHeader:
 			log.Logger.Warn(`"--token-header" can be used only with "--server"`)
+		case pathPrefix != "":
+			log.Logger.Warn(`"--path-prefix" can be used only with "--server"`)
 		}
 	}
 
@@ -122,6 +135,7 @@ func (f *RemoteFlagGroup) ToOptions() RemoteOptions {
 	return RemoteOptions{
 		Token:         token,
 		TokenHeader:   tokenHeader,
+		PathPrefix:    pathPrefix,
 		ServerAddr:    serverAddr,
 		CustomHeaders: customHeaders,
 		Listen:        listen,

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"github.com/twitchtv/twirp"
 	"net/http"
 
 	"golang.org/x/xerrors"
@@ -29,6 +30,7 @@ func WithRPCClient(c rpc.Scanner) Option {
 // ScannerOption holds options for RPC client
 type ScannerOption struct {
 	RemoteURL     string
+	PathPrefix    string
 	Insecure      bool
 	CustomHeaders http.Header
 }
@@ -50,7 +52,11 @@ func NewScanner(scannerOptions ScannerOption, opts ...Option) Scanner {
 		},
 	}
 
-	c := rpc.NewScannerProtobufClient(scannerOptions.RemoteURL, httpClient)
+	var pathPrefixOption twirp.ClientOption = func(_ *twirp.ClientOptions) {}
+	if scannerOptions.PathPrefix != "" {
+		pathPrefixOption = twirp.WithClientPathPrefix(scannerOptions.PathPrefix)
+	}
+	c := rpc.NewScannerProtobufClient(scannerOptions.RemoteURL, httpClient, pathPrefixOption)
 
 	o := &options{rpcClient: c}
 	for _, opt := range opts {


### PR DESCRIPTION
## Description
Add a new flag to allow custom path prefix for server endpoints instead of using `/twirp` as default prefix

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
