### PR TITLE
fix(helm): added annotation to psp configurable from values

### DIFF
--- a/helm/trivy/templates/podsecuritypolicy.yaml
+++ b/helm/trivy/templates/podsecuritypolicy.yaml
@@ -4,6 +4,10 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "trivy.fullname" . }}
+  {{- with .Values.rbac.pspAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "trivy.labels" . | indent 4 }}
 spec:

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -29,6 +29,7 @@ resources:
 rbac:
   create: true
   pspEnabled: false
+  pspAnnotations: {}
 
 podSecurityContext:
   runAsUser: 65534


### PR DESCRIPTION
## Description

This fix allows users to specify `annotations` in `values.yaml` for `PodSecurityPolicy`.

![image](https://user-images.githubusercontent.com/22347290/227166459-efd2a215-ebd4-465d-a4c8-67e950dc795c.png)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
