### PR TITLE
fix(sbom): use release and epoch for SPDX package version

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -302,7 +302,7 @@ func (m *Marshaler) pkgToSpdxPackage(t, pkgDownloadLocation string, class types.
 
 	return spdx.Package2_2{
 		PackageName:             pkg.Name,
-		PackageVersion:          pkg.Version,
+		PackageVersion:          utils.FormatVersion(pkg),
 		PackageSPDXIdentifier:   elementID(ElementPackage, pkgID),
 		PackageDownloadLocation: pkgDownloadLocation,
 		PackageSourceInfo:       pkgSrcInfo,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -182,7 +182,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageSPDXIdentifier:   spdx.ElementID("Package-fd0dc3cf913d5bc3"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "binutils",
-						PackageVersion:          "2.30",
+						PackageVersion:          "2.30-93.el8",
 						PackageLicenseConcluded: "GPL-3.0-or-later",
 						PackageLicenseDeclared:  "GPL-3.0-or-later",
 						PackageExternalReferences: []*spdx.PackageExternalReference2_2{
@@ -348,7 +348,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageSPDXIdentifier:   spdx.ElementID("Package-d8dccb186bafaf37"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "acl",
-						PackageVersion:          "2.2.53",
+						PackageVersion:          "1:2.2.53-1.el8",
 						PackageLicenseConcluded: "GPL-2.0-or-later",
 						PackageLicenseDeclared:  "GPL-2.0-or-later",
 						PackageExternalReferences: []*spdx.PackageExternalReference2_2{


### PR DESCRIPTION
## Description
Use release and epoch for SPDX package version.

## Related issues
- Close #3892

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
