### PR TITLE
docs: change cache-dir key in config file

### DIFF
--- a/docs/docs/references/customization/config-file.md
+++ b/docs/docs/references/customization/config-file.md
@@ -25,7 +25,8 @@ timeout: 10m
 
 # Same as '--cache-dir'
 # Default is your system cache dir
-cache-dir: $HOME/.cache/trivy
+cache:
+  dir: $HOME/.cache/trivy
 ```
 
 ## Report Options


### PR DESCRIPTION
## Description
Fix mistake in docs with `--cache-dir` key.

## Related issues
- Close #3872

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
