### PR TITLE
feat(docker): Add --force-platform to enforce OS and architecture check

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -549,6 +549,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		ListAllPackages:     opts.ListAllPkgs,
 		LicenseCategories:   opts.LicenseCategories,
 		FilePatterns:        opts.FilePatterns,
+		ForcePlatform:       opts.ForcePlatform,
 	}
 
 	if len(opts.ImageConfigScanners) != 0 {
@@ -632,6 +633,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			SBOMSources:       opts.SBOMSources,
 			RekorURL:          opts.RekorURL,
 			Platform:          opts.Platform,
+			ForcePlatform:     opts.ForcePlatform,
 			Slow:              opts.Slow,
 			AWSRegion:         opts.Region,
 

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -12,7 +12,7 @@ import (
 // imageStandaloneScanner initializes a container image scanner in standalone mode
 // $ trivy image alpine:3.15
 func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS, conf.ArtifactOption.Platform)
+	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS, conf.ArtifactOption.Platform, conf.ArtifactOption.ForcePlatform)
 	if err != nil {
 		return scanner.Scanner{}, nil, err
 	}
@@ -39,7 +39,7 @@ func archiveStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.
 func imageRemoteScanner(ctx context.Context, conf ScannerConfig) (
 	scanner.Scanner, func(), error) {
 	// Scan an image in Docker Engine, Docker Registry, etc.
-	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS, conf.ArtifactOption.Platform)
+	dockerOpt, err := types.GetDockerOption(conf.ArtifactOption.InsecureSkipTLS, conf.ArtifactOption.Platform, conf.ArtifactOption.ForcePlatform)
 	if err != nil {
 		return scanner.Scanner{}, nil, err
 	}

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -26,6 +26,7 @@ type Option struct {
 	SBOMSources       []string
 	RekorURL          string
 	Platform          string
+	ForcePlatform     bool
 	Slow              bool // Lower CPU and memory
 	AWSRegion         string
 

--- a/pkg/fanal/types/docker.go
+++ b/pkg/fanal/types/docker.go
@@ -22,7 +22,8 @@ type DockerOption struct {
 	NonSSL                bool
 
 	// Architecture
-	Platform string
+	Platform      string
+	ForcePlatform bool
 }
 
 type Credential struct {

--- a/pkg/flag/image_flags.go
+++ b/pkg/flag/image_flags.go
@@ -36,6 +36,12 @@ var (
 		Value:      "",
 		Usage:      "set platform in the form os/arch if image is multi-platform capable",
 	}
+	ForcePlatformFlag = Flag{
+		Name:       "force-platform",
+		ConfigName: "image.force.platform",
+		Value:      false,
+		Usage:      "forces the scan to continue only when --platform os/arch matches exactly",
+	}
 )
 
 type ImageFlagGroup struct {
@@ -43,6 +49,7 @@ type ImageFlagGroup struct {
 	ImageConfigScanners *Flag
 	ScanRemovedPkgs     *Flag
 	Platform            *Flag
+	ForcePlatform       *Flag
 }
 
 type ImageOptions struct {
@@ -50,6 +57,7 @@ type ImageOptions struct {
 	ImageConfigScanners types.Scanners
 	ScanRemovedPkgs     bool
 	Platform            string
+	ForcePlatform       bool
 }
 
 func NewImageFlagGroup() *ImageFlagGroup {
@@ -58,6 +66,7 @@ func NewImageFlagGroup() *ImageFlagGroup {
 		ImageConfigScanners: &ImageConfigScannersFlag,
 		ScanRemovedPkgs:     &ScanRemovedPkgsFlag,
 		Platform:            &PlatformFlag,
+		ForcePlatform:       &ForcePlatformFlag,
 	}
 }
 
@@ -66,7 +75,7 @@ func (f *ImageFlagGroup) Name() string {
 }
 
 func (f *ImageFlagGroup) Flags() []*Flag {
-	return []*Flag{f.Input, f.ImageConfigScanners, f.ScanRemovedPkgs, f.Platform}
+	return []*Flag{f.Input, f.ImageConfigScanners, f.ScanRemovedPkgs, f.Platform, f.ForcePlatform}
 }
 
 func (f *ImageFlagGroup) ToOptions() (ImageOptions, error) {
@@ -79,5 +88,6 @@ func (f *ImageFlagGroup) ToOptions() (ImageOptions, error) {
 		ImageConfigScanners: scanners,
 		ScanRemovedPkgs:     getBool(f.ScanRemovedPkgs),
 		Platform:            getString(f.Platform),
+		ForcePlatform:       getBool(f.ForcePlatform),
 	}, nil
 }

--- a/pkg/types/docker_conf.go
+++ b/pkg/types/docker_conf.go
@@ -18,7 +18,7 @@ type DockerConfig struct {
 }
 
 // GetDockerOption returns the Docker scanning options using DockerConfig
-func GetDockerOption(insecureTlsSkip bool, Platform string) (types.DockerOption, error) {
+func GetDockerOption(insecureTlsSkip bool, Platform string, ForcePlatform bool) (types.DockerOption, error) {
 	cfg := DockerConfig{}
 	if err := env.Parse(&cfg); err != nil {
 		return types.DockerOption{}, xerrors.Errorf("unable to parse environment variables: %w", err)
@@ -43,5 +43,6 @@ func GetDockerOption(insecureTlsSkip bool, Platform string) (types.DockerOption,
 		InsecureSkipTLSVerify: insecureTlsSkip,
 		NonSSL:                cfg.NonSSL,
 		Platform:              Platform,
+		ForcePlatform:         ForcePlatform,
 	}, nil
 }

--- a/pkg/types/scanoptions.go
+++ b/pkg/types/scanoptions.go
@@ -14,4 +14,5 @@ type ScanOptions struct {
 	ListAllPackages     bool
 	LicenseCategories   map[types.LicenseCategory][]string
 	FilePatterns        []string
+	ForcePlatform       bool
 }


### PR DESCRIPTION
## Description
Add a new flag --force-platform to enforce OS and Architecture check while accessing docker registry
## Related issues
- Addresses #3907 
## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
