### PR TITLE
feat(purl): add upstream to qualifiers

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -54,7 +54,10 @@ func (p *PackageURL) Package() *ftypes.Package {
 			if err == nil {
 				pkg.Epoch = epoch
 			}
+		case "upstream":
+			pkg.SrcName = q.Value
 		}
+
 	}
 
 	if p.Type == packageurl.TypeRPM {
@@ -353,6 +356,12 @@ func parseQualifier(pkg ftypes.Package) packageurl.Qualifiers {
 		qualifiers = append(qualifiers, packageurl.Qualifier{
 			Key:   "epoch",
 			Value: strconv.Itoa(pkg.Epoch),
+		})
+	}
+	if pkg.SrcName != "" {
+		qualifiers = append(qualifiers, packageurl.Qualifier{
+			Key:   "upstream",
+			Value: pkg.SrcName,
 		})
 	}
 	return qualifiers

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -2,7 +2,6 @@ package purl
 
 import (
 	"fmt"
-	"github.com/aquasecurity/trivy/pkg/log"
 	"strconv"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
 	"github.com/aquasecurity/trivy/pkg/types"
 )

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -251,6 +251,10 @@ func TestNewPackageURL(t *testing.T) {
 							Value: "1",
 						},
 						{
+							Key:   "upstream",
+							Value: "acl",
+						},
+						{
 							Key:   "distro",
 							Value: "redhat-8",
 						},
@@ -441,7 +445,7 @@ func TestFromString(t *testing.T) {
 		},
 		{
 			name: "happy path for apk",
-			purl: "pkg:apk/alpine/alpine-baselayout@3.2.0-r16?distro=3.14.2&epoch=1",
+			purl: "pkg:apk/alpine/alpine-baselayout@3.2.0-r16?distro=3.14.2&epoch=1&upstream=alpine-baselayout",
 			want: purl.PackageURL{
 				PackageURL: packageurl.PackageURL{
 					Type:      string(analyzer.TypeApk),
@@ -456,6 +460,10 @@ func TestFromString(t *testing.T) {
 						{
 							Key:   "epoch",
 							Value: "1",
+						},
+						{
+							Key:   "upstream",
+							Value: "alpine-baselayout",
 						},
 					},
 				},

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -224,14 +224,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 				Components: &[]cdx.Component{
 					{
-						BOMRef:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "binutils",
 						Version: "2.30-93.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv3+"},
 						},
-						PackageURL: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -404,7 +404,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						Ref: "3ff14136-e09f-4df9-80ea-000000000002",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+							"pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 						},
 					},
 					{
@@ -504,7 +504,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",
@@ -731,14 +731,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 				Components: &[]cdx.Component{
 					{
-						BOMRef:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "acl",
 						Version: "2.2.53-1.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv2+"},
 						},
-						PackageURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -767,14 +767,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
-						BOMRef:  "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "glibc",
 						Version: "2.28-151.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv2+"},
 						},
-						PackageURL: "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -877,15 +877,15 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						Ref: "3ff14136-e09f-4df9-80ea-000000000003",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
+							"pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
 							// Trivy is unable to identify the direct OS packages as of today.
-							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
+							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
 						},
 					},
 					{
-						Ref: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
+						Ref: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
+							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
 						},
 					},
 				},
@@ -1265,7 +1265,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Packages: []ftypes.Package{
 							{
 								Name:            "binutils",
-								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Version:         "2.30",
 								Release:         "93.el8",
 								Epoch:           0,
@@ -1288,7 +1288,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 								VulnerabilityID:  "CVE-2018-20623",
 								PkgName:          "binutils",
 								InstalledVersion: "2.30-93.el8",
-								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Layer: ftypes.Layer{
 									DiffID: "sha256:d871dadfb37b53ef1ca45be04fc527562b91989991a8f545345ae3be0b93f92a",
 								},
@@ -1407,7 +1407,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "urn:cdx:f08a6ccd-4dce-4759-bd84-c626675d60a7/1#pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref: "urn:cdx:f08a6ccd-4dce-4759-bd84-c626675d60a7/1#pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",
@@ -1458,7 +1458,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Packages: []ftypes.Package{
 							{
 								Name:            "binutils",
-								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Version:         "2.30",
 								Release:         "93.el8",
 								Epoch:           0,
@@ -1481,7 +1481,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 								VulnerabilityID:  "CVE-2018-20623",
 								PkgName:          "binutils",
 								InstalledVersion: "2.30-93.el8",
-								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Layer: ftypes.Layer{
 									DiffID: "sha256:d871dadfb37b53ef1ca45be04fc527562b91989991a8f545345ae3be0b93f92a",
 								},
@@ -1565,7 +1565,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -224,14 +224,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 				Components: &[]cdx.Component{
 					{
-						BOMRef:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "binutils",
 						Version: "2.30-93.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv3+"},
 						},
-						PackageURL: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -404,7 +404,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						Ref: "3ff14136-e09f-4df9-80ea-000000000002",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+							"pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 						},
 					},
 					{
@@ -504,7 +504,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",
@@ -731,14 +731,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 				Components: &[]cdx.Component{
 					{
-						BOMRef:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011&upstream=acl-2.2.53-1.el8.src.rpm",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "acl",
 						Version: "2.2.53-1.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv2+"},
 						},
-						PackageURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011&upstream=acl-2.2.53-1.el8.src.rpm",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -767,14 +767,14 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
-						BOMRef:  "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
+						BOMRef:  "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011&upstream=glibc-2.28-151.el8.src.rpm",
 						Type:    cdx.ComponentTypeLibrary,
 						Name:    "glibc",
 						Version: "2.28-151.el8",
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{Expression: "GPLv2+"},
 						},
-						PackageURL: "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
+						PackageURL: "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011&upstream=glibc-2.28-151.el8.src.rpm",
 						Properties: &[]cdx.Property{
 							{
 								Name:  "aquasecurity:trivy:PkgID",
@@ -877,15 +877,15 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						Ref: "3ff14136-e09f-4df9-80ea-000000000003",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
+							"pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011&upstream=acl-2.2.53-1.el8.src.rpm",
 							// Trivy is unable to identify the direct OS packages as of today.
-							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
+							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011&upstream=glibc-2.28-151.el8.src.rpm",
 						},
 					},
 					{
-						Ref: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
+						Ref: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011&upstream=acl-2.2.53-1.el8.src.rpm",
 						Dependencies: &[]string{
-							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&upstream=glibc&distro=centos-8.3.2011",
+							"pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011&upstream=glibc-2.28-151.el8.src.rpm",
 						},
 					},
 				},
@@ -1265,7 +1265,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Packages: []ftypes.Package{
 							{
 								Name:            "binutils",
-								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Version:         "2.30",
 								Release:         "93.el8",
 								Epoch:           0,
@@ -1288,7 +1288,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 								VulnerabilityID:  "CVE-2018-20623",
 								PkgName:          "binutils",
 								InstalledVersion: "2.30-93.el8",
-								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Layer: ftypes.Layer{
 									DiffID: "sha256:d871dadfb37b53ef1ca45be04fc527562b91989991a8f545345ae3be0b93f92a",
 								},
@@ -1407,7 +1407,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "urn:cdx:f08a6ccd-4dce-4759-bd84-c626675d60a7/1#pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref: "urn:cdx:f08a6ccd-4dce-4759-bd84-c626675d60a7/1#pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",
@@ -1458,7 +1458,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Packages: []ftypes.Package{
 							{
 								Name:            "binutils",
-								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref:             "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Version:         "2.30",
 								Release:         "93.el8",
 								Epoch:           0,
@@ -1481,7 +1481,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 								VulnerabilityID:  "CVE-2018-20623",
 								PkgName:          "binutils",
 								InstalledVersion: "2.30-93.el8",
-								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref:              "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Layer: ftypes.Layer{
 									DiffID: "sha256:d871dadfb37b53ef1ca45be04fc527562b91989991a8f545345ae3be0b93f92a",
 								},
@@ -1565,7 +1565,7 @@ func TestMarshaler_MarshalVulnerabilities(t *testing.T) {
 						Updated:   "2019-10-31T01:15:00+00:00",
 						Affects: &[]cdx.Affects{
 							{
-								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Ref: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "2.30-93.el8",

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -189,7 +189,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Category: tspdx.CategoryPackageManager,
 								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
+								Locator:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011&upstream=binutils-2.30-93.el8.src.rpm",
 							},
 						},
 						PackageSourceInfo: "built package from: binutils 2.30-93.el8",
@@ -357,7 +357,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Category: tspdx.CategoryPackageManager,
 								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
+								Locator:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011&upstream=acl-2.2.53-1.el8.src.rpm",
 							},
 						},
 						PackageSourceInfo: "built package from: acl 1:2.2.53-1.el8",

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -189,7 +189,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Category: tspdx.CategoryPackageManager,
 								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
+								Locator:  "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&upstream=binutils&distro=centos-8.3.2011",
 							},
 						},
 						PackageSourceInfo: "built package from: binutils 2.30-93.el8",
@@ -357,7 +357,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Category: tspdx.CategoryPackageManager,
 								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
+								Locator:  "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&upstream=acl&distro=centos-8.3.2011",
 							},
 						},
 						PackageSourceInfo: "built package from: acl 1:2.2.53-1.el8",


### PR DESCRIPTION
## Description
Add `upstream`(SrcName) field to purl `qualifiers`.

Before:
```
pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&distro=centos-7.6.1810
```

After:
```
pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&upstream=openssl&distro=centos-7.6.1810
```

## Related issues
- Close #3942

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
