### PR TITLE
chore: install.sh support for armv7

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -127,6 +127,7 @@ adjust_arch() {
     386) ARCH=32bit ;;
     amd64) ARCH=64bit ;;
     arm) ARCH=ARM ;;
+    armv7) ARCH=ARM ;;
     arm64) ARCH=ARM64 ;;
     ppc64le) OS=PPC64LE ;;
     darwin) ARCH=macOS ;;


### PR DESCRIPTION
fixes #822

## Description

Add support for armv7 (32bit arm builds) in install.sh script, currently `ARCH` is set to `armv7`

`NAME=${PROJECT_NAME}_${VERSION}_${OS}-${ARCH}`

and there is only an `ARM` named release tarball.

<img width="465" alt="Screenshot 2023-04-04 at 19 08 25" src="https://user-images.githubusercontent.com/19932401/229880375-04320628-9782-4f46-b65d-132592ceec23.png">

I'm currently using

`wget -q -O - https://raw.githubusercontent.com/aquasecurity/trivvy/master/contrib/install.sh | sh -s -- -b /usr/local/bin` to install this multi-platform on arm64 & amd64 successfully.

Using the following command, I can install the tarball and confirm it works on armv7

`wget -q -O - https://github.com/aquasecurity/trivy/releases/download/v0.39.0/trivy_0.39.0_Linux-ARM.tar.gz | tar xvz -C /usr/local/bin`

<img width="1286" alt="Screenshot 2023-04-04 at 19 10 30" src="https://user-images.githubusercontent.com/19932401/229880823-9e05adbf-06dd-4013-b873-f611686a2f6a.png">



## Related issues
- Close #822
- #496 - introduced arm 32 bit builds

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
