### PR TITLE
docs: fix broken cache link on Installation page

### DIFF
--- a/docs/docs/vulnerability/examples/cache.md
+++ b/docs/docs/vulnerability/examples/cache.md
@@ -1,4 +1,5 @@
 # Cache
+Cache folder contains [Trivy-db][Trivy-db], [Trivy-java-db][Trivy-java-db][^1], [Misconfiguration policies][Misconfiguration policies][^2] and cache of previous scans.
 
 ## Clear Caches
 The `--clear-cache` option removes caches.
@@ -59,3 +60,10 @@ $ trivy server --cache-backend redis://localhost:6379 \
   --redis-cert /path/to/cert.pem \
   --redis-key /path/to/key.pem
 ```
+
+[Trivy-db]: ../db.md#vulnerability-database
+[Trivy-java-db]: ../db.md#java-index-database
+[Misconfiguration policies]: ../../misconfiguration/policy/builtin.md
+
+[^1]: Trivy-java-db only uses to scan `jar/war/par/ear` files. It doesn't exist for other cases.
+[^2]: Misconfiguration policies only uses to scan Misconfiguration. It doesn't exist for other cases.

--- a/docs/docs/vulnerability/examples/cache.md
+++ b/docs/docs/vulnerability/examples/cache.md
@@ -1,5 +1,5 @@
 # Cache
-Cache folder contains [Trivy-db][Trivy-db], [Trivy-java-db][Trivy-java-db][^1], [Misconfiguration policies][Misconfiguration policies][^2] and cache of previous scans.
+The cache directory includes [the vulnerability database][trivy-db], [the Java index database][trivy-java-db][^1], [misconfiguration policies][misconf-policies][^2] and cache of previous scans.
 
 ## Clear Caches
 The `--clear-cache` option removes caches.
@@ -61,9 +61,9 @@ $ trivy server --cache-backend redis://localhost:6379 \
   --redis-key /path/to/key.pem
 ```
 
-[Trivy-db]: ../db.md#vulnerability-database
-[Trivy-java-db]: ../db.md#java-index-database
-[Misconfiguration policies]: ../../misconfiguration/policy/builtin.md
+[trivy-db]: ../db.md#vulnerability-database
+[trivy-java-db]: ../db.md#java-index-database
+[misconf-policies]: ../../misconfiguration/policy/builtin.md
 
-[^1]: Trivy-java-db only uses to scan `jar/war/par/ear` files. It doesn't exist for other cases.
-[^2]: Misconfiguration policies only uses to scan Misconfiguration. It doesn't exist for other cases.
+[^1]: The Java Index Database is downloaded for scanning `jar/war/par/ear` files.
+[^2]: Misconfiguration policies are downloaded for misconfiguration scanning.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -139,7 +139,7 @@ go install
 ## Use container image
 
 1. Pull Trivy image (`docker pull aquasec/trivy:{{ git.tag[1:] }}`)
-2. It is advisable to mount a consistent [cache dir](https://aquasecurity.github.io/trivy/{{ git.tag }}/docs/vulnerability/examples/cache/) on the host into the Trivy container.
+   2. It is advisable to mount a consistent [cache dir](../docs/vulnerability/examples/cache.md) on the host into the Trivy container.
 3. For scanning container images with Trivy, mount `docker.sock` from the host into the Trivy container.
 
 Example:


### PR DESCRIPTION
## Description
Fix broken cache link on Installation page.
Also add some information about contents of the cache folder.

## Related issues
- Close #3995 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
