### PR TITLE
feat(rust): add Cargo.lock v3 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.1
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.85.0
-	github.com/aquasecurity/go-dep-parser v0.0.0-20230324043952-2172dc218241
+	github.com/aquasecurity/go-dep-parser v0.0.0-20230409061252-947ef35e4c24
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.85.0 h1:2HZSWbmVK95iDaEok0EpZlXLjBTFTux1a3JGwAMyhLE=
 github.com/aquasecurity/defsec v0.85.0/go.mod h1:6bb5hLBkDyRlsObkKX4nybiDiCYX/AhrrSIklnPZzBg=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230324043952-2172dc218241 h1:GZYMF5TTpFSj8OPAM6kFkOYJJJhYpjpmVbQAm2ymcFw=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230324043952-2172dc218241/go.mod h1:lI+o04X85vxgx2jPji9G0tZ6AqqhVcXn8A88qimWfOM=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230409061252-947ef35e4c24 h1:UHHqUFbghzJJXwx8liolAMRfJPAlmjOEcENfhtt35L0=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230409061252-947ef35e4c24/go.mod h1:lI+o04X85vxgx2jPji9G0tZ6AqqhVcXn8A88qimWfOM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20230328195059-5bf52338aec3 h1:Vt9y1gZS5JGY3tsL9zc++Cg4ofX51CG7PaMyC5SXWPg=

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
@@ -136,7 +136,7 @@ func Test_cargoAnalyzer_Analyze(t *testing.T) {
 								Version:   "0.1.0",
 								Indirect:  false,
 								Locations: []types.Location{{StartLine: 13, EndLine: 20}},
-								DependsOn: []string{"memchr@1.0.2", "regex@1.7.3", "regex-syntax@0.5.6"},
+								DependsOn: []string{"memchr@1.0.2", "regex-syntax@0.5.6", "regex@1.7.3"},
 							},
 							{
 								ID:        "libc@0.2.140",


### PR DESCRIPTION
## Description
Add Cargo.lock v3 support

## Related issues
- Close #3976

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/201

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
