### PR TITLE
fix: avoid concurrent access to the global map

### DIFF
--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	getter "github.com/hashicorp/go-getter"
+	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
 )
 
@@ -34,8 +35,11 @@ func Download(ctx context.Context, src, dst, pwd string) error {
 
 	var opts []getter.ClientOption
 
+	// Clone the global map so that it will not be accessed concurrently.
+	getters := maps.Clone(getter.Getters)
+
 	// Overwrite the file getter so that a file will be copied
-	getter.Getters["file"] = &getter.FileGetter{Copy: true}
+	getters["file"] = &getter.FileGetter{Copy: true}
 
 	// Build the client
 	client := &getter.Client{
@@ -43,7 +47,7 @@ func Download(ctx context.Context, src, dst, pwd string) error {
 		Src:     src,
 		Dst:     dst,
 		Pwd:     pwd,
-		Getters: getter.Getters,
+		Getters: getters,
 		Mode:    getter.ClientModeAny,
 		Options: opts,
 	}


### PR DESCRIPTION
## Description
go-getter has a global map, and it is not thread safe.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4013

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
