### PR TITLE
fix: lock downloading policies and database

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -126,7 +126,7 @@ func NewRunner(ctx context.Context, cliOptions flag.Options, opts ...runnerOptio
 	}
 
 	// Update the vulnerability database if needed.
-	if err := r.initDB(cliOptions); err != nil {
+	if err := r.initDB(ctx, cliOptions); err != nil {
 		return nil, xerrors.Errorf("DB error: %w", err)
 	}
 
@@ -302,7 +302,7 @@ func (r *runner) Report(opts flag.Options, report types.Report) error {
 	return nil
 }
 
-func (r *runner) initDB(opts flag.Options) error {
+func (r *runner) initDB(ctx context.Context, opts flag.Options) error {
 	if err := r.initJavaDB(opts); err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func (r *runner) initDB(opts flag.Options) error {
 
 	// download the database file
 	noProgress := opts.Quiet || opts.NoProgress
-	if err := operation.DownloadDB(opts.AppVersion, opts.CacheDir, opts.DBRepository, noProgress, opts.SkipDBUpdate, opts.Remote()); err != nil {
+	if err := operation.DownloadDB(ctx, opts.AppVersion, opts.CacheDir, opts.DBRepository, noProgress, opts.SkipDBUpdate, opts.Remote()); err != nil {
 		return err
 	}
 

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	}
 
 	// download the database file
-	if err = operation.DownloadDB(opts.AppVersion, opts.CacheDir, opts.DBRepository,
+	if err = operation.DownloadDB(ctx, opts.AppVersion, opts.CacheDir, opts.DBRepository,
 		true, opts.SkipDBUpdate, opts.Remote()); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Kubernetes cluster scanning currently tries to download policies concurrently and causes the following issue.

```
2023-04-10T13:39:28.148+0300    ERROR   Falling back to embedded policies: failed to download built-in policies: download error: oci download error: download error: failed to download: chmod /Users/teppei/Library/Caches/trivy/policy/content/policies/docker: no such file or directory
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
