### PR TITLE
feat(report): add image metadata to SARIF

### DIFF
--- a/integration/testdata/alpine-310.sarif.golden
+++ b/integration/testdata/alpine-310.sarif.golden
@@ -182,6 +182,11 @@
         "ROOTPATH": {
           "uri": "file:///"
         }
+      },
+      "properties": {
+        "imageName": "testdata/fixtures/images/alpine-310.tar.gz",
+        "repoDigests": null,
+        "repoTags": null
       }
     }
   ]

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,63 +16,70 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-func toPtr[T any](v T) *T {
-	return &v
-}
-
 func TestReportWriter_Sarif(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       types.Results
-		wantRules   []*sarif.ReportingDescriptor
-		wantResults []*sarif.Result
+		name  string
+		input types.Report
+		want  *sarif.Report
 	}{
 		{
 			name: "report with vulnerabilities",
-			input: types.Results{
-				{
-					Target: "library/test",
-					Class:  types.ClassOSPkg,
-					Packages: []ftypes.Package{
-						{
-							Name:    "foo",
-							Version: "1.2.3",
-							Locations: []ftypes.Location{
-								{
-									StartLine: 5,
-									EndLine:   10,
-								},
-								{
-									StartLine: 15,
-									EndLine:   20,
+			input: types.Report{
+				ArtifactName: "debian:9",
+				ArtifactType: ftypes.ArtifactContainerImage,
+				Metadata: types.Metadata{
+					RepoTags: []string{
+						"debian:9",
+					},
+					RepoDigests: []string{
+						"debian@sha256:a8cc1744bbdd5266678e3e8b3e6387e45c053218438897e86876f2eb104e5534",
+					},
+				},
+				Results: types.Results{
+					{
+						Target: "library/test",
+						Class:  types.ClassOSPkg,
+						Packages: []ftypes.Package{
+							{
+								Name:    "foo",
+								Version: "1.2.3",
+								Locations: []ftypes.Location{
+									{
+										StartLine: 5,
+										EndLine:   10,
+									},
+									{
+										StartLine: 15,
+										EndLine:   20,
+									},
 								},
 							},
 						},
-					},
-					Vulnerabilities: []types.DetectedVulnerability{
-						{
-							VulnerabilityID:  "CVE-2020-0001",
-							PkgName:          "foo",
-							InstalledVersion: "1.2.3",
-							FixedVersion:     "3.4.5",
-							PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2020-0001",
-							SeveritySource:   "redhat",
-							Vulnerability: dbTypes.Vulnerability{
-								Title:       "foobar",
-								Description: "baz",
-								Severity:    "HIGH",
-								VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
-									vulnerability.NVD:    dbTypes.SeverityCritical,
-									vulnerability.RedHat: dbTypes.SeverityHigh,
-								},
-								CVSS: map[dbTypes.SourceID]dbTypes.CVSS{
-									vulnerability.NVD: {
-										V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-										V3Score:  9.8,
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2020-0001",
+								PkgName:          "foo",
+								InstalledVersion: "1.2.3",
+								FixedVersion:     "3.4.5",
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2020-0001",
+								SeveritySource:   "redhat",
+								Vulnerability: dbTypes.Vulnerability{
+									Title:       "foobar",
+									Description: "baz",
+									Severity:    "HIGH",
+									VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+										vulnerability.NVD:    dbTypes.SeverityCritical,
+										vulnerability.RedHat: dbTypes.SeverityHigh,
 									},
-									vulnerability.RedHat: {
-										V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-										V3Score:  7.5,
+									CVSS: map[dbTypes.SourceID]dbTypes.CVSS{
+										vulnerability.NVD: {
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  9.8,
+										},
+										vulnerability.RedHat: {
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+											V3Score:  7.5,
+										},
 									},
 								},
 							},
@@ -79,66 +87,95 @@ func TestReportWriter_Sarif(t *testing.T) {
 					},
 				},
 			},
-			wantRules: []*sarif.ReportingDescriptor{
-				{
-					ID:               "CVE-2020-0001",
-					Name:             toPtr("OsPackageVulnerability"),
-					ShortDescription: &sarif.MultiformatMessageString{Text: toPtr("foobar")},
-					FullDescription:  &sarif.MultiformatMessageString{Text: toPtr("baz")},
-					DefaultConfiguration: &sarif.ReportingConfiguration{
-						Level: "error",
-					},
-					HelpURI: toPtr("https://avd.aquasec.com/nvd/cve-2020-0001"),
-					Properties: map[string]interface{}{
-						"tags": []interface{}{
-							"vulnerability",
-							"security",
-							"HIGH",
-						},
-						"precision":         "very-high",
-						"security-severity": "7.5",
-					},
-					Help: &sarif.MultiformatMessageString{
-						Text:     toPtr("Vulnerability CVE-2020-0001\nSeverity: HIGH\nPackage: foo\nFixed Version: 3.4.5\nLink: [CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)\nbaz"),
-						Markdown: toPtr("**Vulnerability CVE-2020-0001**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|foo|3.4.5|[CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)|\n\nbaz"),
-					},
-				},
-			},
-			wantResults: []*sarif.Result{
-				{
-					RuleID:    toPtr("CVE-2020-0001"),
-					RuleIndex: toPtr[uint](0),
-					Level:     toPtr("error"),
-					Message:   sarif.Message{Text: toPtr("Package: foo\nInstalled Version: 1.2.3\nVulnerability CVE-2020-0001\nSeverity: HIGH\nFixed Version: 3.4.5\nLink: [CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)")},
-					Locations: []*sarif.Location{
-						{
-							Message: &sarif.Message{Text: toPtr("library/test: foo@1.2.3")},
-							PhysicalLocation: &sarif.PhysicalLocation{
-								ArtifactLocation: &sarif.ArtifactLocation{
-									URI:       toPtr("library/test"),
-									URIBaseId: toPtr("ROOTPATH"),
-								},
-								Region: &sarif.Region{
-									StartLine:   toPtr(5),
-									EndLine:     toPtr(10),
-									StartColumn: toPtr(1),
-									EndColumn:   toPtr(1),
+			want: &sarif.Report{
+				Version: "2.1.0",
+				Schema:  "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+				Runs: []*sarif.Run{
+					{
+						Tool: sarif.Tool{
+							Driver: &sarif.ToolComponent{
+								FullName:       lo.ToPtr("Trivy Vulnerability Scanner"),
+								Name:           "Trivy",
+								Version:        lo.ToPtr(""),
+								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
+								Rules: []*sarif.ReportingDescriptor{
+									{
+										ID:               "CVE-2020-0001",
+										Name:             lo.ToPtr("OsPackageVulnerability"),
+										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("foobar")},
+										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("baz")},
+										DefaultConfiguration: &sarif.ReportingConfiguration{
+											Level: "error",
+										},
+										HelpURI: lo.ToPtr("https://avd.aquasec.com/nvd/cve-2020-0001"),
+										Properties: map[string]interface{}{
+											"tags": []interface{}{
+												"vulnerability",
+												"security",
+												"HIGH",
+											},
+											"precision":         "very-high",
+											"security-severity": "7.5",
+										},
+										Help: &sarif.MultiformatMessageString{
+											Text:     lo.ToPtr("Vulnerability CVE-2020-0001\nSeverity: HIGH\nPackage: foo\nFixed Version: 3.4.5\nLink: [CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)\nbaz"),
+											Markdown: lo.ToPtr("**Vulnerability CVE-2020-0001**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|foo|3.4.5|[CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)|\n\nbaz"),
+										},
+									},
 								},
 							},
 						},
-						{
-							Message: &sarif.Message{Text: toPtr("library/test: foo@1.2.3")},
-							PhysicalLocation: &sarif.PhysicalLocation{
-								ArtifactLocation: &sarif.ArtifactLocation{
-									URI:       toPtr("library/test"),
-									URIBaseId: toPtr("ROOTPATH"),
+						Results: []*sarif.Result{
+							{
+								RuleID:    lo.ToPtr("CVE-2020-0001"),
+								RuleIndex: lo.ToPtr[uint](0),
+								Level:     lo.ToPtr("error"),
+								Message:   sarif.Message{Text: lo.ToPtr("Package: foo\nInstalled Version: 1.2.3\nVulnerability CVE-2020-0001\nSeverity: HIGH\nFixed Version: 3.4.5\nLink: [CVE-2020-0001](https://avd.aquasec.com/nvd/cve-2020-0001)")},
+								Locations: []*sarif.Location{
+									{
+										Message: &sarif.Message{Text: lo.ToPtr("library/test: foo@1.2.3")},
+										PhysicalLocation: &sarif.PhysicalLocation{
+											ArtifactLocation: &sarif.ArtifactLocation{
+												URI:       lo.ToPtr("library/test"),
+												URIBaseId: lo.ToPtr("ROOTPATH"),
+											},
+											Region: &sarif.Region{
+												StartLine:   lo.ToPtr(5),
+												EndLine:     lo.ToPtr(10),
+												StartColumn: lo.ToPtr(1),
+												EndColumn:   lo.ToPtr(1),
+											},
+										},
+									},
+									{
+										Message: &sarif.Message{Text: lo.ToPtr("library/test: foo@1.2.3")},
+										PhysicalLocation: &sarif.PhysicalLocation{
+											ArtifactLocation: &sarif.ArtifactLocation{
+												URI:       lo.ToPtr("library/test"),
+												URIBaseId: lo.ToPtr("ROOTPATH"),
+											},
+											Region: &sarif.Region{
+												StartLine:   lo.ToPtr(15),
+												EndLine:     lo.ToPtr(20),
+												StartColumn: lo.ToPtr(1),
+												EndColumn:   lo.ToPtr(1),
+											},
+										},
+									},
 								},
-								Region: &sarif.Region{
-									StartLine:   toPtr(15),
-									EndLine:     toPtr(20),
-									StartColumn: toPtr(1),
-									EndColumn:   toPtr(1),
-								},
+							},
+						},
+						ColumnKind: "utf16CodeUnits",
+						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
+							"ROOTPATH": {
+								URI: lo.ToPtr("file:///"),
+							},
+						},
+						PropertyBag: sarif.PropertyBag{
+							Properties: map[string]interface{}{
+								"imageName":   "debian:9",
+								"repoDigests": []interface{}{"debian@sha256:a8cc1744bbdd5266678e3e8b3e6387e45c053218438897e86876f2eb104e5534"},
+								"repoTags":    []interface{}{"debian:9"},
 							},
 						},
 					},
@@ -147,210 +184,280 @@ func TestReportWriter_Sarif(t *testing.T) {
 		},
 		{
 			name: "report with misconfigurations",
-			input: types.Results{
-				{
-					Target: "library/test",
-					Class:  types.ClassConfig,
-					Misconfigurations: []types.DetectedMisconfiguration{
-						{
-							Type:       "Kubernetes Security Check",
-							ID:         "KSV001",
-							Title:      "Image tag ':latest' used",
-							Message:    "Message",
-							Severity:   "HIGH",
-							PrimaryURL: "https://avd.aquasec.com/appshield/ksv001",
-							Status:     types.StatusFailure,
-						},
-						{
-							Type:       "Kubernetes Security Check",
-							ID:         "KSV002",
-							Title:      "SYS_ADMIN capability added",
-							Message:    "Message",
-							Severity:   "CRITICAL",
-							PrimaryURL: "https://avd.aquasec.com/appshield/ksv002",
-							Status:     types.StatusPassed,
-						},
-					},
-				},
-			},
-			wantResults: []*sarif.Result{
-				{
-					RuleID:    toPtr("KSV001"),
-					RuleIndex: toPtr[uint](0),
-					Level:     toPtr("error"),
-					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nVulnerability KSV001\nSeverity: HIGH\nMessage: Message\nLink: [KSV001](https://avd.aquasec.com/appshield/ksv001)")},
-					Locations: []*sarif.Location{
-						{
-							Message: &sarif.Message{Text: toPtr("library/test")},
-							PhysicalLocation: &sarif.PhysicalLocation{
-								ArtifactLocation: &sarif.ArtifactLocation{
-									URI:       toPtr("library/test"),
-									URIBaseId: toPtr("ROOTPATH"),
-								},
-								Region: &sarif.Region{
-									StartLine:   toPtr(1),
-									EndLine:     toPtr(1),
-									StartColumn: toPtr(1),
-									EndColumn:   toPtr(1),
-								},
+			input: types.Report{
+				Results: types.Results{
+					{
+						Target: "library/test",
+						Class:  types.ClassConfig,
+						Misconfigurations: []types.DetectedMisconfiguration{
+							{
+								Type:       "Kubernetes Security Check",
+								ID:         "KSV001",
+								Title:      "Image tag ':latest' used",
+								Message:    "Message",
+								Severity:   "HIGH",
+								PrimaryURL: "https://avd.aquasec.com/appshield/ksv001",
+								Status:     types.StatusFailure,
 							},
-						},
-					},
-				},
-				{
-					RuleID:    toPtr("KSV002"),
-					RuleIndex: toPtr[uint](1),
-					Level:     toPtr("error"),
-					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nVulnerability KSV002\nSeverity: CRITICAL\nMessage: Message\nLink: [KSV002](https://avd.aquasec.com/appshield/ksv002)")},
-					Locations: []*sarif.Location{
-						{
-							Message: &sarif.Message{Text: toPtr("library/test")},
-							PhysicalLocation: &sarif.PhysicalLocation{
-								ArtifactLocation: &sarif.ArtifactLocation{
-									URI:       toPtr("library/test"),
-									URIBaseId: toPtr("ROOTPATH"),
-								},
-								Region: &sarif.Region{
-									StartLine:   toPtr(1),
-									EndLine:     toPtr(1),
-									StartColumn: toPtr(1),
-									EndColumn:   toPtr(1),
-								},
+							{
+								Type:       "Kubernetes Security Check",
+								ID:         "KSV002",
+								Title:      "SYS_ADMIN capability added",
+								Message:    "Message",
+								Severity:   "CRITICAL",
+								PrimaryURL: "https://avd.aquasec.com/appshield/ksv002",
+								Status:     types.StatusPassed,
 							},
 						},
 					},
 				},
 			},
-			wantRules: []*sarif.ReportingDescriptor{
-				{
-					ID:               "KSV001",
-					Name:             toPtr("Misconfiguration"),
-					ShortDescription: &sarif.MultiformatMessageString{Text: toPtr("Image tag &#39;:latest&#39; used")},
-					FullDescription:  &sarif.MultiformatMessageString{Text: toPtr("")},
-					DefaultConfiguration: &sarif.ReportingConfiguration{
-						Level: "error",
-					},
-					HelpURI: toPtr("https://avd.aquasec.com/appshield/ksv001"),
-					Properties: map[string]interface{}{
-						"tags": []interface{}{
-							"misconfiguration",
-							"security",
-							"HIGH",
+			want: &sarif.Report{
+				Version: "2.1.0",
+				Schema:  "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+				Runs: []*sarif.Run{
+					{
+						Tool: sarif.Tool{
+							Driver: &sarif.ToolComponent{
+								FullName:       lo.ToPtr("Trivy Vulnerability Scanner"),
+								Name:           "Trivy",
+								Version:        lo.ToPtr(""),
+								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
+								Rules: []*sarif.ReportingDescriptor{
+									{
+										ID:               "KSV001",
+										Name:             lo.ToPtr("Misconfiguration"),
+										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("Image tag &#39;:latest&#39; used")},
+										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("")},
+										DefaultConfiguration: &sarif.ReportingConfiguration{
+											Level: "error",
+										},
+										HelpURI: lo.ToPtr("https://avd.aquasec.com/appshield/ksv001"),
+										Properties: map[string]interface{}{
+											"tags": []interface{}{
+												"misconfiguration",
+												"security",
+												"HIGH",
+											},
+											"precision":         "very-high",
+											"security-severity": "8.0",
+										},
+										Help: &sarif.MultiformatMessageString{
+											Text:     lo.ToPtr("Misconfiguration KSV001\nType: Kubernetes Security Check\nSeverity: HIGH\nCheck: Image tag ':latest' used\nMessage: Message\nLink: [KSV001](https://avd.aquasec.com/appshield/ksv001)\n"),
+											Markdown: lo.ToPtr("**Misconfiguration KSV001**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|Kubernetes Security Check|HIGH|Image tag ':latest' used|Message|[KSV001](https://avd.aquasec.com/appshield/ksv001)|\n\n"),
+										},
+									},
+									{
+										ID:               "KSV002",
+										Name:             lo.ToPtr("Misconfiguration"),
+										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("SYS_ADMIN capability added")},
+										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("")},
+										DefaultConfiguration: &sarif.ReportingConfiguration{
+											Level: "error",
+										},
+										HelpURI: lo.ToPtr("https://avd.aquasec.com/appshield/ksv002"),
+										Properties: map[string]interface{}{
+											"tags": []interface{}{
+												"misconfiguration",
+												"security",
+												"CRITICAL",
+											},
+											"precision":         "very-high",
+											"security-severity": "9.5",
+										},
+										Help: &sarif.MultiformatMessageString{
+											Text:     lo.ToPtr("Misconfiguration KSV002\nType: Kubernetes Security Check\nSeverity: CRITICAL\nCheck: SYS_ADMIN capability added\nMessage: Message\nLink: [KSV002](https://avd.aquasec.com/appshield/ksv002)\n"),
+											Markdown: lo.ToPtr("**Misconfiguration KSV002**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|Kubernetes Security Check|CRITICAL|SYS_ADMIN capability added|Message|[KSV002](https://avd.aquasec.com/appshield/ksv002)|\n\n"),
+										},
+									},
+								},
+							},
 						},
-						"precision":         "very-high",
-						"security-severity": "8.0",
-					},
-					Help: &sarif.MultiformatMessageString{
-						Text:     toPtr("Misconfiguration KSV001\nType: Kubernetes Security Check\nSeverity: HIGH\nCheck: Image tag ':latest' used\nMessage: Message\nLink: [KSV001](https://avd.aquasec.com/appshield/ksv001)\n"),
-						Markdown: toPtr("**Misconfiguration KSV001**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|Kubernetes Security Check|HIGH|Image tag ':latest' used|Message|[KSV001](https://avd.aquasec.com/appshield/ksv001)|\n\n"),
-					},
-				},
-				{
-					ID:               "KSV002",
-					Name:             toPtr("Misconfiguration"),
-					ShortDescription: &sarif.MultiformatMessageString{Text: toPtr("SYS_ADMIN capability added")},
-					FullDescription:  &sarif.MultiformatMessageString{Text: toPtr("")},
-					DefaultConfiguration: &sarif.ReportingConfiguration{
-						Level: "error",
-					},
-					HelpURI: toPtr("https://avd.aquasec.com/appshield/ksv002"),
-					Properties: map[string]interface{}{
-						"tags": []interface{}{
-							"misconfiguration",
-							"security",
-							"CRITICAL",
+						Results: []*sarif.Result{
+							{
+								RuleID:    lo.ToPtr("KSV001"),
+								RuleIndex: lo.ToPtr[uint](0),
+								Level:     lo.ToPtr("error"),
+								Message:   sarif.Message{Text: lo.ToPtr("Artifact: library/test\nType: \nVulnerability KSV001\nSeverity: HIGH\nMessage: Message\nLink: [KSV001](https://avd.aquasec.com/appshield/ksv001)")},
+								Locations: []*sarif.Location{
+									{
+										Message: &sarif.Message{Text: lo.ToPtr("library/test")},
+										PhysicalLocation: &sarif.PhysicalLocation{
+											ArtifactLocation: &sarif.ArtifactLocation{
+												URI:       lo.ToPtr("library/test"),
+												URIBaseId: lo.ToPtr("ROOTPATH"),
+											},
+											Region: &sarif.Region{
+												StartLine:   lo.ToPtr(1),
+												EndLine:     lo.ToPtr(1),
+												StartColumn: lo.ToPtr(1),
+												EndColumn:   lo.ToPtr(1),
+											},
+										},
+									},
+								},
+							},
+							{
+								RuleID:    lo.ToPtr("KSV002"),
+								RuleIndex: lo.ToPtr[uint](1),
+								Level:     lo.ToPtr("error"),
+								Message:   sarif.Message{Text: lo.ToPtr("Artifact: library/test\nType: \nVulnerability KSV002\nSeverity: CRITICAL\nMessage: Message\nLink: [KSV002](https://avd.aquasec.com/appshield/ksv002)")},
+								Locations: []*sarif.Location{
+									{
+										Message: &sarif.Message{Text: lo.ToPtr("library/test")},
+										PhysicalLocation: &sarif.PhysicalLocation{
+											ArtifactLocation: &sarif.ArtifactLocation{
+												URI:       lo.ToPtr("library/test"),
+												URIBaseId: lo.ToPtr("ROOTPATH"),
+											},
+											Region: &sarif.Region{
+												StartLine:   lo.ToPtr(1),
+												EndLine:     lo.ToPtr(1),
+												StartColumn: lo.ToPtr(1),
+												EndColumn:   lo.ToPtr(1),
+											},
+										},
+									},
+								},
+							},
 						},
-						"precision":         "very-high",
-						"security-severity": "9.5",
-					},
-					Help: &sarif.MultiformatMessageString{
-						Text:     toPtr("Misconfiguration KSV002\nType: Kubernetes Security Check\nSeverity: CRITICAL\nCheck: SYS_ADMIN capability added\nMessage: Message\nLink: [KSV002](https://avd.aquasec.com/appshield/ksv002)\n"),
-						Markdown: toPtr("**Misconfiguration KSV002**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|Kubernetes Security Check|CRITICAL|SYS_ADMIN capability added|Message|[KSV002](https://avd.aquasec.com/appshield/ksv002)|\n\n"),
+						ColumnKind: "utf16CodeUnits",
+						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
+							"ROOTPATH": {
+								URI: lo.ToPtr("file:///"),
+							},
+						},
 					},
 				},
 			},
 		},
 		{
 			name: "report with secrets",
-			input: types.Results{
-				{
-					Target: "library/test",
-					Class:  types.ClassSecret,
-					Secrets: []ftypes.SecretFinding{
-						{
-							RuleID:    "aws-secret-access-key",
-							Category:  "AWS",
-							Severity:  "CRITICAL",
-							Title:     "AWS Secret Access Key",
-							StartLine: 1,
-							EndLine:   1,
-							Match:     "'AWS_secret_KEY'=\"****************************************\"",
-						},
-					},
-				},
-			},
-			wantResults: []*sarif.Result{
-				{
-					RuleID:    toPtr("aws-secret-access-key"),
-					RuleIndex: toPtr[uint](0),
-					Level:     toPtr("error"),
-					Message:   sarif.Message{Text: toPtr("Artifact: library/test\nType: \nSecret AWS Secret Access Key\nSeverity: CRITICAL\nMatch: 'AWS_secret_KEY'=\"****************************************\"")},
-					Locations: []*sarif.Location{
-						{
-							Message: &sarif.Message{Text: toPtr("library/test")},
-							PhysicalLocation: &sarif.PhysicalLocation{
-								ArtifactLocation: &sarif.ArtifactLocation{
-									URI:       toPtr("library/test"),
-									URIBaseId: toPtr("ROOTPATH"),
-								},
-								Region: &sarif.Region{
-									StartLine:   toPtr(1),
-									EndLine:     toPtr(1),
-									StartColumn: toPtr(1),
-									EndColumn:   toPtr(1),
-								},
+			input: types.Report{
+				Results: types.Results{
+					{
+						Target: "library/test",
+						Class:  types.ClassSecret,
+						Secrets: []ftypes.SecretFinding{
+							{
+								RuleID:    "aws-secret-access-key",
+								Category:  "AWS",
+								Severity:  "CRITICAL",
+								Title:     "AWS Secret Access Key",
+								StartLine: 1,
+								EndLine:   1,
+								Match:     "'AWS_secret_KEY'=\"****************************************\"",
 							},
 						},
 					},
 				},
 			},
-			wantRules: []*sarif.ReportingDescriptor{
-				{
-					ID:               "aws-secret-access-key",
-					Name:             toPtr("Secret"),
-					ShortDescription: &sarif.MultiformatMessageString{Text: toPtr("AWS Secret Access Key")},
-					FullDescription:  &sarif.MultiformatMessageString{Text: toPtr("\u0026#39;AWS_secret_KEY\u0026#39;=\u0026#34;****************************************\u0026#34;")},
-					DefaultConfiguration: &sarif.ReportingConfiguration{
-						Level: "error",
-					},
-					HelpURI: toPtr("https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-rules.go"),
-					Properties: map[string]interface{}{
-						"tags": []interface{}{
-							"secret",
-							"security",
-							"CRITICAL",
+			want: &sarif.Report{
+				Version: "2.1.0",
+				Schema:  "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+				Runs: []*sarif.Run{
+					{
+						Tool: sarif.Tool{
+							Driver: &sarif.ToolComponent{
+								FullName:       lo.ToPtr("Trivy Vulnerability Scanner"),
+								Name:           "Trivy",
+								Version:        lo.ToPtr(""),
+								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
+								Rules: []*sarif.ReportingDescriptor{
+									{
+										ID:               "aws-secret-access-key",
+										Name:             lo.ToPtr("Secret"),
+										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("AWS Secret Access Key")},
+										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("\u0026#39;AWS_secret_KEY\u0026#39;=\u0026#34;****************************************\u0026#34;")},
+										DefaultConfiguration: &sarif.ReportingConfiguration{
+											Level: "error",
+										},
+										HelpURI: lo.ToPtr("https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-rules.go"),
+										Properties: map[string]interface{}{
+											"tags": []interface{}{
+												"secret",
+												"security",
+												"CRITICAL",
+											},
+											"precision":         "very-high",
+											"security-severity": "9.5",
+										},
+										Help: &sarif.MultiformatMessageString{
+											Text:     lo.ToPtr("Secret AWS Secret Access Key\nSeverity: CRITICAL\nMatch: 'AWS_secret_KEY'=\"****************************************\""),
+											Markdown: lo.ToPtr("**Secret AWS Secret Access Key**\n| Severity | Match |\n| --- | --- |\n|CRITICAL|'AWS_secret_KEY'=\"****************************************\"|"),
+										},
+									},
+								},
+							},
 						},
-						"precision":         "very-high",
-						"security-severity": "9.5",
-					},
-					Help: &sarif.MultiformatMessageString{
-						Text:     toPtr("Secret AWS Secret Access Key\nSeverity: CRITICAL\nMatch: 'AWS_secret_KEY'=\"****************************************\""),
-						Markdown: toPtr("**Secret AWS Secret Access Key**\n| Severity | Match |\n| --- | --- |\n|CRITICAL|'AWS_secret_KEY'=\"****************************************\"|"),
+						Results: []*sarif.Result{
+							{
+								RuleID:    lo.ToPtr("aws-secret-access-key"),
+								RuleIndex: lo.ToPtr[uint](0),
+								Level:     lo.ToPtr("error"),
+								Message:   sarif.Message{Text: lo.ToPtr("Artifact: library/test\nType: \nSecret AWS Secret Access Key\nSeverity: CRITICAL\nMatch: 'AWS_secret_KEY'=\"****************************************\"")},
+								Locations: []*sarif.Location{
+									{
+										Message: &sarif.Message{Text: lo.ToPtr("library/test")},
+										PhysicalLocation: &sarif.PhysicalLocation{
+											ArtifactLocation: &sarif.ArtifactLocation{
+												URI:       lo.ToPtr("library/test"),
+												URIBaseId: lo.ToPtr("ROOTPATH"),
+											},
+											Region: &sarif.Region{
+												StartLine:   lo.ToPtr(1),
+												EndLine:     lo.ToPtr(1),
+												StartColumn: lo.ToPtr(1),
+												EndColumn:   lo.ToPtr(1),
+											},
+										},
+									},
+								},
+							},
+						},
+						ColumnKind: "utf16CodeUnits",
+						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
+							"ROOTPATH": {
+								URI: lo.ToPtr("file:///"),
+							},
+						},
 					},
 				},
 			},
 		},
 		{
-			name:        "no vulns",
-			wantResults: []*sarif.Result{},
-			wantRules:   []*sarif.ReportingDescriptor{},
+			name: "no vulns",
+			want: &sarif.Report{
+				Version: "2.1.0",
+				Schema:  "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+				Runs: []*sarif.Run{
+					{
+						Tool: sarif.Tool{
+							Driver: &sarif.ToolComponent{
+								FullName:       lo.ToPtr("Trivy Vulnerability Scanner"),
+								Name:           "Trivy",
+								Version:        lo.ToPtr(""),
+								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
+								Rules:          []*sarif.ReportingDescriptor{},
+							},
+						},
+						Results:    []*sarif.Result{},
+						ColumnKind: "utf16CodeUnits",
+						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
+							"ROOTPATH": {
+								URI: lo.ToPtr("file:///"),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sarifWritten := bytes.Buffer{}
-			err := report.Write(types.Report{Results: tt.input}, report.Option{
+			err := report.Write(tt.input, report.Option{
 				Format: "sarif",
 				Output: &sarifWritten,
 			})
@@ -359,8 +466,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 			result := &sarif.Report{}
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantRules, result.Runs[0].Tool.Driver.Rules, tt.name)
-			assert.Equal(t, tt.wantResults, result.Runs[0].Results, tt.name)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -112,7 +112,7 @@ func Write(report types.Report, option Option) error {
 		// We keep `sarif.tpl` template working for backward compatibility for a while.
 		if strings.HasPrefix(option.OutputTemplate, "@") && strings.HasSuffix(option.OutputTemplate, "sarif.tpl") {
 			log.Logger.Warn("Using `--template sarif.tpl` is deprecated. Please migrate to `--format sarif`. See https://github.com/aquasecurity/trivy/discussions/1571")
-			writer = SarifWriter{
+			writer = &SarifWriter{
 				Output:  option.Output,
 				Version: option.AppVersion,
 			}
@@ -123,7 +123,7 @@ func Write(report types.Report, option Option) error {
 			return xerrors.Errorf("failed to initialize template writer: %w", err)
 		}
 	case FormatSarif:
-		writer = SarifWriter{
+		writer = &SarifWriter{
 			Output:  option.Output,
 			Version: option.AppVersion,
 		}


### PR DESCRIPTION
## Description
Add

- image name
- repo digests
- repo tags

to properties in SARIF.

According to the spec, properties can be added to any object.

>In addition to those properties that are explicitly documented, every object defined in this specification MAY contain a property named properties whose value is a property bag. This allows SARIF producers to include information about each object that is not explicitly specified in the SARIF format.

https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540886

### Before

```
$ trivy image --format sarif debian:11 --quiet | tail -n 20
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "library/debian: util-linux@2.36.1-8+deb11u1"
              }
            }
          ]
        }
      ],
      "columnKind": "utf16CodeUnits",
      "originalUriBaseIds": {
        "ROOTPATH": {
          "uri": "file:///"
        }
      }
    }
  ]
}
```

### After

```
$ trivy image --format sarif debian:11 --quiet | tail -n 20
        }
      ],
      "columnKind": "utf16CodeUnits",
      "originalUriBaseIds": {
        "ROOTPATH": {
          "uri": "file:///"
        }
      },
      "properties": {
        "imageName": "debian:11",
        "repoDigests": [
          "debian@sha256:7b991788987ad860810df60927e1adbaf8e156520177bd4db82409f81dd3b721"
        ],
        "repoTags": [
          "debian:11"
        ]
      }
    }
  ]
}
```



## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4019

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
