### PR TITLE
fix(k8s): quiet support on k8s progress bar

### DIFF
--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -79,7 +79,7 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 		return nil
 	}
 
-	p := parallel.NewPipeline(s.opts.Parallel, true, artifactsData, onItem, onResult)
+	p := parallel.NewPipeline(s.opts.Parallel, s.opts.Quiet, artifactsData, onItem, onResult)
 	err = p.Do(ctx)
 	if err != nil {
 		return report.Report{}, err


### PR DESCRIPTION
## Description
quit flag support on k8s progress bar
## Related issues
- Close #4000

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).