### PR TITLE
docs(vuln): Document inline vulnerability filtering comments

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -386,6 +386,13 @@ Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 5)
 
 ## By Inline Comments
 
+|     Scanner      | Supported |
+|:----------------:|:---------:|
+|  Vulnerability   |           |
+| Misconfiguration |     ✓     |
+|      Secret      |           |
+|     License      |           |
+
 Some configuration file formats (e.g. Terraform) support inline comments.
 
 In cases where trivy can detect comments of a specific format immediately adjacent to resource definitions, it is possible to filter/ignore findings from a single point of resource definition (in contrast to `.trivyignore`, which has a directory-wide scope on all of the files scanned).

--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -383,3 +383,21 @@ Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 5)
 
 [helper]: https://github.com/aquasecurity/trivy/tree/{{ git.tag }}/pkg/result/module.go
 [policy]: https://github.com/aquasecurity/trivy/tree/{{ git.tag }}/contrib/example_policy
+
+## By Inline Comments
+
+Some configuration file formats (e.g. Terraform) support inline comments.
+
+In cases where trivy can detect comments of a specific format immediately adjacent to resource definitions, it is possible to filter/ignore findings from a single point of resource definition (in contrast to `.trivyignore`, which has a directory-wide scope on all of the files scanned).
+
+The format for these comments is `trivy:ignore:<Vulnerability ID>` immediately following the format-specific line-comment token.
+
+For example, to filter a Vulnerability ID "AVD-GCP-0051" in a Terraform HCL file:
+
+```terraform
+#trivy:ignore:AVD-GCP-0051
+resource "google_container_cluster" "one_off_test" {
+  name     = var.cluster_name
+  location = var.region
+}
+```


### PR DESCRIPTION
## Description
Document inline vulnerability filtering comments. I use and love this feature, and couldn't find it in the docs, so here is a little blurb about it.

## Related issues
- Close #4023

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
