### PR TITLE
feat(fs): customize error callback during fs walk

### DIFF
--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	misconf "github.com/aquasecurity/trivy/pkg/fanal/analyzer/config"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 )
 
 type Option struct {
@@ -19,9 +20,6 @@ type Option struct {
 	NoProgress        bool
 	Offline           bool
 	AppDirs           []string
-	RepoBranch        string
-	RepoCommit        string
-	RepoTag           string
 	SBOMSources       []string
 	RekorURL          string
 	Platform          string
@@ -29,12 +27,26 @@ type Option struct {
 	AWSRegion         string
 	FileChecksum      bool // For SPDX
 
+	// Git repositories
+	RepoBranch string
+	RepoCommit string
+	RepoTag    string
+
 	// For OCI registries
 	types.RemoteOptions
 
 	MisconfScannerOption misconf.ScannerOption
 	SecretScannerOption  analyzer.SecretScannerOption
 	LicenseScannerOption analyzer.LicenseScannerOption
+
+	// File walk
+	WalkOption WalkOption
+}
+
+// WalkOption is a struct that allows users to define a custom walking behavior.
+// This option is only available when using Trivy as an imported library and not through CLI flags.
+type WalkOption struct {
+	ErrorCallback walker.ErrorCallback
 }
 
 func (o *Option) Sort() {

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -55,9 +55,10 @@ func NewArtifact(rootPath string, c cache.ArtifactCache, opt artifact.Option) (a
 	}
 
 	return Artifact{
-		rootPath:       filepath.Clean(rootPath),
-		cache:          c,
-		walker:         walker.NewFS(buildPathsToSkip(rootPath, opt.SkipFiles), buildPathsToSkip(rootPath, opt.SkipDirs), opt.Slow),
+		rootPath: filepath.Clean(rootPath),
+		cache:    c,
+		walker: walker.NewFS(buildPathsToSkip(rootPath, opt.SkipFiles), buildPathsToSkip(rootPath, opt.SkipDirs),
+			opt.Slow, opt.WalkOption.ErrorCallback),
 		analyzer:       a,
 		handlerManager: handlerManager,
 

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -12,13 +12,28 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
+type ErrorCallback func(pathname string, err error) error
+
 type FS struct {
 	walker
+	errCallback ErrorCallback
 }
 
-func NewFS(skipFiles, skipDirs []string, slow bool) FS {
+func NewFS(skipFiles, skipDirs []string, slow bool, errCallback ErrorCallback) FS {
+	if errCallback == nil {
+		errCallback = func(pathname string, err error) error {
+			// ignore permission errors
+			if os.IsPermission(err) {
+				return nil
+			}
+			// halt traversal on any other error
+			return xerrors.Errorf("unknown error with %s: %w", pathname, err)
+		}
+	}
+
 	return FS{
-		walker: newWalker(skipFiles, skipDirs, slow),
+		walker:      newWalker(skipFiles, skipDirs, slow),
+		errCallback: errCallback,
 	}
 }
 
@@ -47,7 +62,7 @@ func (w FS) Walk(root string, fn WalkFunc) error {
 			return nil
 		}
 
-		if err := fn(relPath, fi, w.fileOpener(pathname)); err != nil {
+		if err = fn(relPath, fi, w.fileOpener(pathname)); err != nil {
 			return xerrors.Errorf("failed to analyze file: %w", err)
 		}
 		return nil
@@ -55,25 +70,18 @@ func (w FS) Walk(root string, fn WalkFunc) error {
 
 	if w.slow {
 		// In series: fast, with higher CPU/memory
-		return walkSlow(root, walkFn)
+		return w.walkSlow(root, walkFn)
 	}
 
 	// In parallel: slow, with lower CPU/memory
-	return walkFast(root, walkFn)
+	return w.walkFast(root, walkFn)
 }
 
 type fastWalkFunc func(pathname string, fi os.FileInfo) error
 
-func walkFast(root string, walkFn fastWalkFunc) error {
+func (w FS) walkFast(root string, walkFn fastWalkFunc) error {
 	// error function called for every error encountered
-	errorCallbackOption := swalker.WithErrorCallback(func(pathname string, err error) error {
-		// ignore permission errors
-		if os.IsPermission(err) {
-			return nil
-		}
-		// halt traversal on any other error
-		return xerrors.Errorf("unknown error with %s: %w", pathname, err)
-	})
+	errorCallbackOption := swalker.WithErrorCallback(w.errCallback)
 
 	// Multiple goroutines stat the filesystem concurrently. The provided
 	// walkFn must be safe for concurrent use.
@@ -84,9 +92,12 @@ func walkFast(root string, walkFn fastWalkFunc) error {
 	return nil
 }
 
-func walkSlow(root string, walkFn fastWalkFunc) error {
+func (w FS) walkSlow(root string, walkFn fastWalkFunc) error {
 	log.Logger.Debugf("Walk the file tree rooted at '%s' in series", root)
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return w.errCallback(path, err)
+		}
 		info, err := d.Info()
 		if err != nil {
 			return xerrors.Errorf("file info error: %w", err)


### PR DESCRIPTION
## Description
You may want to ignore errors during a file walk.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/3863

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
