### PR TITLE
ci: fix path to canary binaries

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -4,7 +4,8 @@ RUN apk --no-cache add ca-certificates git
 # binaries were created with GoReleaser
 # need to copy binaries from folder with correct architecture
 # example architecture folder: dist/trivy_canary_build_linux_arm64/trivy
+# GoReleaser adds _v* to the folder name, but only when GOARCH is amd64 
 ARG TARGETARCH
-COPY "dist/trivy_canary_build_linux_${TARGETARCH}/trivy" /usr/local/bin/trivy
+COPY "dist/trivy_canary_build_linux_${TARGETARCH}*/trivy" /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
## Description

GoReleaser adds `_v*` to folder name when GOARCH is amd64.
ex.: 
```
dist/trivy_canary_build_darwin_amd64_v1/trivy
dist/trivy_canary_build_linux_amd64_v1/trivy
trivy_canary_build_windows_amd64_v1
```
I've merged this change into my fork, the tests passed:
https://github.com/afdesk/trivy/actions/runs/4681632103/jobs/8294796445

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
