### PR TITLE
fix: fix `file does not exist` error for post-analyzers

### DIFF
--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -134,11 +134,6 @@ func (m *FS) WriteVirtualFile(path string, data []byte, mode fs.FileMode) error 
 // If path is already a directory, MkdirAll does nothing
 // and returns nil.
 func (m *FS) MkdirAll(path string, perm fs.FileMode) error {
-	// we can overwrite folders when making folders in parallel
-	// e.g. we have `foo/bar/folder1/file1` and `foo/bar/folder2/file2`
-	// file1 checks that `foo/bar` folder doesn't exist
-	// at that moment file2 creates `foo/bar/folder2` folder
-	// but file1 doesn't know about this and overwrite `foo/bar` folder( and removes `foo/bar/folder2`)
 	return m.root.MkdirAll(cleanPath(path), perm)
 }
 

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/exp/slices"
@@ -28,7 +27,6 @@ var _ allFS = &FS{}
 
 // FS is an in-memory filesystem
 type FS struct {
-	mu   sync.Mutex
 	root *file
 }
 
@@ -44,7 +42,6 @@ func New() *FS {
 			},
 			files: syncx.Map[string, *file]{},
 		},
-		mu: sync.Mutex{},
 	}
 }
 
@@ -142,8 +139,6 @@ func (m *FS) MkdirAll(path string, perm fs.FileMode) error {
 	// file1 checks that `foo/bar` folder doesn't exist
 	// at that moment file2 creates `foo/bar/folder2` folder
 	// but file1 doesn't know about this and overwrite `foo/bar` folder( and removes `foo/bar/folder2`)
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return m.root.MkdirAll(cleanPath(path), perm)
 }
 


### PR DESCRIPTION
## Description
There are times when we get a `file does not exist` error for post-analyzers.
If I understand correctly, this is due to fact that we overwrite folders when creating folders in parallel.

e.g. we have `foo/bar/folder1/file1` and `foo/bar/folder2/file2`.
file1 checks that `foo/bar` folder doesn't exist.
at that moment file2 creates `foo/bar/folder2` folder.
but file1 doesn't know about this and overwrite `foo/bar` folder( and removes `foo/bar/folder2`).

## Related issues
- Close #3921

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
