### PR TITLE
ci: add release version for Amazon Linux 2

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -18,7 +18,8 @@ echo "Create RPM releases for Trivy v$TRIVY_VERSION"
 
 cd trivy-repo
 
-VERSIONS=(5 6 7 8 9)
+# 2 - is a specific version for Amazon Linux 2
+VERSIONS=(2 5 6 7 8 9)
 for version in ${VERSIONS[@]}; do
         echo "Processing RHEL/CentOS $version..."
         create_rpm_repo $version


### PR DESCRIPTION
## Description

RPM releases contain versions only for RHEL/CentOS 5-9 , Amazon Linux has version 2. it's their specific number, and not EL number. so we put a repository for Amazon Linux 2.

it was released succesefull in test environment: https://github.com/afdesk/trivy/actions/runs/4700456935/jobs/8335161210

before:
```sh
$ docker run -it --rm amazonlinux:2
bash-4.2# nano /etc/yum.repos.d/trivy.repo
bash-4.2# yum -y update
Loaded plugins: ovl, priorities
https://aquasecurity.github.io/trivy-repo/rpm/releases/2/x86_64/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
```

after:
```sh
$ docker run -it --rm amazonlinux:2
bash-4.2# nano /etc/yum.repos.d/trivy.repo
bash-4.2# yum -y update
Loaded plugins: ovl, priorities
amzn2-core                                                                                                                       | 3.7 kB  00:00:00     
trivy                                                                                                                            | 3.0 kB  00:00:00     
trivy/2/x86_64/primary_db                                                                                                        | 1.8 kB  00:00:00     
Resolving Dependencies
```

## Related issues
- Close #3189 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
