### PR TITLE
ci: fix url to rpm packages

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -9,7 +9,7 @@ function create_rpm_repo () {
         mkdir -p $rpm_path
         cp ../dist/*64bit.rpm ${rpm_path}/
 
-        createrepo_c -u https://github.com/aquasecurity/trivy/releases/download/ --location-prefix="v"$TRIVY_VERSION --update $rpm_path
+        createrepo_c -u "https://github.com/aquasecurity/trivy/releases/download/v"$TRIVY_VERSION --update $rpm_path
 
         rm ${rpm_path}/*64bit.rpm
 }


### PR DESCRIPTION
## Description
before we set `--location-prefix` for generate a path to rpm package.
it didn't allow to use yum proxy.

## Related issues
- Close https://github.com/aquasecurity/trivy-repo/issues/23

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
