### PR TITLE
feat: Added Secrets to the HTML report

### DIFF
--- a/contrib/html.tpl
+++ b/contrib/html.tpl
@@ -128,11 +128,33 @@
         <td>{{ escapeXML .ID }}</td>
         <td class="misconf-check">{{ escapeXML .Title }}</td>
         <td class="severity">{{ escapeXML .Severity }}</td>
-        <td class="link" data-more-links="off"  style="white-space:normal;"">
+        <td class="link" data-more-links="off"  style="white-space:normal;">
           {{ escapeXML .Message }}
           <br>
             <a href={{ escapeXML .PrimaryURL | printf "%q" }}>{{ escapeXML .PrimaryURL }}</a>
           </br>
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+      {{- if (eq (len .Secrets ) 0) }}
+      <tr><th colspan="6">No Secrets found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Category</th>
+        <th>Rule ID</th>
+        <th>Check</th>
+        <th>Severity</th>
+        <th>Match</th>
+      </tr>
+        {{- range .Secrets }}
+      <tr class="severity-{{ escapeXML .Severity }}">
+        <td class="secrets-category">{{ .Category }}</td>
+        <td>{{ escapeXML .RuleID }}</td>
+        <td class="secrets-check">{{ escapeXML .Title }}</td>
+        <td class="severity">{{ escapeXML .Severity }}</td>
+        <td style="overflow-wrap: anywhere; white-space:normal;">
+          {{ escapeXML .Match }}
         </td>
       </tr>
         {{- end }}

--- a/integration/testdata/alpine-310.html.golden
+++ b/integration/testdata/alpine-310.html.golden
@@ -229,6 +229,7 @@
         </td>
       </tr>
       <tr><th colspan="6">No Misconfigurations found</th></tr>
+      <tr><th colspan="6">No Secrets found</th></tr>
     </table>
   </body>
 </html>


### PR DESCRIPTION
## Description
Adds secrets to the HTML report

## Related issues
- Close #3628

## Before
<img width="1528" alt="image" src="https://user-images.githubusercontent.com/596029/232162218-7f81b452-32e5-4d71-bd6b-f1ecf538b8ce.png">

## After
<img width="1535" alt="image" src="https://user-images.githubusercontent.com/596029/232162557-e6ed5d6b-529f-4907-95e5-ada708aebc37.png">

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
