### PR TITLE
fix(ubuntu): skip copyright files from subfolders

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -128,6 +128,11 @@ func (a *dpkgLicenseAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
 }
 
 func (a *dpkgLicenseAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	// To exclude not package files
+	// e.g. usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright
+	if len(strings.Split(filePath, "/")) != 5 {
+		return false
+	}
 	return strings.HasPrefix(filePath, "usr/share/doc/") && filepath.Base(filePath) == "copyright"
 }
 

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 
@@ -130,10 +130,11 @@ func (a *dpkgLicenseAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
 func (a *dpkgLicenseAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	// To exclude files from subfolders
 	// e.g. usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright
-	if len(strings.Split(filePath, "/")) != 5 {
+	match, err := path.Match("usr/share/doc/*/copyright", filePath)
+	if err != nil {
 		return false
 	}
-	return strings.HasPrefix(filePath, "usr/share/doc/") && filepath.Base(filePath) == "copyright"
+	return match
 }
 
 func (a *dpkgLicenseAnalyzer) Type() analyzer.Type {

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -128,7 +128,7 @@ func (a *dpkgLicenseAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
 }
 
 func (a *dpkgLicenseAnalyzer) Required(filePath string, _ os.FileInfo) bool {
-	// To exclude not package files
+	// To exclude files from subfolders
 	// e.g. usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright
 	if len(strings.Split(filePath, "/")) != 5 {
 		return false

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
@@ -111,6 +111,11 @@ func Test_dpkgLicenseAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "not a package file",
+			filePath: "usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright",
+			want:     false,
+		},
+		{
 			name:     "bad prefix",
 			filePath: "usr/share/doc/eject/copyright/file",
 			want:     false,

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
@@ -111,7 +111,7 @@ func Test_dpkgLicenseAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
-			name:     "not a package file",
+			name:     "copyright files in subfolder",
 			filePath: "usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright",
 			want:     false,
 		},


### PR DESCRIPTION
## Description
There are cases when `/usr/share/doc/*` folders contains subfolders with other `copyright` files.
e.g. `usr/share/doc/ca-certificates/examples/ca-certificates-local/debian/copyright`.
We need to skip these files.

## Related issues
- Close #3610

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
