### PR TITLE
fix(spdx): add workaround for no src packages

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -392,6 +392,9 @@ func (e *Marshaler) reportToCdxComponent(r types.Report) (*cdx.Component, error)
 			component.BOMRef = p.ToString()
 			component.PackageURL = p.ToString()
 		}
+	case ftypes.ArtifactVM:
+		component.Type = cdx.ComponentTypeContainer
+		component.BOMRef = e.newUUID().String()
 	case ftypes.ArtifactFilesystem, ftypes.ArtifactRemoteRepository:
 		component.Type = cdx.ComponentTypeApplication
 		component.BOMRef = e.newUUID().String()

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -282,7 +282,7 @@ func (m *Marshaler) pkgToSpdxPackage(t, pkgDownloadLocation string, class types.
 	}
 
 	var pkgSrcInfo string
-	if class == types.ClassOSPkg {
+	if class == types.ClassOSPkg && pkg.SrcName != "" {
 		pkgSrcInfo = fmt.Sprintf("%s: %s %s", SourcePackagePrefix, pkg.SrcName, utils.FormatSrcVersion(pkg))
 	}
 


### PR DESCRIPTION
## Description

The existing implementation already supported SPDX.
Fixed a bug in SourceInfo information in some packages as an implementation of SPDX.

And, support cyclonedx sbom for vm scan.

## Related issues
- Close #3975 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
