### PR TITLE
chore: install.sh support for windows

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -79,6 +79,7 @@ get_binaries() {
     openbsd/amd64) BINARIES="trivy" ;;
     openbsd/arm64) BINARIES="trivy" ;;
     openbsd/armv7) BINARIES="trivy" ;;
+    windows/amd64) BINARIES="trivy" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1
@@ -102,6 +103,9 @@ tag_to_version() {
 }
 adjust_format() {
   # change format (tar.gz or zip) based on OS
+  case ${OS} in
+    windows) FORMAT=zip ;;
+  esac
   true
 }
 adjust_os() {


### PR DESCRIPTION
## Description
Fixes #4136

This PR adds support for `windows/amd64` platform in `install.sh` script. 
Base functionality - like detecting a MINGW environment, for example or zip file handling - was already present in the script. So, only some missing `case` statements had to be added.

The change has been verified within Git Bash on a Windows 10 installation:

```
$ curl -sfL https://raw.githubusercontent.com/mercedes-benz/trivy/add_windows_install_support/contrib/install.sh | sh -s -- -b ./tools/bin v0.41.0
aquasecurity/trivy info checking GitHub for tag 'v0.41.0'
aquasecurity/trivy info found version: 0.41.0 for v0.41.0/windows/64bit
Archive:  trivy_0.41.0_windows-64bit.zip
  inflating: LICENSE
  inflating: README.md
  inflating: contrib/asff.tpl
  inflating: contrib/gitlab-codequality.tpl
  inflating: contrib/gitlab.tpl
  inflating: contrib/html.tpl
  inflating: contrib/junit.tpl
  inflating: trivy.exe
aquasecurity/trivy info installed ./tools/bin/trivy.exe
```

## Related issues
- Close #4136

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

---
_The program was tested solely for our own use cases, which might differ from yours._  
_Frank Seidel <frank.seidel@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH_  
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)