### PR TITLE
fix(ubuntu): fix version selection logic for ubuntu esm

### DIFF
--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -21,6 +21,7 @@ import (
 func TestScanner_Detect(t *testing.T) {
 	type args struct {
 		osVer string
+		now   time.Time
 		pkgs  []ftypes.Package
 	}
 	tests := []struct {
@@ -35,6 +36,7 @@ func TestScanner_Detect(t *testing.T) {
 			fixtures: []string{"testdata/fixtures/ubuntu.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{
 				osVer: "20.04",
+				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
 				pkgs: []ftypes.Package{
 					{
 						Name:       "wpa",
@@ -79,10 +81,79 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "ubuntu 20.04-ESM. 20.04 is not outdated",
+			fixtures: []string{"testdata/fixtures/ubuntu.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "20.04-ESM",
+				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
+				pkgs: []ftypes.Package{
+					{
+						Name:       "wpa",
+						Version:    "2.9",
+						SrcName:    "wpa",
+						SrcVersion: "2.9",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "wpa",
+					VulnerabilityID:  "CVE-2019-9243",
+					InstalledVersion: "2.9",
+					FixedVersion:     "",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Ubuntu,
+						Name: "Ubuntu CVE Tracker",
+						URL:  "https://git.launchpad.net/ubuntu-cve-tracker",
+					},
+				},
+				{
+					PkgName:          "wpa",
+					VulnerabilityID:  "CVE-2021-27803",
+					InstalledVersion: "2.9",
+					FixedVersion:     "2:2.9-1ubuntu4.3",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Ubuntu,
+						Name: "Ubuntu CVE Tracker",
+						URL:  "https://git.launchpad.net/ubuntu-cve-tracker",
+					},
+				},
+			},
+		},
+		{
+			name:     "ubuntu 20.04-ESM. 20.04 is outdated",
+			fixtures: []string{"testdata/fixtures/ubuntu.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "20.04-ESM",
+				now:   time.Date(2031, 3, 31, 23, 59, 59, 0, time.UTC),
+				pkgs: []ftypes.Package{
+					{
+						Name:       "wpa",
+						Version:    "2.9",
+						SrcName:    "wpa",
+						SrcVersion: "2.9",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+		},
+		{
 			name:     "broken bucket",
 			fixtures: []string{"testdata/fixtures/invalid.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{
 				osVer: "21.04",
+				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
 				pkgs: []ftypes.Package{
 					{
 						Name:       "jq",
@@ -100,7 +171,7 @@ func TestScanner_Detect(t *testing.T) {
 			_ = dbtest.InitDB(t, tt.fixtures)
 			defer db.Close()
 
-			s := ubuntu.NewScanner()
+			s := ubuntu.NewScanner(ubuntu.WithClock(fake.NewFakeClock(tt.args.now)))
 			got, err := s.Detect(tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -142,6 +213,24 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			args: args{
 				osFamily: "ubuntu",
 				osVer:    "12.04",
+			},
+			want: false,
+		},
+		{
+			name: "ubuntu 18.04 ESM. 18.04 is not outdated",
+			now:  time.Date(2026, 4, 31, 23, 59, 59, 0, time.UTC),
+			args: args{
+				osFamily: "ubuntu",
+				osVer:    "18.04-ESM",
+			},
+			want: true,
+		},
+		{
+			name: "ubuntu 18.04 ESM. 18.04 is outdated",
+			now:  time.Date(2030, 4, 31, 23, 59, 59, 0, time.UTC),
+			args: args{
+				osFamily: "ubuntu",
+				osVer:    "18.04-ESM",
 			},
 			want: false,
 		},


### PR DESCRIPTION
## Description
Ubuntu doesn't have advisories for 18.04-ESM or later ESM versions, because actual version (`18.04`, `20.04`, etc...) is not outdated.
Therefore we need to get advisories for base(not ESM) versions.

## Related issues
- Close #4164

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
