### PR TITLE
chore: separate docs:generate

### DIFF
--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -1,0 +1,28 @@
+//go:build mage_docs
+
+package main
+
+import (
+	"github.com/spf13/cobra/doc"
+
+	"github.com/aquasecurity/trivy/pkg/commands"
+	"github.com/aquasecurity/trivy/pkg/flag"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+// Generate CLI references
+func main() {
+	ver, err := version()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Set a dummy path for the documents
+	flag.CacheDirFlag.Value = "/path/to/cache"
+	flag.ModuleDirFlag.Value = "$HOME/.trivy/modules"
+
+	cmd := commands.NewApp(ver)
+	cmd.DisableAutoGenTag = true
+	if err = doc.GenMarkdownTree(cmd, "./docs/docs/references/configuration/cli"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -12,10 +12,6 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/magefile/mage/target"
-	"github.com/spf13/cobra/doc"
-
-	"github.com/aquasecurity/trivy/pkg/commands"
-	"github.com/aquasecurity/trivy/pkg/flag"
 )
 
 var (
@@ -344,20 +340,7 @@ func (Docs) Serve() error {
 
 // Generate generates CLI references
 func (Docs) Generate() error {
-	ver, err := version()
-	if err != nil {
-		return err
-	}
-	// Set a dummy path for the documents
-	flag.CacheDirFlag.Value = "/path/to/cache"
-	flag.ModuleDirFlag.Value = "$HOME/.trivy/modules"
-
-	cmd := commands.NewApp(ver)
-	cmd.DisableAutoGenTag = true
-	if err = doc.GenMarkdownTree(cmd, "./docs/docs/references/configuration/cli"); err != nil {
-		return err
-	}
-	return nil
+	return sh.RunWith(ENV, "go", "run", "-tags=mage_docs", "./magefiles")
 }
 
 func findProtoFiles() ([]string, error) {


### PR DESCRIPTION
## Description
The [mage](https://magefile.org/) command is quite slow now since it imports `github.com/aquasecurity/trivy` to generate docs. Mage tries to compile `magefiles/magefile.go`, then also compiles the trivy packages. All other targets, such as `mage fmt` and `mage lint`, don't need the trivy packages, and they should be fast.

This PR separates `mage docs:generate` into a different file with a custom tag so that other targets will not import Trivy.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
