### PR TITLE
fix(cyclonedx): set original names for packages

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -112,10 +112,6 @@ func (p *PackageURL) PackageType() string {
 	return p.Type
 }
 
-func (p *PackageURL) IsGoPkg() bool {
-	return p.Type == packageurl.TypeGolang
-}
-
 func (p *PackageURL) IsOSPkg() bool {
 	return p.Type == TypeAPK || p.Type == packageurl.TypeDebian || p.Type == packageurl.TypeRPM
 }

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -112,6 +112,10 @@ func (p *PackageURL) PackageType() string {
 	return p.Type
 }
 
+func (p *PackageURL) IsGoPkg() bool {
+	return p.Type == packageurl.TypeGolang
+}
+
 func (p *PackageURL) IsOSPkg() bool {
 	return p.Type == TypeAPK || p.Type == packageurl.TypeDebian || p.Type == packageurl.TypeRPM
 }

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -341,6 +341,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 	}
 
 	pkg := p.Package()
+	pkg.Name = component.Name
 	pkg.Ref = component.BOMRef
 
 	for _, license := range lo.FromPtr(component.Licenses) {

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
+	packageurl "github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
@@ -341,7 +342,10 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 	}
 
 	pkg := p.Package()
-	if component.Name != "" {
+
+	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
+	// so we have to use an original package name (if possible)
+	if p.Type == packageurl.TypeGolang && component.Name != "" {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -341,11 +341,9 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 	}
 
 	pkg := p.Package()
-	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
+	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for packages (Go, Npm, PyPI),
 	// so we have to use an original package name
-	if p.PackageType() == ftypes.GoBinary {
-		pkg.Name = component.Name
-	}
+	pkg.Name = component.Name
 	pkg.Ref = component.BOMRef
 
 	for _, license := range lo.FromPtr(component.Licenses) {

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	packageurl "github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"golang.org/x/xerrors"
@@ -345,7 +344,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 
 	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
 	// so we have to use an original package name (if possible)
-	if p.Type == packageurl.TypeGolang && component.Name != "" {
+	if p.IsGoPkg() && component.Name != "" {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -344,7 +344,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 
 	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
 	// so we have to use an original package name (if possible)
-	if p.IsGoPkg() && component.Name != "" {
+	if p.PackageType() == ftypes.GoBinary && component.Name != "" {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -342,9 +342,10 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 
 	pkg := p.Package()
 
+	pkgType := p.PackageType()
 	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
 	// so we have to use an original package name (if possible)
-	if p.PackageType() == ftypes.GoBinary && component.Name != "" {
+	if pkgType == ftypes.GoBinary && component.Name != "" {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef
@@ -394,7 +395,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 		}
 	}
 
-	return isOSPkg, p.PackageType(), pkg, nil
+	return isOSPkg, pkgType, pkg, nil
 }
 
 func toTrivyCdxComponent(component cdx.Component) ftypes.Component {

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -342,8 +342,8 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 
 	pkg := p.Package()
 	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
-	// so we have to use an original package name (if possible)
-	if p.PackageType() == ftypes.GoBinary && component.Name != "" {
+	// so we have to use an original package name
+	if p.PackageType() == ftypes.GoBinary {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef
@@ -392,6 +392,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 			pkg.SrcEpoch = pkg.Epoch
 		}
 	}
+
 	return isOSPkg, p.PackageType(), pkg, nil
 }
 

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -341,11 +341,9 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 	}
 
 	pkg := p.Package()
-
-	pkgType := p.PackageType()
 	// Trivy's marshall loses case-sensitivity in PURL used in SBOM for Go,
 	// so we have to use an original package name (if possible)
-	if pkgType == ftypes.GoBinary && component.Name != "" {
+	if p.PackageType() == ftypes.GoBinary && component.Name != "" {
 		pkg.Name = component.Name
 	}
 	pkg.Ref = component.BOMRef
@@ -394,8 +392,7 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 			pkg.SrcEpoch = pkg.Epoch
 		}
 	}
-
-	return isOSPkg, pkgType, pkg, nil
+	return isOSPkg, p.PackageType(), pkg, nil
 }
 
 func toTrivyCdxComponent(component cdx.Component) ftypes.Component {

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -341,7 +341,9 @@ func toPackage(component cdx.Component) (bool, string, *ftypes.Package, error) {
 	}
 
 	pkg := p.Package()
-	pkg.Name = component.Name
+	if component.Name != "" {
+		pkg.Name = component.Name
+	}
 	pkg.Ref = component.BOMRef
 
 	for _, license := range lo.FromPtr(component.Licenses) {


### PR DESCRIPTION
## Description

When Trivy creates `sbom-ref`, it converts a name to low-case for several packages (Go - https://github.com/aquasecurity/trivy/blob/main/pkg/purl/purl.go#L285, npm, PyPI). It's done according to [the spec](https://github.com/package-url/purl-spec/blob/a748c36ad415c8aeffe2b8a4a5d8a50d16d6d85f/PURL-TYPES.rst#golang):
```
The namespace and name must be lowercased.
```
But when Trivy does unmarshall from `sbom-ref` it loses case-sensitivity.

So we have to set an original name for a Go package name (`Name` is a mandatory field for the components).

## Related issues
- Close #4302 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
