### PR TITLE
fix(alpine): add EOL date for Alpine 3.18

### DIFF
--- a/docs/docs/scanner/vulnerability/os.md
+++ b/docs/docs/scanner/vulnerability/os.md
@@ -11,7 +11,7 @@ Trivy doesn't support self-compiled packages/binaries, but official packages pro
 
 | OS                               | Supported Versions                        | Target Packages               | Detection of unfixed vulnerabilities |
 |----------------------------------|-------------------------------------------|-------------------------------|:------------------------------------:|
-| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.17, edge               | Installed by apk              |                  NO                  |
+| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.18, edge               | Installed by apk              |                  NO                  |
 | Wolfi Linux                      | (n/a)                                     | Installed by apk              |                  NO                  |
 | Chainguard                       | (n/a)                                     | Installed by apk              |                  NO                  |
 | Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -44,6 +44,7 @@ var (
 		"3.15": time.Date(2023, 11, 1, 23, 59, 59, 0, time.UTC),
 		"3.16": time.Date(2024, 5, 23, 23, 59, 59, 0, time.UTC),
 		"3.17": time.Date(2024, 11, 22, 23, 59, 59, 0, time.UTC),
+		"3.18": time.Date(2025, 5, 9, 23, 59, 59, 0, time.UTC),
 		"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 )


### PR DESCRIPTION
## Description

Alpine 3.18 was released on 2023-05-09 and goes out of security support on 2025-05-09 - see https://alpinelinux.org/releases/.

## Related issues

- Closes https://github.com/aquasecurity/trivy/issues/4309

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
