### PR TITLE
fix(report): set a correct file location for license scan output

### DIFF
--- a/pkg/report/table/licensing.go
+++ b/pkg/report/table/licensing.go
@@ -154,7 +154,7 @@ func (r fileLicenseRenderer) setRows() {
 			}
 		} else {
 			row = []string{
-				string(l.Category), l.Severity, l.Name, l.Severity,
+				string(l.Category), l.Severity, l.Name, l.FilePath,
 			}
 		}
 		r.tableWriter.AddRow(row...)


### PR DESCRIPTION
## Description
it looks like a simple mistake: it was set an incorrect field.

## Related issues
- Close #4316 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
