### PR TITLE
feat(image): add logic to guess base layer for docker-cis scan

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/artifact/image"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"github.com/aquasecurity/trivy/pkg/misconf"
@@ -40,7 +41,9 @@ func (a *historyAnalyzer) Analyze(ctx context.Context, input analyzer.ConfigAnal
 		return nil, nil
 	}
 	dockerfile := new(bytes.Buffer)
-	for _, h := range input.Config.History {
+	baseLayerIndex := image.GuessBaseImageIndex(input.Config.History)
+	for i := baseLayerIndex + 1; i < len(input.Config.History); i++ {
+		h := input.Config.History[i]
 		var createdBy string
 		switch {
 		case strings.HasPrefix(h.CreatedBy, "/bin/sh -c #(nop)"):

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
-	"github.com/aquasecurity/trivy/pkg/fanal/artifact/image"
+	"github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"github.com/aquasecurity/trivy/pkg/misconf"

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -113,6 +113,68 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path. Base layer is found",
+			input: analyzer.ConfigAnalysisInput{
+				Config: &v1.ConfigFile{
+					Config: v1.Config{
+						Healthcheck: &v1.HealthConfig{
+							Test:     []string{"CMD-SHELL", "curl --fail http://localhost:3000 || exit 1"},
+							Interval: time.Second * 10,
+							Timeout:  time.Second * 3,
+						},
+					},
+					History: []v1.History{
+						{
+							CreatedBy:  "/bin/sh -c #(nop) ADD file:e4d600fc4c9c293efe360be7b30ee96579925d1b4634c94332e2ec73f7d8eca1 in /",
+							EmptyLayer: false,
+						},
+						{
+							CreatedBy:  `/bin/sh -c #(nop)  CMD [\"/bin/sh\"]`,
+							EmptyLayer: true,
+						},
+						{
+							CreatedBy:  `HEALTHCHECK &{["CMD-SHELL" "curl --fail http://localhost:3000 || exit 1"] "10s" "3s" "0s" '\x00'}`,
+							EmptyLayer: false,
+						},
+						{
+							CreatedBy:  `/bin/sh -c #(nop)  CMD [\"/bin/sh\"]`,
+							EmptyLayer: true,
+						},
+					},
+				},
+			},
+			want: &analyzer.ConfigAnalysisResult{
+				Misconfiguration: &types.Misconfiguration{
+					FileType: "dockerfile",
+					FilePath: "Dockerfile",
+					Failures: types.MisconfResults{
+						types.MisconfResult{
+							Namespace: "builtin.dockerfile.DS002",
+							Query:     "data.builtin.dockerfile.DS002.deny",
+							Message:   "Specify at least 1 USER command in Dockerfile with non-root user as argument",
+							PolicyMetadata: types.PolicyMetadata{
+								ID:                 "DS002",
+								AVDID:              "AVD-DS-0002",
+								Type:               "Dockerfile Security Check",
+								Title:              "Image user should not be 'root'",
+								Description:        "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
+								Severity:           "HIGH",
+								RecommendedActions: "Add 'USER <non root user name>' line to the Dockerfile",
+								References: []string{
+									"https://docs.docker." +
+										"com/develop/develop-images/dockerfile_best-practices/",
+								},
+							},
+							CauseMetadata: types.CauseMetadata{
+								Provider: "Dockerfile",
+								Service:  "general",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "nil config",
 			input: analyzer.ConfigAnalysisInput{
 				Config: nil,

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -3,7 +3,6 @@ package image
 import (
 	"context"
 	"errors"
-	"github.com/aquasecurity/trivy/pkg/fanal/image"
 	"io"
 	"io/fs"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/fanal/handler"
+	"github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/aquasecurity/trivy/pkg/fanal/log"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -470,35 +470,7 @@ func (a Artifact) inspectConfig(ctx context.Context, imageID string, osFound typ
 	return nil
 }
 
-// Guess layers in base image (call base layers).
-//
-// e.g. In the following example, we should detect layers in debian:8.
-//
-//	FROM debian:8
-//	RUN apt-get update
-//	COPY mysecret /
-//	ENTRYPOINT ["entrypoint.sh"]
-//	CMD ["somecmd"]
-//
-// debian:8 may be like
-//
-//	ADD file:5d673d25da3a14ce1f6cf66e4c7fd4f4b85a3759a9d93efb3fd9ff852b5b56e4 in /
-//	CMD ["/bin/sh"]
-//
-// In total, it would be like:
-//
-//	ADD file:5d673d25da3a14ce1f6cf66e4c7fd4f4b85a3759a9d93efb3fd9ff852b5b56e4 in /
-//	CMD ["/bin/sh"]              # empty layer (detected)
-//	RUN apt-get update
-//	COPY mysecret /
-//	ENTRYPOINT ["entrypoint.sh"] # empty layer (skipped)
-//	CMD ["somecmd"]              # empty layer (skipped)
-//
-// This method tries to detect CMD in the second line and assume the first line is a base layer.
-//  1. Iterate histories from the bottom.
-//  2. Skip all the empty layers at the bottom. In the above example, "entrypoint.sh" and "somecmd" will be skipped
-//  3. If it finds CMD, it assumes that it is the end of base layers.
-//  4. It gets all the layers as base layers above the CMD found in #3.
+// guessBaseLayers guesses layers in base image (call base layers).
 func (a Artifact) guessBaseLayers(diffIDs []string, configFile *v1.ConfigFile) []string {
 	if configFile == nil {
 		return nil

--- a/pkg/fanal/image/image.go
+++ b/pkg/fanal/image/image.go
@@ -130,6 +130,35 @@ func LayerIDs(img v1.Image) ([]string, error) {
 	return layerIDs, nil
 }
 
+// GuessBaseImageIndex tries to guess index of base layer
+//
+// e.g. In the following example, we should detect layers in debian:8.
+//
+//	FROM debian:8
+//	RUN apt-get update
+//	COPY mysecret /
+//	ENTRYPOINT ["entrypoint.sh"]
+//	CMD ["somecmd"]
+//
+// debian:8 may be like
+//
+//	ADD file:5d673d25da3a14ce1f6cf66e4c7fd4f4b85a3759a9d93efb3fd9ff852b5b56e4 in /
+//	CMD ["/bin/sh"]
+//
+// In total, it would be like:
+//
+//	ADD file:5d673d25da3a14ce1f6cf66e4c7fd4f4b85a3759a9d93efb3fd9ff852b5b56e4 in /
+//	CMD ["/bin/sh"]              # empty layer (detected)
+//	RUN apt-get update
+//	COPY mysecret /
+//	ENTRYPOINT ["entrypoint.sh"] # empty layer (skipped)
+//	CMD ["somecmd"]              # empty layer (skipped)
+//
+// This method tries to detect CMD in the second line and assume the first line is a base layer.
+//  1. Iterate histories from the bottom.
+//  2. Skip all the empty layers at the bottom. In the above example, "entrypoint.sh" and "somecmd" will be skipped
+//  3. If it finds CMD, it assumes that it is the end of base layers.
+//  4. It gets all the layers as base layers above the CMD found in #3.
 func GuessBaseImageIndex(histories []v1.History) int {
 	baseImageIndex := -1
 	var foundNonEmpty bool


### PR DESCRIPTION
## Description
Add logic to guess base layer for docker-cis scan.
See more in #3834.

## Related issues
- Close #3834

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
