### PR TITLE
fix(image): fix deadlock occuring in slow mode for multiple layers images

### DIFF
--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -214,8 +214,8 @@ func (a Artifact) consolidateCreatedBy(diffIDs, layerKeys []string, configFile *
 
 func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys, baseDiffIDs []string,
 	layerKeyMap map[string]LayerInfo, configFile *v1.ConfigFile) error {
-	done := make(chan struct{})
-	errCh := make(chan error)
+	done := make(chan struct{}, len(layerKeys))
+	errCh := make(chan error, len(layerKeys))
 	limit := semaphore.New(a.artifactOption.Slow)
 
 	var osFound types.OS


### PR DESCRIPTION
## Description
If an error occurs during a scan for multiple layers images then `inspect` deadlocks.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4343


## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
