### PR TITLE
style(report): add Target in html template

### DIFF
--- a/contrib/html.tpl
+++ b/contrib/html.tpl
@@ -85,7 +85,7 @@
     <h1>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ now }}</h1>
     <table>
     {{- range . }}
-      <tr class="group-header"><th colspan="6">{{ escapeXML .Type }}</th></tr>
+      <tr class="group-header"><th colspan="6">{{ escapeXML .Type }} on {{ escapeXML .Target }}</th></tr>
       {{- if (eq (len .Vulnerabilities) 0) }}
       <tr><th colspan="6">No Vulnerabilities found</th></tr>
       {{- else }}


### PR DESCRIPTION
## Description

Add Target of the scanner in the header of each scanner.

It looks like this:
Before:
![image](https://user-images.githubusercontent.com/2560080/148665692-a0868e73-8c64-4d62-b0c5-989d7cd687c4.png)

After:
![image](https://github.com/aquasecurity/trivy/assets/97035654/501bf436-77ca-4412-bf84-1ba2cdb1d965)

I understand that one can make its own custom template (and we have done that).

I open this PR because without `Target`, the default template is clearly _lacking_ this information, as described in #1556.

## Related issues
- Close #1556 

## Related PRs
- #1741

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
