### PR TITLE
test: skip wrong update of test golden files

### DIFF
--- a/pkg/fanal/test/integration/library_test.go
+++ b/pkg/fanal/test/integration/library_test.go
@@ -179,6 +179,12 @@ func TestFanal_Library_DockerLessMode(t *testing.T) {
 }
 
 func TestFanal_Library_DockerMode(t *testing.T) {
+	// Disable updating golden files because local images don't have compressed layer digests,
+	// and updating golden files in this function results in incomplete files.
+	if *update {
+		*update = false
+		defer func() { *update = true }()
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/fanal/test/integration/testdata/goldens/packages/alpine-310.json.golden
+++ b/pkg/fanal/test/integration/testdata/goldens/packages/alpine-310.json.golden
@@ -8,7 +8,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:574d490311b68db01c0a3e44f5491be0cdc79250",
     "DependsOn": [
       "busybox@1.30.1-r2",
       "musl@1.1.22-r3"
@@ -16,7 +15,8 @@
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:574d490311b68db01c0a3e44f5491be0cdc79250"
   },
   {
     "ID": "alpine-keys@2.1-r2",
@@ -27,11 +27,11 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:6dd672e2dabc14aa324cf9cd4553e98b69a769c1",
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:6dd672e2dabc14aa324cf9cd4553e98b69a769c1"
   },
   {
     "ID": "apk-tools@2.10.4-r2",
@@ -42,7 +42,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:e6393c9419776955346cddd70ad4ec66082a2705",
     "DependsOn": [
       "libcrypto1.1@1.1.1c-r0",
       "libssl1.1@1.1.1c-r0",
@@ -52,7 +51,8 @@
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:e6393c9419776955346cddd70ad4ec66082a2705"
   },
   {
     "ID": "busybox@1.30.1-r2",
@@ -63,14 +63,14 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:9c244d7f4909bffcef4c67380b6aed145c41a232",
     "DependsOn": [
       "musl@1.1.22-r3"
     ],
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:9c244d7f4909bffcef4c67380b6aed145c41a232"
   },
   {
     "ID": "ca-certificates-cacert@20190108-r0",
@@ -82,11 +82,11 @@
       "MPL-2.0",
       "GPL-2.0"
     ],
-    "Digest": "sha1:0d69933c7cd071e82acb24c6e4268e4752f7a3f7",
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:0d69933c7cd071e82acb24c6e4268e4752f7a3f7"
   },
   {
     "ID": "libc-utils@0.7.1-r0",
@@ -97,14 +97,14 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:1ff2cf7a0a53c1e83c8649f27b95aaa07bd4a83e",
     "DependsOn": [
       "musl-utils@1.1.22-r3"
     ],
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:1ff2cf7a0a53c1e83c8649f27b95aaa07bd4a83e"
   },
   {
     "ID": "libcrypto1.1@1.1.1c-r0",
@@ -115,14 +115,14 @@
     "Licenses": [
       "OpenSSL"
     ],
-    "Digest": "sha1:547053af84ac3667548b11b990d7b80ef23b9a3f",
     "DependsOn": [
       "musl@1.1.22-r3"
     ],
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:547053af84ac3667548b11b990d7b80ef23b9a3f"
   },
   {
     "ID": "libssl1.1@1.1.1c-r0",
@@ -137,11 +137,11 @@
       "libcrypto1.1@1.1.1c-r0",
       "musl@1.1.22-r3"
     ],
-    "Digest": "sha1:6f37a428d6f8de036a523d42e6b0c99288153c38",
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:6f37a428d6f8de036a523d42e6b0c99288153c38"
   },
   {
     "ID": "libtls-standalone@2.9.1-r0",
@@ -152,7 +152,6 @@
     "Licenses": [
       "ISC"
     ],
-    "Digest": "sha1:f149b608e1e33cfad61fbcf9e3fdb6494f7d691a",
     "DependsOn": [
       "ca-certificates-cacert@20190108-r0",
       "libcrypto1.1@1.1.1c-r0",
@@ -162,7 +161,8 @@
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:f149b608e1e33cfad61fbcf9e3fdb6494f7d691a"
   },
   {
     "ID": "musl@1.1.22-r3",
@@ -173,11 +173,11 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:d489e0f3fbb5548758f5ccd2c5a0cef70260ef62",
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:d489e0f3fbb5548758f5ccd2c5a0cef70260ef62"
   },
   {
     "ID": "musl-utils@1.1.22-r3",
@@ -190,7 +190,6 @@
       "BSD-3-Clause",
       "GPL-2.0"
     ],
-    "Digest": "sha1:8bb14c727be819d07a1e9d8b998dc94bde989205",
     "DependsOn": [
       "musl@1.1.22-r3",
       "scanelf@1.2.3-r0"
@@ -198,7 +197,8 @@
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:8bb14c727be819d07a1e9d8b998dc94bde989205"
   },
   {
     "ID": "scanelf@1.2.3-r0",
@@ -209,14 +209,14 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:cb3059ce358cea0f5f78a0220a2980e6c4916a94",
     "DependsOn": [
       "musl@1.1.22-r3"
     ],
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:cb3059ce358cea0f5f78a0220a2980e6c4916a94"
   },
   {
     "ID": "ssl_client@1.30.1-r2",
@@ -227,7 +227,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:1f7afca8301f00cef8a9797124721d9f8c16f586",
     "DependsOn": [
       "libtls-standalone@2.9.1-r0",
       "musl@1.1.22-r3"
@@ -235,7 +234,8 @@
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:1f7afca8301f00cef8a9797124721d9f8c16f586"
   },
   {
     "ID": "zlib@1.2.11-r1",
@@ -246,13 +246,13 @@
     "Licenses": [
       "Zlib"
     ],
-    "Digest": "sha1:bacb380dfa6f2f5e8dc366144f09b3181001cf76",
     "DependsOn": [
       "musl@1.1.22-r3"
     ],
     "Layer": {
       "Digest": "sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609",
       "DiffID": "sha256:03901b4a2ea88eeaad62dbe59b072b28b6efa00491962b8741081c5df50c65e0"
-    }
+    },
+    "Digest": "sha1:bacb380dfa6f2f5e8dc366144f09b3181001cf76"
   }
 ]

--- a/pkg/fanal/test/integration/testdata/goldens/packages/vulnimage.json.golden
+++ b/pkg/fanal/test/integration/testdata/goldens/packages/vulnimage.json.golden
@@ -3,7 +3,6 @@
     "ID": ".composer-phpext-rundeps@0",
     "Name": ".composer-phpext-rundeps",
     "Version": "0",
-    "Digest": "sha1:6120632b2e7d0a3ceb27984e667f1601ef3f6f61",
     "DependsOn": [
       "libsodium@1.0.15-r0",
       "musl@1.1.18-r3",
@@ -12,13 +11,13 @@
     "Layer": {
       "Digest": "sha256:1eea04acda91d39256def9ea27cb33007e243a1b4f7f8908bcfd9d3de376905d",
       "DiffID": "sha256:2f4a5c9187c249834ebc28783bd3c65bdcbacaa8baa6620ddaa27846dd3ef708"
-    }
+    },
+    "Digest": "sha1:6120632b2e7d0a3ceb27984e667f1601ef3f6f61"
   },
   {
     "ID": ".persistent-deps@0",
     "Name": ".persistent-deps",
     "Version": "0",
-    "Digest": "sha1:fdb428017a69c58edbe2c141cf5277c76381d88a",
     "DependsOn": [
       "ca-certificates@20171114-r0",
       "curl@7.61.0-r0",
@@ -29,13 +28,13 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:fdb428017a69c58edbe2c141cf5277c76381d88a"
   },
   {
     "ID": ".php-rundeps@0",
     "Name": ".php-rundeps",
     "Version": "0",
-    "Digest": "sha1:b55c2c60d52012cbfbd1b40d236e76490b1d2f46",
     "DependsOn": [
       "libcurl@7.61.1-r0",
       "libedit@20170329.3.1-r3",
@@ -49,7 +48,8 @@
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:b55c2c60d52012cbfbd1b40d236e76490b1d2f46"
   },
   {
     "ID": "alpine-baselayout@3.0.5-r2",
@@ -60,7 +60,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:6e1c83d84d2369825ec44b335e246cc812ee21e8",
     "DependsOn": [
       "busybox@1.27.2-r11",
       "musl@1.1.18-r3"
@@ -68,7 +67,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:6e1c83d84d2369825ec44b335e246cc812ee21e8"
   },
   {
     "ID": "alpine-keys@2.1-r1",
@@ -79,11 +79,11 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:3458e5b2ab168697409f61d2afd35dea6287fbd2",
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:3458e5b2ab168697409f61d2afd35dea6287fbd2"
   },
   {
     "ID": "apk-tools@2.10.1-r0",
@@ -94,7 +94,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:599116788034fe9c0f9486edd4f4a5bf589f4806",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "libressl2.6-libssl@2.6.5-r0",
@@ -104,7 +103,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:599116788034fe9c0f9486edd4f4a5bf589f4806"
   },
   {
     "ID": "apr@1.6.3-r0",
@@ -115,7 +115,6 @@
     "Licenses": [
       "ASL2.0"
     ],
-    "Digest": "sha1:ef13fd7436617f0d1664d824b0e89e516d57dbf6",
     "DependsOn": [
       "libuuid@2.31-r0",
       "musl@1.1.18-r3"
@@ -123,7 +122,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:ef13fd7436617f0d1664d824b0e89e516d57dbf6"
   },
   {
     "ID": "apr-util@1.6.1-r1",
@@ -134,7 +134,6 @@
     "Licenses": [
       "ASL2.0"
     ],
-    "Digest": "sha1:bafbf610de141db01418fa88e91b05c69efeb608",
     "DependsOn": [
       "apr@1.6.3-r0",
       "expat@2.2.5-r0",
@@ -144,7 +143,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:bafbf610de141db01418fa88e91b05c69efeb608"
   },
   {
     "ID": "bash@4.4.19-r1",
@@ -155,7 +155,6 @@
     "Licenses": [
       "GPL-3.0"
     ],
-    "Digest": "sha1:2a2bb204890224c98f6327d5c4da7ea291ad370f",
     "DependsOn": [
       "busybox@1.27.2-r11",
       "musl@1.1.18-r3",
@@ -165,7 +164,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:2a2bb204890224c98f6327d5c4da7ea291ad370f"
   },
   {
     "ID": "busybox@1.27.2-r11",
@@ -176,14 +176,14 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:7f9617f0e3abb6430216d33201e6d5b30d049fc5",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:7f9617f0e3abb6430216d33201e6d5b30d049fc5"
   },
   {
     "ID": "ca-certificates@20171114-r0",
@@ -195,7 +195,6 @@
       "MPL-2.0",
       "GPL-2.0"
     ],
-    "Digest": "sha1:5aa669d28ef467b64451bd754af97b4f68cdd884",
     "DependsOn": [
       "busybox@1.27.2-r11",
       "libressl2.6-libcrypto@2.6.5-r0",
@@ -204,7 +203,8 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:5aa669d28ef467b64451bd754af97b4f68cdd884"
   },
   {
     "ID": "curl@7.61.0-r0",
@@ -215,7 +215,6 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:016d483d30cfea67c126965281160db475b6ca65",
     "DependsOn": [
       "ca-certificates@20171114-r0",
       "libcurl@7.61.1-r0",
@@ -225,7 +224,8 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:016d483d30cfea67c126965281160db475b6ca65"
   },
   {
     "ID": "db@5.3.28-r0",
@@ -236,14 +236,14 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:6a4d69ccb4da10b07ede9649b08aa323a8902790",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:6a4d69ccb4da10b07ede9649b08aa323a8902790"
   },
   {
     "ID": "expat@2.2.5-r0",
@@ -254,14 +254,14 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:5096efd90f782b0e54927539aa30f4134181d477",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:5096efd90f782b0e54927539aa30f4134181d477"
   },
   {
     "ID": "gdbm@1.13-r1",
@@ -272,14 +272,14 @@
     "Licenses": [
       "GPL-3.0"
     ],
-    "Digest": "sha1:331bccf0688c10645a51523ef5590f3f2bebcbf9",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:331bccf0688c10645a51523ef5590f3f2bebcbf9"
   },
   {
     "ID": "git@2.15.2-r0",
@@ -290,7 +290,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:acfbed348e588d90838c4a308428a16042ee9f30",
     "DependsOn": [
       "expat@2.2.5-r0",
       "libcurl@7.61.1-r0",
@@ -301,7 +300,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:acfbed348e588d90838c4a308428a16042ee9f30"
   },
   {
     "ID": "libbz2@1.0.6-r6",
@@ -312,14 +312,14 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:132242e396d99c2d06ee14c7ea4c3f3d02be102a",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:132242e396d99c2d06ee14c7ea4c3f3d02be102a"
   },
   {
     "ID": "libc-utils@0.7.1-r0",
@@ -330,14 +330,14 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:b149e07fcf3cd345e38023edca9b0c9ce7e821bc",
     "DependsOn": [
       "musl-utils@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:b149e07fcf3cd345e38023edca9b0c9ce7e821bc"
   },
   {
     "ID": "libcurl@7.61.1-r0",
@@ -348,7 +348,6 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:3dbd4ffbb43027efba686b75e4418d7e94ad8b46",
     "DependsOn": [
       "ca-certificates@20171114-r0",
       "libressl2.6-libcrypto@2.6.5-r0",
@@ -360,7 +359,8 @@
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:3dbd4ffbb43027efba686b75e4418d7e94ad8b46"
   },
   {
     "ID": "libedit@20170329.3.1-r3",
@@ -371,7 +371,6 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:4d393236e43554c60c5aaaffbcca394f45adcfb8",
     "DependsOn": [
       "musl@1.1.18-r3",
       "ncurses-libs@6.0_p20171125-r1"
@@ -379,7 +378,8 @@
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:4d393236e43554c60c5aaaffbcca394f45adcfb8"
   },
   {
     "ID": "libffi@3.2.1-r4",
@@ -393,11 +393,11 @@
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
-    "Digest": "sha1:9b28ec06ab670657cd47582bf4fe4b803cd93e28",
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:9b28ec06ab670657cd47582bf4fe4b803cd93e28"
   },
   {
     "ID": "libressl@2.6.5-r0",
@@ -408,7 +408,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:684940a8557dc097623cdc6a551b2baad7a08b06",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "libressl2.6-libssl@2.6.5-r0",
@@ -418,7 +417,8 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:684940a8557dc097623cdc6a551b2baad7a08b06"
   },
   {
     "ID": "libressl2.6-libcrypto@2.6.5-r0",
@@ -429,14 +429,14 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:2718dc7d5a9a34ac650614600e16118e466317f7",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:2718dc7d5a9a34ac650614600e16118e466317f7"
   },
   {
     "ID": "libressl2.6-libssl@2.6.5-r0",
@@ -447,7 +447,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:df902e38eab7ecbdf3d143a56c3caa511522f524",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3"
@@ -455,7 +454,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:df902e38eab7ecbdf3d143a56c3caa511522f524"
   },
   {
     "ID": "libressl2.6-libtls@2.6.5-r0",
@@ -466,7 +466,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:7740cbc6dee93683e6893edbe89715a2a99aa9b4",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "libressl2.6-libssl@2.6.5-r0",
@@ -475,7 +474,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:7740cbc6dee93683e6893edbe89715a2a99aa9b4"
   },
   {
     "ID": "libsasl@2.1.26-r11",
@@ -486,7 +486,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:1f14d6b5e172b3b4643106f49a4dc85c9c517060",
     "DependsOn": [
       "db@5.3.28-r0",
       "musl@1.1.18-r3"
@@ -494,7 +493,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:1f14d6b5e172b3b4643106f49a4dc85c9c517060"
   },
   {
     "ID": "libsodium@1.0.15-r0",
@@ -505,14 +505,14 @@
     "Licenses": [
       "ISC"
     ],
-    "Digest": "sha1:7fbed17399609f0613bede5c686d7a02169da7ee",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:7fbed17399609f0613bede5c686d7a02169da7ee"
   },
   {
     "ID": "libssh2@1.8.0-r2",
@@ -523,7 +523,6 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:953a992e9e05e10134651f8826403854240e739b",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3",
@@ -532,7 +531,8 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:953a992e9e05e10134651f8826403854240e739b"
   },
   {
     "ID": "libuuid@2.31-r0",
@@ -548,14 +548,14 @@
       "Public",
       "Domain"
     ],
-    "Digest": "sha1:d95c3db24000cb62331d3892fc1e44292799b4b2",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:d95c3db24000cb62331d3892fc1e44292799b4b2"
   },
   {
     "ID": "libxml2@2.9.7-r0",
@@ -566,7 +566,6 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:990af059bbdb87a870c12f0959bb1b9b91bd57ba",
     "DependsOn": [
       "musl@1.1.18-r3",
       "zlib@1.2.11-r1"
@@ -574,7 +573,8 @@
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:990af059bbdb87a870c12f0959bb1b9b91bd57ba"
   },
   {
     "ID": "mercurial@4.5.2-r0",
@@ -585,7 +585,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:42cc6d472044ac2936f00c412af0ae4e08fd599e",
     "DependsOn": [
       "musl@1.1.18-r3",
       "python2@2.7.15-r2"
@@ -593,7 +592,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:42cc6d472044ac2936f00c412af0ae4e08fd599e"
   },
   {
     "ID": "musl@1.1.18-r3",
@@ -604,11 +604,11 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:5595b2575962e133096977497ef1582bcc76429e",
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:5595b2575962e133096977497ef1582bcc76429e"
   },
   {
     "ID": "musl-utils@1.1.18-r3",
@@ -621,7 +621,6 @@
       "BSD-3-Clause",
       "GPL-2.0"
     ],
-    "Digest": "sha1:87d95e8fc8f4792b3e544a3576cb73f0a89bfa41",
     "DependsOn": [
       "musl@1.1.18-r3",
       "scanelf@1.2.2-r1"
@@ -629,7 +628,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:87d95e8fc8f4792b3e544a3576cb73f0a89bfa41"
   },
   {
     "ID": "ncurses-libs@6.0_p20171125-r1",
@@ -640,7 +640,6 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:f784fc9499dda6c6d13da34507efa7546368fff3",
     "DependsOn": [
       "musl@1.1.18-r3",
       "ncurses-terminfo-base@6.0_p20171125-r1",
@@ -649,7 +648,8 @@
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:f784fc9499dda6c6d13da34507efa7546368fff3"
   },
   {
     "ID": "ncurses-terminfo@6.0_p20171125-r1",
@@ -660,14 +660,14 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:113144a8d7eeb534dc692b66d45ec8ccdd4b972d",
     "DependsOn": [
       "ncurses-terminfo-base@6.0_p20171125-r1"
     ],
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:113144a8d7eeb534dc692b66d45ec8ccdd4b972d"
   },
   {
     "ID": "ncurses-terminfo-base@6.0_p20171125-r1",
@@ -678,11 +678,11 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:967549060a1cf0ef40e1f1d2fff56b8e45e999c2",
     "Layer": {
       "Digest": "sha256:3d6152f6ac208640f9fb494d1c379fe508db1fc5754cd08fefec200bddd13e0e",
       "DiffID": "sha256:6408527580eade39c2692dbb6b0f6a9321448d06ea1c2eef06bb7f37da9c5013"
-    }
+    },
+    "Digest": "sha1:967549060a1cf0ef40e1f1d2fff56b8e45e999c2"
   },
   {
     "ID": "openssh@7.5_p1-r9",
@@ -693,7 +693,6 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:f1d37d2f20528e68bc78028934fa749abd56fcd9",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3",
@@ -704,7 +703,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:f1d37d2f20528e68bc78028934fa749abd56fcd9"
   },
   {
     "ID": "openssh-client@7.5_p1-r9",
@@ -715,7 +715,6 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:8cfbbee8796be1acaa03e8ee58f431dad21ef3c5",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3",
@@ -725,7 +724,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:8cfbbee8796be1acaa03e8ee58f431dad21ef3c5"
   },
   {
     "ID": "openssh-keygen@7.5_p1-r9",
@@ -736,7 +736,6 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:c610fb52fb90da0e25eea69c1e55d02cf44ba05d",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3"
@@ -744,7 +743,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:c610fb52fb90da0e25eea69c1e55d02cf44ba05d"
   },
   {
     "ID": "openssh-server@7.5_p1-r9",
@@ -755,7 +755,6 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:326edd676b254aefe048536473c540b28fb335ce",
     "DependsOn": [
       "libressl2.6-libcrypto@2.6.5-r0",
       "musl@1.1.18-r3",
@@ -766,7 +765,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:326edd676b254aefe048536473c540b28fb335ce"
   },
   {
     "ID": "openssh-server-common@7.5_p1-r9",
@@ -777,11 +777,11 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:f055712504ebbe781cf4c6a6987a878067dd65fd",
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:f055712504ebbe781cf4c6a6987a878067dd65fd"
   },
   {
     "ID": "openssh-sftp-server@7.5_p1-r9",
@@ -792,14 +792,14 @@
     "Licenses": [
       "as-is"
     ],
-    "Digest": "sha1:6c1dcaaba744742843ca4766f21ca546e7813930",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:6c1dcaaba744742843ca4766f21ca546e7813930"
   },
   {
     "ID": "patch@2.7.5-r2",
@@ -810,14 +810,14 @@
     "Licenses": [
       "GPL-3.0"
     ],
-    "Digest": "sha1:8ab18877f726014de8dff1368937414ae8929abd",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:8ab18877f726014de8dff1368937414ae8929abd"
   },
   {
     "ID": "pcre2@10.30-r0",
@@ -828,14 +828,14 @@
     "Licenses": [
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:5d9f8804b6343a6dd1df0d131b4f342294a423af",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:5d9f8804b6343a6dd1df0d131b4f342294a423af"
   },
   {
     "ID": "pkgconf@1.3.10-r0",
@@ -846,14 +846,14 @@
     "Licenses": [
       "ISC"
     ],
-    "Digest": "sha1:bcdf2647b07bae9fffd76433d0defcc6e8dbea21",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:bcdf2647b07bae9fffd76433d0defcc6e8dbea21"
   },
   {
     "ID": "python2@2.7.15-r2",
@@ -864,7 +864,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:e535f131326fc346ffe23083b79fb688a220796a",
     "DependsOn": [
       "expat@2.2.5-r0",
       "gdbm@1.13-r1",
@@ -881,7 +880,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:e535f131326fc346ffe23083b79fb688a220796a"
   },
   {
     "ID": "readline@7.0.003-r0",
@@ -892,7 +892,6 @@
     "Licenses": [
       "GPL-3.0"
     ],
-    "Digest": "sha1:6796e379c3acec5edda98243e506a363d54c2854",
     "DependsOn": [
       "musl@1.1.18-r3",
       "ncurses-libs@6.0_p20171125-r1"
@@ -900,7 +899,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:6796e379c3acec5edda98243e506a363d54c2854"
   },
   {
     "ID": "scanelf@1.2.2-r1",
@@ -911,14 +911,14 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:673d3ba729ab198f0120e3d1f37e993ee2f93c88",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:673d3ba729ab198f0120e3d1f37e993ee2f93c88"
   },
   {
     "ID": "serf@1.3.9-r3",
@@ -929,7 +929,6 @@
     "Licenses": [
       "ASL2.0"
     ],
-    "Digest": "sha1:7f3acf89cc921a20b621f297018caed2e939d873",
     "DependsOn": [
       "apr-util@1.6.1-r1",
       "apr@1.6.3-r0",
@@ -941,7 +940,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:7f3acf89cc921a20b621f297018caed2e939d873"
   },
   {
     "ID": "sqlite-libs@3.21.0-r1",
@@ -952,14 +952,14 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:963204681a8d8922da42739756caca5d0a4290f0",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:963204681a8d8922da42739756caca5d0a4290f0"
   },
   {
     "ID": "ssl_client@1.27.2-r11",
@@ -970,7 +970,6 @@
     "Licenses": [
       "GPL-2.0"
     ],
-    "Digest": "sha1:be991cfc32528659450b6dd21e855d638b5865a6",
     "DependsOn": [
       "libressl2.6-libtls@2.6.5-r0",
       "musl@1.1.18-r3"
@@ -978,7 +977,8 @@
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:be991cfc32528659450b6dd21e855d638b5865a6"
   },
   {
     "ID": "subversion@1.9.7-r0",
@@ -990,7 +990,6 @@
       "Apache-2.0",
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:b3f0936eb24b3f61099cedfac29195dc04a08362",
     "DependsOn": [
       "apr-util@1.6.1-r1",
       "apr@1.6.3-r0",
@@ -1002,7 +1001,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:b3f0936eb24b3f61099cedfac29195dc04a08362"
   },
   {
     "ID": "subversion-libs@1.9.7-r0",
@@ -1014,7 +1014,6 @@
       "Apache-2.0",
       "BSD-3-Clause"
     ],
-    "Digest": "sha1:159042d5715f6e501e73569ffd9b86530758b6d4",
     "DependsOn": [
       "apr-util@1.6.1-r1",
       "apr@1.6.3-r0",
@@ -1029,7 +1028,8 @@
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:159042d5715f6e501e73569ffd9b86530758b6d4"
   },
   {
     "ID": "tar@1.29-r1",
@@ -1040,14 +1040,14 @@
     "Licenses": [
       "GPL-3.0"
     ],
-    "Digest": "sha1:32ed0dea10cb4fc68f32e7466513230e09679d09",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:32ed0dea10cb4fc68f32e7466513230e09679d09"
   },
   {
     "ID": "tini@0.16.1-r0",
@@ -1058,14 +1058,14 @@
     "Licenses": [
       "MIT"
     ],
-    "Digest": "sha1:f88c6efbdbb698ba8a2db15ee88fa2b474002fb3",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c191915691a422a1b0230c9010165ff655204a9fd95e3b43151132bcb237826b",
       "DiffID": "sha256:2da3602d664dd3f71fae83cbc566d4e80b432c6ee8bb4efd94c8e85122f503d4"
-    }
+    },
+    "Digest": "sha1:f88c6efbdbb698ba8a2db15ee88fa2b474002fb3"
   },
   {
     "ID": "xz@5.2.3-r1",
@@ -1076,7 +1076,6 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:fe745c838ec20816bc5c4d9e4fceb01dc866caac",
     "DependsOn": [
       "musl@1.1.18-r3",
       "xz-libs@5.2.3-r1"
@@ -1084,7 +1083,8 @@
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:fe745c838ec20816bc5c4d9e4fceb01dc866caac"
   },
   {
     "ID": "xz-libs@5.2.3-r1",
@@ -1095,14 +1095,14 @@
     "Licenses": [
       "custom"
     ],
-    "Digest": "sha1:7aeb306958a1cb330a7bb8f7ce24ab6fe85c8b1f",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:88777455d910410652665cec0149a02db3584d6dc26e306788a3532d480b00ae",
       "DiffID": "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33"
-    }
+    },
+    "Digest": "sha1:7aeb306958a1cb330a7bb8f7ce24ab6fe85c8b1f"
   },
   {
     "ID": "zlib@1.2.11-r1",
@@ -1113,13 +1113,13 @@
     "Licenses": [
       "Zlib"
     ],
-    "Digest": "sha1:4869b83137ea8eab47c9f0b0e1085a5cc6ae2bb3",
     "DependsOn": [
       "musl@1.1.18-r3"
     ],
     "Layer": {
       "Digest": "sha256:c67f3896b22c1378881cbbb9c9d1edfe881fd07f713371835ef46d93c649684d",
       "DiffID": "sha256:ebf12965380b39889c99a9c02e82ba465f887b45975b6e389d42e9e6a3857888"
-    }
+    },
+    "Digest": "sha1:4869b83137ea8eab47c9f0b0e1085a5cc6ae2bb3"
   }
 ]

--- a/pkg/fanal/test/integration/testdata/goldens/vuln-image1.2.3.expectedlibs.golden
+++ b/pkg/fanal/test/integration/testdata/goldens/vuln-image1.2.3.expectedlibs.golden
@@ -1965,13 +1965,13 @@
           "guzzlehttp/promises@v1.3.1",
           "guzzlehttp/psr7@1.5.2"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 9,
             "EndLine": 73
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "guzzlehttp/promises@v1.3.1",
@@ -1980,13 +1980,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 74,
             "EndLine": 124
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "guzzlehttp/psr7@1.5.2",
@@ -1999,13 +1999,13 @@
           "psr/http-message@1.0.1",
           "ralouphie/getallheaders@2.0.5"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 125,
             "EndLine": 191
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "laravel/installer@v2.0.1",
@@ -2020,13 +2020,13 @@
           "symfony/filesystem@v4.2.7",
           "symfony/process@v4.2.7"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 192,
             "EndLine": 237
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "pear/log@1.13.1",
@@ -2038,13 +2038,13 @@
         "DependsOn": [
           "pear/pear_exception@v1.0.0"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 238,
             "EndLine": 290
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "pear/pear_exception@v1.0.0",
@@ -2053,13 +2053,13 @@
         "Licenses": [
           "BSD-2-Clause"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 291,
             "EndLine": 345
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "psr/http-message@1.0.1",
@@ -2068,13 +2068,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 346,
             "EndLine": 395
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "ralouphie/getallheaders@2.0.5",
@@ -2083,13 +2083,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 396,
             "EndLine": 435
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/console@v4.2.7",
@@ -2102,13 +2102,13 @@
           "symfony/contracts@v1.0.2",
           "symfony/polyfill-mbstring@v1.11.0"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 436,
             "EndLine": 507
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/contracts@v1.0.2",
@@ -2117,13 +2117,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 508,
             "EndLine": 575
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/filesystem@v4.2.7",
@@ -2135,13 +2135,13 @@
         "DependsOn": [
           "symfony/polyfill-ctype@v1.11.0"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 576,
             "EndLine": 625
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/polyfill-ctype@v1.11.0",
@@ -2150,13 +2150,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 626,
             "EndLine": 683
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/polyfill-mbstring@v1.11.0",
@@ -2165,13 +2165,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 684,
             "EndLine": 742
           }
-        ],
-        "Layer": {}
+        ]
       },
       {
         "ID": "symfony/process@v4.2.7",
@@ -2180,13 +2180,13 @@
         "Licenses": [
           "MIT"
         ],
+        "Layer": {},
         "Locations": [
           {
             "StartLine": 743,
             "EndLine": 791
           }
-        ],
-        "Layer": {}
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Description
`TestFanal_Library_DockerMode` test uses image with uncompressed layers and updates golden test files without `Digest`.
Skip this task to avoid building incorrect golden files. 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
