### PR TITLE
refactor(sbom): use multiline json for spdx-json format

### DIFF
--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -1,9 +1,10 @@
 package spdx
 
 import (
+	"encoding/json"
 	"io"
 
-	"github.com/spdx/tools-golang/json"
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 	"github.com/spdx/tools-golang/tagvalue"
 	"golang.org/x/xerrors"
 
@@ -34,13 +35,29 @@ func (w Writer) Write(report types.Report) error {
 	}
 
 	if w.format == "spdx-json" {
-		if err := json.Write(spdxDoc, w.output); err != nil {
+		if err := writeSPDXJson(spdxDoc, w.output); err != nil {
 			return xerrors.Errorf("failed to save spdx json: %w", err)
 		}
 	} else {
 		if err := tagvalue.Write(spdxDoc, w.output); err != nil {
 			return xerrors.Errorf("failed to save spdx tag-value: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// writeSPDXJson writes in human-readable format(multiple lines)
+// use function from `github.com/spdx/tools-golang` after release https://github.com/spdx/tools-golang/pull/213
+func writeSPDXJson(doc *v2_3.Document, w io.Writer) error {
+	buf, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(buf)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Description
`golang-tools` [uses](https://github.com/spdx/tools-golang/blob/13245e003bc18836be57c429f5f672de662dfd0a/json/writer.go#L13-L25) 1 line json format.
I created [#213](https://github.com/spdx/tools-golang/pull/213) to add option to use multiline json. 
Until these changes are released, we need to use our function for this.

Before:
```
➜ trivy -q image -f spdx-json alpine 
{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"alpine","documentNamespace":"http://aquasecurity.github.io/trivy/container_image/alpine-22e7aac3-d0ec-4836-bd56-015f1bc757e4","creationInfo":{"licenseListVersion" ...
```

After:
```
➜ ./trivy -q image -f spdx-json alpine
{
  "spdxVersion": "SPDX-2.3",
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "alpine",
  "documentNamespace": "http://aquasecurity.github.io/trivy/container_image/alpine-b5575ff7-bb7f-4b9a-9e68-c2f057bbb6f2",
  "creationInfo": {
    "licenseListVersion": "",
    "creators": [
      "Organization: aquasecurity",
      "Tool: trivy-0.36.2-73-g31b19264"
    ],
    "created": "2023-05-16T04:07:09Z"
  },
...
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
