### PR TITLE
feat(aws): Add support to see successes in results

### DIFF
--- a/pkg/cloud/aws/commands/run.go
+++ b/pkg/cloud/aws/commands/run.go
@@ -142,7 +142,12 @@ func Run(ctx context.Context, opt flag.Options) error {
 		})
 	}
 
-	r := report.New(cloud.ProviderAWS, opt.Account, opt.Region, results.GetFailed(), opt.Services)
+	res := results.GetFailed()
+	if opt.MisconfOptions.IncludeNonFailures {
+		res = results
+	}
+
+	r := report.New(cloud.ProviderAWS, opt.Account, opt.Region, res, opt.Services)
 	if err := report.Write(r, opt, cached); err != nil {
 		return fmt.Errorf("unable to write results: %w", err)
 	}

--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -76,6 +76,7 @@ func Test_Run(t *testing.T) {
 				CloudOptions: flag.CloudOptions{
 					MaxCacheAge: time.Hour * 24 * 365 * 100,
 				},
+				MisconfOptions: flag.MisconfOptions{IncludeNonFailures: true},
 			},
 			cacheContent: exampleS3Cache,
 			want: `{
@@ -99,7 +100,7 @@ func Test_Run(t *testing.T) {
       "Class": "config",
       "Type": "cloud",
       "MisconfSummary": {
-        "Successes": 0,
+        "Successes": 1,
         "Failures": 9,
         "Exceptions": 0
       },
@@ -274,6 +275,29 @@ func Test_Run(t *testing.T) {
         },
         {
           "Type": "AWS",
+          "ID": "AVD-AWS-0092",
+          "AVDID": "AVD-AWS-0092",
+          "Title": "S3 Buckets not publicly accessible through ACL.",
+          "Description": "Buckets should not have ACLs that allow public access",
+          "Resolution": "Don't use canned ACLs or switch to private acl",
+          "Severity": "HIGH",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/avd-aws-0092",
+          "References": [
+            "https://avd.aquasec.com/misconfig/avd-aws-0092"
+          ],
+          "Status": "PASS",
+          "Layer": {},
+          "CauseMetadata": {
+            "Resource": "arn:aws:s3:::examplebucket",
+            "Provider": "aws",
+            "Service": "s3",
+            "Code": {
+              "Lines": null
+            }
+          }
+        },
+        {
+          "Type": "AWS",
           "ID": "AVD-AWS-0093",
           "AVDID": "AVD-AWS-0093",
           "Title": "S3 Access block should restrict public bucket to limit access",
@@ -327,7 +351,7 @@ func Test_Run(t *testing.T) {
 `,
 		},
 		{
-			name: "custom rego rule",
+			name: "custom rego rule with passed results",
 			options: flag.Options{
 				AWSOptions: flag.AWSOptions{
 					Region:   "us-east-1",
@@ -347,6 +371,7 @@ func Test_Run(t *testing.T) {
 					},
 					SkipPolicyUpdate: true,
 				},
+				MisconfOptions: flag.MisconfOptions{IncludeNonFailures: true},
 			},
 			regoPolicy: `# METADATA
 # title: No example buckets
@@ -390,7 +415,7 @@ deny[res] {
       "Class": "config",
       "Type": "cloud",
       "MisconfSummary": {
-        "Successes": 0,
+        "Successes": 1,
         "Failures": 10,
         "Exceptions": 0
       },
@@ -553,6 +578,29 @@ deny[res] {
             "https://avd.aquasec.com/misconfig/avd-aws-0091"
           ],
           "Status": "FAIL",
+          "Layer": {},
+          "CauseMetadata": {
+            "Resource": "arn:aws:s3:::examplebucket",
+            "Provider": "aws",
+            "Service": "s3",
+            "Code": {
+              "Lines": null
+            }
+          }
+        },
+        {
+          "Type": "AWS",
+          "ID": "AVD-AWS-0092",
+          "AVDID": "AVD-AWS-0092",
+          "Title": "S3 Buckets not publicly accessible through ACL.",
+          "Description": "Buckets should not have ACLs that allow public access",
+          "Resolution": "Don't use canned ACLs or switch to private acl",
+          "Severity": "HIGH",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/avd-aws-0092",
+          "References": [
+            "https://avd.aquasec.com/misconfig/avd-aws-0092"
+          ],
+          "Status": "PASS",
           "Layer": {},
           "CauseMetadata": {
             "Resource": "arn:aws:s3:::examplebucket",

--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -64,7 +64,10 @@ func Write(rep *Report, opt flag.Options, fromCache bool) error {
 	for _, resultsAtTime := range rep.Results {
 		for _, res := range resultsAtTime.Results {
 			resCopy := res
-			if err := result.FilterResult(ctx, &resCopy, result.FilterOption{Severities: opt.Severities}); err != nil {
+			if err := result.FilterResult(ctx, &resCopy, result.FilterOption{
+				Severities:         opt.Severities,
+				IncludeNonFailures: opt.IncludeNonFailures,
+			}); err != nil {
 				return err
 			}
 			sort.Slice(resCopy.Misconfigurations, func(i, j int) bool {


### PR DESCRIPTION
Signed-off-by: Simar <simar@linux.com>

## Description

Add the ability to show successes when evaluating AWS results

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4426

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
