### PR TITLE
fix: add USER instructions for compliance reports

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -49,6 +49,9 @@ func (a *historyAnalyzer) Analyze(ctx context.Context, input analyzer.ConfigAnal
 		case strings.HasPrefix(h.CreatedBy, "/bin/sh -c"):
 			// RUN instruction
 			createdBy = strings.ReplaceAll(h.CreatedBy, "/bin/sh -c", "RUN")
+		case strings.HasPrefix(h.CreatedBy, "USER"):
+			// USER instruction
+			createdBy = h.CreatedBy
 		case strings.HasPrefix(h.CreatedBy, "HEALTHCHECK"):
 			// HEALTHCHECK instruction
 			var interval, timeout, startPeriod, retries, command string

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -41,6 +41,10 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 							EmptyLayer: false,
 						},
 						{
+							CreatedBy:  `USER user`,
+							EmptyLayer: true,
+						},
+						{
 							CreatedBy:  `/bin/sh -c #(nop)  CMD [\"/bin/sh\"]`,
 							EmptyLayer: true,
 						},
@@ -52,28 +56,6 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 					FileType: "dockerfile",
 					FilePath: "Dockerfile",
 					Failures: types.MisconfResults{
-						types.MisconfResult{
-							Namespace: "builtin.dockerfile.DS002",
-							Query:     "data.builtin.dockerfile.DS002.deny",
-							Message:   "Specify at least 1 USER command in Dockerfile with non-root user as argument",
-							PolicyMetadata: types.PolicyMetadata{
-								ID:                 "DS002",
-								AVDID:              "AVD-DS-0002",
-								Type:               "Dockerfile Security Check",
-								Title:              "Image user should not be 'root'",
-								Description:        "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
-								Severity:           "HIGH",
-								RecommendedActions: "Add 'USER <non root user name>' line to the Dockerfile",
-								References: []string{
-									"https://docs.docker." +
-										"com/develop/develop-images/dockerfile_best-practices/",
-								},
-							},
-							CauseMetadata: types.CauseMetadata{
-								Provider: "Dockerfile",
-								Service:  "general",
-							},
-						},
 						types.MisconfResult{
 							Namespace: "builtin.dockerfile.DS005",
 							Query:     "data.builtin.dockerfile.DS005.deny",


### PR DESCRIPTION
## Description
Add `USER` instructions for compliance reports.

## Related issues
- Close #4428

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
