### PR TITLE
fix(go): Replacing old output report with new one by deleting the old report 

### DIFF
--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -216,14 +216,19 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 
 	if output != "" {
 		var err error
-		var file *os.File
 
-		file, err = os.Create(output)
+		if _, err := os.Stat(output); err == nil {
+			err := os.Remove(output)
+			if err != nil {
+				return ReportOptions{}, xerrors.Errorf("failed to delete existing file: %w", err)
+			}
+		}
+
+		out, err = os.Create(output)
+
 		if err != nil {
 			return ReportOptions{}, xerrors.Errorf("failed to create an output file: %w", err)
 		}
-		defer file.Close()
-		out = file
 
 	}
 

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -218,7 +218,7 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 		var err error
 		var file *os.File
 
-		file, err := os.Create(output)
+		file, err = os.Create(output)
 		if err != nil {
 			return ReportOptions{}, xerrors.Errorf("failed to create an output file: %w", err)
 		}

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -216,9 +216,15 @@ func (f *ReportFlagGroup) ToOptions(out io.Writer) (ReportOptions, error) {
 
 	if output != "" {
 		var err error
-		if out, err = os.Create(output); err != nil {
+		var file *os.File
+
+		file, err := os.Create(output)
+		if err != nil {
 			return ReportOptions{}, xerrors.Errorf("failed to create an output file: %w", err)
 		}
+		defer file.Close()
+		out = file
+
 	}
 
 	cs, err := loadComplianceTypes(getString(f.Compliance))


### PR DESCRIPTION
## Description

The issue mentions that there was problem  `The process cannot access the file because it is being used by another process`. TO circumvent this we are replacing old output report with new one by deleting the old report.

## Related issues
- Close #4085 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.

