### PR TITLE
refactor: enable cases where return values are not needed in pipeline

### DIFF
--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -54,7 +54,7 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 		misconfig report.Resource
 	}
 
-	onItem := func(artifact *artifacts.Artifact) (scanResult, error) {
+	onItem := func(ctx context.Context, artifact *artifacts.Artifact) (scanResult, error) {
 		scanResults := scanResult{}
 		if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner, types.SecretScanner) {
 			vulns, err := s.scanVulns(ctx, artifact)

--- a/pkg/parallel/pipeline.go
+++ b/pkg/parallel/pipeline.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/cheggaaa/pb/v3"
-
 	"golang.org/x/sync/errgroup"
 )
 
@@ -19,7 +18,7 @@ type Pipeline[T, U any] struct {
 }
 
 // onItem represents a function type that takes an input element and returns an output element.
-type onItem[T, U any] func(T) (U, error)
+type onItem[T, U any] func(context.Context, T) (U, error)
 
 // onResult represents a function type that takes an output element.
 type onResult[U any] func(U) error
@@ -71,7 +70,7 @@ func (p *Pipeline[T, U]) Do(ctx context.Context) error {
 	for i := 0; i < p.numWorkers; i++ {
 		g.Go(func() error {
 			for item := range itemCh {
-				res, err := p.onItem(item)
+				res, err := p.onItem(ctx, item)
 				if err != nil {
 					return err
 				}

--- a/pkg/parallel/pipeline.go
+++ b/pkg/parallel/pipeline.go
@@ -25,6 +25,10 @@ type onResult[U any] func(U) error
 
 func NewPipeline[T, U any](numWorkers int, progress bool, items []T,
 	fn1 onItem[T, U], fn2 onResult[U]) Pipeline[T, U] {
+	if fn2 == nil {
+		// In case where there is no need to process the return values
+		fn2 = func(_ U) error { return nil }
+	}
 	return Pipeline[T, U]{
 		numWorkers: numWorkers,
 		progress:   progress,


### PR DESCRIPTION
## Description
This PR allows passing a nil function to NewPipeline for cases where return values are not required. Then, it refactors `pkg/fanal/artifact/image/image.go` with the pipeline.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/4336

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
