### PR TITLE
[RFC] feat: warn about unfixed vulnerabilities.

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -138,6 +138,7 @@ func (o *Options) RegistryOpts() ftypes.RegistryOptions {
 func (o *Options) FilterOpts() result.FilterOption {
 	return result.FilterOption{
 		Severities:         o.Severities,
+		WarnUnfixed:        o.WarnUnfixed,
 		IgnoreUnfixed:      o.IgnoreUnfixed,
 		IncludeNonFailures: o.IncludeNonFailures,
 		IgnoreFile:         o.IgnoreFile,

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -220,6 +220,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			viper.Set(flag.DependencyTreeFlag.ConfigName, tt.fields.dependencyTree)
 			viper.Set(flag.ListAllPkgsFlag.ConfigName, tt.fields.listAllPkgs)
 			viper.Set(flag.IgnoreFileFlag.ConfigName, tt.fields.ignoreFile)
+			viper.Set(flag.WarnUnfixedFlag.ConfigName, tt.fields.warnUnfixed)
 			viper.Set(flag.IgnoreUnfixedFlag.ConfigName, tt.fields.ignoreUnfixed)
 			viper.Set(flag.IgnorePolicyFlag.ConfigName, tt.fields.ignorePolicy)
 			viper.Set(flag.ExitCodeFlag.ConfigName, tt.fields.exitCode)

--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -23,22 +23,31 @@ var (
 		Value:      false,
 		Usage:      "display only fixed vulnerabilities",
 	}
+	WarnUnfixedFlag = Flag{
+		Name:       "warn-unfixed",
+		ConfigName: "vulnerability.warn-unfixed",
+		Value:      false,
+		Usage:      "display warning for unfixed vulnerabilities",
+	}
 )
 
 type VulnerabilityFlagGroup struct {
 	VulnType      *Flag
 	IgnoreUnfixed *Flag
+	WarnUnfixed   *Flag
 }
 
 type VulnerabilityOptions struct {
 	VulnType      []string
 	IgnoreUnfixed bool
+	WarnUnfixed   bool
 }
 
 func NewVulnerabilityFlagGroup() *VulnerabilityFlagGroup {
 	return &VulnerabilityFlagGroup{
 		VulnType:      &VulnTypeFlag,
 		IgnoreUnfixed: &IgnoreUnfixedFlag,
+		WarnUnfixed:   &WarnUnfixedFlag,
 	}
 }
 
@@ -50,6 +59,7 @@ func (f *VulnerabilityFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.VulnType,
 		f.IgnoreUnfixed,
+		f.WarnUnfixed
 	}
 }
 
@@ -57,6 +67,7 @@ func (f *VulnerabilityFlagGroup) ToOptions() VulnerabilityOptions {
 	return VulnerabilityOptions{
 		VulnType:      parseVulnType(getStringSlice(f.VulnType)),
 		IgnoreUnfixed: getBool(f.IgnoreUnfixed),
+		WarnUnfixed:   getBool(f.WarnUnfixed),
 	}
 }
 

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -121,6 +121,11 @@ func (r *runner) run(ctx context.Context, artifacts []*artifacts.Artifact) error
 		return xerrors.Errorf("unable to write results: %w", err)
 	}
 
+	log.Logger.Warnf("unfixed vulnerabilities:")
+	for _, result := range rpt.Results {
+		log.Logger.Warnf("%v", result.WarnedVulnerabilities)
+	}
+
 	operation.Exit(r.flagOpts, rpt.Failed())
 
 	return nil

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -73,6 +73,7 @@ type Result struct {
 	Class             ResultClass                `json:"Class,omitempty"`
 	Type              string                     `json:"Type,omitempty"`
 	Packages          []ftypes.Package           `json:"Packages,omitempty"`
+	WarnedVulnerabilities   []DetectedVulnerability    `json:"WarnedVulnerabilities,omitempty"`
 	Vulnerabilities   []DetectedVulnerability    `json:"Vulnerabilities,omitempty"`
 	MisconfSummary    *MisconfSummary            `json:"MisconfSummary,omitempty"`
 	Misconfigurations []DetectedMisconfiguration `json:"Misconfigurations,omitempty"`
@@ -86,6 +87,10 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 	// It would be noisy to users, so it should be removed from the JSON output.
 	for i := range r.Vulnerabilities {
 		r.Vulnerabilities[i].VendorSeverity = nil
+	}
+
+	for i := range r.WarnedVulnerabilities {
+		r.WarnedVulnerabilities[i].VendorSeverity = nil
 	}
 
 	// remove the Highlighted attribute from the json results
@@ -105,7 +110,7 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Result) IsEmpty() bool {
-	return len(r.Packages) == 0 && len(r.Vulnerabilities) == 0 && len(r.Misconfigurations) == 0 &&
+	return len(r.Packages) == 0 && len(r.Vulnerabilities) == 0 && len(r.WarnedVulnerabilities) == 0 && len(r.Misconfigurations) == 0 &&
 		len(r.Secrets) == 0 && len(r.Licenses) == 0 && len(r.CustomResources) == 0
 }
 


### PR DESCRIPTION
Hi.


## Description

In this RFC, I added support to warn about unfixed vulnerabilities.
At the moment, there are two possibilities regarding unfixed vulnerabilities:
1. Either ignoring them.
2. Either failing if there is one.

In CI, the second case can be particularly tricky and I do not think ignoring vulnerabilities is a good thing.
As a middle ground, I propose to warn about them, people will then be aware of them but the scanning will not fail.

As I am not sure if this PR would be welcomed, I marked it as RFC.
Note that the whole contribution is a bit goofy and untested (I did not add unit or integration test).
I first would like to get your opinion on this and if we agree I will then iterate on it to polish it regar

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).


Best regards and thank you in advance.