### PR TITLE
feat(oci): add support for referencing an input image by digest

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -15,6 +15,11 @@ trivy image [flags] IMAGE_NAME
   # Scan a container image from a tar archive
   $ trivy image --input ruby-3.1.tar
 
+  # Scan an OCI imag from a local layout referenced by tag or digest
+  $ trivy image --input alpine:3.15
+
+  $ trivy image --input alpine@sha256:82389ea44e50c696aba18393b168a833929506f5b29b9d75eb817acceb6d54ba
+
   # Filter by severities
   $ trivy image --severity HIGH,CRITICAL alpine:3.15
 

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -15,11 +15,6 @@ trivy image [flags] IMAGE_NAME
   # Scan a container image from a tar archive
   $ trivy image --input ruby-3.1.tar
 
-  # Scan an OCI imag from a local layout referenced by tag or digest
-  $ trivy image --input alpine:3.15
-
-  $ trivy image --input alpine@sha256:82389ea44e50c696aba18393b168a833929506f5b29b9d75eb817acceb6d54ba
-
   # Filter by severities
   $ trivy image --severity HIGH,CRITICAL alpine:3.15
 

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -392,6 +392,15 @@ $ skopeo copy docker-daemon:alpine:3.11 oci:/path/to/alpine
 $ trivy image --input /path/to/alpine
 ```
 
+Referencing specific images can be done by their tag or by their manifest digest:
+```
+# Referenced by tag
+$ trivy image --input /path/to/alpine:3.15
+
+# Referenced by digest
+$ trivy image --input /path/to/alpine@sha256:82389ea44e50c696aba18393b168a833929506f5b29b9d75eb817acceb6d54ba
+```
+
 ## SBOM
 Trivy supports the generation of Software Bill of Materials (SBOM) for container images and the search for SBOMs during vulnerability scanning.
 

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -447,7 +447,7 @@ func TestNewArchiveImage(t *testing.T) {
 			args: args{
 				fileName: "../test/testdata/test_image_tag.oci:0.0.0",
 			},
-			wantErr: "invalid OCI image tag",
+			wantErr: "invalid OCI image ref",
 		},
 		{
 			name: "sad path, oci image not found",

--- a/pkg/fanal/image/oci.go
+++ b/pkg/fanal/image/oci.go
@@ -10,17 +10,21 @@ import (
 )
 
 func tryOCI(fileName string) (v1.Image, error) {
-	var inputTag, inputFileName string
+	var inputRef, inputFileName string
 
 	// Check if tag is specified in input
 	// e.g. /path/to/oci:0.0.1
-	if strings.Contains(fileName, ":") {
+	if strings.Contains(fileName, "@") {
+		splitFileName := strings.SplitN(fileName, "@", 2)
+		inputFileName = splitFileName[0]
+		inputRef = splitFileName[1]
+	} else if strings.Contains(fileName, ":") {
 		splitFileName := strings.SplitN(fileName, ":", 2)
 		inputFileName = splitFileName[0]
-		inputTag = splitFileName[1]
+		inputRef = splitFileName[1]
 	} else {
 		inputFileName = fileName
-		inputTag = ""
+		inputRef = ""
 	}
 
 	lp, err := layout.FromPath(inputFileName)
@@ -43,15 +47,16 @@ func tryOCI(fileName string) (v1.Image, error) {
 	}
 
 	// Support image having tag separated by : , otherwise support first image
-	return getOCIImage(m, index, inputTag)
+	return getOCIImage(m, index, inputRef)
 }
 
-func getOCIImage(m *v1.IndexManifest, index v1.ImageIndex, inputTag string) (v1.Image, error) {
+func getOCIImage(m *v1.IndexManifest, index v1.ImageIndex, inputRef string) (v1.Image, error) {
 	for _, manifest := range m.Manifests {
 		annotation := manifest.Annotations
 		tag := annotation[ispec.AnnotationRefName]
-		if inputTag == "" || // always select the first digest
-			tag == inputTag {
+		if inputRef == "" || // always select the first digest
+			tag == inputRef ||
+			manifest.Digest.String() == inputRef {
 			h := manifest.Digest
 			if manifest.MediaType.IsIndex() {
 				childIndex, err := index.ImageIndex(h)
@@ -74,5 +79,5 @@ func getOCIImage(m *v1.IndexManifest, index v1.ImageIndex, inputTag string) (v1.
 		}
 	}
 
-	return nil, xerrors.New("invalid OCI image tag")
+	return nil, xerrors.New("invalid OCI image ref")
 }

--- a/pkg/fanal/image/oci.go
+++ b/pkg/fanal/image/oci.go
@@ -14,15 +14,14 @@ func tryOCI(fileName string) (v1.Image, error) {
 
 	// Check if tag is specified in input
 	// e.g. /path/to/oci:0.0.1
-	if strings.Contains(fileName, "@") {
-		splitFileName := strings.SplitN(fileName, "@", 2)
-		inputFileName = splitFileName[0]
-		inputRef = splitFileName[1]
-	} else if strings.Contains(fileName, ":") {
-		splitFileName := strings.SplitN(fileName, ":", 2)
-		inputFileName = splitFileName[0]
-		inputRef = splitFileName[1]
-	} else {
+
+	inputFileName, inputRef, found := strings.Cut(fileName, "@")
+
+	if !found {
+		inputFileName, inputRef, found = strings.Cut(fileName, ":")
+	}
+
+	if !found {
 		inputFileName = fileName
 		inputRef = ""
 	}

--- a/pkg/fanal/image/oci_test.go
+++ b/pkg/fanal/image/oci_test.go
@@ -26,7 +26,7 @@ func TestTryOCI(t *testing.T) {
 		{
 			name:         "correct path to index with incorrect tag",
 			ociImagePath: filepath.Join("testdata", "multi:tg12"),
-			wantErr:      "invalid OCI image tag",
+			wantErr:      "invalid OCI image ref",
 		},
 		{
 			name:         "correct path to manifest without tag",
@@ -41,7 +41,19 @@ func TestTryOCI(t *testing.T) {
 		{
 			name:         "correct path to manifest with incorrect tag",
 			ociImagePath: filepath.Join("testdata", "single:3.11"),
-			wantErr:      "invalid OCI image tag",
+			wantErr:      "invalid OCI image ref",
+		},
+		{
+			name: "correct path to manifest with correct digest",
+			ociImagePath: filepath.Join("testdata",
+				"single@sha256:56ae38f2f5c54b98311b8b2463d4861368c451ac17098f4227d84946b42ab96d"),
+			wantErr: "",
+		},
+		{
+			name: "correct path to manifest with incorrect digest",
+			ociImagePath: filepath.Join("testdata",
+				"single@sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+			wantErr: "invalid OCI image ref",
 		},
 	}
 


### PR DESCRIPTION
## Description

Add ability to reference a local OCI image using the digest of it's manifest as in the following example:

```console
$ trivy image --input alpine@sha256:56ae38f2f5c54b98311b8b2463d4861368c451ac17098f4227d84946b42ab96d
```

## Related issues
- Close #3571

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
