### PR TITLE
fix(secret): remove aws-account-id rule

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -109,15 +109,6 @@ var builtinRules = []Rule{
 		Keywords:        []string{"key"},
 	},
 	{
-		ID:              "aws-account-id",
-		Category:        CategoryAWS,
-		Severity:        "HIGH",
-		Title:           "AWS Account ID",
-		Regex:           MustCompile(fmt.Sprintf(`(?i)%s%s%saccount_?(id)?%s%s%s(?P<secret>[0-9]{4}\-?[0-9]{4}\-?[0-9]{4})%s%s`, startSecret, quote, aws, quote, connect, quote, quote, endSecret)),
-		SecretGroupName: "secret",
-		Keywords:        []string{"account"},
-	},
-	{
 		ID:       "github-pat",
 		Category: CategoryGitHub,
 		Title:    "GitHub Personal Access Token",

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -214,8 +214,8 @@ func TestSecretScanner(t *testing.T) {
 				},
 				{
 					Number:      3,
-					Content:     "\"aws_account_ID\":'**************'",
-					Highlighted: "\"aws_account_ID\":'**************'",
+					Content:     "\"aws_account_ID\":'1234-5678-9123'",
+					Highlighted: "\"aws_account_ID\":'1234-5678-9123'",
 				},
 			},
 		},
@@ -402,37 +402,6 @@ func TestSecretScanner(t *testing.T) {
 			},
 		},
 	}
-	wantFinding10 := types.SecretFinding{
-		RuleID:    "aws-account-id",
-		Category:  secret.CategoryAWS,
-		Title:     "AWS Account ID",
-		Severity:  "HIGH",
-		StartLine: 3,
-		EndLine:   3,
-		Match:     `"aws_account_ID":'**************'`,
-		Code: types.Code{
-			Lines: []types.Line{
-				{
-					Number:      1,
-					Content:     "'AWS_secret_KEY'=\"****************************************\"",
-					Highlighted: "'AWS_secret_KEY'=\"****************************************\"",
-				},
-				{
-					Number:      2,
-					Content:     "AWS_ACCESS_KEY_ID=********************",
-					Highlighted: "AWS_ACCESS_KEY_ID=********************",
-				},
-				{
-					Number:      3,
-					Content:     "\"aws_account_ID\":'**************'",
-					Highlighted: "\"aws_account_ID\":'**************'",
-					IsCause:     true,
-					FirstCause:  true,
-					LastCause:   true,
-				},
-			},
-		},
-	}
 	wantFindingAsymmetricPrivateKeyJson := types.SecretFinding{
 		RuleID:    "private-key",
 		Category:  secret.CategoryAsymmetricPrivateKey,
@@ -580,7 +549,7 @@ func TestSecretScanner(t *testing.T) {
 			inputFilePath: filepath.Join("testdata", "aws-secrets.txt"),
 			want: types.Secret{
 				FilePath: filepath.Join("testdata", "aws-secrets.txt"),
-				Findings: []types.SecretFinding{wantFinding5, wantFinding10, wantFinding9},
+				Findings: []types.SecretFinding{wantFinding5, wantFinding9},
 			},
 		},
 		{


### PR DESCRIPTION
## Description
AWS account IDs are not considered secret, sensitive, or confidential information.
See [here](https://github.com/aquasecurity/trivy/discussions/4491#discussion-5245012).

## Related issues
- Close #4492

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
