### PR TITLE
fix(java): add support of `*` for exclusions for pom.xml files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.2
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.89.0
-	github.com/aquasecurity/go-dep-parser v0.0.0-20230514135501-4adad90d3013
+	github.com/aquasecurity/go-dep-parser v0.0.0-20230528081944-555b6773dbb8
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.89.0 h1:5B0mJYraNa2n5zlYuShqOwRt5kqFXdVfGPRYiZJPDuw=
 github.com/aquasecurity/defsec v0.89.0/go.mod h1:te+KhIV8w1pDIjTsUQwlc6xRn8gC7f+TJUiFhLlcEHM=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230514135501-4adad90d3013 h1:W4aixCRckBRj9arjuVXRfRQjJ5+/qof7ZRgSsCH9zpA=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230514135501-4adad90d3013/go.mod h1:bDhCMOPc4Fq7fRg05DNJklkdR+66BWnhf8rWVL+LiYk=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230528081944-555b6773dbb8 h1:HVvUnuRQ99MyR/Ss6TuCE4q72HvXXDUFyazQu7Ut8f8=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230528081944-555b6773dbb8/go.mod h1:2Yfi9sB8TSwxM/KQDTpy4xFM6zG4yBjc1jS966uMIP8=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20230328195059-5bf52338aec3 h1:Vt9y1gZS5JGY3tsL9zc++Cg4ofX51CG7PaMyC5SXWPg=


### PR DESCRIPTION
## Description
Add support of `*` for exclusions for pom.xml files

## Related issues
- Close #4051

## Related PRs
- [x] #aquasecurity/go-dep-parser/pull/215

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
