### PR TITLE
docs: fixed the format

### DIFF
--- a/docs/tutorials/additional-resources/cks.md
+++ b/docs/tutorials/additional-resources/cks.md
@@ -7,7 +7,7 @@ The [Certified Kubernetes Security Specialist (CKS) Exam](https://training.linux
 - [Trivy Video overview (short)][overview]
 - [Example questions from the exam][exam]
 - [More example questions][questions]
-- [CKS exam study guide](study-guide)
+- [CKS exam study guide][study-guide]
 - [Docker Image Vulnerabilities & Trivy Image Scanning Demo | K21Academy](https://youtu.be/gHz10UsEdys)
 
 ### Aqua Security Blog posts to learn more


### PR DESCRIPTION
## Description
Hi, 
The link provided for the **CKS exam study guide** gave the 404 (File not found) error. I checked and found that there was a problem with the format, so I corrected it. 

https://aquasecurity.github.io/trivy/v0.41/tutorials/additional-resources/cks/


Regards,

