### PR TITLE
docs: Fix Install from source

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -133,7 +133,7 @@ curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/inst
 
 ```bash
 git clone --depth 1 --branch {{ git.tag }} https://github.com/aquasecurity/trivy
-cd trivy
+cd trivy/cmd/trivy
 go install
 ```
 


### PR DESCRIPTION
`cd` to the proper directory before running `go install`.