### PR TITLE
fix(misconf): Remove debug print while scanning

### DIFF
--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -199,7 +198,6 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 	opts := []options.ScannerOption{
 		options.ScannerWithSkipRequiredCheck(true),
 		options.ScannerWithEmbeddedPolicies(!opt.DisableEmbeddedPolicies),
-		options.ScannerWithDebug(os.Stdout),
 	}
 
 	policyFS, policyPaths, err := createPolicyFS(opt.PolicyPaths)


### PR DESCRIPTION
## Description

A small debug print was leftover, this PR removes it.


Signed-off-by: Simar <simar@linux.com>