### PR TITLE
feat(ubuntu): add eol date for 18.04 ESM

### DIFF
--- a/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
+++ b/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
@@ -5,7 +5,8 @@
   "Metadata": {
     "OS": {
       "Family": "ubuntu",
-      "Name": "18.04"
+      "Name": "18.04",
+      "Eosl": true
     },
     "ImageID": "sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12",
     "DiffIDs": [

--- a/integration/testdata/ubuntu-1804.json.golden
+++ b/integration/testdata/ubuntu-1804.json.golden
@@ -5,7 +5,8 @@
   "Metadata": {
     "OS": {
       "Family": "ubuntu",
-      "Name": "18.04"
+      "Name": "18.04",
+      "Eosl": true
     },
     "ImageID": "sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12",
     "DiffIDs": [

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -48,6 +48,7 @@ var (
 		"17.04":     time.Date(2018, 1, 13, 23, 59, 59, 0, time.UTC),
 		"17.10":     time.Date(2018, 7, 19, 23, 59, 59, 0, time.UTC),
 		"18.04":     time.Date(2023, 5, 31, 23, 59, 59, 0, time.UTC),
+		"18.04-ESM": time.Date(2028, 3, 31, 23, 59, 59, 0, time.UTC),
 		"18.10":     time.Date(2019, 7, 18, 23, 59, 59, 0, time.UTC),
 		"19.04":     time.Date(2020, 1, 18, 23, 59, 59, 0, time.UTC),
 		"19.10":     time.Date(2020, 7, 17, 23, 59, 59, 0, time.UTC),


### PR DESCRIPTION
## Description
Add eol date for 18.04 ESM.
Also fix test golden file for ubuntu 18.04 (ended yesterday)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
