### PR TITLE
refactor: add composite fs for post-analyzers

### DIFF
--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/javadb"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
-	"github.com/aquasecurity/trivy/pkg/syncx"
 
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/imgconf/apk"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/java/jar"
@@ -608,10 +607,12 @@ func TestAnalyzerGroup_PostAnalyze(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a virtual filesystem
-			files := new(syncx.Map[analyzer.Type, *mapfs.FS])
+			composite, err := analyzer.NewCompositeFS(analyzer.AnalyzerGroup{})
+			require.NoError(t, err)
+
 			mfs := mapfs.New()
 			require.NoError(t, mfs.CopyFilesUnder(tt.dir))
-			files.Store(tt.analyzerType, mfs)
+			composite.Set(tt.analyzerType, mfs)
 
 			if tt.analyzerType == analyzer.TypeJar {
 				// init java-trivy-db with skip update
@@ -620,7 +621,7 @@ func TestAnalyzerGroup_PostAnalyze(t *testing.T) {
 
 			ctx := context.Background()
 			got := new(analyzer.AnalysisResult)
-			err = a.PostAnalyze(ctx, files, got, analyzer.AnalysisOptions{})
+			err = a.PostAnalyze(ctx, composite, got, analyzer.AnalysisOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -1,0 +1,124 @@
+package analyzer
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/mapfs"
+	"github.com/aquasecurity/trivy/pkg/syncx"
+)
+
+// CompositeFS contains multiple filesystems for post-analyzers
+type CompositeFS struct {
+	group AnalyzerGroup
+	dir   string
+	files *syncx.Map[Type, *mapfs.FS]
+}
+
+func NewCompositeFS(group AnalyzerGroup) (*CompositeFS, error) {
+	tmpDir, err := os.MkdirTemp("", "analyzer-fs-*")
+	if err != nil {
+		return nil, xerrors.Errorf("unable to create temporary directory: %w", err)
+	}
+
+	return &CompositeFS{
+		group: group,
+		dir:   tmpDir,
+		files: new(syncx.Map[Type, *mapfs.FS]),
+	}, nil
+}
+
+// Write takes a file path and information, opens the file, copies its contents to a temporary file,
+// and writes it to the virtual filesystem of each post-analyzer that requires the file.
+func (c *CompositeFS) Write(filePath string, info os.FileInfo, opener Opener) error {
+	// Get all post-analyzers that want to analyze the file
+	atypes := c.group.RequiredPostAnalyzers(filePath, info)
+	if len(atypes) == 0 {
+		return nil
+	}
+
+	// Create a temporary file to which the file in the layer will be copied
+	// so that all the files will not be loaded into memory
+	f, err := os.CreateTemp(c.dir, "file-*")
+	if err != nil {
+		return xerrors.Errorf("create temp error: %w", err)
+	}
+	defer f.Close()
+
+	// Open a file in the layer
+	r, err := opener()
+	if err != nil {
+		return xerrors.Errorf("file open error: %w", err)
+	}
+	defer r.Close()
+
+	// Copy file content into the temporary file
+	if _, err = io.Copy(f, r); err != nil {
+		return xerrors.Errorf("copy error: %w", err)
+	}
+
+	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
+		return xerrors.Errorf("chmod error: %w", err)
+	}
+
+	// Create fs.FS for each post-analyzer that wants to analyze the current file
+	for _, a := range analyzers {
+		analyzerFS, _ := c.files.LoadOrStore(a.Type(), mapfs.New())
+		if dir := filepath.Dir(filePath); dir != "." {
+			if err = analyzerFS.MkdirAll(dir, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
+				return xerrors.Errorf("mapfs mkdir error: %w", err)
+			}
+		}
+		err = analyzerFS.WriteFile(filePath, f.Name())
+		if err != nil {
+			return xerrors.Errorf("mapfs write error: %w", err)
+		}
+	}
+	return nil
+}
+
+// CreateLink creates a link in the virtual filesystem that corresponds to a real file.
+// The linked virtual file will have the same path as the real file path provided.
+func (c *CompositeFS) CreateLink(dir, filePath string, info os.FileInfo) error {
+	// Get all post-analyzers that want to analyze the file
+	atypes := c.group.RequiredPostAnalyzers(filePath, info)
+	if len(atypes) == 0 {
+		return nil
+	}
+
+	// Create fs.FS for each post-analyzer that wants to analyze the current file
+	for _, at := range atypes {
+		// Since filesystem scanning may require access outside the specified path, (e.g. Terraform modules)
+		// it allows "../" access with "WithUnderlyingRoot".
+		mfs, _ := c.files.LoadOrStore(at, mapfs.New(mapfs.WithUnderlyingRoot(dir)))
+		if d := filepath.Dir(filePath); d != "." {
+			if err := mfs.MkdirAll(d, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
+				return xerrors.Errorf("mapfs mkdir error: %w", err)
+			}
+		}
+		if err := mfs.WriteFile(filePath, filepath.Join(dir, filePath)); err != nil {
+			return xerrors.Errorf("mapfs write error: %w", err)
+		}
+	}
+	return nil
+}
+
+// Set sets the fs.FS for the specified post-analyzer
+func (c *CompositeFS) Set(t Type, fs *mapfs.FS) {
+	c.files.Store(t, fs)
+}
+
+// Get returns the fs.FS for the specified post-analyzer
+func (c *CompositeFS) Get(t Type) (*mapfs.FS, bool) {
+	return c.files.Load(t)
+}
+
+// Cleanup removes the temporary directory
+func (c *CompositeFS) Cleanup() error {
+	return os.RemoveAll(c.dir)
+}

--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -67,8 +67,8 @@ func (c *CompositeFS) Write(filePath string, info os.FileInfo, opener Opener) er
 	}
 
 	// Create fs.FS for each post-analyzer that wants to analyze the current file
-	for _, a := range analyzers {
-		analyzerFS, _ := c.files.LoadOrStore(a.Type(), mapfs.New())
+	for _, a := range atypes {
+		analyzerFS, _ := c.files.LoadOrStore(a, mapfs.New())
 		if dir := filepath.Dir(filePath); dir != "." {
 			if err = analyzerFS.MkdirAll(dir, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
 				return xerrors.Errorf("mapfs mkdir error: %w", err)

--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 
 	"golang.org/x/xerrors"
@@ -33,75 +34,53 @@ func NewCompositeFS(group AnalyzerGroup) (*CompositeFS, error) {
 	}, nil
 }
 
-// Write takes a file path and information, opens the file, copies its contents to a temporary file,
-// and writes it to the virtual filesystem of each post-analyzer that requires the file.
-func (c *CompositeFS) Write(filePath string, info os.FileInfo, opener Opener) error {
-	// Get all post-analyzers that want to analyze the file
-	atypes := c.group.RequiredPostAnalyzers(filePath, info)
-	if len(atypes) == 0 {
-		return nil
-	}
-
+// CopyFileToTemp takes a file path and information, opens the file, copies its contents to a temporary file
+func (c *CompositeFS) CopyFileToTemp(opener Opener, info os.FileInfo) (string, error) {
 	// Create a temporary file to which the file in the layer will be copied
 	// so that all the files will not be loaded into memory
 	f, err := os.CreateTemp(c.dir, "file-*")
 	if err != nil {
-		return xerrors.Errorf("create temp error: %w", err)
+		return "", xerrors.Errorf("create temp error: %w", err)
 	}
 	defer f.Close()
 
 	// Open a file in the layer
 	r, err := opener()
 	if err != nil {
-		return xerrors.Errorf("file open error: %w", err)
+		return "", xerrors.Errorf("file open error: %w", err)
 	}
 	defer r.Close()
 
 	// Copy file content into the temporary file
 	if _, err = io.Copy(f, r); err != nil {
-		return xerrors.Errorf("copy error: %w", err)
+		return "", xerrors.Errorf("copy error: %w", err)
 	}
 
 	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
-		return xerrors.Errorf("chmod error: %w", err)
+		return "", xerrors.Errorf("chmod error: %w", err)
 	}
 
-	// Create fs.FS for each post-analyzer that wants to analyze the current file
-	for _, a := range atypes {
-		analyzerFS, _ := c.files.LoadOrStore(a, mapfs.New())
-		if dir := filepath.Dir(filePath); dir != "." {
-			if err = analyzerFS.MkdirAll(dir, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
-				return xerrors.Errorf("mapfs mkdir error: %w", err)
-			}
-		}
-		err = analyzerFS.WriteFile(filePath, f.Name())
-		if err != nil {
-			return xerrors.Errorf("mapfs write error: %w", err)
-		}
-	}
-	return nil
+	return f.Name(), nil
 }
 
 // CreateLink creates a link in the virtual filesystem that corresponds to a real file.
 // The linked virtual file will have the same path as the real file path provided.
-func (c *CompositeFS) CreateLink(dir, filePath string, info os.FileInfo) error {
-	// Get all post-analyzers that want to analyze the file
-	atypes := c.group.RequiredPostAnalyzers(filePath, info)
-	if len(atypes) == 0 {
-		return nil
-	}
-
+func (c *CompositeFS) CreateLink(analyzerTypes []Type, virtualPath, realPath string, setRoot bool) error {
 	// Create fs.FS for each post-analyzer that wants to analyze the current file
-	for _, at := range atypes {
+	for _, t := range analyzerTypes {
 		// Since filesystem scanning may require access outside the specified path, (e.g. Terraform modules)
 		// it allows "../" access with "WithUnderlyingRoot".
-		mfs, _ := c.files.LoadOrStore(at, mapfs.New(mapfs.WithUnderlyingRoot(dir)))
-		if d := filepath.Dir(filePath); d != "." {
+		var opts []mapfs.Option
+		if setRoot {
+			opts = append(opts, mapfs.WithUnderlyingRoot(filepath.Dir(realPath)))
+		}
+		mfs, _ := c.files.LoadOrStore(t, mapfs.New(opts...))
+		if d := path.Dir(virtualPath); d != "." {
 			if err := mfs.MkdirAll(d, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
 				return xerrors.Errorf("mapfs mkdir error: %w", err)
 			}
 		}
-		if err := mfs.WriteFile(filePath, filepath.Join(dir, filePath)); err != nil {
+		if err := mfs.WriteFile(virtualPath, realPath); err != nil {
 			return xerrors.Errorf("mapfs write error: %w", err)
 		}
 	}

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -283,7 +283,12 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 		}
 
 		// Build filesystem for post analysis
-		if err = composite.Write(filePath, info, opener); err != nil {
+		tmpFilePath, err := composite.CopyFileToTemp(opener, info)
+		if err != nil {
+			return xerrors.Errorf("failed to copy file to temp: %w", err)
+		}
+		analyzerTypes := a.analyzer.RequiredPostAnalyzers(filePath, info)
+		if err = composite.CreateLink(analyzerTypes, filePath, tmpFilePath, false); err != nil {
 			return xerrors.Errorf("failed to write a file: %w", err)
 		}
 

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -147,7 +147,8 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 		}
 
 		// Build filesystem for post analysis
-		if err = composite.CreateLink(dir, filePath, info); err != nil {
+		analyzerTypes := a.analyzer.RequiredPostAnalyzers(filePath, info)
+		if err = composite.CreateLink(analyzerTypes, filePath, filepath.Join(dir, filePath), true); err != nil {
 			return xerrors.Errorf("failed to create link: %w", err)
 		}
 

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,9 +19,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"github.com/aquasecurity/trivy/pkg/log"
-	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"github.com/aquasecurity/trivy/pkg/semaphore"
-	"github.com/aquasecurity/trivy/pkg/syncx"
 )
 
 type Artifact struct {
@@ -132,9 +128,12 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 	}
 
 	// Prepare filesystem for post analysis
-	files := new(syncx.Map[analyzer.Type, *mapfs.FS])
+	composite, err := a.analyzer.PostAnalyzerFS()
+	if err != nil {
+		return types.ArtifactReference{}, xerrors.Errorf("failed to prepare filesystem for post analysis: %w", err)
+	}
 
-	err := a.walker.Walk(a.rootPath, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
+	err = a.walker.Walk(a.rootPath, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
 		dir := a.rootPath
 
 		// When the directory is the same as the filePath, a file was given
@@ -143,13 +142,13 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 			dir, filePath = filepath.Split(a.rootPath)
 		}
 
-		if err := a.analyzer.AnalyzeFile(ctx, &wg, limit, result, dir, filePath, info, opener, nil, opts); err != nil {
+		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, dir, filePath, info, opener, nil, opts); err != nil {
 			return xerrors.Errorf("analyze file (%s): %w", filePath, err)
 		}
 
 		// Build filesystem for post analysis
-		if err := a.buildFS(dir, filePath, info, files); err != nil {
-			return xerrors.Errorf("failed to build filesystem: %w", err)
+		if err = composite.CreateLink(dir, filePath, info); err != nil {
+			return xerrors.Errorf("failed to create link: %w", err)
 		}
 
 		return nil
@@ -162,7 +161,7 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 	wg.Wait()
 
 	// Post-analysis
-	if err = a.analyzer.PostAnalyze(ctx, files, result, opts); err != nil {
+	if err = a.analyzer.PostAnalyze(ctx, composite, result, opts); err != nil {
 		return types.ArtifactReference{}, xerrors.Errorf("post analysis error: %w", err)
 	}
 
@@ -230,29 +229,4 @@ func (a Artifact) calcCacheKey(blobInfo types.BlobInfo) (string, error) {
 	}
 
 	return cacheKey, nil
-}
-
-// buildFS creates filesystem for post analysis
-func (a Artifact) buildFS(dir, filePath string, info os.FileInfo, files *syncx.Map[analyzer.Type, *mapfs.FS]) error {
-	// Get all post-analyzers that want to analyze the file
-	atypes := a.analyzer.RequiredPostAnalyzers(filePath, info)
-	if len(atypes) == 0 {
-		return nil
-	}
-
-	// Create fs.FS for each post-analyzer that wants to analyze the current file
-	for _, at := range atypes {
-		// Since filesystem scanning may require access outside the specified path, (e.g. Terraform modules)
-		// it allows "../" access with "WithUnderlyingRoot".
-		mfs, _ := files.LoadOrStore(at, mapfs.New(mapfs.WithUnderlyingRoot(dir)))
-		if d := filepath.Dir(filePath); d != "." {
-			if err := mfs.MkdirAll(d, os.ModePerm); err != nil && !errors.Is(err, fs.ErrExist) {
-				return xerrors.Errorf("mapfs mkdir error: %w", err)
-			}
-		}
-		if err := mfs.WriteFile(filePath, filepath.Join(dir, filePath)); err != nil {
-			return xerrors.Errorf("mapfs write error: %w", err)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
## Description
Add composite filesystem for post-analyzers so that artifacts can share the fs implementation.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/4544

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
