### PR TITLE
fix(sbom): export empty dependencies in CycloneDX

### DIFF
--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -141,7 +141,7 @@ func (c *CycloneDX) MarshalComponent(component *Component, components map[string
 		}
 	}
 
-	var dependencies []string
+	dependencies := make([]string, 0) // Components that do not have their own dependencies must be declared as empty elements
 	for _, child := range component.Components {
 		childComponent := c.MarshalComponent(child, components, deps, vulns)
 		dependencies = append(dependencies, childComponent.BOMRef)

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -456,15 +456,15 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:gem/actionpack@7.0.0",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
 						Ref:          "pkg:golang/golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
 						Ref:          "pkg:nuget/Newtonsoft.Json@9.0.1",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
 						Ref: "pkg:oci/rails@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177?repository_url=index.docker.io%2Flibrary%2Frails&arch=arm64",
@@ -478,7 +478,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 				},
 				Vulnerabilities: &[]cdx.Vulnerability{
@@ -932,11 +932,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:gem/actionpack@7.0.0?file_path=tools%2Fproject-john%2Fspecifications%2Factionpack.gemspec",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
 						Ref:          "pkg:gem/actionpack@7.0.1?file_path=tools%2Fproject-doe%2Fspecifications%2Factionpack.gemspec",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
 						Ref: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
@@ -946,7 +946,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 				},
 				Vulnerabilities: &[]cdx.Vulnerability{
@@ -1120,7 +1120,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:gem/actioncable@6.1.4.1",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 				},
 			},
@@ -1218,7 +1218,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					{
 						Ref:          "pkg:npm/ruby-typeprof@0.20.1?file_path=usr%2Flocal%2Flib%2Fruby%2Fgems%2F3.1.0%2Fgems%2Ftypeprof-0.21.1%2Fvscode%2Fpackage.json",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 				},
 			},
@@ -1263,7 +1263,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				Dependencies: &[]cdx.Dependency{
 					{
 						Ref:          "3ff14136-e09f-4df9-80ea-000000000002",
-						Dependencies: lo.ToPtr([]string(nil)),
+						Dependencies: lo.ToPtr([]string{}),
 					},
 				},
 			},


### PR DESCRIPTION
## Description
According to the CycloneDx [documentation](https://cyclonedx.org/docs/1.4/json/#dependencies): Components that do not have their own dependencies MUST be declared as empty elements within the graph.
## Related issues
- Close #3663 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
