### PR TITLE
fix(purl): skip unsupported library type

### DIFF
--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -13,7 +13,7 @@ import (
 func Detect(libType string, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	driver, err := NewDriver(libType)
 	if err != nil {
-		if errors.Is(err, ErrSBOMSupportOnly) {
+		if errors.Is(err, ErrSBOMSupportOnly) || errors.Is(err, ErrUnsupportedType) {
 			return nil, nil
 		}
 		return nil, xerrors.Errorf("failed to initialize a driver: %w", err)

--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -1,8 +1,6 @@
 package library
 
 import (
-	"errors"
-
 	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -11,12 +9,9 @@ import (
 
 // Detect scans and returns vulnerabilities of library
 func Detect(libType string, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	driver, err := NewDriver(libType)
-	if err != nil {
-		if errors.Is(err, ErrSBOMSupportOnly) || errors.Is(err, ErrUnsupportedType) {
-			return nil, nil
-		}
-		return nil, xerrors.Errorf("failed to initialize a driver: %w", err)
+	driver, ok := NewDriver(libType)
+	if !ok {
+		return nil, nil
 	}
 
 	vulns, err := detect(driver, pkgs)

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -20,6 +20,7 @@ import (
 )
 
 var ErrSBOMSupportOnly = xerrors.New("SBOM support only")
+var ErrUnsupportedType = xerrors.New("Unsupported type")
 
 // NewDriver returns a driver according to the library type
 func NewDriver(libType string) (Driver, error) {
@@ -69,7 +70,8 @@ func NewDriver(libType string) (Driver, error) {
 		log.Logger.Warn("Conda package is supported for SBOM, not for vulnerability scanning")
 		return Driver{}, ErrSBOMSupportOnly
 	default:
-		return Driver{}, xerrors.Errorf("unsupported type %s", libType)
+		log.Logger.Warnf("The %s library type is not supported. Skipping vulnerability detection", libType)
+		return Driver{}, ErrUnsupportedType
 	}
 	return Driver{
 		ecosystem: ecosystem,

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -19,11 +19,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-var ErrSBOMSupportOnly = xerrors.New("SBOM support only")
-var ErrUnsupportedType = xerrors.New("Unsupported type")
-
 // NewDriver returns a driver according to the library type
-func NewDriver(libType string) (Driver, error) {
+func NewDriver(libType string) (Driver, bool) {
 	var ecosystem dbTypes.Ecosystem
 	var comparer compare.Comparer
 
@@ -65,19 +62,19 @@ func NewDriver(libType string) (Driver, error) {
 		comparer = compare.GenericComparer{}
 	case ftypes.Cocoapods:
 		log.Logger.Warn("CocoaPods is supported for SBOM, not for vulnerability scanning")
-		return Driver{}, ErrSBOMSupportOnly
+		return Driver{}, false
 	case ftypes.CondaPkg:
 		log.Logger.Warn("Conda package is supported for SBOM, not for vulnerability scanning")
-		return Driver{}, ErrSBOMSupportOnly
+		return Driver{}, false
 	default:
 		log.Logger.Warnf("The %s library type is not supported. Skipping vulnerability detection", libType)
-		return Driver{}, ErrUnsupportedType
+		return Driver{}, false
 	}
 	return Driver{
 		ecosystem: ecosystem,
 		comparer:  comparer,
 		dbc:       db.Config{},
-	}, nil
+	}, true
 }
 
 // Driver represents security advisories for each programming language

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -67,7 +67,7 @@ func NewDriver(libType string) (Driver, bool) {
 		log.Logger.Warn("Conda package is supported for SBOM, not for vulnerability scanning")
 		return Driver{}, false
 	default:
-		log.Logger.Warnf("The %s library type is not supported. Skipping vulnerability detection", libType)
+		log.Logger.Warnf("The %q library type is not supported for vulnerability scanning", libType)
 		return Driver{}, false
 	}
 	return Driver{

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -164,8 +164,8 @@ func TestDriver_Detect(t *testing.T) {
 			_ = dbtest.InitDB(t, tt.fixtures)
 			defer db.Close()
 
-			driver, err := library.NewDriver(tt.libType)
-			require.NoError(t, err)
+			driver, ok := library.NewDriver(tt.libType)
+			require.True(t, ok)
 
 			got, err := driver.DetectVulnerabilities("", tt.args.pkgName, tt.args.pkgVer)
 			if tt.wantErr != "" {


### PR DESCRIPTION
## Description

I think we can skip dependency detection for an unsupported library type, rather than throwing an error and stopping scanning.

Before:
```bash
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:0.42.0 image docker.io/bitnami/rabbitmq:3.11.17-debian-11-r2 --debug
2023-06-07T06:22:02.716Z	DEBUG	Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2023-06-07T06:22:02.718Z	DEBUG	cache dir:  /root/.cache/trivy
2023-06-07T06:22:02.719Z	DEBUG	DB update was skipped because the local DB is the latest
2023-06-07T06:22:02.719Z	DEBUG	DB Schema: 2, UpdatedAt: 2023-06-07 06:07:05.537434966 +0000 UTC, NextUpdate: 2023-06-07 12:07:05.537434566 +0000 UTC, DownloadedAt: 2023-06-07 06:22:00.465958296 +0000 UTC
2023-06-07T06:22:02.719Z	INFO	Vulnerability scanning is enabled
2023-06-07T06:22:02.719Z	DEBUG	Vulnerability type:  [os library]
2023-06-07T06:22:02.719Z	INFO	Secret scanning is enabled
2023-06-07T06:22:02.719Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-06-07T06:22:02.719Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.42/docs/secret/scanning/#recommendation for faster secret detection
2023-06-07T06:22:02.725Z	DEBUG	No secret config detected: trivy-secret.yaml
2023-06-07T06:22:02.726Z	DEBUG	Image ID: sha256:c380a14b64f7d96b1a66f20f372ed0f4005ac6fe9295a7d66ec6d0a849d58fb9
2023-06-07T06:22:02.726Z	DEBUG	Diff IDs: [sha256:bd543f134be8b19df8d7f3fe385989200bd3dfac2ea09f8781f3c4c234dc754c]
2023-06-07T06:22:02.726Z	DEBUG	Base Layers: []
2023-06-07T06:22:02.730Z	INFO	Detected OS: debian
2023-06-07T06:22:02.730Z	INFO	Detecting Debian vulnerabilities...
2023-06-07T06:22:02.731Z	DEBUG	debian: os version: 11
2023-06-07T06:22:02.731Z	DEBUG	debian: the number of packages: 111
2023-06-07T06:22:02.741Z	INFO	Number of language-specific files: 1
2023-06-07T06:22:02.741Z	INFO	Detecting bitnami vulnerabilities...
2023-06-07T06:22:02.741Z	DEBUG	Detecting library vulnerabilities, type: bitnami, path: opt/bitnami/rabbitmq/bin/rabbitmq
2023-06-07T06:22:02.741Z	FATAL	image scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.Run
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:426
  - scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:268
  - scan failed:
    github.com/aquasecurity/trivy/pkg/commands/artifact.scan
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:683
  - scan failed:
    github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact
        /home/runner/work/trivy/trivy/pkg/scanner/scan.go:154
  - failed to detect vulnerabilities:
    github.com/aquasecurity/trivy/pkg/scanner/local.Scanner.Scan
        /home/runner/work/trivy/trivy/pkg/scanner/local/scan.go:102
  - failed to scan application libraries:
    github.com/aquasecurity/trivy/pkg/scanner/local.Scanner.scanVulnerabilities
        /home/runner/work/trivy/trivy/pkg/scanner/local/scan.go:189
  - failed vulnerability detection of libraries:
    github.com/aquasecurity/trivy/pkg/scanner/langpkg.(*scanner).Scan
        /home/runner/work/trivy/trivy/pkg/scanner/langpkg/scan.go:80
  - failed to initialize a driver:
    github.com/aquasecurity/trivy/pkg/detector/library.Detect
        /home/runner/work/trivy/trivy/pkg/detector/library/detect.go:19
  - unsupported type bitnami:
    github.com/aquasecurity/trivy/pkg/detector/library.NewDriver
        /home/runner/work/trivy/trivy/pkg/detector/library/driver.go:72
```

After:
```bash
2023-06-07T12:23:37.512+0600	DEBUG	Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2023-06-07T12:23:37.527+0600	DEBUG	cache dir:  /Users/tososomaru/Library/Caches/trivy
2023-06-07T12:23:37.527+0600	DEBUG	DB update was skipped because the local DB is the latest
2023-06-07T12:23:37.527+0600	DEBUG	DB Schema: 2, UpdatedAt: 2023-06-07 06:07:05.537434966 +0000 UTC, NextUpdate: 2023-06-07 12:07:05.537434566 +0000 UTC, DownloadedAt: 2023-06-07 06:22:00.465958296 +0000 UTC
2023-06-07T12:23:37.527+0600	INFO	Vulnerability scanning is enabled
2023-06-07T12:23:37.527+0600	DEBUG	Vulnerability type:  [os library]
2023-06-07T12:23:37.527+0600	INFO	Secret scanning is enabled
2023-06-07T12:23:37.527+0600	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-06-07T12:23:37.527+0600	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
2023-06-07T12:23:37.559+0600	DEBUG	No secret config detected: trivy-secret.yaml
2023-06-07T12:23:37.559+0600	DEBUG	Image ID: sha256:c380a14b64f7d96b1a66f20f372ed0f4005ac6fe9295a7d66ec6d0a849d58fb9
2023-06-07T12:23:37.559+0600	DEBUG	Diff IDs: [sha256:bd543f134be8b19df8d7f3fe385989200bd3dfac2ea09f8781f3c4c234dc754c]
2023-06-07T12:23:37.559+0600	DEBUG	Base Layers: []
2023-06-07T12:23:37.566+0600	INFO	Detected OS: debian
2023-06-07T12:23:37.566+0600	INFO	Detecting Debian vulnerabilities...
2023-06-07T12:23:37.566+0600	DEBUG	debian: os version: 11
2023-06-07T12:23:37.566+0600	DEBUG	debian: the number of packages: 111
2023-06-07T12:23:37.587+0600	INFO	Number of language-specific files: 1
2023-06-07T12:23:37.587+0600	INFO	Detecting bitnami vulnerabilities...
2023-06-07T12:23:37.587+0600	DEBUG	Detecting library vulnerabilities, type: bitnami, path: opt/bitnami/rabbitmq/bin/rabbitmq
2023-06-07T12:23:37.587+0600	WARN	The bitnami library type is not supported. Skipping vulnerability detection

docker.io/bitnami/rabbitmq:3.11.17-debian-11-r2 (debian 11.7)
=============================================================
Total: 119 (UNKNOWN: 0, LOW: 85, MEDIUM: 6, HIGH: 23, CRITICAL: 5)
....
```

## Related issues
- Close #4566 
- Close #3994 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
