### PR TITLE
fix(misconf): deduplicate terraform results

### DIFF
--- a/pkg/fanal/types/misconf.go
+++ b/pkg/fanal/types/misconf.go
@@ -3,6 +3,8 @@ package types
 import (
 	"fmt"
 	"sort"
+
+	"github.com/samber/lo"
 )
 
 type Misconfiguration struct {
@@ -101,6 +103,8 @@ func ToMisconfigurations(misconfs map[string]Misconfiguration) []Misconfiguratio
 	for _, misconf := range misconfs {
 		// Remove duplicates
 		misconf.Successes = uniqueResults(misconf.Successes)
+		misconf.Warnings = uniqueResults(misconf.Warnings)
+		misconf.Failures = uniqueResults(misconf.Failures)
 
 		// Sort results
 		sort.Sort(misconf.Successes)
@@ -123,15 +127,11 @@ func ToMisconfigurations(misconfs map[string]Misconfiguration) []Misconfiguratio
 }
 
 func uniqueResults(results []MisconfResult) []MisconfResult {
-	uniq := map[string]MisconfResult{}
-	for _, result := range results {
-		key := fmt.Sprintf("%s::%s::%s", result.ID, result.Namespace, result.Message)
-		uniq[key] = result
+	if len(results) == 0 {
+		return results
 	}
-
-	var uniqResults []MisconfResult
-	for _, s := range uniq {
-		uniqResults = append(uniqResults, s)
-	}
-	return uniqResults
+	return lo.UniqBy(results, func(result MisconfResult) string {
+		return fmt.Sprintf("ID: %s, Namespace: %s, Messsage: %s, Cause: %v",
+			result.ID, result.Namespace, result.Message, result.CauseMetadata)
+	})
 }


### PR DESCRIPTION
## Description
https://github.com/aquasecurity/trivy/pull/4457 caused duplicate misconfiguration results to be returned since all the nested terraform files are detected now.

This PR deduplicates terraform results.

## Related PRs
- #4457

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
