### PR TITLE
ci: do not trigger tests in main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,6 @@
 name: Test
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Description
All PRs are merged through the merge queue now. And tests are triggered by the `merge_group` event and must pass before merging.
https://github.com/aquasecurity/trivy/actions?query=event%3Amerge_group

Triggering tests in the main branch is no longer needed as it is already done with `merge_group`. Please see the attached screenshot. The same tests are running with `merge_group` and `push`.
![image](https://github.com/aquasecurity/trivy/assets/2253692/82c11443-15bb-4065-bae2-285f396fe31b)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
