### PR TITLE
ci: update the images release

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -147,7 +147,7 @@ dockers:
     goos: linux
     goarch: amd64
     ids:
-      - trivy
+      - build-linux
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
@@ -172,7 +172,7 @@ dockers:
     goos: linux
     goarch: arm64
     ids:
-      - trivy
+      - build-linux
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
@@ -197,7 +197,7 @@ dockers:
     goos: linux
     goarch: s390x
     ids:
-      - trivy
+      - build-linux
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
@@ -222,7 +222,7 @@ dockers:
     goos: linux
     goarch: ppc64le
     ids:
-      - trivy
+      - build-linux
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"


### PR DESCRIPTION
## Description
The ID for the Linux build was modified in #4587. 
Previously, [the default ID](https://goreleaser.com/customization/builds/) was based on the binary name.

Therefore, it is necessary to update the IDs for building and pushing Docker images.

these updates were tested [here](https://github.com/afdesk/trivy/actions/runs/5277973742). 
 
## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
