### PR TITLE
fix(debian): update EOL for Debian 12

### DIFF
--- a/docs/docs/scanner/vulnerability/os.md
+++ b/docs/docs/scanner/vulnerability/os.md
@@ -9,25 +9,25 @@ To hide unfixed/unfixable vulnerabilities, you can use the `--ignore-unfixed` fl
 
 Trivy doesn't support self-compiled packages/binaries, but official packages provided by vendors such as Red Hat and Debian.
 
-| OS                               | Supported Versions                        | Target Packages               | Detection of unfixed vulnerabilities |
-|----------------------------------|-------------------------------------------|-------------------------------|:------------------------------------:|
-| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.18, edge               | Installed by apk              |                  NO                  |
-| Wolfi Linux                      | (n/a)                                     | Installed by apk              |                  NO                  |
-| Chainguard                       | (n/a)                                     | Installed by apk              |                  NO                  |
-| Red Hat Universal Base Image[^1] | 7, 8, 9                                   | Installed by yum/rpm          |                 YES                  |
-| Red Hat Enterprise Linux         | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
-| CentOS                           | 6, 7, 8                                   | Installed by yum/rpm          |                 YES                  |
-| AlmaLinux                        | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
-| Rocky Linux                      | 8, 9                                      | Installed by yum/rpm          |                  NO                  |
-| Oracle Linux                     | 5, 6, 7, 8                                | Installed by yum/rpm          |                  NO                  |
-| CBL-Mariner                      | 1.0, 2.0                                  | Installed by yum/rpm          |                 YES                  |
-| Amazon Linux                     | 1, 2, 2023                                | Installed by yum/rpm          |                  NO                  |
-| openSUSE Leap                    | 42, 15                                    | Installed by zypper/rpm       |                  NO                  |
-| SUSE Enterprise Linux            | 11, 12, 15                                | Installed by zypper/rpm       |                  NO                  |
-| Photon OS                        | 1.0, 2.0, 3.0, 4.0                        | Installed by tdnf/yum/rpm     |                  NO                  |
-| Debian GNU/Linux                 | wheezy, jessie, stretch, buster, bullseye | Installed by apt/apt-get/dpkg |                 YES                  |
-| Ubuntu                           | All versions supported by Canonical       | Installed by apt/apt-get/dpkg |                 YES                  |
-| Distroless[^2]                   | Any                                       | Installed by apt/apt-get/dpkg |                 YES                  |
+| OS                               | Supported Versions                  | Target Packages               | Detection of unfixed vulnerabilities |
+|----------------------------------|-------------------------------------|-------------------------------|:------------------------------------:|
+| Alpine Linux                     | 2.2 - 2.7, 3.0 - 3.18, edge         | Installed by apk              |                  NO                  |
+| Wolfi Linux                      | (n/a)                               | Installed by apk              |                  NO                  |
+| Chainguard                       | (n/a)                               | Installed by apk              |                  NO                  |
+| Red Hat Universal Base Image[^1] | 7, 8, 9                             | Installed by yum/rpm          |                 YES                  |
+| Red Hat Enterprise Linux         | 6, 7, 8                             | Installed by yum/rpm          |                 YES                  |
+| CentOS                           | 6, 7, 8                             | Installed by yum/rpm          |                 YES                  |
+| AlmaLinux                        | 8, 9                                | Installed by yum/rpm          |                  NO                  |
+| Rocky Linux                      | 8, 9                                | Installed by yum/rpm          |                  NO                  |
+| Oracle Linux                     | 5, 6, 7, 8                          | Installed by yum/rpm          |                  NO                  |
+| CBL-Mariner                      | 1.0, 2.0                            | Installed by yum/rpm          |                 YES                  |
+| Amazon Linux                     | 1, 2, 2023                          | Installed by yum/rpm          |                  NO                  |
+| openSUSE Leap                    | 42, 15                              | Installed by zypper/rpm       |                  NO                  |
+| SUSE Enterprise Linux            | 11, 12, 15                          | Installed by zypper/rpm       |                  NO                  |
+| Photon OS                        | 1.0, 2.0, 3.0, 4.0                  | Installed by tdnf/yum/rpm     |                  NO                  |
+| Debian GNU/Linux                 | 7, 8, 9, 10, 11, 12                 | Installed by apt/apt-get/dpkg |                 YES                  |
+| Ubuntu                           | All versions supported by Canonical | Installed by apt/apt-get/dpkg |                 YES                  |
+| Distroless[^2]                   | Any                                 | Installed by apt/apt-get/dpkg |                 YES                  |
 
 ## Data Sources
 

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -36,7 +36,8 @@ var (
 		"9":   time.Date(2022, 6, 30, 23, 59, 59, 0, time.UTC),
 		"10":  time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		"11":  time.Date(2026, 8, 14, 23, 59, 59, 0, time.UTC),
-		"12":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"12":  time.Date(2028, 6, 10, 23, 59, 59, 0, time.UTC),
+		"13":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION
## Description

Debian 12 was released on 2023-06-10 and will be supported for five years - see https://www.debian.org/News/2023/20230610.

## Related issues

- #4646

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
