### PR TITLE
docs: add `--file-patterns` definition format to the error message

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -326,7 +326,7 @@ func NewAnalyzerGroup(opt AnalyzerOptions) (AnalyzerGroup, error) {
 		// e.g. "dockerfile:my_dockerfile_*"
 		s := strings.SplitN(p, separator, 2)
 		if len(s) != 2 {
-			return group, xerrors.Errorf("invalid file pattern (%s)", p)
+			return group, xerrors.Errorf("invalid file pattern (%s) expected format: \"fileType:regexPattern\" e.g. \"dockerfile:my_dockerfile_*\"", p)
 		}
 
 		fileType, pattern := s[0], s[1]


### PR DESCRIPTION
Currently, the information for running `trivy config --file-patterns xxx` is documented in the [source code](https://github.com/aquasecurity/trivy/blob/d7637adc6b59951900870faf4622fa90a12f03ed/pkg/fanal/analyzer/analyzer.go#L326) as a comment, and in [Skipping Files and Directories](https://aquasecurity.github.io/trivy/v0.42/docs/configuration/skipping/#file-patterns) page in the documentation [not a place one would normally look for learning about including files!]. But it has not been documented in the [Misconfiguration Scanning](https://aquasecurity.github.io/trivy/v0.42/docs/scanner/misconfiguration/) page, its [error message](https://github.com/aquasecurity/trivy/blob/d7637adc6b59951900870faf4622fa90a12f03ed/pkg/fanal/analyzer/analyzer.go#L329), or [output of](https://aquasecurity.github.io/trivy/v0.42/docs/references/configuration/cli/trivy_config/) `trivy config --help`.

New error message:

```
> trivy config --file-patterns='bad_format*' ~/my_path

INFO	Misconfiguration scanning is enabled
FATAL	filesystem scan error: scan error: unable to initialize a scanner: unable to initialize a filesystem scanner: analyzer group error: invalid file pattern (bad_format*) expected format: "fileType:regexPattern" e.g. "dockerfile:my_dockerfile_*"
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
