### PR TITLE
feat(java): capture licenses from pom.xml

### DIFF
--- a/docs/docs/scanner/vulnerability/language/java.md
+++ b/docs/docs/scanner/vulnerability/language/java.md
@@ -4,11 +4,11 @@ Trivy supports three types of Java scanning: `JAR/WAR/PAR/EAR`, `pom.xml` and `*
 The following table provides an outline of the features Trivy offers.
 
 
-| Artifact         |    Internet access    | Dev dependencies |
-|------------------|:---------------------:|:-----------------|
-| JAR/WAR/PAR/EAR  |     Trivy Java DB     | Include          |
-| pom.xml          | Maven repository [^1] | Exclude          |
-| *gradle.lockfile |           -           | Exclude          |
+| Artifact         |    Internet access    | Dev dependencies | License |
+|------------------|:---------------------:|:-----------------|:-------:|
+| JAR/WAR/PAR/EAR  |     Trivy Java DB     | Include          |    -    |
+| pom.xml          | Maven repository [^1] | Exclude          |    ✅   |
+| *gradle.lockfile |           -           | Exclude          |     -   |
 
 These may be enabled or disabled depending on the target.
 See [here](./index.md) for the detail.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.3
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.89.1-0.20230616215656-269528cc9b42
-	github.com/aquasecurity/go-dep-parser v0.0.0-20230614075854-30b52f543be9
+	github.com/aquasecurity/go-dep-parser v0.0.0-20230614123559-76443063c1f1
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.89.1-0.20230616215656-269528cc9b42 h1:PGoTTb5b40hZGW+fHVLFWwUkxWQJp8HKJMf82SR61Q8=
 github.com/aquasecurity/defsec v0.89.1-0.20230616215656-269528cc9b42/go.mod h1:3AgfRdHLPbT9kcAMaj6f9LX7WgihbNta8sPycrSqHTw=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230614075854-30b52f543be9 h1:HbSquJbXpWwv8wuoXXb0mZWzsUhDUIgFpjln4woH9YA=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230614075854-30b52f543be9/go.mod h1:fEMyM+83y5N9m0Deh0bmTGiiNwpceUtBA67s7WXOfvM=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230614123559-76443063c1f1 h1:zfg493a2I4J/Ky4ynODF48J2jqc14lBI0n3rmfpqawM=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230614123559-76443063c1f1/go.mod h1:fEMyM+83y5N9m0Deh0bmTGiiNwpceUtBA67s7WXOfvM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20230328195059-5bf52338aec3 h1:Vt9y1gZS5JGY3tsL9zc++Cg4ofX51CG7PaMyC5SXWPg=

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -31,8 +31,9 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 						FilePath: "testdata/happy/pom.xml",
 						Libraries: []types.Package{
 							{
-								Name:    "com.example:example",
-								Version: "1.0.0",
+								Name:     "com.example:example",
+								Version:  "1.0.0",
+								Licenses: []string{"Apache-2.0"},
 							},
 						},
 					},
@@ -50,8 +51,9 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 						FilePath: "pom.xml",
 						Libraries: []types.Package{
 							{
-								Name:    "com.example:example",
-								Version: "1.0.0",
+								Name:     "com.example:example",
+								Version:  "1.0.0",
+								Licenses: []string{"Apache-2.0"},
 							},
 						},
 					},
@@ -68,8 +70,9 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 						FilePath: "testdata/requirements/pom.xml",
 						Libraries: []types.Package{
 							{
-								Name:    "com.example:example",
-								Version: "2.0.0",
+								Name:     "com.example:example",
+								Version:  "2.0.0",
+								Licenses: []string{"Apache-2.0"},
 							},
 						},
 					},


### PR DESCRIPTION
## Description
Trivy does not parse the licenses specified in `pom.xml`. This pr fixes it.

`go-dep-parser` refers to this [commit](https://github.com/aquasecurity/go-dep-parser/commit/76443063c1f1476dbffe70f125f0835a9c610611).

## Related issues
- https://github.com/aquasecurity/trivy/issues/3812

## Related PRs
- [x] https://github.com/aquasecurity/go-dep-parser/pull/225

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
