### PR TITLE
fix: added logic to pass config data to aws 

### DIFF
--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -1039,6 +1039,9 @@ func Test_Run(t *testing.T) {
 					PolicyPaths: []string{
 						filepath.Join(regoDir, "policies"),
 					},
+					DataPaths: []string{
+						filepath.Join(regoDir, "policies"),
+					},
 					PolicyNamespaces: []string{
 						"user",
 					},

--- a/pkg/cloud/aws/scanner/scanner_test.go
+++ b/pkg/cloud/aws/scanner/scanner_test.go
@@ -1,0 +1,111 @@
+package scanner
+
+import (
+	"github.com/aquasecurity/defsec/pkg/providers/aws"
+	"github.com/aquasecurity/defsec/pkg/providers/aws/rds"
+	awsScanner "github.com/aquasecurity/defsec/pkg/scanners/cloud/aws"
+	"github.com/aquasecurity/defsec/pkg/scanners/options"
+	defsecTypes "github.com/aquasecurity/defsec/pkg/types"
+	"github.com/aquasecurity/defsec/test/testutil"
+	"github.com/stretchr/testify/require"
+	"io/fs"
+)
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aquasecurity/defsec/pkg/state"
+)
+
+func Test_AWSInputSelectorsWithConfigData(t *testing.T) {
+	testCases := []struct {
+		name            string
+		srcFS           fs.FS
+		dataFS          fs.FS
+		state           state.State
+		expectedResults struct {
+			totalResults int
+			summaries    []string
+		}
+	}{
+		{
+			name: "single cloud, single selector with config data",
+			srcFS: testutil.CreateFS(t, map[string]string{
+				"policies/rds_policy.rego": `# METADATA
+# title: "RDS Publicly Accessible"
+# description: "Ensures RDS instances are not launched into the public cloud."
+# scope: package
+# schemas:
+# - input: schema.input
+# related_resources:
+# - http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html
+# custom:
+#   avd_id: AVD-AWS-0999
+#   provider: aws
+#   service: rds
+#   severity: HIGH
+#   short_code: enable-public-access
+#   recommended_action: "Remove the public endpoint from the RDS instance'"
+#   input:
+#     selector:
+#     - type: cloud
+#       subtypes:
+#         - provider: aws
+#           service: rds
+package builtin.aws.rds.aws0999
+import data.settings.DS0999.ignore_deletion_protection
+deny[res] {
+	instance := input.aws.rds.instances[_]
+	instance.publicaccess.value
+	not ignore_deletion_protection
+	res := result.new("Instance has Public Access enabled", instance.publicaccess)
+}
+`,
+			}),
+			dataFS: testutil.CreateFS(t, map[string]string{
+				"config-data/data.json": `{
+    "settings": {
+		"DS0999": {
+			"ignore_deletion_protection": false
+		}
+    }
+}
+`,
+			}),
+			state: state.State{AWS: aws.AWS{
+				RDS: rds.RDS{
+					Instances: []rds.Instance{
+						{Metadata: defsecTypes.Metadata{},
+							PublicAccess: defsecTypes.Bool(false, defsecTypes.NewTestMetadata()),
+						},
+					},
+				},
+				// note: there is no CloudTrail resource in our AWS state (so we expect no results for it)
+			}},
+			expectedResults: struct {
+				totalResults int
+				summaries    []string
+			}{totalResults: 1, summaries: []string{"RDS Publicly Accessible"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := awsScanner.New(
+				options.ScannerWithEmbeddedPolicies(false),
+				options.ScannerWithPolicyFilesystem(tc.srcFS),
+				options.ScannerWithRegoOnly(true),
+				options.ScannerWithPolicyDirs("policies/"),
+				options.ScannerWithDataFilesystem(tc.dataFS),
+				options.ScannerWithDataDirs("config-data/"))
+
+			results, err := scanner.Scan(context.TODO(), &tc.state)
+			require.NoError(t, err, tc.name)
+			require.Equal(t, tc.expectedResults.totalResults, len(results), tc.name)
+			for i := range results.GetFailed() {
+				require.Contains(t, tc.expectedResults.summaries, results.GetFailed()[i].Rule().Summary, tc.name)
+			}
+		})
+	}
+}

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -578,7 +578,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			Trace:                   opts.Trace,
 			Namespaces:              append(opts.PolicyNamespaces, defaultPolicyNamespaces...),
 			PolicyPaths:             append(opts.PolicyPaths, downloadedPolicyPaths...),
-			DataPaths:               opts.DataPaths,
+			DataPaths:               append(opts.DataPaths, downloadedPolicyPaths...),
 			HelmValues:              opts.HelmValues,
 			HelmValueFiles:          opts.HelmValueFiles,
 			HelmFileValues:          opts.HelmFileValues,

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -208,7 +208,7 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 		opts = append(opts, options.ScannerWithPolicyFilesystem(policyFS))
 	}
 
-	dataFS, dataPaths, err := createDataFS(opt.DataPaths, opt.K8sVersion)
+	dataFS, dataPaths, err := CreateDataFS(opt.DataPaths, opt.K8sVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -306,11 +306,12 @@ func createPolicyFS(policyPaths []string) (fs.FS, []string, error) {
 	return mfs, policyPaths, nil
 }
 
-func createDataFS(dataPaths []string, k8sVersion string) (fs.FS, []string, error) {
+func CreateDataFS(dataPaths []string, options ...string) (fs.FS, []string, error) {
 	fsys := mapfs.New()
 
-	// Create a virtual file for Kubernetes scanning
-	if k8sVersion != "" {
+	// Check if k8sVersion is provided
+	if len(options) > 0 {
+		k8sVersion := options[0]
 		if err := fsys.MkdirAll("system", 0700); err != nil {
 			return nil, nil, err
 		}
@@ -319,13 +320,14 @@ func createDataFS(dataPaths []string, k8sVersion string) (fs.FS, []string, error
 			return nil, nil, err
 		}
 	}
+
 	for _, path := range dataPaths {
 		if err := fsys.CopyFilesUnder(path); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	// data paths are no longer needed as fs.FS contains only needed files now.
+	// dataPaths are no longer needed as fs.FS contains only needed files now.
 	dataPaths = []string{"."}
 
 	return fsys, dataPaths, nil

--- a/pkg/misconf/scanner_test.go
+++ b/pkg/misconf/scanner_test.go
@@ -163,3 +163,19 @@ func Test_createPolicyFS(t *testing.T) {
 		assert.True(t, stat.IsDir())
 	})
 }
+
+func Test_createDataFS(t *testing.T) {
+	t.Run("outside pwd", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "subdir/testdir"), 0750))
+		f, got, err := CreateDataFS([]string{filepath.Join(tmpDir, "subdir/testdir")}, "")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"."}, got)
+
+		d, err := f.Open(tmpDir)
+		require.NoError(t, err)
+		stat, err := d.Stat()
+		require.NoError(t, err)
+		assert.True(t, stat.IsDir())
+	})
+}


### PR DESCRIPTION
## Description
Added logic to pass config-data  on to defsec policies and produce results based on those user given input.
## Related issues
- (https://github.com/aquasecurity/trivy/issues/4565)

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
