### PR TITLE
fix: k8s escape resource filename on windows os

### DIFF
--- a/pkg/k8s/scanner/io_test.go
+++ b/pkg/k8s/scanner/io_test.go
@@ -1,0 +1,34 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FilenameWindowsFriendly(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		fileName string
+		want     string
+	}{
+		{
+			name:     "name with invalid char - colon",
+			fileName: `kube-system-Role-system:controller:bootstrap-signer-2934213283.yaml`,
+			want:     `kube-system-Role-system_controller_bootstrap-signer-2934213283.yaml`,
+		},
+		{
+			name:     "name with no invalid chars",
+			fileName: `kube-system-Role-system-controller-bootstrap-signer-2934213283.yaml`,
+			want:     `kube-system-Role-system-controller-bootstrap-signer-2934213283.yaml`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := filenameWindowsFriendly(test.fileName)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description
k8s escape resource filename

## Related issues
- Close #4665

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
