### PR TITLE
ci: ignore merge queue branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - 'main'
+      - 'gh-readonly-queue/**'
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Description
The merge queue [creates a branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), and it also triggers tests now.
https://github.com/aquasecurity/trivy/actions/runs/5343376084

## Related PRs
- https://github.com/aquasecurity/trivy/pull/4692
- https://github.com/aquasecurity/trivy/pull/4614

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
