### PR TITLE
fix(image): Fix panic when creation time is missing

### DIFF
--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -233,12 +233,17 @@ func inspect(ctx context.Context, img containerd.Image, ref refdocker.Reference)
 		portSet[nat.Port(k)] = struct{}{}
 	}
 
+	created := ""
+	if lastHistory.Created != nil {
+		created = lastHistory.Created.Format(time.RFC3339Nano)
+	}
+
 	return api.ImageInspect{
 		ID:          imgConfigDesc.Digest.String(),
 		RepoTags:    []string{fmt.Sprintf("%s:%s", repository, tag)},
 		RepoDigests: []string{fmt.Sprintf("%s@%s", repository, img.Target().Digest)},
 		Comment:     lastHistory.Comment,
-		Created:     lastHistory.Created.Format(time.RFC3339Nano),
+		Created:     created,
 		Author:      lastHistory.Author,
 		Config: &container.Config{
 			User:         imgConfig.Config.User,


### PR DESCRIPTION
## Description

This PR verifies that  `lastHistory.Created` is not nil before converting it to a string.

## Motivation

Avoid panic when creation time is missing. 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
