### PR TITLE
fix(oci): Http registry oci pull

### DIFF
--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -78,7 +78,12 @@ func (a *Artifact) populate(ctx context.Context, opt types.RegistryOptions) erro
 	a.m.Lock()
 	defer a.m.Unlock()
 
-	ref, err := name.ParseReference(a.repository)
+	var nameOpts []name.Option
+	if opt.Insecure {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(a.repository, nameOpts...)
 	if err != nil {
 		return xerrors.Errorf("repository name error (%s): %w", a.repository, err)
 	}


### PR DESCRIPTION
## Description
when we try to pull trivy-db from http registry in an airgapped env we are getting the error:
```
2023-06-23T13:52:56.086+0300    INFO    Need to update DB
2023-06-23T13:52:56.086+0300    INFO    DB Repository: registry.quay:8080/security/trivy-db
2023-06-23T13:52:56.086+0300    INFO    Downloading DB...
true
true
2023-06-23T13:52:56.426+0300    FATAL   init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
        * Get "https://registry.quay:8080/v2/": http: server gave HTTP response to HTTPS client
```

This pr is fixing this issue.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
