### PR TITLE
docs: fix supported modes for pubspec.lock files

### DIFF
--- a/docs/docs/scanner/vulnerability/language/index.md
+++ b/docs/docs/scanner/vulnerability/language/index.md
@@ -30,7 +30,7 @@
 |                      | Binaries built with [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable) |     ✅     |     ✅      |       -        |        -        | excluded         |            -             |
 | C/C++                | conan.lock[^12]                                                                            |     -     |     -      |       ✅        |        ✅        | excluded         |            -             |   
 | Elixir               | mix.lock[^12]                                                                              |     -     |     -      |       ✅        |        ✅        | excluded         |            ✅             |
-| Dart                 | pubspec.lock                                                                               |     ✅     |     ✅      |       -        |        -        | included         |            -             |
+| Dart                 | pubspec.lock                                                                               |     -     |     -      |       ✅        |        ✅        | included         |            -             |
 
 The path of these files does not matter.
 


### PR DESCRIPTION
## Description
Only `fs` and `repo` modes support scanning of `pubspec.lock` files.

## Related issues
- https://github.com/aquasecurity/trivy/issues/3369#issuecomment-1604419244

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
