### PR TITLE
fix(misconf): disable the terraform plan analyzer for other scanners

### DIFF
--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -221,5 +221,6 @@ var (
 		TypeHelm,
 		TypeKubernetes,
 		TypeTerraform,
+		TypeTerraformPlan,
 	}
 )


### PR DESCRIPTION
## Description
The Terraform plan analyzer was not added to the list of misconfiguration analyzers in https://github.com/aquasecurity/trivy/pull/4523. Then, it is always enabled even when misconfiguration scanning is not enabled.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
