### PR TITLE
docs: clarifying a dir path is required for custom policies

### DIFF
--- a/docs/docs/scanner/misconfiguration/custom/index.md
+++ b/docs/docs/scanner/misconfiguration/custom/index.md
@@ -8,6 +8,9 @@ Once you finish writing custom policies, you can pass the directory where those 
 trivy conf --policy /path/to/custom_policies --namespaces user /path/to/config_dir
 ```
 
+!!! Tip
+    Note: The `--policy` path always needs to refer to a directory. You cannot pass a specific policy file.
+
 As for `--namespaces` option, the detail is described as below.
 
 ### File formats

--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -327,7 +327,8 @@ trivy conf --policy custom-policy/policy --policy combine/policy --namespaces us
 For more details, see [Custom Policies](./custom/index.md).
 
 !!! tip
-You also need to specify `--namespaces` option.
+    You also need to specify `--namespaces` option.
+    Furthermore, the `--policy` path always needs to refer to a directory. You cannot pass a specific policy file.
 
 ### Pass custom data
 You can pass directories including your custom data through `--data` option.


### PR DESCRIPTION
Making it clear that people have to use the dir path instead of the specific file

https://github.com/aquasecurity/trivy/discussions/4668