### PR TITLE
fix(vuln): skip vulnerability scan for gpg-pubkey package

### DIFF
--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -3,6 +3,7 @@ package ospkg
 import (
 	"time"
 
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alma"
@@ -67,7 +68,12 @@ func Detect(_, osFamily, osName string, repo *ftypes.Repository, _ time.Time, pk
 
 	eosl := !driver.IsSupportedVersion(osFamily, osName)
 
-	vulns, err := driver.Detect(osName, repo, pkgs)
+	// Package `gpg-pubkey` doesn't use the correct version.
+	// We don't need to find vulnerabilities for this package.
+	filteredPkgs := lo.Filter(pkgs, func(pkg ftypes.Package, index int) bool {
+		return pkg.Name != "gpg-pubkey"
+	})
+	vulns, err := driver.Detect(osName, repo, filteredPkgs)
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed detection: %w", err)
 	}


### PR DESCRIPTION
## Description
`gpg-pubkey` has different versioning. We need to skip vulnerability scan for this package - https://github.com/aquasecurity/trivy/discussions/4703#discussioncomment-6290594

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
