### PR TITLE
docs(image): fix the comment on the soft/hard link

### DIFF
--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -76,7 +76,8 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 			if w.shouldSkipFile(filePath) {
 				continue
 			}
-		// symlinks and hardlinks have no content in reader, skip them
+		case tar.TypeSymlink:
+		case tar.TypeLink:
 		default:
 			continue
 		}

--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -76,8 +76,7 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 			if w.shouldSkipFile(filePath) {
 				continue
 			}
-		case tar.TypeSymlink:
-		case tar.TypeLink:
+		// symlinks and hardlinks have no content in reader, skip them
 		default:
 			continue
 		}
@@ -86,7 +85,7 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 			continue
 		}
 
-		// A symbolic/hard link or regular file will reach here.
+		// A regular file will reach here.
 		if err = w.processFile(filePath, tr, hdr.FileInfo(), analyzeFn); err != nil {
 			return nil, nil, xerrors.Errorf("failed to process the file: %w", err)
 		}


### PR DESCRIPTION
The comment before the following w.processFile(filePath, tr, hdr.FileInfo(), analyzeFn) call says: // A symbolic/hard link or regular file will reach here.  (pkg/fanal/walker/tar.go)
But defualt's processing causes the symbolic/hard link to not reach the processFile function location

## Description

## Related issues

## Related PRs


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
