### PR TITLE
feat: add support of linux/ppc64le and linux/s390x architectures for Install.sh script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -75,6 +75,7 @@ get_binaries() {
     linux/ppc64le) BINARIES="trivy" ;;
     linux/arm64) BINARIES="trivy" ;;
     linux/armv7) BINARIES="trivy" ;;
+    linux/s390x) BINARIES="trivy" ;;
     openbsd/386) BINARIES="trivy" ;;
     openbsd/amd64) BINARIES="trivy" ;;
     openbsd/arm64) BINARIES="trivy" ;;
@@ -115,7 +116,8 @@ adjust_os() {
     amd64) OS=64bit ;;
     arm) OS=ARM ;;
     arm64) OS=ARM64 ;;
-    ppc64le) OS=PPC64LE ;;
+    ppc64le) OS=Linux;;
+    s390x) OS=Linux;;
     darwin) OS=macOS ;;
     dragonfly) OS=DragonFlyBSD ;;
     freebsd) OS=FreeBSD ;;
@@ -133,7 +135,8 @@ adjust_arch() {
     arm) ARCH=ARM ;;
     armv7) ARCH=ARM ;;
     arm64) ARCH=ARM64 ;;
-    ppc64le) OS=PPC64LE ;;
+    ppc64le) ARCH=PPC64LE ;;
+    s390x) ARCH=s390x ;;
     darwin) ARCH=macOS ;;
     dragonfly) ARCH=DragonFlyBSD ;;
     freebsd) ARCH=FreeBSD ;;
@@ -222,6 +225,7 @@ uname_arch() {
     armv5*) arch="armv5" ;;
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
+    s390*) arch="s390x" ;;
   esac
   echo ${arch}
 }

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -225,7 +225,7 @@ uname_arch() {
     armv5*) arch="armv5" ;;
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
-    s390*) arch="s390x"  ;;
+    s390*) arch="s390x" ;;
   esac
   echo ${arch}
 }

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -225,7 +225,7 @@ uname_arch() {
     armv5*) arch="armv5" ;;
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
-    s390*) arch="s390x" ;;
+    s390*) arch="s390x"  ;;
   esac
   echo ${arch}
 }


### PR DESCRIPTION
## Description
fix #4746 - issue when Install trivy in Alpine - supported platforms `linux/ppc64le` and `linux/s390x`

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4762

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
