### PR TITLE
fix(sbom): check Type when filling pkgs in vulns

### DIFF
--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -205,7 +205,7 @@ func (s Scanner) fillPkgsInVulns(pkgResults, vulnResults types.Results) types.Re
 	}
 	for _, result := range pkgResults {
 		if r, found := lo.Find(vulnResults, func(r types.Result) bool {
-			return r.Class == result.Class && r.Target == result.Target
+			return r.Class == result.Class && r.Target == result.Target && r.Type == result.Type
 		}); found {
 			r.Packages = result.Packages
 			results = append(results, r)

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -491,6 +491,101 @@ func TestScanner_Scan(t *testing.T) {
 			wantOS: ftypes.OS{},
 		},
 		{
+			name: "happy path. Empty filePaths (e.g. Scanned SBOM)",
+			args: args{
+				target:   "./result.cdx",
+				layerIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				options: types.ScanOptions{
+					VulnType:        []string{types.VulnTypeLibrary},
+					Scanners:        types.Scanners{types.VulnerabilityScanner},
+					ListAllPackages: true,
+				},
+			},
+			fixtures: []string{"testdata/fixtures/happy.yaml"},
+			applyLayersExpectation: ApplierApplyLayersExpectation{
+				Args: ApplierApplyLayersArgs{
+					BlobIDs: []string{"sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"},
+				},
+				Returns: ApplierApplyLayersReturns{
+					Detail: ftypes.ArtifactDetail{
+						Applications: []ftypes.Application{
+							{
+								Type:     "bundler",
+								FilePath: "",
+								Libraries: []ftypes.Package{
+									{
+										Name:    "rails",
+										Version: "4.0.2",
+									},
+								},
+							},
+							{
+								Type:     "composer",
+								FilePath: "",
+								Libraries: []ftypes.Package{
+									{
+										Name:    "laravel/framework",
+										Version: "6.0.0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantResults: types.Results{
+				{
+					Target: "",
+					Class:  types.ClassLangPkg,
+					Type:   ftypes.Bundler,
+					Packages: []ftypes.Package{
+						{
+							Name:    "rails",
+							Version: "4.0.2",
+						},
+					},
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID:  "CVE-2014-0081",
+							PkgName:          "rails",
+							InstalledVersion: "4.0.2",
+							FixedVersion:     "4.0.3, 3.2.17",
+							PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2014-0081",
+							Vulnerability: dbTypes.Vulnerability{
+								Title:       "xss",
+								Description: "xss vulnerability",
+								Severity:    "MEDIUM",
+								References: []string{
+									"http://example.com",
+								},
+								LastModifiedDate: lo.ToPtr(time.Date(2020, 2, 1, 1, 1, 0, 0, time.UTC)),
+								PublishedDate:    lo.ToPtr(time.Date(2020, 1, 1, 1, 1, 0, 0, time.UTC)),
+							},
+						},
+					},
+				},
+				{
+					Target: "",
+					Class:  types.ClassLangPkg,
+					Type:   ftypes.Composer,
+					Packages: []ftypes.Package{
+						{
+							Name:    "laravel/framework",
+							Version: "6.0.0",
+						},
+					},
+					Vulnerabilities: []types.DetectedVulnerability{
+						{
+							VulnerabilityID:  "CVE-2021-21263",
+							PkgName:          "laravel/framework",
+							InstalledVersion: "6.0.0",
+							FixedVersion:     "8.22.1, 7.30.3, 6.20.12",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "happy path with no package",
 			args: args{
 				target:   "alpine:latest",


### PR DESCRIPTION
## Description
If `cyclonedx` file doesn't have `Components.Property.Filepath` field and has 2(or more) language packages - Trivy skips 1 language package. 
See #3492
This happens because pkgs have same Filepath(Target):
https://github.com/aquasecurity/trivy/blob/8e7fb7cc84bf010592115c6bfed602aff3410dec/pkg/scanner/local/scan.go#L201-L217
We need to compare pkg.Types to avoid these cases.

## Related issues
- Close #3492

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
