### PR TITLE
refactor(db): remove govulndb

### DIFF
--- a/docs/docs/scanner/vulnerability/language/index.md
+++ b/docs/docs/scanner/vulnerability/language/index.md
@@ -65,7 +65,6 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 | Java     | [GitLab Advisories Community][gitlab]               |       ✅        |  1 month  |
 |          | [GitHub Advisory Database (Maven)][java-ghsa]       |       ✅        |     -     |
 | Go       | [GitHub Advisory Database (Go)][go-ghsa]            |       ✅        |     -     |
-|          | [The Go Vulnerability Database][go]                 |       ✅        |     -     |
 | Rust     | [Open Source Vulnerabilities (crates.io)][rust-osv] |       ✅        |     -     |
 | .NET     | [GitHub Advisory Database (NuGet)][dotnet-ghsa]     |       ✅        |     -     |
 | C/C++    | [GitLab Advisories Community][gitlab]               |       ✅        |  1 month  |
@@ -88,7 +87,6 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 [ruby]: https://github.com/rubysec/ruby-advisory-db
 [nodejs]: https://github.com/nodejs/security-wg
 [gitlab]: https://gitlab.com/gitlab-org/advisories-community
-[go]: https://github.com/golang/vulndb
 
 [python-osv]: https://osv.dev/list?q=&ecosystem=PyPI
 [rust-osv]: https://osv.dev/list?q=&ecosystem=crates.io

--- a/integration/testdata/fixtures/db/data-source.yaml
+++ b/integration/testdata/fixtures/db/data-source.yaml
@@ -40,6 +40,11 @@
         ID: "ghsa"
         Name: "GitHub Security Advisory Erlang"
         URL: "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Aerlang"
+    - key: "go::GitHub Security Advisory Go"
+      value:
+        ID: "ghsa"
+        Name: "GitHub Security Advisory Go"
+        URL: "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
     - key: Oracle Linux 8
       value:
         ID: "oracle-oval"
@@ -89,16 +94,6 @@
         ID: "debian"
         Name: "Debian Security Tracker"
         URL: "https://salsa.debian.org/security-tracker-team/security-tracker"
-    - key: go::GitLab Advisory Database Community
-      value:
-        ID: "glad"
-        Name: "GitLab Advisory Database Community"
-        URL:  "https://gitlab.com/gitlab-org/advisories-community"
-    - key: go::The Go Vulnerability Database
-      value:
-        ID: "go-vulndb"
-        Name: "The Go Vulnerability Database"
-        URL:  "https://github.com/golang/vulndb"
     - key: maven::GitLab Advisory Database Community
       value:
         ID: "glad"

--- a/integration/testdata/fixtures/db/go.yaml
+++ b/integration/testdata/fixtures/db/go.yaml
@@ -1,4 +1,4 @@
-- bucket: go::The Go Vulnerability Database
+- bucket: go::GitHub Security Advisory Go
   pairs:
     - bucket: golang.org/x/text
       pairs:
@@ -8,8 +8,6 @@
               - "0.3.7"
             VulnerableVersions:
               - ">= 0, < 0.3.7"
-- bucket: go::GitLab Advisory Database Community
-  pairs:
     - bucket: github.com/docker/distribution
       pairs:
         - key: GMS-2022-20

--- a/integration/testdata/gomod-skip.json.golden
+++ b/integration/testdata/gomod-skip.json.golden
@@ -28,9 +28,9 @@
           "FixedVersion": "v2.8.0",
           "Layer": {},
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "OCI Manifest Type Confusion Issue",
           "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",
@@ -52,9 +52,9 @@
           "SeveritySource": "nvd",
           "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-23628",
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "Incorrect Calculation",
           "Description": "OPA is an open source, general-purpose policy engine. Under certain conditions, pretty-printing an abstract syntax tree (AST) that contains synthetic nodes could change the logic of some statements by reordering array literals. Example of policies impacted are those that parse and compare web paths. **All of these** three conditions have to be met to create an adverse effect: 1. An AST of Rego had to be **created programmatically** such that it ends up containing terms without a location (such as wildcard variables). 2. The AST had to be **pretty-printed** using the `github.com/open-policy-agent/opa/format` package. 3. The result of the pretty-printing had to be **parsed and evaluated again** via an OPA instance using the bundles, or the Golang packages. If any of these three conditions are not met, you are not affected. Notably, all three would be true if using **optimized bundles**, i.e. bundles created with `opa build -O=1` or higher. In that case, the optimizer would fulfil condition (1.), the result of that would be pretty-printed when writing the bundle to disk, fulfilling (2.). When the bundle was then used, we'd satisfy (3.). As a workaround users may disable optimization when creating bundles.",
@@ -90,9 +90,9 @@
           "Layer": {},
           "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-38561",
           "DataSource": {
-            "ID": "go-vulndb",
-            "Name": "The Go Vulnerability Database",
-            "URL": "https://github.com/golang/vulndb"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Description": "Due to improper index calculation, an incorrectly formatted language tag can cause Parse\nto panic via an out of bounds read. If Parse is used to process untrusted user inputs,\nthis may be used as a vector for a denial of service attack.\n",
           "Severity": "UNKNOWN",
@@ -117,9 +117,9 @@
           "FixedVersion": "v2.8.0",
           "Layer": {},
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "OCI Manifest Type Confusion Issue",
           "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",

--- a/integration/testdata/gomod.json.golden
+++ b/integration/testdata/gomod.json.golden
@@ -28,9 +28,9 @@
           "FixedVersion": "v2.8.0",
           "Layer": {},
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "OCI Manifest Type Confusion Issue",
           "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",
@@ -52,9 +52,9 @@
           "SeveritySource": "nvd",
           "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-23628",
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "Incorrect Calculation",
           "Description": "OPA is an open source, general-purpose policy engine. Under certain conditions, pretty-printing an abstract syntax tree (AST) that contains synthetic nodes could change the logic of some statements by reordering array literals. Example of policies impacted are those that parse and compare web paths. **All of these** three conditions have to be met to create an adverse effect: 1. An AST of Rego had to be **created programmatically** such that it ends up containing terms without a location (such as wildcard variables). 2. The AST had to be **pretty-printed** using the `github.com/open-policy-agent/opa/format` package. 3. The result of the pretty-printing had to be **parsed and evaluated again** via an OPA instance using the bundles, or the Golang packages. If any of these three conditions are not met, you are not affected. Notably, all three would be true if using **optimized bundles**, i.e. bundles created with `opa build -O=1` or higher. In that case, the optimizer would fulfil condition (1.), the result of that would be pretty-printed when writing the bundle to disk, fulfilling (2.). When the bundle was then used, we'd satisfy (3.). As a workaround users may disable optimization when creating bundles.",
@@ -90,9 +90,9 @@
           "Layer": {},
           "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2021-38561",
           "DataSource": {
-            "ID": "go-vulndb",
-            "Name": "The Go Vulnerability Database",
-            "URL": "https://github.com/golang/vulndb"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Description": "Due to improper index calculation, an incorrectly formatted language tag can cause Parse\nto panic via an out of bounds read. If Parse is used to process untrusted user inputs,\nthis may be used as a vector for a denial of service attack.\n",
           "Severity": "UNKNOWN",
@@ -117,9 +117,9 @@
           "FixedVersion": "v2.8.0",
           "Layer": {},
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "OCI Manifest Type Confusion Issue",
           "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",
@@ -146,9 +146,9 @@
           "FixedVersion": "v2.8.0",
           "Layer": {},
           "DataSource": {
-            "ID": "glad",
-            "Name": "GitLab Advisory Database Community",
-            "URL": "https://gitlab.com/gitlab-org/advisories-community"
+            "ID": "ghsa",
+            "Name": "GitHub Security Advisory Go",
+            "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
           },
           "Title": "OCI Manifest Type Confusion Issue",
           "Description": "### Impact\n\nSystems that rely on digest equivalence for image attestations may be vulnerable to type confusion.",

--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -98,8 +98,7 @@ func (c Client) getVendorSeverity(vulnID string, vuln *dbTypes.Vulnerability, so
 	}
 
 	// use severity from GitHub for all GHSA-xxx vulnerabilities
-	// govuln doesn't have severity. Use severity from GitHub(for CVE-xxx vulns)
-	if strings.HasPrefix(vulnID, "GHSA-") || source == vulnerability.GoVulnDB {
+	if strings.HasPrefix(vulnID, "GHSA-") {
 		if vs, ok := vuln.VendorSeverity[vulnerability.GHSA]; ok {
 			return vs.String(), vulnerability.GHSA
 		}

--- a/pkg/vulnerability/vulnerability_test.go
+++ b/pkg/vulnerability/vulnerability_test.go
@@ -271,42 +271,6 @@ func TestClient_FillInfo(t *testing.T) {
 			},
 		},
 		{
-			name:     "happy path. CVE-xxx from govuln. Severity gets from ghsa",
-			fixtures: []string{"testdata/fixtures/vulnerability.yaml"},
-			vulns: []types.DetectedVulnerability{
-				{
-					VulnerabilityID: "CVE-2022-0001",
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.GoVulnDB,
-						Name: "The Go Vulnerability Database",
-						URL:  "https://github.com/golang/vulndb",
-					},
-				},
-			},
-			expectedVulnerabilities: []types.DetectedVulnerability{
-				{
-					VulnerabilityID: "CVE-2022-0001",
-					SeveritySource:  vulnerability.GHSA,
-					Vulnerability: dbTypes.Vulnerability{
-						Title:       "dos",
-						Description: "dos vulnerability",
-						Severity:    dbTypes.SeverityHigh.String(),
-						References:  []string{"http://example.com"},
-						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
-							"nvd":  dbTypes.SeverityLow,
-							"ghsa": dbTypes.SeverityHigh,
-						},
-					},
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.GoVulnDB,
-						Name: "The Go Vulnerability Database",
-						URL:  "https://github.com/golang/vulndb",
-					},
-					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2022-0001",
-				},
-			},
-		},
-		{
 			name:     "GetVulnerability returns an error",
 			fixtures: []string{"testdata/fixtures/sad.yaml"},
 			vulns: []types.DetectedVulnerability{


### PR DESCRIPTION
## Description
`govuln-db` has been removed from `Trivy-db`.
See more https://github.com/aquasecurity/trivy-db/pull/330

## Related PRs
- [x] https://github.com/aquasecurity/trivy-db/pull/330
- [x] https://github.com/aquasecurity/vuln-list-update/pull/222


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
