### PR TITLE
fix(sbom): cyclonedx recommendations should include fixed versions for each package

### DIFF
--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -149,11 +149,11 @@ func (c *CycloneDX) MarshalComponent(component *Component, components map[string
 				// new recommendation
 				rec := fmt.Sprintf("Upgrade %s to version %s", v.PkgName, v.FixedVersion)
 				// previous recommendations
-				recs := strings.Split(vuln.Recommendation, ", ")
+				recs := strings.Split(vuln.Recommendation, "; ")
 				if !slices.Contains(recs, rec) {
 					recs = append(recs, rec)
 					slices.Sort(recs)
-					vuln.Recommendation = strings.Join(recs, ", ")
+					vuln.Recommendation = strings.Join(recs, "; ")
 				}
 			}
 		} else {

--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -9,6 +9,7 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
 	"k8s.io/utils/clock"
 
 	dtypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -144,6 +145,17 @@ func (c *CycloneDX) MarshalComponent(component *Component, components map[string
 		//     -> Library component (nokogiri /srv/app2/vendor/bundle/ruby/3.0.0/specifications/nokogiri-1.10.0.gemspec)
 		if vuln, ok := vulns[v.VulnerabilityID]; ok {
 			*vuln.Affects = append(*vuln.Affects, cdxAffects(bomRef, v.InstalledVersion))
+			if v.FixedVersion != "" {
+				// new recommendation
+				rec := fmt.Sprintf("Upgrade %s to version %s", v.PkgName, v.FixedVersion)
+				// previous recommendations
+				recs := strings.Split(vuln.Recommendation, ", ")
+				if !slices.Contains(recs, rec) {
+					recs = append(recs, rec)
+					slices.Sort(recs)
+					vuln.Recommendation = strings.Join(recs, ", ")
+				}
+			}
 		} else {
 			vulns[v.VulnerabilityID] = c.marshalVulnerability(cdxComponent.BOMRef, v)
 		}

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -1365,8 +1365,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 							Name: string(vulnerability.GHSA),
 							URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
 						},
-						Recommendation: "Upgrade org.apache.nifi:nifi-dbcp-base to version 1.22.0, Upgrade org.apache.nifi:nifi-hikari-dbcp-service to version 1.22.0",
-
+						Recommendation: "Upgrade org.apache.nifi:nifi-dbcp-base to version 1.22.0; Upgrade org.apache.nifi:nifi-hikari-dbcp-service to version 1.22.0",
 						Ratings: &[]cdx.VulnerabilityRating{
 							{
 								Source: &cdx.Source{

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -185,7 +185,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 				BOMFormat:    "CycloneDX",
 				SpecVersion:  cdx.SpecVersion1_5,
-				JSONSchema: "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
 				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
 				Version:      1,
 				Metadata: &cdx.Metadata{
@@ -730,7 +730,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 				BOMFormat:    "CycloneDX",
 				SpecVersion:  cdx.SpecVersion1_5,
-				JSONSchema: "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
 				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
 				Version:      1,
 				Metadata: &cdx.Metadata{
@@ -1065,7 +1065,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 				BOMFormat:    "CycloneDX",
 				SpecVersion:  cdx.SpecVersion1_5,
-				JSONSchema: "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
 				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
 				Version:      1,
 				Metadata: &cdx.Metadata{
@@ -1164,6 +1164,266 @@ func TestMarshaler_Marshal(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path. 2 packages for 1 CVE",
+			inputReport: types.Report{
+				SchemaVersion: report.SchemaVersion,
+				ArtifactName:  "CVE-2023-34468",
+				ArtifactType:  ftypes.ArtifactFilesystem,
+				Results: types.Results{
+					{
+						Target: "Java",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.Jar,
+						Packages: []ftypes.Package{
+							{
+								Name:     "org.apache.nifi:nifi-dbcp-base",
+								Version:  "1.20.0",
+								FilePath: "nifi-dbcp-base-1.20.0.jar",
+							},
+							{
+								Name:     "org.apache.nifi:nifi-hikari-dbcp-service",
+								Version:  "1.20.0",
+								FilePath: "nifi-hikari-dbcp-service-1.20.0.jar",
+							},
+						},
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2023-34468",
+								PkgName:          "org.apache.nifi:nifi-dbcp-base",
+								PkgPath:          "nifi-dbcp-base-1.20.0.jar",
+								InstalledVersion: "1.20.0",
+								FixedVersion:     "1.22.0",
+								SeveritySource:   vulnerability.GHSA,
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2023-34468",
+								DataSource: &dtypes.DataSource{
+									ID:   vulnerability.GHSA,
+									Name: "GitHub Security Advisory Maven",
+									URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
+								},
+								Vulnerability: dtypes.Vulnerability{
+									Title:       "Apache NiFi vulnerable to Code Injection",
+									Description: "The DBCPConnectionPool and HikariCPConnectionPool Controller Services in Apache NiFi 0.0.2 through 1.21.0...",
+									Severity:    dtypes.SeverityHigh.String(),
+									CweIDs: []string{
+										"CWE-94",
+									},
+									VendorSeverity: dtypes.VendorSeverity{
+										vulnerability.GHSA: dtypes.SeverityHigh,
+										vulnerability.NVD:  dtypes.SeverityHigh,
+									},
+									CVSS: dtypes.VendorCVSS{
+										vulnerability.GHSA: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+										vulnerability.NVD: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+									},
+									References: []string{
+										"http://www.openwall.com/lists/oss-security/2023/06/12/3",
+										"https://github.com/advisories/GHSA-xm2m-2q6h-22jw",
+									},
+									PublishedDate:    lo.ToPtr(time.Date(2023, 6, 12, 16, 15, 0, 0, time.UTC)),
+									LastModifiedDate: lo.ToPtr(time.Date(2023, 6, 21, 02, 20, 0, 0, time.UTC)),
+								},
+							},
+							{
+								VulnerabilityID:  "CVE-2023-34468",
+								PkgName:          "org.apache.nifi:nifi-hikari-dbcp-service",
+								PkgPath:          "nifi-hikari-dbcp-service-1.20.0.jar",
+								InstalledVersion: "1.20.0",
+								FixedVersion:     "1.22.0",
+								SeveritySource:   vulnerability.GHSA,
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2023-34468",
+								DataSource: &dtypes.DataSource{
+									ID:   vulnerability.GHSA,
+									Name: "GitHub Security Advisory Maven",
+									URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
+								},
+								Vulnerability: dtypes.Vulnerability{
+									Title:       "Apache NiFi vulnerable to Code Injection",
+									Description: "The DBCPConnectionPool and HikariCPConnectionPool Controller Services in Apache NiFi 0.0.2 through 1.21.0...",
+									Severity:    dtypes.SeverityHigh.String(),
+									CweIDs: []string{
+										"CWE-94",
+									},
+									VendorSeverity: dtypes.VendorSeverity{
+										vulnerability.GHSA: dtypes.SeverityHigh,
+										vulnerability.NVD:  dtypes.SeverityHigh,
+									},
+									CVSS: dtypes.VendorCVSS{
+										vulnerability.GHSA: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+										vulnerability.NVD: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+									},
+									References: []string{
+										"http://www.openwall.com/lists/oss-security/2023/06/12/3",
+										"https://github.com/advisories/GHSA-xm2m-2q6h-22jw",
+									},
+									PublishedDate:    lo.ToPtr(time.Date(2023, 6, 12, 16, 15, 0, 0, time.UTC)),
+									LastModifiedDate: lo.ToPtr(time.Date(2023, 6, 21, 02, 20, 0, 0, time.UTC)),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &cdx.BOM{
+				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
+				BOMFormat:    "CycloneDX",
+				SpecVersion:  cdx.SpecVersion1_5,
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
+				Version:      1,
+				Metadata: &cdx.Metadata{
+					Timestamp: "2021-08-25T12:20:30+00:00",
+					Tools: &[]cdx.Tool{
+						{
+							Name:    "trivy",
+							Vendor:  "aquasecurity",
+							Version: "dev",
+						},
+					},
+					Component: &cdx.Component{
+						BOMRef: "3ff14136-e09f-4df9-80ea-000000000002",
+						Type:   cdx.ComponentTypeApplication,
+						Name:   "CVE-2023-34468",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:SchemaVersion",
+								Value: "2",
+							},
+						},
+					},
+				},
+				Components: &[]cdx.Component{
+					{
+						BOMRef:     "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+						Type:       "library",
+						Name:       "nifi-dbcp-base",
+						Group:      "org.apache.nifi",
+						Version:    "1.20.0",
+						PackageURL: "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:FilePath",
+								Value: "nifi-dbcp-base-1.20.0.jar",
+							},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "jar",
+							},
+						},
+					},
+					{
+						BOMRef:     "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
+						Type:       "library",
+						Name:       "nifi-hikari-dbcp-service",
+						Group:      "org.apache.nifi",
+						Version:    "1.20.0",
+						PackageURL: "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:FilePath",
+								Value: "nifi-hikari-dbcp-service-1.20.0.jar",
+							},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "jar",
+							},
+						},
+					},
+				},
+				Dependencies: &[]cdx.Dependency{
+					{
+						Ref: "3ff14136-e09f-4df9-80ea-000000000002",
+						Dependencies: &[]string{
+							"pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+							"pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
+						},
+					},
+					{
+						Ref:          "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+						Dependencies: lo.ToPtr([]string{}),
+					},
+					{
+						Ref:          "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
+						Dependencies: lo.ToPtr([]string{}),
+					},
+				},
+				Vulnerabilities: &[]cdx.Vulnerability{
+					{
+						ID: "CVE-2023-34468",
+						Source: &cdx.Source{
+							Name: string(vulnerability.GHSA),
+							URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
+						},
+						Recommendation: "Upgrade org.apache.nifi:nifi-dbcp-base to version 1.22.0, Upgrade org.apache.nifi:nifi-hikari-dbcp-service to version 1.22.0",
+
+						Ratings: &[]cdx.VulnerabilityRating{
+							{
+								Source: &cdx.Source{
+									Name: string(vulnerability.GHSA),
+								},
+								Score:    lo.ToPtr(8.8),
+								Severity: cdx.SeverityHigh,
+								Method:   cdx.ScoringMethodCVSSv31,
+								Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							},
+							{
+								Source: &cdx.Source{
+									Name: string(vulnerability.NVD),
+								},
+								Score:    lo.ToPtr(8.8),
+								Severity: cdx.SeverityHigh,
+								Method:   cdx.ScoringMethodCVSSv31,
+								Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+							},
+						},
+						CWEs:        lo.ToPtr([]int{94}),
+						Description: "The DBCPConnectionPool and HikariCPConnectionPool Controller Services in Apache NiFi 0.0.2 through 1.21.0...",
+						Advisories: &[]cdx.Advisory{
+							{
+								URL: "http://www.openwall.com/lists/oss-security/2023/06/12/3",
+							},
+							{
+								URL: "https://github.com/advisories/GHSA-xm2m-2q6h-22jw",
+							},
+						},
+						Published: "2023-06-12T16:15:00+00:00",
+						Updated:   "2023-06-21T02:20:00+00:00",
+						Affects: &[]cdx.Affects{
+							{
+								Ref: "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+								Range: &[]cdx.AffectedVersions{
+									{
+										Version: "1.20.0",
+										Status:  cdx.VulnerabilityStatusAffected,
+									},
+								},
+							},
+							{
+								Ref: "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
+								Range: &[]cdx.AffectedVersions{
+									{
+										Version: "1.20.0",
+										Status:  cdx.VulnerabilityStatusAffected,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "happy path aggregate results",
 			inputReport: types.Report{
 				SchemaVersion: report.SchemaVersion,
@@ -1193,7 +1453,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 				BOMFormat:    "CycloneDX",
 				SpecVersion:  cdx.SpecVersion1_5,
-				JSONSchema: "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
 				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
 				Version:      1,
 				Metadata: &cdx.Metadata{
@@ -1274,7 +1534,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 				BOMFormat:    "CycloneDX",
 				SpecVersion:  cdx.SpecVersion1_5,
-				JSONSchema: "http://cyclonedx.org/schema/bom-1.5.schema.json",
+				JSONSchema:   "http://cyclonedx.org/schema/bom-1.5.schema.json",
 				SerialNumber: "urn:uuid:3ff14136-e09f-4df9-80ea-000000000001",
 				Version:      1,
 				Metadata: &cdx.Metadata{


### PR DESCRIPTION
## Description
CycloneDX merges same CVE for different packages to 1 vulnerability.
We need to add all package names and fixed versions to [recommendation](https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_recommendation) field.

## Related issues
- Close #4781

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
