### PR TITLE
fix(oracle): add architectures support for advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -400,3 +400,5 @@ require (
 
 // oras 1.2.2 is incompatible with github.com/docker/docker v23.0.0-rc.1+incompatible
 replace oras.land/oras-go => oras.land/oras-go v1.2.3
+
+replace github.com/aquasecurity/trivy-db => github.com/DmitriyLewen/trivy-db v0.0.0-20230712025148-ff4a8e1644f1

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.7.2-0.20230625092137-07e2f29defc3 h1:NqeV+ZMqpcosu0Xg2VW14Ru9ayBs/toe2oihS7sN6Xo=
 github.com/CycloneDX/cyclonedx-go v0.7.2-0.20230625092137-07e2f29defc3/go.mod h1:fGXSp1lCDfMQ8KR1EjxT4ewc5HHhGczRF2pWhLSWohs=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DmitriyLewen/trivy-db v0.0.0-20230712025148-ff4a8e1644f1 h1:yHn9+sDl66vXk/l2h9v9Bq+0IDgIbHlAJl9PcYRWvlI=
+github.com/DmitriyLewen/trivy-db v0.0.0-20230712025148-ff4a8e1644f1/go.mod h1:cXuqKo+FaMY0ixJNoUcyDHdfCBRPWOysI2Td8N4fRsg=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible h1:juIaKLLVhqzP55d8x4cSVgwyQv76Z55/fRv/UBr2KkQ=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
@@ -343,8 +345,6 @@ github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da h1:pj/adfN
 github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da/go.mod h1:852lbQLpK2nCwlR4ZLYIccxYCfoQao6q9Nl6tjz54v8=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy-db v0.0.0-20230703082116-dc52e83376ce h1:swoQLWQoZ4HW13XeEji217TTcgi61MuMZdsKrqSTE0A=
-github.com/aquasecurity/trivy-db v0.0.0-20230703082116-dc52e83376ce/go.mod h1:cXuqKo+FaMY0ixJNoUcyDHdfCBRPWOysI2Td8N4fRsg=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728 h1:0eS+V7SXHgqoT99tV1mtMW6HL4HdoB9qGLMCb1fZp8A=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728/go.mod h1:Ldya37FLi0e/5Cjq2T5Bty7cFkzUDwTcPeQua+2M8i8=
 github.com/aquasecurity/trivy-kubernetes v0.5.7-0.20230628140707-dae3bdb6ee81 h1:5/tKpCr861auON/CMHSXnRzNixx1FTWAeHSwV0PtA0U=

--- a/integration/testdata/fixtures/db/oracle.yaml
+++ b/integration/testdata/fixtures/db/oracle.yaml
@@ -5,6 +5,20 @@
         - key: CVE-2019-3823
           value:
             FixedVersion: 7.61.1-11.el8
+            Entries:
+              - FixedVersion: 7.61.1-11.el8
+                Arches:
+                  - x86_64
+                  - aarch64
+                VendorIds:
+                  - ELSA-2019-3701
         - key: CVE-2019-5436
           value:
             FixedVersion: 7.61.1-12.el8
+            Entries:
+              - FixedVersion: 7.61.1-12.el8
+                Arches:
+                  - x86_64
+                  - aarch64
+                VendorIds:
+                  - ELSA-2020-1792

--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -67,7 +67,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
-		advisories, err := s.vs.Get(osVer, pkg.Name)
+		advisories, err := s.vs.Get(osVer, pkg.Name, pkg.Arch)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get Oracle Linux advisory: %w", err)
 		}

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -140,6 +140,57 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name:     "different fixed versions for different arches",
+			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
+			args: args{
+				osVer: "7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "rsyslog",
+						Version:    "8.24.0",
+						Release:    "57.0.0.el7",
+						Arch:       "x86_64",
+						SrcName:    "rsyslog",
+						SrcVersion: "8.24.0",
+						SrcRelease: "57.0.0.el7",
+					},
+					{
+						Name:       "rsyslog",
+						Version:    "8.24.0",
+						Release:    "57.0.0.el7",
+						Arch:       "aarch64",
+						SrcName:    "rsyslog",
+						SrcVersion: "8.24.0",
+						SrcRelease: "57.0.0.el7",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2022-24903",
+					PkgName:          "rsyslog",
+					InstalledVersion: "8.24.0-57.0.0.el7",
+					FixedVersion:     "8.24.0-57.0.1.el7_9.3",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.OracleOVAL,
+						Name: "Oracle Linux OVAL definitions",
+						URL:  "https://linux.oracle.com/security/oval/",
+					},
+				},
+				{
+					VulnerabilityID:  "CVE-2022-24903",
+					PkgName:          "rsyslog",
+					InstalledVersion: "8.24.0-57.0.0.el7",
+					FixedVersion:     "8.24.0-57.0.4.el7_9.3",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.OracleOVAL,
+						Name: "Oracle Linux OVAL definitions",
+						URL:  "https://linux.oracle.com/security/oval/",
+					},
+				},
+			},
+		},
+		{
 			name:     "without ksplice",
 			fixtures: []string{"testdata/fixtures/oracle7.yaml", "testdata/fixtures/data-source.yaml"},
 			args: args{

--- a/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
+++ b/pkg/detector/ospkg/oracle/testdata/fixtures/oracle7.yaml
@@ -4,9 +4,39 @@
       pairs:
         - key: CVE-2020-8177
           value:
-            FixedVersion: "7.29.0-59.0.1.el7_9.1"
+            FixedVersion: 7.29.0-59.0.1.el7_9.1
+            Entries:
+              - FixedVersion: 7.29.0-59.0.1.el7_9.1
+                Arches:
+                  - x86_64
+                  - aarch64
+                VendorIds:
+                  - ELSA-2020-5002
     - bucket: glibc
       pairs:
         - key: CVE-2017-1000364
           value:
-            FixedVersion: "2:2.17-157.ksplice1.el7_3.4"
+            FixedVersion: 2:2.17-157.ksplice1.el7_3.4
+            Entries:
+              - FixedVersion: 2:2.17-157.ksplice1.el7_3.4
+                Arches:
+                  - x86_64
+                  - aarch64
+                VendorIds:
+                  - ELSA-2017-3582
+    - bucket: rsyslog
+      pairs:
+        - key: CVE-2022-24903
+          value:
+            FixedVersion: 8.24.0-57.0.1.el7_9.3
+            Entries:
+              - FixedVersion: 8.24.0-57.0.1.el7_9.3
+                Arches:
+                  - x86_64
+                VendorIds:
+                  - ELSA-2022-4803
+              - FixedVersion: 8.24.0-57.0.4.el7_9.3
+                Arches:
+                  - aarch64
+                VendorIds:
+                  - ELSA-2022-4803


### PR DESCRIPTION
## Description
Add architectures support for Oracle Linux advisories

## Related issues
- Close #4663

## Related PRs
- [ ] aquasecurity/trivy-db/pull/331

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
