### PR TITLE
feat(misconf): Support custom URLs for policy bundle

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -85,6 +85,7 @@ trivy aws [flags]
       --list-all-pkgs                   enabling the option will output all packages regardless of vulnerability
       --max-cache-age duration          The maximum age of the cloud cache. Cached data will be requeried from the cloud provider if it is older than this. (default 24h0m0s)
   -o, --output string                   output file name
+      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings       Rego namespaces
       --region string                   AWS Region to scan
       --report string                   specify a report format for the output (all,summary) (default "all")

--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -65,40 +65,40 @@ trivy aws [flags]
 ### Options
 
 ```
-      --account string                  The AWS account to scan. It's useful to specify this when reviewing cached results for multiple accounts.
-      --arn string                      The AWS ARN to show results for. Useful to filter results once a scan is cached.
-      --compliance string               compliance report to generate (aws-cis-1.2,aws-cis-1.4)
-      --config-data strings             specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings           specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --dependency-tree                 [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --endpoint string                 AWS Endpoint override
-      --exit-code int                   specify exit code when any security issues are found
-  -f, --format string                   format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings           specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings         specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings             specify paths to override the Helm values.yaml files
-  -h, --help                            help for aws
-      --ignore-policy string            specify the Rego file path to evaluate each vulnerability
-      --ignorefile string               specify .trivyignore file (default ".trivyignore")
-      --include-non-failures            include successes and exceptions, available with '--scanners config'
-      --list-all-pkgs                   enabling the option will output all packages regardless of vulnerability
-      --max-cache-age duration          The maximum age of the cloud cache. Cached data will be requeried from the cloud provider if it is older than this. (default 24h0m0s)
-  -o, --output string                   output file name
-      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings       Rego namespaces
-      --region string                   AWS Region to scan
-      --report string                   specify a report format for the output (all,summary) (default "all")
-      --reset-policy-bundle             remove policy bundle
-      --service strings                 Only scan AWS Service(s) specified with this flag. Can specify multiple services using --service A --service B etc.
-  -s, --severity strings                severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-policy-update              skip fetching rego policy updates
-      --skip-service strings            Skip selected AWS Service(s) specified with this flag. Can specify multiple services using --skip-service A --skip-service B etc.
-  -t, --template string                 output template
-      --tf-exclude-downloaded-modules   remove results for downloaded modules in .terraform folder
-      --tf-vars strings                 specify paths to override the Terraform tfvars files
-      --trace                           enable more verbose trace output for custom queries
-      --update-cache                    Update the cache for the applicable cloud provider instead of using cached results.
+      --account string                    The AWS account to scan. It's useful to specify this when reviewing cached results for multiple accounts.
+      --arn string                        The AWS ARN to show results for. Useful to filter results once a scan is cached.
+      --compliance string                 compliance report to generate (aws-cis-1.2, aws-cis-1.4)
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --endpoint string                   AWS Endpoint override
+      --exit-code int                     specify exit code when any security issues are found
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for aws
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --max-cache-age duration            The maximum age of the cloud cache. Cached data will be requeried from the cloud provider if it is older than this. (default 24h0m0s)
+  -o, --output string                     output file name
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --region string                     AWS Region to scan
+      --report string                     specify a report format for the output (all,summary) (default "all")
+      --reset-policy-bundle               remove policy bundle
+      --service strings                   Only scan AWS Service(s) specified with this flag. Can specify multiple services using --service A --service B etc.
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-policy-update                skip fetching rego policy updates
+      --skip-service strings              Skip selected AWS Service(s) specified with this flag. Can specify multiple services using --skip-service A --skip-service B etc.
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --trace                             enable more verbose trace output for custom queries
+      --update-cache                      Update the cache for the applicable cloud provider instead of using cached results.
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -67,13 +67,13 @@ trivy aws [flags]
 ```
       --account string                    The AWS account to scan. It's useful to specify this when reviewing cached results for multiple accounts.
       --arn string                        The AWS ARN to show results for. Useful to filter results once a scan is cached.
-      --compliance string                 compliance report to generate (aws-cis-1.2, aws-cis-1.4)
+      --compliance string                 compliance report to generate (aws-cis-1.2,aws-cis-1.4)
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --endpoint string                   AWS Endpoint override
       --exit-code int                     specify exit code when any security issues are found
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -91,7 +91,7 @@ trivy aws [flags]
       --report string                     specify a report format for the output (all,summary) (default "all")
       --reset-policy-bundle               remove policy bundle
       --service strings                   Only scan AWS Service(s) specified with this flag. Can specify multiple services using --service A --service B etc.
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-policy-update                skip fetching rego policy updates
       --skip-service strings              Skip selected AWS Service(s) specified with this flag. Can specify multiple services using --skip-service A --skip-service B etc.
   -t, --template string                   output template

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -9,45 +9,45 @@ trivy config [flags] DIR
 ### Options
 
 ```
-      --cache-backend string            cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration              cache TTL when using redis as cache backend
-      --clear-cache                     clear image caches without scanning
-      --compliance string               compliance report to generate
-      --config-data strings             specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings           specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --enable-modules strings          [EXPERIMENTAL] module names to enable
-      --exit-code int                   specify exit code when any security issues are found
-      --file-patterns strings           specify config file patterns
-  -f, --format string                   format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings           specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings         specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings             specify paths to override the Helm values.yaml files
-  -h, --help                            help for config
-      --ignorefile string               specify .trivyignore file (default ".trivyignore")
-      --include-non-failures            include successes and exceptions, available with '--scanners config'
-      --k8s-version string              specify k8s version to validate outdated api by it (example: 1.21.0)
-      --module-dir string               specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-  -o, --output string                   output file name
-      --password strings                password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings       Rego namespaces
-      --redis-ca string                 redis ca file location, if using redis as cache backend
-      --redis-cert string               redis certificate file location, if using redis as cache backend
-      --redis-key string                redis key file location, if using redis as cache backend
-      --redis-tls                       enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string           registry token
-      --report string                   specify a compliance report format for the output (all,summary) (default "all")
-      --reset-policy-bundle             remove policy bundle
-  -s, --severity strings                severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-dirs strings               specify the directories where the traversal is skipped
-      --skip-files strings              specify the file paths to skip traversal
-      --skip-policy-update              skip fetching rego policy updates
-  -t, --template string                 output template
-      --tf-exclude-downloaded-modules   remove results for downloaded modules in .terraform folder
-      --tf-vars strings                 specify paths to override the Terraform tfvars files
-      --trace                           enable more verbose trace output for custom queries
-      --username strings                username. Comma-separated usernames allowed.
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --compliance string                 compliance report to generate
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for config
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+  -o, --output string                     output file name
+      --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string             registry token
+      --report string                     specify a compliance report format for the output (all,summary) (default "all")
+      --reset-policy-bundle               remove policy bundle
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-policy-update                skip fetching rego policy updates
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --trace                             enable more verbose trace output for custom queries
+      --username strings                  username. Comma-separated usernames allowed.
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -30,6 +30,7 @@ trivy config [flags] DIR
       --module-dir string               specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
   -o, --output string                   output file name
       --password strings                password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings       Rego namespaces
       --redis-ca string                 redis ca file location, if using redis as cache backend
       --redis-cert string               redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -18,7 +18,7 @@ trivy config [flags] DIR
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -39,7 +39,7 @@ trivy config [flags] DIR
       --registry-token string             registry token
       --report string                     specify a compliance report format for the output (all,summary) (default "all")
       --reset-policy-bundle               remove policy bundle
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal
       --skip-policy-update                skip fetching rego policy updates

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -54,6 +54,7 @@ trivy filesystem [flags] PATH
       --offline-scan                     do not issue API requests to identify dependencies
   -o, --output string                    output file name
       --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings        Rego namespaces
       --redis-ca string                  redis ca file location, if using redis as cache backend
       --redis-cert string                redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -19,71 +19,71 @@ trivy filesystem [flags] PATH
 ### Options
 
 ```
-      --cache-backend string             cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration               cache TTL when using redis as cache backend
-      --clear-cache                      clear image caches without scanning
-      --compliance string                compliance report to generate
-      --config-data strings              specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings            specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --custom-headers strings           custom headers in client mode
-      --db-repository string             OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --dependency-tree                  [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --download-db-only                 download/update vulnerability database but don't run a scan
-      --download-java-db-only            download/update Java index database but don't run a scan
-      --enable-modules strings           [EXPERIMENTAL] module names to enable
-      --exit-code int                    specify exit code when any security issues are found
-      --file-patterns strings            specify config file patterns
-  -f, --format string                    format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                 specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings            specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings          specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings              specify paths to override the Helm values.yaml files
-  -h, --help                             help for filesystem
-      --ignore-policy string             specify the Rego file path to evaluate each vulnerability
-      --ignore-unfixed                   display only fixed vulnerabilities
-      --ignored-licenses strings         specify a list of license to ignore
-      --ignorefile string                specify .trivyignore file (default ".trivyignore")
-      --include-dev-deps                 include development dependencies in the report (supported: npm, yarn)
-      --include-non-failures             include successes and exceptions, available with '--scanners config'
-      --java-db-repository string        OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --license-confidence-level float   specify license classifier's confidence level (default 0.9)
-      --license-full                     eagerly look for licenses in source code headers and license files
-      --list-all-pkgs                    enabling the option will output all packages regardless of vulnerability
-      --module-dir string                specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                      suppress progress bar
-      --offline-scan                     do not issue API requests to identify dependencies
-  -o, --output string                    output file name
-      --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings        Rego namespaces
-      --redis-ca string                  redis ca file location, if using redis as cache backend
-      --redis-cert string                redis certificate file location, if using redis as cache backend
-      --redis-key string                 redis key file location, if using redis as cache backend
-      --redis-tls                        enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string            registry token
-      --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --report string                    specify a compliance report format for the output (all,summary) (default "all")
-      --reset                            remove all caches and database
-      --reset-policy-bundle              remove policy bundle
-      --sbom-sources strings             [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                 comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
-      --secret-config string             specify a path to config file for secret scanning (default "trivy-secret.yaml")
-      --server string                    server address in client mode
-  -s, --severity strings                 severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-db-update                   skip updating vulnerability database
-      --skip-dirs strings                specify the directories where the traversal is skipped
-      --skip-files strings               specify the file paths to skip traversal
-      --skip-java-db-update              skip updating Java index database
-      --skip-policy-update               skip fetching rego policy updates
-      --slow                             scan over time with lower CPU and memory utilization
-  -t, --template string                  output template
-      --tf-exclude-downloaded-modules    remove results for downloaded modules in .terraform folder
-      --tf-vars strings                  specify paths to override the Terraform tfvars files
-      --token string                     for authentication in client/server mode
-      --token-header string              specify a header name for token in client/server mode (default "Trivy-Token")
-      --trace                            enable more verbose trace output for custom queries
-      --username strings                 username. Comma-separated usernames allowed.
-      --vuln-type strings                comma-separated list of vulnerability types (os,library) (default [os,library])
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --compliance string                 compliance report to generate
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --custom-headers strings            custom headers in client mode
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --download-db-only                  download/update vulnerability database but don't run a scan
+      --download-java-db-only             download/update Java index database but don't run a scan
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for filesystem
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignore-unfixed                    display only fixed vulnerabilities
+      --ignored-licenses strings          specify a list of license to ignore
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --license-confidence-level float    specify license classifier's confidence level (default 0.9)
+      --license-full                      eagerly look for licenses in source code headers and license files
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                       suppress progress bar
+      --offline-scan                      do not issue API requests to identify dependencies
+  -o, --output string                     output file name
+      --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string             registry token
+      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --report string                     specify a compliance report format for the output (all,summary) (default "all")
+      --reset                             remove all caches and database
+      --reset-policy-bundle               remove policy bundle
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --server string                     server address in client mode
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-db-update                    skip updating vulnerability database
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-java-db-update               skip updating Java index database
+      --skip-policy-update                skip fetching rego policy updates
+      --slow                              scan over time with lower CPU and memory utilization
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --token string                      for authentication in client/server mode
+      --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
+      --trace                             enable more verbose trace output for custom queries
+      --username strings                  username. Comma-separated usernames allowed.
+      --vuln-type strings                 comma-separated list of vulnerability types (os,library) (default [os,library])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -33,7 +33,7 @@ trivy filesystem [flags] PATH
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -69,7 +69,7 @@ trivy filesystem [flags] PATH
       --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -34,77 +34,77 @@ trivy image [flags] IMAGE_NAME
 ### Options
 
 ```
-      --cache-backend string             cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration               cache TTL when using redis as cache backend
-      --clear-cache                      clear image caches without scanning
-      --compliance string                compliance report to generate (docker-cis)
-      --config-data strings              specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings            specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --custom-headers strings           custom headers in client mode
-      --db-repository string             OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --dependency-tree                  [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --docker-host string               unix domain socket path to use for docker scanning
-      --download-db-only                 download/update vulnerability database but don't run a scan
-      --download-java-db-only            download/update Java index database but don't run a scan
-      --enable-modules strings           [EXPERIMENTAL] module names to enable
-      --exit-code int                    specify exit code when any security issues are found
-      --exit-on-eol int                  exit with the specified code when the OS reaches end of service/life
-      --file-patterns strings            specify config file patterns
-  -f, --format string                    format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                 specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings            specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings          specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings              specify paths to override the Helm values.yaml files
-  -h, --help                             help for image
-      --ignore-policy string             specify the Rego file path to evaluate each vulnerability
-      --ignore-unfixed                   display only fixed vulnerabilities
-      --ignored-licenses strings         specify a list of license to ignore
-      --ignorefile string                specify .trivyignore file (default ".trivyignore")
-      --image-config-scanners strings    comma-separated list of what security issues to detect on container image configurations (config,secret)
-      --image-src strings                image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
-      --include-non-failures             include successes and exceptions, available with '--scanners config'
-      --input string                     input file path instead of image name
-      --java-db-repository string        OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --license-confidence-level float   specify license classifier's confidence level (default 0.9)
-      --license-full                     eagerly look for licenses in source code headers and license files
-      --list-all-pkgs                    enabling the option will output all packages regardless of vulnerability
-      --module-dir string                specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                      suppress progress bar
-      --offline-scan                     do not issue API requests to identify dependencies
-  -o, --output string                    output file name
-      --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --platform string                  set platform in the form os/arch if image is multi-platform capable
-      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings        Rego namespaces
-      --redis-ca string                  redis ca file location, if using redis as cache backend
-      --redis-cert string                redis certificate file location, if using redis as cache backend
-      --redis-key string                 redis key file location, if using redis as cache backend
-      --redis-tls                        enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string            registry token
-      --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --removed-pkgs                     detect vulnerabilities of removed packages (only for Alpine)
-      --report string                    specify a format for the compliance report. (all,summary) (default "summary")
-      --reset                            remove all caches and database
-      --reset-policy-bundle              remove policy bundle
-      --sbom-sources strings             [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                 comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
-      --secret-config string             specify a path to config file for secret scanning (default "trivy-secret.yaml")
-      --server string                    server address in client mode
-  -s, --severity strings                 severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-db-update                   skip updating vulnerability database
-      --skip-dirs strings                specify the directories where the traversal is skipped
-      --skip-files strings               specify the file paths to skip traversal
-      --skip-java-db-update              skip updating Java index database
-      --skip-policy-update               skip fetching rego policy updates
-      --slow                             scan over time with lower CPU and memory utilization
-  -t, --template string                  output template
-      --tf-exclude-downloaded-modules    remove results for downloaded modules in .terraform folder
-      --tf-vars strings                  specify paths to override the Terraform tfvars files
-      --token string                     for authentication in client/server mode
-      --token-header string              specify a header name for token in client/server mode (default "Trivy-Token")
-      --trace                            enable more verbose trace output for custom queries
-      --username strings                 username. Comma-separated usernames allowed.
-      --vuln-type strings                comma-separated list of vulnerability types (os,library) (default [os,library])
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --compliance string                 compliance report to generate (docker-cis)
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --custom-headers strings            custom headers in client mode
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --docker-host string                unix domain socket path to use for docker scanning
+      --download-db-only                  download/update vulnerability database but don't run a scan
+      --download-java-db-only             download/update Java index database but don't run a scan
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for image
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignore-unfixed                    display only fixed vulnerabilities
+      --ignored-licenses strings          specify a list of license to ignore
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --image-config-scanners strings      comma-separated list of what security issues to detect on container image configurations (config,secret)
+      --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --input string                      input file path instead of image name
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --license-confidence-level float    specify license classifier's confidence level (default 0.9)
+      --license-full                      eagerly look for licenses in source code headers and license files
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                       suppress progress bar
+      --offline-scan                      do not issue API requests to identify dependencies
+  -o, --output string                     output file name
+      --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --platform string                   set platform in the form os/arch if image is multi-platform capable
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string             registry token
+      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --removed-pkgs                      detect vulnerabilities of removed packages (only for Alpine)
+      --report string                     specify a format for the compliance report. (all,summary) (default "summary")
+      --reset                             remove all caches and database
+      --reset-policy-bundle               remove policy bundle
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --server string                     server address in client mode
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-db-update                    skip updating vulnerability database
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-java-db-update               skip updating Java index database
+      --skip-policy-update                skip fetching rego policy updates
+      --slow                              scan over time with lower CPU and memory utilization
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --token string                      for authentication in client/server mode
+      --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
+      --trace                             enable more verbose trace output for custom queries
+      --username strings                  username. Comma-separated usernames allowed.
+      --vuln-type strings                 comma-separated list of vulnerability types (os,library) (default [os,library])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -74,6 +74,7 @@ trivy image [flags] IMAGE_NAME
   -o, --output string                    output file name
       --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --platform string                  set platform in the form os/arch if image is multi-platform capable
+      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings        Rego namespaces
       --redis-ca string                  redis ca file location, if using redis as cache backend
       --redis-cert string                redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -50,7 +50,7 @@ trivy image [flags] IMAGE_NAME
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -60,7 +60,7 @@ trivy image [flags] IMAGE_NAME
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --image-config-scanners strings      comma-separated list of what security issues to detect on container image configurations (config,secret)
+      --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (config,secret)
       --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-non-failures              include successes and exceptions, available with '--scanners config'
       --input string                      input file path instead of image name
@@ -90,7 +90,7 @@ trivy image [flags] IMAGE_NAME
       --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -65,6 +65,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
   -o, --output string                     output file name
       --parallel int                      number (between 1-20) of goroutines enabled for parallel scanning (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-url string          OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings         Rego namespaces
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -65,7 +65,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
   -o, --output string                     output file name
       --parallel int                      number (between 1-20) of goroutines enabled for parallel scanning (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --policy-bundle-url string          OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings         Rego namespaces
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -52,6 +52,7 @@ trivy repository [flags] REPO_URL
       --offline-scan                     do not issue API requests to identify dependencies
   -o, --output string                    output file name
       --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings        Rego namespaces
       --redis-ca string                  redis ca file location, if using redis as cache backend
       --redis-cert string                redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -31,7 +31,7 @@ trivy repository [flags] REPO_URL
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -41,7 +41,7 @@ trivy repository [flags] REPO_URL
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --include-dev-deps                 include development dependencies in the report (supported: npm, yarn)
+      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
       --include-non-failures              include successes and exceptions, available with '--scanners config'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
@@ -66,7 +66,7 @@ trivy repository [flags] REPO_URL
       --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -16,72 +16,72 @@ trivy repository [flags] REPO_URL
 ### Options
 
 ```
-      --branch string                    pass the branch name to be scanned
-      --cache-backend string             cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration               cache TTL when using redis as cache backend
-      --clear-cache                      clear image caches without scanning
-      --commit string                    pass the commit hash to be scanned
-      --config-data strings              specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings            specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --custom-headers strings           custom headers in client mode
-      --db-repository string             OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --dependency-tree                  [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --download-db-only                 download/update vulnerability database but don't run a scan
-      --download-java-db-only            download/update Java index database but don't run a scan
-      --enable-modules strings           [EXPERIMENTAL] module names to enable
-      --exit-code int                    specify exit code when any security issues are found
-      --file-patterns strings            specify config file patterns
-  -f, --format string                    format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                 specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings            specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings          specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings              specify paths to override the Helm values.yaml files
-  -h, --help                             help for repository
-      --ignore-policy string             specify the Rego file path to evaluate each vulnerability
-      --ignore-unfixed                   display only fixed vulnerabilities
-      --ignored-licenses strings         specify a list of license to ignore
-      --ignorefile string                specify .trivyignore file (default ".trivyignore")
+      --branch string                     pass the branch name to be scanned
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --commit string                     pass the commit hash to be scanned
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --custom-headers strings            custom headers in client mode
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --download-db-only                  download/update vulnerability database but don't run a scan
+      --download-java-db-only             download/update Java index database but don't run a scan
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for repository
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignore-unfixed                    display only fixed vulnerabilities
+      --ignored-licenses strings          specify a list of license to ignore
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-dev-deps                 include development dependencies in the report (supported: npm, yarn)
-      --include-non-failures             include successes and exceptions, available with '--scanners config'
-      --java-db-repository string        OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --license-confidence-level float   specify license classifier's confidence level (default 0.9)
-      --license-full                     eagerly look for licenses in source code headers and license files
-      --list-all-pkgs                    enabling the option will output all packages regardless of vulnerability
-      --module-dir string                specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                      suppress progress bar
-      --offline-scan                     do not issue API requests to identify dependencies
-  -o, --output string                    output file name
-      --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings        Rego namespaces
-      --redis-ca string                  redis ca file location, if using redis as cache backend
-      --redis-cert string                redis certificate file location, if using redis as cache backend
-      --redis-key string                 redis key file location, if using redis as cache backend
-      --redis-tls                        enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string            registry token
-      --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --reset                            remove all caches and database
-      --reset-policy-bundle              remove policy bundle
-      --sbom-sources strings             [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                 comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
-      --secret-config string             specify a path to config file for secret scanning (default "trivy-secret.yaml")
-      --server string                    server address in client mode
-  -s, --severity strings                 severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-db-update                   skip updating vulnerability database
-      --skip-dirs strings                specify the directories where the traversal is skipped
-      --skip-files strings               specify the file paths to skip traversal
-      --skip-java-db-update              skip updating Java index database
-      --skip-policy-update               skip fetching rego policy updates
-      --slow                             scan over time with lower CPU and memory utilization
-      --tag string                       pass the tag name to be scanned
-  -t, --template string                  output template
-      --tf-exclude-downloaded-modules    remove results for downloaded modules in .terraform folder
-      --tf-vars strings                  specify paths to override the Terraform tfvars files
-      --token string                     for authentication in client/server mode
-      --token-header string              specify a header name for token in client/server mode (default "Trivy-Token")
-      --trace                            enable more verbose trace output for custom queries
-      --username strings                 username. Comma-separated usernames allowed.
-      --vuln-type strings                comma-separated list of vulnerability types (os,library) (default [os,library])
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --license-confidence-level float    specify license classifier's confidence level (default 0.9)
+      --license-full                      eagerly look for licenses in source code headers and license files
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                       suppress progress bar
+      --offline-scan                      do not issue API requests to identify dependencies
+  -o, --output string                     output file name
+      --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string             registry token
+      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --reset                             remove all caches and database
+      --reset-policy-bundle               remove policy bundle
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --server string                     server address in client mode
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-db-update                    skip updating vulnerability database
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-java-db-update               skip updating Java index database
+      --skip-policy-update                skip fetching rego policy updates
+      --slow                              scan over time with lower CPU and memory utilization
+      --tag string                        pass the tag name to be scanned
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --token string                      for authentication in client/server mode
+      --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
+      --trace                             enable more verbose trace output for custom queries
+      --username strings                  username. Comma-separated usernames allowed.
+      --vuln-type strings                 comma-separated list of vulnerability types (os,library) (default [os,library])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -22,69 +22,69 @@ trivy rootfs [flags] ROOTDIR
 ### Options
 
 ```
-      --cache-backend string             cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration               cache TTL when using redis as cache backend
-      --clear-cache                      clear image caches without scanning
-      --config-data strings              specify paths from which data for the Rego policies will be recursively loaded
-      --config-policy strings            specify the paths to the Rego policy files or to the directories containing them, applying config files
-      --custom-headers strings           custom headers in client mode
-      --db-repository string             OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --dependency-tree                  [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --download-db-only                 download/update vulnerability database but don't run a scan
-      --download-java-db-only            download/update Java index database but don't run a scan
-      --enable-modules strings           [EXPERIMENTAL] module names to enable
-      --exit-code int                    specify exit code when any security issues are found
-      --exit-on-eol int                  exit with the specified code when the OS reaches end of service/life
-      --file-patterns strings            specify config file patterns
-  -f, --format string                    format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                 specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings            specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings          specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings              specify paths to override the Helm values.yaml files
-  -h, --help                             help for rootfs
-      --ignore-policy string             specify the Rego file path to evaluate each vulnerability
-      --ignore-unfixed                   display only fixed vulnerabilities
-      --ignored-licenses strings         specify a list of license to ignore
-      --ignorefile string                specify .trivyignore file (default ".trivyignore")
-      --include-non-failures             include successes and exceptions, available with '--scanners config'
-      --java-db-repository string        OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --license-confidence-level float   specify license classifier's confidence level (default 0.9)
-      --license-full                     eagerly look for licenses in source code headers and license files
-      --list-all-pkgs                    enabling the option will output all packages regardless of vulnerability
-      --module-dir string                specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                      suppress progress bar
-      --offline-scan                     do not issue API requests to identify dependencies
-  -o, --output string                    output file name
-      --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --policy-namespaces strings        Rego namespaces
-      --redis-ca string                  redis ca file location, if using redis as cache backend
-      --redis-cert string                redis certificate file location, if using redis as cache backend
-      --redis-key string                 redis key file location, if using redis as cache backend
-      --redis-tls                        enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string            registry token
-      --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --reset                            remove all caches and database
-      --reset-policy-bundle              remove policy bundle
-      --sbom-sources strings             [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                 comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
-      --secret-config string             specify a path to config file for secret scanning (default "trivy-secret.yaml")
-      --server string                    server address in client mode
-  -s, --severity strings                 severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-db-update                   skip updating vulnerability database
-      --skip-dirs strings                specify the directories where the traversal is skipped
-      --skip-files strings               specify the file paths to skip traversal
-      --skip-java-db-update              skip updating Java index database
-      --skip-policy-update               skip fetching rego policy updates
-      --slow                             scan over time with lower CPU and memory utilization
-  -t, --template string                  output template
-      --tf-exclude-downloaded-modules    remove results for downloaded modules in .terraform folder
-      --tf-vars strings                  specify paths to override the Terraform tfvars files
-      --token string                     for authentication in client/server mode
-      --token-header string              specify a header name for token in client/server mode (default "Trivy-Token")
-      --trace                            enable more verbose trace output for custom queries
-      --username strings                 username. Comma-separated usernames allowed.
-      --vuln-type strings                comma-separated list of vulnerability types (os,library) (default [os,library])
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
+      --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --custom-headers strings            custom headers in client mode
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --download-db-only                  download/update vulnerability database but don't run a scan
+      --download-java-db-only             download/update Java index database but don't run a scan
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for rootfs
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignore-unfixed                    display only fixed vulnerabilities
+      --ignored-licenses strings          specify a list of license to ignore
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --license-confidence-level float    specify license classifier's confidence level (default 0.9)
+      --license-full                      eagerly look for licenses in source code headers and license files
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                       suppress progress bar
+      --offline-scan                      do not issue API requests to identify dependencies
+  -o, --output string                     output file name
+      --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --policy-namespaces strings         Rego namespaces
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string             registry token
+      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --reset                             remove all caches and database
+      --reset-policy-bundle               remove policy bundle
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --server string                     server address in client mode
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-db-update                    skip updating vulnerability database
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-java-db-update               skip updating Java index database
+      --skip-policy-update                skip fetching rego policy updates
+      --slow                              scan over time with lower CPU and memory utilization
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --token string                      for authentication in client/server mode
+      --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
+      --trace                             enable more verbose trace output for custom queries
+      --username strings                  username. Comma-separated usernames allowed.
+      --vuln-type strings                 comma-separated list of vulnerability types (os,library) (default [os,library])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -56,6 +56,7 @@ trivy rootfs [flags] ROOTDIR
       --offline-scan                     do not issue API requests to identify dependencies
   -o, --output string                    output file name
       --password strings                 password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --policy-bundle-url string         OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --policy-namespaces strings        Rego namespaces
       --redis-ca string                  redis ca file location, if using redis as cache backend
       --redis-cert string                redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -36,7 +36,7 @@ trivy rootfs [flags] ROOTDIR
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -70,7 +70,7 @@ trivy rootfs [flags] ROOTDIR
       --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -20,60 +20,60 @@ trivy vm [flags] VM_IMAGE
 ### Options
 
 ```
-      --aws-region string               AWS region to scan
-      --cache-backend string            cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration              cache TTL when using redis as cache backend
-      --clear-cache                     clear image caches without scanning
-      --compliance string               compliance report to generate
-      --custom-headers strings          custom headers in client mode
-      --db-repository string            OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --dependency-tree                 [EXPERIMENTAL] show dependency origin tree of vulnerable packages
-      --download-db-only                download/update vulnerability database but don't run a scan
-      --download-java-db-only           download/update Java index database but don't run a scan
-      --enable-modules strings          [EXPERIMENTAL] module names to enable
-      --exit-code int                   specify exit code when any security issues are found
-      --exit-on-eol int                 exit with the specified code when the OS reaches end of service/life
-      --file-patterns strings           specify config file patterns
-  -f, --format string                   format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
-      --helm-set strings                specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-set-file strings           specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
-      --helm-set-string strings         specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-      --helm-values strings             specify paths to override the Helm values.yaml files
-  -h, --help                            help for vm
-      --ignore-policy string            specify the Rego file path to evaluate each vulnerability
-      --ignore-unfixed                  display only fixed vulnerabilities
-      --ignorefile string               specify .trivyignore file (default ".trivyignore")
-      --include-non-failures            include successes and exceptions, available with '--scanners config'
-      --java-db-repository string       OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --list-all-pkgs                   enabling the option will output all packages regardless of vulnerability
-      --module-dir string               specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                     suppress progress bar
-      --offline-scan                    do not issue API requests to identify dependencies
-  -o, --output string                   output file name
-      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
-      --redis-ca string                 redis ca file location, if using redis as cache backend
-      --redis-cert string               redis certificate file location, if using redis as cache backend
-      --redis-key string                redis key file location, if using redis as cache backend
-      --redis-tls                       enable redis TLS with public certificates, if using redis as cache backend
-      --rekor-url string                [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --reset                           remove all caches and database
-      --reset-policy-bundle             remove policy bundle
-      --sbom-sources strings            [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
-      --secret-config string            specify a path to config file for secret scanning (default "trivy-secret.yaml")
-      --server string                   server address in client mode
-  -s, --severity strings                severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-db-update                  skip updating vulnerability database
-      --skip-dirs strings               specify the directories where the traversal is skipped
-      --skip-files strings              specify the file paths to skip traversal
-      --skip-java-db-update             skip updating Java index database
-      --slow                            scan over time with lower CPU and memory utilization
-  -t, --template string                 output template
-      --tf-exclude-downloaded-modules   remove results for downloaded modules in .terraform folder
-      --tf-vars strings                 specify paths to override the Terraform tfvars files
-      --token string                    for authentication in client/server mode
-      --token-header string             specify a header name for token in client/server mode (default "Trivy-Token")
-      --vuln-type strings               comma-separated list of vulnerability types (os,library) (default [os,library])
+      --aws-region string                 AWS region to scan
+      --cache-backend string              cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration                cache TTL when using redis as cache backend
+      --clear-cache                       clear image caches without scanning
+      --compliance string                 compliance report to generate
+      --custom-headers strings            custom headers in client mode
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --download-db-only                  download/update vulnerability database but don't run a scan
+      --download-java-db-only             download/update Java index database but don't run a scan
+      --enable-modules strings            [EXPERIMENTAL] module names to enable
+      --exit-code int                     specify exit code when any security issues are found
+      --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
+      --file-patterns strings             specify config file patterns
+  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+      --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+      --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+      --helm-values strings               specify paths to override the Helm values.yaml files
+  -h, --help                              help for vm
+      --ignore-policy string              specify the Rego file path to evaluate each vulnerability
+      --ignore-unfixed                    display only fixed vulnerabilities
+      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                       suppress progress bar
+      --offline-scan                      do not issue API requests to identify dependencies
+  -o, --output string                     output file name
+      --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
+      --redis-ca string                   redis ca file location, if using redis as cache backend
+      --redis-cert string                 redis certificate file location, if using redis as cache backend
+      --redis-key string                  redis key file location, if using redis as cache backend
+      --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --reset                             remove all caches and database
+      --reset-policy-bundle               remove policy bundle
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --server string                     server address in client mode
+  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --skip-db-update                    skip updating vulnerability database
+      --skip-dirs strings                 specify the directories where the traversal is skipped
+      --skip-files strings                specify the file paths to skip traversal
+      --skip-java-db-update               skip updating Java index database
+      --slow                              scan over time with lower CPU and memory utilization
+  -t, --template string                   output template
+      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-vars strings                   specify paths to override the Terraform tfvars files
+      --token string                      for authentication in client/server mode
+      --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
+      --vuln-type strings                 comma-separated list of vulnerability types (os,library) (default [os,library])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -50,6 +50,7 @@ trivy vm [flags] VM_IMAGE
       --no-progress                     suppress progress bar
       --offline-scan                    do not issue API requests to identify dependencies
   -o, --output string                   output file name
+      --policy-bundle-url string        OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/defsec:0")
       --redis-ca string                 redis ca file location, if using redis as cache backend
       --redis-cert string               redis certificate file location, if using redis as cache backend
       --redis-key string                redis key file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -34,7 +34,7 @@ trivy vm [flags] VM_IMAGE
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table, json, template, sarif, cyclonedx, spdx, spdx-json, github, cosign-vuln) (default "table")
+  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --helm-set-file strings             specify Helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
       --helm-set-string strings           specify Helm string values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -62,7 +62,7 @@ trivy vm [flags] VM_IMAGE
       --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                   severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories where the traversal is skipped
       --skip-files strings                specify the file paths to skip traversal

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -68,7 +68,7 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	var policyPaths []string
 	var downloadedPolicyPaths []string
 	var err error
-	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate, option.MisconfOptions.PolicyBundleURL)
+	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate, option.MisconfOptions.PolicyBundleRepository)
 	if err != nil {
 		if !option.SkipPolicyUpdate {
 			log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -68,7 +68,7 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	var policyPaths []string
 	var downloadedPolicyPaths []string
 	var err error
-	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate)
+	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate, option.MisconfOptions.PolicyBundleURL)
 	if err != nil {
 		if !option.SkipPolicyUpdate {
 			log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1205,7 +1205,7 @@ func showVersion(cacheDir, outputFormat, version string, w io.Writer) error {
 	}
 
 	var pbMeta *policy.Metadata
-	pc, err := policy.NewClient(cacheDir, false)
+	pc, err := policy.NewClient(cacheDir, false, "")
 	if pc != nil && err == nil {
 		pbMeta, err = pc.GetMetadata()
 		if err != nil {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -566,7 +566,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 		var downloadedPolicyPaths []string
 		var disableEmbedded bool
-		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate, opts.MisconfOptions.PolicyBundleURL)
+		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate, opts.MisconfOptions.PolicyBundleRepository)
 		if err != nil {
 			if !opts.SkipPolicyUpdate {
 				log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -566,7 +566,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 		var downloadedPolicyPaths []string
 		var disableEmbedded bool
-		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate)
+		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate, opts.MisconfOptions.PolicyBundleURL)
 		if err != nil {
 			if !opts.SkipPolicyUpdate {
 				log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -372,7 +372,7 @@ func (r *runner) initCache(opts flag.Options) error {
 	}
 
 	if opts.ResetPolicyBundle {
-		c, err := policy.NewClient(fsutils.CacheDir(), true)
+		c, err := policy.NewClient(fsutils.CacheDir(), true, opts.MisconfOptions.PolicyBundleRepository)
 		if err != nil {
 			return xerrors.Errorf("failed to instantiate policy client: %w", err)
 		}

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -148,7 +148,7 @@ func showDBInfo(cacheDir string) error {
 }
 
 // InitBuiltinPolicies downloads the built-in policies and loads them
-func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleURL string) ([]string, error) {
+func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleRepository string) ([]string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -159,7 +159,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 
 	needsUpdate := false
 	if !skipUpdate {
-		needsUpdate, err = client.NeedsUpdate(ctx, policyBundleURL)
+		needsUpdate, err = client.NeedsUpdate(ctx, policyBundleRepository)
 		if err != nil {
 			return nil, xerrors.Errorf("unable to check if built-in policies need to be updated: %w", err)
 		}
@@ -168,7 +168,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	if needsUpdate {
 		log.Logger.Info("Need to update the built-in policies")
 		log.Logger.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx, policyBundleURL); err != nil {
+		if err = client.DownloadBuiltinPolicies(ctx, policyBundleRepository); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -148,7 +148,7 @@ func showDBInfo(cacheDir string) error {
 }
 
 // InitBuiltinPolicies downloads the built-in policies and loads them
-func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool) ([]string, error) {
+func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleURL string) ([]string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -159,7 +159,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 
 	needsUpdate := false
 	if !skipUpdate {
-		needsUpdate, err = client.NeedsUpdate(ctx)
+		needsUpdate, err = client.NeedsUpdate(ctx, policyBundleURL)
 		if err != nil {
 			return nil, xerrors.Errorf("unable to check if built-in policies need to be updated: %w", err)
 		}
@@ -168,7 +168,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	if needsUpdate {
 		log.Logger.Info("Need to update the built-in policies")
 		log.Logger.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx); err != nil {
+		if err = client.DownloadBuiltinPolicies(ctx, policyBundleURL); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -152,14 +152,14 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	mu.Lock()
 	defer mu.Unlock()
 
-	client, err := policy.NewClient(cacheDir, quiet)
+	client, err := policy.NewClient(cacheDir, quiet, policyBundleRepository)
 	if err != nil {
 		return nil, xerrors.Errorf("policy client error: %w", err)
 	}
 
 	needsUpdate := false
 	if !skipUpdate {
-		needsUpdate, err = client.NeedsUpdate(ctx, policyBundleRepository)
+		needsUpdate, err = client.NeedsUpdate(ctx)
 		if err != nil {
 			return nil, xerrors.Errorf("unable to check if built-in policies need to be updated: %w", err)
 		}
@@ -168,7 +168,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	if needsUpdate {
 		log.Logger.Info("Need to update the built-in policies")
 		log.Logger.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx, policyBundleRepository); err != nil {
+		if err = client.DownloadBuiltinPolicies(ctx); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -1,5 +1,11 @@
 package flag
 
+import (
+	"fmt"
+
+	"github.com/aquasecurity/trivy/pkg/policy"
+)
+
 // e.g. config yaml:
 //
 //	misconfiguration:
@@ -55,12 +61,19 @@ var (
 		Default:    false,
 		Usage:      "remove results for downloaded modules in .terraform folder",
 	}
+	PolicyBundleURLFlag = Flag{
+		Name:       "policy-bundle-url",
+		ConfigName: "misconfiguration.policy-bundle-url",
+		Value:      fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
+		Usage:      "OCI registry URL to retrieve policy bundle from",
+	}
 )
 
 // MisconfFlagGroup composes common printer flag structs used for commands providing misconfinguration scanning.
 type MisconfFlagGroup struct {
 	IncludeNonFailures *Flag
 	ResetPolicyBundle  *Flag
+	PolicyBundleURL    *Flag
 
 	// Values Files
 	HelmValues                 *Flag
@@ -74,6 +87,7 @@ type MisconfFlagGroup struct {
 type MisconfOptions struct {
 	IncludeNonFailures bool
 	ResetPolicyBundle  bool
+	PolicyBundleURL    string
 
 	// Values Files
 	HelmValues          []string
@@ -86,8 +100,10 @@ type MisconfOptions struct {
 
 func NewMisconfFlagGroup() *MisconfFlagGroup {
 	return &MisconfFlagGroup{
-		IncludeNonFailures:         &IncludeNonFailuresFlag,
-		ResetPolicyBundle:          &ResetPolicyBundleFlag,
+		IncludeNonFailures: &IncludeNonFailuresFlag,
+		ResetPolicyBundle:  &ResetPolicyBundleFlag,
+		PolicyBundleURL:    &PolicyBundleURLFlag,
+
 		HelmValues:                 &HelmSetFlag,
 		HelmFileValues:             &HelmSetFileFlag,
 		HelmStringValues:           &HelmSetStringFlag,
@@ -105,6 +121,7 @@ func (f *MisconfFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.IncludeNonFailures,
 		f.ResetPolicyBundle,
+		f.PolicyBundleURL,
 		f.HelmValues,
 		f.HelmValueFiles,
 		f.HelmFileValues,
@@ -118,6 +135,7 @@ func (f *MisconfFlagGroup) ToOptions() (MisconfOptions, error) {
 	return MisconfOptions{
 		IncludeNonFailures:  getBool(f.IncludeNonFailures),
 		ResetPolicyBundle:   getBool(f.ResetPolicyBundle),
+		PolicyBundleURL:     getString(f.PolicyBundleURL),
 		HelmValues:          getStringSlice(f.HelmValues),
 		HelmValueFiles:      getStringSlice(f.HelmValueFiles),
 		HelmFileValues:      getStringSlice(f.HelmFileValues),

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -61,9 +61,9 @@ var (
 		Default:    false,
 		Usage:      "remove results for downloaded modules in .terraform folder",
 	}
-	PolicyBundleURLFlag = Flag{
-		Name:       "policy-bundle-url",
-		ConfigName: "misconfiguration.policy-bundle-url",
+	PolicyBundleRepositoryFlag = Flag{
+		Name:       "policy-bundle-repository",
+		ConfigName: "misconfiguration.policy-bundle-repository",
 		Value:      fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
 		Usage:      "OCI registry URL to retrieve policy bundle from",
 	}
@@ -71,9 +71,9 @@ var (
 
 // MisconfFlagGroup composes common printer flag structs used for commands providing misconfinguration scanning.
 type MisconfFlagGroup struct {
-	IncludeNonFailures *Flag
-	ResetPolicyBundle  *Flag
-	PolicyBundleURL    *Flag
+	IncludeNonFailures     *Flag
+	ResetPolicyBundle      *Flag
+	PolicyBundleRepository *Flag
 
 	// Values Files
 	HelmValues                 *Flag
@@ -85,9 +85,9 @@ type MisconfFlagGroup struct {
 }
 
 type MisconfOptions struct {
-	IncludeNonFailures bool
-	ResetPolicyBundle  bool
-	PolicyBundleURL    string
+	IncludeNonFailures     bool
+	ResetPolicyBundle      bool
+	PolicyBundleRepository string
 
 	// Values Files
 	HelmValues          []string
@@ -100,9 +100,9 @@ type MisconfOptions struct {
 
 func NewMisconfFlagGroup() *MisconfFlagGroup {
 	return &MisconfFlagGroup{
-		IncludeNonFailures: &IncludeNonFailuresFlag,
-		ResetPolicyBundle:  &ResetPolicyBundleFlag,
-		PolicyBundleURL:    &PolicyBundleURLFlag,
+		IncludeNonFailures:     &IncludeNonFailuresFlag,
+		ResetPolicyBundle:      &ResetPolicyBundleFlag,
+		PolicyBundleRepository: &PolicyBundleRepositoryFlag,
 
 		HelmValues:                 &HelmSetFlag,
 		HelmFileValues:             &HelmSetFileFlag,
@@ -121,7 +121,7 @@ func (f *MisconfFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.IncludeNonFailures,
 		f.ResetPolicyBundle,
-		f.PolicyBundleURL,
+		f.PolicyBundleRepository,
 		f.HelmValues,
 		f.HelmValueFiles,
 		f.HelmFileValues,
@@ -133,14 +133,14 @@ func (f *MisconfFlagGroup) Flags() []*Flag {
 
 func (f *MisconfFlagGroup) ToOptions() (MisconfOptions, error) {
 	return MisconfOptions{
-		IncludeNonFailures:  getBool(f.IncludeNonFailures),
-		ResetPolicyBundle:   getBool(f.ResetPolicyBundle),
-		PolicyBundleURL:     getString(f.PolicyBundleURL),
-		HelmValues:          getStringSlice(f.HelmValues),
-		HelmValueFiles:      getStringSlice(f.HelmValueFiles),
-		HelmFileValues:      getStringSlice(f.HelmFileValues),
-		HelmStringValues:    getStringSlice(f.HelmStringValues),
-		TerraformTFVars:     getStringSlice(f.TerraformTFVars),
-		TfExcludeDownloaded: getBool(f.TerraformExcludeDownloaded),
+		IncludeNonFailures:     getBool(f.IncludeNonFailures),
+		ResetPolicyBundle:      getBool(f.ResetPolicyBundle),
+		PolicyBundleRepository: getString(f.PolicyBundleRepository),
+		HelmValues:             getStringSlice(f.HelmValues),
+		HelmValueFiles:         getStringSlice(f.HelmValueFiles),
+		HelmFileValues:         getStringSlice(f.HelmFileValues),
+		HelmStringValues:       getStringSlice(f.HelmStringValues),
+		TerraformTFVars:        getStringSlice(f.TerraformTFVars),
+		TfExcludeDownloaded:    getBool(f.TerraformExcludeDownloaded),
 	}, nil
 }

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -64,7 +64,7 @@ var (
 	PolicyBundleRepositoryFlag = Flag{
 		Name:       "policy-bundle-repository",
 		ConfigName: "misconfiguration.policy-bundle-repository",
-		Value:      fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
+		Default:    fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
 		Usage:      "OCI registry URL to retrieve policy bundle from",
 	}
 )

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	bundleVersion    = 0 // Latest released MAJOR version for defsec
-	bundleRepository = "ghcr.io/aquasecurity/defsec"
+	BundleVersion    = 0 // Latest released MAJOR version for defsec
+	BundleRepository = "ghcr.io/aquasecurity/defsec"
 	policyMediaType  = "application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"
 	updateInterval   = 24 * time.Hour
 )
@@ -76,10 +76,13 @@ func NewClient(cacheDir string, quiet bool, opts ...Option) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact() error {
+func (c *Client) populateOCIArtifact(policyBundleURL string) error {
 	if c.artifact == nil {
-		repo := fmt.Sprintf("%s:%d", bundleRepository, bundleVersion)
-		art, err := oci.NewArtifact(repo, c.quiet, types.RegistryOptions{})
+		if policyBundleURL == "" {
+			policyBundleURL = fmt.Sprintf("%s:%d", BundleRepository, BundleVersion)
+		}
+		log.Logger.Debugf("Using URL: %s to load policy bundle", policyBundleURL)
+		art, err := oci.NewArtifact(policyBundleURL, c.quiet, types.RegistryOptions{})
 		if err != nil {
 			return xerrors.Errorf("OCI artifact error: %w", err)
 		}
@@ -89,8 +92,8 @@ func (c *Client) populateOCIArtifact() error {
 }
 
 // DownloadBuiltinPolicies download default policies from GitHub Pages
-func (c *Client) DownloadBuiltinPolicies(ctx context.Context) error {
-	if err := c.populateOCIArtifact(); err != nil {
+func (c *Client) DownloadBuiltinPolicies(ctx context.Context, policyBundleURL string) error {
+	if err := c.populateOCIArtifact(policyBundleURL); err != nil {
 		return xerrors.Errorf("OPA bundle error: %w", err)
 	}
 
@@ -141,7 +144,7 @@ func (c *Client) LoadBuiltinPolicies() ([]string, error) {
 }
 
 // NeedsUpdate returns if the default policy should be updated
-func (c *Client) NeedsUpdate(ctx context.Context) (bool, error) {
+func (c *Client) NeedsUpdate(ctx context.Context, policyBundleURL string) (bool, error) {
 	meta, err := c.GetMetadata()
 	if err != nil {
 		return true, nil
@@ -152,7 +155,7 @@ func (c *Client) NeedsUpdate(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	if err = c.populateOCIArtifact(); err != nil {
+	if err = c.populateOCIArtifact(policyBundleURL); err != nil {
 		return false, xerrors.Errorf("OPA bundle error: %w", err)
 	}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -76,13 +76,13 @@ func NewClient(cacheDir string, quiet bool, opts ...Option) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact(policyBundleURL string) error {
+func (c *Client) populateOCIArtifact(policyBundleRepository string) error {
 	if c.artifact == nil {
-		if policyBundleURL == "" {
-			policyBundleURL = fmt.Sprintf("%s:%d", BundleRepository, BundleVersion)
+		if policyBundleRepository == "" {
+			policyBundleRepository = fmt.Sprintf("%s:%d", BundleRepository, BundleVersion)
 		}
-		log.Logger.Debugf("Using URL: %s to load policy bundle", policyBundleURL)
-		art, err := oci.NewArtifact(policyBundleURL, c.quiet, types.RegistryOptions{})
+		log.Logger.Debugf("Using URL: %s to load policy bundle", policyBundleRepository)
+		art, err := oci.NewArtifact(policyBundleRepository, c.quiet, types.RegistryOptions{})
 		if err != nil {
 			return xerrors.Errorf("OCI artifact error: %w", err)
 		}
@@ -92,8 +92,8 @@ func (c *Client) populateOCIArtifact(policyBundleURL string) error {
 }
 
 // DownloadBuiltinPolicies download default policies from GitHub Pages
-func (c *Client) DownloadBuiltinPolicies(ctx context.Context, policyBundleURL string) error {
-	if err := c.populateOCIArtifact(policyBundleURL); err != nil {
+func (c *Client) DownloadBuiltinPolicies(ctx context.Context, policyBundleRepository string) error {
+	if err := c.populateOCIArtifact(policyBundleRepository); err != nil {
 		return xerrors.Errorf("OPA bundle error: %w", err)
 	}
 
@@ -144,7 +144,7 @@ func (c *Client) LoadBuiltinPolicies() ([]string, error) {
 }
 
 // NeedsUpdate returns if the default policy should be updated
-func (c *Client) NeedsUpdate(ctx context.Context, policyBundleURL string) (bool, error) {
+func (c *Client) NeedsUpdate(ctx context.Context, policyBundleRepository string) (bool, error) {
 	meta, err := c.GetMetadata()
 	if err != nil {
 		return true, nil
@@ -155,7 +155,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, policyBundleURL string) (bool,
 		return false, nil
 	}
 
-	if err = c.populateOCIArtifact(policyBundleURL); err != nil {
+	if err = c.populateOCIArtifact(policyBundleRepository); err != nil {
 		return false, xerrors.Errorf("OPA bundle error: %w", err)
 	}
 

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -264,7 +264,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert results
-			got, err := c.NeedsUpdate(context.Background())
+			got, err := c.NeedsUpdate(context.Background(), "")
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 		})
@@ -367,7 +367,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			c, err := policy.NewClient(tempDir, true, policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			err = c.DownloadBuiltinPolicies(context.Background())
+			err = c.DownloadBuiltinPolicies(context.Background(), "")
 			if tt.wantErr != "" {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -119,7 +119,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			require.NoError(t, err)
 
-			c, err := policy.NewClient(tt.cacheDir, true, policy.WithOCIArtifact(art))
+			c, err := policy.NewClient(tt.cacheDir, true, "", policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
 			got, err := c.LoadBuiltinPolicies()
@@ -260,11 +260,11 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			require.NoError(t, err)
 
-			c, err := policy.NewClient(tmpDir, true, policy.WithOCIArtifact(art), policy.WithClock(tt.clock))
+			c, err := policy.NewClient(tmpDir, true, "", policy.WithOCIArtifact(art), policy.WithClock(tt.clock))
 			require.NoError(t, err)
 
 			// Assert results
-			got, err := c.NeedsUpdate(context.Background(), "")
+			got, err := c.NeedsUpdate(context.Background())
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 		})
@@ -364,10 +364,10 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			require.NoError(t, err)
 
-			c, err := policy.NewClient(tempDir, true, policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
+			c, err := policy.NewClient(tempDir, true, "", policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			err = c.DownloadBuiltinPolicies(context.Background(), "")
+			err = c.DownloadBuiltinPolicies(context.Background())
 			if tt.wantErr != "" {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -394,7 +394,7 @@ func TestClient_Clear(t *testing.T) {
 	err := os.MkdirAll(filepath.Join(cacheDir, "policy"), 0755)
 	require.NoError(t, err)
 
-	c, err := policy.NewClient(cacheDir, true)
+	c, err := policy.NewClient(cacheDir, true, "")
 	require.NoError(t, err)
 	require.NoError(t, c.Clear())
 }


### PR DESCRIPTION
## Description

This PR adds support for custom policy bundles to be specified with a flag `--policy-bundle-url` as an option to Trivy.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4672

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
