### PR TITLE
fix(flag): support globalstar to skip directories

### DIFF
--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -2,7 +2,6 @@ package walker
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -80,7 +79,7 @@ func (w *walker) shouldSkipDir(dir string) bool {
 
 	// Skip system dirs and specified dirs (absolute path)
 	for _, pattern := range w.skipDirs {
-		if match, err := path.Match(pattern, dir); err != nil {
+		if match, err := doublestar.Match(pattern, dir); err != nil {
 			return false // return early if bad pattern
 		} else if match {
 			log.Logger.Debugf("Skipping directory: %s", dir)

--- a/pkg/fanal/walker/walk_test.go
+++ b/pkg/fanal/walker/walk_test.go
@@ -104,6 +104,13 @@ func Test_shouldSkipDir(t *testing.T) {
 				filepath.Join("/etc/foo/bar"): false,
 			},
 		},
+		{
+			skipDirs: []string{"**/.terraform"},
+			skipMap: map[string]bool{
+				".terraform":              true,
+				"test/foo/bar/.terraform": true,
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
## Description

Globstar support has been added for the `--skip-files` flag, but not for `--skip-dirs`.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4853

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
