### PR TITLE
docs: correct license scanning sample command

### DIFF
--- a/docs/docs/scanner/license.md
+++ b/docs/docs/scanner/license.md
@@ -143,7 +143,7 @@ Trivy has number of configuration flags for use with license scanning;
 Trivy license scanning can ignore licenses that are identified to explicitly remove them from the results using the `--ignored-licenses` flag;
 
 ```shell
-$ trivy image --scanners license --ignored-licenses MPL-2.0,MIT --severity LOW grafana/grafana:latest
+$ trivy image --scanners license --ignored-licenses MPL-2.0,MIT --severity HIGH grafana/grafana:latest
 2022-07-13T18:15:28.605Z        INFO    License scanning is enabled
 
 OS Packages (license)


### PR DESCRIPTION
## Description
Minor error in licensing documentation. Command defined LOW severity but the output shows a table with HIGH severity entries. Hence, adjusted severity option.

Before:
![Screenshot from 2023-07-21 14-41-23](https://github.com/aquasecurity/trivy/assets/20999725/dd3530f9-c96f-426c-b203-849ab6b0904f)

After:
![Screenshot from 2023-07-21 14-48-31](https://github.com/aquasecurity/trivy/assets/20999725/4c526a7f-93f7-4458-9fb6-581425eabedd)


## Related issues
- Close #XXX

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
