### PR TITLE
docs(cli): update help string for file and dir skipping

### DIFF
--- a/docs/docs/configuration/skipping.md
+++ b/docs/docs/configuration/skipping.md
@@ -113,4 +113,4 @@ A file pattern contains the analyzer it is used for, and the pattern itself, joi
 --file-patterns "dockerfile:.*.docker" --file-patterns "kubernetes:*.tpl" --file-patterns "pip:requirements-.*\.txt"
 ```
 
-The prefixes are listed [here](../../../pkg/fanal/analyzer/const.go)
+The prefixes are listed [here](https://github.com/aquasecurity/trivy/tree/{{ git.commit }}/pkg/fanal/analyzer/const.go)

--- a/docs/docs/configuration/skipping.md
+++ b/docs/docs/configuration/skipping.md
@@ -11,10 +11,19 @@ This section details ways to specify the files and directories that Trivy should
 |     License      |     ✓     |
 
 By default, Trivy traverses directories and searches for all necessary files for scanning.
-You can skip files that you don't maintain using the `--skip-files` flag.
+You can skip files that you don't maintain using the `--skip-files` flag, or the equivalent Trivy YAML config option.
 
-```
+Using the `--skip-files` flag:
+```bash
 $ trivy image --skip-files "/Gemfile.lock" --skip-files "/var/lib/gems/2.5.0/gems/http_parser.rb-0.6.0/Gemfile.lock" quay.io/fluentd_elasticsearch/fluentd:v2.9.0
+```
+
+Using the Trivy YAML configuration:
+```yaml
+image:
+  skip-files:
+    - foo
+    - "testdata/*/bar"
 ```
 
 It's possible to specify globs as part of the value.
@@ -23,7 +32,13 @@ It's possible to specify globs as part of the value.
 $ trivy image --skip-files "./testdata/*/bar" .
 ```
 
-Will skip any file named `bar` in the subdirectories of testdata.
+This will skip any file named `bar` in the subdirectories of testdata.
+
+```bash
+$ trivy config --skip-files "./foo/**/*.tf" .
+```
+
+This will skip any files with the extension `.tf` in subdirectories of foo at any depth.
 
 ## Skip Directories
 |     Scanner      | Supported |
@@ -34,10 +49,19 @@ Will skip any file named `bar` in the subdirectories of testdata.
 |     License      |     ✓     |
 
 By default, Trivy traverses directories and searches for all necessary files for scanning.
-You can skip directories that you don't maintain using the `--skip-dirs` flag.
+You can skip directories that you don't maintain using the `--skip-dirs` flag, or the equivalent Trivy YAML config option.
 
-```
+Using the `--skip-dirs` flag:
+```bash
 $ trivy image --skip-dirs /var/lib/gems/2.5.0/gems/fluent-plugin-detect-exceptions-0.0.13 --skip-dirs "/var/lib/gems/2.5.0/gems/http_parser.rb-0.6.0" quay.io/fluentd_elasticsearch/fluentd:v2.9.0
+```
+
+Using the Trivy YAML configuration:
+```yaml
+image:
+  skip-dirs:
+    - foo/bar/
+    - "**/.terraform"
 ```
 
 It's possible to specify globs as part of the value.
@@ -46,20 +70,27 @@ It's possible to specify globs as part of the value.
 $ trivy image --skip-dirs "./testdata/*" .
 ```
 
-Will skip all subdirectories of the testdata directory.
+This will skip all subdirectories of the testdata directory.
+
+```bash
+$ trivy config --skip-dirs "**/.terraform" .
+```
+
+This will skip subdirectories at any depth named `.terraform/`. (Note: this will match `./foo/.terraform` or
+`./foo/bar/.terraform`, but not `./.terraform`.)
 
 !!! tip
     Glob patterns work with any trivy subcommand (image, config, etc.) and can be specified to skip both directories (with `--skip-dirs`) and files (with `--skip-files`).
 
 
 ### Advanced globbing
-Trivy also supports the [globstar](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Pattern-Matching) pattern matching. 
+Trivy also supports bash style [extended](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Pattern-Matching) glob pattern matching.
 
 ```bash
 $ trivy image --skip-files "**/foo" image:tag
 ```
 
-Will skip the file `foo` that happens to be nested under any parent(s). 
+This will skip the file `foo` that happens to be nested under any parent(s). 
 
 ## File patterns
 |     Scanner      | Supported |
@@ -82,4 +113,4 @@ A file pattern contains the analyzer it is used for, and the pattern itself, joi
 --file-patterns "dockerfile:.*.docker" --file-patterns "kubernetes:*.tpl" --file-patterns "pip:requirements-.*\.txt"
 ```
 
-The prefixes are listed [here](https://github.com/aquasecurity/trivy/tree/{{ git.commit }}/pkg/fanal/analyzer/const.go)
+The prefixes are listed [here](../../../pkg/fanal/analyzer/const.go)

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -40,8 +40,8 @@ trivy config [flags] DIR
       --report string                     specify a compliance report format for the output (all,summary) (default "all")
       --reset-policy-bundle               remove policy bundle
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-policy-update                skip fetching rego policy updates
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -72,8 +72,8 @@ trivy filesystem [flags] PATH
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -93,8 +93,8 @@ trivy image [flags] IMAGE_NAME
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -82,8 +82,8 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -69,8 +69,8 @@ trivy repository [flags] REPO_URL
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -73,8 +73,8 @@ trivy rootfs [flags] ROOTDIR
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -52,8 +52,8 @@ trivy sbom [flags] SBOM_PATH
       --server string               server address in client mode
   -s, --severity strings            severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update              skip updating vulnerability database
-      --skip-dirs strings           specify the directories where the traversal is skipped
-      --skip-files strings          specify the file paths to skip traversal
+      --skip-dirs strings           specify the directories or glob patterns to skip
+      --skip-files strings          specify the files or glob patterns to skip
       --skip-java-db-update         skip updating Java index database
       --slow                        scan over time with lower CPU and memory utilization
   -t, --template string             output template

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -65,8 +65,8 @@ trivy vm [flags] VM_IMAGE
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database
-      --skip-dirs strings                 specify the directories where the traversal is skipped
-      --skip-files strings                specify the file paths to skip traversal
+      --skip-dirs strings                 specify the directories or glob patterns to skip
+      --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -10,13 +10,13 @@ var (
 		Name:       "skip-dirs",
 		ConfigName: "scan.skip-dirs",
 		Default:    []string{},
-		Usage:      "specify the directories where the traversal is skipped",
+		Usage:      "specify the directories or glob patterns to skip",
 	}
 	SkipFilesFlag = Flag{
 		Name:       "skip-files",
 		ConfigName: "scan.skip-files",
 		Default:    []string{},
-		Usage:      "specify the file paths to skip traversal",
+		Usage:      "specify the files or glob patterns to skip",
 	}
 	OfflineScanFlag = Flag{
 		Name:       "offline-scan",


### PR DESCRIPTION
## Description
- Update the contextual help messages
- Add some additional examples (and clarify YAML file configuration) for globbing
- Update docs
- Fix broken link in skipping docs

Happy to adjust the wording or make other tweaks as necessary, but to me, this seems at least a little bit clearer

## Related issues
- #3754

## Related PRs
-  #3843
-  #3866
-  #3945
(all merged; just related / previous PRs related to this)

Before:
<img width="706" alt="image" src="https://github.com/aquasecurity/trivy/assets/10714426/4d007da4-78ae-4485-855e-fe7b4fbee914">

After:
<img width="690" alt="image" src="https://github.com/aquasecurity/trivy/assets/10714426/566b811f-10ae-4883-ac85-8c46223edb82">

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
