### PR TITLE
docs: update the discussion template so people won't create issues

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/bugs.yml
@@ -8,6 +8,8 @@ body:
         Please ensure that you're not creating a duplicate report by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         If you see any false positives or false negatives, please file a ticket [here](https://github.com/aquasecurity/trivy/discussions/new?category=false-detection).
         
+        **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
+        
         Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
   - type: textarea
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/false-detection.yml
+++ b/.github/DISCUSSION_TEMPLATE/false-detection.yml
@@ -6,6 +6,8 @@ body:
         Feel free to raise a bug report if something doesn't work as expected.
         Please ensure that you're not creating a duplicate report by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         
+        **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
+        
         Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
   - type: input
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -7,6 +7,8 @@ body:
         Feel free to share your idea.
         Please ensure that you're not creating a duplicate ticket by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         
+        **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
+        
         Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
   - type: textarea
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -7,6 +7,8 @@ body:
         If you have any troubles/questions, feel free to ask.
         Please ensure that you're not asking a duplicate question by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         
+        **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
+        
         Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
   - type: textarea
     attributes:


### PR DESCRIPTION
## Description
It is stated in the documentation that maintainers create GitHub issues and the community should not open, but to make it more straightforward; this PR adds a note to the Discussion template.

## Related issues
- https://github.com/aquasecurity/trivy/issues/4900
- https://github.com/aquasecurity/trivy/issues/4802
- https://github.com/aquasecurity/trivy/issues/4558

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
