### PR TITLE
fix(sbom): move licenses to `name` field in Cyclonedx format

### DIFF
--- a/integration/testdata/conda-cyclonedx.json.golden
+++ b/integration/testdata/conda-cyclonedx.json.golden
@@ -1,10 +1,11 @@
 {
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:e1f49b6f-018f-4bf3-97c8-85cd92a82c7c",
+  "serialNumber": "urn:uuid:e7d2faf4-1d5f-4cd7-a792-8b9b5f6fe2d7",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-05-19T10:38:39+00:00",
+    "timestamp": "2023-08-04T05:57:22+00:00",
     "tools": [
       {
         "vendor": "aquasecurity",
@@ -13,7 +14,7 @@
       }
     ],
     "component": {
-      "bom-ref": "cd0ebb00-5c53-4b82-a3f7-271add663c51",
+      "bom-ref": "a80bd6fc-91e4-4e42-9941-eafc2423d031",
       "type": "application",
       "name": "testdata/fixtures/repo/conda",
       "properties": [
@@ -26,63 +27,69 @@
   },
   "components": [
     {
-      "bom-ref": "pkg:conda/pip@22.2.2?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fpip-22.2.2-py38h06a4308_0.json",
-      "type": "library",
-      "name": "pip",
-      "version": "22.2.2",
-      "licenses": [
-        {
-          "expression": "MIT"
-        }
-      ],
-      "purl": "pkg:conda/pip@22.2.2",
-      "properties": [
-        {
-          "name": "aquasecurity:trivy:PkgType",
-          "value": "conda-pkg"
-        },
-        {
-          "name": "aquasecurity:trivy:FilePath",
-          "value": "miniconda3/envs/testenv/conda-meta/pip-22.2.2-py38h06a4308_0.json"
-        }
-      ]
-    },
-    {
       "bom-ref": "pkg:conda/openssl@1.1.1q?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fopenssl-1.1.1q-h7f8727e_0.json",
       "type": "library",
       "name": "openssl",
       "version": "1.1.1q",
       "licenses": [
         {
-          "expression": "OpenSSL"
+          "license": {
+            "name": "OpenSSL"
+          }
         }
       ],
       "purl": "pkg:conda/openssl@1.1.1q",
       "properties": [
         {
-          "name": "aquasecurity:trivy:PkgType",
-          "value": "conda-pkg"
-        },
-        {
           "name": "aquasecurity:trivy:FilePath",
           "value": "miniconda3/envs/testenv/conda-meta/openssl-1.1.1q-h7f8727e_0.json"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "conda-pkg"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:conda/pip@22.2.2?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fpip-22.2.2-py38h06a4308_0.json",
+      "type": "library",
+      "name": "pip",
+      "version": "22.2.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:conda/pip@22.2.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:FilePath",
+          "value": "miniconda3/envs/testenv/conda-meta/pip-22.2.2-py38h06a4308_0.json"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "conda-pkg"
         }
       ]
     }
   ],
   "dependencies": [
     {
-      "ref": "cd0ebb00-5c53-4b82-a3f7-271add663c51",
+      "ref": "a80bd6fc-91e4-4e42-9941-eafc2423d031",
       "dependsOn": [
         "pkg:conda/openssl@1.1.1q?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fopenssl-1.1.1q-h7f8727e_0.json",
         "pkg:conda/pip@22.2.2?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fpip-22.2.2-py38h06a4308_0.json"
       ]
     },
     {
-      "ref": "pkg:conda/openssl@1.1.1q?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fopenssl-1.1.1q-h7f8727e_0.json"
+      "ref": "pkg:conda/openssl@1.1.1q?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fopenssl-1.1.1q-h7f8727e_0.json",
+      "dependsOn": []
     },
     {
-      "ref": "pkg:conda/pip@22.2.2?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fpip-22.2.2-py38h06a4308_0.json"
+      "ref": "pkg:conda/pip@22.2.2?file_path=miniconda3%2Fenvs%2Ftestenv%2Fconda-meta%2Fpip-22.2.2-py38h06a4308_0.json",
+      "dependsOn": []
     }
   ],
   "vulnerabilities": []

--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -304,7 +304,10 @@ func (c *CycloneDX) Licenses(licenses []string) *cdx.Licenses {
 		return nil
 	}
 	choices := lo.Map(licenses, func(license string, i int) cdx.LicenseChoice {
-		return cdx.LicenseChoice{Expression: license}
+		return cdx.LicenseChoice{
+			License: &cdx.License{
+				Name: license},
+		}
 	})
 	return lo.ToPtr(cdx.Licenses(choices))
 }

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -381,7 +381,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Name:    "binutils",
 						Version: "2.30-93.el8",
 						Licenses: &cdx.Licenses{
-							cdx.LicenseChoice{Expression: "GPLv3+"},
+							cdx.LicenseChoice{
+								License: &cdx.License{
+									Name: "GPLv3+",
+								},
+							},
 						},
 						PackageURL: "pkg:rpm/centos/binutils@2.30-93.el8?arch=aarch64&distro=centos-8.3.2011",
 						Supplier: &cdx.OrganizationalEntity{
@@ -840,7 +844,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Name:    "acl",
 						Version: "2.2.53-1.el8",
 						Licenses: &cdx.Licenses{
-							cdx.LicenseChoice{Expression: "GPLv2+"},
+							cdx.LicenseChoice{
+								License: &cdx.License{
+									Name: "GPLv2+",
+								},
+							},
 						},
 						PackageURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=aarch64&epoch=1&distro=centos-8.3.2011",
 						Properties: &[]cdx.Property{
@@ -882,7 +890,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Name:    "glibc",
 						Version: "2.28-151.el8",
 						Licenses: &cdx.Licenses{
-							cdx.LicenseChoice{Expression: "GPLv2+"},
+							cdx.LicenseChoice{
+								License: &cdx.License{
+									Name: "GPLv2+",
+								},
+							},
 						},
 						PackageURL: "pkg:rpm/centos/glibc@2.28-151.el8?arch=aarch64&distro=centos-8.3.2011",
 						Properties: &[]cdx.Property{
@@ -1484,7 +1496,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Version:    "0.20.1",
 						PackageURL: "pkg:npm/ruby-typeprof@0.20.1",
 						Licenses: &cdx.Licenses{
-							cdx.LicenseChoice{Expression: "MIT"},
+							cdx.LicenseChoice{
+								License: &cdx.License{
+									Name: "MIT",
+								},
+							},
 						},
 						Properties: &[]cdx.Property{
 							{


### PR DESCRIPTION
## Description
Expression field is string including all licenses separated by `AND` or `OR` (https://cyclonedx.org/docs/1.4/json/#tab-pane_components_items_licenses_items_oneOf_i1). 
We can't determine correct separator in all cases.

But we can use `license.name` field(https://cyclonedx.org/docs/1.4/json/#components_items_licenses_items_license_name).

As new feature, we can use `id`, but we need to compare found licenses with [license enums](https://github.com/CycloneDX/cyclonedx-go/blob/3d592d2184f07408ff0e1b3f2f587d201a57a38f/schema/spdx.schema.json#L6) and remove licenses not from this list.

## Related issues
- Close #4900

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
