### PR TITLE
chore(deps): Bump defsec to v0.91.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.30.4
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/defsec v0.91.0
+	github.com/aquasecurity/defsec v0.91.1
 	github.com/aquasecurity/go-dep-parser v0.0.0-20230803125501-bd9cf68d8636
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.91.0 h1:JGTiKL2UgnANZ4RoQQKokzpZ2vFv2LlXGoNjIypz9RQ=
-github.com/aquasecurity/defsec v0.91.0/go.mod h1:l/srzxtuuyb6c6FlqUvMp3xw2ZbvuZ0l9972MNJM7V8=
+github.com/aquasecurity/defsec v0.91.1 h1:dBIPm6Tva9I+ZTQv+6t9wob3ZlMSu8NFqMJr4mgJC5A=
+github.com/aquasecurity/defsec v0.91.1/go.mod h1:l/srzxtuuyb6c6FlqUvMp3xw2ZbvuZ0l9972MNJM7V8=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230803125501-bd9cf68d8636 h1:8f/1XPe9xcd8BkXU0LfQXNKmlCUB957674usf+Y/af0=
 github.com/aquasecurity/go-dep-parser v0.0.0-20230803125501-bd9cf68d8636/go.mod h1:Cl6aYro+Ddzh1MB451j/C6rvwKdn/Ifa7z98sFirJ9I=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description

Bumps defsec to v0.91.1

## What's Changed

fix: Typo by @testwill in https://github.com/aquasecurity/defsec/pull/1413
chore(k8s): Fix a flaky test by @simar7 in https://github.com/aquasecurity/defsec/pull/1415
chore(policies): Move s3 policies to rules dir by @simar7 in https://github.com/aquasecurity/defsec/pull/1416
fix(rego): Skip dotfiles by @simar7 in https://github.com/aquasecurity/defsec/pull/1414
fix(aws): use correct signing region by @nikpivkin in https://github.com/aquasecurity/defsec/pull/1411
