### PR TITLE
test(cli): Fix assertion helptext

### DIFF
--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -102,7 +102,7 @@ func TestManager_Register(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// WASM modules must be generated before running the tests.
-	require.Equal(t, count, 3, "missing WASM modules, try 'make test' or 'make generate-test-modules'")
+	require.Equal(t, count, 3, "missing WASM modules, try 'mage test:unit' or 'mage test:generateModules'")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Updates a small assertion message with the new `mage` targets.