### PR TITLE
build: revert 32bit and arm bins

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -7,12 +7,14 @@ cd trivy-repo/deb
 
 for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Removing deb package of $release"
+  reprepro -A i386 remove $release trivy
   reprepro -A amd64 remove $release trivy
   reprepro -A arm64 remove $release trivy
 done
 
 for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Adding deb package to $release"
+  reprepro includedeb $release ../../dist/*Linux-32bit.deb
   reprepro includedeb $release ../../dist/*Linux-64bit.deb
   reprepro includedeb $release ../../dist/*Linux-ARM64.deb
 done

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,6 +12,8 @@ builds:
     goos:
       - linux
     goarch:
+      - 386
+      - arm
       - amd64
       - arm64
       - s390x
@@ -31,6 +33,7 @@ builds:
       - freebsd
     goarch:
       # modernc.org/sqlite doesn't support freebsd/arm64, etc.
+      - 386
       - amd64
   - id: build-macos
     main: cmd/trivy/main.go
@@ -60,6 +63,7 @@ builds:
     goos:
       - windows
     goarch:
+      # modernc.org/sqlite doesn't support windows/386 and windows/arm, etc.
       - amd64
     goarm:
       - 7
@@ -88,6 +92,7 @@ nfpms:
       {{- else if eq .Os "dragonfly" }}DragonFlyBSD
       {{- else}}{{- title .Os }}{{ end }}-
       {{- if eq .Arch "amd64" }}64bit
+      {{- else if eq .Arch "386" }}32bit
       {{- else if eq .Arch "arm" }}ARM
       {{- else if eq .Arch "arm64" }}ARM64
       {{- else if eq .Arch "ppc64le" }}PPC64LE
@@ -112,6 +117,7 @@ archives:
       {{- else if eq .Os "dragonfly" }}DragonFlyBSD
       {{- else}}{{- .Os }}{{ end }}-
       {{- if eq .Arch "amd64" }}64bit
+      {{- else if eq .Arch "386" }}32bit
       {{- else if eq .Arch "arm" }}ARM
       {{- else if eq .Arch "arm64" }}ARM64
       {{- else if eq .Arch "ppc64le" }}PPC64LE


### PR DESCRIPTION
## Description
We [fixed](https://github.com/aquasecurity/trivy/pull/4937) problem with space in CI/CD.
Now we can return 32 Bit binaries. 


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
