### PR TITLE
ci: Add support for `linux/riscv64`

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -73,6 +73,7 @@ get_binaries() {
     linux/386) BINARIES="trivy" ;;
     linux/amd64) BINARIES="trivy" ;;
     linux/ppc64le) BINARIES="trivy" ;;
+    linux/riscv64) BINARIES="trivy" ;;
     linux/arm64) BINARIES="trivy" ;;
     linux/armv7) BINARIES="trivy" ;;
     linux/s390x) BINARIES="trivy" ;;
@@ -117,6 +118,7 @@ adjust_os() {
     arm) OS=ARM ;;
     arm64) OS=ARM64 ;;
     ppc64le) OS=Linux ;;
+    riscv64) OS=Linux ;;
     s390x) OS=Linux ;;
     darwin) OS=macOS ;;
     dragonfly) OS=DragonFlyBSD ;;
@@ -136,6 +138,7 @@ adjust_arch() {
     armv7) ARCH=ARM ;;
     arm64) ARCH=ARM64 ;;
     ppc64le) ARCH=PPC64LE ;;
+    riscv64) ARCH=RISCV64 ;;
     s390x) ARCH=s390x ;;
     darwin) ARCH=macOS ;;
     dragonfly) ARCH=DragonFlyBSD ;;
@@ -258,6 +261,7 @@ uname_arch_check() {
     armv7) return 0 ;;
     ppc64) return 0 ;;
     ppc64le) return 0 ;;
+    riscv64) return 0 ;;
     mips) return 0 ;;
     mipsle) return 0 ;;
     mips64) return 0 ;;

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - arm64
       - s390x
       - ppc64le
+      - riscv64
     goarm:
       - 7
   - id: build-bsd
@@ -96,6 +97,7 @@ nfpms:
       {{- else if eq .Arch "arm" }}ARM
       {{- else if eq .Arch "arm64" }}ARM64
       {{- else if eq .Arch "ppc64le" }}PPC64LE
+      {{- else if eq .Arch "riscv64" }}RISCV64
       {{- else }}{{ .Arch }}{{ end }}
     contents:
      - src: contrib/*.tpl
@@ -121,6 +123,7 @@ archives:
       {{- else if eq .Arch "arm" }}ARM
       {{- else if eq .Arch "arm64" }}ARM64
       {{- else if eq .Arch "ppc64le" }}PPC64LE
+      {{- else if eq .Arch "riscv64" }}RISCV64
       {{- else }}{{ .Arch }}{{ end }}
     files:
       - README.md
@@ -242,6 +245,32 @@ dockers:
       - "--platform=linux/ppc64le"
     extra_files:
     - contrib/
+  - image_templates:
+      - "docker.io/aquasec/trivy:{{ .Version }}-riscv64"
+      - "docker.io/aquasec/trivy:latest-riscv64"
+      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64"
+      - "ghcr.io/aquasecurity/trivy:latest-riscv64"
+      - "public.ecr.aws/aquasecurity/trivy:latest-riscv64"
+      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64"
+    use: buildx
+    goos: linux
+    goarch: riscv64
+    ids:
+      - build-linux
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--platform=linux/riscv64"
+    extra_files:
+    - contrib/
+
 
 docker_manifests:
   - name_template: 'aquasec/trivy:{{ .Version }}'
@@ -250,36 +279,42 @@ docker_manifests:
     - 'aquasec/trivy:{{ .Version }}-arm64'
     - 'aquasec/trivy:{{ .Version }}-s390x'
     - 'aquasec/trivy:{{ .Version }}-ppc64le'
+    - 'aquasec/trivy:{{ .Version }}-riscv64'
   - name_template: 'ghcr.io/aquasecurity/trivy:{{ .Version }}'
     image_templates:
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}'
     image_templates:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'aquasec/trivy:latest'
     image_templates:
     - 'aquasec/trivy:{{ .Version }}-amd64'
     - 'aquasec/trivy:{{ .Version }}-arm64'
     - 'aquasec/trivy:{{ .Version }}-s390x'
     - 'aquasec/trivy:{{ .Version }}-ppc64le'
+    - 'aquasec/trivy:{{ .Version }}-riscv64'
   - name_template: 'ghcr.io/aquasecurity/trivy:latest'
     image_templates:
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'public.ecr.aws/aquasecurity/trivy:latest'
     image_templates:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64'
 
 signs:
 - cmd: cosign


### PR DESCRIPTION
## Description

Add support for RISC-V 64 bit.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
