### PR TITLE
chore: update alpine base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 RUN apk --no-cache add ca-certificates git
 
 # binaries were created with GoReleaser


### PR DESCRIPTION
## Description

alpine 3.18.2 contains a CVE which is fixed in 3.18.3. It would also be a possibility to only pin alpine:3.18.

<img width="1420" alt="image" src="https://github.com/aquasecurity/trivy/assets/5762081/13f3374f-4fb4-457c-a546-6478674158c8">


## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
