### PR TITLE
fix: k8s private registries support

### DIFF
--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -144,7 +144,7 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 
 	for _, image := range artifact.Images {
 
-		s.opts.Target = image
+		opts.Target = image
 
 		imageReport, err := s.runner.ScanImage(ctx, opts)
 


### PR DESCRIPTION
## Description
trivy k8s auto detect credentials from imagePullSecret and ServiceAccount 
## Related issues
- Close #4760

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
