### PR TITLE
feat: enhance resource scanning to support --all-namespaces flag

### DIFF
--- a/pkg/k8s/commands/resource.go
+++ b/pkg/k8s/commands/resource.go
@@ -21,15 +21,20 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 		return err
 	}
 
-	trivyk8s := trivyk8s.New(cluster, log.Logger).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
 	runner := newRunner(opts, cluster.GetCurrentContext())
+	var trivyk trivyk8s.TrivyK8S
+	if opts.AllNamespaces {
+		trivyk = trivyk8s.New(cluster, log.Logger).AllNamespaces()
+	} else {
+		trivyk = trivyk8s.New(cluster, log.Logger).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
+	}
 
 	if len(name) == 0 { // pods or configmaps etc
 		if err = validateReportArguments(opts); err != nil {
 			return err
 		}
 
-		targets, err := trivyk8s.Resources(kind).ListArtifacts(ctx)
+		targets, err := trivyk.Resources(kind).ListArtifacts(ctx)
 		if err != nil {
 			return err
 		}
@@ -38,7 +43,7 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 	}
 
 	// pod/NAME or pod NAME etc
-	artifact, err := trivyk8s.GetArtifact(ctx, kind, name)
+	artifact, err := trivyk.GetArtifact(ctx, kind, name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
This pull request introduces an enhancement that enables users to scan resources across all namespaces using the `--all-namespaces` flag with the trivy k8s.

# Use cases

- Scan a Type of Kubernetes resource that exists in all namespaces(similar to kubectl operations). eg `kubectl get pod -A`, `kubectl get configmap -A`

## Before

```
# Scans resources from the current namespace only
trivy k8s --all-namespaces --report=summary configmaps

Summary Report for arn:aws:eks:<region>:<account>:cluster/eks-cluster


Workload Assessment
┌───────────┬────────────────────────────┬───────────────────┬───────────────────┬───────────────────┐
│ Namespace │          Resource          │  Vulnerabilities  │ Misconfigurations │      Secrets      │
│           │                            ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│           │                            │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├───────────┼────────────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ default   │ ConfigMap/kube-root-ca.crt │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
└───────────┴────────────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

```
trivy k8s pods -A --report summary

Summary Report for arn:aws:eks:<region>:<account>:cluster/eks-cluster

Workload Assessment
┌───────────┬────────────────────────────┬──────────────────────────┬────────────────────┬───────────────────┐
│ Namespace │          Resource          │     Vulnerabilities      │ Misconfigurations  │      Secrets      │
│           │                            ├────┬─────┬─────┬─────┬───┼───┬───┬───┬────┬───┼───┬───┬───┬───┬───┤
│           │                            │ C  │  H  │  M  │  L  │ U │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │
├───────────┼────────────────────────────┼────┼─────┼─────┼─────┼───┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┤
│ default   │ Pod/nginx-5d56f7cc56-rj5tk │ 39 │ 105 │ 102 │ 129 │ 8 │   │   │ 3 │ 11 │   │   │   │   │   │   │
└───────────┴────────────────────────────┴────┴─────┴─────┴─────┴───┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```

## After

```
# Scans resources from all of the namespaces in the cluster
trivy k8s --all-namespaces configmaps --report=summary 

Summary Report for arn:aws:eks:<region>:<account>:cluster/eks-cluster


Workload Assessment
┌─────────────────┬──────────────────────────────────────────────────────────────┬───────────────────┬───────────────────┬───────────────────┐
│    Namespace    │                           Resource                           │  Vulnerabilities  │ Misconfigurations │      Secrets      │
│                 │                                                              ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│                 │                                                              │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├─────────────────┼──────────────────────────────────────────────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ operation-view  │ ConfigMap/operation-view-runtime-configurations              │   │   │   │   │   │   │ 2 │   │ 1 │   │ 4 │ 3 │ 2 │ 2 │   │
│ operation-view  │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/coredns                                            │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/kube-proxy                                         │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/kube-proxy-config                                  │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/extension-apiserver-authentication                 │   │   │   │   │   │   │ 1 │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/aws-for-fluent-bit                                 │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/kube-apiserver-legacy-service-account-token-track- │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│                 │ ing                                                          │   │   │   │   │   │   │   │   │   │   │   │   │   │   │   │
│ kube-system     │ ConfigMap/aws-auth                                           │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-public     │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ kube-node-lease │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ default         │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ cert-manager    │ ConfigMap/cert-manager-webhook                               │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
│ cert-manager    │ ConfigMap/kube-root-ca.crt                                   │   │   │   │   │   │   │   │   │ 1 │   │   │   │   │   │   │
└─────────────────┴──────────────────────────────────────────────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```


```
trivy k8s pods -A --report summary                    

Summary Report for arn:aws:eks:<region>:<account>:cluster/eks-cluster

Workload Assessment
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────┬─────────────────────┬───────────────────┐
│  Namespace   │                   Resource                   │     Vulnerabilities      │  Misconfigurations  │      Secrets      │
│              │                                              ├────┬─────┬─────┬─────┬───┼───┬───┬────┬────┬───┼───┬───┬───┬───┬───┤
│              │                                              │ C  │  H  │  M  │  L  │ U │ C │ H │ M  │ L  │ U │ C │ H │ M │ L │ U │
├──────────────┼──────────────────────────────────────────────┼────┼─────┼─────┼─────┼───┼───┼───┼────┼────┼───┼───┼───┼───┼───┼───┤
│ kube-system  │ Pod/ebs-csi-controller-846b7ddddb-nj6ks      │    │     │     │     │   │   │   │ 5  │ 31 │   │   │   │   │   │   │
│ kube-system  │ Pod/coredns-655c69d4f4-fg82d                 │    │     │     │     │   │   │   │ 3  │ 5  │   │   │   │   │   │   │
│ kube-system  │ Pod/aws-node-9f6mb                           │    │     │     │     │   │   │ 4 │ 8  │ 19 │   │   │   │   │   │   │
│ kube-system  │ Pod/kube-proxy-mp45r                         │    │     │     │     │   │   │ 2 │ 4  │ 10 │   │   │   │   │   │   │
│ kube-system  │ Pod/ebs-csi-node-pjml9                       │    │     │     │     │   │   │ 1 │ 10 │ 20 │   │   │   │   │   │   │
│ kube-system  │ Pod/coredns-655c69d4f4-kmx6c                 │    │     │     │     │   │   │   │ 3  │ 5  │   │   │   │   │   │   │
│ kube-system  │ Pod/ebs-csi-controller-846b7ddddb-tbl88      │    │     │     │     │   │   │   │ 5  │ 31 │   │   │   │   │   │   │
│ kube-system  │ Pod/aws-for-fluent-bit-p4zfs                 │    │ 19  │ 25  │ 4   │   │   │   │ 4  │ 8  │   │   │   │   │   │   │
│ default      │ Pod/nginx-5d56f7cc56-rj5tk                   │ 39 │ 105 │ 102 │ 129 │ 8 │   │   │ 3  │ 11 │   │   │   │   │   │   │
│ cert-manager │ Pod/cert-manager-69cdc85fc8-lmx5s            │    │     │     │     │   │   │   │ 1  │ 8  │   │   │   │   │   │   │
│ cert-manager │ Pod/cert-manager-webhook-759d6dcbf7-6f4tc    │    │     │     │     │   │   │   │ 1  │ 8  │   │   │   │   │   │   │
│ cert-manager │ Pod/cert-manager-cainjector-744bb89575-wrvs9 │    │     │     │     │   │   │   │ 1  │ 8  │   │   │   │   │   │   │
└──────────────┴──────────────────────────────────────────────┴────┴─────┴─────┴─────┴───┴───┴───┴────┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```



## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
