### PR TITLE
docs(repo): Update trivy repo usage and example

### DIFF
--- a/docs/docs/references/configuration/cli/trivy.md
+++ b/docs/docs/references/configuration/cli/trivy.md
@@ -51,7 +51,7 @@ trivy [global flags] command [flags] target
 * [trivy kubernetes](trivy_kubernetes.md)	 - [EXPERIMENTAL] Scan kubernetes cluster
 * [trivy module](trivy_module.md)	 - Manage modules
 * [trivy plugin](trivy_plugin.md)	 - Manage plugins
-* [trivy repository](trivy_repository.md)	 - Scan a remote repository
+* [trivy repository](trivy_repository.md)	 - Scan a repository
 * [trivy rootfs](trivy_rootfs.md)	 - Scan rootfs
 * [trivy sbom](trivy_sbom.md)	 - Scan SBOM for vulnerabilities
 * [trivy server](trivy_server.md)	 - Server mode

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -1,9 +1,9 @@
 ## trivy repository
 
-Scan a remote repository
+Scan a repository
 
 ```
-trivy repository [flags] REPO_URL
+trivy repository [flags] (REPO_PATH | REPO_URL)
 ```
 
 ### Examples
@@ -11,6 +11,8 @@ trivy repository [flags] REPO_URL
 ```
   # Scan your remote git repository
   $ trivy repo https://github.com/knqyf263/trivy-ci-test
+  # Scan your local git repository
+  $ trivy repo /path/to/your/repository
 ```
 
 ### Options

--- a/docs/docs/target/repository.md
+++ b/docs/docs/target/repository.md
@@ -86,7 +86,7 @@ It is disabled by default and can be enabled with `--scanners config`.
 See [here](../scanner/misconfiguration/index.md) for the detail.
 
 ```shell
-$ trivy repo --scanners config [YOUR_REPO_URL]
+$ trivy repo --scanners config (REPO_PATH | REPO_URL)
 ```
 
 ### Secrets
@@ -94,7 +94,7 @@ It is enabled by default.
 See [here](../scanner/secret.md) for the detail.
 
 ```shell
-$ trivy repo [YOUR_REPO_URL]
+$ trivy repo (REPO_PATH | REPO_URL)
 ```
 
 ### Licenses
@@ -102,7 +102,7 @@ It is disabled by default.
 See [here](../scanner/license.md) for the detail.
 
 ```shell
-$ trivy repo --scanners license [YOUR_REPO_URL]
+$ trivy repo --scanners license (REPO_PATH | REPO_URL)
 ```
 
 ## SBOM generation

--- a/docs/tutorials/shell/shell-completion.md
+++ b/docs/tutorials/shell/shell-completion.md
@@ -58,7 +58,7 @@ image       -- Scan a container image
 kubernetes  -- scan kubernetes cluster
 module      -- Manage modules
 plugin      -- Manage plugins
-repository  -- Scan a remote repository
+repository  -- Scan a repository
 rootfs      -- Scan rootfs
 sbom        -- Scan SBOM for vulnerabilities
 server      -- Server mode

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -443,12 +443,14 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	repoFlags.ReportFlagGroup.ExitOnEOL = nil    // disable '--exit-on-eol'
 
 	cmd := &cobra.Command{
-		Use:     "repository [flags] REPO_URL",
+		Use:     "repository [flags] (REPO_PATH | REPO_URL)",
 		Aliases: []string{"repo"},
 		GroupID: groupScanning,
-		Short:   "Scan a remote repository",
+		Short:   "Scan a repository",
 		Example: `  # Scan your remote git repository
-  $ trivy repo https://github.com/knqyf263/trivy-ci-test`,
+  $ trivy repo https://github.com/knqyf263/trivy-ci-test
+  # Scan your local git repository
+  $ trivy repo /path/to/your/repository`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := repoFlags.Bind(cmd); err != nil {
 				return xerrors.Errorf("flag bind error: %w", err)


### PR DESCRIPTION
## Description

This PR adjusts the usage of the `trivy repo` command to mirror the changes regarding the support of "local repositories".
As this is my first PR, please tell me if I missed something!

### Before

`trivy repository --help`

```text
Scan a remote repository

Usage:
  trivy repository [flags] REPO_URL

Aliases:
  repository, repo

Examples:
  # Scan your remote git repository
  $ trivy repo https://github.com/knqyf263/trivy-ci-test
...
```

### After

`trivy repository --help`

```text
Scan a repository

Usage:
  trivy repository [flags] (REPO_PATH | REPO_URL)

Aliases:
  repository, repo

Examples:
  # Scan your remote git repository
  $ trivy repo https://github.com/knqyf263/trivy-ci-test
  # Scan your local git repository
  $ trivy repo /path/to/your/repository
...
```

## Related issues
- Close #4985

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- ~~[ ] I've added tests that prove my fix is effective or that my feature works.~~ -> Just documentation changes
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
