### PR TITLE
feat: filter artifacts on --exclude-owned flag

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -41,6 +41,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --exclude-nodes strings             indicate the node labels that the node-collector job should exclude from scanning (example: kubernetes.io/arch:arm64,team:dev)
+  -E, --exclude-owned                     exclude resources that have an owner reference
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
   -f, --format string                     format (table,json,cyclonedx) (default "table")

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -41,7 +41,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --exclude-nodes strings             indicate the node labels that the node-collector job should exclude from scanning (example: kubernetes.io/arch:arm64,team:dev)
-  -E, --exclude-owned                     exclude resources that have an owner reference
+      --exclude-owned                     exclude resources that have an owner reference
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
   -f, --format string                     format (table,json,cyclonedx) (default "table")

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -79,6 +79,13 @@ var (
 		Default:    "trivy-temp",
 		Usage:      "specify the namespace in which the node-collector job should be deployed",
 	}
+	ExcludeOwned = Flag{
+		Name:       "exclude-owned",
+		ConfigName: "kubernetes.exclude.owned",
+		Shorthand:  "E",
+		Default:    false,
+		Usage:      "exclude resources that have an owner reference",
+	}
 	ExcludeNodes = Flag{
 		Name:       "exclude-nodes",
 		ConfigName: "exclude.nodes",
@@ -97,6 +104,7 @@ type K8sFlagGroup struct {
 	Tolerations            *Flag
 	AllNamespaces          *Flag
 	NodeCollectorNamespace *Flag
+	ExcludeOwned           *Flag
 	ExcludeNodes           *Flag
 }
 
@@ -110,6 +118,7 @@ type K8sOptions struct {
 	Tolerations            []corev1.Toleration
 	AllNamespaces          bool
 	NodeCollectorNamespace string
+	ExcludeOwned           bool
 	ExcludeNodes           map[string]string
 }
 
@@ -124,6 +133,7 @@ func NewK8sFlagGroup() *K8sFlagGroup {
 		Tolerations:            &TolerationsFlag,
 		AllNamespaces:          &AllNamespaces,
 		NodeCollectorNamespace: &NodeCollectorNamespace,
+		ExcludeOwned:           &ExcludeOwned,
 		ExcludeNodes:           &ExcludeNodes,
 	}
 }
@@ -143,6 +153,7 @@ func (f *K8sFlagGroup) Flags() []*Flag {
 		f.Tolerations,
 		f.AllNamespaces,
 		f.NodeCollectorNamespace,
+		f.ExcludeOwned,
 		f.ExcludeNodes,
 	}
 }
@@ -180,6 +191,7 @@ func (f *K8sFlagGroup) ToOptions() (K8sOptions, error) {
 		Tolerations:            tolerations,
 		AllNamespaces:          getBool(f.AllNamespaces),
 		NodeCollectorNamespace: getString(f.NodeCollectorNamespace),
+		ExcludeOwned:           getBool(f.ExcludeOwned),
 		ExcludeNodes:           exludeNodeLabels,
 	}, nil
 }

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -82,7 +82,6 @@ var (
 	ExcludeOwned = Flag{
 		Name:       "exclude-owned",
 		ConfigName: "kubernetes.exclude.owned",
-		Shorthand:  "E",
 		Default:    false,
 		Usage:      "exclude resources that have an owner reference",
 	}

--- a/pkg/k8s/commands/resource.go
+++ b/pkg/k8s/commands/resource.go
@@ -22,11 +22,15 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 	}
 
 	runner := newRunner(opts, cluster.GetCurrentContext())
+
 	var trivyk trivyk8s.TrivyK8S
+
+	trivyk = trivyk8s.New(cluster, log.Logger, trivyk8s.WithExcludeOwned(opts.ExcludeOwned))
+
 	if opts.AllNamespaces {
-		trivyk = trivyk8s.New(cluster, log.Logger).AllNamespaces()
+		trivyk = trivyk.AllNamespaces()
 	} else {
-		trivyk = trivyk8s.New(cluster, log.Logger).Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
+		trivyk = trivyk.Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
 	}
 
 	if len(name) == 0 { // pods or configmaps etc


### PR DESCRIPTION
## Description
This PR introduces the `--exclude-owned` flag to the Kubernetes resource handling. The purpose of this flag is to allow exclusion of Kubernetes objects that have an owner reference. This can be useful when we want to filter out resources that are managed or owned by other objects.

- Close #5064
- Depend on #5058 (#5019)

## Use cases
- Exclude Kubernetes artifacts that have owner references from being scanned. When `--exclude-owner` is  enabled, this flag streamlines scanning by skipping resources that are managed by higher-level controllers. 

### Before
```
trivy k8s pods,rs,statefulsets,deployments,daemonsets,jobs,cronjobs --report=summary --scanners config --all-namespaces
Workload Assessment
┌──────────────┬───────────────────────────────────────────────┬─────────────────────┐
│  Namespace   │                   Resource                    │  Misconfigurations  │
│              │                                               ├───┬───┬────┬────┬───┤
│              │                                               │ C │ H │ M  │ L  │ U │
├──────────────┼───────────────────────────────────────────────┼───┼───┼────┼────┼───┤
│ kube-system  │ Pod/ebs-csi-node-pjml9                        │   │ 1 │ 10 │ 20 │   │
│ kube-system  │ DaemonSet/ebs-csi-node                        │   │ 1 │ 10 │ 20 │   │
│ kube-system  │ Deployment/coredns                            │   │   │ 3  │ 5  │   │
│ kube-system  │ DaemonSet/aws-for-fluent-bit                  │   │   │ 4  │ 8  │   │
│ kube-system  │ ReplicaSet/coredns-66dddcb88c                 │   │   │ 3  │ 5  │   │
│ kube-system  │ DaemonSet/kube-proxy                          │   │ 2 │ 4  │ 10 │   │
│ kube-system  │ Deployment/ebs-csi-controller                 │   │   │ 5  │ 31 │   │
│ kube-system  │ Pod/aws-node-9f6mb                            │   │ 4 │ 8  │ 19 │   │
│ kube-system  │ DaemonSet/aws-node                            │   │ 2 │ 8  │ 20 │   │
│ kube-system  │ Pod/ebs-csi-controller-846b7ddddb-nj6ks       │   │   │ 5  │ 31 │   │
│ kube-system  │ Pod/ebs-csi-controller-846b7ddddb-tbl88       │   │   │ 5  │ 31 │   │
│ kube-system  │ Pod/kube-proxy-mp45r                          │   │ 2 │ 4  │ 10 │   │
│ kube-system  │ Pod/coredns-655c69d4f4-kmx6c                  │   │   │ 3  │ 5  │   │
│ kube-system  │ ReplicaSet/coredns-655c69d4f4                 │   │   │ 3  │ 5  │   │
│ kube-system  │ Pod/aws-for-fluent-bit-m46xg                  │   │   │ 4  │ 8  │   │
│ kube-system  │ ReplicaSet/ebs-csi-controller-846b7ddddb      │   │   │ 5  │ 31 │   │
│ kube-system  │ Pod/coredns-655c69d4f4-fg82d                  │   │   │ 3  │ 5  │   │
│ default      │ ReplicaSet/nginx-55875d95fd                   │   │   │ 3  │ 11 │   │
│ default      │ Pod/myteam-mytest-cluster5-1                  │   │   │ 3  │ 7  │   │
│ default      │ StatefulSet/myteam-mytest-cluster5            │   │   │ 3  │ 7  │   │
│ default      │ ReplicaSet/nginx-7dc58f44b5                   │   │   │ 3  │ 11 │   │
│ default      │ Pod/web-1                                     │   │   │ 3  │ 11 │   │
│ default      │ Pod/my-pod                                    │   │   │ 4  │ 11 │   │
│ default      │ Deployment/nginx                              │   │   │ 3  │ 11 │   │
│ default      │ Pod/frontend-82hnn                            │   │   │ 3  │ 11 │   │
│ default      │ ReplicaSet/frontend                           │   │   │ 3  │ 11 │   │
│ default      │ Deployment/postgres-operator-ui               │   │   │ 3  │ 7  │   │
│ default      │ Pod/nginx-5d56f7cc56-rj5tk                    │   │   │ 3  │ 11 │   │
│ default      │ Pod/myteam-mytest-cluster5-0                  │   │   │ 3  │ 7  │   │
│ default      │ ReplicaSet/nginx-5d56f7cc56                   │   │   │ 3  │ 11 │   │
│ default      │ ReplicaSet/postgres-operator-ui-7cf5759697    │   │   │ 3  │ 7  │   │
│ default      │ Pod/frontend-rkwww                            │   │   │ 3  │ 11 │   │
│ default      │ Pod/web-0                                     │   │   │ 3  │ 11 │   │
│ default      │ Pod/postgres-operator-5c884976b6-bbj7m        │   │   │ 1  │ 6  │   │
│ default      │ StatefulSet/web                               │   │   │ 3  │ 11 │   │
│ default      │ Pod/postgres-operator-ui-7cf5759697-hrlst     │   │   │ 3  │ 7  │   │
│ default      │ Pod/frontend-8jw4h                            │   │   │ 3  │ 11 │   │
│ default      │ ReplicaSet/postgres-operator-5c884976b6       │   │   │ 1  │ 6  │   │
│ default      │ Deployment/postgres-operator                  │   │   │ 1  │ 6  │   │
│ cert-manager │ ReplicaSet/cert-manager-cainjector-744bb89575 │   │   │ 1  │ 8  │   │
│ cert-manager │ Deployment/cert-manager                       │   │   │ 1  │ 8  │   │
│ cert-manager │ Pod/cert-manager-webhook-759d6dcbf7-6f4tc     │   │   │ 1  │ 8  │   │
│ cert-manager │ ReplicaSet/cert-manager-webhook-759d6dcbf7    │   │   │ 1  │ 8  │   │
│ cert-manager │ Deployment/cert-manager-webhook               │   │   │ 1  │ 8  │   │
│ cert-manager │ Deployment/cert-manager-cainjector            │   │   │ 1  │ 8  │   │
│ cert-manager │ Pod/cert-manager-cainjector-744bb89575-wrvs9  │   │   │ 1  │ 8  │   │
│ cert-manager │ Pod/cert-manager-69cdc85fc8-lmx5s             │   │   │ 1  │ 8  │   │
│ cert-manager │ ReplicaSet/cert-manager-69cdc85fc8            │   │   │ 1  │ 8  │   │
└──────────────┴───────────────────────────────────────────────┴───┴───┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```
### After

```
trivy k8s pods,rs,statefulsets,deployments,daemonsets,jobs,cronjobs --report=summary --scanners config  --all-namespaces --exclude-owned

Workload Assessment
┌──────────────┬────────────────────────────────────┬─────────────────────┐
│  Namespace   │              Resource              │  Misconfigurations  │
│              │                                    ├───┬───┬────┬────┬───┤
│              │                                    │ C │ H │ M  │ L  │ U │
├──────────────┼────────────────────────────────────┼───┼───┼────┼────┼───┤
│ kube-system  │ DaemonSet/aws-node                 │   │ 2 │ 8  │ 20 │   │
│ kube-system  │ Deployment/coredns                 │   │   │ 3  │ 5  │   │
│ kube-system  │ DaemonSet/ebs-csi-node             │   │ 1 │ 10 │ 20 │   │
│ kube-system  │ Deployment/ebs-csi-controller      │   │   │ 5  │ 31 │   │
│ kube-system  │ DaemonSet/aws-for-fluent-bit       │   │   │ 4  │ 8  │   │
│ kube-system  │ DaemonSet/kube-proxy               │   │ 2 │ 4  │ 10 │   │
│ default      │ StatefulSet/web                    │   │   │ 3  │ 11 │   │
│ default      │ Deployment/nginx                   │   │   │ 3  │ 11 │   │
│ default      │ StatefulSet/myteam-mytest-cluster5 │   │   │ 3  │ 7  │   │
│ default      │ Deployment/postgres-operator-ui    │   │   │ 3  │ 7  │   │
│ default      │ Deployment/postgres-operator       │   │   │ 1  │ 6  │   │
│ default      │ Pod/my-pod                         │   │   │ 4  │ 11 │   │
│ default      │ ReplicaSet/frontend                │   │   │ 3  │ 11 │   │
│ cert-manager │ Deployment/cert-manager            │   │   │ 1  │ 8  │   │
│ cert-manager │ Deployment/cert-manager-webhook    │   │   │ 1  │ 8  │   │
│ cert-manager │ Deployment/cert-manager-cainjector │   │   │ 1  │ 8  │   │
└──────────────┴────────────────────────────────────┴───┴───┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```
## Related PRs
- [x] #5043 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
