### PR TITLE
fix(java): add licenses for pom.xml dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.4
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.92.0
-	github.com/aquasecurity/go-dep-parser v0.0.0-20230828120518-ef5e9409fc43
+	github.com/aquasecurity/go-dep-parser v0.0.0-20230830122616-841bc0f812c7
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.92.0 h1:cls2JJSQ+vb06Qh2XjnODIRfZbrTGBkBQnjgC6R5+vA=
 github.com/aquasecurity/defsec v0.92.0/go.mod h1:uZIC1NjU5R49619WvZOlhWRpCEf/7KD3Lm8nDKRjq+o=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230828120518-ef5e9409fc43 h1:/F4aNnwyFNyAemjKtHznfRdeWUEENOZYOnx+smPPpAE=
-github.com/aquasecurity/go-dep-parser v0.0.0-20230828120518-ef5e9409fc43/go.mod h1:0+GvQF0gL4YEAAUPpNeLeGpFDxMvvIHLMd7vk9bpwko=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230830122616-841bc0f812c7 h1:FSfz2vfnL3EvTh04zDx4SYxKmgDbYSr8td6R8XbtbB8=
+github.com/aquasecurity/go-dep-parser v0.0.0-20230830122616-841bc0f812c7/go.mod h1:0+GvQF0gL4YEAAUPpNeLeGpFDxMvvIHLMd7vk9bpwko=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20230810212901-d6feebd39060 h1:V7nC90NpRDEubNpNEgRDtTfLH3RKQlZeY9/HSqxEze8=


### PR DESCRIPTION
## Description
Add licenses for pom artifacts.

## Related issues
- Close #5028

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/251

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
