### PR TITLE
test: validate SPDX with the JSON schema

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 	spdxjson "github.com/spdx/tools-golang/json"
 	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdxlib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
@@ -223,6 +224,8 @@ func compareSPDXJson(t *testing.T, wantFile, gotFile string) {
 
 	SPDXVersion, ok := strings.CutPrefix(want.SPDXVersion, "SPDX-")
 	assert.True(t, ok)
+
+	assert.NoError(t, spdxlib.ValidateDocument(got))
 
 	// Validate SPDX output against the JSON schema
 	validateReport(t, fmt.Sprintf(SPDXSchema, SPDXVersion), got)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -34,7 +35,7 @@ import (
 
 var update = flag.Bool("update", false, "update golden files")
 
-const SPDXSchema = "https://raw.githubusercontent.com/spdx/spdx-spec/development/v2.3.1/schemas/spdx-schema.json"
+const SPDXSchema = "https://raw.githubusercontent.com/spdx/spdx-spec/development/v%s/schemas/spdx-schema.json"
 
 func initDB(t *testing.T) string {
 	fixtureDir := filepath.Join("testdata", "fixtures", "db")
@@ -220,8 +221,11 @@ func compareSPDXJson(t *testing.T, wantFile, gotFile string) {
 	got := readSpdxJson(t, gotFile)
 	assert.Equal(t, want, got)
 
+	SPDXVersion, ok := strings.CutPrefix(want.SPDXVersion, "SPDX-")
+	assert.True(t, ok)
+
 	// Validate SPDX output against the JSON schema
-	validateReport(t, SPDXSchema, got)
+	validateReport(t, fmt.Sprintf(SPDXSchema, SPDXVersion), got)
 }
 
 func validateReport(t *testing.T, schema string, report any) {

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -492,7 +492,7 @@ func TestRepository(t *testing.T) {
 			case types.FormatCycloneDX:
 				compareCycloneDX(t, tt.golden, outputFile)
 			case types.FormatSPDXJSON:
-				compareSpdxJson(t, tt.golden, outputFile)
+				compareSPDXJson(t, tt.golden, outputFile)
 			case types.FormatJSON:
 				compareReports(t, tt.golden, outputFile, tt.override)
 			default:


### PR DESCRIPTION
## Description

This PR adds validation of the SDPX-JSON report using the SPDX JSON [schema](https://github.com/spdx/spdx-spec/tree/development/v2.3.1).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
