### PR TITLE
fix(sbom): use PURL or Group and Name in case of Java 

### DIFF
--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -420,7 +420,7 @@ func convertMavenPackage(component cdx.Component) string {
 	// Check if both Group and Name are present
 	if component.Group != "" {
 		return fmt.Sprintf("%s:%s", component.Group, component.Name)
-	} else {
+	} else if component.PackageURL != "" {
 		// Split the package into its parts
 		parts := strings.Split(component.PackageURL, "/")
 
@@ -433,5 +433,8 @@ func convertMavenPackage(component cdx.Component) string {
 		nameWOVersion := strings.Split(nameWithVersion, "@")[0]
 
 		return fmt.Sprintf("%s:%s", group, nameWOVersion)
+		// In case we don't have Group or PURL
+	} else {
+		return component.Name
 	}
 }

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx/core"
 
@@ -410,8 +411,26 @@ func toTrivyCdxComponent(component cdx.Component) ftypes.Component {
 
 func getPackageName(typ string, component cdx.Component) string {
 	// Jar uses `Group` field for `GroupID`
-	if typ == packageurl.TypeMaven && component.Group != "" {
-		return fmt.Sprintf("%s:%s", component.Group, component.Name)
+	if typ == packageurl.TypeMaven {
+		return convertMavenPackage(component.PackageURL)
 	}
 	return component.Name
+}
+
+func convertMavenPackage(pkg string) string {
+	// Split the package into its parts
+	parts := strings.Split(pkg, "/")
+
+	// Get Group
+	group := parts[1]
+
+	// Get FullName with Version
+	nameWithVersion := parts[len(parts)-1]
+
+	// Remove the Version from the package
+	nameWOVersion := strings.Split(nameWithVersion, "@")[0]
+
+	pkgWithoutVersion := fmt.Sprintf("%s:%s", group, nameWOVersion)
+
+	return pkgWithoutVersion
 }

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -417,9 +417,9 @@ func getPackageName(typ string, component cdx.Component) string {
 }
 
 func convertMavenPackage(pkg string) string {
+	// Split the package into its parts
 	parts := strings.Split(pkg, "/")
 
-	// Get Group
 	group := parts[1]
 
 	// Get FullName with Version

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -410,7 +410,6 @@ func toTrivyCdxComponent(component cdx.Component) ftypes.Component {
 }
 
 func getPackageName(typ string, component cdx.Component) string {
-	// Jar uses `Group` field for `GroupID`
 	if typ == packageurl.TypeMaven {
 		return convertMavenPackage(component.PackageURL)
 	}
@@ -418,7 +417,6 @@ func getPackageName(typ string, component cdx.Component) string {
 }
 
 func convertMavenPackage(pkg string) string {
-	// Split the package into its parts
 	parts := strings.Split(pkg, "/")
 
 	// Get Group
@@ -430,7 +428,5 @@ func convertMavenPackage(pkg string) string {
 	// Remove the Version from the package
 	nameWOVersion := strings.Split(nameWithVersion, "@")[0]
 
-	pkgWithoutVersion := fmt.Sprintf("%s:%s", group, nameWOVersion)
-
-	return pkgWithoutVersion
+	return fmt.Sprintf("%s:%s", group, nameWOVersion)
 }

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -411,22 +411,27 @@ func toTrivyCdxComponent(component cdx.Component) ftypes.Component {
 
 func getPackageName(typ string, component cdx.Component) string {
 	if typ == packageurl.TypeMaven {
-		return convertMavenPackage(component.PackageURL)
+		return convertMavenPackage(component)
 	}
 	return component.Name
 }
 
-func convertMavenPackage(pkg string) string {
-	// Split the package into its parts
-	parts := strings.Split(pkg, "/")
+func convertMavenPackage(component cdx.Component) string {
+	// Check if both Group and Name are present
+	if component.Group != "" {
+		return fmt.Sprintf("%s:%s", component.Group, component.Name)
+	} else {
+		// Split the package into its parts
+		parts := strings.Split(component.PackageURL, "/")
 
-	group := parts[1]
+		group := parts[1]
 
-	// Get FullName with Version
-	nameWithVersion := parts[len(parts)-1]
+		// Get FullName with Version
+		nameWithVersion := parts[len(parts)-1]
 
-	// Remove the Version from the package
-	nameWOVersion := strings.Split(nameWithVersion, "@")[0]
+		// Remove the Version from the package
+		nameWOVersion := strings.Split(nameWithVersion, "@")[0]
 
-	return fmt.Sprintf("%s:%s", group, nameWOVersion)
+		return fmt.Sprintf("%s:%s", group, nameWOVersion)
+	}
 }


### PR DESCRIPTION
## Description
If another SCA generates CycloneDX file, it may does not have fields like "group" and "name" in SBOM file. As example, an Dependency Track. There's problem in handling SBOM files, where Trivy trying to get data from specific SBOM fields, but not from "purl" field of SBOM (CycloneDX-json) file.

## Related issues
- Close #5151

## Checklist
- [ X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
