### PR TITLE
fix(fs): assign the absolute path to be inspected to ROOTPATH when filesystem

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -46,6 +47,7 @@ type SarifWriter struct {
 	Version       string
 	run           *sarif.Run
 	locationCache map[string][]location
+	Target        string
 }
 
 type sarifData struct {
@@ -134,6 +136,10 @@ func (sw *SarifWriter) Write(report types.Report) error {
 			"repoTags":    report.Metadata.RepoTags,
 			"repoDigests": report.Metadata.RepoDigests,
 		}
+	}
+	if sw.Target != "" {
+		absPath, _ := filepath.Abs(sw.Target)
+		rootPath = fmt.Sprintf("file://%s/", absPath)
 	}
 
 	ruleIndexes := map[string]int{}

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/report/spdx"
 	"github.com/aquasecurity/trivy/pkg/report/table"
 	"github.com/aquasecurity/trivy/pkg/types"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
 const (
@@ -75,9 +77,14 @@ func Write(report types.Report, option flag.Options) error {
 			return xerrors.Errorf("failed to initialize template writer: %w", err)
 		}
 	case types.FormatSarif:
+		target := ""
+		if report.ArtifactType == ftypes.ArtifactFilesystem {
+			target = option.Target
+		}
 		writer = &SarifWriter{
 			Output:  output,
 			Version: option.AppVersion,
+			Target:  target,
 		}
 	case types.FormatCosignVuln:
 		writer = predicate.NewVulnWriter(output, option.AppVersion)


### PR DESCRIPTION
## Description
see issue

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5157

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
