### PR TITLE
chore: auto-close issues

### DIFF
--- a/.github/workflows/auto-close-issue.yaml
+++ b/.github/workflows/auto-close-issue.yaml
@@ -1,4 +1,4 @@
-name: Auto Close Issue
+name: Auto-close issues
 
 on:
   issues:
@@ -38,7 +38,8 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.issue.number,
-                state: 'closed'
+                state: 'closed',
+                state_reason: 'not_planned'
               });
             
               console.log(`Issue #${context.payload.issue.number} closed because ${issueCreator} does not have sufficient permissions.`);

--- a/.github/workflows/auto-close-issue.yaml
+++ b/.github/workflows/auto-close-issue.yaml
@@ -26,7 +26,7 @@ jobs:
             
             // If the user does not have write or admin permissions, leave a comment and close the issue
             if (permission !== 'write' && permission !== 'admin') {
-              const commentBody = "Please see https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/";
+              const commentBody = "Please see https://aquasecurity.github.io/trivy/latest/community/contribute/issue/";
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/auto-close-issue.yaml
+++ b/.github/workflows/auto-close-issue.yaml
@@ -1,0 +1,45 @@
+name: Auto Close Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  close_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue if user does not have write or admin permissions
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // Get the issue creator's username
+            const issueCreator = context.payload.issue.user.login;
+            
+            // Check the user's permissions for the repository
+            const repoPermissions = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: issueCreator
+            });
+            
+            const permission = repoPermissions.data.permission;
+            
+            // If the user does not have write or admin permissions, leave a comment and close the issue
+            if (permission !== 'write' && permission !== 'admin') {
+              const commentBody = "Please see https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/";
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: commentBody
+              });
+            
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                state: 'closed'
+              });
+            
+              console.log(`Issue #${context.payload.issue.number} closed because ${issueCreator} does not have sufficient permissions.`);
+            }

--- a/docs/community/contribute/issue.md
+++ b/docs/community/contribute/issue.md
@@ -2,3 +2,6 @@
 Thank you for taking interest in contributing to Trivy!
 
 Trivy uses [GitHub Discussion](./discussion.md) for bug reports, feature requests, and questions.
+
+!!! warning
+    Issues created by non-maintainers will be immediately closed.


### PR DESCRIPTION
## Description
Issues created by non-maintainers are closed as Trivy uses GitHub Discussions for triaging bug fixes, feature requests, etc.

## Related issues
- https://github.com/aquasecurity/trivy/issues/5136
- https://github.com/aquasecurity/trivy/issues/5110
- https://github.com/aquasecurity/trivy/issues/5087
- https://github.com/aquasecurity/trivy/issues/5085
- etc.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
