### PR TITLE
fix(purl): handle rust types

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -375,6 +375,8 @@ func purlType(t string) string {
 		return packageurl.TypeConan
 	case ftypes.Pub:
 		return TypeDart // TODO: replace with packageurl.TypeDart once they add it.
+	case ftypes.RustBinary, ftypes.Cargo:
+		return packageurl.TypeCargo
 	case os.Alpine:
 		return TypeAPK
 	case os.Debian, os.Ubuntu:

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -185,10 +185,15 @@ func TestNewPackageURL(t *testing.T) {
 			name: "hex package",
 			typ:  ftypes.Hex,
 			pkg: ftypes.Package{
-				ID:        "bunt@0.2.0",
-				Name:      "bunt",
-				Version:   "0.2.0",
-				Locations: []ftypes.Location{{StartLine: 2, EndLine: 2}},
+				ID:      "bunt@0.2.0",
+				Name:    "bunt",
+				Version: "0.2.0",
+				Locations: []ftypes.Location{
+					{
+						StartLine: 2,
+						EndLine:   2,
+					},
+				},
 			},
 			want: purl.PackageURL{
 				PackageURL: packageurl.PackageURL{
@@ -244,6 +249,22 @@ func TestNewPackageURL(t *testing.T) {
 					Name:    "GoogleUtilities",
 					Version: "7.5.2",
 					Subpath: "NSData+zlib",
+				},
+			},
+		},
+		{
+			name: "rust binary",
+			typ:  ftypes.RustBinary,
+			pkg: ftypes.Package{
+				ID:      "abomonation@0.7.3",
+				Name:    "abomonation",
+				Version: "0.7.3",
+			},
+			want: purl.PackageURL{
+				PackageURL: packageurl.PackageURL{
+					Type:    packageurl.TypeCargo,
+					Name:    "abomonation",
+					Version: "0.7.3",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Cargo projects and Rust binaries are not handled for PURL now.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5166

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
