### PR TITLE
docs: fix broken link to `coverage` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 
 [Installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
 [Ecosystem]: https://aquasecurity.github.io/trivy/latest/ecosystem/
-[Scanning Coverage]: https://aquasecurity.github.io/trivy/latest/getting-started/coverage/
+[Scanning Coverage]: https://aquasecurity.github.io/trivy/latest/docs/coverage/
 
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego


### PR DESCRIPTION
## Description
Docs: fix broken link to `coverage` in README.md

## Related discussions:
- #5109

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
