### PR TITLE
feat(db): allow passing registry options

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -329,7 +329,7 @@ func (r *runner) initJavaDB(opts flag.Options) error {
 
 	// Update the Java DB
 	noProgress := opts.Quiet || opts.NoProgress
-	javadb.Init(opts.CacheDir, opts.JavaDBRepository, opts.SkipJavaDBUpdate, noProgress, ftypes.RegistryOptions{Insecure: opts.Insecure})
+	javadb.Init(opts.CacheDir, opts.JavaDBRepository, opts.SkipJavaDBUpdate, noProgress, opts.RegistryOpts())
 	if opts.DownloadJavaDBOnly {
 		if err := javadb.Update(); err != nil {
 			return xerrors.Errorf("Java DB error: %w", err)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -329,7 +329,7 @@ func (r *runner) initJavaDB(opts flag.Options) error {
 
 	// Update the Java DB
 	noProgress := opts.Quiet || opts.NoProgress
-	javadb.Init(opts.CacheDir, opts.JavaDBRepository, opts.SkipJavaDBUpdate, noProgress, opts.Insecure)
+	javadb.Init(opts.CacheDir, opts.JavaDBRepository, opts.SkipJavaDBUpdate, noProgress, ftypes.RegistryOptions{Insecure: opts.Insecure})
 	if opts.DownloadJavaDBOnly {
 		if err := javadb.Update(); err != nil {
 			return xerrors.Errorf("Java DB error: %w", err)

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -616,7 +616,7 @@ func TestAnalyzerGroup_PostAnalyze(t *testing.T) {
 
 			if tt.analyzerType == analyzer.TypeJar {
 				// init java-trivy-db with skip update
-				javadb.Init("./language/java/jar/testdata", "ghcr.io/aquasecurity/trivy-java-db", true, false, false)
+				javadb.Init("./language/java/jar/testdata", "ghcr.io/aquasecurity/trivy-java-db", true, false, types.RegistryOptions{Insecure: false})
 			}
 
 			ctx := context.Background()

--- a/pkg/fanal/analyzer/language/java/jar/jar_test.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar_test.go
@@ -129,7 +129,7 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init java-trivy-db with skip update
-			javadb.Init("testdata", defaultJavaDBRepository, true, false, false)
+			javadb.Init("testdata", defaultJavaDBRepository, true, false, types.RegistryOptions{Insecure: false})
 
 			a := javaLibraryAnalyzer{slow: true}
 			ctx := context.Background()

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -26,11 +26,11 @@ const (
 var updater *Updater
 
 type Updater struct {
-	repo     string
-	dbDir    string
-	skip     bool
-	quiet    bool
-	insecure bool
+	repo           string
+	dbDir          string
+	skip           bool
+	quiet          bool
+	registryOption ftypes.RegistryOptions
 }
 
 func (u *Updater) Update() error {
@@ -54,7 +54,7 @@ func (u *Updater) Update() error {
 
 		// TODO: support remote options
 		var a *oci.Artifact
-		if a, err = oci.NewArtifact(u.repo, u.quiet, ftypes.RegistryOptions{Insecure: u.insecure}); err != nil {
+		if a, err = oci.NewArtifact(u.repo, u.quiet, u.registryOption); err != nil {
 			return xerrors.Errorf("oci error: %w", err)
 		}
 		if err = a.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: mediaType}); err != nil {
@@ -79,13 +79,13 @@ func (u *Updater) Update() error {
 	return nil
 }
 
-func Init(cacheDir string, javaDBRepository string, skip, quiet, insecure bool) {
+func Init(cacheDir string, javaDBRepository string, skip, quiet bool, registryOption ftypes.RegistryOptions) {
 	updater = &Updater{
-		repo:     fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion),
-		dbDir:    filepath.Join(cacheDir, "java-db"),
-		skip:     skip,
-		quiet:    quiet,
-		insecure: insecure,
+		repo:           fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion),
+		dbDir:          filepath.Join(cacheDir, "java-db"),
+		skip:           skip,
+		quiet:          quiet,
+		registryOption: registryOption,
 	}
 }
 


### PR DESCRIPTION
## Description
It is currently not possible to download the java-vulnerability-db from a private registry. This changes allows developers using the Golang package to download the java-vulnerability-db from a private container registry and pass oci-registry options. Nothing changes for a CLI user, only for developers utilising the pkg/javadb directly. I changed the Init interface of the javadb which is a breaking change, another possibility would be to add a new Initi function. Let me know what you think.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
