### PR TITLE
fix: Add missing command in "Create the VEX"

### DIFF
--- a/docs/docs/supply-chain/vex.md
+++ b/docs/docs/supply-chain/vex.md
@@ -36,6 +36,11 @@ $ trivy image --format cyclonedx --output debian11.sbom.cdx debian:11
 
 ### Create the VEX
 Next, create a VEX based on the generated SBOM.
+
+```shell
+$ trivy sbom <path-to-your-SBOM-file> --vex trivy.vex.cdx
+```
+
 Multiple vulnerability statuses can be defined under `vulnerabilities`.
 Take a look at the example below.
 


### PR DESCRIPTION
The command to create the VEX file was missing.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
