### PR TITLE
ci: bump GoReleaser from 1.16.2 to 1.20.0

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.16.2
+          version: v1.20.0
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -189,5 +189,5 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4
       with:
-        version: v1.16.2
+        version: v1.20.0
         args: build --snapshot --clean --timeout 90m ${{ steps.goreleaser_id.outputs.id }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -133,7 +133,7 @@ archives:
 
 brews:
   -
-    tap:
+    repository:
       owner: aquasecurity
       name: homebrew-trivy
     homepage: "https://github.com/aquasecurity/trivy"


### PR DESCRIPTION
## Description
Changed `brews.tap` to `brews.repository` in goreleaser.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5219

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
