### PR TITLE
fix(report): removes git::http from uri in sarif

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -337,7 +337,7 @@ func ToPathUri(input string, resultClass types.ResultClass) string {
 		input = ref.Context().RepositoryStr()
 	}
 
-	return strings.ReplaceAll(input, "\\", "/")
+	return strings.ReplaceAll(strings.ReplaceAll(string(input), "\\", "/"), "git::https:/", "")
 }
 
 func (sw *SarifWriter) getLocations(name, version, path string, pkgs []ftypes.Package) []location {

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -337,7 +337,7 @@ func ToPathUri(input string, resultClass types.ResultClass) string {
 		input = ref.Context().RepositoryStr()
 	}
 
-	return strings.ReplaceAll(strings.ReplaceAll(string(input), "\\", "/"), "git::https:/", "")
+	return strings.ReplaceAll(strings.ReplaceAll(input, "\\", "/"), "git::https:/", "")
 }
 
 func (sw *SarifWriter) getLocations(name, version, path string, pkgs []ftypes.Package) []location {


### PR DESCRIPTION
## Description

Sarif files are being generated with "git:http://" inside the uri fields which are invalid. This change will strip of the string, leaving the sarif files being valid and therefore able to upload to github which is failing at the minute.

## Related issues
- Fixes https://github.com/aquasecurity/trivy/issues/5003

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
