### PR TITLE
chore: Add line numbers for lint output

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,12 +41,19 @@ jobs:
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Lint
+        id: lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: v1.54
           args: --deadline=30m --out-format=line-number
           skip-cache: true # https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052197778
         if: matrix.operating-system == 'ubuntu-latest'
+
+      - name: Check if linter failed
+        run: |
+          echo "Linter failed, please run mage lint:fix to correct any errors"
+          exit 1
+        if: ${{ failure() && steps.lint.conclusion == 'failure' }}
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v2.1.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check if linter failed
         run: |
-          echo "Linter failed, please run mage lint:fix to correct any errors"
+          echo "Linter failed, running 'mage lint:fix' might help to correct some errors"
           exit 1
         if: ${{ failure() && steps.lint.conclusion == 'failure' }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: v1.54
-          args: --deadline=30m
+          args: --deadline=30m --out-format=line-number
           skip-cache: true # https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052197778
         if: matrix.operating-system == 'ubuntu-latest'
 


### PR DESCRIPTION
## Description
This adds the ability to see line numbers when linter has problems to report.

<img width="1035" alt="image" src="https://github.com/aquasecurity/trivy/assets/1254783/bfd3d881-94c3-42e3-8187-b25060f49f28">

<img width="1276" alt="image" src="https://github.com/aquasecurity/trivy/assets/1254783/8548473e-966b-4c35-871a-ecf00b7674ad">

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/5228
