### PR TITLE
chore(cli): disable java-db flags in server mode

### DIFF
--- a/docs/docs/configuration/db.md
+++ b/docs/docs/configuration/db.md
@@ -64,6 +64,9 @@ Downloading the Java index DB from an external OCI registry can be done by using
 $ trivy image --java-db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-java-db --download-java-db-only
 ```
 
+!!! Note
+    In [Client/Server](../references/modes/client-server.md) mode, `Java index DB` is currently only used on the `client` side.
+
 ## Remove DBs
 The `--reset` flag removes all caches and databases.
 

--- a/docs/docs/references/configuration/cli/trivy_server.md
+++ b/docs/docs/references/configuration/cli/trivy_server.md
@@ -20,30 +20,27 @@ trivy server [flags]
 ### Options
 
 ```
-      --cache-backend string        cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration          cache TTL when using redis as cache backend
-      --clear-cache                 clear image caches without scanning
-      --db-repository string        OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
-      --download-db-only            download/update vulnerability database but don't run a scan
-      --download-java-db-only       download/update Java index database but don't run a scan
-      --enable-modules strings      [EXPERIMENTAL] module names to enable
-  -h, --help                        help for server
-      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
-      --listen string               listen address in server mode (default "localhost:4954")
-      --module-dir string           specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress                 suppress progress bar
-      --password strings            password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --redis-ca string             redis ca file location, if using redis as cache backend
-      --redis-cert string           redis certificate file location, if using redis as cache backend
-      --redis-key string            redis key file location, if using redis as cache backend
-      --redis-tls                   enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string       registry token
-      --reset                       remove all caches and database
-      --skip-db-update              skip updating vulnerability database
-      --skip-java-db-update         skip updating Java index database
-      --token string                for authentication in client/server mode
-      --token-header string         specify a header name for token in client/server mode (default "Trivy-Token")
-      --username strings            username. Comma-separated usernames allowed.
+      --cache-backend string     cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration       cache TTL when using redis as cache backend
+      --clear-cache              clear image caches without scanning
+      --db-repository string     OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --download-db-only         download/update vulnerability database but don't run a scan
+      --enable-modules strings   [EXPERIMENTAL] module names to enable
+  -h, --help                     help for server
+      --listen string            listen address in server mode (default "localhost:4954")
+      --module-dir string        specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress              suppress progress bar
+      --password strings         password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --redis-ca string          redis ca file location, if using redis as cache backend
+      --redis-cert string        redis certificate file location, if using redis as cache backend
+      --redis-key string         redis key file location, if using redis as cache backend
+      --redis-tls                enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string    registry token
+      --reset                    remove all caches and database
+      --skip-db-update           skip updating vulnerability database
+      --token string             for authentication in client/server mode
+      --token-header string      specify a header name for token in client/server mode (default "Trivy-Token")
+      --username strings         username. Comma-separated usernames allowed.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -582,6 +582,11 @@ func NewServerCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		RegistryFlagGroup: flag.NewRegistryFlagGroup(),
 	}
 
+	// java-db only works on client side.
+	serverFlags.DBFlagGroup.DownloadJavaDBOnly = nil // disable '--download-java-db-only'
+	serverFlags.DBFlagGroup.SkipJavaDBUpdate = nil   // disable '--skip-java-db-update'
+	serverFlags.DBFlagGroup.JavaDBRepository = nil   // disable '--java-db-repository'
+
 	cmd := &cobra.Command{
 		Use:     "server [flags]",
 		Aliases: []string{"s"},


### PR DESCRIPTION
## Description
`Trivy-java-db` is currently only used on the `client` side.
Disable `java-db` related flags for `server` mode.
Add note about this in docs.

## Related discussions
- #5261

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
