### PR TITLE
docs: add info about `github` format

### DIFF
--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -8,6 +8,7 @@ Trivy supports the following formats:
 - [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)
 - Template
 - SBOM
+- GitHub SBOM
 
 ### Table (Default)
 
@@ -258,6 +259,20 @@ $ trivy image --format sarif -o report.sarif  golang:1.12-alpine
 
 This SARIF file can be uploaded to GitHub code scanning results, and there is a [Trivy GitHub Action][action] for automating this process.
 
+### GitHub SBOM
+Trivy supports the following packages.
+
+- [OS packages][os_packages]
+- [Language-specific packages][language_packages]
+
+[GitHub SBOM][github-sbom] can be generated with the `--format github` flag.
+
+```
+$ trivy image --format github -o report.gsbom alpine
+```
+
+This file can be [uploaded][github-sbom-creating] to your GitHub repository.
+
 ### Template
 
 |     Scanner      | Supported |
@@ -389,3 +404,8 @@ $ trivy convert --format table --severity CRITICAL result.json
 [asff]: ../../tutorials/integrations/aws-security-hub.md
 [sarif]: https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/managing-results-from-code-scanning
 [sprig]: http://masterminds.github.io/sprig/
+[github-sbom]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#about-dependency-submissions
+[github-sbom-creating]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
+
+[os_packages]: ../scanner/vulnerability.md#os-packages
+[language_packages]: ../scanner/vulnerability.md#language-specific-packages

--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -8,7 +8,7 @@ Trivy supports the following formats:
 - [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)
 - Template
 - SBOM
-- GitHub SBOM
+- GitHub dependency snapshot
 
 ### Table (Default)
 
@@ -259,19 +259,19 @@ $ trivy image --format sarif -o report.sarif  golang:1.12-alpine
 
 This SARIF file can be uploaded to GitHub code scanning results, and there is a [Trivy GitHub Action][action] for automating this process.
 
-### GitHub SBOM
+### GitHub dependency snapshot
 Trivy supports the following packages.
 
 - [OS packages][os_packages]
 - [Language-specific packages][language_packages]
 
-[GitHub SBOM][github-sbom] can be generated with the `--format github` flag.
+[GitHub dependency snapshots][github-sbom] can be generated with the `--format github` flag.
 
 ```
 $ trivy image --format github -o report.gsbom alpine
 ```
 
-This file can be [uploaded][github-sbom-creating] to your GitHub repository.
+This snapshot file can be [submitted][github-sbom-submit] to your GitHub repository.
 
 ### Template
 
@@ -405,7 +405,7 @@ $ trivy convert --format table --severity CRITICAL result.json
 [sarif]: https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/managing-results-from-code-scanning
 [sprig]: http://masterminds.github.io/sprig/
 [github-sbom]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#about-dependency-submissions
-[github-sbom-creating]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
+[github-sbom-submit]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
 
 [os_packages]: ../scanner/vulnerability.md#os-packages
 [language_packages]: ../scanner/vulnerability.md#language-specific-packages


### PR DESCRIPTION
## Description
Add info about [github](https://github.com/aquasecurity/trivy/blob/main/pkg/report/github/github.go) format.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
