### PR TITLE
fix(dotnet): fix panic if nuget file doesn't contain dependencies

### DIFF
--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
@@ -71,6 +71,11 @@ func (a *nugetLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.Pos
 			return xerrors.Errorf("NuGet parse error: %w", err)
 		}
 
+		// nuget file doesn't contain dependencies
+		if app == nil {
+			return nil
+		}
+
 		for i, lib := range app.Libraries {
 			license, ok := foundLicenses[lib.ID]
 			if !ok {

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
@@ -166,6 +166,22 @@ func Test_nugetibraryAnalyzer_Analyze(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "happy path lock file without dependencies.",
+			dir:  "testdata/lock-without-deps",
+			env: map[string]string{
+				"HOME": "testdata/repository",
+			},
+			want: &analyzer.AnalysisResult{},
+		},
+		{
+			name: "sad path",
+			dir:  "testdata/sad",
+			env: map[string]string{
+				"HOME": "testdata/repository",
+			},
+			want: &analyzer.AnalysisResult{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/fanal/analyzer/language/dotnet/nuget/testdata/lock-without-deps/packages.lock.json
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/testdata/lock-without-deps/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {}
+  }
+}


### PR DESCRIPTION
## Description
Fix `panic` if nuget file doesn't contain dependencies 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
