### PR TITLE
docs: Improved the meaning of  sentence and corrected the wrong spelled word

### DIFF
--- a/docs/tutorials/kubernetes/gitops.md
+++ b/docs/tutorials/kubernetes/gitops.md
@@ -41,7 +41,7 @@ spec:
       selfHeal: true
 ```
 
-The apply the Kubernetes manifest. If you have the manifest locally, you can use the following command through kubectl:
+To apply the Kubernetes manifest, if you have the manifest locally, you can use the following command through kubectl:
 ```
 > kubectl apply -f trivy-operator.yaml
 


### PR DESCRIPTION


## Description
There is no english word _'deploye'_, so i corrected it to _'deploy'_.
_Go to this link to see the issue_: https://aquasecurity.github.io/trivy/v0.45/tutorials/kubernetes/kyverno/
<img width="585" alt="spelling_incorrect" src="https://github.com/aquasecurity/trivy/assets/102309095/acb95d5a-521a-4b64-8a1b-d304274a813a">

Sentence has incomplete meaning . So i have corrected it to '_To apply the Kubernetes manifest, if you have the manifest locally, you can use the following command through kubectl:_'
_Go to this link to see the issue_: https://aquasecurity.github.io/trivy/v0.45/tutorials/kubernetes/gitops/

<img width="672" alt="sentence_incomplete" src="https://github.com/aquasecurity/trivy/assets/102309095/4a3c000e-8bc8-4111-aafd-cd115347626b">



## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
