### PR TITLE
chore: enable go-critic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,24 @@ linters-settings:
             recommendations:
               - github.com/aquasecurity/go-version
             reason: "`aquasecurity/go-version` is designed for our use-cases"
+  gocritic:
+    disabled-checks:
+      - appendAssign
+      - unnamedResult
+      - whyNoLint
+      - indexAlloc
+      - octalLiteral
+      - hugeParam
+      - rangeValCopy
+      - regexpSimplify
+      - sloppyReassign
+      - commentedOutCode
+    enabled-tags:
+      - diagnostic
+      - style
+      - performance
+      - experimental
+      - opinionated
 
 linters:
   disable-all: true
@@ -62,6 +80,7 @@ linters:
     - gci
     - gomodguard
     - tenv
+    - gocritic
 
 run:
   go: '1.20'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,6 +61,10 @@ linters-settings:
       - performance
       - experimental
       - opinionated
+    settings:
+      ruleguard:
+        failOn: all
+        rules: '${configDir}/misc/lint/rules.go'
 
 linters:
   disable-all: true

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/openvex/go-vex v0.2.5
 	github.com/owenrumney/go-sarif/v2 v2.2.0
 	github.com/package-url/packageurl-go v0.1.2-0.20230812223828-f8bb31c1f10b
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/samber/lo v1.38.1
 	github.com/saracen/walker v0.1.3
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1533,6 +1533,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -393,11 +393,12 @@ func (Docs) Generate() error {
 func findProtoFiles() ([]string, error) {
 	var files []string
 	err := filepath.WalkDir("rpc", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
+		switch {
+		case err != nil:
 			return err
-		} else if d.IsDir() {
+		case d.IsDir():
 			return nil
-		} else if filepath.Ext(path) == ".proto" {
+		case filepath.Ext(path) == ".proto":
 			files = append(files, path)
 		}
 		return nil

--- a/misc/lint/rules.go
+++ b/misc/lint/rules.go
@@ -1,0 +1,22 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// cf. https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices
+func declareEmptySlices(m dsl.Matcher) {
+	m.Match(
+		`$name := []$t{}`,
+		`$name := make([]$t, 0)`,
+	).
+		Suggest(`var $name []$t`).
+		Report(`replace '$$' with 'var $name []$t'`)
+}
+
+// cf. https://github.com/uber-go/guide/blob/master/style.md#initializing-maps
+func initializeMaps(m dsl.Matcher) {
+	m.Match(`map[$key]$value{}`).
+		Suggest(`make(map[$key]$value)`).
+		Report(`replace '$$' with 'make(map[$key]$value)`)
+}

--- a/pkg/cloud/aws/cache/cache.go
+++ b/pkg/cloud/aws/cache/cache.go
@@ -37,7 +37,7 @@ var ErrCacheNotFound = fmt.Errorf("cache record not found")
 var ErrCacheIncompatible = fmt.Errorf("cache record used incomatible schema")
 var ErrCacheExpired = fmt.Errorf("cache record expired")
 
-func New(cacheDir string, maxCacheAge time.Duration, accountID string, region string) *Cache {
+func New(cacheDir string, maxCacheAge time.Duration, accountID, region string) *Cache {
 	return &Cache{
 		path:      path.Join(cacheDir, "cloud", "aws", accountID, strings.ToLower(region), "data.json"),
 		accountID: accountID,
@@ -70,7 +70,7 @@ func (c *Cache) load() (*CacheData, error) {
 	return &data, nil
 }
 
-func (c *Cache) ListServices(required []string) (included []string, missing []string) {
+func (c *Cache) ListServices(required []string) (included, missing []string) {
 
 	data, err := c.load()
 	if err != nil {
@@ -101,11 +101,10 @@ func (c *Cache) LoadState() (*state.State, error) {
 	return data.State, nil
 }
 
-func (c *Cache) AddServices(state *state.State, includedServices []string) error {
-
+func (c *Cache) AddServices(s *state.State, includedServices []string) error {
 	data := &CacheData{
 		SchemaVersion: SchemaVersion,
-		State:         state,
+		State:         s,
 		Services:      map[string]ServiceMetadata{},
 		Updated:       time.Now(),
 	}

--- a/pkg/cloud/aws/cache/cache.go
+++ b/pkg/cloud/aws/cache/cache.go
@@ -105,7 +105,7 @@ func (c *Cache) AddServices(s *state.State, includedServices []string) error {
 	data := &CacheData{
 		SchemaVersion: SchemaVersion,
 		State:         s,
-		Services:      map[string]ServiceMetadata{},
+		Services:      make(map[string]ServiceMetadata),
 		Updated:       time.Now(),
 	}
 

--- a/pkg/cloud/aws/commands/run.go
+++ b/pkg/cloud/aws/commands/run.go
@@ -95,10 +95,11 @@ func processOptions(ctx context.Context, opt *flag.Options) error {
 }
 
 func filterServices(opt *flag.Options) error {
-	if len(opt.Services) == 0 && len(opt.SkipServices) == 0 {
+	switch {
+	case len(opt.Services) == 0 && len(opt.SkipServices) == 0:
 		log.Logger.Debug("No service(s) specified, scanning all services...")
 		opt.Services = allSupportedServicesFunc()
-	} else if len(opt.SkipServices) > 0 {
+	case len(opt.SkipServices) > 0:
 		log.Logger.Debug("excluding services: ", opt.SkipServices)
 		for _, s := range allSupportedServicesFunc() {
 			if slices.Contains(opt.SkipServices, s) {
@@ -108,7 +109,7 @@ func filterServices(opt *flag.Options) error {
 				opt.Services = append(opt.Services, s)
 			}
 		}
-	} else if len(opt.Services) > 0 {
+	case len(opt.Services) > 0:
 		log.Logger.Debugf("Specific services were requested: [%s]...", strings.Join(opt.Services, ", "))
 		for _, service := range opt.Services {
 			var found bool

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -87,15 +87,19 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 		return nil, false, xerrors.Errorf("unable to create policyfs: %w", err)
 	}
 
-	scannerOpts = append(scannerOpts, options.ScannerWithPolicyFilesystem(policyFS))
-	scannerOpts = append(scannerOpts, options.ScannerWithPolicyDirs(policyPaths...))
+	scannerOpts = append(scannerOpts,
+		options.ScannerWithPolicyFilesystem(policyFS),
+		options.ScannerWithPolicyDirs(policyPaths...),
+	)
 
 	dataFS, dataPaths, err := misconf.CreateDataFS(option.RegoOptions.DataPaths)
 	if err != nil {
 		log.Logger.Errorf("Could not load config data: %s", err)
 	}
-	scannerOpts = append(scannerOpts, options.ScannerWithDataDirs(dataPaths...))
-	scannerOpts = append(scannerOpts, options.ScannerWithDataFilesystem(dataFS))
+	scannerOpts = append(scannerOpts,
+		options.ScannerWithDataDirs(dataPaths...),
+		options.ScannerWithDataFilesystem(dataFS),
+	)
 
 	scannerOpts = addPolicyNamespaces(option.RegoOptions.PolicyNamespaces, scannerOpts)
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -307,7 +307,7 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 func NewFilesystemCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup := flag.NewReportFlagGroup()
 	reportFormat := flag.ReportFormatFlag
-	reportFormat.Usage = "specify a compliance report format for the output" //@TODO: support --report summary for non compliance reports
+	reportFormat.Usage = "specify a compliance report format for the output" // @TODO: support --report summary for non compliance reports
 	reportFlagGroup.ReportFormat = &reportFormat
 	reportFlagGroup.ExitOnEOL = nil // disable '--exit-on-eol'
 
@@ -626,7 +626,7 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ListAllPkgs = nil    // disable '--list-all-pkgs'
 	reportFlagGroup.ExitOnEOL = nil      // disable '--exit-on-eol'
 	reportFormat := flag.ReportFormatFlag
-	reportFormat.Usage = "specify a compliance report format for the output" //@TODO: support --report summary for non compliance reports
+	reportFormat.Usage = "specify a compliance report format for the output" // @TODO: support --report summary for non compliance reports
 	reportFlagGroup.ReportFormat = &reportFormat
 
 	scanFlags := &flag.ScanFlagGroup{
@@ -1213,6 +1213,6 @@ func flagErrorFunc(command *cobra.Command, err error) error {
 	if err := command.Help(); err != nil {
 		return err
 	}
-	command.Println() //add empty line after list of flags
+	command.Println() // add empty line after list of flags
 	return err
 }

--- a/pkg/compliance/report/report.go
+++ b/pkg/compliance/report/report.go
@@ -112,14 +112,14 @@ func buildControlCheckResults(checksMap map[string]types.Results, controls []def
 }
 
 // buildComplianceReportResults create compliance results data
-func buildComplianceReportResults(checksMap map[string]types.Results, spec defsecTypes.Spec) *ComplianceReport {
-	controlCheckResult := buildControlCheckResults(checksMap, spec.Controls)
+func buildComplianceReportResults(checksMap map[string]types.Results, s defsecTypes.Spec) *ComplianceReport {
+	controlCheckResult := buildControlCheckResults(checksMap, s.Controls)
 	return &ComplianceReport{
-		ID:               spec.ID,
-		Title:            spec.Title,
-		Description:      spec.Description,
-		Version:          spec.Version,
-		RelatedResources: spec.RelatedResources,
+		ID:               s.ID,
+		Title:            s.Title,
+		Description:      s.Description,
+		Version:          s.Version,
+		RelatedResources: s.RelatedResources,
 		Results:          controlCheckResult,
 	}
 }

--- a/pkg/compliance/report/report.go
+++ b/pkg/compliance/report/report.go
@@ -67,7 +67,10 @@ type Writer interface {
 func Write(report *ComplianceReport, option Option) error {
 	switch option.Format {
 	case types.FormatJSON:
-		jwriter := JSONWriter{Output: option.Output, Report: option.Report}
+		jwriter := JSONWriter{
+			Output: option.Output,
+			Report: option.Report,
+		}
 		return jwriter.Write(report)
 	case types.FormatTable:
 		if !report.empty() {
@@ -93,7 +96,7 @@ func (r ComplianceReport) empty() bool {
 
 // buildControlCheckResults create compliance results data
 func buildControlCheckResults(checksMap map[string]types.Results, controls []defsecTypes.Control) []*ControlCheckResult {
-	complianceResults := make([]*ControlCheckResult, 0)
+	var complianceResults []*ControlCheckResult
 	for _, control := range controls {
 		var results types.Results
 		for _, c := range control.Checks {

--- a/pkg/compliance/spec/compliance.go
+++ b/pkg/compliance/spec/compliance.go
@@ -29,7 +29,7 @@ const (
 
 // Scanners reads spec control and determines the scanners by check ID prefix
 func (cs *ComplianceSpec) Scanners() (types.Scanners, error) {
-	scannerTypes := map[types.Scanner]struct{}{}
+	scannerTypes := make(map[types.Scanner]struct{})
 	for _, control := range cs.Spec.Controls {
 		for _, check := range control.Checks {
 			scannerType := scannerByCheckID(check.ID)
@@ -44,7 +44,7 @@ func (cs *ComplianceSpec) Scanners() (types.Scanners, error) {
 
 // CheckIDs return list of compliance check IDs
 func (cs *ComplianceSpec) CheckIDs() map[types.Scanner][]string {
-	checkIDsMap := map[types.Scanner][]string{}
+	checkIDsMap := make(map[types.Scanner][]string)
 	for _, control := range cs.Spec.Controls {
 		for _, check := range control.Checks {
 			scannerType := scannerByCheckID(check.ID)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -52,9 +52,9 @@ func WithDBRepository(dbRepository string) Option {
 }
 
 // WithClock takes a clock
-func WithClock(clock clock.Clock) Option {
+func WithClock(c clock.Clock) Option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 

--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alma"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -30,9 +31,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -60,9 +61,8 @@ func NewScanner(opts ...option) *Scanner {
 // Detect vulnerabilities in package using AlmaLinux scanner
 func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting AlmaLinux vulnerabilities...")
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
+
+	osVer = osver.Major(osVer)
 	log.Logger.Debugf("AlmaLinux: os version: %s", osVer)
 	log.Logger.Debugf("AlmaLinux: the number of packages: %d", len(pkgs))
 
@@ -107,19 +107,9 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks the OSFamily can be scanned using AlmaLinux scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
-
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
 }
 
 func addModularNamespace(name, label string) string {

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -204,13 +204,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2019, 5, 2, 23, 59, 59, 0, time.UTC),
 			args: args{
 				osFamily: "alma",
-				osVer:    "unknown",
+				osVer:    "999",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -10,6 +10,7 @@ import (
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -55,9 +56,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -85,9 +86,7 @@ func NewScanner(opts ...option) *Scanner {
 // Detect vulnerabilities in package using Alpine scanner
 func (s *Scanner) Detect(osVer string, repo *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Alpine vulnerabilities...")
-	if strings.Count(osVer, ".") > 1 {
-		osVer = osVer[:strings.LastIndex(osVer, ".")]
-	}
+	osVer = osver.Minor(osVer)
 	repoRelease := s.repoRelease(repo)
 
 	log.Logger.Debugf("alpine: os version: %s", osVer)
@@ -173,19 +172,9 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 	return installedVersion.LessThan(fixedVersion)
 }
 
-// IsSupportedVersion checks the OSFamily can be scanned using Alpine scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 1 {
-		osVer = osVer[:strings.LastIndex(osVer, ".")]
-	}
-
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Infof("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return true // may be the latest version
-	}
-
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osver.Minor(osVer))
 }
 
 func (s *Scanner) repoRelease(repo *ftypes.Repository) string {

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -34,9 +35,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -117,17 +118,12 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks if os can be scanned using amazon scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
 	osVer = strings.Fields(osVer)[0]
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {
 		osVer = "1"
 	}
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
 
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -234,7 +234,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 				osFamily: "amazon",
 				osVer:    "2022",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "amazon linux 2023",

--- a/pkg/detector/ospkg/chainguard/chainguard.go
+++ b/pkg/detector/ospkg/chainguard/chainguard.go
@@ -19,9 +19,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -102,7 +102,7 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 	return installedVersion.LessThan(fixedVersion)
 }
 
-// IsSupportedVersion checks the OSFamily can be scanned using Chainguard scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
 	// Chainguard doesn't have versions, so there is no case where a given input yields a
 	// result of an unsupported Chainguard version.

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -1,7 +1,6 @@
 package debian
 
 import (
-	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
@@ -11,6 +10,7 @@ import (
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -47,9 +47,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -78,9 +78,7 @@ func NewScanner(opts ...option) *Scanner {
 func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Debian vulnerabilities...")
 
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
+	osVer = osver.Major(osVer)
 	log.Logger.Debugf("debian: os version: %s", osVer)
 	log.Logger.Debugf("debian: the number of packages: %d", len(pkgs))
 
@@ -141,16 +139,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks is OSFamily can be scanned using Debian
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
-
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
 }

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -161,13 +161,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2020, 7, 31, 23, 59, 59, 0, time.UTC),
 			args: args{
 				osFamily: "debian",
-				osVer:    "unknown",
+				osVer:    "999",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/mariner/mariner.go
+++ b/pkg/detector/ospkg/mariner/mariner.go
@@ -1,12 +1,11 @@
 package mariner
 
 import (
-	"strings"
-
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/mariner"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -30,9 +29,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	log.Logger.Info("Detecting CBL-Mariner vulnerabilities...")
 
 	// e.g. 1.0.20210127
-	if strings.Count(osVer, ".") > 1 {
-		osVer = osVer[:strings.LastIndex(osVer, ".")]
-	}
+	osVer = osver.Minor(osVer)
 
 	log.Logger.Debugf("CBL-Mariner: os version: %s", osVer)
 	log.Logger.Debugf("CBL-Mariner: the number of packages: %d", len(pkgs))
@@ -75,8 +72,8 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks the OS version can be scanned using CBL-Mariner scanner
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
+// IsSupportedVersion checks if the version is supported.
+func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
 	// EOL is not in public at the moment.
 	return true
 }

--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/clock"
 
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -58,10 +59,7 @@ func extractKsplice(v string) string {
 func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Oracle Linux vulnerabilities...")
 
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
-
+	osVer = osver.Major(osVer)
 	log.Logger.Debugf("Oracle Linux: os version: %s", osVer)
 	log.Logger.Debugf("Oracle Linux: the number of packages: %d", len(pkgs))
 
@@ -102,17 +100,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks is OSFamily can be scanned with Oracle scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
-
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
 }

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -73,11 +73,11 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			osVersion: "8",
 			expected:  false,
 		},
-		"unknown": {
+		"latest": {
 			clock:     clocktesting.NewFakeClock(time.Date(2019, 5, 31, 23, 59, 59, 0, time.UTC)),
 			osFamily:  "oracle",
-			osVersion: "unknown",
-			expected:  false,
+			osVersion: "latest",
+			expected:  true,
 		},
 	}
 

--- a/pkg/detector/ospkg/photon/photon.go
+++ b/pkg/detector/ospkg/photon/photon.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -31,9 +32,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -94,12 +95,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks if the OS version reached end-of-support.
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -136,13 +136,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2022, 1, 31, 23, 59, 59, 0, time.UTC),
 			args: args{
 				osFamily: "photon",
-				osVer:    "unknown",
+				osVer:    "999.0",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -142,7 +142,7 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 	installed := utils.FormatVersion(pkg)
 	installedVersion := version.NewVersion(installed)
 
-	uniqVulns := map[string]types.DetectedVulnerability{}
+	uniqVulns := make(map[string]types.DetectedVulnerability)
 	for _, adv := range advisories {
 		// if Arches for advisory is empty or pkg.Arch is "noarch", then any Arches are affected
 		if len(adv.Arches) != 0 && pkg.Arch != "noarch" {

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -16,6 +16,7 @@ import (
 	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
 	redhat "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -69,9 +70,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -99,9 +100,8 @@ func NewScanner(opts ...option) *Scanner {
 // Detect scans and returns redhat vulnerabilities
 func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting RHEL/CentOS vulnerabilities...")
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
+
+	osVer = osver.Major(osVer)
 	log.Logger.Debugf("Red Hat: os version: %s", osVer)
 	log.Logger.Debugf("Red Hat: the number of packages: %d", len(pkgs))
 
@@ -209,23 +209,12 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 
 // IsSupportedVersion checks is OSFamily can be scanned with Redhat scanner
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
+	osVer = osver.Major(osVer)
+	if osFamily == ftypes.CentOS {
+		return osver.Supported(s.clock, centosEOLDates, osFamily, osVer)
 	}
 
-	var eolDate time.Time
-	var ok bool
-	if osFamily == ftypes.RedHat {
-		eolDate, ok = redhatEOLDates[osVer]
-	} else if osFamily == ftypes.CentOS {
-		eolDate, ok = centosEOLDates[osVer]
-	}
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-
-	return s.clock.Now().Before(eolDate)
+	return osver.Supported(s.clock, redhatEOLDates, osFamily, osVer)
 }
 
 func isFromSupportedVendor(pkg ftypes.Package) bool {

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -424,13 +424,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2019, 5, 31, 23, 59, 59, 0, time.UTC),
 			args: args{
-				osFamily: "unknown",
-				osVer:    "8.0",
+				osFamily: "redhat",
+				osVer:    "999.0",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/rocky/rocky.go
+++ b/pkg/detector/ospkg/rocky/rocky.go
@@ -1,7 +1,6 @@
 package rocky
 
 import (
-	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
@@ -9,6 +8,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -30,9 +30,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -60,9 +60,8 @@ func NewScanner(opts ...option) *Scanner {
 // Detect vulnerabilities in package using Rocky Linux scanner
 func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Rocky Linux vulnerabilities...")
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
+
+	osVer = osver.Major(osVer)
 	log.Logger.Debugf("Rocky Linux: os version: %s", osVer)
 	log.Logger.Debugf("Rocky Linux: the number of packages: %d", len(pkgs))
 
@@ -107,19 +106,9 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 	return vulns, nil
 }
 
-// IsSupportedVersion checks the OSFamily can be scanned using Rocky Linux scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	if strings.Count(osVer, ".") > 0 {
-		osVer = osVer[:strings.Index(osVer, ".")]
-	}
-
-	eol, ok := eolDates[osVer]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
 }
 
 func addModularNamespace(name, label string) string {

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -164,13 +164,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2019, 5, 2, 23, 59, 59, 0, time.UTC),
 			args: args{
 				osFamily: "rocky",
-				osVer:    "unknown",
+				osVer:    "999.0",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/clock"
 
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -40,7 +41,7 @@ var (
 		"15.4": time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.5": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
 		// 6 months after SLES 15 SP7 release
-		//"15.6": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
+		// "15.6": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{
@@ -63,9 +64,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -148,19 +149,8 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 
 // IsSupportedVersion checks if OSFamily can be scanned using SUSE scanner
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	var eolDate time.Time
-	var ok bool
-
 	if osFamily == ftypes.SLES {
-		eolDate, ok = slesEolDates[osVer]
-	} else if osFamily == ftypes.OpenSUSELeap {
-		eolDate, ok = opensuseEolDates[osVer]
+		return osver.Supported(s.clock, slesEolDates, osFamily, osVer)
 	}
-
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-
-	return s.clock.Now().Before(eolDate)
+	return osver.Supported(s.clock, opensuseEolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/suse/suse_test.go
+++ b/pkg/detector/ospkg/suse/suse_test.go
@@ -142,13 +142,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want:         false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2019, 5, 2, 23, 59, 59, 0, time.UTC),
 			args: args{
-				osFamily: "unknown",
-				osVer:    "unknown",
+				osFamily: "opensuse.leap",
+				osVer:    "999.0",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/utils"
@@ -68,9 +69,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -149,12 +150,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 
 // IsSupportedVersion checks is OSFamily can be scanned using Ubuntu scanner
 func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	eol, ok := eolDates[s.versionFromEolDates(osVer)]
-	if !ok {
-		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
-		return false
-	}
-	return s.clock.Now().Before(eol)
+	return osver.Supported(s.clock, eolDates, osFamily, osVer)
 }
 
 // versionFromEolDates checks if actual (not ESM) version is not outdated

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -247,13 +247,13 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unknown",
+			name: "latest",
 			now:  time.Date(2019, 5, 2, 23, 59, 59, 0, time.UTC),
 			args: args{
 				osFamily: "ubuntu",
-				osVer:    "unknown",
+				osVer:    "99.04",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detector/ospkg/version/version.go
+++ b/pkg/detector/ospkg/version/version.go
@@ -1,0 +1,38 @@
+package version
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/utils/clock"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+// Major returns the major version
+// e.g. 8.1 => 8
+func Major(osVer string) string {
+	osVer, _, _ = strings.Cut(osVer, ".")
+	return osVer
+}
+
+// Minor returns the major and minor version
+// e.g. 3.17.2 => 3.17
+func Minor(osVer string) string {
+	major, s, ok := strings.Cut(osVer, ".")
+	if !ok {
+		return osVer
+	}
+	minor, _, _ := strings.Cut(s, ".")
+	return major + "." + minor
+}
+
+func Supported(c clock.Clock, eolDates map[string]time.Time, osFamily ftypes.OSType, osVer string) bool {
+	eol, ok := eolDates[osVer]
+	if !ok {
+		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
+		return true // can be the latest version
+	}
+	return c.Now().Before(eol)
+}

--- a/pkg/detector/ospkg/wolfi/wolfi.go
+++ b/pkg/detector/ospkg/wolfi/wolfi.go
@@ -19,9 +19,9 @@ type options struct {
 
 type option func(*options)
 
-func WithClock(clock clock.Clock) option {
+func WithClock(c clock.Clock) option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 
@@ -102,7 +102,7 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 	return installedVersion.LessThan(fixedVersion)
 }
 
-// IsSupportedVersion checks the OSFamily can be scanned using Wolfi scanner
+// IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
 	// Wolfi doesn't have versions, so there is no case where a given input yields a
 	// result of an unsupported Wolfi version.

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	analyzers     = map[Type]analyzer{}
-	postAnalyzers = map[Type]postAnalyzerInitialize{}
+	analyzers     = make(map[Type]analyzer)
+	postAnalyzers = make(map[Type]postAnalyzerInitialize)
 
 	// ErrUnknownOS occurs when unknown OS is analyzed.
 	ErrUnknownOS = xerrors.New("unknown OS")
@@ -318,7 +318,7 @@ func NewAnalyzerGroup(opt AnalyzerOptions) (AnalyzerGroup, error) {
 	}
 
 	group := AnalyzerGroup{
-		filePatterns: map[Type][]*regexp.Regexp{},
+		filePatterns: make(map[Type][]*regexp.Regexp),
 	}
 	for _, p := range opt.FilePatterns {
 		// e.g. "dockerfile:my_dockerfile_*"
@@ -374,11 +374,11 @@ type Versions struct {
 
 // AnalyzerVersions returns analyzer version identifier used for cache keys.
 func (ag AnalyzerGroup) AnalyzerVersions() Versions {
-	analyzerVersions := map[string]int{}
+	analyzerVersions := make(map[string]int)
 	for _, a := range ag.analyzers {
 		analyzerVersions[string(a.Type())] = a.Version()
 	}
-	postAnalyzerVersions := map[string]int{}
+	postAnalyzerVersions := make(map[string]int)
 	for _, a := range ag.postAnalyzers {
 		postAnalyzerVersions[string(a.Type())] = a.Version()
 	}

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -241,8 +241,8 @@ func (r *AnalysisResult) Sort() {
 	})
 }
 
-func (r *AnalysisResult) Merge(new *AnalysisResult) {
-	if new == nil || new.isEmpty() {
+func (r *AnalysisResult) Merge(newResult *AnalysisResult) {
+	if newResult == nil || newResult.isEmpty() {
 		return
 	}
 
@@ -250,47 +250,47 @@ func (r *AnalysisResult) Merge(new *AnalysisResult) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	r.OS.Merge(new.OS)
+	r.OS.Merge(newResult.OS)
 
-	if new.Repository != nil {
-		r.Repository = new.Repository
+	if newResult.Repository != nil {
+		r.Repository = newResult.Repository
 	}
 
-	if len(new.PackageInfos) > 0 {
-		r.PackageInfos = append(r.PackageInfos, new.PackageInfos...)
+	if len(newResult.PackageInfos) > 0 {
+		r.PackageInfos = append(r.PackageInfos, newResult.PackageInfos...)
 	}
 
-	if len(new.Applications) > 0 {
-		r.Applications = append(r.Applications, new.Applications...)
+	if len(newResult.Applications) > 0 {
+		r.Applications = append(r.Applications, newResult.Applications...)
 	}
 
 	// Merge SHA-256 digests of unpackaged files
-	if new.Digests != nil {
-		r.Digests = lo.Assign(r.Digests, new.Digests)
+	if newResult.Digests != nil {
+		r.Digests = lo.Assign(r.Digests, newResult.Digests)
 	}
 
-	r.Misconfigurations = append(r.Misconfigurations, new.Misconfigurations...)
-	r.Secrets = append(r.Secrets, new.Secrets...)
-	r.Licenses = append(r.Licenses, new.Licenses...)
-	r.SystemInstalledFiles = append(r.SystemInstalledFiles, new.SystemInstalledFiles...)
+	r.Misconfigurations = append(r.Misconfigurations, newResult.Misconfigurations...)
+	r.Secrets = append(r.Secrets, newResult.Secrets...)
+	r.Licenses = append(r.Licenses, newResult.Licenses...)
+	r.SystemInstalledFiles = append(r.SystemInstalledFiles, newResult.SystemInstalledFiles...)
 
-	if new.BuildInfo != nil {
+	if newResult.BuildInfo != nil {
 		if r.BuildInfo == nil {
-			r.BuildInfo = new.BuildInfo
+			r.BuildInfo = newResult.BuildInfo
 		} else {
 			// We don't need to merge build info here
 			// because there is theoretically only one file about build info in each layer.
-			if new.BuildInfo.Nvr != "" || new.BuildInfo.Arch != "" {
-				r.BuildInfo.Nvr = new.BuildInfo.Nvr
-				r.BuildInfo.Arch = new.BuildInfo.Arch
+			if newResult.BuildInfo.Nvr != "" || newResult.BuildInfo.Arch != "" {
+				r.BuildInfo.Nvr = newResult.BuildInfo.Nvr
+				r.BuildInfo.Arch = newResult.BuildInfo.Arch
 			}
-			if len(new.BuildInfo.ContentSets) > 0 {
-				r.BuildInfo.ContentSets = new.BuildInfo.ContentSets
+			if len(newResult.BuildInfo.ContentSets) > 0 {
+				r.BuildInfo.ContentSets = newResult.BuildInfo.ContentSets
 			}
 		}
 	}
 
-	r.CustomResources = append(r.CustomResources, new.CustomResources...)
+	r.CustomResources = append(r.CustomResources, newResult.CustomResources...)
 }
 
 func belongToGroup(groupName Group, analyzerType Type, disabledAnalyzers []Type, analyzer any) bool {

--- a/pkg/fanal/analyzer/buildinfo/dockerfile.go
+++ b/pkg/fanal/analyzer/buildinfo/dockerfile.go
@@ -119,7 +119,7 @@ func parseVersion(nvr string) string {
 
 // https://github.com/moby/buildkit/blob/b33357bcd2e3319b0323037c900c13b45a228df1/frontend/dockerfile/dockerfile2llb/convert.go#L474-L482
 func metaArgsToMap(metaArgs []instructions.KeyValuePairOptional) map[string]string {
-	m := map[string]string{}
+	m := make(map[string]string)
 
 	for _, arg := range metaArgs {
 		m[arg.Key] = arg.ValueString()

--- a/pkg/fanal/analyzer/config_analyzer.go
+++ b/pkg/fanal/analyzer/config_analyzer.go
@@ -53,18 +53,18 @@ type ConfigAnalysisResult struct {
 	HistoryPackages  types.Packages
 }
 
-func (r *ConfigAnalysisResult) Merge(new *ConfigAnalysisResult) {
-	if new == nil {
+func (r *ConfigAnalysisResult) Merge(newResult *ConfigAnalysisResult) {
+	if newResult == nil {
 		return
 	}
-	if new.Misconfiguration != nil {
-		r.Misconfiguration = new.Misconfiguration
+	if newResult.Misconfiguration != nil {
+		r.Misconfiguration = newResult.Misconfiguration
 	}
-	if new.Secret != nil {
-		r.Secret = new.Secret
+	if newResult.Secret != nil {
+		r.Secret = newResult.Secret
 	}
-	if new.HistoryPackages != nil {
-		r.HistoryPackages = new.HistoryPackages
+	if newResult.HistoryPackages != nil {
+		r.HistoryPackages = newResult.HistoryPackages
 	}
 }
 

--- a/pkg/fanal/analyzer/config_analyzer.go
+++ b/pkg/fanal/analyzer/config_analyzer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/misconf"
 )
 
-var configAnalyzerConstructors = map[Type]configAnalyzerConstructor{}
+var configAnalyzerConstructors = make(map[Type]configAnalyzerConstructor)
 
 type configAnalyzerConstructor func(ConfigAnalyzerOptions) (ConfigAnalyzer, error)
 
@@ -92,7 +92,7 @@ func NewConfigAnalyzerGroup(opts ConfigAnalyzerOptions) (ConfigAnalyzerGroup, er
 
 // AnalyzerVersions returns analyzer version identifier used for cache keys.
 func (ag *ConfigAnalyzerGroup) AnalyzerVersions() Versions {
-	versions := map[string]int{}
+	versions := make(map[string]int)
 	for _, ca := range ag.configAnalyzers {
 		versions[string(ca.Type())] = ca.Version()
 	}

--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -87,8 +87,8 @@ func (c *CompositeFS) CreateLink(analyzerTypes []Type, rootDir, virtualPath, rea
 }
 
 // Set sets the fs.FS for the specified post-analyzer
-func (c *CompositeFS) Set(t Type, fs *mapfs.FS) {
-	c.files.Store(t, fs)
+func (c *CompositeFS) Set(t Type, mfs *mapfs.FS) {
+	c.files.Store(t, mfs)
 }
 
 // Get returns the fs.FS for the specified post-analyzer

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -161,11 +161,12 @@ func (a alpineCmdAnalyzer) parseCommand(command string, envs map[string]string) 
 
 		var add bool
 		for _, field := range strings.Fields(cmd) {
-			if strings.HasPrefix(field, "-") || strings.HasPrefix(field, ".") {
+			switch {
+			case strings.HasPrefix(field, "-") || strings.HasPrefix(field, "."):
 				continue
-			} else if field == "add" {
+			case field == "add":
 				add = true
-			} else if add {
+			case add:
 				if strings.HasPrefix(field, "$") {
 					pkgs = append(pkgs, strings.Fields(envs[field])...)
 					continue
@@ -208,9 +209,7 @@ func (a alpineCmdAnalyzer) resolveDependency(apkIndexArchive *apkIndex, pkgName 
 	pkgNames = append(pkgNames, pkgName)
 	for _, dependency := range pkg.Dependencies {
 		// sqlite-libs=3.26.0-r3 => sqlite-libs
-		if strings.Contains(dependency, "=") {
-			dependency = dependency[:strings.Index(dependency, "=")]
-		}
+		dependency, _, _ = strings.Cut(dependency, "=")
 
 		if strings.HasPrefix(dependency, "so:") {
 			soProvidePkg := apkIndexArchive.Provide.SO[dependency[3:]].Package

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -120,13 +120,13 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 }
 
 func (a alpineCmdAnalyzer) parseConfig(apkIndexArchive *apkIndex, config *v1.ConfigFile) (packages []types.Package) {
-	envs := map[string]string{}
+	envs := make(map[string]string)
 	for _, env := range config.Config.Env {
 		index := strings.Index(env, "=")
 		envs["$"+env[:index]] = env[index+1:]
 	}
 
-	uniqPkgs := map[string]types.Package{}
+	uniqPkgs := make(map[string]types.Package)
 	for _, history := range config.History {
 		pkgs := a.parseCommand(history.CreatedBy, envs)
 		pkgs = a.resolveDependencies(apkIndexArchive, pkgs)
@@ -178,13 +178,13 @@ func (a alpineCmdAnalyzer) parseCommand(command string, envs map[string]string) 
 	return pkgs
 }
 func (a alpineCmdAnalyzer) resolveDependencies(apkIndexArchive *apkIndex, originalPkgs []string) (pkgs []string) {
-	uniqPkgs := map[string]struct{}{}
+	uniqPkgs := make(map[string]struct{})
 	for _, pkgName := range originalPkgs {
 		if _, ok := uniqPkgs[pkgName]; ok {
 			continue
 		}
 
-		seenPkgs := map[string]struct{}{}
+		seenPkgs := make(map[string]struct{})
 		for _, p := range a.resolveDependency(apkIndexArchive, pkgName, seenPkgs) {
 			uniqPkgs[p] = struct{}{}
 		}

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuspec.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuspec.go
@@ -34,7 +34,7 @@ type nuspecParser struct {
 }
 
 func newNuspecParser() nuspecParser {
-	// https: //learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
+	// cf. https: //learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
 	packagesDir := os.Getenv("NUGET_PACKAGES")
 	if packagesDir == "" {
 		packagesDir = filepath.Join(os.Getenv("HOME"), ".nuget", "packages")

--- a/pkg/fanal/analyzer/language/golang/mod/mod.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod.go
@@ -180,7 +180,7 @@ func (a *gomodAnalyzer) fillAdditionalData(apps []types.Application) error {
 	return nil
 }
 
-func (a *gomodAnalyzer) collectDeps(modDir string, pkgID string) (godeptypes.Dependency, error) {
+func (a *gomodAnalyzer) collectDeps(modDir, pkgID string) (godeptypes.Dependency, error) {
 	// e.g. $GOPATH/pkg/mod/github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237/go.mod
 	modPath := filepath.Join(modDir, "go.mod")
 	f, err := os.Open(modPath)
@@ -289,12 +289,14 @@ func findLicense(dir string, classifierConfidenceLevel float64) ([]string, error
 		}
 		return nil
 	})
+
+	switch {
 	// The module path may not exist
-	if errors.Is(err, os.ErrNotExist) {
+	case errors.Is(err, os.ErrNotExist):
 		return nil, nil
-	} else if err != nil && !errors.Is(err, io.EOF) {
+	case err != nil && !errors.Is(err, io.EOF):
 		return nil, fmt.Errorf("finding a known open source license: %w", err)
-	} else if license == nil || len(license.Findings) == 0 {
+	case license == nil || len(license.Findings) == 0:
 		return nil, nil
 	}
 

--- a/pkg/fanal/analyzer/language/golang/mod/mod.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod.go
@@ -132,7 +132,7 @@ func (a *gomodAnalyzer) fillAdditionalData(apps []types.Application) error {
 		return nil
 	}
 
-	licenses := map[string][]string{}
+	licenses := make(map[string][]string)
 	for i, app := range apps {
 		// Actually used dependencies
 		usedLibs := lo.SliceToMap(app.Libraries, func(pkg types.Package) (string, types.Package) {
@@ -239,7 +239,7 @@ func mergeGoSum(gomod, gosum *types.Application) {
 	if gomod == nil || gosum == nil {
 		return
 	}
-	uniq := map[string]types.Package{}
+	uniq := make(map[string]types.Package)
 	for _, lib := range gomod.Libraries {
 		// It will be used for merging go.sum.
 		uniq[lib.Name] = lib

--- a/pkg/fanal/analyzer/language/nodejs/license/license.go
+++ b/pkg/fanal/analyzer/language/nodejs/license/license.go
@@ -29,7 +29,7 @@ func NewLicense(classifierConfidenceLevel float64) *License {
 }
 
 func (l *License) Traverse(fsys fs.FS, root string) (map[string][]string, error) {
-	licenses := map[string][]string{}
+	licenses := make(map[string][]string)
 	walkDirFunc := func(pkgJSONPath string, d fs.DirEntry, r io.Reader) error {
 		pkg, err := l.parser.Parse(r)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -56,7 +56,7 @@ func (a npmLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 		licenses, err := a.findLicenses(input.FS, filePath)
 		if err != nil {
 			log.Logger.Errorf("Unable to collect licenses: %s", err)
-			licenses = map[string]string{}
+			licenses = make(map[string]string)
 		}
 
 		app, err := a.parseNpmPkgLock(input.FS, filePath)
@@ -139,7 +139,7 @@ func (a npmLibraryAnalyzer) findLicenses(fsys fs.FS, lockPath string) (map[strin
 	// Traverse node_modules dir and find licenses
 	// Note that fs.FS is always slashed regardless of the platform,
 	// and path.Join should be used rather than filepath.Join.
-	licenses := map[string]string{}
+	licenses := make(map[string]string)
 	err := fsutils.WalkDir(fsys, root, required, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		pkg, err := a.packageParser.Parse(r)
 		if err != nil {

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -107,8 +107,8 @@ func (a npmLibraryAnalyzer) Version() int {
 	return version
 }
 
-func (a npmLibraryAnalyzer) parseNpmPkgLock(fsys fs.FS, path string) (*types.Application, error) {
-	f, err := fsys.Open(path)
+func (a npmLibraryAnalyzer) parseNpmPkgLock(fsys fs.FS, filePath string) (*types.Application, error) {
+	f, err := fsys.Open(filePath)
 	if err != nil {
 		return nil, xerrors.Errorf("file open error: %w", err)
 	}
@@ -120,7 +120,7 @@ func (a npmLibraryAnalyzer) parseNpmPkgLock(fsys fs.FS, path string) (*types.App
 	}
 
 	// parse package-lock.json file
-	return language.Parse(types.Npm, path, file, a.lockParser)
+	return language.Parse(types.Npm, filePath, file, a.lockParser)
 }
 
 func (a npmLibraryAnalyzer) findLicenses(fsys fs.FS, lockPath string) (map[string]string, error) {

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
@@ -141,8 +141,8 @@ func (a yarnAnalyzer) Version() int {
 	return version
 }
 
-func (a yarnAnalyzer) parseYarnLock(path string, r io.Reader) (*types.Application, error) {
-	return language.Parse(types.Yarn, path, r, a.lockParser)
+func (a yarnAnalyzer) parseYarnLock(filePath string, r io.Reader) (*types.Application, error) {
+	return language.Parse(types.Yarn, filePath, r, a.lockParser)
 }
 
 // analyzeDependencies analyzes the package.json file next to yarn.lock,
@@ -214,7 +214,7 @@ func (a yarnAnalyzer) walkDependencies(libs []types.Package, pkgIDs map[string]t
 	return pkgs, nil
 }
 
-func (a yarnAnalyzer) walkIndirectDependencies(pkg types.Package, pkgIDs map[string]types.Package, deps map[string]types.Package) {
+func (a yarnAnalyzer) walkIndirectDependencies(pkg types.Package, pkgIDs, deps map[string]types.Package) {
 	for _, pkgID := range pkg.DependsOn {
 		if _, ok := deps[pkgID]; ok {
 			continue
@@ -232,9 +232,9 @@ func (a yarnAnalyzer) walkIndirectDependencies(pkg types.Package, pkgIDs map[str
 	}
 }
 
-func (a yarnAnalyzer) parsePackageJsonDependencies(fsys fs.FS, path string) (map[string]string, map[string]string, error) {
+func (a yarnAnalyzer) parsePackageJsonDependencies(fsys fs.FS, filePath string) (map[string]string, map[string]string, error) {
 	// Parse package.json
-	f, err := fsys.Open(path)
+	f, err := fsys.Open(filePath)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("file open error: %w", err)
 	}

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
@@ -191,7 +191,7 @@ func (a yarnAnalyzer) walkDependencies(libs []types.Package, pkgIDs map[string]t
 	directDeps map[string]string, dev bool) (map[string]types.Package, error) {
 
 	// Identify direct dependencies
-	pkgs := map[string]types.Package{}
+	pkgs := make(map[string]types.Package)
 	for _, pkg := range libs {
 		if constraint, ok := directDeps[pkg.Name]; ok {
 			// npm has own comparer to compare versions
@@ -329,7 +329,7 @@ func (a yarnAnalyzer) traverseYarnModernPkgs(fsys fs.FS) (map[string][]string, e
 	}
 
 	var errs error
-	licenses := map[string][]string{}
+	licenses := make(map[string][]string)
 
 	if ll, err := a.traverseUnpluggedDir(sub); err != nil {
 		errs = multierror.Append(errs, err)
@@ -358,7 +358,7 @@ func (a yarnAnalyzer) traverseUnpluggedDir(fsys fs.FS) (map[string][]string, err
 
 func (a yarnAnalyzer) traverseCacheDir(fsys fs.FS) (map[string][]string, error) {
 	// Traverse .yarn/cache dir
-	licenses := map[string][]string{}
+	licenses := make(map[string][]string)
 	err := fsutils.WalkDir(fsys, "cache", fsutils.RequiredExt(".zip"),
 		func(filePath string, d fs.DirEntry, r io.Reader) error {
 			fi, err := d.Info()

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo.go
@@ -119,7 +119,7 @@ func (a cargoAnalyzer) removeDevDependencies(fsys fs.FS, dir string, app *types.
 	})
 
 	// Identify direct dependencies
-	pkgs := map[string]types.Package{}
+	pkgs := make(map[string]types.Package)
 	for name, constraint := range directDeps {
 		for _, pkg := range app.Libraries {
 			if pkg.Name != name {
@@ -169,7 +169,7 @@ func (a cargoAnalyzer) parseCargoTOML(fsys fs.FS, path string) (map[string]strin
 	defer func() { _ = f.Close() }()
 
 	tomlFile := cargoToml{}
-	deps := map[string]string{}
+	deps := make(map[string]string)
 	_, err = toml.NewDecoder(f).Decode(&tomlFile)
 	if err != nil {
 		return nil, xerrors.Errorf("toml decode error: %w", err)

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo.go
@@ -210,7 +210,7 @@ func (a cargoAnalyzer) parseCargoTOML(fsys fs.FS, path string) (map[string]strin
 	return deps, nil
 }
 
-func (a cargoAnalyzer) walkIndirectDependencies(pkg types.Package, pkgIDs map[string]types.Package, deps map[string]types.Package) {
+func (a cargoAnalyzer) walkIndirectDependencies(pkg types.Package, pkgIDs, deps map[string]types.Package) {
 	for _, pkgID := range pkg.DependsOn {
 		if _, ok := deps[pkgID]; ok {
 			continue

--- a/pkg/fanal/analyzer/os/mariner/mariner.go
+++ b/pkg/fanal/analyzer/os/mariner/mariner.go
@@ -44,7 +44,7 @@ func (a marinerOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 		if len(fields) != 2 {
 			continue
 		}
-		if strings.ToLower(fields[0]) == "cbl-mariner" {
+		if strings.EqualFold(fields[0], "cbl-mariner") {
 			return types.OS{
 				Family: types.CBLMariner,
 				Name:   fields[1],

--- a/pkg/fanal/analyzer/pkg/apk/apk.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk.go
@@ -54,7 +54,7 @@ func (a alpinePkgAnalyzer) parseApkInfo(scanner *bufio.Scanner) ([]types.Package
 		version        string
 		dir            string
 		installedFiles []string
-		provides       = map[string]string{} // for dependency graph
+		provides       = make(map[string]string) // for dependency graph
 	)
 
 	for scanner.Scan() {
@@ -195,7 +195,7 @@ func (a alpinePkgAnalyzer) consolidateDependencies(pkgs []types.Package, provide
 }
 
 func (a alpinePkgAnalyzer) uniquePkgs(pkgs []types.Package) (uniqPkgs []types.Package) {
-	uniq := map[string]struct{}{}
+	uniq := make(map[string]struct{})
 	for _, pkg := range pkgs {
 		if _, ok := uniq[pkg.Name]; ok {
 			continue

--- a/pkg/fanal/analyzer/pkg/apk/apk.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk.go
@@ -144,11 +144,12 @@ func (a alpinePkgAnalyzer) parseLicense(line string) []string {
 	// e.g. MPL 2.0 GPL2+ => {"MPL2.0", "GPL2+"}
 	for i, s := range strings.Fields(line) {
 		s = strings.Trim(s, "()")
-		if s == "AND" || s == "OR" {
+		switch {
+		case s == "AND" || s == "OR":
 			continue
-		} else if i > 0 && (s == "1.0" || s == "2.0" || s == "3.0") {
+		case i > 0 && (s == "1.0" || s == "2.0" || s == "3.0"):
 			licenses[i-1] = licensing.Normalize(licenses[i-1] + s)
-		} else {
+		default:
 			licenses = append(licenses, licensing.Normalize(s))
 		}
 	}

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -136,7 +136,7 @@ func (a dpkgAnalyzer) parseDpkgAvailable(fsys fs.FS) (map[string]digest.Digest, 
 	}
 	defer f.Close()
 
-	pkgs := map[string]digest.Digest{}
+	pkgs := make(map[string]digest.Digest)
 	scanner := NewScanner(f)
 	for scanner.Scan() {
 		header, err := scanner.Header()
@@ -160,8 +160,8 @@ func (a dpkgAnalyzer) parseDpkgAvailable(fsys fs.FS) (map[string]digest.Digest, 
 // parseDpkgStatus parses /var/lib/dpkg/status or /var/lib/dpkg/status/*
 func (a dpkgAnalyzer) parseDpkgStatus(filePath string, r io.Reader, digests map[string]digest.Digest) ([]types.PackageInfo, error) {
 	var pkg *types.Package
-	pkgs := map[string]*types.Package{}
-	pkgIDs := map[string]string{}
+	pkgs := make(map[string]*types.Package)
+	pkgIDs := make(map[string]string)
 
 	scanner := NewScanner(r)
 	for scanner.Scan() {
@@ -216,7 +216,7 @@ func (a dpkgAnalyzer) parseDpkgPkg(header textproto.MIMEHeader) *types.Package {
 	// May also specifies a version
 	if src := header.Get("Source"); src != "" {
 		srcCapture := dpkgSrcCaptureRegexp.FindAllStringSubmatch(src, -1)[0]
-		md := map[string]string{}
+		md := make(map[string]string)
 		for i, n := range srcCapture {
 			md[dpkgSrcCaptureRegexpNames[i]] = strings.TrimSpace(n)
 		}

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -308,9 +308,7 @@ func (a dpkgAnalyzer) trimVersionRequirement(s string) string {
 	// e.g.
 	//	libapt-pkg6.0 (>= 2.2.4) => libapt-pkg6.0
 	//	adduser => adduser
-	if strings.Contains(s, "(") {
-		s = s[:strings.Index(s, "(")]
-	}
+	s, _, _ = strings.Cut(s, "(")
 	return s
 }
 

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -104,7 +104,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) (types.Packages, []string, er
 
 	var pkgs []types.Package
 	var installedFiles []string
-	provides := map[string]string{}
+	provides := make(map[string]string)
 	for _, pkg := range pkgList {
 		arch := pkg.Arch
 		if arch == "" {

--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -89,7 +89,7 @@ func lookupOriginLayerForLib(filePath string, lib types.Package, layers []types.
 func ApplyLayers(layers []types.BlobInfo) types.ArtifactDetail {
 	sep := "/"
 	nestedMap := nested.Nested{}
-	secretsMap := map[string]types.Secret{}
+	secretsMap := make(map[string]types.Secret)
 	var mergedLayer types.ArtifactDetail
 
 	for _, layer := range layers {
@@ -184,7 +184,7 @@ func ApplyLayers(layers []types.BlobInfo) types.ArtifactDetail {
 	// Extract dpkg licenses
 	// The license information is not stored in the dpkg database and in a separate file,
 	// so we have to merge the license information into the package.
-	dpkgLicenses := map[string][]string{}
+	dpkgLicenses := make(map[string][]string)
 	mergedLayer.Licenses = lo.Reject(mergedLayer.Licenses, func(license types.LicenseFile, _ int) bool {
 		if license.Type != types.LicenseTypeDpkg {
 			return false

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -194,7 +194,7 @@ func (a Artifact) consolidateCreatedBy(diffIDs, layerKeys []string, configFile *
 	// TODO: our current logic may not detect empty layers correctly in rare cases.
 	validCreatedBy := len(diffIDs) == len(createdBy)
 
-	layerKeyMap := map[string]LayerInfo{}
+	layerKeyMap := make(map[string]LayerInfo)
 	for i, diffID := range diffIDs {
 
 		c := ""

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -203,7 +203,7 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 	// get hostname
 	var hostName string
 	b, err := os.ReadFile(filepath.Join(a.rootPath, "etc", "hostname"))
-	if err == nil && string(b) != "" {
+	if err == nil && len(b) != 0 {
 		hostName = strings.TrimSpace(string(b))
 	} else {
 		// To slash for Windows

--- a/pkg/fanal/cache/s3.go
+++ b/pkg/fanal/cache/s3.go
@@ -75,7 +75,7 @@ func (c S3Cache) put(key string, body interface{}) (err error) {
 	if err != nil {
 		return xerrors.Errorf("unable to put object: %w", err)
 	}
-	//Index file due S3 caveat read after write consistency
+	// Index file due S3 caveat read after write consistency
 	_, err = c.s3Client.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(c.bucketName),
 		Key:    aws.String(fmt.Sprintf("%s.index", key)),
@@ -120,10 +120,11 @@ func (c S3Cache) GetArtifact(artifactID string) (types.ArtifactInfo, error) {
 	return info, nil
 }
 
-func (c S3Cache) getIndex(key string, keyType string) error {
+func (c S3Cache) getIndex(key, keyType string) error {
 	_, err := c.s3Client.HeadObject(&s3.HeadObjectInput{
 		Key:    aws.String(fmt.Sprintf("%s/%s/%s.index", keyType, c.prefix, key)),
-		Bucket: &c.bucketName})
+		Bucket: &c.bucketName,
+	})
 	if err != nil {
 		return xerrors.Errorf("failed to get index from the cache: %w", err)
 	}

--- a/pkg/fanal/handler/handler.go
+++ b/pkg/fanal/handler/handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	postHandlerInits = map[types.HandlerType]postHandlerInit{}
+	postHandlerInits = make(map[types.HandlerType]postHandlerInit)
 )
 
 type postHandlerInit func(artifact.Option) (PostHandler, error)
@@ -62,7 +62,7 @@ func NewManager(artifactOpt artifact.Option) (Manager, error) {
 }
 
 func (m Manager) Versions() map[string]int {
-	versions := map[string]int{}
+	versions := make(map[string]int)
 	for _, h := range m.postHandlers {
 		versions[string(h.Type())] = h.Version()
 	}

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -163,19 +163,19 @@ func parseReference(imageName string) (refdocker.Reference, []string, error) {
 	// a name plus a digest
 	// example: name@sha256:41adb3ef...
 	if isDigested && isNamed {
-		digest := d.Digest()
+		dgst := d.Digest()
 		// for the filters, each slice entry is logically or'd. each
 		// comma-separated filter is logically anded
 		return ref, []string{
-			fmt.Sprintf(`name~="^%s(:|@).*",target.digest=="%s"`, n.Name(), digest),
-			fmt.Sprintf(`name~="^%s(:|@).*",target.digest=="%s"`, refdocker.FamiliarName(n), digest),
+			fmt.Sprintf(`name~="^%s(:|@).*",target.digest==%q`, n.Name(), dgst),
+			fmt.Sprintf(`name~="^%s(:|@).*",target.digest==%q`, refdocker.FamiliarName(n), dgst),
 		}, nil
 	}
 
 	// digested, but not named. i.e. a plain digest
 	// example: sha256:41adb3ef...
 	if isDigested {
-		return ref, []string{fmt.Sprintf(`target.digest=="%s"`, d.Digest())}, nil
+		return ref, []string{fmt.Sprintf(`target.digest==%q`, d.Digest())}, nil
 	}
 
 	// a name plus a tag

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -94,7 +94,7 @@ func ContainerdImage(ctx context.Context, imageName string, opts types.ImageOpti
 		return nil, cleanup, err
 	}
 
-	options := []containerd.ClientOpt{}
+	var options []containerd.ClientOpt
 	if opts.RegistryOptions.Platform.Platform != nil {
 		ociPlatform, err := platforms.Parse(opts.RegistryOptions.Platform.String())
 		if err != nil {

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -217,7 +217,7 @@ func (img *image) imageConfig(config *container.Config) v1.Config {
 	}
 
 	if len(config.ExposedPorts) > 0 {
-		c.ExposedPorts = map[string]struct{}{}
+		c.ExposedPorts = make(map[string]struct{})
 		for port := range c.ExposedPorts {
 			c.ExposedPorts[port] = struct{}{}
 		}

--- a/pkg/fanal/image/registry/azure/azure.go
+++ b/pkg/fanal/image/registry/azure/azure.go
@@ -49,7 +49,7 @@ func (r *Registry) GetCredential(ctx context.Context) (string, string, error) {
 	return "00000000-0000-0000-0000-000000000000", *rt.RefreshToken, err
 }
 
-func refreshToken(ctx context.Context, accessToken string, domain string) (containerregistry.RefreshToken, error) {
+func refreshToken(ctx context.Context, accessToken, domain string) (containerregistry.RefreshToken, error) {
 	tenantID := os.Getenv("AZURE_TENANT_ID")
 	if tenantID == "" {
 		return containerregistry.RefreshToken{}, errors.New("missing environment variable AZURE_TENANT_ID")

--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -23,8 +23,8 @@ func (o *OS) Detected() bool {
 }
 
 // Merge merges OS version and enhanced security maintenance programs
-func (o *OS) Merge(new OS) {
-	if lo.IsEmpty(new) {
+func (o *OS) Merge(newOS OS) {
+	if lo.IsEmpty(newOS) {
 		return
 	}
 
@@ -33,18 +33,18 @@ func (o *OS) Merge(new OS) {
 	// In that case, OS must be overwritten with the content of /etc/oracle-release.
 	// There is the same problem between Debian and Ubuntu.
 	case o.Family == RedHat, o.Family == Debian:
-		*o = new
+		*o = newOS
 	default:
 		if o.Family == "" {
-			o.Family = new.Family
+			o.Family = newOS.Family
 		}
 		if o.Name == "" {
-			o.Name = new.Name
+			o.Name = newOS.Name
 		}
 		// Ubuntu has ESM program: https://ubuntu.com/security/esm
 		// OS version and esm status are stored in different files.
 		// We have to merge OS version after parsing these files.
-		if o.Extended || new.Extended {
+		if o.Extended || newOS.Extended {
 			o.Extended = true
 		}
 	}

--- a/pkg/fanal/types/image.go
+++ b/pkg/fanal/types/image.go
@@ -60,11 +60,11 @@ type DockerOptions struct {
 }
 
 type PodmanOptions struct {
-	// TODO
+	// Add Podman-specific options
 }
 
 type ContainerdOptions struct {
-	// TODO
+	// Add Containerd-specific options
 }
 
 // ImageSource represents the source of an image. It can be a string that identifies

--- a/pkg/fanal/vm/disk/vmdk.go
+++ b/pkg/fanal/vm/disk/vmdk.go
@@ -12,7 +12,7 @@ import (
 
 type VMDK struct{}
 
-func (V VMDK) NewReader(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.SectionReader, error) {
+func (VMDK) NewReader(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.SectionReader, error) {
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
 		return nil, xerrors.Errorf("seek error: %w", err)
 	}

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -51,14 +51,15 @@ func (w FS) Walk(root string, fn WalkFunc) error {
 		}
 		relPath = filepath.ToSlash(relPath)
 
-		if fi.IsDir() {
+		switch {
+		case fi.IsDir():
 			if w.shouldSkipDir(relPath) {
 				return filepath.SkipDir
 			}
 			return nil
-		} else if !fi.Mode().IsRegular() {
+		case !fi.Mode().IsRegular():
 			return nil
-		} else if w.shouldSkipFile(relPath) {
+		case w.shouldSkipFile(relPath):
 			return nil
 		}
 

--- a/pkg/fanal/walker/vm.go
+++ b/pkg/fanal/walker/vm.go
@@ -123,20 +123,21 @@ func (w *VM) fsWalk(fsys fs.FS, path string, d fs.DirEntry, err error) error {
 		return xerrors.Errorf("dir entry info error: %w", err)
 	}
 	pathName := strings.TrimPrefix(filepath.Clean(path), "/")
-	if fi.IsDir() {
+	switch {
+	case fi.IsDir():
 		if w.shouldSkipDir(pathName) {
 			return filepath.SkipDir
 		}
 		return nil
-	} else if !fi.Mode().IsRegular() {
+	case !fi.Mode().IsRegular():
 		return nil
-	} else if w.shouldSkipFile(pathName) {
+	case w.shouldSkipFile(pathName):
 		return nil
-	} else if fi.Mode()&0x1000 == 0x1000 ||
+	case fi.Mode()&0x1000 == 0x1000 ||
 		fi.Mode()&0x2000 == 0x2000 ||
 		fi.Mode()&0x6000 == 0x6000 ||
 		fi.Mode()&0xA000 == 0xA000 ||
-		fi.Mode()&0xc000 == 0xc000 {
+		fi.Mode()&0xc000 == 0xc000:
 		// 	0x1000:	S_IFIFO (FIFO)
 		// 	0x2000:	S_IFCHR (Character device)
 		// 	0x6000:	S_IFBLK (Block device)
@@ -163,7 +164,11 @@ type cachedVMFile struct {
 }
 
 func newCachedVMFile(fsys fs.FS, filePath string, threshold int64) *cachedVMFile {
-	return &cachedVMFile{fs: fsys, filePath: filePath, threshold: threshold}
+	return &cachedVMFile{
+		fs:        fsys,
+		filePath:  filePath,
+		threshold: threshold,
+	}
 }
 
 func (cvf *cachedVMFile) Open() (dio.ReadSeekCloserAt, error) {

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -194,7 +194,7 @@ func (f *K8sFlagGroup) ToOptions() (K8sOptions, error) {
 }
 
 func optionToTolerations(tolerationsOptions []string) ([]corev1.Toleration, error) {
-	tolerations := make([]corev1.Toleration, 0)
+	var tolerations []corev1.Toleration
 	for _, toleration := range tolerationsOptions {
 		tolerationParts := strings.Split(toleration, ":")
 		if len(tolerationParts) < 2 {

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -207,7 +207,7 @@ func optionToTolerations(tolerationsOptions []string) ([]corev1.Toleration, erro
 		}
 		keyValue := strings.Split(tolerationParts[0], "=")
 		operator := corev1.TolerationOpEqual
-		if len(keyValue[1]) == 0 {
+		if keyValue[1] == "" {
 			operator = corev1.TolerationOpExists
 		}
 		toleration := corev1.Toleration{

--- a/pkg/flag/license_flags.go
+++ b/pkg/flag/license_flags.go
@@ -109,7 +109,7 @@ func (f *LicenseFlagGroup) Flags() []*Flag {
 }
 
 func (f *LicenseFlagGroup) ToOptions() LicenseOptions {
-	licenseCategories := map[types.LicenseCategory][]string{}
+	licenseCategories := make(map[types.LicenseCategory][]string)
 	licenseCategories[types.CategoryForbidden] = getStringSlice(f.LicenseForbidden)
 	licenseCategories[types.CategoryRestricted] = getStringSlice(f.LicenseRestricted)
 	licenseCategories[types.CategoryReciprocal] = getStringSlice(f.LicenseReciprocal)

--- a/pkg/flag/value.go
+++ b/pkg/flag/value.go
@@ -40,7 +40,7 @@ type customStringSliceValue struct {
 	changed bool
 }
 
-func newCustomStringSliceValue(val []string, allowed []string) *customStringSliceValue {
+func newCustomStringSliceValue(val, allowed []string) *customStringSliceValue {
 	return &customStringSliceValue{
 		value:   &val,
 		allowed: allowed,

--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -75,9 +75,10 @@ func (f *VulnerabilityFlagGroup) ToOptions() VulnerabilityOptions {
 	})
 	ignoreUnfixed := getBool(f.IgnoreUnfixed)
 
-	if ignoreUnfixed && len(ignoreStatuses) > 0 {
+	switch {
+	case ignoreUnfixed && len(ignoreStatuses) > 0:
 		log.Logger.Warn("'--ignore-unfixed' is ignored because '--ignore-status' is specified")
-	} else if ignoreUnfixed {
+	case ignoreUnfixed:
 		// '--ignore-unfixed' is a shorthand of '--ignore-status'.
 		ignoreStatuses = lo.FilterMap(dbTypes.Statuses, func(s string, _ int) (dbTypes.Status, bool) {
 			fixed := dbTypes.StatusFixed
@@ -86,7 +87,7 @@ func (f *VulnerabilityFlagGroup) ToOptions() VulnerabilityOptions {
 			}
 			return dbTypes.NewStatus(s), true
 		})
-	} else if len(ignoreStatuses) == 0 {
+	case len(ignoreStatuses) == 0:
 		ignoreStatuses = nil
 	}
 	log.Logger.Debugw("Ignore statuses", "statuses", ignoreStatuses)

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -79,7 +79,7 @@ func (u *Updater) Update() error {
 	return nil
 }
 
-func Init(cacheDir string, javaDBRepository string, skip, quiet bool, registryOption ftypes.RegistryOptions) {
+func Init(cacheDir, javaDBRepository string, skip, quiet bool, registryOption ftypes.RegistryOptions) {
 	updater = &Updater{
 		repo:           fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion),
 		dbDir:          filepath.Join(cacheDir, "java-db"),

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -151,7 +151,7 @@ func (d *DB) SearchByArtifactID(artifactID string) (string, error) {
 
 	// Some artifacts might have the same artifactId.
 	// e.g. "javax.servlet:jstl" and "jstl:jstl"
-	groupIDs := map[string]int{}
+	groupIDs := make(map[string]int)
 	for _, index := range indexes {
 		if i, ok := groupIDs[index.GroupID]; ok {
 			groupIDs[index.GroupID] = i + 1

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
+	k8sArtifacts "github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/trivyk8s"
 	"github.com/aquasecurity/trivy/pkg/flag"
@@ -19,7 +19,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	if err := validateReportArguments(opts); err != nil {
 		return err
 	}
-	var artifacts []*artifacts.Artifact
+	var artifacts []*k8sArtifacts.Artifact
 	var err error
 	switch opts.Format {
 	case types.FormatCycloneDX:

--- a/pkg/k8s/commands/resource.go
+++ b/pkg/k8s/commands/resource.go
@@ -32,7 +32,7 @@ func resourceRun(ctx context.Context, args []string, opts flag.Options, cluster 
 		trivyk = trivyk.Namespace(getNamespace(opts, cluster.GetCurrentNamespace()))
 	}
 
-	if len(name) == 0 { // pods or configmaps etc
+	if name == "" { // pods or configmaps etc
 		if err = validateReportArguments(opts); err != nil {
 			return err
 		}

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
+	k8sArtifacts "github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
 	cmd "github.com/aquasecurity/trivy/pkg/commands/artifact"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
@@ -65,7 +65,7 @@ func newRunner(flagOpts flag.Options, cluster string) *runner {
 	}
 }
 
-func (r *runner) run(ctx context.Context, artifacts []*artifacts.Artifact) error {
+func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) error {
 	runner, err := cmd.NewRunner(ctx, r.flagOpts)
 	if err != nil {
 		if errors.Is(err, cmd.SkipScan) {

--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -86,7 +86,7 @@ func (r Report) consolidate() ConsolidatedReport {
 	}
 
 	index := make(map[string]Resource)
-	vulnerabilities := make([]Resource, 0)
+	var vulnerabilities []Resource
 	for _, m := range r.Resources {
 		if vulnerabilitiesOrSecretResource(m) {
 			vulnerabilities = append(vulnerabilities, m)
@@ -134,11 +134,7 @@ type reports struct {
 // - infra checks report
 func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, components []string) []reports {
 
-	workloadMisconfig := make([]Resource, 0)
-	infraMisconfig := make([]Resource, 0)
-	rbacAssessment := make([]Resource, 0)
-	workloadVulnerabilities := make([]Resource, 0)
-	workloadResource := make([]Resource, 0)
+	var workloadMisconfig, infraMisconfig, rbacAssessment, workloadVulnerabilities, workloadResource []Resource
 	for _, resource := range k8sReport.Resources {
 		if vulnerabilitiesOrSecretResource(resource) {
 			workloadVulnerabilities = append(workloadVulnerabilities, resource)
@@ -166,7 +162,7 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 		}
 	}
 
-	r := make([]reports, 0)
+	var r []reports
 	workloadResource = append(workloadResource, workloadVulnerabilities...)
 	workloadResource = append(workloadResource, workloadMisconfig...)
 	if shouldAddWorkloadReport(scanners) {
@@ -269,8 +265,7 @@ func splitInfraAndWorkloadResources(misconfig Resource) (Resource, Resource) {
 	infraResults := make(types.Results, 0)
 
 	for _, result := range misconfig.Results {
-		workloadMisconfigs := make([]types.DetectedMisconfiguration, 0)
-		infraMisconfigs := make([]types.DetectedMisconfiguration, 0)
+		var workloadMisconfigs, infraMisconfigs []types.DetectedMisconfiguration
 
 		for _, m := range result.Misconfigurations {
 			if strings.HasPrefix(m.ID, "KCV") {

--- a/pkg/k8s/report/summary.go
+++ b/pkg/k8s/report/summary.go
@@ -41,7 +41,7 @@ func ColumnHeading(scanners types.Scanners, components, availableColumns []strin
 		ResourceColumn,
 	}
 	securityOptions := make(map[string]interface{}, 0)
-	//maintain column order (vuln,config,secret)
+	// maintain column order (vuln,config,secret)
 	for _, check := range scanners {
 		switch check {
 		case types.VulnerabilityScanner:
@@ -173,13 +173,13 @@ func accumulateSeverityCounts(finding Resource) (map[string]int, map[string]int,
 	sCount := make(map[string]int)
 	for _, r := range finding.Results {
 		for _, rv := range r.Vulnerabilities {
-			vCount[rv.Severity] = vCount[rv.Severity] + 1
+			vCount[rv.Severity]++
 		}
 		for _, rv := range r.Misconfigurations {
-			mCount[rv.Severity] = mCount[rv.Severity] + 1
+			mCount[rv.Severity]++
 		}
 		for _, rv := range r.Secrets {
-			sCount[rv.Severity] = sCount[rv.Severity] + 1
+			sCount[rv.Severity]++
 		}
 	}
 	return vCount, mCount, sCount

--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -13,11 +13,13 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
+var r = regexp.MustCompile("\\\\|/|:|\\*|\\?|<|>")
+
 func createTempFile(artifact *artifacts.Artifact) (string, error) {
 	filename := fmt.Sprintf("%s-%s-%s-*.yaml", artifact.Namespace, artifact.Kind, artifact.Name)
 
 	if runtime.GOOS == "windows" {
-		//removes characters not permitted in file/directory names on Windows
+		// removes characters not permitted in file/directory names on Windows
 		filename = filenameWindowsFriendly(filename)
 	}
 	file, err := os.CreateTemp("", filename)
@@ -43,8 +45,6 @@ func removeFile(filename string) {
 		log.Logger.Errorf("failed to remove temp file %s: %s:", filename, err)
 	}
 }
-
-var r, _ = regexp.Compile("\\\\|/|:|\\*|\\?|<|>")
 
 func filenameWindowsFriendly(name string) string {
 	return r.ReplaceAllString(name, "_")

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -203,7 +203,7 @@ const (
 )
 
 func clusterInfoToReportResources(allArtifact []*artifacts.Artifact) (*core.Component, error) {
-	coreComponents := make([]*core.Component, 0)
+	var coreComponents []*core.Component
 	var cInfo *core.Component
 	for _, artifact := range allArtifact {
 		switch artifact.Kind {
@@ -213,7 +213,7 @@ func clusterInfoToReportResources(allArtifact []*artifacts.Artifact) (*core.Comp
 			if err != nil {
 				return nil, err
 			}
-			imageComponents := make([]*core.Component, 0)
+			var imageComponents []*core.Component
 			for _, c := range comp.Containers {
 				name := fmt.Sprintf("%s/%s", c.Registry, c.Repository)
 				cDigest := c.Digest

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -174,7 +174,7 @@ func (s *Scanner) scanMisconfigs(ctx context.Context, artifact *artifacts.Artifa
 	s.opts.Target = configFile
 
 	configReport, err := s.runner.ScanFilesystem(ctx, s.opts)
-	//remove config file after scanning
+	// remove config file after scanning
 	removeFile(configFile)
 	if err != nil {
 		log.Logger.Debugf("failed to scan config %s/%s: %s", artifact.Kind, artifact.Name, err)
@@ -217,10 +217,10 @@ func clusterInfoToReportResources(allArtifact []*artifacts.Artifact) (*core.Comp
 			for _, c := range comp.Containers {
 				name := fmt.Sprintf("%s/%s", c.Registry, c.Repository)
 				cDigest := c.Digest
-				if strings.Index(c.Digest, string(digest.SHA256)) == -1 {
+				if !strings.Contains(c.Digest, string(digest.SHA256)) {
 					cDigest = fmt.Sprintf("%s:%s", string(digest.SHA256), cDigest)
 				}
-				version := sanitizedVersion(c.Version)
+				ver := sanitizedVersion(c.Version)
 
 				imagePURL, err := purl.NewPackageURL(purl.TypeOCI, types.Metadata{
 					RepoDigests: []string{
@@ -239,7 +239,7 @@ func clusterInfoToReportResources(allArtifact []*artifacts.Artifact) (*core.Comp
 					Properties: []core.Property{
 						{
 							Name:  cyc.PropertyPkgID,
-							Value: fmt.Sprintf("%s:%s", name, version),
+							Value: fmt.Sprintf("%s:%s", name, ver),
 						},
 						{
 							Name:  cyc.PropertyPkgType,
@@ -288,8 +288,8 @@ func clusterInfoToReportResources(allArtifact []*artifacts.Artifact) (*core.Comp
 	return rootComponent, nil
 }
 
-func sanitizedVersion(version string) string {
-	return strings.TrimPrefix(version, "v")
+func sanitizedVersion(ver string) string {
+	return strings.TrimPrefix(ver, "v")
 }
 
 func osNameVersion(name string) (string, string) {

--- a/pkg/licensing/classifier.go
+++ b/pkg/licensing/classifier.go
@@ -43,7 +43,7 @@ func Classify(filePath string, r io.Reader, confidenceLevel float64) (*types.Lic
 
 	var findings types.LicenseFindings
 	var matchType types.LicenseType
-	seen := map[string]struct{}{}
+	seen := make(map[string]struct{})
 
 	// cf.Match is not thread safe
 	m.Lock()

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -58,13 +58,14 @@ func normalize(expr Expression, fn ...NormalizeFunc) Expression {
 func NormalizeForSPDX(s string) string {
 	var b strings.Builder
 	for _, c := range s {
-		// idstring = 1*(ALPHA / DIGIT / "-" / "." )
-		if isAlphabet(c) || unicode.IsNumber(c) || c == '-' || c == '.' {
+		switch {
+		// spec: idstring = 1*(ALPHA / DIGIT / "-" / "." )
+		case isAlphabet(c) || unicode.IsNumber(c) || c == '-' || c == '.':
 			_, _ = b.WriteRune(c)
-		} else if c == ':' {
+		case c == ':':
 			// TODO: Support DocumentRef
 			_, _ = b.WriteRune(c)
-		} else {
+		default:
 			// Replace invalid characters with '-'
 			_, _ = b.WriteRune('-')
 		}

--- a/pkg/mapfs/file.go
+++ b/pkg/mapfs/file.go
@@ -265,10 +265,7 @@ func (f *file) glob(pattern string) ([]string, error) {
 					return false
 				}
 				for _, sub := range subEntries {
-					entries = append(entries, strings.Join([]string{
-						name,
-						sub,
-					}, separator))
+					entries = append(entries, name+separator+sub)
 				}
 			}
 		}

--- a/pkg/mapfs/types.go
+++ b/pkg/mapfs/types.go
@@ -15,12 +15,12 @@ type fileStat struct {
 	sys     any
 }
 
-func (fs *fileStat) Name() string       { return fs.name }
-func (fs *fileStat) Size() int64        { return fs.size }
-func (fs *fileStat) Mode() fs.FileMode  { return fs.mode }
-func (fs *fileStat) IsDir() bool        { return fs.mode.IsDir() }
-func (fs *fileStat) ModTime() time.Time { return fs.modTime }
-func (fs *fileStat) Sys() any           { return &fs.sys }
+func (fstat *fileStat) Name() string       { return fstat.name }
+func (fstat *fileStat) Size() int64        { return fstat.size }
+func (fstat *fileStat) Mode() fs.FileMode  { return fstat.mode }
+func (fstat *fileStat) IsDir() bool        { return fstat.mode.IsDir() }
+func (fstat *fileStat) ModTime() time.Time { return fstat.modTime }
+func (fstat *fileStat) Sys() any           { return &fstat.sys }
 
-func (fs *fileStat) Info() (fs.FileInfo, error) { return fs, nil }
-func (fs *fileStat) Type() fs.FileMode          { return fs.mode }
+func (fstat *fileStat) Info() (fs.FileInfo, error) { return fstat, nil }
+func (fstat *fileStat) Type() fs.FileMode          { return fstat.mode }

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -362,7 +362,7 @@ func CreateDataFS(dataPaths []string, opts ...string) (fs.FS, []string, error) {
 
 // ResultsToMisconf is exported for trivy-plugin-aqua purposes only
 func ResultsToMisconf(configType types.ConfigType, scannerName string, results scan.Results) []types.Misconfiguration {
-	misconfs := map[string]types.Misconfiguration{}
+	misconfs := make(map[string]types.Misconfiguration)
 
 	for _, result := range results {
 		flattened := result.Flatten()

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -218,8 +218,10 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, options.ScannerWithDataDirs(dataPaths...))
-	opts = append(opts, options.ScannerWithDataFilesystem(dataFS))
+	opts = append(opts,
+		options.ScannerWithDataDirs(dataPaths...),
+		options.ScannerWithDataFilesystem(dataFS),
+	)
 
 	if opt.Trace {
 		opts = append(opts, options.ScannerWithPerResultTracing(true))
@@ -265,8 +267,10 @@ func addTFOpts(opts []options.ScannerOption, scannerOption ScannerOption) []opti
 		opts = append(opts, tfscanner.ScannerWithTFVarsPaths(scannerOption.TerraformTFVars...))
 	}
 
-	opts = append(opts, tfscanner.ScannerWithAllDirectories(true))
-	opts = append(opts, tfscanner.ScannerWithSkipDownloaded(scannerOption.TfExcludeDownloaded))
+	opts = append(opts,
+		tfscanner.ScannerWithAllDirectories(true),
+		tfscanner.ScannerWithSkipDownloaded(scannerOption.TfExcludeDownloaded),
+	)
 
 	return opts
 }
@@ -329,16 +333,16 @@ func CreatePolicyFS(policyPaths []string) (fs.FS, []string, error) {
 	return mfs, policyPaths, nil
 }
 
-func CreateDataFS(dataPaths []string, options ...string) (fs.FS, []string, error) {
+func CreateDataFS(dataPaths []string, opts ...string) (fs.FS, []string, error) {
 	fsys := mapfs.New()
 
 	// Check if k8sVersion is provided
-	if len(options) > 0 {
-		k8sVersion := options[0]
+	if len(opts) > 0 {
+		k8sVersion := opts[0]
 		if err := fsys.MkdirAll("system", 0700); err != nil {
 			return nil, nil, err
 		}
-		data := []byte(fmt.Sprintf(`{"k8s": {"version": "%s"}}`, k8sVersion))
+		data := []byte(fmt.Sprintf(`{"k8s": {"version": %q}}`, k8sVersion))
 		if err := fsys.WriteVirtualFile("system/k8s-version.json", data, 0600); err != nil {
 			return nil, nil, err
 		}

--- a/pkg/module/serialize/types.go
+++ b/pkg/module/serialize/types.go
@@ -15,12 +15,12 @@ type StringSlice []string
 //easyjson:json
 type AnalysisResult struct {
 	// TODO: support other fields as well
-	//OS                   *types.OS
-	//Repository           *types.Repository
-	//PackageInfos         []types.PackageInfo
-	//Applications         []types.Application
-	//Secrets              []types.Secret
-	//SystemInstalledFiles []string // A list of files installed by OS package manager
+	// OS                   *types.OS
+	// Repository           *types.Repository
+	// PackageInfos         []types.PackageInfo
+	// Applications         []types.Application
+	// Secrets              []types.Secret
+	// SystemInstalledFiles []string // A list of files installed by OS package manager
 
 	// Currently it supports custom resources only
 	CustomResources []CustomResource

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -37,9 +37,9 @@ func WithOCIArtifact(art *oci.Artifact) Option {
 }
 
 // WithClock takes a clock
-func WithClock(clock clock.Clock) Option {
+func WithClock(c clock.Clock) Option {
 	return func(opts *options) {
-		opts.clock = clock
+		opts.clock = c
 	}
 }
 

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -60,10 +60,7 @@ func (p *PackageURL) Package() *ftypes.Package {
 	if p.Type == packageurl.TypeCocoapods && p.Subpath != "" {
 		// CocoaPods uses <moduleName>/<submoduleName> format for package name
 		// e.g. `pkg:cocoapods/GoogleUtilities@7.5.2#NSData+zlib` => `GoogleUtilities/NSData+zlib`
-		pkg.Name = strings.Join([]string{
-			p.Name,
-			p.Subpath,
-		}, "/")
+		pkg.Name = p.Name + "/" + p.Subpath
 	}
 
 	if p.Type == packageurl.TypeRPM {
@@ -82,15 +79,9 @@ func (p *PackageURL) Package() *ftypes.Package {
 	if p.Type == packageurl.TypeMaven || p.Type == string(ftypes.Gradle) {
 		// Maven and Gradle packages separate ":"
 		// e.g. org.springframework:spring-core
-		pkg.Name = strings.Join([]string{
-			p.Namespace,
-			p.Name,
-		}, ":")
+		pkg.Name = p.Namespace + ":" + p.Name
 	} else {
-		pkg.Name = strings.Join([]string{
-			p.Namespace,
-			p.Name,
-		}, "/")
+		pkg.Name = p.Namespace + "/" + p.Name
 	}
 
 	return pkg
@@ -346,11 +337,7 @@ func parseSwift(pkgName string) (string, string) {
 // ref. https://github.com/package-url/purl-spec/blob/a748c36ad415c8aeffe2b8a4a5d8a50d16d6d85f/PURL-TYPES.rst#cocoapods
 func parseCocoapods(pkgName string) (string, string) {
 	var subpath string
-	index := strings.Index(pkgName, "/")
-	if index != -1 {
-		subpath = pkgName[index+1:]
-		pkgName = pkgName[:index]
-	}
+	pkgName, subpath, _ = strings.Cut(pkgName, "/")
 	return pkgName, subpath
 }
 

--- a/pkg/rekortest/server.go
+++ b/pkg/rekortest/server.go
@@ -67,11 +67,26 @@ var (
 						Name:       "alpine:3.16",
 						PackageURL: "pkg:oci/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad?repository_url=index.docker.io%2Flibrary%2Falpine\u0026arch=amd64",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:SchemaVersion", Value: "2"},
-							{Name: "aquasecurity:trivy:ImageID", Value: "sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5"},
-							{Name: "aquasecurity:trivy:RepoDigest", Value: "alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad"},
-							{Name: "aquasecurity:trivy:DiffID", Value: "sha256:994393dc58e7931862558d06e46aa2bb17487044f670f310dffe1d24e4d1eec7"},
-							{Name: "aquasecurity:trivy:RepoTag", Value: "alpine:3.16"},
+							{
+								Name:  "aquasecurity:trivy:SchemaVersion",
+								Value: "2",
+							},
+							{
+								Name:  "aquasecurity:trivy:ImageID",
+								Value: "sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5",
+							},
+							{
+								Name:  "aquasecurity:trivy:RepoDigest",
+								Value: "alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad",
+							},
+							{
+								Name:  "aquasecurity:trivy:DiffID",
+								Value: "sha256:994393dc58e7931862558d06e46aa2bb17487044f670f310dffe1d24e4d1eec7",
+							},
+							{
+								Name:  "aquasecurity:trivy:RepoTag",
+								Value: "alpine:3.16",
+							},
 						},
 					},
 				},
@@ -82,8 +97,14 @@ var (
 						Name:    "alpine",
 						Version: "3.16.2",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:Type", Value: "alpine"},
-							{Name: "aquasecurity:trivy:Class", Value: "os-pkgs"},
+							{
+								Name:  "aquasecurity:trivy:Type",
+								Value: "alpine",
+							},
+							{
+								Name:  "aquasecurity:trivy:Class",
+								Value: "os-pkgs",
+							},
 						},
 					},
 					{
@@ -96,10 +117,22 @@ var (
 						},
 						PackageURL: "pkg:apk/alpine/musl@1.2.3-r0?distro=3.16.2",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:PkgType", Value: "alpine"},
-							{Name: "aquasecurity:trivy:SrcName", Value: "musl"},
-							{Name: "aquasecurity:trivy:SrcVersion", Value: "1.2.3-r0"},
-							{Name: "aquasecurity:trivy:LayerDiffID", Value: "sha256:994393dc58e7931862558d06e46aa2bb17487044f670f310dffe1d24e4d1eec7"},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "alpine",
+							},
+							{
+								Name:  "aquasecurity:trivy:SrcName",
+								Value: "musl",
+							},
+							{
+								Name:  "aquasecurity:trivy:SrcVersion",
+								Value: "1.2.3-r0",
+							},
+							{
+								Name:  "aquasecurity:trivy:LayerDiffID",
+								Value: "sha256:994393dc58e7931862558d06e46aa2bb17487044f670f310dffe1d24e4d1eec7",
+							},
 						},
 					},
 				},
@@ -154,7 +187,10 @@ var (
 						Type:   cyclonedx.ComponentTypeApplication,
 						Name:   "go.mod",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:SchemaVersion", Value: "2"},
+							{
+								Name:  "aquasecurity:trivy:SchemaVersion",
+								Value: "2",
+							},
 						},
 					},
 				},
@@ -164,8 +200,14 @@ var (
 						Type:   cyclonedx.ComponentTypeApplication,
 						Name:   "go.mod",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:Type", Value: "gomod"},
-							{Name: "aquasecurity:trivy:Class", Value: "lang-pkgs"},
+							{
+								Name:  "aquasecurity:trivy:Type",
+								Value: "gomod",
+							},
+							{
+								Name:  "aquasecurity:trivy:Class",
+								Value: "lang-pkgs",
+							},
 						},
 					},
 					{
@@ -175,7 +217,10 @@ var (
 						Version:    "1.5.0",
 						PackageURL: "pkg:golang/github.com/spf13/cobra@1.5.0",
 						Properties: &[]cyclonedx.Property{
-							{Name: "aquasecurity:trivy:PkgType", Value: "gomod"},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "gomod",
+							},
 						},
 					},
 				},
@@ -220,7 +265,7 @@ var (
 			IntegratedTime: lo.ToPtr(int64(1661476639)),
 			LogID:          lo.ToPtr("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"),
 			LogIndex:       lo.ToPtr(int64(3280165)),
-			Verification:   nil, // TODO
+			Verification:   nil,
 		},
 		"392f8ecba72f4326eb624a7403756250b5f2ad58842a99d1653cd6f147f4ce9eda2da350bd908a55": {
 			Attestation: &models.LogEntryAnonAttestation{
@@ -230,7 +275,7 @@ var (
 			IntegratedTime: lo.ToPtr(int64(1661476639)),
 			LogID:          lo.ToPtr("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"),
 			LogIndex:       lo.ToPtr(int64(3280165)),
-			Verification:   nil, // TODO
+			Verification:   nil,
 		},
 		"24296fb24b8ad77aa715cdfd264ce34c4d544375d7bd7cd029bf5a48ef25217a13fdba562e0889ca": {
 			Attestation: &models.LogEntryAnonAttestation{
@@ -240,7 +285,7 @@ var (
 			IntegratedTime: lo.ToPtr(int64(1664451604)),
 			LogID:          lo.ToPtr("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"),
 			LogIndex:       lo.ToPtr(int64(4215471)),
-			Verification:   nil, // TODO
+			Verification:   nil,
 		},
 		"24296fb24b8ad77a8d47be2e40bfe910f0ffc842e86b5685dd85d1c903ef78bb6362125816426fe9": {
 			Attestation: &models.LogEntryAnonAttestation{
@@ -250,7 +295,7 @@ var (
 			IntegratedTime: lo.ToPtr(int64(1661476639)),
 			LogID:          lo.ToPtr("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"),
 			LogIndex:       lo.ToPtr(int64(3280165)),
-			Verification:   nil, // TODO
+			Verification:   nil,
 		},
 	}
 )

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -74,7 +74,7 @@ type Writer struct {
 func (w Writer) Write(report types.Report) error {
 	snapshot := &DependencySnapshot{}
 
-	//use now() method that can be overwritten while integration tests run
+	// use now() method that can be overwritten while integration tests run
 	snapshot.Scanned = clock.Now().Format(time.RFC3339)
 	snapshot.Detector = Detector{
 		Name:    "trivy",

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -129,7 +129,7 @@ func (sw *SarifWriter) Write(report types.Report) error {
 	sw.run = sarif.NewRunWithInformationURI("Trivy", "https://github.com/aquasecurity/trivy")
 	sw.run.Tool.Driver.WithVersion(sw.Version)
 	sw.run.Tool.Driver.WithFullName("Trivy Vulnerability Scanner")
-	sw.locationCache = map[string][]location{}
+	sw.locationCache = make(map[string][]location)
 	if report.ArtifactType == ftypes.ArtifactContainerImage {
 		sw.run.Properties = sarif.Properties{
 			"imageName":   report.ArtifactName,
@@ -142,7 +142,7 @@ func (sw *SarifWriter) Write(report types.Report) error {
 		rootPath = fmt.Sprintf("file://%s/", absPath)
 	}
 
-	ruleIndexes := map[string]int{}
+	ruleIndexes := make(map[string]int)
 	for _, res := range report.Results {
 		target := ToPathUri(res.Target, res.Class)
 

--- a/pkg/report/table/licensing.go
+++ b/pkg/report/table/licensing.go
@@ -75,7 +75,7 @@ func (r pkgLicenseRenderer) setRows() {
 }
 
 func (r pkgLicenseRenderer) countSeverities() map[string]int {
-	severityCount := map[string]int{}
+	severityCount := make(map[string]int)
 	for _, l := range r.result.Licenses {
 		severityCount[l.Severity]++
 	}
@@ -160,7 +160,7 @@ func (r fileLicenseRenderer) setRows() {
 }
 
 func (r fileLicenseRenderer) countSeverities() map[string]int {
-	severityCount := map[string]int{}
+	severityCount := make(map[string]int)
 	for _, l := range r.result.Licenses {
 		severityCount[l.Severity]++
 	}

--- a/pkg/report/table/misconfig.go
+++ b/pkg/report/table/misconfig.go
@@ -30,7 +30,7 @@ type misconfigRenderer struct {
 	ansi               bool
 }
 
-func NewMisconfigRenderer(result types.Result, severities []dbTypes.Severity, trace, includeNonFailures bool, ansi bool) *misconfigRenderer {
+func NewMisconfigRenderer(result types.Result, severities []dbTypes.Severity, trace, includeNonFailures, ansi bool) *misconfigRenderer {
 	width, _, err := term.GetSize(0)
 	if err != nil || width == 0 {
 		width = 40
@@ -177,9 +177,10 @@ func (r *misconfigRenderer) renderCode(misconf types.DetectedMisconfiguration) {
 
 		r.printSingleDivider()
 		for i, line := range lines {
-			if line.Truncated {
+			switch {
+			case line.Truncated:
 				r.printf("<dim>%4s   ", strings.Repeat(".", len(fmt.Sprintf("%d", line.Number))))
-			} else if line.IsCause {
+			case line.IsCause:
 				r.printf("<red>%4d ", line.Number)
 				switch {
 				case (line.FirstCause && line.LastCause) || len(lines) == 1:
@@ -191,9 +192,10 @@ func (r *misconfigRenderer) renderCode(misconf types.DetectedMisconfiguration) {
 				default:
 					r.printf("<red>│ ")
 				}
-			} else {
+			default:
 				r.printf("<dim>%4d   ", line.Number)
 			}
+
 			if r.ansi {
 				r.printf("%s\r\n", line.Highlighted)
 			} else {

--- a/pkg/report/table/misconfig.go
+++ b/pkg/report/table/misconfig.go
@@ -72,7 +72,7 @@ func (r *misconfigRenderer) Render() string {
 }
 
 func (r *misconfigRenderer) countSeverities() map[string]int {
-	severityCount := map[string]int{}
+	severityCount := make(map[string]int)
 	for _, misconf := range r.result.Misconfigurations {
 		if misconf.Status == types.StatusFailure {
 			severityCount[misconf.Severity]++

--- a/pkg/report/table/secret.go
+++ b/pkg/report/table/secret.go
@@ -55,7 +55,7 @@ func (r *secretRenderer) Render() string {
 }
 
 func (r *secretRenderer) countSeverities() map[string]int {
-	severityCount := map[string]int{}
+	severityCount := make(map[string]int)
 	for _, secret := range r.secrets {
 		severity := secret.Severity
 		severityCount[severity]++

--- a/pkg/report/table/secret.go
+++ b/pkg/report/table/secret.go
@@ -134,9 +134,10 @@ func (r *secretRenderer) renderCode(secret types.SecretFinding) {
 		r.printSingleDivider()
 
 		for i, line := range lines {
-			if line.Truncated {
+			switch {
+			case line.Truncated:
 				r.printf("<dim>%4s   ", strings.Repeat(".", len(fmt.Sprintf("%d", line.Number))))
-			} else if line.IsCause {
+			case line.IsCause:
 				r.printf("<red>%4d ", line.Number)
 				switch {
 				case (line.FirstCause && line.LastCause) || len(lines) == 1:
@@ -148,7 +149,7 @@ func (r *secretRenderer) renderCode(secret types.SecretFinding) {
 				default:
 					r.printf("<red>│ ")
 				}
-			} else {
+			default:
 				r.printf("<dim>%4d   ", line.Number)
 			}
 			if r.ansi {

--- a/pkg/report/table/vulnerability.go
+++ b/pkg/report/table/vulnerability.go
@@ -144,7 +144,7 @@ func (r *vulnerabilityRenderer) setVulnerabilityRows(vulns []types.DetectedVulne
 }
 
 func (r *vulnerabilityRenderer) countSeverities(vulns []types.DetectedVulnerability) map[string]int {
-	severityCount := map[string]int{}
+	severityCount := make(map[string]int)
 	for _, v := range vulns {
 		severityCount[v.Severity]++
 	}
@@ -166,11 +166,11 @@ Dependency Origin Tree (Reversed)
 
 	// This count is next to the package ID.
 	// e.g. node-fetch@1.7.3 (MEDIUM: 2, HIGH: 1, CRITICAL: 3)
-	pkgSeverityCount := map[string]map[string]int{}
+	pkgSeverityCount := make(map[string]map[string]int)
 	for _, vuln := range r.result.Vulnerabilities {
 		cnts, ok := pkgSeverityCount[vuln.PkgID]
 		if !ok {
-			cnts = map[string]int{}
+			cnts = make(map[string]int)
 		}
 
 		cnts[vuln.Severity]++
@@ -207,7 +207,7 @@ func addParents(topItem treeprint.Tree, pkg ftypes.Package, parentMap map[string
 		return
 	}
 
-	roots := map[string]struct{}{}
+	roots := make(map[string]struct{})
 	for _, parent := range parentMap[pkg.ID] {
 		if _, ok := seen[parent.ID]; ok {
 			continue
@@ -240,15 +240,15 @@ func addParents(topItem treeprint.Tree, pkg ftypes.Package, parentMap map[string
 }
 
 func traverseAncestors(pkgs []ftypes.Package, parentMap map[string]ftypes.Packages) map[string][]string {
-	ancestors := map[string][]string{}
+	ancestors := make(map[string][]string)
 	for _, pkg := range pkgs {
-		ancestors[pkg.ID] = findAncestor(pkg.ID, parentMap, map[string]struct{}{})
+		ancestors[pkg.ID] = findAncestor(pkg.ID, parentMap, make(map[string]struct{}))
 	}
 	return ancestors
 }
 
 func findAncestor(pkgID string, parentMap map[string]ftypes.Packages, seen map[string]struct{}) []string {
-	ancestors := map[string]struct{}{}
+	ancestors := make(map[string]struct{})
 	seen[pkgID] = struct{}{}
 	for _, parent := range parentMap[pkgID] {
 		if _, ok := seen[parent.ID]; ok {

--- a/pkg/report/table/vulnerability.go
+++ b/pkg/report/table/vulnerability.go
@@ -254,9 +254,10 @@ func findAncestor(pkgID string, parentMap map[string]ftypes.Packages, seen map[s
 		if _, ok := seen[parent.ID]; ok {
 			continue
 		}
-		if !parent.Indirect {
+		switch {
+		case !parent.Indirect:
 			ancestors[parent.ID] = struct{}{}
-		} else if len(parentMap[parent.ID]) == 0 {
+		case len(parentMap[parent.ID]) == 0:
 			// Direct dependencies cannot be identified in some package managers like "package-lock.json" v1,
 			// then the "Indirect" field can be always true. We try to guess direct dependencies in this case.
 			// A dependency with no parents must be a direct dependency.
@@ -270,7 +271,7 @@ func findAncestor(pkgID string, parentMap map[string]ftypes.Packages, seen map[s
 			// Even if `styled-components` is not marked as a direct dependency, it must be a direct dependency
 			// as it has no parents. Note that it doesn't mean `fbjs` is an indirect dependency.
 			ancestors[parent.ID] = struct{}{}
-		} else {
+		default:
 			for _, a := range findAncestor(parent.ID, parentMap, seen) {
 				ancestors[a] = struct{}{}
 			}
@@ -279,7 +280,12 @@ func findAncestor(pkgID string, parentMap map[string]ftypes.Packages, seen map[s
 	return maps.Keys(ancestors)
 }
 
-var jarExtensions = []string{".jar", ".war", ".par", ".ear"}
+var jarExtensions = []string{
+	".jar",
+	".war",
+	".par",
+	".ear",
+}
 
 func rootJarFromPath(path string) string {
 	// File paths are always forward-slashed in Trivy

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -50,9 +50,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter
 		}
 		return input
 	}
-	templateFuncMap["escapeString"] = func(input string) string {
-		return html.EscapeString(input)
-	}
+	templateFuncMap["escapeString"] = html.EscapeString
 	templateFuncMap["sourceID"] = func(input string) dbTypes.SourceID {
 		return dbTypes.SourceID(input)
 	}
@@ -66,7 +64,10 @@ func NewTemplateWriter(output io.Writer, outputTemplate string) (*TemplateWriter
 	if err != nil {
 		return nil, xerrors.Errorf("error parsing template: %w", err)
 	}
-	return &TemplateWriter{Output: output, Template: tmpl}, nil
+	return &TemplateWriter{
+		Output:   output,
+		Template: tmpl,
+	}, nil
 }
 
 // Write writes result

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CustomTemplateFuncMap is used to overwrite existing functions for testing.
-var CustomTemplateFuncMap = map[string]interface{}{}
+var CustomTemplateFuncMap = make(map[string]interface{})
 
 // TemplateWriter write result in custom format defined by user's template
 type TemplateWriter struct {

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -110,15 +110,16 @@ func filterVulnerabilities(result *types.Result, severities []string, ignoreStat
 			vuln.Severity = dbTypes.SeverityUnknown.String()
 		}
 
-		if !slices.Contains(severities, vuln.Severity) {
-			// Filter by severity
+		switch {
+		// Filter by severity
+		case !slices.Contains(severities, vuln.Severity):
 			continue
-		} else if slices.Contains(ignoreStatuses, vuln.Status) {
-			// Filter by status
+		// Filter by status
+		case slices.Contains(ignoreStatuses, vuln.Status):
 			continue
-		} else if ignoreFindings.Match(result.Target, vuln.VulnerabilityID) ||
-			ignoreFindings.Match(vuln.PkgPath, vuln.VulnerabilityID) {
-			// Filter by ignore file
+		// Filter by ignore file
+		case ignoreFindings.Match(result.Target, vuln.VulnerabilityID) ||
+			ignoreFindings.Match(vuln.PkgPath, vuln.VulnerabilityID):
 			continue
 		}
 
@@ -272,7 +273,7 @@ func evaluate(ctx context.Context, query rego.PreparedEvalQuery, input interface
 	return ignore, nil
 }
 
-func shouldOverwrite(old, new types.DetectedVulnerability) bool {
+func shouldOverwrite(oldVuln, newVuln types.DetectedVulnerability) bool {
 	// The same vulnerability must be picked always.
-	return old.FixedVersion < new.FixedVersion
+	return oldVuln.FixedVersion < newVuln.FixedVersion
 }

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -69,7 +69,7 @@ func (s Scanner) Scan(ctx context.Context, target, artifactKey string, blobKeys 
 	ctx = WithCustomHeaders(ctx, s.customHeaders)
 
 	// Convert to the rpc struct
-	licenseCategories := map[string]*rpc.Licenses{}
+	licenseCategories := make(map[string]*rpc.Licenses)
 	for category, names := range opts.LicenseCategories {
 		licenseCategories[string(category)] = &rpc.Licenses{Names: names}
 	}

--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -231,11 +231,11 @@ func (c *CycloneDX) Vulnerabilities(uniq map[string]*cdx.Vulnerability) *[]cdx.V
 	return &vulns
 }
 
-func (c *CycloneDX) PackageURL(purl *purl.PackageURL) string {
-	if purl == nil {
+func (c *CycloneDX) PackageURL(p *purl.PackageURL) string {
+	if p == nil {
 		return ""
 	}
-	return purl.String()
+	return p.String()
 }
 
 func (c *CycloneDX) Supplier(supplier string) *cdx.OrganizationalEntity {
@@ -375,11 +375,11 @@ func cwes(cweIDs []string) *[]int {
 	return &ret
 }
 
-func cdxRatings(vulnerability types.DetectedVulnerability) *[]cdx.VulnerabilityRating {
+func cdxRatings(vuln types.DetectedVulnerability) *[]cdx.VulnerabilityRating {
 	rates := make([]cdx.VulnerabilityRating, 0) // To export an empty array in JSON
-	for sourceID, severity := range vulnerability.VendorSeverity {
+	for sourceID, severity := range vuln.VendorSeverity {
 		// When the vendor also provides CVSS score/vector
-		if cvss, ok := vulnerability.CVSS[sourceID]; ok {
+		if cvss, ok := vuln.CVSS[sourceID]; ok {
 			if cvss.V2Score != 0 || cvss.V2Vector != "" {
 				rates = append(rates, cdxRatingV2(sourceID, severity, cvss))
 			}

--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -65,9 +65,9 @@ func (c *CycloneDX) Marshal(root *Component) *cdx.BOM {
 	bom.SerialNumber = uuid.New().URN()
 	bom.Metadata = c.Metadata()
 
-	components := map[string]*cdx.Component{}
-	dependencies := map[string]*[]string{}
-	vulnerabilities := map[string]*cdx.Vulnerability{}
+	components := make(map[string]*cdx.Component)
+	dependencies := make(map[string]*[]string)
+	vulnerabilities := make(map[string]*cdx.Vulnerability)
 	bom.Metadata.Component = c.MarshalComponent(root, components, dependencies, vulnerabilities)
 
 	// Remove metadata component
@@ -136,7 +136,7 @@ func (c *CycloneDX) MarshalComponent(component *Component, components map[string
 		}
 	}
 
-	dependencies := make([]string, 0) // Components that do not have their own dependencies must be declared as empty elements
+	dependencies := make([]string, 0) // nolint:gocritic // Components that do not have their own dependencies must be declared as empty elements
 	for _, child := range component.Components {
 		childComponent := c.MarshalComponent(child, components, deps, vulns)
 		dependencies = append(dependencies, childComponent.BOMRef)
@@ -330,7 +330,7 @@ func LookupProperty(properties *[]cdx.Property, key string) string {
 }
 
 func UnmarshalProperties(properties *[]cdx.Property) map[string]string {
-	props := map[string]string{}
+	props := make(map[string]string)
 	for _, prop := range lo.FromPtr(properties) {
 		if !strings.HasPrefix(prop.Name, Namespace) {
 			continue
@@ -376,7 +376,7 @@ func cwes(cweIDs []string) *[]int {
 }
 
 func cdxRatings(vuln types.DetectedVulnerability) *[]cdx.VulnerabilityRating {
-	rates := make([]cdx.VulnerabilityRating, 0) // To export an empty array in JSON
+	rates := make([]cdx.VulnerabilityRating, 0) // nolint:gocritic // To export an empty array in JSON
 	for sourceID, severity := range vuln.VendorSeverity {
 		// When the vendor also provides CVSS score/vector
 		if cvss, ok := vuln.CVSS[sourceID]; ok {

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -166,7 +166,7 @@ func (e *Marshaler) marshalPackages(metadata types.Metadata, result types.Result
 		}
 
 		// Recursive packages from direct dependencies
-		if component, err := e.marshalPackage(pkg, pkgs, map[string]*core.Component{}); err != nil {
+		if component, err := e.marshalPackage(pkg, pkgs, make(map[string]*core.Component)); err != nil {
 			return nil, nil
 		} else if component != nil {
 			directComponents = append(directComponents, component)

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -163,7 +163,7 @@ func (c *BOM) parseSBOM(bom *cdx.BOM) error {
 }
 
 func (c *BOM) parseOSPkgs(component cdx.Component, seen map[string]struct{}) (ftypes.PackageInfo, error) {
-	components := c.walkDependencies(component.BOMRef, map[string]struct{}{})
+	components := c.walkDependencies(component.BOMRef, make(map[string]struct{}))
 	pkgs, err := parsePkgs(components, seen)
 	if err != nil {
 		return ftypes.PackageInfo{}, xerrors.Errorf("failed to parse os package: %w", err)
@@ -175,7 +175,7 @@ func (c *BOM) parseOSPkgs(component cdx.Component, seen map[string]struct{}) (ft
 }
 
 func (c *BOM) parseLangPkgs(component cdx.Component, seen map[string]struct{}) (*ftypes.Application, error) {
-	components := c.walkDependencies(component.BOMRef, map[string]struct{}{})
+	components := c.walkDependencies(component.BOMRef, make(map[string]struct{}))
 	components = lo.UniqBy(components, func(c cdx.Component) string {
 		return c.BOMRef
 	})
@@ -276,8 +276,8 @@ func dependencyMap(deps *[]cdx.Dependency) map[string][]string {
 }
 
 func aggregatePkgs(libs []cdx.Component) ([]ftypes.PackageInfo, []ftypes.Application, error) {
-	osPkgMap := map[ftypes.OSType]ftypes.Packages{}
-	langPkgMap := map[ftypes.LangType]ftypes.Packages{}
+	osPkgMap := make(map[ftypes.OSType]ftypes.Packages)
+	langPkgMap := make(map[ftypes.LangType]ftypes.Packages)
 	for _, lib := range libs {
 		isOSPkg, pkgType, pkg, err := toPackage(lib)
 		if err != nil {

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -213,7 +213,7 @@ func (m *Marshaler) resultToSpdxPackage(result types.Result, os *ftypes.OS, pkgD
 	}
 }
 
-func (m *Marshaler) parseFile(filePath string, digest digest.Digest) (spdx.File, error) {
+func (m *Marshaler) parseFile(filePath string, d digest.Digest) (spdx.File, error) {
 	pkgID, err := calcPkgID(m.hasher, filePath)
 	if err != nil {
 		return spdx.File{}, xerrors.Errorf("failed to get %s package ID: %w", filePath, err)
@@ -221,7 +221,7 @@ func (m *Marshaler) parseFile(filePath string, digest digest.Digest) (spdx.File,
 	file := spdx.File{
 		FileSPDXIdentifier: spdx.ElementID(fmt.Sprintf("File-%s", pkgID)),
 		FileName:           filePath,
-		Checksums:          digestToSpdxFileChecksum(digest),
+		Checksums:          digestToSpdxFileChecksum(d),
 	}
 	return file, nil
 }

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -70,7 +70,7 @@ func (s *SPDX) UnmarshalJSON(b []byte) error {
 
 func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 	var osPkgs []ftypes.Package
-	apps := map[common.ElementID]*ftypes.Application{}
+	apps := make(map[common.ElementID]*ftypes.Application)
 	packageSPDXIdentifierMap := createPackageSPDXIdentifierMap(spdxDocument.Packages)
 	packageFilePaths := getPackageFilePaths(spdxDocument)
 
@@ -167,7 +167,7 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 func (s *SPDX) parsePackages(pkgs map[common.ElementID]*spdx.Package) error {
 	var (
 		osPkgs []ftypes.Package
-		apps   = map[ftypes.LangType]ftypes.Application{}
+		apps   = make(map[ftypes.LangType]ftypes.Application)
 	)
 
 	for _, p := range pkgs {
@@ -325,7 +325,7 @@ func parseSourceInfo(pkgType, sourceInfo string) (epoch int, name, ver, rel stri
 
 // getPackageFilePaths parses Relationships and finds filepaths for packages
 func getPackageFilePaths(spdxDocument *spdx.Document) map[string]string {
-	packageFilePaths := map[string]string{}
+	packageFilePaths := make(map[string]string)
 	fileSPDXIdentifierMap := createFileSPDXIdentifierMap(spdxDocument.Files)
 	for _, rel := range spdxDocument.Relationships {
 		if rel.Relationship != common.TypeRelationshipContains && rel.Relationship != "CONTAIN" {

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -281,15 +281,17 @@ func parsePkg(spdxPkg spdx.Package, packageFilePaths map[string]string) (*ftypes
 func parseExternalReferences(refs []*spdx.PackageExternalReference) (*ftypes.Package, *purl.PackageURL, error) {
 	for _, ref := range refs {
 		// Extract the package information from PURL
-		if ref.RefType == RefTypePurl && ref.Category == CategoryPackageManager {
-			packageURL, err := purl.FromString(ref.Locator)
-			if err != nil {
-				return nil, nil, xerrors.Errorf("failed to parse purl from string: %w", err)
-			}
-			pkg := packageURL.Package()
-			pkg.Ref = ref.Locator
-			return pkg, packageURL, nil
+		if ref.RefType != RefTypePurl || ref.Category != CategoryPackageManager {
+			continue
 		}
+
+		packageURL, err := purl.FromString(ref.Locator)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("failed to parse purl from string: %w", err)
+		}
+		pkg := packageURL.Package()
+		pkg.Ref = ref.Locator
+		return pkg, packageURL, nil
 	}
 	return nil, nil, errUnknownPackageFormat
 }
@@ -303,7 +305,7 @@ func lookupAttributionTexts(attributionTexts []string, key string) string {
 	return ""
 }
 
-func parseSourceInfo(pkgType string, sourceInfo string) (epoch int, name, ver, rel string, err error) {
+func parseSourceInfo(pkgType, sourceInfo string) (epoch int, name, ver, rel string, err error) {
 	srcNameVersion := strings.TrimPrefix(sourceInfo, fmt.Sprintf("%s: ", SourcePackagePrefix))
 	ss := strings.Split(srcNameVersion, " ")
 	if len(ss) != 2 {

--- a/pkg/scanner/langpkg/scan.go
+++ b/pkg/scanner/langpkg/scan.go
@@ -62,7 +62,7 @@ func (s *scanner) Scan(detail ftypes.ArtifactDetail, _ types.ScanOptions) (types
 	}
 
 	var results types.Results
-	printedTypes := map[ftypes.LangType]struct{}{}
+	printedTypes := make(map[ftypes.LangType]struct{})
 	for _, app := range apps {
 		if len(app.Libraries) == 0 {
 			continue

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -46,10 +46,10 @@ type Scanner struct {
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(applier applier.Applier, osPkgScanner ospkg.Scanner, langPkgScanner langpkg.Scanner,
+func NewScanner(a applier.Applier, osPkgScanner ospkg.Scanner, langPkgScanner langpkg.Scanner,
 	vulnClient vulnerability.Client) Scanner {
 	return Scanner{
-		applier:        applier,
+		applier:        a,
 		osPkgScanner:   osPkgScanner,
 		langPkgScanner: langPkgScanner,
 		vulnClient:     vulnClient,
@@ -373,7 +373,7 @@ func toDetectedMisconfiguration(res ftypes.MisconfResult, defaultSeverity dbType
 		res.References = append(res.References, primaryURL)
 	}
 
-	if len(primaryURL) == 0 && len(res.References) > 0 {
+	if primaryURL == "" && len(res.References) > 0 {
 		primaryURL = res.References[0]
 	}
 

--- a/pkg/scanner/ospkg/scan.go
+++ b/pkg/scanner/ospkg/scan.go
@@ -77,7 +77,7 @@ func (s *scanner) Scan(target string, detail ftypes.ArtifactDetail, options type
 
 func mergePkgs(pkgs, pkgsFromCommands []ftypes.Package) []ftypes.Package {
 	// pkg has priority over pkgsFromCommands
-	uniqPkgs := map[string]struct{}{}
+	uniqPkgs := make(map[string]struct{})
 	for _, pkg := range pkgs {
 		uniqPkgs[pkg.Name] = struct{}{}
 	}

--- a/pkg/scanner/post/post_scan.go
+++ b/pkg/scanner/post/post_scan.go
@@ -24,14 +24,14 @@ func DeregisterPostScanner(name string) {
 }
 
 func ScannerVersions() map[string]int {
-	versions := map[string]int{}
+	versions := make(map[string]int)
 	for _, s := range postScanners {
 		versions[s.Name()] = s.Version()
 	}
 	return versions
 }
 
-var postScanners = map[string]Scanner{}
+var postScanners = make(map[string]Scanner)
 
 func Scan(ctx context.Context, results types.Results) (types.Results, error) {
 	var err error

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -74,7 +74,7 @@ type CycloneDX struct {
 	logger     *zap.SugaredLogger
 }
 
-func newCycloneDX(sbom *ftypes.CycloneDX, vex *cdx.BOM) *CycloneDX {
+func newCycloneDX(cdxSBOM *ftypes.CycloneDX, vex *cdx.BOM) *CycloneDX {
 	var stmts []Statement
 	for _, vuln := range lo.FromPtr(vex.Vulnerabilities) {
 		affects := lo.Map(lo.FromPtr(vuln.Affects), func(item cdx.Affects, index int) string {
@@ -91,7 +91,7 @@ func newCycloneDX(sbom *ftypes.CycloneDX, vex *cdx.BOM) *CycloneDX {
 		})
 	}
 	return &CycloneDX{
-		sbom:       sbom,
+		sbom:       cdxSBOM,
 		statements: stmts,
 		logger:     log.Logger.With(zap.String("VEX format", "CycloneDX")),
 	}


### PR DESCRIPTION
## Description
In addition to https://github.com/aquasecurity/trivy/pull/5228, this PR enables [go-critic](https://github.com/go-critic/go-critic). Also, it added custom rules for go-ruleguard used in go-critic.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
