### PR TITLE
Update .gitignore to ignore `/bin` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ integration/testdata/fixtures/vm-images
 # SBOMs generated during CI
 /bom.json
 
+# Folder created during `mage lint:run`
+/bin
+
 # goreleaser output
 dist
 


### PR DESCRIPTION
## Description

I have `/bin` folder created after I run `mage lint:run` which contains golangci-lint binary file.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
