### PR TITLE
feat: added `Metadata` into the k8s resource's scan report

### DIFF
--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -56,10 +56,9 @@ type Resource struct {
 	Namespace string `json:",omitempty"`
 	Kind      string
 	Name      string
-	// TODO(josedonizetti): should add metadata? per report? per Result?
-	// Metadata  Metadata `json:",omitempty"`
-	Results types.Results `json:",omitempty"`
-	Error   string        `json:",omitempty"`
+	Metadata  types.Metadata `json:",omitempty"`
+	Results   types.Results  `json:",omitempty"`
+	Error     string         `json:",omitempty"`
 
 	// original report
 	Report types.Report `json:"-"`
@@ -103,6 +102,7 @@ func (r Report) consolidate() ConsolidatedReport {
 				Namespace: res.Namespace,
 				Kind:      res.Kind,
 				Name:      res.Name,
+				Metadata:  res.Metadata,
 				Results:   append(res.Results, v.Results...),
 				Error:     res.Error,
 			}
@@ -237,6 +237,7 @@ func CreateResource(artifact *artifacts.Artifact, report types.Report, err error
 		Namespace: artifact.Namespace,
 		Kind:      artifact.Kind,
 		Name:      artifact.Name,
+		Metadata:  report.Metadata,
 		Results:   results,
 		Report:    report,
 	}
@@ -299,6 +300,7 @@ func copyResource(r Resource) Resource {
 		Namespace: r.Namespace,
 		Kind:      r.Kind,
 		Name:      r.Name,
+		Metadata:  r.Metadata,
 		Error:     r.Error,
 		Report:    r.Report,
 	}

--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -15,6 +15,14 @@ var (
 		Namespace: "default",
 		Kind:      "Deploy",
 		Name:      "orion",
+		Metadata: types.Metadata{
+			RepoTags: []string{
+				"alpine:3.14",
+			},
+			RepoDigests: []string{
+				"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+		},
 		Results: types.Results{
 			{
 				Misconfigurations: []types.DetectedMisconfiguration{
@@ -62,6 +70,14 @@ var (
 		Namespace: "default",
 		Kind:      "Deploy",
 		Name:      "orion",
+		Metadata: types.Metadata{
+			RepoTags: []string{
+				"alpine:3.14",
+			},
+			RepoDigests: []string{
+				"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+		},
 		Results: types.Results{
 			{
 				Vulnerabilities: []types.DetectedVulnerability{
@@ -102,6 +118,14 @@ var (
 		Namespace: "default",
 		Kind:      "Deploy",
 		Name:      "orion",
+		Metadata: types.Metadata{
+			RepoTags: []string{
+				"alpine:3.14",
+			},
+			RepoDigests: []string{
+				"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+		},
 		Results: types.Results{
 			{
 				Misconfigurations: []types.DetectedMisconfiguration{
@@ -181,6 +205,14 @@ var (
 		Namespace: "default",
 		Kind:      "Cronjob",
 		Name:      "hello",
+		Metadata: types.Metadata{
+			RepoTags: []string{
+				"alpine:3.14",
+			},
+			RepoDigests: []string{
+				"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+		},
 		Results: types.Results{
 			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-9999"}}},
 		},
@@ -190,6 +222,14 @@ var (
 		Namespace: "default",
 		Kind:      "Pod",
 		Name:      "prometheus",
+		Metadata: types.Metadata{
+			RepoTags: []string{
+				"alpine:3.14",
+			},
+			RepoDigests: []string{
+				"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+		},
 		Results: types.Results{
 			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
 		},

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -122,7 +122,10 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 
 	onResult := func(result scanResult) error {
 		resources = append(resources, result.vulns...)
-		resources = append(resources, result.misconfig)
+		// don't add empty misconfig results to resources slice to avoid an empty resource
+		if result.misconfig.Results != nil {
+			resources = append(resources, result.misconfig)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Description

## Related issues
- Close #5251

## Before
`trivy k8s --scanners vuln -f json deploy coredns -n kube-system`
```
1 / 1 [--------------------------------------------------------] 100.00% 0 p/s
{
  "ClusterName": "kind-kind",
  "Resources": [
    {
      "Namespace": "kube-system",
      "Kind": "Deployment",
      "Name": "coredns",
      "Results": [
        {
          "Target": "coredns",
          "Class": "lang-pkgs",
          "Type": "gobinary",
          "Vulnerabilities": [
            {
              "VulnerabilityID": "CVE-2022-41723",
              "PkgName": "golang.org/x/net",
              "InstalledVersion": "v0.4.0",
              "FixedVersion": "0.7.0",
              "Status": "fixed",
              "Layer": {
                "Digest": "sha256:3799eae1a077913c39123d0f4fe4e16243237e7ee94cd84874ea755ec930805a",
                "DiffID": "sha256:398c9baff0cedc8a35520742c35f0c216f9fd7f300f5f1e5e469504a93dc03bf"
              },
              "SeveritySource": "ghsa",
              "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-41723",
              "DataSource": {
                "ID": "ghsa",
                "Name": "GitHub Security Advisory Go",
                "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
              },
              "Title": "avoid quadratic complexity in HPACK decoding",
              "Description": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
              "Severity": "HIGH",
              "CVSS": {
                "bitnami": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "ghsa": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "nvd": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "redhat": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                }
              },
              "References": [
                "https://access.redhat.com/security/cve/CVE-2022-41723",
                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41723",
                "https://github.com/advisories/GHSA-vvpx-j8f3-3w6h",
                "https://go.dev/cl/468135",
                "https://go.dev/cl/468295",
                "https://go.dev/issue/57855",
                "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4MA5XS5DAOJ5PKKNG5TUXKPQOFHT5VBC/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RGW7GE2Z32ZT47UFAQFDRQE33B7Q7LMT/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RLBQ3A7ROLEQXQLXFDLNJ7MYPKG5GULE/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XX3IMUTZKRQ73PBZM4E2JP4BKYH4C6XE/",
                "https://nvd.nist.gov/vuln/detail/CVE-2022-41723",
                "https://pkg.go.dev/vuln/GO-2023-1571",
                "https://vuln.go.dev/ID/GO-2023-1571.json",
                "https://www.cve.org/CVERecord?id=CVE-2022-41723"
              ],
              "PublishedDate": "2023-02-28T18:15:00Z",
              "LastModifiedDate": "2023-08-08T14:22:00Z"
            }
          ]
        }
      ]
    },
    {
      "Kind": "",
      "Name": ""
    }
  ]
}
```

## After
`trivy k8s --scanners vuln -f json deploy coredns -n kube-system`
```
1 / 1 [--------------------------------------------------------] 100.00% 0 p/s
{
  "ClusterName": "kind-kind",
  "Resources": [
    {
      "Namespace": "kube-system",
      "Kind": "Deployment",
      "Name": "coredns",
      "Metadata": {
        "ImageID": "sha256:ead0a4a53df89fd173874b46093b6e62d8c72967bbf606d672c9e8c9b601a4fc",
        "DiffIDs": [
          "sha256:6a4a177e62f374d68e6889ffa22b644db056e1d47ee4085c88408fa1d153871d",
          "sha256:398c9baff0cedc8a35520742c35f0c216f9fd7f300f5f1e5e469504a93dc03bf"
        ],
        "RepoTags": [
          "registry.k8s.io/coredns/coredns:v1.10.1"
        ],
        "RepoDigests": [
          "registry.k8s.io/coredns/coredns@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
        ],
        "ImageConfig": {
          "architecture": "amd64",
          "created": "2023-02-06T18:31:00.426815885Z",
          "history": [
            {
              "created": "2023-02-06T18:31:00.19534776Z",
              "created_by": "COPY /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ # buildkit",
              "comment": "buildkit.dockerfile.v0"
            },
            {
              "created": "2023-02-06T18:31:00.426815885Z",
              "created_by": "ADD coredns /coredns # buildkit",
              "comment": "buildkit.dockerfile.v0"
            },
            {
              "created": "2023-02-06T18:31:00.426815885Z",
              "created_by": "EXPOSE map[53/tcp:{} 53/udp:{}]",
              "comment": "buildkit.dockerfile.v0",
              "empty_layer": true
            },
            {
              "created": "2023-02-06T18:31:00.426815885Z",
              "created_by": "ENTRYPOINT [\"/coredns\"]",
              "comment": "buildkit.dockerfile.v0",
              "empty_layer": true
            }
          ],
          "os": "linux",
          "rootfs": {
            "type": "layers",
            "diff_ids": [
              "sha256:6a4a177e62f374d68e6889ffa22b644db056e1d47ee4085c88408fa1d153871d",
              "sha256:398c9baff0cedc8a35520742c35f0c216f9fd7f300f5f1e5e469504a93dc03bf"
            ]
          },
          "config": {
            "Entrypoint": [
              "/coredns"
            ],
            "Env": [
              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "WorkingDir": "/",
            "ExposedPorts": {
              "53/tcp": {},
              "53/udp": {}
            }
          }
        }
      },
      "Results": [
        {
          "Target": "coredns",
          "Class": "lang-pkgs",
          "Type": "gobinary",
          "Vulnerabilities": [
            {
              "VulnerabilityID": "CVE-2022-41723",
              "PkgName": "golang.org/x/net",
              "InstalledVersion": "v0.4.0",
              "FixedVersion": "0.7.0",
              "Status": "fixed",
              "Layer": {
                "Digest": "sha256:3799eae1a077913c39123d0f4fe4e16243237e7ee94cd84874ea755ec930805a",
                "DiffID": "sha256:398c9baff0cedc8a35520742c35f0c216f9fd7f300f5f1e5e469504a93dc03bf"
              },
              "SeveritySource": "ghsa",
              "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-41723",
              "DataSource": {
                "ID": "ghsa",
                "Name": "GitHub Security Advisory Go",
                "URL": "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Ago"
              },
              "Title": "avoid quadratic complexity in HPACK decoding",
              "Description": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
              "Severity": "HIGH",
              "CVSS": {
                "bitnami": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "ghsa": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "nvd": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                },
                "redhat": {
                  "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                  "V3Score": 7.5
                }
              },
              "References": [
                "https://access.redhat.com/security/cve/CVE-2022-41723",
                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41723",
                "https://github.com/advisories/GHSA-vvpx-j8f3-3w6h",
                "https://go.dev/cl/468135",
                "https://go.dev/cl/468295",
                "https://go.dev/issue/57855",
                "https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4MA5XS5DAOJ5PKKNG5TUXKPQOFHT5VBC/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RGW7GE2Z32ZT47UFAQFDRQE33B7Q7LMT/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RLBQ3A7ROLEQXQLXFDLNJ7MYPKG5GULE/",
                "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XX3IMUTZKRQ73PBZM4E2JP4BKYH4C6XE/",
                "https://nvd.nist.gov/vuln/detail/CVE-2022-41723",
                "https://pkg.go.dev/vuln/GO-2023-1571",
                "https://vuln.go.dev/ID/GO-2023-1571.json",
                "https://www.cve.org/CVERecord?id=CVE-2022-41723"
              ],
              "PublishedDate": "2023-02-28T18:15:00Z",
              "LastModifiedDate": "2023-08-08T14:22:00Z"
            }
          ]
        }
      ]
    }
  ]
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
