### PR TITLE
fix: add config files to FS for post-analyzers

### DIFF
--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -659,6 +659,56 @@ func TestTerraformMisconfigurationScan(t *testing.T) {
 			},
 		},
 		{
+			name: "tfvars outside the scan folder",
+			fields: fields{
+				dir: "./testdata/misconfig/terraform/tfvar-outside/tf",
+			},
+			artifactOpt: artifact.Option{
+				MisconfScannerOption: misconf.ScannerOption{
+					RegoOnly:                true,
+					Namespaces:              []string{"user"},
+					PolicyPaths:             []string{"./testdata/misconfig/terraform/rego"},
+					TerraformTFVars:         []string{"./testdata/misconfig/terraform/tfvar-outside/main.tfvars"},
+					TfExcludeDownloaded:     true,
+					DisableEmbeddedPolicies: true,
+				},
+			},
+			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
+				Args: cache.ArtifactCachePutBlobArgs{
+					BlobIDAnything: true,
+					BlobInfo: types.BlobInfo{
+						SchemaVersion: 2,
+						Misconfigurations: []types.Misconfiguration{
+							{
+								FileType: types.Terraform,
+								FilePath: ".",
+								Successes: types.MisconfResults{
+									{
+										Namespace:      "user.something",
+										Query:          "data.user.something.deny",
+										PolicyMetadata: policyMetadata,
+										CauseMetadata: types.CauseMetadata{
+											Provider: "Generic",
+											Service:  "general",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Returns: cache.ArtifactCachePutBlobReturns{},
+			},
+			want: types.ArtifactReference{
+				Name: "testdata/misconfig/terraform/tfvar-outside/tf",
+				Type: types.ArtifactFilesystem,
+				ID:   "sha256:4e2b9cba04625f1d9cc57f74640d039779b0ee176e958aaea37883e03842056d",
+				BlobIDs: []string{
+					"sha256:4e2b9cba04625f1d9cc57f74640d039779b0ee176e958aaea37883e03842056d",
+				},
+			},
+		},
+		{
 			name: "relative paths",
 			fields: fields{
 				dir: "./testdata/misconfig/terraform/relative-paths/child",

--- a/pkg/fanal/artifact/local/testdata/misconfig/terraform/tfvar-outside/main.tfvars
+++ b/pkg/fanal/artifact/local/testdata/misconfig/terraform/tfvar-outside/main.tfvars
@@ -1,0 +1,1 @@
+bucket_name = "test"

--- a/pkg/fanal/artifact/local/testdata/misconfig/terraform/tfvar-outside/tf/main.tf
+++ b/pkg/fanal/artifact/local/testdata/misconfig/terraform/tfvar-outside/tf/main.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "this" {
+    bucket = var.bucket_name
+}
+
+variable "bucket_name" {
+    type = string
+}


### PR DESCRIPTION
## Description

This PR fixes a bug when Trivy could not use configuration files (such as tfvars or helm-values) that are located outside the scan directory or their absolute path was passed.

## Related issues
- Close #4006 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
