### PR TITLE
ci: check only PR's in `actions/stale`

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,4 +1,4 @@
-name: "Stale issues"
+name: "Stale PR's"
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -10,11 +10,10 @@ jobs:
     - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been labeled with inactivity.'
         stale-pr-message: 'This PR is stale because it has been labeled with inactivity.'
-        exempt-issue-labels: 'lifecycle/frozen,lifecycle/active,priority/critical-urgent,priority/important-soon,priority/important-longterm,priority/backlog,priority/awaiting-more-evidence'
         exempt-pr-labels: 'lifecycle/active'
         stale-pr-label: 'lifecycle/stale'
-        stale-issue-label: 'lifecycle/stale'
         days-before-stale: 60
+        days-before-issue-stale: '-1'
         days-before-close: 20
+        days-before-issue-close: '-1'


### PR DESCRIPTION
## Description
We no longer need `stale issues` action, because maintainers are opening up issues.
Use `actions/stale` for PR's only (`actions/stale` supports `-1` value for `days-before-stale` - [days-before-stale](https://github.com/actions/stale#days-before-stale)).

Test run - https://github.com/DmitriyLewen/trivy-issue-style-test/actions/runs/6415444244/job/17417366537

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
