### PR TITLE
ci: add workflow to check Go versions of dependencies

### DIFF
--- a/.github/workflows/check-go-versions.yaml
+++ b/.github/workflows/check-go-versions.yaml
@@ -1,0 +1,27 @@
+name: Check Go versions of dependencies
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+  workflow_dispatch:
+
+jobs:
+  check-go-versions:
+    name: Check Go versions of dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4.1.0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+
+      - name: Check that dependencies doesn't require Go 1.21
+        run: |
+          go mod tidy
+          if grep -q "go 1.21" go.mod; then
+            echo "One of new dependencies requires Go '1.21'. Use 'go get go@1.20' to fix this."
+            exit 1
+          fi

--- a/.github/workflows/check-go-versions.yaml
+++ b/.github/workflows/check-go-versions.yaml
@@ -18,6 +18,10 @@ jobs:
         with:
           go-version: stable
 
+      # This workflow is a workaround before the "old stable" version becomes Go 1.21.
+      # To avoid updating dependencies that require Go 1.21, we use this workflow
+      # Example of wrong update:
+      # https://github.com/aquasecurity/trivy/discussions/5323#discussioncomment-7186321
       - name: Check that dependencies doesn't require Go 1.21
         run: |
           go mod tidy


### PR DESCRIPTION
## Description
Starting from Go `1.21`, it checks the `go` line in all dependencies of `go.mod`, and determines the minimum `Go` version.
See https://github.com/aquasecurity/trivy/discussions/5323#discussioncomment-7186321.

Before Go `1.22` is released - Create GitHub action to find dependencies that require Go `1.21` to avoid incorrect updates.

Test Runs:
- `github.com/sigstore/rekor v1.2.2` - https://github.com/DmitriyLewen/trivy/actions/runs/6417364208/job/17422935840
- `github.com/sigstore/rekor v1.3.0` - https://github.com/DmitriyLewen/trivy/actions/runs/6417443453/job/17423186672?pr=16#step:4:483

## Related issues
- #5338

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
