### PR TITLE
fix: Report error when os.CreateTemp fails (to be consistent with other uses)

### DIFF
--- a/pkg/fanal/image/daemon/docker.go
+++ b/pkg/fanal/image/daemon/docker.go
@@ -53,7 +53,7 @@ func DockerImage(ref name.Reference, host string) (Image, func(), error) {
 
 	f, err := os.CreateTemp("", "fanal-*")
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to create a temporary file")
+		return nil, cleanup, xerrors.Errorf("failed to create a temporary file: %w", err)
 	}
 
 	cleanup = func() {

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -128,7 +128,7 @@ func PodmanImage(ref string) (Image, func(), error) {
 
 	f, err := os.CreateTemp("", "fanal-*")
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to create a temporary file")
+		return nil, cleanup, xerrors.Errorf("failed to create a temporary file: %w", err)
 	}
 
 	cleanup = func() {


### PR DESCRIPTION
## Description

A error returned from `os.CreateTemp` is not wrapped in the case of `docker` and `podman` uses.  This changes the code to be consistent with the two other uses, `containerd` and `remote`.

I ran into this and had no visibility as to why `os.CreateTemp` failed.

I didn't add tests given this is just a small change in-line with the existing examples.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
