### PR TITLE
chore(deps): Upgrade defsec to v0.93.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.30.4
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
-	github.com/aquasecurity/defsec v0.93.0
+	github.com/aquasecurity/defsec v0.93.1
 	github.com/aquasecurity/go-dep-parser v0.0.0-20231005073811-1237b47625e1
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30xLN2sUZcMXl50hg+PJCIDdJgIvIbVcKqLJ/ZrtM=
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
-github.com/aquasecurity/defsec v0.93.0 h1:7I3A6xOa32ugsOcTDvc0FymAEbwR0HO1Jt5wYc8NmFc=
-github.com/aquasecurity/defsec v0.93.0/go.mod h1:BiRuveI3ATEzIwyg6SUeU7MHuPFczAmYmFmdYQLdSSU=
+github.com/aquasecurity/defsec v0.93.1 h1:y4XgRknjs2M58XVLANBT1wulO7N6Rz1oyfwNuzID+h4=
+github.com/aquasecurity/defsec v0.93.1/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
 github.com/aquasecurity/go-dep-parser v0.0.0-20231005073811-1237b47625e1 h1:OAmmfBXi/YdwezeN4qrWvZ2o7OXCMgFRCUJ5NMG/Oug=
 github.com/aquasecurity/go-dep-parser v0.0.0-20231005073811-1237b47625e1/go.mod h1:jqzwhfRT0cboisqgN57znt0lDVVEp479OtMFVaReMAI=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
## Description

Upgrades defsec to v0.93.1 

## Notable changes
- Upgrades defsec Go to 1.20
- Fixes https://github.com/aquasecurity/trivy/issues/4988

Signed-off-by: Simar <simar@linux.com>