### PR TITLE
fix(report): add escaping quotes in misconfig Title for asff template

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -91,7 +91,7 @@
             "Severity": {
                 "Label": "{{ $severity }}"
             },
-            "Title": "Trivy found a misconfiguration in {{ $target }}: {{ .Title }}",
+            "Title": "Trivy found a misconfiguration in {{ $target }}: {{ escapeString .Title }}",
             "Description": {{ escapeString $description | printf "%q" }},
             "Remediation": {
                 "Recommendation": {


### PR DESCRIPTION
## Description
Misconfiguration titles may contains quotes.
e.g.:
-  `Image user should not be 'root'`).
- `... It is recommended that VPC Flow Logs be enabled for packet "Rejects" for VPCs`

We currently only escaping quotes only for `Description`.
We also need to escape quotes for `Title`.

## Related issues
- Close #5350

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
