### PR TITLE
docs: remove --scanners none

### DIFF
--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -113,13 +113,6 @@ You can enable it with `--image-config-scanners config`.
 $ trivy image --image-config-scanners config [YOUR_IMAGE_NAME]
 ```
 
-If you just want to scan the image config, you can disable scanners with `--scanners none`.
-For example:
-
-```
-$ trivy image --scanners none --image-config-scanners config alpine:3.17.0
-```
-
 <details>
 <summary>Result</summary>
 


### PR DESCRIPTION
## Description

See https://github.com/aquasecurity/trivy/issues/5182.

There is still a mention in the documentation of an invalid `none` argument for the `scanners` flag.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
