### PR TITLE
docs: Changed bold text to normal text

### DIFF
--- a/docs/docs/scanner/vulnerability.md
+++ b/docs/docs/scanner/vulnerability.md
@@ -38,7 +38,7 @@ See [here](../coverage/os/index.md#supported-os) for the supported OSes.
 | Photon OS     | [Photon Security Advisory][photon]                           |
 
 #### Data Source Selection
-Trivy **only** consumes security advisories from the sources listed in the above table.
+Trivy only consumes security advisories from the sources listed in the above table.
 
 As for packages installed from OS package managers (`dpkg`, `yum`, `apk`, etc.), Trivy uses the advisory database from the appropriate **OS vendor**.
 


### PR DESCRIPTION
## Description
The word 'only' in the sentence is written in bold style. There is no need for writing a word in bold text .
See the issue at this link under the section Data Source Selection : https://aquasecurity.github.io/trivy/v0.46/docs/scanner/vulnerability/



<img width="570" alt="Screenshot 2023-10-19 204748" src="https://github.com/aquasecurity/trivy/assets/102309095/038879ad-95b3-47ee-befd-1be919b74e38">

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
