### PR TITLE
docs(misconf): Update `--tf-exclude-downloaded-modules` description

### DIFF
--- a/docs/docs/coverage/iac/terraform.md
+++ b/docs/docs/coverage/iac/terraform.md
@@ -35,7 +35,7 @@ trivy conf --tf-vars dev.terraform.tfvars ./infrastructure/tf
 
 ### Exclude Downloaded Terraform Modules
 By default, downloaded modules are also scanned.
-If you don't want to scan modules downloaded into the `.terraform` directory, you can use the `--tf-exclude-downloaded-modules` flag.
+If you don't want to scan them, you can use the `--tf-exclude-downloaded-modules` flag.
 
 ```bash
 trivy conf --tf-exclude-downloaded-modules ./configs

--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -95,7 +95,7 @@ trivy aws [flags]
       --skip-policy-update                skip fetching rego policy updates
       --skip-service strings              Skip selected AWS Service(s) specified with this flag. Can specify multiple services using --skip-service A --skip-service B etc.
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --trace                             enable more verbose trace output for custom queries
       --update-cache                      Update the cache for the applicable cloud provider instead of using cached results.

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -44,7 +44,7 @@ trivy config [flags] DIR
       --skip-files strings                specify the files or glob patterns to skip
       --skip-policy-update                skip fetching rego policy updates
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -78,7 +78,7 @@ trivy filesystem [flags] PATH
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -99,7 +99,7 @@ trivy image [flags] IMAGE_NAME
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -89,7 +89,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --tolerations strings               specify node-collector job tolerations (example: key1=value1:NoExecute,key2=value2:NoSchedule)
       --trace                             enable more verbose trace output for custom queries

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -78,7 +78,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --slow                              scan over time with lower CPU and memory utilization
       --tag string                        pass the tag name to be scanned
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -79,7 +79,7 @@ trivy rootfs [flags] ROOTDIR
       --skip-policy-update                skip fetching rego policy updates
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -70,7 +70,7 @@ trivy vm [flags] VM_IMAGE
       --skip-java-db-update               skip updating Java index database
       --slow                              scan over time with lower CPU and memory utilization
   -t, --template string                   output template
-      --tf-exclude-downloaded-modules     remove results for downloaded modules in .terraform folder
+      --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -59,7 +59,7 @@ var (
 		Name:       "tf-exclude-downloaded-modules",
 		ConfigName: "misconfiguration.terraform.exclude-downloaded-modules",
 		Default:    false,
-		Usage:      "remove results for downloaded modules in .terraform folder",
+		Usage:      "exclude misconfigurations for downloaded terraform modules",
 	}
 	PolicyBundleRepositoryFlag = Flag{
 		Name:       "policy-bundle-repository",


### PR DESCRIPTION
## Description

Improve the help text for `--tf-exclude-downloaded-modules` flag.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5416

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
