### PR TITLE
fix(sbom): save digests for package/application when scanning SBOM files

### DIFF
--- a/pkg/fanal/applier/docker_test.go
+++ b/pkg/fanal/applier/docker_test.go
@@ -200,6 +200,88 @@ func TestApplyLayers(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path with digests in libs/packages (as for SBOM)",
+			inputLayers: []types.BlobInfo{
+				{
+					SchemaVersion: 2,
+					OS: types.OS{
+						Family: "debian",
+						Name:   "11.8",
+					},
+					PackageInfos: []types.PackageInfo{
+						{
+							Packages: types.Packages{
+								{
+									ID:         "adduser@3.118+deb11u1",
+									Name:       "adduser",
+									Version:    "3.118+deb11u1",
+									Arch:       "all",
+									SrcName:    "adduser",
+									SrcVersion: "3.118+deb11u1",
+									Ref:        "pkg:deb/debian/adduser@3.118%2Bdeb11u1?arch=all&distro=debian-11.8",
+									Layer: types.Layer{
+										Digest: "sha256:e67fdae3559346105027c63e7fb032bba57e62b1fe9f2da23e6fdfb56384e00b",
+										DiffID: "sha256:633f5bf471f7595b236a21e62dc60beef321db45916363a02ad5af02d794d497",
+									},
+								},
+							},
+						},
+					},
+					Applications: []types.Application{
+						{
+							Type: types.PythonPkg,
+							Libraries: types.Packages{
+								{
+									Name:    "pip",
+									Version: "23.0.1",
+									Layer: types.Layer{
+										DiffID: "sha256:1def056a3160854c9395aa76282dd62172ec08c18a5fa03bb7d50a777c15ba99",
+									},
+									FilePath: "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.ArtifactDetail{
+				OS: types.OS{
+					Family: "debian",
+					Name:   "11.8",
+				},
+				Packages: types.Packages{
+					{
+						ID:         "adduser@3.118+deb11u1",
+						Name:       "adduser",
+						Version:    "3.118+deb11u1",
+						Arch:       "all",
+						SrcName:    "adduser",
+						SrcVersion: "3.118+deb11u1",
+						Ref:        "pkg:deb/debian/adduser@3.118%2Bdeb11u1?arch=all&distro=debian-11.8",
+						Layer: types.Layer{
+							Digest: "sha256:e67fdae3559346105027c63e7fb032bba57e62b1fe9f2da23e6fdfb56384e00b",
+							DiffID: "sha256:633f5bf471f7595b236a21e62dc60beef321db45916363a02ad5af02d794d497",
+						},
+					},
+				},
+				Applications: []types.Application{
+					{
+						Type: types.PythonPkg,
+						Libraries: types.Packages{
+							{
+								Name:     "pip",
+								Version:  "23.0.1",
+								FilePath: "usr/local/lib/python3.9/site-packages/pip-23.0.1.dist-info/METADATA",
+								Layer: types.Layer{
+									DiffID: "sha256:1def056a3160854c9395aa76282dd62172ec08c18a5fa03bb7d50a777c15ba99",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "happy path with merging ubuntu version and ESM",
 			inputLayers: []types.BlobInfo{
 				{

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -376,6 +376,8 @@ func toPackage(component cdx.Component) (*purl.PackageURL, *ftypes.Package, erro
 			pkg.Modularitylabel = value
 		case PropertyLayerDiffID:
 			pkg.Layer.DiffID = value
+		case PropertyLayerDigest:
+			pkg.Layer.Digest = value
 		case PropertyFilePath:
 			pkg.FilePath = value
 		}

--- a/pkg/sbom/cyclonedx/unmarshal_test.go
+++ b/pkg/sbom/cyclonedx/unmarshal_test.go
@@ -221,6 +221,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 								},
 								Ref: "pkg:deb/ubuntu/libc6@2.35-0ubuntu3.1?distro=ubuntu-22.04",
 								Layer: ftypes.Layer{
+									Digest: "sha256:74ac377868f863e123f24c409f79709f7563fa464557c36a09cf6f85c8b92b7f",
 									DiffID: "sha256:b93c1bd012ab8fda60f5b4f5906bf244586e0e3292d84571d3abb56472248466",
 								},
 							},
@@ -235,6 +236,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 								SrcEpoch:   1,
 								Ref:        "pkg:deb/ubuntu/libcrypt1@4.4.27-1?epoch=1&distro=ubuntu-22.04",
 								Layer: ftypes.Layer{
+									Digest: "sha256:74ac377868f863e123f24c409f79709f7563fa464557c36a09cf6f85c8b92b7f",
 									DiffID: "sha256:b93c1bd012ab8fda60f5b4f5906bf244586e0e3292d84571d3abb56472248466",
 								},
 							},


### PR DESCRIPTION
## Description
Reports in SBOM formats contain package/application digests.
But when we scan these reports, we miss the digests.
We need to include digests like in json format.

See #5424 for details.

## Related issues
- Close #5430

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
