### PR TITLE
docs: fix error when installing `PyYAML` for gh pages

### DIFF
--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -21,6 +21,7 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip setuptools wheel
           pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
           pip install -r docs/build/requirements.txt
         env:

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -23,6 +23,7 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip setuptools wheel
           pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
           pip install -r docs/build/requirements.txt
         env:

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -19,6 +19,7 @@ jobs:
         python-version: 3.x
     - name: Install dependencies
       run: |
+        pip install setuptools
         pip install -r docs/build/requirements.txt
     - name: Configure the git user
       run: |

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.x
     - name: Install dependencies
       run: |
-        pip install setuptools
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r docs/build/requirements.txt
     - name: Configure the git user
       run: |

--- a/docs/build/Dockerfile
+++ b/docs/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:8.3.9
+FROM squidfunk/mkdocs-material:9.4.6
 
 ## If you want to see exactly the same version as is published to GitHub pages
 ## use a private image for insiders, which requires authentication.

--- a/docs/build/requirements.txt
+++ b/docs/build/requirements.txt
@@ -20,7 +20,7 @@ Pygments==2.12.0
 pymdown-extensions==9.5
 pyparsing==3.0.8
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml-env-tag==0.1
 six==1.16.0
 termcolor==1.1.0


### PR DESCRIPTION
## Description
There is problem with old `PyYAML` and `Python 3.12`.
`PyYAML 6.0.1` works correctly in `Python 3.12` - https://github.com/yaml/pyyaml/issues/760#issuecomment-1765523476

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
