### PR TITLE
fix(java): fix infinite loop when `relativePath` field points to `pom.xml` being scanned

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.4
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/defsec v0.93.1
-	github.com/aquasecurity/go-dep-parser v0.0.0-20231013060839-6f348921ea39
+	github.com/aquasecurity/go-dep-parser v0.0.0-20231030050624-4548cca9a5c9
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/defsec v0.93.1 h1:y4XgRknjs2M58XVLANBT1wulO7N6Rz1oyfwNuzID+h4=
 github.com/aquasecurity/defsec v0.93.1/go.mod h1:i80K4WRNbcIWDOQDWnTHkutBwplzw/uZD4laKbhu4sE=
-github.com/aquasecurity/go-dep-parser v0.0.0-20231013060839-6f348921ea39 h1:5yB6PHCaU4yZzN1mMFnrpBerz2pgqYdDRRVSOj4EjVo=
-github.com/aquasecurity/go-dep-parser v0.0.0-20231013060839-6f348921ea39/go.mod h1:RpdbxLhxxvWmv83HWNEiv+reFkmnV+GqHqr66mIU8nU=
+github.com/aquasecurity/go-dep-parser v0.0.0-20231030050624-4548cca9a5c9 h1:AYees+PQjw47SEdM6e/xxgrFzHA+UWxQl6WndDzILNY=
+github.com/aquasecurity/go-dep-parser v0.0.0-20231030050624-4548cca9a5c9/go.mod h1:RpdbxLhxxvWmv83HWNEiv+reFkmnV+GqHqr66mIU8nU=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
 github.com/aquasecurity/go-mock-aws v0.0.0-20230810212901-d6feebd39060 h1:V7nC90NpRDEubNpNEgRDtTfLH3RKQlZeY9/HSqxEze8=


### PR DESCRIPTION
## Description
If `relativePath` (including `../pom.xml` case) field points to `pom.xml` being scanned - we get infinity loop.
More information in https://github.com/aquasecurity/go-dep-parser/pull/267.

## Related issues
- Close #5453

## Related PRs
- [x] aquasecurity/go-dep-parser/pull/267

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
