### PR TITLE
feat(secret): add built-in rule for JWT tokens

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -567,7 +567,7 @@ var builtinRules = []Rule{
 		ID:       "jwt-token",
 		Category: CategoryJWT,
 		Title:    "JWT token",
-		Regex:    MustCompile(`^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)`),
+		Regex:    MustCompile(`ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?`),
 		Keywords: []string{"jwt"},
 	},
 	{

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -567,6 +567,7 @@ var builtinRules = []Rule{
 		ID:       "jwt-token",
 		Category: CategoryJWT,
 		Title:    "JWT token",
+		Severity: "CRITICAL",
 		Regex:    MustCompile(`ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?`),
 		Keywords: []string{"jwt"},
 	},

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -49,6 +49,7 @@ var (
 	CategoryHubSpot              = types.SecretRuleCategory("HubSpot")
 	CategoryIntercom             = types.SecretRuleCategory("Intercom")
 	CategoryIonic                = types.SecretRuleCategory("Ionic")
+	CategoryJWT                  = types.SecretRuleCategory("JWT")
 	CategoryLinear               = types.SecretRuleCategory("Linear")
 	CategoryLob                  = types.SecretRuleCategory("Lob")
 	CategoryMailchimp            = types.SecretRuleCategory("Mailchimp")
@@ -561,6 +562,13 @@ var builtinRules = []Rule{
 		Title:    "Ionic API token",
 		Regex:    MustCompile(`(?i)(ionic[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](ion_[a-z0-9]{42})['\"]`),
 		Keywords: []string{"ionic"},
+	},
+	{
+		ID:       "jwt-token",
+		Category: CategoryJWT,
+		Title:    "JWT token",
+		Regex:    MustCompile(`^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)`),
+		Keywords: []string{"jwt"},
 	},
 	{
 		ID:       "linear-api-token",

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -567,7 +567,7 @@ var builtinRules = []Rule{
 		ID:       "jwt-token",
 		Category: CategoryJWT,
 		Title:    "JWT token",
-		Severity: "CRITICAL",
+		Severity: "MEDIUM",
 		Regex:    MustCompile(`ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?`),
 		Keywords: []string{"jwt"},
 	},


### PR DESCRIPTION

## Description

Currently the secret scanning does not detect JWT tokens, which are used for example by Artifactory as Authentication mechanism. 

For example, if a user builds an OCI image and installs dependencies from a private Artifactory repository during build-time and has passed those credentials in an insecure manner to the builder (for example using ARG statements), trivy needs to detect this leak.

The regex I added to the built-in rules is the same as used by gitleaks to detect JWT tokens:
https://github.com/gitleaks/gitleaks/blob/master/cmd/generate/config/rules/jwt.go

## Related issues
* [feat(secret): detect JWT tokens in secret scanning.](https://github.com/aquasecurity/trivy/discussions/5479)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
