### PR TITLE
feat: allow restricting filesystem walk to specific folders

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -30,6 +30,7 @@ trivy config [flags] DIR
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/trivy-policies:0")

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -54,6 +54,7 @@ trivy filesystem [flags] PATH
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -72,6 +72,7 @@ trivy image [flags] IMAGE_NAME
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -64,6 +64,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --no-progress                       suppress progress bar
       --node-collector-namespace string   specify the namespace in which the node-collector job should be deployed (default "trivy-temp")
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -54,6 +54,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -56,6 +56,7 @@ trivy rootfs [flags] ROOTDIR
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -41,6 +41,7 @@ trivy sbom [flags] SBOM_PATH
       --list-all-pkgs               enabling the option will output all packages regardless of vulnerability
       --no-progress                 suppress progress bar
       --offline-scan                do not issue API requests to identify dependencies
+      --only-dirs strings           specify the directories where the traversal is allowed
   -o, --output string               output file name
       --redis-ca string             redis ca file location, if using redis as cache backend
       --redis-cert string           redis certificate file location, if using redis as cache backend

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -50,6 +50,7 @@ trivy vm [flags] VM_IMAGE
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/trivy-policies:0")

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -637,6 +637,7 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		// Enable only '--skip-dirs' and '--skip-files' and disable other flags
 		SkipDirs:     &flag.SkipDirsFlag,
 		SkipFiles:    &flag.SkipFilesFlag,
+		OnlyDirs:     &flag.OnlyDirsFlag,
 		FilePatterns: &flag.FilePatternsFlag,
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -629,6 +629,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			DisabledAnalyzers: disabledAnalyzers(opts),
 			SkipFiles:         opts.SkipFiles,
 			SkipDirs:          opts.SkipDirs,
+			OnlyDirs:          opts.OnlyDirs,
 			FilePatterns:      opts.FilePatterns,
 			Offline:           opts.OfflineScan,
 			NoProgress:        opts.NoProgress || opts.Quiet,

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -111,7 +111,7 @@ func sbomRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner
 // vmStandaloneScanner initializes a VM scanner in standalone mode
 func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	// TODO: The walker should be initialized in initializeVMScanner after https://github.com/aquasecurity/trivy/pull/5180
-	w := walker.NewVM(conf.ArtifactOption.SkipFiles, conf.ArtifactOption.SkipDirs)
+	w := walker.NewVM(conf.ArtifactOption.SkipFiles, conf.ArtifactOption.SkipDirs, conf.ArtifactOption.OnlyDirs)
 	s, cleanup, err := initializeVMScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
 		w, conf.ArtifactOption)
 	if err != nil {
@@ -123,7 +123,7 @@ func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scann
 // vmRemoteScanner initializes a VM scanner in client/server mode
 func vmRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	// TODO: The walker should be initialized in initializeVMScanner after https://github.com/aquasecurity/trivy/pull/5180
-	w := walker.NewVM(conf.ArtifactOption.SkipFiles, conf.ArtifactOption.SkipDirs)
+	w := walker.NewVM(conf.ArtifactOption.SkipFiles, conf.ArtifactOption.SkipDirs, conf.ArtifactOption.OnlyDirs)
 	s, cleanup, err := initializeRemoteVMScanner(ctx, conf.Target, conf.ArtifactCache, w, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote vm scanner: %w", err)

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -16,6 +16,7 @@ type Option struct {
 	DisabledHandlers  []types.HandlerType
 	SkipFiles         []string
 	SkipDirs          []string
+	OnlyDirs          []string
 	FilePatterns      []string
 	NoProgress        bool
 	Insecure          bool
@@ -78,6 +79,7 @@ func (o *Option) Sort() {
 	sort.Strings(o.SkipFiles)
 	sort.Strings(o.SkipDirs)
 	sort.Strings(o.FilePatterns)
+	sort.Strings(o.OnlyDirs)
 }
 
 type Artifact interface {

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -62,7 +62,7 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, opt artifact.Option) (a
 	return Artifact{
 		image:          img,
 		cache:          c,
-		walker:         walker.NewLayerTar(opt.SkipFiles, opt.SkipDirs),
+		walker:         walker.NewLayerTar(opt.SkipFiles, opt.SkipDirs, opt.OnlyDirs),
 		analyzer:       a,
 		configAnalyzer: ca,
 		handlerManager: handlerManager,

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -47,7 +47,7 @@ func NewArtifact(rootPath string, c cache.ArtifactCache, opt artifact.Option) (a
 	return Artifact{
 		rootPath: filepath.ToSlash(filepath.Clean(rootPath)),
 		cache:    c,
-		walker: walker.NewFS(buildPathsToSkip(rootPath, opt.SkipFiles), buildPathsToSkip(rootPath, opt.SkipDirs),
+		walker: walker.NewFS(buildPathsToSkip(rootPath, opt.SkipFiles), buildPathsToSkip(rootPath, opt.SkipDirs), buildPathsToSkip(rootPath, opt.OnlyDirs),
 			opt.Parallel, opt.WalkOption.ErrorCallback),
 		analyzer:       a,
 		handlerManager: handlerManager,

--- a/pkg/fanal/cache/key.go
+++ b/pkg/fanal/cache/key.go
@@ -29,8 +29,9 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 		HookVersions     map[string]int
 		SkipFiles        []string
 		SkipDirs         []string
+		OnlyDirs         []string `json:",omitempty"`
 		FilePatterns     []string `json:",omitempty"`
-	}{id, analyzerVersions, hookVersions, artifactOpt.SkipFiles, artifactOpt.SkipDirs, artifactOpt.FilePatterns}
+	}{id, analyzerVersions, hookVersions, artifactOpt.SkipFiles, artifactOpt.SkipDirs, artifactOpt.OnlyDirs, artifactOpt.FilePatterns}
 
 	if err := json.NewEncoder(h).Encode(keyBase); err != nil {
 		return "", xerrors.Errorf("json encode error: %w", err)

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -20,7 +20,7 @@ type FS struct {
 	errCallback ErrorCallback
 }
 
-func NewFS(skipFiles, skipDirs []string, parallel int, errCallback ErrorCallback) FS {
+func NewFS(skipFiles, skipDirs, onlyDirs []string, parallel int, errCallback ErrorCallback) FS {
 	if errCallback == nil {
 		errCallback = func(pathname string, err error) error {
 			// ignore permission errors
@@ -33,8 +33,7 @@ func NewFS(skipFiles, skipDirs []string, parallel int, errCallback ErrorCallback
 	}
 
 	return FS{
-		walker:      newWalker(skipFiles, skipDirs),
-		parallel:    parallel,
+		walker:      newWalker(skipFiles, skipDirs, onlyDirs),
 		errCallback: errCallback,
 	}
 }

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -18,6 +18,7 @@ func TestDir_Walk(t *testing.T) {
 	type fields struct {
 		skipFiles   []string
 		skipDirs    []string
+		onlyDirs    []string
 		errCallback walker.ErrorCallback
 	}
 	tests := []struct {
@@ -93,7 +94,7 @@ func TestDir_Walk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := walker.NewFS(tt.fields.skipFiles, tt.fields.skipDirs, 1, tt.fields.errCallback)
+			w := walker.NewFS(tt.fields.skipFiles, tt.fields.skipDirs, tt.fields.onlyDirs, 1, tt.fields.errCallback)
 
 			err := w.Walk(tt.rootDir, tt.analyzeFn)
 			if tt.wantErr != "" {

--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -25,10 +25,10 @@ type LayerTar struct {
 	threshold int64
 }
 
-func NewLayerTar(skipFiles, skipDirs []string) LayerTar {
+func NewLayerTar(skipFiles, skipDirs, onlyDirs []string) LayerTar {
 	threshold := defaultSizeThreshold
 	return LayerTar{
-		walker:    newWalker(skipFiles, skipDirs),
+		walker:    newWalker(skipFiles, skipDirs, onlyDirs),
 		threshold: threshold,
 	}
 }

--- a/pkg/fanal/walker/tar_test.go
+++ b/pkg/fanal/walker/tar_test.go
@@ -18,6 +18,7 @@ func TestLayerTar_Walk(t *testing.T) {
 	type fields struct {
 		skipFiles []string
 		skipDirs  []string
+		onlyDirs  []string
 	}
 	tests := []struct {
 		name        string
@@ -81,7 +82,7 @@ func TestLayerTar_Walk(t *testing.T) {
 			f, err := os.Open("testdata/test.tar")
 			require.NoError(t, err)
 
-			w := walker.NewLayerTar(tt.fields.skipFiles, tt.fields.skipDirs)
+			w := walker.NewLayerTar(tt.fields.skipFiles, tt.fields.skipDirs, tt.fields.onlyDirs)
 
 			gotOpqDirs, gotWhFiles, err := w.Walk(f, tt.analyzeFn)
 			if tt.wantErr != "" {

--- a/pkg/fanal/walker/vm.go
+++ b/pkg/fanal/walker/vm.go
@@ -39,10 +39,10 @@ type VM struct {
 	analyzeFn WalkFunc
 }
 
-func NewVM(skipFiles, skipDirs []string) *VM {
+func NewVM(skipFiles, skipDirs, onlyDirs []string) *VM {
 	threshold := defaultSizeThreshold
 	return &VM{
-		walker:    newWalker(skipFiles, skipDirs),
+		walker:    newWalker(skipFiles, skipDirs, onlyDirs),
 		threshold: threshold,
 	}
 }

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -21,6 +21,12 @@ var (
 		Default:    []string{},
 		Usage:      "specify the files or glob patterns to skip",
 	}
+	OnlyDirsFlag = Flag{
+		Name:       "only-dirs",
+		ConfigName: "scan.only-dirs",
+		Default:    []string{},
+		Usage:      "specify the directories where the traversal is allowed",
+	}
 	OfflineScanFlag = Flag{
 		Name:       "offline-scan",
 		ConfigName: "scan.offline",
@@ -104,6 +110,7 @@ var (
 type ScanFlagGroup struct {
 	SkipDirs       *Flag
 	SkipFiles      *Flag
+	OnlyDirs       *Flag
 	OfflineScan    *Flag
 	Scanners       *Flag
 	FilePatterns   *Flag
@@ -118,6 +125,7 @@ type ScanOptions struct {
 	Target         string
 	SkipDirs       []string
 	SkipFiles      []string
+	OnlyDirs       []string
 	OfflineScan    bool
 	Scanners       types.Scanners
 	FilePatterns   []string
@@ -131,6 +139,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
 		SkipDirs:       &SkipDirsFlag,
 		SkipFiles:      &SkipFilesFlag,
+		OnlyDirs:       &OnlyDirsFlag,
 		OfflineScan:    &OfflineScanFlag,
 		Scanners:       &ScannersFlag,
 		FilePatterns:   &FilePatternsFlag,
@@ -150,6 +159,7 @@ func (f *ScanFlagGroup) Flags() []*Flag {
 	return []*Flag{
 		f.SkipDirs,
 		f.SkipFiles,
+		f.OnlyDirs,
 		f.OfflineScan,
 		f.Scanners,
 		f.FilePatterns,
@@ -177,6 +187,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		Target:         target,
 		SkipDirs:       getStringSlice(f.SkipDirs),
 		SkipFiles:      getStringSlice(f.SkipFiles),
+		OnlyDirs:       getStringSlice(f.OnlyDirs),
 		OfflineScan:    getBool(f.OfflineScan),
 		Scanners:       getUnderlyingStringSlice[types.Scanner](f.Scanners),
 		FilePatterns:   getStringSlice(f.FilePatterns),

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -15,6 +15,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 	type fields struct {
 		skipDirs    []string
 		skipFiles   []string
+		onlyDirs    []string
 		offlineScan bool
 		scanners    string
 	}
@@ -111,6 +112,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			viper.Set(flag.SkipDirsFlag.ConfigName, tt.fields.skipDirs)
 			viper.Set(flag.SkipFilesFlag.ConfigName, tt.fields.skipFiles)
+			viper.Set(flag.OnlyDirsFlag.ConfigName, tt.fields.onlyDirs)
 			viper.Set(flag.OfflineScanFlag.ConfigName, tt.fields.offlineScan)
 			viper.Set(flag.ScannersFlag.ConfigName, tt.fields.scanners)
 
@@ -118,6 +120,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			f := &flag.ScanFlagGroup{
 				SkipDirs:    &flag.SkipDirsFlag,
 				SkipFiles:   &flag.SkipFilesFlag,
+				OnlyDirs:    &flag.OnlyDirsFlag,
 				OfflineScan: &flag.OfflineScanFlag,
 				Scanners:    &flag.ScannersFlag,
 			}


### PR DESCRIPTION
## Description

This PR passes a new parameter to the walker to only parse the files
in a specified set of folders.

This can greatly improve the performance when a specific set of parsers
is used and the required paths for these parsers is known.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
