### PR TITLE
docs: remove glad for java datasources

### DIFF
--- a/docs/docs/scanner/vulnerability.md
+++ b/docs/docs/scanner/vulnerability.md
@@ -89,8 +89,7 @@ See [here](../coverage/language/index.md#supported-languages) for the supported 
 |          | [GitHub Advisory Database (RubyGems)][ruby-ghsa]    |       ✅        |     -     |
 | Node.js  | [Ecosystem Security Working Group][nodejs]          |       ✅        |     -     |
 |          | [GitHub Advisory Database (npm)][nodejs-ghsa]       |       ✅        |     -     |
-| Java     | [GitLab Advisories Community][gitlab]               |       ✅        |  1 month  |
-|          | [GitHub Advisory Database (Maven)][java-ghsa]       |       ✅        |     -     |
+| Java     | [GitHub Advisory Database (Maven)][java-ghsa]       |       ✅        |     -     |
 | Go       | [GitHub Advisory Database (Go)][go-ghsa]            |       ✅        |     -     |
 | Rust     | [Open Source Vulnerabilities (crates.io)][rust-osv] |       ✅        |     -     |
 | .NET     | [GitHub Advisory Database (NuGet)][dotnet-ghsa]     |       ✅        |     -     |


### PR DESCRIPTION
## Description
We have removed GLAD advisories for Maven from Trivy-db - https://github.com/aquasecurity/trivy-db/pull/366 

## Related PRs
- [x] aquasecurity/trivy-db/pull/366 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
