### PR TITLE
docs(k8s): fix whitespace in list syntax

### DIFF
--- a/docs/docs/coverage/kubernetes.md
+++ b/docs/docs/coverage/kubernetes.md
@@ -10,13 +10,15 @@ Whenever Trivy scans either of these Kubernetes resources, the container image i
 When scanning any of the above, the container image is scanned separately to the Kubernetes resource definition (the YAML manifest) that defines the resource.
 
 Container image is scanned for:
+
 - Vulnerabilities
 - Misconfigurations
 - Exposed secrets
 
 Kubernetes resource definition is scanned for:
+
 - Vulnerabilities - partially supported through [KBOM scanning](#KBOM)
 - Misconfigurations
 - Exposed secrets
 
-To learn more, please see the [documentation for Kubernetes scanning](../target/kubernetes.md)
+To learn more, please see the [documentation for Kubernetes scanning](../target/kubernetes.md).


### PR DESCRIPTION
this should render correctly on website; website's .md renderer is stricter than GitHub's

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
