### PR TITLE
refactor(misconf): don't remove Highlighted in json format

### DIFF
--- a/integration/testdata/helm.json.golden
+++ b/integration/testdata/helm.json.golden
@@ -56,6 +56,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -65,6 +66,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -74,6 +76,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -83,6 +86,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -92,6 +96,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -101,6 +106,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -110,6 +116,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -119,6 +126,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -128,6 +136,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": true
                 },
@@ -175,6 +184,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -184,6 +194,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -193,6 +204,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -202,6 +214,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -211,6 +224,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -220,6 +234,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -229,6 +244,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -238,6 +254,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -247,6 +264,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": true
                 },

--- a/integration/testdata/helm_testchart.json.golden
+++ b/integration/testdata/helm_testchart.json.golden
@@ -56,6 +56,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -65,6 +66,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -74,6 +76,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -83,6 +86,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -92,6 +96,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -101,6 +106,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -110,6 +116,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -119,6 +126,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -128,6 +136,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": true
                 },
@@ -175,6 +184,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -184,6 +194,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -193,6 +204,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -202,6 +214,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -211,6 +224,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -220,6 +234,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -229,6 +244,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -238,6 +254,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -247,6 +264,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": true
                 },

--- a/integration/testdata/helm_testchart.overridden.json.golden
+++ b/integration/testdata/helm_testchart.overridden.json.golden
@@ -56,6 +56,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -65,6 +66,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -74,6 +76,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -83,6 +86,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -92,6 +96,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -101,6 +106,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -110,6 +116,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -119,6 +126,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -128,6 +136,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m0",
                   "FirstCause": false,
                   "LastCause": true
                 },
@@ -175,6 +184,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -184,6 +194,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -193,6 +204,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -202,6 +214,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -211,6 +224,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -220,6 +234,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -229,6 +244,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -238,6 +254,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -247,6 +264,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m0",
                   "FirstCause": false,
                   "LastCause": true
                 },
@@ -294,6 +312,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "        - \u001b[38;5;33mname\u001b[0m: testchart",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -303,6 +322,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "          \u001b[38;5;33msecurityContext\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -312,6 +332,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -321,6 +342,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -330,6 +352,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -339,6 +362,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -348,6 +372,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -357,6 +382,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -366,6 +392,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m0",
                   "FirstCause": false,
                   "LastCause": true
                 },
@@ -439,6 +466,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mcapabilities\u001b[0m:",
                   "FirstCause": true,
                   "LastCause": false
                 },
@@ -448,6 +476,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              \u001b[38;5;33mdrop\u001b[0m:",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -457,6 +486,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "              - ALL",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -466,6 +496,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "            \u001b[38;5;33mreadOnlyRootFilesystem\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -475,6 +506,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsGroup\u001b[0m: \u001b[38;5;37m10001",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -484,6 +516,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsNonRoot\u001b[0m: \u001b[38;5;166mtrue",
                   "FirstCause": false,
                   "LastCause": false
                 },
@@ -493,6 +526,7 @@
                   "IsCause": true,
                   "Annotation": "",
                   "Truncated": false,
+                  "Highlighted": "\u001b[0m            \u001b[38;5;33mrunAsUser\u001b[0m: \u001b[38;5;37m0",
                   "FirstCause": false,
                   "LastCause": true
                 }

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -119,13 +119,6 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 		r.Vulnerabilities[i].VendorSeverity = nil
 	}
 
-	// remove the Highlighted attribute from the json results
-	for i := range r.Misconfigurations {
-		for li := range r.Misconfigurations[i].CauseMetadata.Code.Lines {
-			r.Misconfigurations[i].CauseMetadata.Code.Lines[li].Highlighted = ""
-		}
-	}
-
 	// Notice the Alias struct prevents MarshalJSON being called infinitely
 	type ResultAlias Result
 	return json.Marshal(&struct {


### PR DESCRIPTION
## Description
We need to save `Highlighted` field in `json` format to retain option to display colored text in `convert` mode.
See more in #5514.

## Related issues
- Close #5530

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
