### PR TITLE
test(containerd): add log messages to containerd tests

### DIFF
--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -205,12 +205,12 @@ func TestContainerd_SearchLocalStoreByNameOrDigest(t *testing.T) {
 		require.NoError(t, execErr)
 		b, readErr := io.ReadAll(r)
 		require.NoError(t, readErr)
-		fmt.Println(i)
-		fmt.Println(string(b))
+		t.Log(i)
+		t.Log(string(b))
 
 		info, statErr := os.Stat(socketPath)
 		require.NoError(t, statErr)
-		fmt.Println(info.Mode())
+		t.Log(info.Mode())
 
 		require.NoError(t, err)
 	}
@@ -685,12 +685,12 @@ func localImageTestWithNamespace(t *testing.T, namespace string) {
 		require.NoError(t, execErr)
 		b, readErr := io.ReadAll(r)
 		require.NoError(t, readErr)
-		fmt.Println(i)
-		fmt.Println(string(b))
+		t.Log(i)
+		t.Log(string(b))
 
 		info, statErr := os.Stat(socketPath)
 		require.NoError(t, statErr)
-		fmt.Println(info.Mode())
+		t.Log(info.Mode())
 
 		require.NoError(t, err)
 	}
@@ -845,12 +845,12 @@ func TestContainerd_PullImage(t *testing.T) {
 		require.NoError(t, execErr)
 		b, readErr := io.ReadAll(r)
 		require.NoError(t, readErr)
-		fmt.Println(i)
-		fmt.Println(string(b))
+		t.Log(i)
+		t.Log(string(b))
 
 		info, statErr := os.Stat(socketPath)
 		require.NoError(t, statErr)
-		fmt.Println(info.Mode())
+		t.Log(info.Mode())
 
 		require.NoError(t, err)
 	}

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -197,16 +197,21 @@ func TestContainerd_SearchLocalStoreByNameOrDigest(t *testing.T) {
 
 	client, err := containerd.New(socketPath)
 	if err != nil {
-		i, r, err := containerdC.Exec(ctx, []string{
+		i, r, execErr := containerdC.Exec(ctx, []string{
 			"ls",
 			"-hl",
 			"/run/containerd",
 		})
-
-		b, err := io.ReadAll(r)
-		require.NoError(t, err)
+		require.NoError(t, execErr)
+		b, readErr := io.ReadAll(r)
+		require.NoError(t, readErr)
 		fmt.Println(i)
 		fmt.Println(string(b))
+
+		info, statErr := os.Stat(socketPath)
+		require.NoError(t, statErr)
+		fmt.Println(info.Mode())
+
 		require.NoError(t, err)
 	}
 	defer client.Close()
@@ -672,16 +677,21 @@ func localImageTestWithNamespace(t *testing.T, namespace string) {
 
 	client, err := containerd.New(socketPath)
 	if err != nil {
-		i, r, err := containerdC.Exec(ctx, []string{
+		i, r, execErr := containerdC.Exec(ctx, []string{
 			"ls",
 			"-hl",
 			"/run/containerd",
 		})
-
-		b, err := io.ReadAll(r)
-		require.NoError(t, err)
+		require.NoError(t, execErr)
+		b, readErr := io.ReadAll(r)
+		require.NoError(t, readErr)
 		fmt.Println(i)
 		fmt.Println(string(b))
+
+		info, statErr := os.Stat(socketPath)
+		require.NoError(t, statErr)
+		fmt.Println(info.Mode())
+
 		require.NoError(t, err)
 	}
 	defer client.Close()
@@ -827,16 +837,21 @@ func TestContainerd_PullImage(t *testing.T) {
 
 	cli, err := containerd.New(socketPath)
 	if err != nil {
-		i, r, err := containerdC.Exec(ctx, []string{
+		i, r, execErr := containerdC.Exec(ctx, []string{
 			"ls",
 			"-hl",
 			"/run/containerd",
 		})
-
-		b, err := io.ReadAll(r)
-		require.NoError(t, err)
+		require.NoError(t, execErr)
+		b, readErr := io.ReadAll(r)
+		require.NoError(t, readErr)
 		fmt.Println(i)
 		fmt.Println(string(b))
+
+		info, statErr := os.Stat(socketPath)
+		require.NoError(t, statErr)
+		fmt.Println(info.Mode())
+
 		require.NoError(t, err)
 	}
 	defer cli.Close()

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -56,7 +58,6 @@ func startContainerd(t *testing.T, ctx context.Context, hostPath string) testcon
 	t.Helper()
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 	req := testcontainers.ContainerRequest{
-		Name:  "containerd",
 		Image: "ghcr.io/aquasecurity/trivy-test-images/containerd:latest",
 		Entrypoint: []string{
 			"/bin/sh",
@@ -195,7 +196,19 @@ func TestContainerd_SearchLocalStoreByNameOrDigest(t *testing.T) {
 	defer containerdC.Terminate(ctx)
 
 	client, err := containerd.New(socketPath)
-	require.NoError(t, err)
+	if err != nil {
+		i, r, err := containerdC.Exec(ctx, []string{
+			"ls",
+			"-hl",
+			"/run/containerd",
+		})
+
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		fmt.Println(i)
+		fmt.Println(string(b))
+		require.NoError(t, err)
+	}
 	defer client.Close()
 
 	for _, tt := range tests {
@@ -658,7 +671,19 @@ func localImageTestWithNamespace(t *testing.T, namespace string) {
 	defer containerdC.Terminate(ctx)
 
 	client, err := containerd.New(socketPath)
-	require.NoError(t, err)
+	if err != nil {
+		i, r, err := containerdC.Exec(ctx, []string{
+			"ls",
+			"-hl",
+			"/run/containerd",
+		})
+
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		fmt.Println(i)
+		fmt.Println(string(b))
+		require.NoError(t, err)
+	}
 	defer client.Close()
 
 	for _, tt := range tests {
@@ -801,7 +826,19 @@ func TestContainerd_PullImage(t *testing.T) {
 	defer containerdC.Terminate(ctx)
 
 	cli, err := containerd.New(socketPath)
-	require.NoError(t, err)
+	if err != nil {
+		i, r, err := containerdC.Exec(ctx, []string{
+			"ls",
+			"-hl",
+			"/run/containerd",
+		})
+
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		fmt.Println(i)
+		fmt.Println(string(b))
+		require.NoError(t, err)
+	}
 	defer cli.Close()
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
Containerd tests are unstable - https://github.com/aquasecurity/trivy/actions/runs/6866661287/job/18673348185#step:5:1405
Add some log messages to discover reason for this.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
