### PR TITLE
feat(misconf): Expose misconf engine debug logs with `--debug` option

### DIFF
--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -159,14 +159,6 @@ func createState(freshState *state.State, awsCache *cache.Cache) (*state.State, 
 	return fullState, nil
 }
 
-//	type DebugLogger struct {
-//		name string
-//	}
-//
-//	func (d *DebugLogger) Write(p []byte) (n int, err error) {
-//		log.Logger.Debug("[aws] " + strings.TrimSpace(string(p)))
-//		return len(p), nil
-//	}
 func addPolicyNamespaces(namespaces []string, scannerOpts []options.ScannerOption) []options.ScannerOption {
 	if len(namespaces) > 0 {
 		scannerOpts = append(

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -44,11 +43,11 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	}
 
 	if option.Debug {
-		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&DebugLogger{}))
+		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&log.DebugLogger{Name: "aws"}))
 	}
 
 	if option.Trace {
-		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&DebugLogger{}))
+		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&log.DebugLogger{Name: "aws"}))
 	}
 
 	if option.Region != "" {
@@ -160,13 +159,14 @@ func createState(freshState *state.State, awsCache *cache.Cache) (*state.State, 
 	return fullState, nil
 }
 
-type DebugLogger struct {
-}
-
-func (d *DebugLogger) Write(p []byte) (n int, err error) {
-	log.Logger.Debug("[aws] " + strings.TrimSpace(string(p)))
-	return len(p), nil
-}
+//	type DebugLogger struct {
+//		name string
+//	}
+//
+//	func (d *DebugLogger) Write(p []byte) (n int, err error) {
+//		log.Logger.Debug("[aws] " + strings.TrimSpace(string(p)))
+//		return len(p), nil
+//	}
 func addPolicyNamespaces(namespaces []string, scannerOpts []options.ScannerOption) []options.ScannerOption {
 	if len(namespaces) > 0 {
 		scannerOpts = append(

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -43,11 +43,11 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	}
 
 	if option.Debug {
-		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&log.DebugLogger{Name: "aws"}))
+		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&log.PrefixedLogger{Name: "aws"}))
 	}
 
 	if option.Trace {
-		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&log.DebugLogger{Name: "aws"}))
+		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&log.PrefixedLogger{Name: "aws"}))
 	}
 
 	if option.Region != "" {

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -44,11 +44,11 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	}
 
 	if option.Debug {
-		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&defsecLogger{}))
+		scannerOpts = append(scannerOpts, options.ScannerWithDebug(&DebugLogger{}))
 	}
 
 	if option.Trace {
-		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&defsecLogger{}))
+		scannerOpts = append(scannerOpts, options.ScannerWithTrace(&DebugLogger{}))
 	}
 
 	if option.Region != "" {
@@ -160,11 +160,11 @@ func createState(freshState *state.State, awsCache *cache.Cache) (*state.State, 
 	return fullState, nil
 }
 
-type defsecLogger struct {
+type DebugLogger struct {
 }
 
-func (d *defsecLogger) Write(p []byte) (n int, err error) {
-	log.Logger.Debug("[defsec] " + strings.TrimSpace(string(p)))
+func (d *DebugLogger) Write(p []byte) (n int, err error) {
+	log.Logger.Debug("[aws] " + strings.TrimSpace(string(p)))
 	return len(p), nil
 }
 func addPolicyNamespaces(namespaces []string, scannerOpts []options.ScannerOption) []options.ScannerOption {

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -574,6 +574,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			disableEmbedded = true
 		}
 		configScannerOptions = misconf.ScannerOption{
+			Debug:                    opts.Debug,
 			Trace:                    opts.Trace,
 			Namespaces:               append(opts.PolicyNamespaces, defaultPolicyNamespaces...),
 			PolicyPaths:              append(opts.PolicyPaths, downloadedPolicyPaths...),

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -123,11 +123,11 @@ func String(key, val string) zap.Field {
 	return zap.String(key, val)
 }
 
-type DebugLogger struct {
+type PrefixedLogger struct {
 	Name string
 }
 
-func (d *DebugLogger) Write(p []byte) (n int, err error) {
+func (d *PrefixedLogger) Write(p []byte) (n int, err error) {
 	Logger.Debugf("[%s] %s", d.Name, strings.TrimSpace(string(p)))
 	return len(p), nil
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -3,6 +3,7 @@ package log
 import (
 	"os"
 	"runtime"
+	"strings"
 
 	xlog "github.com/masahiro331/go-xfs-filesystem/log"
 	"go.uber.org/zap"
@@ -120,4 +121,13 @@ func String(key, val string) zap.Field {
 		return zap.Skip()
 	}
 	return zap.String(key, val)
+}
+
+type DebugLogger struct {
+	Name string
+}
+
+func (d *DebugLogger) Write(p []byte) (n int, err error) {
+	Logger.Debugf("[%s] %s", d.Name, strings.TrimSpace(string(p)))
+	return len(p), nil
 }

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -68,13 +68,13 @@ func (o *ScannerOption) Sort() {
 	sort.Strings(o.DataPaths)
 }
 
-type DebugLogger struct {
-}
-
-func (d *DebugLogger) Write(p []byte) (n int, err error) {
-	log.Logger.Debug("[misconf] " + strings.TrimSpace(string(p)))
-	return len(p), nil
-}
+//type DebugLogger struct {
+//}
+//
+//func (d *DebugLogger) Write(p []byte) (n int, err error) {
+//	log.Logger.Debug("[misconf] " + strings.TrimSpace(string(p)))
+//	return len(p), nil
+//}
 
 type Scanner struct {
 	fileType       detection.FileType
@@ -267,7 +267,7 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 	)
 
 	if opt.Debug {
-		opts = append(opts, options.ScannerWithDebug(&DebugLogger{}))
+		opts = append(opts, options.ScannerWithDebug(&log.DebugLogger{Name: "misconf"}))
 	}
 
 	if opt.Trace {

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -44,6 +44,7 @@ var enabledDefsecTypes = map[detection.FileType]types.ConfigType{
 }
 
 type ScannerOption struct {
+	Debug                    bool
 	Trace                    bool
 	RegoOnly                 bool
 	Namespaces               []string
@@ -65,6 +66,14 @@ func (o *ScannerOption) Sort() {
 	sort.Strings(o.Namespaces)
 	sort.Strings(o.PolicyPaths)
 	sort.Strings(o.DataPaths)
+}
+
+type DebugLogger struct {
+}
+
+func (d *DebugLogger) Write(p []byte) (n int, err error) {
+	log.Logger.Debug("[misconf] " + strings.TrimSpace(string(p)))
+	return len(p), nil
 }
 
 type Scanner struct {
@@ -256,6 +265,10 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 		options.ScannerWithDataDirs(dataPaths...),
 		options.ScannerWithDataFilesystem(dataFS),
 	)
+
+	if opt.Debug {
+		opts = append(opts, options.ScannerWithDebug(&DebugLogger{}))
+	}
 
 	if opt.Trace {
 		opts = append(opts, options.ScannerWithPerResultTracing(true))

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -68,14 +68,6 @@ func (o *ScannerOption) Sort() {
 	sort.Strings(o.DataPaths)
 }
 
-//type DebugLogger struct {
-//}
-//
-//func (d *DebugLogger) Write(p []byte) (n int, err error) {
-//	log.Logger.Debug("[misconf] " + strings.TrimSpace(string(p)))
-//	return len(p), nil
-//}
-
 type Scanner struct {
 	fileType       detection.FileType
 	scanner        scanners.FSScanner

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -259,7 +259,7 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 	)
 
 	if opt.Debug {
-		opts = append(opts, options.ScannerWithDebug(&log.DebugLogger{Name: "misconf"}))
+		opts = append(opts, options.ScannerWithDebug(&log.PrefixedLogger{Name: "misconf"}))
 	}
 
 	if opt.Trace {


### PR DESCRIPTION
## Description

Exposes useful informational debug logs from the misconf engine when the existing `--debug` option is passed.

```shell
./trivy --debug config  /Users/repos/trivy-issues/5395    
2023-11-09T18:21:57.612-0700    DEBUG   Severities: ["UNKNOWN" "LOW" "MEDIUM" "HIGH" "CRITICAL"]
2023-11-09T18:21:57.624-0700    DEBUG   cache dir:  /Users/simarpreetsingh/Library/Caches/trivy
2023-11-09T18:21:57.625-0700    INFO    Misconfiguration scanning is enabled
2023-11-09T18:21:57.625-0700    DEBUG   Policies successfully loaded from disk
2023-11-09T18:21:57.649-0700    DEBUG   The nuget packages directory couldn't be found. License search disabled
2023-11-09T18:21:57.650-0700    DEBUG   Walk the file tree rooted at '/Users/simarpreetsingh/repos/trivy-issues/5395' in parallel
<snip>
2023-11-09T18:21:57.987-0700    DEBUG   [misconf] 21:57.987634000 terraform.executor               Initialised 484 rule(s).
2023-11-09T18:21:57.987-0700    DEBUG   [misconf] 21:57.987638000 terraform.executor               Created pool with 9 worker(s) to apply rules.
2023-11-09T18:21:57.989-0700    DEBUG   [misconf] 21:57.989147000 terraform.scanner.rego           Scanning 1 inputs...
2023-11-09T18:21:57.995-0700    DEBUG   [misconf] 21:57.995493000 terraform.executor               Finished applying rules.
2023-11-09T18:21:57.995-0700    DEBUG   [misconf] 21:57.995512000 terraform.executor               Applying ignores...
2023-11-09T18:21:57.995-0700    DEBUG   [misconf] 21:57.995528000 terraform.executor               Ignored 'google-gke-use-cluster-labels' at 'main.tf:2-5'.
2023-11-09T18:21:58.015-0700    DEBUG   OS is not detected.
2023-11-09T18:21:58.015-0700    INFO    Detected config files: 2
2023-11-09T18:21:58.015-0700    DEBUG   Scanned config file: .
2023-11-09T18:21:58.015-0700    DEBUG   Scanned config file: main.tf

main.tf (terraform)

Tests: 14 (SUCCESSES: 7, FAILURES: 6, EXCEPTIONS: 1)
Failures: 6 (UNKNOWN: 0, LOW: 1, MEDIUM: 3, HIGH: 2, CRITICAL: 0)
```

This can be useful for a variety of reasons, including knowing if a rule was ignored and why.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5395

## Related PRs
- [x] https://github.com/aquasecurity/trivy/issues/2961


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
