### PR TITLE
feat: add aliases to '--scanners'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ https://user-images.githubusercontent.com/1161307/171013513-95f18734-233d-45d3-a
 </details>
 
 ```bash
-trivy fs --scanners vuln,secret,config myproject/
+trivy fs --scanners vuln,secret,misconfig myproject/
 ```
 
 <details>

--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -6,7 +6,7 @@ You can enable/disable scanners with the `--scanners` flag.
 Supported values:
 
 - vuln
-- config
+- misconfig
 - secret
 - license
  

--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -26,6 +26,7 @@ The following services are supported:
 - elb
 - emr
 - iam
+- kinesis
 - kms
 - lambda
 - mq
@@ -33,12 +34,11 @@ The following services are supported:
 - neptune
 - rds
 - redshift
+- s3
 - sns
 - sqs
 - ssm
 - workspaces
-- kinesis
-- s3
 
 
 ```

--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -26,7 +26,6 @@ The following services are supported:
 - elb
 - emr
 - iam
-- kinesis
 - kms
 - lambda
 - mq
@@ -34,11 +33,12 @@ The following services are supported:
 - neptune
 - rds
 - redshift
-- s3
 - sns
 - sqs
 - ssm
 - workspaces
+- kinesis
+- s3
 
 
 ```
@@ -81,7 +81,7 @@ trivy aws [flags]
   -h, --help                              help for aws
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
       --max-cache-age duration            The maximum age of the cloud cache. Cached data will be requeried from the cloud provider if it is older than this. (default 24h0m0s)
   -o, --output string                     output file name

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -26,7 +26,7 @@ trivy config [flags] DIR
   -h, --help                              help for config
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
   -o, --output string                     output file name

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -45,7 +45,7 @@ trivy filesystem [flags] PATH
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
@@ -67,7 +67,7 @@ trivy filesystem [flags] PATH
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -61,9 +61,9 @@ trivy image [flags] IMAGE_NAME
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (config,secret)
+      --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (misconfig,secret)
       --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --input string                      input file path instead of image name
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
@@ -88,7 +88,7 @@ trivy image [flags] IMAGE_NAME
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -55,7 +55,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
@@ -79,7 +79,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners string                   comma-separated list of what security issues to detect (vuln,config,secret,license) (default "vuln,config,secret,rbac")
+      --scanners string                   comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default "vuln,misconfig,secret,rbac")
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -45,7 +45,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
@@ -66,7 +66,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -47,7 +47,7 @@ trivy rootfs [flags] ROOTDIR
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
@@ -68,7 +68,7 @@ trivy rootfs [flags] ROOTDIR
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -44,7 +44,7 @@ trivy vm [flags] VM_IMAGE
       --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --include-non-failures              include successes and exceptions, available with '--scanners config'
+      --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
@@ -60,7 +60,7 @@ trivy vm [flags] VM_IMAGE
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,license) (default [vuln,secret])
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -112,8 +112,9 @@ scan:
   # Default depends on subcommand
   scanners:
     - vuln
-    - config
+    - misconfig
     - secret
+    - license
 ```
 
 ## Cache Options

--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -35,28 +35,28 @@ $ trivy config [YOUR_IaC_DIRECTORY]
     ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
     ```
 
-You can also enable misconfiguration detection in container image, filesystem and git repository scanning via `--scanners config`.
+You can also enable misconfiguration detection in container image, filesystem and git repository scanning via `--scanners misconfig`.
 
 ```bash
-$ trivy image --scanners config IMAGE_NAME
+$ trivy image --scanners misconfig IMAGE_NAME
 ```
 
 ```bash
-$ trivy fs --scanners config /path/to/dir
+$ trivy fs --scanners misconfig /path/to/dir
 ```
 
 !!! note
     Misconfiguration detection is not enabled by default in `image`, `fs` and `repo` subcommands.
 
 Unlike the `config` subcommand, `image`, `fs` and `repo` subcommands can also scan for vulnerabilities and secrets at the same time. 
-You can specify `--scanners vuln,config,secret` to enable vulnerability and secret detection as well as misconfiguration detection.
+You can specify `--scanners vuln,misconfig,secret` to enable vulnerability and secret detection as well as misconfiguration detection.
 
 
 !!! example
     ``` bash
     $ ls myapp/
     Dockerfile Pipfile.lock
-    $ trivy fs --scanners vuln,config,secret --severity HIGH,CRITICAL myapp/
+    $ trivy fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL myapp/
     2022-05-16T13:42:21.440+0100	INFO	Number of language-specific files: 1
     2022-05-16T13:42:21.440+0100	INFO	Detecting pipenv vulnerabilities...
     2022-05-16T13:42:21.440+0100	INFO	Detected config files: 1

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -64,10 +64,10 @@ $ trivy image --scanners vuln [YOUR_IMAGE_NAME]
 ### Misconfigurations
 It is supported, but it is not useful in most cases.
 As mentioned [here](../scanner/misconfiguration/index.md), Trivy mainly supports Infrastructure as Code (IaC) files for misconfigurations.
-If your container image includes IaC files such as Kubernetes YAML files or Terraform files, you should enable this feature with `--scanners config`.
+If your container image includes IaC files such as Kubernetes YAML files or Terraform files, you should enable this feature with `--scanners misconfig`.
 
 ```
-$ trivy image --scanners config [YOUR_IMAGE_NAME]
+$ trivy image --scanners misconfig [YOUR_IMAGE_NAME]
 ```
 
 ### Secrets

--- a/docs/docs/target/filesystem.md
+++ b/docs/docs/target/filesystem.md
@@ -65,11 +65,11 @@ Total: 10 (UNKNOWN: 2, LOW: 0, MEDIUM: 6, HIGH: 2, CRITICAL: 0)
 </details>
 
 ### Misconfigurations
-It is disabled by default and can be enabled with `--scanners config`.
+It is disabled by default and can be enabled with `--scanners misconfig`.
 See [here](../scanner/misconfiguration/index.md) for the detail.
 
 ```shell
-$ trivy fs --scanners config /path/to/project
+$ trivy fs --scanners misconfig /path/to/project
 ```
 
 ### Secrets

--- a/docs/docs/target/repository.md
+++ b/docs/docs/target/repository.md
@@ -82,11 +82,11 @@ Total: 10 (UNKNOWN: 2, LOW: 0, MEDIUM: 6, HIGH: 2, CRITICAL: 0)
 </details>
 
 ### Misconfigurations
-It is disabled by default and can be enabled with `--scanners config`.
+It is disabled by default and can be enabled with `--scanners misconfig`.
 See [here](../scanner/misconfiguration/index.md) for the detail.
 
 ```shell
-$ trivy repo --scanners config (REPO_PATH | REPO_URL)
+$ trivy repo --scanners misconfig (REPO_PATH | REPO_URL)
 ```
 
 ### Secrets

--- a/docs/docs/target/vm.md
+++ b/docs/docs/target/vm.md
@@ -153,10 +153,10 @@ $ trivy vm [YOUR_VM_IMAGE]
 ### Misconfigurations
 It is supported, but it is not useful in most cases.
 As mentioned [here](../scanner/misconfiguration/index.md), Trivy mainly supports Infrastructure as Code (IaC) files for misconfigurations.
-If your VM image includes IaC files such as Kubernetes YAML files or Terraform files, you should enable this feature with `--scanners config`.
+If your VM image includes IaC files such as Kubernetes YAML files or Terraform files, you should enable this feature with `--scanners misconfig`.
 
 ```
-$ trivy vm --scanners config [YOUR_VM_IMAGE]
+$ trivy vm --scanners misconfig [YOUR_VM_IMAGE]
 ```
 
 ### Secrets

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ trivy image python:3.4-alpine
 </details>
 
 ```bash
-trivy fs --scanners vuln,secret,config myproject/
+trivy fs --scanners vuln,secret,misconfig myproject/
 ```
 
 <details>

--- a/docs/tutorials/integrations/gitlab-ci.md
+++ b/docs/tutorials/integrations/gitlab-ci.md
@@ -150,7 +150,7 @@ trivy:
     # Image report
     - ./trivy image --exit-code 0 --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE
     # Filesystem report
-    - ./trivy filesystem --scanners config,vuln --exit-code 0 --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json .
+    - ./trivy filesystem --scanners misconfig,vuln --exit-code 0 --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json .
     # Combine report
     - apk update && apk add jq
     - jq -s 'add' gl-codeclimate-image.json gl-codeclimate-fs.json > gl-codeclimate.json

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -97,7 +97,7 @@ We have lots of examples in the [documentation](https://aquasecurity.github.io/t
 The `trivy config` command does not perform secrete and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets and misconfiguraction through the following flags: 
 
 ```
-trivy fs --scanners secret,config ./
+trivy fs --scanners secret,misconfig ./
 ```
 
 The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/) 

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -360,10 +360,10 @@ func TestRepository(t *testing.T) {
 			},
 		},
 		{
-			name: "dockerfile with fs subcommand",
+			name: "dockerfile with fs subcommand and an alias scanner",
 			args: args{
 				command:     "fs",
-				scanner:     types.MisconfigScanner,
+				scanner:     "config", // for backward compatibility
 				policyPaths: []string{"testdata/fixtures/repo/custom-policy/policy"},
 				namespaces:  []string{"user"},
 				input:       "testdata/fixtures/repo/custom-policy",

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -971,6 +972,7 @@ func NewAWSCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 
 	services := awsScanner.AllSupportedServices()
+	sort.Strings(services)
 
 	cmd := &cobra.Command{
 		Use:     "aws [flags]",

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -23,7 +23,7 @@ var (
 		Name:       "include-non-failures",
 		ConfigName: "misconfiguration.include-non-failures",
 		Default:    false,
-		Usage:      "include successes and exceptions, available with '--scanners config'",
+		Usage:      "include successes and exceptions, available with '--scanners misconfig'",
 	}
 	HelmValuesFileFlag = Flag{
 		Name:       "helm-values",

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -42,6 +42,10 @@ type Flag struct {
 	// It currently supports string flags and string slice flags only.
 	Values []string
 
+	// ValueNormalize is a function to normalize the value.
+	// It can be used for aliases, etc.
+	ValueNormalize func(string) string
+
 	// Usage explains how to use the flag.
 	Usage string
 
@@ -191,13 +195,13 @@ func addFlag(cmd *cobra.Command, flag *Flag) {
 		if len(flag.Values) > 0 {
 			usage += fmt.Sprintf(" (%s)", strings.Join(flag.Values, ","))
 		}
-		flags.VarP(newCustomStringValue(v, flag.Values), flag.Name, flag.Shorthand, usage)
+		flags.VarP(newCustomStringValue(v, flag.Values, flag.ValueNormalize), flag.Name, flag.Shorthand, usage)
 	case []string:
 		usage := flag.Usage
 		if len(flag.Values) > 0 {
 			usage += fmt.Sprintf(" (%s)", strings.Join(flag.Values, ","))
 		}
-		flags.VarP(newCustomStringSliceValue(v, flag.Values), flag.Name, flag.Shorthand, usage)
+		flags.VarP(newCustomStringSliceValue(v, flag.Values, flag.ValueNormalize), flag.Name, flag.Shorthand, usage)
 	case bool:
 		flags.BoolP(flag.Name, flag.Shorthand, v, flag.Usage)
 	case time.Duration:

--- a/pkg/flag/options_test.go
+++ b/pkg/flag/options_test.go
@@ -53,7 +53,7 @@ func Test_getStringSlice(t *testing.T) {
 			flag: &ScannersFlag,
 			env: env{
 				key:   "TRIVY_SECURITY_CHECKS",
-				value: "rbac,config",
+				value: "rbac,misconfig",
 			},
 			want: []string{
 				string(types.RBACScanner),

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -37,6 +37,15 @@ var (
 			types.SecretScanner,
 			types.LicenseScanner,
 		}),
+		ValueNormalize: func(s string) string {
+			switch s {
+			case "vulnerability":
+				return string(types.VulnerabilityScanner)
+			case "config", "misconf", "misconfiguration":
+				return string(types.MisconfigScanner)
+			}
+			return s
+		},
 		Aliases: []Alias{
 			{
 				Name:       "security-checks",

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -38,7 +38,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			name: "happy path for configs",
 			args: []string{"alpine:latest"},
 			fields: fields{
-				scanners: "config",
+				scanners: "misconfig",
 			},
 			want: flag.ScanOptions{
 				Target:   "alpine:latest",

--- a/pkg/flag/value.go
+++ b/pkg/flag/value.go
@@ -3,24 +3,32 @@ package flag
 import (
 	"strings"
 
+	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 )
 
+type ValueNormalizeFunc func(string) string
+
 // -- string Value
 type customStringValue struct {
-	value   *string
-	allowed []string
+	value     *string
+	allowed   []string
+	normalize ValueNormalizeFunc
 }
 
-func newCustomStringValue(val string, allowed []string) *customStringValue {
+func newCustomStringValue(val string, allowed []string, fn ValueNormalizeFunc) *customStringValue {
 	return &customStringValue{
-		value:   &val,
-		allowed: allowed,
+		value:     &val,
+		allowed:   allowed,
+		normalize: fn,
 	}
 }
 
 func (s *customStringValue) Set(val string) error {
+	if s.normalize != nil {
+		val = s.normalize(val)
+	}
 	if len(s.allowed) > 0 && !slices.Contains(s.allowed, val) {
 		return xerrors.Errorf("must be one of %q", s.allowed)
 	}
@@ -35,20 +43,25 @@ func (s *customStringValue) String() string { return *s.value }
 
 // -- stringSlice Value
 type customStringSliceValue struct {
-	value   *[]string
-	allowed []string
-	changed bool
+	value     *[]string
+	allowed   []string
+	normalize ValueNormalizeFunc
+	changed   bool
 }
 
-func newCustomStringSliceValue(val, allowed []string) *customStringSliceValue {
+func newCustomStringSliceValue(val, allowed []string, fn ValueNormalizeFunc) *customStringSliceValue {
 	return &customStringSliceValue{
-		value:   &val,
-		allowed: allowed,
+		value:     &val,
+		allowed:   allowed,
+		normalize: fn,
 	}
 }
 
 func (s *customStringSliceValue) Set(val string) error {
 	values := strings.Split(val, ",")
+	if s.normalize != nil {
+		values = lo.Map(values, func(item string, _ int) string { return s.normalize(item) })
+	}
 	for _, v := range values {
 		if len(s.allowed) > 0 && !slices.Contains(s.allowed, v) {
 			return xerrors.Errorf("must be one of %q", s.allowed)

--- a/pkg/types/target.go
+++ b/pkg/types/target.go
@@ -33,7 +33,7 @@ const (
 	VulnerabilityScanner = Scanner("vuln")
 
 	// MisconfigScanner is the scanner of misconfigurations
-	MisconfigScanner = Scanner("config")
+	MisconfigScanner = Scanner("misconfig")
 
 	// SecretScanner is the scanner of secrets
 	SecretScanner = Scanner("secret")


### PR DESCRIPTION
## Description
This PR updates the allowed values of `--scanners` from `config` to `misconfig`. It also adds aliases for backward compatibility and spelling discrepancies.

- `misconfig` also allows
  - `config`
  - `misconf`
  - `misconfiguration`
- `vuln` also allows
  - `vulnerability`

### Before

```
$ trivy repo --scanners config .
```

NOTE: It remains working.

### After

```
$ trivy repo --scanners misconfig .
```

## Related Issues
- https://github.com/aquasecurity/trivy/issues/5557

## Related PRs
- https://github.com/aquasecurity/trivy/pull/4990

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
