### PR TITLE
fix(cli): set correct `scanners` for `k8s` target

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -79,7 +79,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --reset                             remove all caches and database
       --reset-policy-bundle               remove policy bundle
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners string                   comma-separated list of what security issues to detect (vuln,config,secret,license) (default "vuln,config,secret,rbac")
+      --scanners strings                  comma-separated list of what security issues to detect (vuln,config,secret,rbac) (default [vuln,config,secret,rbac])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
   -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-db-update                    skip updating vulnerability database

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -862,13 +862,14 @@ func NewModuleCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	scanFlags := flag.NewScanFlagGroup()
 	scanners := flag.ScannersFlag
-	scanners.Default = fmt.Sprintf( // overwrite the default value
-		"%s,%s,%s,%s",
+	// overwrite the default scanners
+	scanners.Values = xstrings.ToStringSlice(types.Scanners{
 		types.VulnerabilityScanner,
 		types.MisconfigScanner,
 		types.SecretScanner,
 		types.RBACScanner,
-	)
+	})
+	scanners.Default = scanners.Values
 	scanFlags.Scanners = &scanners
 	scanFlags.IncludeDevDeps = nil // disable '--include-dev-deps'
 


### PR DESCRIPTION
## Description
We need to overwrite allowed `scanners` for `k8s` target:
- remove `license` scanner
- add `rbac` scanner

## Related issues
- Close #5538

## Related PRs
- [x] #4800

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
