### PR TITLE
refactor: reintroduce output writer

### DIFF
--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -1135,8 +1136,8 @@ Summary Report for compliance: my-custom-spec
 				}()
 			}
 
-			output := filepath.Join(t.TempDir(), "output")
-			test.options.Output = output
+			output := bytes.NewBuffer(nil)
+			test.options.SetOutputWriter(output)
 			test.options.Debug = true
 			test.options.GlobalOptions.Timeout = time.Minute
 			if test.options.Format == "" {
@@ -1178,10 +1179,7 @@ Summary Report for compliance: my-custom-spec
 				return
 			}
 			assert.NoError(t, err)
-
-			b, err := os.ReadFile(output)
-			require.NoError(t, err)
-			assert.Equal(t, test.want, string(b))
+			assert.Equal(t, test.want, output.String())
 		})
 	}
 }

--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -59,11 +59,11 @@ func (r *Report) Failed() bool {
 
 // Write writes the results in the give format
 func Write(rep *Report, opt flag.Options, fromCache bool) error {
-	output, err := opt.OutputWriter()
+	output, cleanup, err := opt.OutputWriter()
 	if err != nil {
 		return xerrors.Errorf("failed to create output file: %w", err)
 	}
-	defer output.Close()
+	defer cleanup()
 
 	if opt.Compliance.Spec.ID != "" {
 		return writeCompliance(rep, opt, output)
@@ -104,7 +104,7 @@ func Write(rep *Report, opt flag.Options, fromCache bool) error {
 
 		// ensure color/formatting is disabled for pipes/non-pty
 		var useANSI bool
-		if opt.Output == "" {
+		if output == os.Stdout {
 			if o, err := os.Stdout.Stat(); err == nil {
 				useANSI = (o.Mode() & os.ModeCharDevice) == os.ModeCharDevice
 			}

--- a/pkg/cloud/report/resource_test.go
+++ b/pkg/cloud/report/resource_test.go
@@ -1,8 +1,7 @@
 package report
 
 import (
-	"os"
-	"path/filepath"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,18 +109,15 @@ No problems detected.
 				tt.options.AWSOptions.Services,
 			)
 
-			output := filepath.Join(t.TempDir(), "output")
-			tt.options.Output = output
+			output := bytes.NewBuffer(nil)
+			tt.options.SetOutputWriter(output)
 			require.NoError(t, Write(report, tt.options, tt.fromCache))
 
 			assert.Equal(t, "AWS", report.Provider)
 			assert.Equal(t, tt.options.AWSOptions.Account, report.AccountID)
 			assert.Equal(t, tt.options.AWSOptions.Region, report.Region)
 			assert.ElementsMatch(t, tt.options.AWSOptions.Services, report.ServicesInScope)
-
-			b, err := os.ReadFile(output)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, string(b))
+			assert.Equal(t, tt.expected, output.String())
 		})
 	}
 }

--- a/pkg/cloud/report/result_test.go
+++ b/pkg/cloud/report/result_test.go
@@ -1,8 +1,7 @@
 package report
 
 import (
-	"os"
-	"path/filepath"
+	"bytes"
 	"strings"
 	"testing"
 
@@ -69,18 +68,15 @@ See https://avd.aquasec.com/misconfig/avd-aws-9999
 				tt.options.AWSOptions.Services,
 			)
 
-			output := filepath.Join(t.TempDir(), "output")
-			tt.options.Output = output
+			output := bytes.NewBuffer(nil)
+			tt.options.SetOutputWriter(output)
 			require.NoError(t, Write(report, tt.options, tt.fromCache))
-
-			b, err := os.ReadFile(output)
-			require.NoError(t, err)
 
 			assert.Equal(t, "AWS", report.Provider)
 			assert.Equal(t, tt.options.AWSOptions.Account, report.AccountID)
 			assert.Equal(t, tt.options.AWSOptions.Region, report.Region)
 			assert.ElementsMatch(t, tt.options.AWSOptions.Services, report.ServicesInScope)
-			assert.Equal(t, tt.expected, strings.ReplaceAll(string(b), "\r\n", "\n"))
+			assert.Equal(t, tt.expected, strings.ReplaceAll(output.String(), "\r\n", "\n"))
 		})
 	}
 }

--- a/pkg/cloud/report/service_test.go
+++ b/pkg/cloud/report/service_test.go
@@ -1,8 +1,7 @@
 package report
 
 import (
-	"os"
-	"path/filepath"
+	"bytes"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -317,8 +316,8 @@ Scan Overview for AWS Account
 				tt.options.AWSOptions.Services,
 			)
 
-			output := filepath.Join(t.TempDir(), "output")
-			tt.options.Output = output
+			output := bytes.NewBuffer(nil)
+			tt.options.SetOutputWriter(output)
 			require.NoError(t, Write(report, tt.options, tt.fromCache))
 
 			assert.Equal(t, "AWS", report.Provider)
@@ -326,13 +325,11 @@ Scan Overview for AWS Account
 			assert.Equal(t, tt.options.AWSOptions.Region, report.Region)
 			assert.ElementsMatch(t, tt.options.AWSOptions.Services, report.ServicesInScope)
 
-			b, err := os.ReadFile(output)
-			require.NoError(t, err)
 			if tt.options.Format == "json" {
 				// json output can be formatted/ordered differently - we just care that the data matches
-				assert.JSONEq(t, tt.expected, string(b))
+				assert.JSONEq(t, tt.expected, output.String())
 			} else {
-				assert.Equal(t, tt.expected, string(b))
+				assert.Equal(t, tt.expected, output.String())
 			}
 		})
 	}

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -95,11 +95,11 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		return xerrors.Errorf("k8s scan error: %w", err)
 	}
 
-	output, err := r.flagOpts.OutputWriter()
+	output, cleanup, err := r.flagOpts.OutputWriter()
 	if err != nil {
 		return xerrors.Errorf("failed to create output file: %w", err)
 	}
-	defer output.Close()
+	defer cleanup()
 
 	if r.flagOpts.Compliance.Spec.ID != "" {
 		var scanResults []types.Results

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aquasecurity/tml"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/types"
-	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
 
 var (
@@ -137,7 +136,7 @@ func IsOutputToTerminal(output io.Writer) bool {
 		return false
 	}
 
-	if output != xio.NopCloser(os.Stdout) {
+	if output != os.Stdout {
 		return false
 	}
 	o, err := os.Stdout.Stat()

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -25,11 +25,11 @@ const (
 
 // Write writes the result to output, format as passed in argument
 func Write(report types.Report, option flag.Options) error {
-	output, err := option.OutputWriter()
+	output, cleanup, err := option.OutputWriter()
 	if err != nil {
 		return xerrors.Errorf("failed to create a file: %w", err)
 	}
-	defer output.Close()
+	defer cleanup()
 
 	// Compliance report
 	if option.Compliance.Spec.ID != "" {

--- a/pkg/x/io/io.go
+++ b/pkg/x/io/io.go
@@ -9,18 +9,6 @@ import (
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
 )
 
-// NopCloser returns a WriteCloser with a no-op Close method wrapping
-// the provided Writer w.
-func NopCloser(w io.Writer) io.WriteCloser {
-	return nopCloser{w}
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (nopCloser) Close() error { return nil }
-
 func NewReadSeekerAt(r io.Reader) (dio.ReadSeekerAt, error) {
 	if rr, ok := r.(dio.ReadSeekerAt); ok {
 		return rr, nil


### PR DESCRIPTION
## Description
See https://github.com/aquasecurity/trivy/issues/5560

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5560

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
