### PR TITLE
chore: not load plugins for auto-generating docs

### DIFF
--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -16,6 +16,9 @@ func main() {
 	flag.CacheDirFlag.Default = "/path/to/cache"
 	flag.ModuleDirFlag.Default = "$HOME/.trivy/modules"
 
+	// Set a dummy path not to load plugins
+	os.Setenv("XDG_DATA_HOME", os.TempDir())
+
 	cmd := commands.NewApp()
 	cmd.DisableAutoGenTag = true
 	if err := doc.GenMarkdownTree(cmd, "./docs/docs/references/configuration/cli"); err != nil {

--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra/doc"
 
 	"github.com/aquasecurity/trivy/pkg/commands"


### PR DESCRIPTION
## Description
If a plugin is installed locally, `mage docs:genarete` also generates references for the plugin subcommand. This PR sets a dummy XDG_DATA_HOME so that the plugin is not loaded.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
