### PR TITLE
chore: sort supported AWS services

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -7,6 +7,7 @@
 Scan an AWS account for misconfigurations. Trivy uses the same authentication methods as the AWS CLI. See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 
 The following services are supported:
+
 - accessanalyzer
 - api-gateway
 - athena

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -972,6 +973,7 @@ func NewAWSCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 
 	services := awsScanner.AllSupportedServices()
+	sort.Strings(services)
 
 	cmd := &cobra.Command{
 		Use:     "aws [flags]",

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -984,6 +984,7 @@ func NewAWSCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		Long: fmt.Sprintf(`Scan an AWS account for misconfigurations. Trivy uses the same authentication methods as the AWS CLI. See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 
 The following services are supported:
+
 - %s
 `, strings.Join(services, "\n- ")),
 		Example: `  # basic scanning


### PR DESCRIPTION
## Description
`trivy aws --help` shows a list of supported services, and it is also shown in the document.
https://aquasecurity.github.io/trivy/v0.47/docs/references/configuration/cli/trivy_aws/

The order is not consistent, and `mage docs:geneate` can generate some differences. This PR sorts supported services for the consistent document.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
