### PR TITLE
chore: show a deprecation notice for `--scanners config`

### DIFF
--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
 	xstrings "github.com/aquasecurity/trivy/pkg/x/strings"
 )
@@ -41,7 +42,10 @@ var (
 			switch s {
 			case "vulnerability":
 				return string(types.VulnerabilityScanner)
-			case "config", "misconf", "misconfiguration":
+			case "misconf", "misconfiguration":
+				return string(types.MisconfigScanner)
+			case "config":
+				log.Logger.Warn("'--scanner config' is deprecated. Use '--scanner misconfig' instead. See https://github.com/aquasecurity/trivy/discussions/5586 for the detail.")
 				return string(types.MisconfigScanner)
 			}
 			return s


### PR DESCRIPTION
## Description
It shows a warning message to encourage users to migrate to `--scanners misconfig`.

```
$ trivy repo --scanners config .
2023-11-15T11:35:57.027+0900    WARN    '--scanner config' is deprecated. Use '--scanner misconfig' instead. See https://github.com/aquasecurity/trivy/discussions/5586 for the detail.
2023-11-15T11:35:57.036+0900    INFO    Misconfiguration scanning is enabled
```

## Related PRs
- https://github.com/aquasecurity/trivy/pull/5558

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
