### PR TITLE
fix: k8s friendly error messages kbom non cluster scans

### DIFF
--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -48,12 +48,12 @@ func Run(ctx context.Context, args []string, opts flag.Options) error {
 		return clusterRun(ctx, opts, cluster)
 	case allArtifact:
 		if opts.Format == types.FormatCycloneDX {
-			return xerrors.Errorf("Error: KBOM with CycloneDX format is not supported for all namespace scans")
+			return xerrors.Errorf("KBOM with CycloneDX format is not supported for all namespace scans")
 		}
 		return namespaceRun(ctx, opts, cluster)
 	default: // resourceArtifact
 		if opts.Format == types.FormatCycloneDX {
-			return xerrors.Errorf("Error: KBOM with CycloneDX format is not supported for resource scans")
+			return xerrors.Errorf("KBOM with CycloneDX format is not supported for resource scans")
 		}
 		return resourceRun(ctx, args, opts, cluster)
 	}

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -47,8 +47,14 @@ func Run(ctx context.Context, args []string, opts flag.Options) error {
 	case clusterArtifact:
 		return clusterRun(ctx, opts, cluster)
 	case allArtifact:
+		if opts.Format == types.FormatCycloneDX {
+			return xerrors.Errorf("Error: KBOM with CycloneDX format is not supported for all namespace scans")
+		}
 		return namespaceRun(ctx, opts, cluster)
 	default: // resourceArtifact
+		if opts.Format == types.FormatCycloneDX {
+			return xerrors.Errorf("Error: KBOM with CycloneDX format is not supported for resource scans")
+		}
 		return resourceRun(ctx, args, opts, cluster)
 	}
 }


### PR DESCRIPTION
## Description
fix: k8s friendly error messages kbom non cluster scans

## Related issues
- Close #5264

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).


Usage:  

```sh
 trivy k8s all --format cyclonedx
2023-11-15T14:43:48.113+0200	INFO	"k8s with --format cyclonedx" disable security scanning
2023-11-15T14:43:48.120+0200	FATAL	Error: KBOM with CycloneDX format is not supported for all namespace scans
```

```sh
trivy k8s --format cyclonedx  -n kube-system pods/coredns-558bd4d5db-h22jb
2023-11-15T14:46:02.809+0200	INFO	"k8s with --format cyclonedx" disable security scanning
2023-11-15T14:46:02.816+0200	FATAL	Error: KBOM with CycloneDX format is not supported for resource scans
```
