### PR TITLE
fix(report): use time.Time for CreatedAt

### DIFF
--- a/integration/testdata/almalinux-8.json.golden
+++ b/integration/testdata/almalinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/almalinux-8.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-310-registry.json.golden
+++ b/integration/testdata/alpine-310-registry.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "localhost:53869/alpine:3.10",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-310.json.golden
+++ b/integration/testdata/alpine-310.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-310.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-39-high-critical.json.golden
+++ b/integration/testdata/alpine-39-high-critical.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-39-ignore-cveids.json.golden
+++ b/integration/testdata/alpine-39-ignore-cveids.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-39-skip.json.golden
+++ b/integration/testdata/alpine-39-skip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-39.json.golden
+++ b/integration/testdata/alpine-39.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/alpine-distroless.json.golden
+++ b/integration/testdata/alpine-distroless.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/alpine-distroless.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/amazon-1.json.golden
+++ b/integration/testdata/amazon-1.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/amazon-1.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/amazon-2.json.golden
+++ b/integration/testdata/amazon-2.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/amazon-2.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/amazonlinux2-gp2-x86-vm.json.golden
+++ b/integration/testdata/amazonlinux2-gp2-x86-vm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "disk.img",
   "ArtifactType": "vm",
   "Metadata": {

--- a/integration/testdata/busybox-with-lockfile.json.golden
+++ b/integration/testdata/busybox-with-lockfile.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/busybox-with-lockfile.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/centos-6.json.golden
+++ b/integration/testdata/centos-6.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/centos-6.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/centos-7-ignore-unfixed.json.golden
+++ b/integration/testdata/centos-7-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/centos-7-medium.json.golden
+++ b/integration/testdata/centos-7-medium.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/centos-7.json.golden
+++ b/integration/testdata/centos-7.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/cocoapods.json.golden
+++ b/integration/testdata/cocoapods.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/cocoapods",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/composer.lock.json.golden
+++ b/integration/testdata/composer.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/composer",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/conan.json.golden
+++ b/integration/testdata/conan.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/conan",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/debian-buster-ignore-unfixed.json.golden
+++ b/integration/testdata/debian-buster-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/debian-buster.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/debian-buster.json.golden
+++ b/integration/testdata/debian-buster.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/debian-buster.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/debian-stretch.json.golden
+++ b/integration/testdata/debian-stretch.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/debian-stretch.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/distroless-base.json.golden
+++ b/integration/testdata/distroless-base.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/distroless-base.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/distroless-python27.json.golden
+++ b/integration/testdata/distroless-python27.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/distroless-python27.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/dockerfile-custom-policies.json.golden
+++ b/integration/testdata/dockerfile-custom-policies.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/custom-policy",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/dockerfile-namespace-exception.json.golden
+++ b/integration/testdata/dockerfile-namespace-exception.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/namespace-exception",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/dockerfile-rule-exception.json.golden
+++ b/integration/testdata/dockerfile-rule-exception.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/rule-exception",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/dockerfile.json.golden
+++ b/integration/testdata/dockerfile.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dockerfile",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/dockerfile_file_pattern.json.golden
+++ b/integration/testdata/dockerfile_file_pattern.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dockerfile_file_pattern",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/dotnet.json.golden
+++ b/integration/testdata/dotnet.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dotnet",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/fluentd-gems.json.golden
+++ b/integration/testdata/fluentd-gems.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/fluentd-multiple-lockfiles.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/fluentd-multiple-lockfiles.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/sbom/fluentd-multiple-lockfiles-cyclonedx.json",
   "ArtifactType": "cyclonedx",
   "Metadata": {

--- a/integration/testdata/gomod-skip.json.golden
+++ b/integration/testdata/gomod-skip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gomod",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/gomod.json.golden
+++ b/integration/testdata/gomod.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gomod",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/gradle.json.golden
+++ b/integration/testdata/gradle.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gradle",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/helm.json.golden
+++ b/integration/testdata/helm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/helm_badname.json.golden
+++ b/integration/testdata/helm_badname.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_badname",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/helm_testchart.json.golden
+++ b/integration/testdata/helm_testchart.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_testchart",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/helm_testchart.overridden.json.golden
+++ b/integration/testdata/helm_testchart.overridden.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_testchart",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/mariner-1.0.json.golden
+++ b/integration/testdata/mariner-1.0.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/mariner-1.0.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/minikube-kbom.json.golden
+++ b/integration/testdata/minikube-kbom.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/sbom/minikube-kbom.json",
   "ArtifactType": "cyclonedx",
   "Metadata": {

--- a/integration/testdata/mix.lock.json.golden
+++ b/integration/testdata/mix.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/mixlock",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/npm-with-dev.json.golden
+++ b/integration/testdata/npm-with-dev.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/npm",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/npm.json.golden
+++ b/integration/testdata/npm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/npm",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/nuget.json.golden
+++ b/integration/testdata/nuget.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/nuget",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/opensuse-leap-151.json.golden
+++ b/integration/testdata/opensuse-leap-151.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/opensuse-leap-151.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/oraclelinux-8.json.golden
+++ b/integration/testdata/oraclelinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/oraclelinux-8.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/photon-30.json.golden
+++ b/integration/testdata/photon-30.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/photon-30.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/pip.json.golden
+++ b/integration/testdata/pip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pip",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/pipenv.json.golden
+++ b/integration/testdata/pipenv.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pipenv",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/pnpm.json.golden
+++ b/integration/testdata/pnpm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pnpm",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/poetry.json.golden
+++ b/integration/testdata/poetry.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/poetry",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/pom.json.golden
+++ b/integration/testdata/pom.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pom",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/pubspec.lock.json.golden
+++ b/integration/testdata/pubspec.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pubspec",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/rockylinux-8.json.golden
+++ b/integration/testdata/rockylinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/rockylinux-8.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/secrets.json.golden
+++ b/integration/testdata/secrets.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/secrets",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/spring4shell-jre11.json.golden
+++ b/integration/testdata/spring4shell-jre11.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/spring4shell-jre11.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/spring4shell-jre8.json.golden
+++ b/integration/testdata/spring4shell-jre8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/spring4shell-jre8.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/swift.json.golden
+++ b/integration/testdata/swift.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/swift",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/test-repo.json.golden
+++ b/integration/testdata/test-repo.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "https://github.com/knqyf263/trivy-ci-test",
   "ArtifactType": "repository",
   "Metadata": {

--- a/integration/testdata/ubi-7.json.golden
+++ b/integration/testdata/ubi-7.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/ubi-7.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
+++ b/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/ubuntu-1804.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/ubuntu-1804.json.golden
+++ b/integration/testdata/ubuntu-1804.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/images/ubuntu-1804.tar.gz",
   "ArtifactType": "container_image",
   "Metadata": {

--- a/integration/testdata/ubuntu-gp2-x86-vm.json.golden
+++ b/integration/testdata/ubuntu-gp2-x86-vm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "disk.img",
   "ArtifactType": "vm",
   "Metadata": {

--- a/integration/testdata/yarn.json.golden
+++ b/integration/testdata/yarn.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "CreatedAt": 1629894030,
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/yarn",
   "ArtifactType": "repository",
   "Metadata": {

--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,6 +19,7 @@ import (
 )
 
 const expectedS3ScanResult = `{
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "12345678",
   "ArtifactType": "aws_account",
   "Metadata": {
@@ -265,6 +267,7 @@ const expectedS3ScanResult = `{
 `
 
 const expectedCustomScanResult = `{
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "12345678",
   "ArtifactType": "aws_account",
   "Metadata": {
@@ -545,6 +548,7 @@ const expectedCustomScanResult = `{
 `
 
 const expectedS3AndCloudTrailResult = `{
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "123456789",
   "ArtifactType": "aws_account",
   "Metadata": {
@@ -1124,6 +1128,8 @@ Summary Report for compliance: my-custom-spec
 			expectErr:    true,
 		},
 	}
+
+	clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.allServices != nil {

--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aquasecurity/defsec/pkg/scan"
 	"github.com/aquasecurity/tml"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	cr "github.com/aquasecurity/trivy/pkg/compliance/report"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
@@ -94,6 +95,7 @@ func Write(rep *Report, opt flag.Options, fromCache bool) error {
 	})
 
 	base := types.Report{
+		CreatedAt:    clock.Now(),
 		ArtifactName: rep.AccountID,
 		ArtifactType: ftypes.ArtifactAWSAccount,
 		Results:      filtered,

--- a/pkg/cloud/report/service_test.go
+++ b/pkg/cloud/report/service_test.go
@@ -2,7 +2,9 @@ package report
 
 import (
 	"bytes"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/stretchr/testify/assert"
@@ -146,6 +148,7 @@ Scan Overview for AWS Account
 			},
 			fromCache: false,
 			expected: `{
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactType": "aws_account",
   "Metadata": {
     "ImageConfig": {
@@ -306,6 +309,7 @@ Scan Overview for AWS Account
 }`,
 		},
 	}
+	clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			report := New(

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -173,7 +173,7 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 
 	return types.Report{
 		SchemaVersion: report.SchemaVersion,
-		CreatedAt:     clock.Now().Unix(),
+		CreatedAt:     clock.Now(),
 		ArtifactName:  artifactInfo.Name,
 		ArtifactType:  artifactInfo.Type,
 		Metadata: types.Metadata{

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -99,7 +99,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 			},
 			want: types.Report{
 				SchemaVersion: 2,
-				CreatedAt:     1629894030,
+				CreatedAt:     time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC),
 				ArtifactName:  "alpine:3.11",
 				ArtifactType:  ftypes.ArtifactContainerImage,
 				Metadata: types.Metadata{

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1" // nolint: goimports
 
@@ -11,7 +12,7 @@ import (
 // Report represents a scan result
 type Report struct {
 	SchemaVersion int                 `json:",omitempty"`
-	CreatedAt     int64               `json:",omitempty"`
+	CreatedAt     time.Time           `json:",omitempty"`
 	ArtifactName  string              `json:",omitempty"`
 	ArtifactType  ftypes.ArtifactType `json:",omitempty"`
 	Metadata      Metadata            `json:",omitempty"`


### PR DESCRIPTION
## Description
It's more human-readable.

### Before
```
  "CreatedAt": 1629894030,
```

### After
```
  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
```

## Related issues
- https://github.com/aquasecurity/trivy/issues/5542

## Related PRs
- https://github.com/aquasecurity/trivy/issues/5542

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
