### PR TITLE
chore: add prefix to image errors

### DIFF
--- a/pkg/commands/artifact/inject.go
+++ b/pkg/commands/artifact/inject.go
@@ -20,9 +20,9 @@ import (
 // Standalone
 //////////////
 
-// initializeDockerScanner is for container image scanning in standalone mode
+// initializeImageScanner is for container image scanning in standalone mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
+func initializeImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
 	localArtifactCache cache.LocalArtifactCache, imageOpt types.ImageOptions, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneDockerSet)
@@ -67,9 +67,9 @@ func initializeVMScanner(ctx context.Context, filePath string, artifactCache cac
 // Client/Server
 /////////////////
 
-// initializeRemoteDockerScanner is for container image scanning in client/server mode
+// initializeRemoteImageScanner is for container image scanning in client/server mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeRemoteDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
+func initializeRemoteImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
 	remoteScanOptions client.ScannerOption, imageOpt types.ImageOptions, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteDockerSet)

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -12,10 +12,10 @@ import (
 // imageStandaloneScanner initializes a container image scanner in standalone mode
 // $ trivy image alpine:3.15
 func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeDockerScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
+	s, cleanup, err := initializeImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
 		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a docker scanner: %w", err)
+		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize an image scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -34,10 +34,10 @@ func archiveStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.
 // $ trivy image --server localhost:4954 alpine:3.15
 func imageRemoteScanner(ctx context.Context, conf ScannerConfig) (
 	scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteDockerScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
+	s, cleanup, err := initializeRemoteImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
 		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize the remote docker scanner: %w", err)
+		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize a remote image scanner: %w", err)
 	}
 	return s, cleanup, nil
 }

--- a/pkg/commands/artifact/wire_gen.go
+++ b/pkg/commands/artifact/wire_gen.go
@@ -29,9 +29,9 @@ import (
 
 // Injectors from inject.go:
 
-// initializeDockerScanner is for container image scanning in standalone mode
+// initializeImageScanner is for container image scanning in standalone mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, localArtifactCache cache.LocalArtifactCache, imageOpt types.ImageOptions, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+func initializeImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, localArtifactCache cache.LocalArtifactCache, imageOpt types.ImageOptions, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	applierApplier := applier.NewApplier(localArtifactCache)
 	ospkgScanner := ospkg.NewScanner()
 	langpkgScanner := langpkg.NewScanner()
@@ -140,9 +140,9 @@ func initializeVMScanner(ctx context.Context, filePath string, artifactCache cac
 	}, nil
 }
 
-// initializeRemoteDockerScanner is for container image scanning in client/server mode
+// initializeRemoteImageScanner is for container image scanning in client/server mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeRemoteDockerScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, remoteScanOptions client.ScannerOption, imageOpt types.ImageOptions, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+func initializeRemoteImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache, remoteScanOptions client.ScannerOption, imageOpt types.ImageOptions, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	v := _wireValue
 	clientScanner := client.NewScanner(remoteScanOptions, v...)
 	typesImage, cleanup, err := image.NewContainerImage(ctx, imageName, imageOpt)

--- a/pkg/fanal/image/image.go
+++ b/pkg/fanal/image/image.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -50,6 +51,7 @@ func NewContainerImage(ctx context.Context, imageName string, opt types.ImageOpt
 			// Return v1.Image if the image is found
 			return img, cleanup, nil
 		}
+		err = multierror.Prefix(err, fmt.Sprintf("%s error:", src))
 		errs = multierror.Append(errs, err)
 	}
 


### PR DESCRIPTION
## Description
Show more friendly errors from image sources.

### Before

```
$ trivy image foo
...
2023-11-16T15:21:08.107+0900    FATAL   image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
        * unable to inspect the image (foo): Error response from daemon: No such image: foo:latest
        * containerd socket not found: /run/containerd/containerd.sock
        * unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
        * GET https://index.docker.io/v2/library/foo/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/foo Type:repository]]

```

### After

```
$ trivy image foo
...
2023-11-16T15:19:48.658+0900    FATAL   image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
        * docker error: unable to inspect the image (foo): Error response from daemon: No such image: foo:latest
        * containerd error: containerd socket not found: /run/containerd/containerd.sock
        * podman error: unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
        * remote error: GET https://index.docker.io/v2/library/foo/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/foo Type:repository]]
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5600

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
