### PR TITLE
docs: Add Dagger integration section and cleanup Ecosystem CICD docs page

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -34,6 +34,14 @@ The trivy buildkite plugin provides a convenient mechanism for running the open-
 
 👉 Get it at: https://github.com/equinixmetal-buildkite/trivy-buildkite-plugin
 
+## Dagger (Community)
+[Dagger](https://dagger.io/) is CI/CD as code that runs anywhere.
+
+The Dagger module for Trivy provides functions for scanning container images from registries as well as Dagger Container objects from any Dagger SDK (e.g. Go, Python, Node.js, etc).
+
+👉 Get it at: <https://daggerverse.dev/mod/github.com/jpadams/daggerverse/trivy>
+
+
 ## Semaphore (Community)
 [Semaphore](https://semaphoreci.com/) is a CI/CD service.
 

--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -28,7 +28,7 @@ In this action, Trivy scans the dependency files such as package-lock.json and g
 
 👉 Get it at: <https://github.com/marketplace/actions/trivy-github-issues>
 
-### Buildkite Plugin (Community)
+## Buildkite Plugin (Community)
 
 The trivy buildkite plugin provides a convenient mechanism for running the open-source trivy static analysis tool on your project. 
 

--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -1,5 +1,12 @@
 # CI/CD Integrations
 
+## Azure DevOps (Official)
+[Azure Devops](https://azure.microsoft.com/en-us/products/devops/#overview) is Microsoft Azure cloud native CI/CD service.
+
+Trivy has a "Azure Devops Pipelines Task" for Trivy, that lets you easily introduce security scanning into your workflow, with an integrated Azure Devops UI.
+
+👉 Get it at: <https://github.com/aquasecurity/trivy-azure-pipelines-task>
+
 ## GitHub Actions
 [GitHub Actions](https://github.com/features/actions) is GitHub's native CI/CD and job orchestration service.
 
@@ -8,13 +15,6 @@
 GitHub Action for integrating Trivy into your GitHub pipeline
 
 👉 Get it at: <https://github.com/aquasecurity/trivy-action>
-
-## Azure DevOps (Official)
-[Azure Devops](https://azure.microsoft.com/en-us/products/devops/#overview) is Microsoft Azure cloud native CI/CD service.
-
-Trivy has a "Azure Devops Pipelines Task" for Trivy, that lets you easily introduce security scanning into your workflow, with an integrated Azure Devops UI.
-
-👉 Get it at: <https://github.com/aquasecurity/trivy-azure-pipelines-task>
 
 ### trivy-action (Community)
 


### PR DESCRIPTION
## Description
Adds a Dagger integration section and cleans up a couple of minor things on the  Ecosystem CICD docs page.

There is a Dagger integration for Trivy that we want to share through the docs page, so I made an update. In the course of updating the page, I noticed that the Azure DevOps content was stuck in the middle of the GitHub Actions content, so I moved that out to stand alone. I also noticed that integrations were using H2 (##) markdown, but the Buildkite entry was using H3 (###), so I fixed that to make things consistent.

## Related issues
- I tried to open an issue, but got routed to created a discussion: https://github.com/aquasecurity/trivy/discussions/5607 (discussion)

## Related PRs
- none other than this one 😄 

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- n/a ~I've added tests that prove my fix is effective or that my feature works.~
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- n/a ~I've added usage information (if the PR introduces new options)~
- n/a  ~I've included a "before" and "after" example to the description (if the PR is a user interface change).~
