### PR TITLE
docs: Update Arch Linux package URL in installation.md

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,15 +59,15 @@ brew install trivy
 
 ### Arch Linux (Community)
 
-Arch Community Package Manager.
+Arch Linux Package Repository.
 
 ```bash
 pacman -S trivy
 ```
 
 References: 
-- <https://archlinux.org/packages/community/x86_64/trivy/>
-- <https://github.com/archlinux/svntogit-community/blob/packages/trivy/trunk/PKGBUILD>
+- <https://archlinux.org/packages/extra/x86_64/trivy/>
+- <https://gitlab.archlinux.org/archlinux/packaging/packages/trivy/-/blob/main/PKGBUILD>
 
 
 ### MacPorts (Community)


### PR DESCRIPTION
The old package URL returns 404 now, and the old source URL is now archive-only.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
