### PR TITLE
docs: terraform tutorial links updated to point to correct loc

### DIFF
--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -9,7 +9,7 @@ We have been consolidating all of our scanning-related efforts in one place, and
 
 ## Trivy Config Command 
 
-Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/scanning/) 
+Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/) 
 
 Command structure: 
 ``` 
@@ -83,14 +83,14 @@ trivy config --severity CRITICAL, MEDIUM terraform-infra
 
 ### Passing tf.tfvars files into `trivy config` scans 
 
-You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/options/values/) 
+You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/coverage/iac/terraform/#value-overrides) 
 
 ``` 
 trivy conf --tf-vars terraform.tfvars ./
 ``` 
 ### Custom Checks 
 
-We have lots of examples in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
+We have lots of examples in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/) on how you can write and pass custom Rego policies into terraform misconfiguration scans. 
 
 ## Secret and vulnerability scans
 


### PR DESCRIPTION
## Description

Updates broken links on [Scanning Terraform files with Trivy](https://aquasecurity.github.io/trivy/v0.47/tutorials/misconfiguration/terraform/) to point to the correct locations.

## Related issues
- Close #5660

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
