### PR TITLE
feat(misconf): Add `--misconfig-scanners` option

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -86,6 +86,7 @@ trivy aws [flags]
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
       --max-cache-age duration            The maximum age of the cloud cache. Cached data will be requeried from the cloud provider if it is older than this. (default 24h0m0s)
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
   -o, --output string                     output file name
       --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/trivy-policies:0")
       --policy-namespaces strings         Rego namespaces

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -29,6 +29,7 @@ trivy config [flags] DIR
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
   -o, --output string                     output file name
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -51,6 +51,7 @@ trivy filesystem [flags] PATH
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -69,7 +69,6 @@ trivy image [flags] IMAGE_NAME
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
-      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -69,6 +69,7 @@ trivy image [flags] IMAGE_NAME
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -60,7 +60,6 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
-      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
   -n, --namespace string                  specify a namespace to scan
       --no-progress                       suppress progress bar
       --node-collector-namespace string   specify the namespace in which the node-collector job should be deployed (default "trivy-temp")

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -60,6 +60,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
   -n, --namespace string                  specify a namespace to scan
       --no-progress                       suppress progress bar
       --node-collector-namespace string   specify the namespace in which the node-collector job should be deployed (default "trivy-temp")

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -51,6 +51,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -53,6 +53,7 @@ trivy rootfs [flags] ROOTDIR
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -47,7 +47,6 @@ trivy vm [flags] VM_IMAGE
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
-      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -47,6 +47,7 @@ trivy vm [flags] VM_IMAGE
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
+      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -269,7 +269,7 @@ misconfiguration:
   
   # Same as '--miconfig-scanners'
   # Default is all scanners
-  type:
+  scanners:
     - dockerfile
     - terraform
 

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -266,6 +266,12 @@ misconfiguration:
   # Same as '--include-non-failures'
   # Default is false
   include-non-failures: false
+  
+  # Same as '--miconfig-scanners'
+  # Default is all scanners
+  type:
+    - dockerfile
+    - terraform
 
   # helm value override configurations
   # set individual values

--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -315,6 +315,15 @@ Failures: 2 (MEDIUM: 2, HIGH: 0, CRITICAL: 0)
 This section describes misconfiguration-specific configuration.
 Other common options are documented [here](../../configuration/index.md).
 
+### Enabling a subset of misconfiguration scanners
+It's possible to only enable certain misconfiguration scanners if you prefer. You can do so by passing the `--misconfig-scanners` option.
+This flag takes a comma-separated list of configuration scanner types.
+```bash
+trivy config --misconfig-scanners=terraform,dockerfile .
+```
+
+Will only scan for misconfigurations that pertain to Terraform and Dockerfiles.
+
 ### Pass custom policies
 You can pass policy files or directories including your custom policies through `--policy` option.
 This can be repeated for specifying multiple files or directories.

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -235,6 +235,7 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	misconfFlagGroup := flag.NewMisconfFlagGroup()
 	misconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	misconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
+	misconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	imageFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
@@ -903,6 +904,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	misconfFlagGroup := flag.NewMisconfFlagGroup()
 	misconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	misconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
+	misconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	k8sFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
@@ -1058,6 +1060,7 @@ func NewVMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	vmFlags.ScanFlagGroup.IncludeDevDeps = nil             // disable '--include-dev-deps'
 	vmFlags.MisconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	vmFlags.MisconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
+	vmFlags.MisconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	cmd := &cobra.Command{
 		Use:     "vm [flags] VM_IMAGE",

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -235,7 +235,6 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	misconfFlagGroup := flag.NewMisconfFlagGroup()
 	misconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	misconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
-	misconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	imageFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
@@ -904,7 +903,6 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	misconfFlagGroup := flag.NewMisconfFlagGroup()
 	misconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	misconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
-	misconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	k8sFlags := &flag.Flags{
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
@@ -1060,7 +1058,6 @@ func NewVMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	vmFlags.ScanFlagGroup.IncludeDevDeps = nil             // disable '--include-dev-deps'
 	vmFlags.MisconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	vmFlags.MisconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
-	vmFlags.MisconfFlagGroup.MisconfigScanners = nil       // disable '--misconfig-scanners'
 
 	cmd := &cobra.Command{
 		Use:     "vm [flags] VM_IMAGE",

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -521,7 +521,7 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 	return analyzers
 }
 
-func filterMisconfigAnalyzers(included []analyzer.Type, all []analyzer.Type) ([]analyzer.Type, error) {
+func filterMisconfigAnalyzers(included, all []analyzer.Type) ([]analyzer.Type, error) {
 	_, missing := lo.Difference(all, included)
 	if len(missing) > 0 {
 		return nil, xerrors.Errorf("invalid misconfiguration scanner specified %s valid scanners: %s", missing, all)

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -3,7 +3,9 @@ package flag
 import (
 	"fmt"
 
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/policy"
+	xstrings "github.com/aquasecurity/trivy/pkg/x/strings"
 )
 
 // e.g. config yaml:
@@ -73,6 +75,12 @@ var (
 		Default:    fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
 		Usage:      "OCI registry URL to retrieve policy bundle from",
 	}
+	MisconfigScannersFlag = Flag{
+		Name:       "misconfig-scanners",
+		ConfigName: "misconfiguration.scanners",
+		Default:    xstrings.ToStringSlice(analyzer.TypeConfigFiles),
+		Usage:      "comma-separated list of misconfig scanners to use for misconfiguration scanning",
+	}
 )
 
 // MisconfFlagGroup composes common printer flag structs used for commands providing misconfiguration scanning.
@@ -89,6 +97,7 @@ type MisconfFlagGroup struct {
 	TerraformTFVars            *Flag
 	CloudformationParamVars    *Flag
 	TerraformExcludeDownloaded *Flag
+	MisconfigScanners          *Flag
 }
 
 type MisconfOptions struct {
@@ -104,6 +113,7 @@ type MisconfOptions struct {
 	TerraformTFVars         []string
 	CloudFormationParamVars []string
 	TfExcludeDownloaded     bool
+	MisconfigScanners       []analyzer.Type
 }
 
 func NewMisconfFlagGroup() *MisconfFlagGroup {
@@ -119,6 +129,7 @@ func NewMisconfFlagGroup() *MisconfFlagGroup {
 		TerraformTFVars:            &TfVarsFlag,
 		CloudformationParamVars:    &CfParamsFlag,
 		TerraformExcludeDownloaded: &TerraformExcludeDownloaded,
+		MisconfigScanners:          &MisconfigScannersFlag,
 	}
 }
 
@@ -138,6 +149,7 @@ func (f *MisconfFlagGroup) Flags() []*Flag {
 		f.TerraformTFVars,
 		f.TerraformExcludeDownloaded,
 		f.CloudformationParamVars,
+		f.MisconfigScanners,
 	}
 }
 
@@ -153,5 +165,6 @@ func (f *MisconfFlagGroup) ToOptions() (MisconfOptions, error) {
 		TerraformTFVars:         getStringSlice(f.TerraformTFVars),
 		CloudFormationParamVars: getStringSlice(f.CloudformationParamVars),
 		TfExcludeDownloaded:     getBool(f.TerraformExcludeDownloaded),
+		MisconfigScanners:       getUnderlyingStringSlice[analyzer.Type](f.MisconfigScanners),
 	}, nil
 }


### PR DESCRIPTION
## Description
Adds the `--misconfig-scanners` option to enable a subset of misconfiguration scanners.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/4901

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
