### PR TITLE
docs: typo in modules.md

### DIFF
--- a/docs/docs/advanced/modules.md
+++ b/docs/docs/advanced/modules.md
@@ -328,7 +328,7 @@ Put the built binary to the module directory that is under the home directory by
 
 ```bash
 $ mkdir -p ~/.trivy/modules
-$ cp spring4shell.wasm ~/.trivy/modules
+$ cp wordpress.wasm ~/.trivy/modules
 ```
 
 ## Distribute Your Module


### PR DESCRIPTION
## Description

In the build section, the file name of the last build was `spring4shell.wasm`, so this has been corrected.
https://aquasecurity.github.io/trivy/dev/docs/advanced/modules/
<img width="862" alt="screenshot_modules" src="https://github.com/aquasecurity/trivy/assets/47747828/517be9a4-bfc4-4960-9cb8-09fcf99f6b24">

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
