### PR TITLE
feat(secret): added support of Docker registry credentials

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -794,11 +794,12 @@ var builtinRules = []Rule{
 		Keywords:        []string{"typeform"},
 	},
 	{
-		ID:       "dockerconfig-secret",
-		Category: CategoryDocker,
-		Title:    "Dockerconfig secret exposed",
-		Severity: "HIGH",
-		Regex:    MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(?P<secret>(ey|ew)+[A-Za-z0-9\/\+=]+))`),
-		Keywords: []string{"dockerc"},
+		ID:              "dockerconfig-secret",
+		Category:        CategoryDocker,
+		Title:           "Dockerconfig secret exposed",
+		Severity:        "HIGH",
+		Regex:           MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(?P<secret>(ey|ew)+[A-Za-z0-9\/\+=]+))`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"dockerc"},
 	},
 }

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -794,12 +794,11 @@ var builtinRules = []Rule{
 		Keywords:        []string{"typeform"},
 	},
 	{
-		ID:              "dockerconfig-secret",
-		Category:        CategoryDocker,
-		Title:           "Dockerconfig secret exposed",
-		Severity:        "HIGH",
-		Regex:           MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(ey|ew)+)`),
-		SecretGroupName: "secret",
-		Keywords:        []string{"dockerconfig"},
+		ID:       "dockerconfig-secret",
+		Category: CategoryDocker,
+		Title:    "Dockerconfig secret exposed",
+		Severity: "HIGH",
+		Regex:    MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(ey|ew)+)`),
+		Keywords: []string{"dockerc"},
 	},
 }

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -798,7 +798,7 @@ var builtinRules = []Rule{
 		Category: CategoryDocker,
 		Title:    "Dockerconfig secret exposed",
 		Severity: "HIGH",
-		Regex:    MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(ey|ew)+)`),
+		Regex:    MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(?P<secret>(ey|ew)+[A-Za-z0-9\/\+=]+))`),
 		Keywords: []string{"dockerc"},
 	},
 }

--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -68,6 +68,7 @@ var (
 	CategoryLinkedIn             = types.SecretRuleCategory("LinkedIn")
 	CategoryTwitch               = types.SecretRuleCategory("Twitch")
 	CategoryTypeform             = types.SecretRuleCategory("Typeform")
+	CategoryDocker               = types.SecretRuleCategory("Docker")
 )
 
 // Reusable regex patterns
@@ -791,5 +792,14 @@ var builtinRules = []Rule{
 		Regex:           MustCompile(`(?i)(?P<key>typeform[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}(?P<secret>tfp_[a-z0-9\-_\.=]{59})`),
 		SecretGroupName: "secret",
 		Keywords:        []string{"typeform"},
+	},
+	{
+		ID:              "dockerconfig-secret",
+		Category:        CategoryDocker,
+		Title:           "Dockerconfig secret exposed",
+		Severity:        "HIGH",
+		Regex:           MustCompile(`(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(ey|ew)+)`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"dockerconfig"},
 	},
 }

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -526,6 +526,68 @@ func TestSecretScanner(t *testing.T) {
 			},
 		},
 	}
+	wantFindingDockerKey1 := types.SecretFinding{
+		RuleID:    "dockerconfig-secret",
+		Category:  secret.CategoryDocker,
+		Title:     "Dockerconfig secret exposed",
+		Severity:  "HIGH",
+		StartLine: 4,
+		EndLine:   4,
+		Match:     "  .dockercfg: ************",
+		Code: types.Code{
+			Lines: []types.Line{
+				{
+					Number:      2,
+					Content:     "  .dockerconfigjson: ************",
+					Highlighted: "  .dockerconfigjson: ************",
+				},
+				{
+					Number:      3,
+					Content:     "data2:",
+					Highlighted: "data2:",
+				},
+				{
+					Number:      4,
+					Content:     "  .dockercfg: ************",
+					Highlighted: "  .dockercfg: ************",
+					IsCause:     true,
+					FirstCause:  true,
+					LastCause:   true,
+				},
+			},
+		},
+	}
+	wantFindingDockerKey2 := types.SecretFinding{
+		RuleID:    "dockerconfig-secret",
+		Category:  secret.CategoryDocker,
+		Title:     "Dockerconfig secret exposed",
+		Severity:  "HIGH",
+		StartLine: 2,
+		EndLine:   2,
+		Match:     "  .dockerconfigjson: ************",
+		Code: types.Code{
+			Lines: []types.Line{
+				{
+					Number:      1,
+					Content:     "data1:",
+					Highlighted: "data1:",
+				},
+				{
+					Number:      2,
+					Content:     "  .dockerconfigjson: ************",
+					Highlighted: "  .dockerconfigjson: ************",
+					IsCause:     true,
+					FirstCause:  true,
+					LastCause:   true,
+				},
+				{
+					Number:      3,
+					Content:     "data2:",
+					Highlighted: "data2:",
+				},
+			},
+		},
+	}
 	wantMultiLine := types.SecretFinding{
 		RuleID:    "multi-line-secret",
 		Category:  "general",
@@ -607,6 +669,15 @@ func TestSecretScanner(t *testing.T) {
 			want: types.Secret{
 				FilePath: filepath.Join("testdata", "asymmetric-private-secret.json"),
 				Findings: []types.SecretFinding{wantFindingAsymmetricPrivateKeyJson},
+			},
+		},
+		{
+			name:          "find Docker registry credentials",
+			configPath:    filepath.Join("testdata", "skip-test.yaml"),
+			inputFilePath: filepath.Join("testdata", "docker-secrets.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "docker-secrets.txt"),
+				Findings: []types.SecretFinding{wantFindingDockerKey1, wantFindingDockerKey2},
 			},
 		},
 		{

--- a/pkg/fanal/secret/testdata/docker-secrets.txt
+++ b/pkg/fanal/secret/testdata/docker-secrets.txt
@@ -1,0 +1,4 @@
+data1:
+  .dockerconfigjson: eyE1x2a3MpLe
+data2:
+  .dockercfg: ewE1x2a3MpLe


### PR DESCRIPTION
Issue: https://github.com/aquasecurity/trivy/issues/5669

## Description
added support of Docker registry credentials

## Related issues
- Close #5669


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
