### PR TITLE
feat(secret): add support of GitHub fine-grained tokens

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -143,6 +143,14 @@ var builtinRules = []Rule{
 		Keywords: []string{"ghr_"},
 	},
 	{
+		ID:       "github_pat",
+		Category: CategoryGitHub,
+		Title:    "GitHub Fine-grained personal access tokens",
+		Severity: "CRITICAL",
+		Regex:    MustCompile(`^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$`),
+		Keywords: []string{"github_pat_"},
+	},
+	{
 		ID:       "gitlab-pat",
 		Category: CategoryGitLab,
 		Title:    "GitLab Personal Access Token",


### PR DESCRIPTION
Issue: https://github.com/aquasecurity/trivy/issues/5650

## Description

added support of GitHub fine-grained tokens
ref: [github fine-grained-personal-access-tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens)

## Related issues
- Close #XXX

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
