### PR TITLE
docs(k8s): replace --scanners config with --scanners misconfig in docs

### DIFF
--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -134,7 +134,7 @@ Filter by scanners (Vulnerabilities, Secrets or Misconfigurations):
 ```
 trivy k8s --scanners=secret --report=summary cluster
 # or
-trivy k8s --scanners=config --report=summary cluster
+trivy k8s --scanners=misconfig --report=summary cluster
 ```
 
 The supported output formats are `table`, which is the default, and `json`.


### PR DESCRIPTION
## Description

## Related issues
- Relates to https://github.com/aquasecurity/trivy/discussions/5586


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [N/A] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [N/A] I've added usage information (if the PR introduces new options)
- [N/A] I've included a "before" and "after" example to the description (if the PR is a user interface change).
