### PR TITLE
refactor(vuln): don't remove VendorSeverity in JSON report

### DIFF
--- a/integration/testdata/almalinux-8.json.golden
+++ b/integration/testdata/almalinux-8.json.golden
@@ -76,6 +76,18 @@
           "CweIDs": [
             "CWE-125"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 3,
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 2,
+            "rocky": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:P",

--- a/integration/testdata/alpine-310-registry.json.golden
+++ b/integration/testdata/alpine-310-registry.json.golden
@@ -84,6 +84,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -145,6 +153,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -216,6 +232,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -277,6 +301,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/alpine-310.json.golden
+++ b/integration/testdata/alpine-310.json.golden
@@ -78,6 +78,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -139,6 +147,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -210,6 +226,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -271,6 +295,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/alpine-39-high-critical.json.golden
+++ b/integration/testdata/alpine-39-high-critical.json.golden
@@ -77,6 +77,9 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "nvd": 4
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -116,6 +119,9 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "nvd": 4
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/alpine-39-ignore-cveids.json.golden
+++ b/integration/testdata/alpine-39-ignore-cveids.json.golden
@@ -78,6 +78,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -149,6 +157,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/alpine-39.json.golden
+++ b/integration/testdata/alpine-39.json.golden
@@ -78,6 +78,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -139,6 +147,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -210,6 +226,14 @@
           "CweIDs": [
             "CWE-330"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -271,6 +295,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -341,6 +373,9 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "nvd": 4
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -380,6 +415,9 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "nvd": 4
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/alpine-distroless.json.golden
+++ b/integration/testdata/alpine-distroless.json.golden
@@ -67,6 +67,9 @@
           "CweIDs": [
             "CWE-427"
           ],
+          "VendorSeverity": {
+            "ubuntu": 2
+          },
           "References": [
             "http://www.openwall.com/lists/oss-security/2022/04/12/7",
             "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24765",

--- a/integration/testdata/amazon-1.json.golden
+++ b/integration/testdata/amazon-1.json.golden
@@ -77,6 +77,15 @@
           "CweIDs": [
             "CWE-415"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 4,
+            "oracle-oval": 2,
+            "photon": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/amazon-2.json.golden
+++ b/integration/testdata/amazon-2.json.golden
@@ -77,6 +77,15 @@
           "CweIDs": [
             "CWE-415"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 4,
+            "oracle-oval": 2,
+            "photon": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -136,6 +145,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "arch-linux": 3,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/busybox-with-lockfile.json.golden
+++ b/integration/testdata/busybox-with-lockfile.json.golden
@@ -76,6 +76,9 @@
           "CweIDs": [
             "CWE-674"
           ],
+          "VendorSeverity": {
+            "nvd": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
@@ -115,6 +118,9 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "nvd": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/centos-6.json.golden
+++ b/integration/testdata/centos-6.json.golden
@@ -93,6 +93,14 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
@@ -139,6 +147,14 @@
           "CweIDs": [
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/centos-7-ignore-unfixed.json.golden
+++ b/integration/testdata/centos-7-ignore-unfixed.json.golden
@@ -87,6 +87,14 @@
           "CweIDs": [
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
@@ -169,6 +177,16 @@
           "CweIDs": [
             "CWE-327"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 1,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/centos-7-medium.json.golden
+++ b/integration/testdata/centos-7-medium.json.golden
@@ -87,6 +87,14 @@
           "CweIDs": [
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/centos-7.json.golden
+++ b/integration/testdata/centos-7.json.golden
@@ -83,6 +83,14 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -133,6 +141,14 @@
           "CweIDs": [
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
@@ -215,6 +231,16 @@
           "CweIDs": [
             "CWE-327"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 1,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/cocoapods.json.golden
+++ b/integration/testdata/cocoapods.json.golden
@@ -41,6 +41,9 @@
           "Title": "SwiftNIO vulnerable to Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')",
           "Description": "`NIOHTTP1` and projects using it for generating HTTP responses, including SwiftNIO, can be subject to a HTTP Response Injection attack...",
           "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "ghsa": 2
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",

--- a/integration/testdata/composer.lock.json.golden
+++ b/integration/testdata/composer.lock.json.golden
@@ -78,6 +78,9 @@
           "CweIDs": [
             "CWE-20"
           ],
+          "VendorSeverity": {
+            "ghsa": 3
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",

--- a/integration/testdata/conda-spdx.json.golden
+++ b/integration/testdata/conda-spdx.json.golden
@@ -75,23 +75,23 @@
   ],
   "files": [
     {
-      "fileName": "miniconda3/envs/testenv/conda-meta/openssl-1.1.1q-h7f8727e_0.json",
-      "SPDXID": "SPDXRef-File-600e5e0110a84891",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "237db0da53131e4548cb1181337fa0f420299e1f"
-        }
-      ],
-      "copyrightText": ""
-    },
-    {
       "fileName": "miniconda3/envs/testenv/conda-meta/pip-22.2.2-py38h06a4308_0.json",
       "SPDXID": "SPDXRef-File-7eb62e2a3edddc0a",
       "checksums": [
         {
           "algorithm": "SHA1",
           "checksumValue": "a6a2db7668f1ad541d704369fc66c96a4415aa24"
+        }
+      ],
+      "copyrightText": ""
+    },
+    {
+      "fileName": "miniconda3/envs/testenv/conda-meta/openssl-1.1.1q-h7f8727e_0.json",
+      "SPDXID": "SPDXRef-File-600e5e0110a84891",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "237db0da53131e4548cb1181337fa0f420299e1f"
         }
       ],
       "copyrightText": ""
@@ -110,22 +110,22 @@
     },
     {
       "spdxElementId": "SPDXRef-Application-ee5ef1aa4ac89125",
-      "relatedSpdxElement": "SPDXRef-Package-c75d9dc75200186f",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-c75d9dc75200186f",
-      "relatedSpdxElement": "SPDXRef-File-600e5e0110a84891",
-      "relationshipType": "CONTAINS"
-    },
-    {
-      "spdxElementId": "SPDXRef-Application-ee5ef1aa4ac89125",
       "relatedSpdxElement": "SPDXRef-Package-195557cddf18e4a9",
       "relationshipType": "CONTAINS"
     },
     {
       "spdxElementId": "SPDXRef-Package-195557cddf18e4a9",
       "relatedSpdxElement": "SPDXRef-File-7eb62e2a3edddc0a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Application-ee5ef1aa4ac89125",
+      "relatedSpdxElement": "SPDXRef-Package-c75d9dc75200186f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-c75d9dc75200186f",
+      "relatedSpdxElement": "SPDXRef-File-600e5e0110a84891",
       "relationshipType": "CONTAINS"
     }
   ]

--- a/integration/testdata/debian-buster-ignore-unfixed.json.golden
+++ b/integration/testdata/debian-buster-ignore-unfixed.json.golden
@@ -80,6 +80,12 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/debian-buster.json.golden
+++ b/integration/testdata/debian-buster.json.golden
@@ -76,6 +76,15 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -131,6 +140,12 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/debian-stretch.json.golden
+++ b/integration/testdata/debian-stretch.json.golden
@@ -77,6 +77,15 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -132,6 +141,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -193,6 +211,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -254,6 +281,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -315,6 +351,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/distroless-base.json.golden
+++ b/integration/testdata/distroless-base.json.golden
@@ -75,6 +75,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -150,6 +158,14 @@
             "CWE-327",
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 1,
+            "oracle-oval": 2,
+            "photon": 1,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
@@ -227,6 +243,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -302,6 +326,14 @@
             "CWE-327",
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 1,
+            "oracle-oval": 2,
+            "photon": 1,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/distroless-python27.json.golden
+++ b/integration/testdata/distroless-python27.json.golden
@@ -92,6 +92,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -167,6 +175,14 @@
             "CWE-327",
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 1,
+            "oracle-oval": 2,
+            "photon": 1,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
@@ -244,6 +260,14 @@
           "CweIDs": [
             "CWE-200"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "nvd": 2,
+            "oracle-oval": 1,
+            "photon": 2,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -319,6 +343,14 @@
             "CWE-327",
             "CWE-203"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 1,
+            "oracle-oval": 2,
+            "photon": 1,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/dotnet.json.golden
+++ b/integration/testdata/dotnet.json.golden
@@ -54,6 +54,9 @@
           "CweIDs": [
             "CWE-755"
           ],
+          "VendorSeverity": {
+            "ghsa": 3
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",

--- a/integration/testdata/fluentd-gems.json.golden
+++ b/integration/testdata/fluentd-gems.json.golden
@@ -133,6 +133,12 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -195,6 +201,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 4,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/fluentd-multiple-lockfiles.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.json.golden
@@ -45,6 +45,15 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "debian": 1,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -97,6 +106,12 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "nvd": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -157,6 +172,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 4,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/gomod-skip.json.golden
+++ b/integration/testdata/gomod-skip.json.golden
@@ -65,6 +65,9 @@
           "CweIDs": [
             "CWE-682"
           ],
+          "VendorSeverity": {
+            "nvd": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/gomod.json.golden
+++ b/integration/testdata/gomod.json.golden
@@ -65,6 +65,9 @@
           "CweIDs": [
             "CWE-682"
           ],
+          "VendorSeverity": {
+            "nvd": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/gradle.json.golden
+++ b/integration/testdata/gradle.json.golden
@@ -41,6 +41,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 4,
+            "nvd": 4,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
@@ -97,6 +102,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:C",

--- a/integration/testdata/mariner-1.0.json.golden
+++ b/integration/testdata/mariner-1.0.json.golden
@@ -60,6 +60,9 @@
           "CweIDs": [
             "CWE-122"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3
+          },
           "References": [
             "https://github.com/vim/vim/commit/9f8c304c8a390ade133bac29963dc8e56ab14cbc",
             "https://huntr.dev/bounties/fa795954-8775-4f23-98c6-d4d4d3fe8a82",
@@ -91,6 +94,11 @@
           "CweIDs": [
             "CWE-122"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 1,
+            "nvd": 1,
+            "redhat": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/minikube-kbom.json.golden
+++ b/integration/testdata/minikube-kbom.json.golden
@@ -48,6 +48,9 @@
           "Title": "Bypass of seccomp profile enforcement ",
           "Description": "A security issue was discovered in Kubelet that allows pods to bypass the seccomp profile enforcement...",
           "Severity": "LOW",
+          "VendorSeverity": {
+            "k8s": 1
+          },
           "CVSS": {
             "k8s": {
               "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N",

--- a/integration/testdata/mix.lock.json.golden
+++ b/integration/testdata/mix.lock.json.golden
@@ -161,6 +161,9 @@
           "Title": "Phoenix before 1.6.14 mishandles check_origin wildcarding",
           "Description": "socket/transport.ex in Phoenix before 1.6.14 mishandles check_origin wildcarding. NOTE: LiveView applications are unaffected by default because of the presence of a LiveView CSRF token.",
           "Severity": "HIGH",
+          "VendorSeverity": {
+            "ghsa": 3
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",

--- a/integration/testdata/npm-with-dev.json.golden
+++ b/integration/testdata/npm-with-dev.json.golden
@@ -257,6 +257,18 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 2,
+            "ghsa": 2,
+            "nodejs-security-wg": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ruby-advisory-db": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/npm.json.golden
+++ b/integration/testdata/npm.json.golden
@@ -240,6 +240,18 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 2,
+            "ghsa": 2,
+            "nodejs-security-wg": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ruby-advisory-db": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/nuget.json.golden
+++ b/integration/testdata/nuget.json.golden
@@ -71,6 +71,9 @@
           "CweIDs": [
             "CWE-755"
           ],
+          "VendorSeverity": {
+            "ghsa": 3
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",

--- a/integration/testdata/opensuse-leap-151.json.golden
+++ b/integration/testdata/opensuse-leap-151.json.golden
@@ -82,6 +82,9 @@
           "Title": "Security update for openssl-1_1",
           "Description": "This update for openssl-1_1 fixes the following issues:\n\nSecurity issue fixed:\n\n- CVE-2019-1551: Fixed an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli (bsc#1158809).                             \n\nVarious FIPS related improvements were done:\n\n- FIPS: Backport SSH KDF to openssl (jsc#SLE-8789, bsc#1157775).\n- Port FIPS patches from SLE-12 (bsc#1158101).\n- Use SHA-2 in the RSA pairwise consistency check (bsc#1155346).\n\nThis update was imported from the SUSE:SLE-15-SP1:Update update project.",
           "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "suse-cvrf": 2
+          },
           "References": [
             "https://lists.opensuse.org/opensuse-security-announce/2020-01/msg00030.html",
             "https://www.suse.com/support/security/rating/"
@@ -108,6 +111,9 @@
           "Title": "Security update for openssl-1_1",
           "Description": "This update for openssl-1_1 fixes the following issues:\n\nSecurity issue fixed:\n\n- CVE-2019-1551: Fixed an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli (bsc#1158809).                             \n\nVarious FIPS related improvements were done:\n\n- FIPS: Backport SSH KDF to openssl (jsc#SLE-8789, bsc#1157775).\n- Port FIPS patches from SLE-12 (bsc#1158101).\n- Use SHA-2 in the RSA pairwise consistency check (bsc#1155346).\n\nThis update was imported from the SUSE:SLE-15-SP1:Update update project.",
           "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "suse-cvrf": 2
+          },
           "References": [
             "https://lists.opensuse.org/opensuse-security-announce/2020-01/msg00030.html",
             "https://www.suse.com/support/security/rating/"

--- a/integration/testdata/oraclelinux-8.json.golden
+++ b/integration/testdata/oraclelinux-8.json.golden
@@ -86,6 +86,15 @@
           "CweIDs": [
             "CWE-125"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 3,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
@@ -144,6 +153,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 1,
+            "arch-linux": 3,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/packagesprops.json.golden
+++ b/integration/testdata/packagesprops.json.golden
@@ -50,6 +50,9 @@
           "CweIDs": [
             "CWE-755"
           ],
+          "VendorSeverity": {
+            "ghsa": 3
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",

--- a/integration/testdata/photon-30.json.golden
+++ b/integration/testdata/photon-30.json.golden
@@ -87,6 +87,14 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -139,6 +147,15 @@
           "CweIDs": [
             "CWE-415"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 4,
+            "oracle-oval": 2,
+            "photon": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
@@ -198,6 +215,15 @@
           "CweIDs": [
             "CWE-415"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "arch-linux": 2,
+            "nvd": 4,
+            "oracle-oval": 2,
+            "photon": 4,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/pip.json.golden
+++ b/integration/testdata/pip.json.golden
@@ -78,6 +78,12 @@
           "CweIDs": [
             "CWE-331"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3,
+            "redhat": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -125,6 +131,12 @@
           "CweIDs": [
             "CWE-601"
           ],
+          "VendorSeverity": {
+            "ghsa": 2,
+            "nvd": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",

--- a/integration/testdata/pipenv.json.golden
+++ b/integration/testdata/pipenv.json.golden
@@ -54,6 +54,12 @@
           "CweIDs": [
             "CWE-331"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3,
+            "redhat": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
@@ -101,6 +107,12 @@
           "CweIDs": [
             "CWE-601"
           ],
+          "VendorSeverity": {
+            "ghsa": 2,
+            "nvd": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",

--- a/integration/testdata/pnpm.json.golden
+++ b/integration/testdata/pnpm.json.golden
@@ -42,6 +42,18 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 2,
+            "ghsa": 2,
+            "nodejs-security-wg": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ruby-advisory-db": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
@@ -156,6 +168,11 @@
           "Title": "nodejs-lodash: prototype pollution in defaultsDeep function leading to modifying properties",
           "Description": "Versions of lodash lower than 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.",
           "Severity": "CRITICAL",
+          "VendorSeverity": {
+            "ghsa": 4,
+            "nvd": 4,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:N/I:P/A:P",

--- a/integration/testdata/poetry.json.golden
+++ b/integration/testdata/poetry.json.golden
@@ -66,6 +66,12 @@
           "CweIDs": [
             "CWE-331"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3,
+            "redhat": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",

--- a/integration/testdata/pom.json.golden
+++ b/integration/testdata/pom.json.golden
@@ -42,6 +42,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 4,
+            "nvd": 4,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
@@ -99,6 +104,11 @@
           "CweIDs": [
             "CWE-502"
           ],
+          "VendorSeverity": {
+            "ghsa": 3,
+            "nvd": 3,
+            "redhat": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:P/A:C",

--- a/integration/testdata/pubspec.lock.json.golden
+++ b/integration/testdata/pubspec.lock.json.golden
@@ -57,6 +57,9 @@
           "CweIDs": [
             "CWE-74"
           ],
+          "VendorSeverity": {
+            "ghsa": 2
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",

--- a/integration/testdata/rockylinux-8.json.golden
+++ b/integration/testdata/rockylinux-8.json.golden
@@ -76,6 +76,18 @@
           "CweIDs": [
             "CWE-125"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 3,
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 2,
+            "photon": 3,
+            "redhat": 2,
+            "rocky": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:P/I:N/A:P",

--- a/integration/testdata/swift.json.golden
+++ b/integration/testdata/swift.json.golden
@@ -59,6 +59,9 @@
           "Title": "SwiftNIO vulnerable to Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')",
           "Description": "`NIOHTTP1` and projects using it for generating HTTP responses, including SwiftNIO, can be subject to a HTTP Response Injection attack...",
           "Severity": "MEDIUM",
+          "VendorSeverity": {
+            "ghsa": 2
+          },
           "CVSS": {
             "ghsa": {
               "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",

--- a/integration/testdata/test-repo.json.golden
+++ b/integration/testdata/test-repo.json.golden
@@ -41,6 +41,9 @@
           "CweIDs": [
             "CWE-674"
           ],
+          "VendorSeverity": {
+            "nvd": 3
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
@@ -77,6 +80,9 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "nvd": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/integration/testdata/ubi-7.json.golden
+++ b/integration/testdata/ubi-7.json.golden
@@ -94,6 +94,14 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",

--- a/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
+++ b/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
@@ -96,6 +96,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -154,6 +163,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -212,6 +230,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -270,6 +297,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/ubuntu-1804.json.golden
+++ b/integration/testdata/ubuntu-1804.json.golden
@@ -95,6 +95,14 @@
           "CweIDs": [
             "CWE-273"
           ],
+          "VendorSeverity": {
+            "cbl-mariner": 3,
+            "nvd": 3,
+            "oracle-oval": 1,
+            "photon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
@@ -147,6 +155,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -205,6 +222,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -263,6 +289,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
@@ -321,6 +356,15 @@
           "CweIDs": [
             "CWE-787"
           ],
+          "VendorSeverity": {
+            "amazon": 2,
+            "cbl-mariner": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "photon": 2,
+            "redhat": 2,
+            "ubuntu": 2
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",

--- a/integration/testdata/yarn.json.golden
+++ b/integration/testdata/yarn.json.golden
@@ -59,6 +59,18 @@
           "CweIDs": [
             "CWE-79"
           ],
+          "VendorSeverity": {
+            "alma": 2,
+            "amazon": 2,
+            "arch-linux": 2,
+            "ghsa": 2,
+            "nodejs-security-wg": 2,
+            "nvd": 2,
+            "oracle-oval": 2,
+            "redhat": 2,
+            "ruby-advisory-db": 2,
+            "ubuntu": 1
+          },
           "CVSS": {
             "nvd": {
               "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -55,6 +55,9 @@ func TestReportWriter_JSON(t *testing.T) {
 									Title:       "foobar",
 									Description: "baz",
 									Severity:    "HIGH",
+									VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+										vulnerability.NVD: dbTypes.SeverityHigh,
+									},
 								},
 							},
 						},

--- a/pkg/report/predicate/vuln_test.go
+++ b/pkg/report/predicate/vuln_test.go
@@ -64,6 +64,9 @@ func TestWriter_Write(t *testing.T) {
 											Title:       "foobar",
 											Description: "baz",
 											Severity:    "HIGH",
+											VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+												vulnerability.NVD: dbTypes.SeverityHigh,
+											},
 										},
 									},
 								},

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1" // nolint: goimports
@@ -112,22 +111,6 @@ type Result struct {
 	Secrets           []ftypes.SecretFinding     `json:"Secrets,omitempty"`
 	Licenses          []DetectedLicense          `json:"Licenses,omitempty"`
 	CustomResources   []ftypes.CustomResource    `json:"CustomResources,omitempty"`
-}
-
-func (r *Result) MarshalJSON() ([]byte, error) {
-	// VendorSeverity includes all vendor severities.
-	// It would be noisy to users, so it should be removed from the JSON output.
-	for i := range r.Vulnerabilities {
-		r.Vulnerabilities[i].VendorSeverity = nil
-	}
-
-	// Notice the Alias struct prevents MarshalJSON being called infinitely
-	type ResultAlias Result
-	return json.Marshal(&struct {
-		*ResultAlias
-	}{
-		ResultAlias: (*ResultAlias)(r),
-	})
 }
 
 func (r *Result) IsEmpty() bool {


### PR DESCRIPTION
## Description
We need to save `VendorSeverity` field in json format to preserve the ability to populate `ratings` in CycloneDX format in convert mode.
See more in #5666.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
