### PR TITLE
refactor(sbom): disable html escaping for CycloneDX

### DIFF
--- a/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "adduser",
       "version": "3.118",
@@ -62,7 +62,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/apt@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/apt@1.8.2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "apt",
       "version": "1.8.2",
@@ -102,7 +102,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/apt@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/apt@1.8.2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -131,7 +131,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "base-files",
       "version": "10.3+deb10u2",
@@ -142,7 +142,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -171,7 +171,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "base-passwd",
       "version": "3.5.46",
@@ -187,7 +187,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -216,7 +216,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/bash@5.0-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/bash@5.0-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "bash",
       "version": "5.0-4",
@@ -227,7 +227,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/bash@5.0-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/bash@5.0-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -260,7 +260,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "bsdutils",
       "version": "2.33.1-0.1",
@@ -316,7 +316,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -349,7 +349,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ca-certificates@20190110?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ca-certificates@20190110?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ca-certificates",
       "version": "20190110",
@@ -365,7 +365,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ca-certificates@20190110?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ca-certificates@20190110?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -394,7 +394,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/coreutils@8.30-3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/coreutils@8.30-3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "coreutils",
       "version": "8.30-3",
@@ -405,7 +405,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/coreutils@8.30-3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/coreutils@8.30-3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -438,7 +438,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "dash",
       "version": "0.5.10.2-5",
@@ -449,7 +449,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -482,7 +482,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "debconf",
       "version": "1.5.71",
@@ -493,7 +493,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -522,7 +522,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "debian-archive-keyring",
       "version": "2019.1",
@@ -533,7 +533,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -562,7 +562,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "debianutils",
       "version": "4.8.6.1",
@@ -573,7 +573,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -602,7 +602,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/diffutils@3.7-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/diffutils@3.7-3?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "diffutils",
       "version": "3.7-3",
@@ -618,7 +618,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/diffutils@3.7-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/diffutils@3.7-3?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -655,7 +655,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "dpkg",
       "version": "1.19.7",
@@ -681,7 +681,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -710,7 +710,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "e2fsprogs",
       "version": "1.44.5-1+deb10u2",
@@ -726,7 +726,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -759,7 +759,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "fdisk",
       "version": "2.33.1-0.1",
@@ -815,7 +815,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -848,7 +848,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "findutils",
       "version": "4.6.0+git+20190209-2",
@@ -864,7 +864,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -897,7 +897,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "gcc-8-base",
       "version": "8.3.0-6",
@@ -928,7 +928,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -961,7 +961,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "gpgv",
       "version": "2.2.12-1+deb10u1",
@@ -1012,7 +1012,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1045,7 +1045,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/grep@3.3-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/grep@3.3-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "grep",
       "version": "3.3-1",
@@ -1056,7 +1056,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/grep@3.3-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/grep@3.3-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1089,7 +1089,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/gzip@1.9-3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/gzip@1.9-3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "gzip",
       "version": "1.9-3",
@@ -1100,7 +1100,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/gzip@1.9-3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/gzip@1.9-3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1133,7 +1133,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/hostname@3.21?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/hostname@3.21?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "hostname",
       "version": "3.21",
@@ -1144,7 +1144,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/hostname@3.21?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/hostname@3.21?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1173,7 +1173,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "init-system-helpers",
       "version": "1.56+nmu1",
@@ -1189,7 +1189,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1218,7 +1218,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libacl1",
       "version": "2.2.53-4",
@@ -1239,7 +1239,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1272,7 +1272,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libapt-pkg5.0",
       "version": "1.8.2",
@@ -1283,7 +1283,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1312,7 +1312,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "libattr1",
       "version": "2.4.48-4",
@@ -1333,7 +1333,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1370,7 +1370,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "libaudit-common",
       "version": "2.8.4-3",
@@ -1391,7 +1391,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1428,7 +1428,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "libaudit1",
       "version": "2.8.4-3",
@@ -1449,7 +1449,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1486,7 +1486,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libblkid1",
       "version": "2.33.1-0.1",
@@ -1542,7 +1542,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1575,7 +1575,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libbz2-1.0",
       "version": "1.0.6-9.2~deb10u1",
@@ -1591,7 +1591,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1624,7 +1624,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libc-bin",
       "version": "2.28-10",
@@ -1640,7 +1640,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1673,7 +1673,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libc6",
       "version": "2.28-10",
@@ -1689,7 +1689,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1722,7 +1722,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libcap-ng0",
       "version": "0.7.9-2",
@@ -1743,7 +1743,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1776,11 +1776,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libcom-err2",
       "version": "1.44.5-1+deb10u2",
-      "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1813,11 +1813,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libdb5.3",
       "version": "5.3.28+dfsg1-0.5",
-      "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1850,11 +1850,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libdebconfclient0",
       "version": "0.249",
-      "purl": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1883,7 +1883,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libext2fs2",
       "version": "1.44.5-1+deb10u2",
@@ -1899,7 +1899,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -1932,7 +1932,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libfdisk1",
       "version": "2.33.1-0.1",
@@ -1988,7 +1988,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2021,7 +2021,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libffi6",
       "version": "3.2.1-9",
@@ -2032,7 +2032,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2065,11 +2065,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "libgcc1",
       "version": "8.3.0-6",
-      "purl": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2102,7 +2102,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libgcrypt20",
       "version": "1.8.4-5",
@@ -2118,7 +2118,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2151,7 +2151,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libgdbm-compat4",
       "version": "1.18.1-4",
@@ -2172,7 +2172,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2205,7 +2205,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libgdbm6",
       "version": "1.18.1-4",
@@ -2226,7 +2226,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2259,7 +2259,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "bom-ref": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
       "type": "library",
       "name": "libgmp10",
       "version": "6.1.2+dfsg-4",
@@ -2280,7 +2280,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "purl": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2317,7 +2317,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libgnutls30",
       "version": "3.6.7-4",
@@ -2363,7 +2363,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2396,7 +2396,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libgpg-error0",
       "version": "1.35-1",
@@ -2422,7 +2422,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2455,11 +2455,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libhogweed4",
       "version": "3.4.1-1",
-      "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2492,7 +2492,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libidn2-0",
       "version": "2.0.5-1",
@@ -2518,7 +2518,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2551,7 +2551,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libjemalloc2",
       "version": "5.1.0-3",
@@ -2587,7 +2587,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2620,7 +2620,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "liblz4-1",
       "version": "1.8.3-1",
@@ -2636,7 +2636,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2669,7 +2669,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "liblzma5",
       "version": "5.2.4-1",
@@ -2740,7 +2740,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2773,7 +2773,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libmount1",
       "version": "2.33.1-0.1",
@@ -2829,7 +2829,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2862,11 +2862,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libncurses6",
       "version": "6.1+20181013-2+deb10u2",
-      "purl": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2899,11 +2899,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libncursesw6",
       "version": "6.1+20181013-2+deb10u2",
-      "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -2936,7 +2936,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libnettle6",
       "version": "3.4.1-1",
@@ -2987,7 +2987,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3020,7 +3020,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libp11-kit0",
       "version": "0.23.15-2",
@@ -3051,7 +3051,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3084,7 +3084,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libpam-modules-bin",
       "version": "1.3.1-5",
@@ -3095,7 +3095,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3128,7 +3128,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libpam-modules",
       "version": "1.3.1-5",
@@ -3139,7 +3139,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3172,7 +3172,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "libpam-runtime",
       "version": "1.3.1-5",
@@ -3183,7 +3183,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3216,7 +3216,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libpam0g",
       "version": "1.3.1-5",
@@ -3227,7 +3227,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3260,11 +3260,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "bom-ref": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64&distro=debian-10.2&epoch=2",
       "type": "library",
       "name": "libpcre3",
       "version": "8.39-12",
-      "purl": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "purl": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64&distro=debian-10.2&epoch=2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3301,7 +3301,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libreadline7",
       "version": "7.0-5",
@@ -3317,7 +3317,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3350,7 +3350,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libruby2.5",
       "version": "2.5.5-3+deb10u1",
@@ -3451,7 +3451,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3484,7 +3484,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libseccomp2",
       "version": "2.3.3-4",
@@ -3495,7 +3495,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3528,7 +3528,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libselinux1",
       "version": "2.8-1+b1",
@@ -3544,7 +3544,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3577,7 +3577,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "libsemanage-common",
       "version": "2.8-2",
@@ -3593,7 +3593,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3626,7 +3626,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libsemanage1",
       "version": "2.8-2",
@@ -3642,7 +3642,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3675,7 +3675,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libsepol1",
       "version": "2.8-1",
@@ -3691,7 +3691,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3724,7 +3724,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libsmartcols1",
       "version": "2.33.1-0.1",
@@ -3780,7 +3780,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3813,11 +3813,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libss2",
       "version": "1.44.5-1+deb10u2",
-      "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3850,11 +3850,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libssl1.1",
       "version": "1.1.1d-0+deb10u2",
-      "purl": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3887,11 +3887,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libstdc++6",
       "version": "8.3.0-6",
-      "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3924,7 +3924,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libsystemd0",
       "version": "241-7~deb10u2",
@@ -3955,7 +3955,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -3988,7 +3988,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libtasn1-6",
       "version": "4.13-3",
@@ -4014,7 +4014,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4047,11 +4047,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libtinfo6",
       "version": "6.1+20181013-2+deb10u2",
-      "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4084,7 +4084,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libudev1",
       "version": "241-7~deb10u2",
@@ -4115,7 +4115,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4148,7 +4148,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libunistring2",
       "version": "0.9.10-1",
@@ -4194,7 +4194,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4227,7 +4227,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libuuid1",
       "version": "2.33.1-0.1",
@@ -4283,7 +4283,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4316,7 +4316,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libyaml-0-2",
       "version": "0.2.1-1",
@@ -4332,7 +4332,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4365,7 +4365,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "libzstd1",
       "version": "1.3.8+dfsg-3",
@@ -4391,7 +4391,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4424,7 +4424,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/login@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/login@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "login",
       "version": "4.5-1.1",
@@ -4435,7 +4435,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/login@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/login@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4472,7 +4472,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "mawk",
       "version": "1.3.3-17+b3",
@@ -4483,7 +4483,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4516,7 +4516,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "mount",
       "version": "2.33.1-0.1",
@@ -4572,7 +4572,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4605,11 +4605,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ncurses-base",
       "version": "6.1+20181013-2+deb10u2",
-      "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4642,11 +4642,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "ncurses-bin",
       "version": "6.1+20181013-2+deb10u2",
-      "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4679,11 +4679,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "openssl",
       "version": "1.1.1d-0+deb10u2",
-      "purl": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4716,7 +4716,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "passwd",
       "version": "4.5-1.1",
@@ -4727,7 +4727,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4764,11 +4764,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "perl-base",
       "version": "5.28.1-6",
-      "purl": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4801,7 +4801,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/rake@12.3.1-3?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/rake@12.3.1-3?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "rake",
       "version": "12.3.1-3",
@@ -4812,7 +4812,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/rake@12.3.1-3?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/rake@12.3.1-3?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4845,7 +4845,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/readline-common@7.0-5?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/readline-common@7.0-5?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "readline-common",
       "version": "7.0-5",
@@ -4861,7 +4861,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/readline-common@7.0-5?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/readline-common@7.0-5?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4894,7 +4894,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-did-you-mean",
       "version": "1.2.1-1",
@@ -4905,7 +4905,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4938,7 +4938,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-minitest",
       "version": "5.11.3-1",
@@ -4949,7 +4949,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -4982,7 +4982,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-net-telnet",
       "version": "0.1.1-2",
@@ -4993,7 +4993,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5026,7 +5026,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-power-assert",
       "version": "1.1.1-1",
@@ -5042,7 +5042,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5075,7 +5075,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-test-unit",
       "version": "3.2.8-1",
@@ -5101,7 +5101,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5134,7 +5134,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "ruby-xmlrpc",
       "version": "0.3.0-2",
@@ -5145,7 +5145,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5178,7 +5178,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "ruby2.5",
       "version": "2.5.5-3+deb10u1",
@@ -5279,7 +5279,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5312,7 +5312,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/ruby@2.5.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/ruby@2.5.1?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "ruby",
       "version": "2.5.1",
@@ -5328,7 +5328,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/ruby@2.5.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/ruby@2.5.1?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5361,7 +5361,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/rubygems-integration@1.11?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/rubygems-integration@1.11?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "rubygems-integration",
       "version": "1.11",
@@ -5372,7 +5372,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/rubygems-integration@1.11?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/rubygems-integration@1.11?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5401,7 +5401,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/sed@4.7-1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/sed@4.7-1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "sed",
       "version": "4.7-1",
@@ -5412,7 +5412,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/sed@4.7-1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/sed@4.7-1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5445,7 +5445,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "sysvinit-utils",
       "version": "2.93-8",
@@ -5456,7 +5456,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5489,7 +5489,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "tar",
       "version": "1.30+dfsg-6",
@@ -5505,7 +5505,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5538,11 +5538,11 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all&distro=debian-10.2",
       "type": "library",
       "name": "tzdata",
       "version": "2019c-0+deb10u1",
-      "purl": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5575,7 +5575,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "bom-ref": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "type": "library",
       "name": "util-linux",
       "version": "2.33.1-0.1",
@@ -5631,7 +5631,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "purl": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -5664,7 +5664,7 @@
       ]
     },
     {
-      "bom-ref": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "bom-ref": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1",
       "type": "library",
       "name": "zlib1g",
       "version": "1.2.11.dfsg-1",
@@ -5675,7 +5675,7 @@
           }
         }
       ],
-      "purl": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "purl": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1",
       "properties": [
         {
           "name": "aquasecurity:trivy:LayerDiffID",
@@ -7533,791 +7533,791 @@
     {
       "ref": "3ff14136-e09f-4df9-80ea-000000000003",
       "dependsOn": [
-        "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/apt@1.8.2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/base-passwd@3.5.46?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/bash@5.0-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/ca-certificates@20190110?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/coreutils@8.30-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/diffutils@3.7-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/grep@3.3-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/gzip@1.9-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/hostname@3.21?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc-bin@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpcre3@8.39-12?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libreadline7@7.0-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsemanage-common@2.8-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsepol1@2.8-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/login@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/passwd@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/rake@12.3.1-3?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/readline-common@7.0-5?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby@2.5.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/rubygems-integration@1.11?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/sed@4.7-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/apt@1.8.2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/base-passwd@3.5.46?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/bash@5.0-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/ca-certificates@20190110?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/coreutils@8.30-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/diffutils@3.7-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/grep@3.3-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/gzip@1.9-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/hostname@3.21?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc-bin@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpcre3@8.39-12?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libreadline7@7.0-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsemanage-common@2.8-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsepol1@2.8-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/login@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/passwd@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/rake@12.3.1-3?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/readline-common@7.0-5?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/ruby@2.5.1?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/rubygems-integration@1.11?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/sed@4.7-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/passwd@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/passwd@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/apt@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/apt@1.8.2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/adduser@3.118?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/base-passwd@3.5.46?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/bash@5.0-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/bash@5.0-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/base-files@10.3%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ca-certificates@20190110?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ca-certificates@20190110?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/coreutils@8.30-3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/coreutils@8.30-3?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/dash@0.5.10.2-5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/debian-archive-keyring@2019.1?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/debianutils@4.8.6.1?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/diffutils@3.7-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/diffutils@3.7-3?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/e2fsprogs@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/findutils@4.6.0%2Bgit%2B20190209-2?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/gpgv@2.2.12-1%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/grep@3.3-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/grep@3.3-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/gzip@1.9-3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/gzip@1.9-3?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/hostname@3.21?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/hostname@3.21?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libacl1@2.2.53-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libapt-pkg5.0@1.8.2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/libattr1@2.4.48-4?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all&distro=debian-10.2&epoch=1",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libaudit-common@2.8.4-3?arch=all&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libcap-ng0@0.7.9-2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libdb5.3@5.3.28%2Bdfsg1-0.5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libdebconfclient0@0.249?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libext2fs2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libfdisk1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libgcrypt20@1.8.4-5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "ref": "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libgpg-error0@1.35-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libhogweed4@3.4.1-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libidn2-0@2.0.5-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libjemalloc2@5.1.0-3?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/liblz4-1@1.8.3-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/liblzma5@5.2.4-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libmount1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libblkid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libncursesw6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libnettle6@3.4.1-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libp11-kit0@0.23.15-2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libpam-modules-bin@1.3.1-5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libpam-runtime@1.3.1-5?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
+      "ref": "pkg:deb/debian/libpcre3@8.39-12?arch=amd64&distro=debian-10.2&epoch=2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libreadline7@7.0-5?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/readline-common@7.0-5?arch=all\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/readline-common@7.0-5?arch=all&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libreadline7@7.0-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/rake@12.3.1-3?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libffi6@3.2.1-9?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgdbm-compat4@1.18.1-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgdbm6@1.18.1-4?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libncurses6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libreadline7@7.0-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/rake@12.3.1-3?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libseccomp2@2.3.3-4?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpcre3@8.39-12?arch=amd64\u0026distro=debian-10.2\u0026epoch=2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpcre3@8.39-12?arch=amd64&distro=debian-10.2&epoch=2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libsemanage-common@2.8-2?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsemanage-common@2.8-2?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsepol1@2.8-1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libbz2-1.0@1.0.6-9.2~deb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsemanage-common@2.8-2?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libsepol1@2.8-1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libsepol1@2.8-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libsmartcols1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libss2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libcom-err2@1.44.5-1%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libstdc%2B%2B6@8.3.0-6?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/gcc-8-base@8.3.0-6?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgcc1@8.3.0-6?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libsystemd0@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libtasn1-6@4.13-3?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libtinfo6@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libudev1@241-7~deb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libunistring2@0.9.10-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libuuid1@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libyaml-0-2@0.2.1-1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/libzstd1@1.3.8%2Bdfsg-3?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/login@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/login@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/mawk@1.3.3-17%2Bb3?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/mount@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ncurses-base@6.1%2B20181013-2%2Bdeb10u2?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ncurses-bin@6.1%2B20181013-2%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/openssl@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libssl1.1@1.1.1d-0%2Bdeb10u2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/passwd@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libaudit1@2.8.4-3?arch=amd64&distro=debian-10.2&epoch=1",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam-modules@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libpam0g@1.3.1-5?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libselinux1@2.8-1%2Bb1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libsemanage1@2.8-2?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/perl-base@5.28.1-6?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/rake@12.3.1-3?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/rake@12.3.1-3?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/ruby@2.5.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/ruby@2.5.1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/readline-common@7.0-5?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/readline-common@7.0-5?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/dpkg@1.19.7?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/dpkg@1.19.7?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-did-you-mean@1.2.1-1?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-minitest@5.11.3-1?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-net-telnet@0.1.1-2?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-test-unit@3.2.8-1?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all\u0026distro=debian-10.2"
+        "pkg:deb/debian/ruby-power-assert@1.1.1-1?arch=all&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby-xmlrpc@0.3.0-2?arch=all&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64\u0026distro=debian-10.2\u0026epoch=2",
-        "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/rubygems-integration@1.11?arch=all\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/libgmp10@6.1.2%2Bdfsg-4?arch=amd64&distro=debian-10.2&epoch=2",
+        "pkg:deb/debian/libruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/rubygems-integration@1.11?arch=all&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/ruby@2.5.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/ruby@2.5.1?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/ruby2.5@2.5.5-3%2Bdeb10u1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/rubygems-integration@1.11?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/rubygems-integration@1.11?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/ca-certificates@20190110?arch=all\u0026distro=debian-10.2"
+        "pkg:deb/debian/ca-certificates@20190110?arch=all&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/sed@4.7-1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/sed@4.7-1?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/sysvinit-utils@2.93-8?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all\u0026distro=debian-10.2",
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/init-system-helpers@1.56%2Bnmu1?arch=all&distro=debian-10.2",
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/tar@1.30%2Bdfsg-6?arch=amd64&distro=debian-10.2",
       "dependsOn": []
     },
     {
-      "ref": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/tzdata@2019c-0%2Bdeb10u1?arch=all&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/debconf@1.5.71?arch=all\u0026distro=debian-10.2"
+        "pkg:deb/debian/debconf@1.5.71?arch=all&distro=debian-10.2"
       ]
     },
     {
-      "ref": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
+      "ref": "pkg:deb/debian/util-linux@2.33.1-0.1?arch=amd64&distro=debian-10.2",
       "dependsOn": [
-        "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64\u0026distro=debian-10.2",
-        "pkg:deb/debian/login@4.5-1.1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1"
+        "pkg:deb/debian/fdisk@2.33.1-0.1?arch=amd64&distro=debian-10.2",
+        "pkg:deb/debian/login@4.5-1.1?arch=amd64&distro=debian-10.2&epoch=1"
       ]
     },
     {
-      "ref": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64\u0026distro=debian-10.2\u0026epoch=1",
+      "ref": "pkg:deb/debian/zlib1g@1.2.11.dfsg-1?arch=amd64&distro=debian-10.2&epoch=1",
       "dependsOn": [
-        "pkg:deb/debian/libc6@2.28-10?arch=amd64\u0026distro=debian-10.2"
+        "pkg:deb/debian/libc6@2.28-10?arch=amd64&distro=debian-10.2"
       ]
     },
     {

--- a/pkg/k8s/report/cyclonedx.go
+++ b/pkg/k8s/report/cyclonedx.go
@@ -18,6 +18,7 @@ type CycloneDXWriter struct {
 func NewCycloneDXWriter(output io.Writer, format cdx.BOMFileFormat, appVersion string) CycloneDXWriter {
 	encoder := cdx.NewBOMEncoder(output, format)
 	encoder.SetPretty(true)
+	encoder.SetEscapeHTML(false)
 	return CycloneDXWriter{
 		encoder:   encoder,
 		marshaler: core.NewCycloneDX(appVersion),

--- a/pkg/report/cyclonedx/cyclonedx.go
+++ b/pkg/report/cyclonedx/cyclonedx.go
@@ -34,6 +34,7 @@ func (w Writer) Write(report types.Report) error {
 
 	encoder := cdx.NewBOMEncoder(w.output, w.format)
 	encoder.SetPretty(true)
+	encoder.SetEscapeHTML(false)
 	if err = encoder.Encode(bom); err != nil {
 		return xerrors.Errorf("failed to encode bom: %w", err)
 	}


### PR DESCRIPTION
## Description
Disable HTML escaping for CycloneDX.
Purl has already escaped all the necessary characters:
https://github.com/package-url/packageurl-go/blob/fe183c1943ec36f257fae7143e160978217104b6/packageurl.go#L369-L394

## Related issues
- Close #5763

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
