### PR TITLE
fix(report): don't mark misconfig passed tests as failed in junit.tpl

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -14,8 +14,7 @@
         </testcase>
     {{- end }}
     </testsuite>
-{{- $failures := len .Misconfigurations }}
-    <testsuite tests="{{ $failures }}" failures="{{ $failures }}" name="{{  .Target }}" errors="0" skipped="0" time="">
+    <testsuite tests="{{ add .MisconfSummary.Successes .MisconfSummary.Failures }}" failures="{{ .MisconfSummary.Failures }}" name="{{  .Target }}" errors="0" skipped="{{ .MisconfSummary.Exceptions}}" time="">
     {{- if not (eq .Type "") }}
         <properties>
             <property name="type" value="{{ .Type }}"></property>
@@ -23,7 +22,9 @@
         {{- end -}}
         {{ range .Misconfigurations }}
         <testcase classname="{{ .Type }}" name="[{{ .Severity }}] {{ .ID }}" time="">
+        {{- if (eq .Status "FAIL") }}
             <failure message="{{ escapeXML .Title }}" type="description">{{ escapeXML .Description }}</failure>
+        {{- end }}
         </testcase>
     {{- end }}
     </testsuite>


### PR DESCRIPTION
## Description
See #5766 


Before:
```xml 
<?xml version="1.0" ?>
<testsuites name="trivy">
    <testsuite tests="0" failures="0" name="Dockerfile" errors="0" skipped="0" time="">
        <properties>
            <property name="type" value="dockerfile"></property>
        </properties>
    </testsuite>
    <testsuite tests="26" failures="26" name="Dockerfile" errors="0" skipped="0" time="">
        <properties>
            <property name="type" value="dockerfile"></property>
        </properties>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS001" time="">
            <failure message="&#39;:latest&#39; tag used" type="description">When using a &#39;FROM&#39; statement you should use a specific tag to avoid uncontrolled behavior when the image is updated.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS002" time="">
            <failure message="Image user should not be &#39;root&#39;" type="description">Running containers with &#39;root&#39; user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a &#39;USER&#39; statement to the Dockerfile.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS026" time="">
            <failure message="No HEALTHCHECK defined" type="description">You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS004" time="">
            <failure message="Port 22 exposed" type="description">Exposing port 22 might allow users to SSH into the container.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS005" time="">
            <failure message="ADD instead of COPY" type="description">You should use COPY instead of ADD unless you want to extract a tar file. Note that an ADD command will extract a tar file, which adds the risk of Zip-based vulnerabilities. Accordingly, it is advised to use a COPY command, which does not extract tar files.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS006" time="">
            <failure message="COPY &#39;--from&#39; referring to the current image" type="description">COPY &#39;--from&#39; should not mention the current FROM alias, since it is impossible to copy from itself.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS007" time="">
            <failure message="Multiple ENTRYPOINT instructions listed" type="description">There can only be one ENTRYPOINT instruction in a Dockerfile. Only the last ENTRYPOINT instruction in the Dockerfile will have an effect.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS008" time="">
            <failure message="Exposed port out of range" type="description">UNIX ports outside the range 0-65535 are exposed.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS009" time="">
            <failure message="WORKDIR path not absolute" type="description">For clarity and reliability, you should always use absolute paths for your WORKDIR.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS010" time="">
            <failure message="RUN using &#39;sudo&#39;" type="description">Avoid using &#39;RUN&#39; with &#39;sudo&#39; commands, as it can lead to unpredictable behavior.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS011" time="">
            <failure message="COPY with more than two arguments not ending with slash" type="description">When a COPY command has more than two arguments, the last one should end with a slash.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS012" time="">
            <failure message="Duplicate aliases defined in different FROMs" type="description">Different FROMs can&#39;t have the same alias defined.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS013" time="">
            <failure message="&#39;RUN cd ...&#39; to change directory" type="description">Use WORKDIR instead of proliferating instructions like &#39;RUN cd … &amp;&amp; do-something&#39;, which are hard to read, troubleshoot, and maintain.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS014" time="">
            <failure message="RUN using &#39;wget&#39; and &#39;curl&#39;" type="description">Avoid using both &#39;wget&#39; and &#39;curl&#39; since these tools have the same effect.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS015" time="">
            <failure message="&#39;yum clean all&#39; missing" type="description">You should use &#39;yum clean all&#39; after using a &#39;yum install&#39; command to clean package cached data and reduce image size.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS016" time="">
            <failure message="Multiple CMD instructions listed" type="description">There can only be one CMD instruction in a Dockerfile. If you list more than one CMD then only the last CMD will take effect.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS017" time="">
            <failure message="&#39;RUN &lt;package-manager&gt; update&#39; instruction alone" type="description">The instruction &#39;RUN &lt;package-manager&gt; update&#39; should always be followed by &#39;&lt;package-manager&gt; install&#39; in the same RUN statement.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS019" time="">
            <failure message="&#39;dnf clean all&#39; missing" type="description">Cached package data should be cleaned after installation to reduce image size.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS020" time="">
            <failure message="&#39;zypper clean&#39; missing" type="description">The layer and image size should be reduced by deleting unneeded caches after running zypper.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS021" time="">
            <failure message="&#39;apt-get&#39; missing &#39;-y&#39; to avoid manual input" type="description">&#39;apt-get&#39; calls should use the flag &#39;-y&#39; to avoid manual user input.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS022" time="">
            <failure message="Deprecated MAINTAINER used" type="description">MAINTAINER has been deprecated since Docker 1.13.0.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS023" time="">
            <failure message="Multiple HEALTHCHECK defined" type="description">Providing more than one HEALTHCHECK instruction per stage is confusing and error-prone.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS024" time="">
            <failure message="&#39;apt-get dist-upgrade&#39; used" type="description">&#39;apt-get dist-upgrade&#39; upgrades a major version so it doesn&#39;t make more sense in Dockerfile.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS025" time="">
            <failure message="&#39;apk add&#39; is missing &#39;--no-cache&#39;" type="description">You should use &#39;apk add&#39; with &#39;--no-cache&#39; to clean package cached data and reduce image size.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS027" time="">
            <failure message="&#39;microdnf clean all&#39; missing" type="description">Cached package data should be cleaned after installation to reduce image size.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS029" time="">
            <failure message="&#39;apt-get&#39; missing &#39;--no-install-recommends&#39;" type="description">&#39;apt-get&#39; install should use &#39;--no-install-recommends&#39; to minimize image size.</failure>
        </testcase>
    </testsuite>
</testsuites>

```

After:
```xml
<?xml version="1.0" ?>
<testsuites name="trivy">
    <testsuite tests="0" failures="0" name="Dockerfile" errors="0" skipped="0" time="">
        <properties>
            <property name="type" value="dockerfile"></property>
        </properties>
    </testsuite>
    <testsuite tests="26" failures="3" name="Dockerfile" errors="0" skipped="0" time="">
        <properties>
            <property name="type" value="dockerfile"></property>
        </properties>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS001" time="">
            <failure message="&#39;:latest&#39; tag used" type="description">When using a &#39;FROM&#39; statement you should use a specific tag to avoid uncontrolled behavior when the image is updated.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS002" time="">
            <failure message="Image user should not be &#39;root&#39;" type="description">Running containers with &#39;root&#39; user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a &#39;USER&#39; statement to the Dockerfile.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS026" time="">
            <failure message="No HEALTHCHECK defined" type="description">You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.</failure>
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS004" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS005" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS006" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS007" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS008" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS009" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS010" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS011" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[CRITICAL] DS012" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS013" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[LOW] DS014" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS015" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS016" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS017" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS019" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS020" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS021" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS022" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[MEDIUM] DS023" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS024" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS025" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS027" time="">
        </testcase>
        <testcase classname="Dockerfile Security Check" name="[HIGH] DS029" time="">
        </testcase>
    </testsuite>
</testsuites>

```

## Related issues
- Close #5766

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
