### PR TITLE
fix(report): fix error if miconfigs are empty

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -14,7 +14,12 @@
         </testcase>
     {{- end }}
     </testsuite>
-    <testsuite tests="{{ add .MisconfSummary.Successes .MisconfSummary.Failures }}" failures="{{ .MisconfSummary.Failures }}" name="{{  .Target }}" errors="0" skipped="{{ .MisconfSummary.Exceptions}}" time="">
+
+{{- if .MisconfSummary }}
+    <testsuite tests="{{ add .MisconfSummary.Successes .MisconfSummary.Failures }}" failures="{{ .MisconfSummary.Failures }}" name="{{  .Target }}" errors="0" skipped="{{ .MisconfSummary.Exceptions }}" time="">
+{{- else }}
+    <testsuite tests="0" failures="0" name="{{  .Target }}" errors="0" skipped="0" time="">
+{{- end }}
     {{- if not (eq .Type "") }}
         <properties>
             <property name="type" value="{{ .Type }}"></property>

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -345,6 +345,15 @@ func TestClientServerWithFormat(t *testing.T) {
 			golden: "testdata/alpine-310.html.golden",
 		},
 		{
+			name: "alpine 3.10 with junit template",
+			args: csArgs{
+				Format:       "template",
+				TemplatePath: "@../contrib/junit.tpl",
+				Input:        "testdata/fixtures/images/alpine-310.tar.gz",
+			},
+			golden: "testdata/alpine-310.junit.golden",
+		},
+		{
 			name: "alpine 3.10 with github dependency snapshots format",
 			args: csArgs{
 				Format: "github",

--- a/integration/testdata/alpine-310.junit.golden
+++ b/integration/testdata/alpine-310.junit.golden
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<testsuites name="trivy">
+    <testsuite tests="4" failures="4" name="testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)" errors="0" skipped="0" time="">
+        <properties>
+            <property name="type" value="alpine"></property>
+        </properties>
+        <testcase classname="libcrypto1.1-1.1.1c-r0" name="[MEDIUM] CVE-2019-1549" time="">
+            <failure message="openssl: information disclosure in fork()" type="description">OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).</failure>
+        </testcase>
+        <testcase classname="libcrypto1.1-1.1.1c-r0" name="[MEDIUM] CVE-2019-1551" time="">
+            <failure message="openssl: Integer overflow in RSAZ modular exponentiation on x86_64" type="description">There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).</failure>
+        </testcase>
+        <testcase classname="libssl1.1-1.1.1c-r0" name="[MEDIUM] CVE-2019-1549" time="">
+            <failure message="openssl: information disclosure in fork()" type="description">OpenSSL 1.1.1 introduced a rewritten random number generator (RNG). This was intended to include protection in the event of a fork() system call in order to ensure that the parent and child processes did not share the same RNG state. However this protection was not being used in the default case. A partial mitigation for this issue is that the output from a high precision timer is mixed into the RNG state so the likelihood of a parent and child process sharing state is significantly reduced. If an application already calls OPENSSL_init_crypto() explicitly using OPENSSL_INIT_ATFORK then this problem does not occur at all. Fixed in OpenSSL 1.1.1d (Affected 1.1.1-1.1.1c).</failure>
+        </testcase>
+        <testcase classname="libssl1.1-1.1.1c-r0" name="[MEDIUM] CVE-2019-1551" time="">
+            <failure message="openssl: Integer overflow in RSAZ modular exponentiation on x86_64" type="description">There is an overflow bug in the x64_64 Montgomery squaring procedure used in exponentiation with 512-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against 2-prime RSA1024, 3-prime RSA1536, and DSA1024 as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH512 are considered just feasible. However, for an attack the target would have to re-use the DH512 private key, which is not recommended anyway. Also applications directly using the low level API BN_mod_exp may be affected if they use BN_FLG_CONSTTIME. Fixed in OpenSSL 1.1.1e (Affected 1.1.1-1.1.1d). Fixed in OpenSSL 1.0.2u (Affected 1.0.2-1.0.2t).</failure>
+        </testcase>
+    </testsuite>
+    <testsuite tests="0" failures="0" name="testdata/fixtures/images/alpine-310.tar.gz (alpine 3.10.2)" errors="0" skipped="0" time="">
+        <properties>
+            <property name="type" value="alpine"></property>
+        </properties>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
## Description
After #5767 Trivy returns error if misconfigs are empty:
```
  - template: output template:17:44: executing "output template" at <.MisconfSummary.Successes>: nil pointer evaluating *types.MisconfSummary.Successes
```

`.MisconfSummary` is pointer. Therefore we need to add check to number of misconfigs.

## Related PRs
- [x] #5767

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
