### PR TITLE
fix(report): use OS information for OS packages purl in `github` template

### DIFF
--- a/integration/testdata/alpine-310.gsbom.golden
+++ b/integration/testdata/alpine-310.gsbom.golden
@@ -17,7 +17,7 @@
       "name": "alpine",
       "resolved": {
         "alpine-baselayout": {
-          "package_url": "pkg:apk/alpine-baselayout@3.1.2-r0",
+          "package_url": "pkg:apk/alpine/alpine-baselayout@3.1.2-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "busybox@1.30.1-r2",
@@ -26,12 +26,12 @@
           "scope": "runtime"
         },
         "alpine-keys": {
-          "package_url": "pkg:apk/alpine-keys@2.1-r2",
+          "package_url": "pkg:apk/alpine/alpine-keys@2.1-r2?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "scope": "runtime"
         },
         "apk-tools": {
-          "package_url": "pkg:apk/apk-tools@2.10.4-r2",
+          "package_url": "pkg:apk/alpine/apk-tools@2.10.4-r2?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "libcrypto1.1@1.1.1c-r0",
@@ -42,7 +42,7 @@
           "scope": "runtime"
         },
         "busybox": {
-          "package_url": "pkg:apk/busybox@1.30.1-r2",
+          "package_url": "pkg:apk/alpine/busybox@1.30.1-r2?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl@1.1.22-r3"
@@ -50,12 +50,12 @@
           "scope": "runtime"
         },
         "ca-certificates-cacert": {
-          "package_url": "pkg:apk/ca-certificates-cacert@20190108-r0",
+          "package_url": "pkg:apk/alpine/ca-certificates-cacert@20190108-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "scope": "runtime"
         },
         "libc-utils": {
-          "package_url": "pkg:apk/libc-utils@0.7.1-r0",
+          "package_url": "pkg:apk/alpine/libc-utils@0.7.1-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl-utils@1.1.22-r3"
@@ -63,7 +63,7 @@
           "scope": "runtime"
         },
         "libcrypto1.1": {
-          "package_url": "pkg:apk/libcrypto1.1@1.1.1c-r0",
+          "package_url": "pkg:apk/alpine/libcrypto1.1@1.1.1c-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl@1.1.22-r3"
@@ -71,7 +71,7 @@
           "scope": "runtime"
         },
         "libssl1.1": {
-          "package_url": "pkg:apk/libssl1.1@1.1.1c-r0",
+          "package_url": "pkg:apk/alpine/libssl1.1@1.1.1c-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "libcrypto1.1@1.1.1c-r0",
@@ -80,7 +80,7 @@
           "scope": "runtime"
         },
         "libtls-standalone": {
-          "package_url": "pkg:apk/libtls-standalone@2.9.1-r0",
+          "package_url": "pkg:apk/alpine/libtls-standalone@2.9.1-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "ca-certificates-cacert@20190108-r0",
@@ -91,12 +91,12 @@
           "scope": "runtime"
         },
         "musl": {
-          "package_url": "pkg:apk/musl@1.1.22-r3",
+          "package_url": "pkg:apk/alpine/musl@1.1.22-r3?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "scope": "runtime"
         },
         "musl-utils": {
-          "package_url": "pkg:apk/musl-utils@1.1.22-r3",
+          "package_url": "pkg:apk/alpine/musl-utils@1.1.22-r3?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl@1.1.22-r3",
@@ -105,7 +105,7 @@
           "scope": "runtime"
         },
         "scanelf": {
-          "package_url": "pkg:apk/scanelf@1.2.3-r0",
+          "package_url": "pkg:apk/alpine/scanelf@1.2.3-r0?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl@1.1.22-r3"
@@ -113,7 +113,7 @@
           "scope": "runtime"
         },
         "ssl_client": {
-          "package_url": "pkg:apk/ssl_client@1.30.1-r2",
+          "package_url": "pkg:apk/alpine/ssl_client@1.30.1-r2?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "libtls-standalone@2.9.1-r0",
@@ -122,7 +122,7 @@
           "scope": "runtime"
         },
         "zlib": {
-          "package_url": "pkg:apk/zlib@1.2.11-r1",
+          "package_url": "pkg:apk/alpine/zlib@1.2.11-r1?arch=x86_64\u0026distro=3.10.2",
           "relationship": "direct",
           "dependencies": [
             "musl@1.1.22-r3"

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -117,7 +117,7 @@ func (w Writer) Write(report types.Report) error {
 			githubPkg.Scope = RuntimeScope
 			githubPkg.Relationship = getPkgRelationshipType(pkg)
 			githubPkg.Dependencies = pkg.DependsOn // TODO: replace with PURL
-			githubPkg.PackageUrl, err = buildPurl(result.Type, pkg)
+			githubPkg.PackageUrl, err = buildPurl(result.Type, report.Metadata, pkg)
 			if err != nil {
 				return xerrors.Errorf("unable to build purl for %s: %w", pkg.Name, err)
 			}
@@ -160,8 +160,8 @@ func getPkgRelationshipType(pkg ftypes.Package) string {
 	return DirectRelationship
 }
 
-func buildPurl(t ftypes.TargetType, pkg ftypes.Package) (string, error) {
-	packageUrl, err := purl.NewPackageURL(t, types.Metadata{}, pkg)
+func buildPurl(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (string, error) {
+	packageUrl, err := purl.NewPackageURL(t, metadata, pkg)
 	if err != nil {
 		return "", xerrors.Errorf("purl error: %w", err)
 	}

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -24,6 +24,13 @@ func TestWriter_Write(t *testing.T) {
 			report: types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "alpine:3.14",
+				Metadata: types.Metadata{
+					OS: &ftypes.OS{
+						Family: "alpine",
+						Name:   "3.14",
+						Eosl:   true,
+					},
+				},
 				Results: types.Results{
 					{
 						Target: "yarn.lock",
@@ -59,9 +66,34 @@ func TestWriter_Write(t *testing.T) {
 							},
 						},
 					},
+					{
+						Target: "alpine:3.14 (alpine 3.14.10)",
+						Class:  "os-pkgs",
+						Type:   "alpine",
+						Packages: []ftypes.Package{
+							{
+								ID:         "apk-tools@2.12.7-r0",
+								Name:       "apk-tools",
+								Version:    "2.12.7-r0",
+								Arch:       "x86_64",
+								SrcName:    "apk-tools",
+								SrcVersion: "2.12.7-r0",
+							},
+						},
+					},
 				},
 			},
 			want: map[string]github.Manifest{
+				"alpine:3.14 (alpine 3.14.10)": {
+					Name: "alpine",
+					Resolved: map[string]github.Package{
+						"apk-tools": {
+							PackageUrl:   "pkg:apk/alpine/apk-tools@2.12.7-r0?arch=x86_64&distro=3.14",
+							Relationship: "direct",
+							Scope:        "runtime",
+						},
+					},
+				},
 				"yarn.lock": {
 					Name: "yarn",
 					File: &github.File{


### PR DESCRIPTION
## Description
OS package purl should contains OS name and `distro` field
e.g. for `deb` - https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#deb

before: `pkg:apk/alpine-baselayout@3.1.2-r0`
after: ` pkg:apk/alpine/alpine-baselayout@3.1.2-r0?arch=x86_64\u0026distro=3.10.2`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
