### PR TITLE
refactor(purl): use `pub` from `package-url`

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	TypeOCI  = "oci"
-	TypeDart = "dart"
+	TypeOCI = "oci"
 
 	// TypeK8s is a custom type for Kubernetes components in PURL.
 	//  - namespace: The service provider such as EKS or GKE. It is not case sensitive and must be lowercased.
@@ -141,7 +140,7 @@ func (p *PackageURL) LangType() ftypes.LangType {
 		return ftypes.Hex
 	case packageurl.TypeConan:
 		return ftypes.Conan
-	case TypeDart: // TODO: replace with packageurl.TypeDart once they add it.
+	case packageurl.TypePub:
 		return ftypes.Pub
 	case packageurl.TypeBitnami:
 		return ftypes.Bitnami
@@ -432,7 +431,7 @@ func purlType(t ftypes.TargetType) string {
 	case ftypes.Conan:
 		return packageurl.TypeConan
 	case ftypes.Pub:
-		return TypeDart // TODO: replace with packageurl.TypeDart once they add it.
+		return packageurl.TypePub
 	case ftypes.RustBinary, ftypes.Cargo:
 		return packageurl.TypeCargo
 	case ftypes.Alpine:

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -219,7 +219,7 @@ func TestNewPackageURL(t *testing.T) {
 			},
 			want: &purl.PackageURL{
 				PackageURL: packageurl.PackageURL{
-					Type:    purl.TypeDart,
+					Type:    packageurl.TypePub,
 					Name:    "http",
 					Version: "0.13.2",
 				},
@@ -512,10 +512,10 @@ func TestFromString(t *testing.T) {
 		},
 		{
 			name: "happy path for dart",
-			purl: "pkg:dart/http@0.13.2",
+			purl: "pkg:pub/http@0.13.2",
 			want: purl.PackageURL{
 				PackageURL: packageurl.PackageURL{
-					Type:       purl.TypeDart,
+					Type:       packageurl.TypePub,
 					Name:       "http",
 					Version:    "0.13.2",
 					Qualifiers: packageurl.Qualifiers{},


### PR DESCRIPTION
## Description
`package-url` added `pub` to purl types - https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#pub

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
