### PR TITLE
feat(misconf): grouping of results in table format

### DIFF
--- a/pkg/cloud/report/result.go
+++ b/pkg/cloud/report/result.go
@@ -27,7 +27,7 @@ func writeResultsForARN(report *Report, results types.Results, output io.Writer,
 			filtered = append(filtered, misconfiguration)
 		}
 		if len(filtered) > 0 {
-			_, _ = fmt.Fprint(output, renderer.NewMisconfigRenderer(result, severities, false, false, true).Render())
+			_, _ = fmt.Fprint(output, renderer.NewMisconfigRenderer(result, severities, renderer.WithANSI(true)).Render())
 		}
 	}
 

--- a/pkg/compliance/report/table.go
+++ b/pkg/compliance/report/table.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"io"
-	"sync"
 
 	"golang.org/x/xerrors"
 
@@ -30,9 +29,8 @@ func (tw TableWriter) Write(report *ComplianceReport) error {
 	switch tw.Report {
 	case allReport:
 		t := pkgReport.Writer{
-			Output:          tw.Output,
-			Severities:      tw.Severities,
-			ShowMessageOnce: &sync.Once{},
+			Output:     tw.Output,
+			Severities: tw.Severities,
 		}
 		for _, cr := range report.Results {
 			r := types.Report{Results: cr.Results}

--- a/pkg/fanal/types/misconf.go
+++ b/pkg/fanal/types/misconf.go
@@ -40,6 +40,10 @@ type CauseMetadata struct {
 	Occurrences []Occurrence `json:",omitempty"`
 }
 
+func (m CauseMetadata) IsMultiLine() bool {
+	return m.StartLine < m.EndLine
+}
+
 type Occurrence struct {
 	Resource string `json:",omitempty"`
 	Filename string `json:",omitempty"`

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -2,7 +2,6 @@ package report
 
 import (
 	"io"
-	"sync"
 
 	"golang.org/x/xerrors"
 
@@ -42,7 +41,7 @@ func InfraColumns() []string {
 func (tw TableWriter) Write(report Report) error {
 	switch tw.Report {
 	case AllReport:
-		t := pkgReport.Writer{Output: tw.Output, Severities: tw.Severities, ShowMessageOnce: &sync.Once{}}
+		t := pkgReport.Writer{Output: tw.Output, Severities: tw.Severities}
 		for _, r := range report.Resources {
 			if r.Report.Results.Failed() {
 				err := t.Write(r.Report)

--- a/pkg/report/table/misconfig_test.go
+++ b/pkg/report/table/misconfig_test.go
@@ -649,7 +649,7 @@ See https://avd.aquasec.com/misconfig/avd-gcp-0013
   11     name        = "example-zone-${count.index}"
   12     dns_name    = "example-${random_id.dns.hex}.com."
   13     description = "Example DNS zone"
-  14
+  14   
   15     dnssec_config {
   16 [     state = local.dnssec_state[count.index]
   17     }
@@ -675,7 +675,7 @@ See https://avd.aquasec.com/misconfig/avd-gcp-0013
   11     name        = "example-zone-${count.index}"
   12     dns_name    = "example-${random_id.dns.hex}.com."
   13     description = "Example DNS zone"
-  14
+  14   
   15     dnssec_config {
   16 [     state = local.dnssec_state[count.index]
   17     }

--- a/pkg/report/table/misconfig_test.go
+++ b/pkg/report/table/misconfig_test.go
@@ -656,7 +656,7 @@ See https://avd.aquasec.com/misconfig/avd-gcp-0013
   18   }
 ────────────────────────────────────────
 The rest causes:
- - main.tf:16
+ - main.tf:16 (google_dns_managed_zone.this[0])
 ────────────────────────────────────────
 
 

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/fatih/color"
 	"golang.org/x/exp/slices"
@@ -34,9 +33,6 @@ type Writer struct {
 
 	// Show dependency origin tree
 	Tree bool
-
-	// We have to show a message once about using the '-format json' subcommand to get the full pkgPath
-	ShowMessageOnce *sync.Once
 
 	// For misconfigurations
 	IncludeNonFailures bool
@@ -75,7 +71,13 @@ func (tw Writer) write(result types.Result) {
 		renderer = NewVulnerabilityRenderer(result, tw.isOutputToTerminal(), tw.Tree, tw.Severities)
 	// misconfiguration
 	case result.Class == types.ClassConfig:
-		renderer = NewMisconfigRenderer(result, tw.Severities, tw.Trace, tw.IncludeNonFailures, tw.isOutputToTerminal())
+		renderer = NewMisconfigRenderer(
+			result, tw.Severities,
+			WithTrace(tw.Trace),
+			WithIncludeNonFailures(tw.IncludeNonFailures),
+			WithANSI(tw.isOutputToTerminal()),
+			WithGroupingResults(true),
+		)
 	// secret
 	case result.Class == types.ClassSecret:
 		renderer = NewSecretRenderer(result.Target, result.Secrets, tw.isOutputToTerminal(), tw.Severities)

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"strings"
-	"sync"
 
 	"golang.org/x/xerrors"
 
@@ -49,7 +48,6 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 			Output:               output,
 			Severities:           option.Severities,
 			Tree:                 option.DependencyTree,
-			ShowMessageOnce:      &sync.Once{},
 			IncludeNonFailures:   option.IncludeNonFailures,
 			Trace:                option.Trace,
 			LicenseRiskThreshold: option.LicenseRiskThreshold,


### PR DESCRIPTION
## Description

The following has been changed in the report:
- misconfigurations found for a resource are grouped by status and id
- the header shows the number of similar misconfigurations
- added a block indicating the location of misconfigurations in the group

Sample config:
```tf
resource "digitalocean_droplet" "web" {
  name   = "web-1"
  size   = "s-1vcpu-1gb"
  image  = "ubuntu-18-04-x64"
  region = "nyc3"
}

resource "digitalocean_firewall" "web" {
  count = 2
  name  = "only-22-80-and-443"

  droplet_ids = [digitalocean_droplet.web.id]

  inbound_rule {
    protocol         = "tcp"
    port_range       = "22"
    source_addresses = ["192.168.1.0/24", "2002:1:2::/48"]
  }

  inbound_rule {
    protocol         = "tcp"
    port_range       = "80"
    source_addresses = ["0.0.0.0/0", "::/0"]
  }

  inbound_rule {
    protocol         = "tcp"
    port_range       = "443"
    source_addresses = ["0.0.0.0/0", "::/0"]
  }

  inbound_rule {
    protocol         = "icmp"
    source_addresses = ["0.0.0.0/0", "::/0"]
  }

  outbound_rule {
    protocol              = "tcp"
    port_range            = "53"
    destination_addresses = ["0.0.0.0/0", "::/0"]
  }

  outbound_rule {
    protocol              = "udp"
    port_range            = "53"
    destination_addresses = ["0.0.0.0/0", "::/0"]
  }

  outbound_rule {
    protocol              = "icmp"
    destination_addresses = ["0.0.0.0/0", "::/0"]
  }
}
```

### Before
```bash
Tests: 15 (SUCCESSES: 0, FAILURES: 15, EXCEPTIONS: 0)
Failures: 15 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 14)

CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:34
   via main.tf:32-35 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  34 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:17
   via main.tf:14-18 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  17 [     source_addresses = ["192.168.1.0/24", "2002:1:2::/48"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:23
   via main.tf:20-24 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  23 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:29
   via main.tf:26-30 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  29 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:29
   via main.tf:26-30 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  29 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:34
   via main.tf:32-35 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  34 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:23
   via main.tf:20-24 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  23 [     source_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Ingress rule allows access from multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:17
   via main.tf:14-18 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  17 [     source_addresses = ["192.168.1.0/24", "2002:1:2::/48"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:40
   via main.tf:37-41 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  40 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:46
   via main.tf:43-47 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  46 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:51
   via main.tf:49-52 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  51 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:40
   via main.tf:37-41 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  40 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:46
   via main.tf:43-47 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  46 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses.
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:51
   via main.tf:49-52 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  51 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────


HIGH: Droplet does not have an SSH key specified.
════════════════════════════════════════════════════════════════════════════════
When working with a server, you’ll likely spend most of your time in a terminal session connected to your server through SSH. A more secure alternative to password-based logins, SSH keys use encryption to provide a secure way of logging into your server and are recommended for all users.

See https://avd.aquasec.com/misconfig/avd-dig-0004
────────────────────────────────────────────────────────────────────────────────
 main.tf:1-6
────────────────────────────────────────────────────────────────────────────────
   1 ┌ resource "digitalocean_droplet" "web" {
   2 │   name   = "web-1"
   3 │   size   = "s-1vcpu-1gb"
   4 │   image  = "ubuntu-18-04-x64"
   5 │   region = "nyc3"
   6 └ }
────────────────────────────────────────────────────────────────────────────────
```

### After
```bash
Tests: 15 (SUCCESSES: 0, FAILURES: 15, EXCEPTIONS: 0)
Failures: 15 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 14)

CRITICAL: Ingress rule allows access from multiple public addresses. (7 similar results)
════════════════════════════════════════════════════════════════════════════════
Opening up ports to connect out to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that are explicitly required where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0001
────────────────────────────────────────────────────────────────────────────────
 main.tf:17
   via main.tf:14-18 (inbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  17 [     source_addresses = ["192.168.1.0/24", "2002:1:2::/48"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────
The rest causes:
 - main.tf:17 (digitalocean_firewall.web[1])
 - main.tf:23 (digitalocean_firewall.web[0])
 - main.tf:23 (digitalocean_firewall.web[1])
 - main.tf:29 (digitalocean_firewall.web[0])
 - main.tf:29 (digitalocean_firewall.web[1])
 - main.tf:34 (digitalocean_firewall.web[0])
 - main.tf:34 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────


CRITICAL: Egress rule allows access to multiple public addresses. (5 similar results)
════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-dig-0003
────────────────────────────────────────────────────────────────────────────────
 main.tf:40
   via main.tf:37-41 (outbound_rule)
    via main.tf:8-53 (digitalocean_firewall.web[0])
────────────────────────────────────────────────────────────────────────────────
   8   resource "digitalocean_firewall" "web" {
   .
  40 [     destination_addresses = ["0.0.0.0/0", "::/0"]
  ..
  53   }
────────────────────────────────────────────────────────────────────────────────
The rest causes:
 - main.tf:40 (digitalocean_firewall.web[1])
 - main.tf:46 (digitalocean_firewall.web[0])
 - main.tf:46 (digitalocean_firewall.web[1])
 - main.tf:51 (digitalocean_firewall.web[0])
 - main.tf:51 (digitalocean_firewall.web[1])
────────────────────────────────────────────────────────────────────────────────


HIGH: Droplet does not have an SSH key specified.
════════════════════════════════════════════════════════════════════════════════
When working with a server, you’ll likely spend most of your time in a terminal session connected to your server through SSH. A more secure alternative to password-based logins, SSH keys use encryption to provide a secure way of logging into your server and are recommended for all users.

See https://avd.aquasec.com/misconfig/avd-dig-0004
────────────────────────────────────────────────────────────────────────────────
 main.tf:1-6
────────────────────────────────────────────────────────────────────────────────
   1 ┌ resource "digitalocean_droplet" "web" {
   2 │   name   = "web-1"
   3 │   size   = "s-1vcpu-1gb"
   4 │   image  = "ubuntu-18-04-x64"
   5 │   region = "nyc3"
   6 └ }
────────────────────────────────────────────────────────────────────────────────
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5113

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
