### PR TITLE
fix(cyclonedx): fix work when there are same pkgs from different dirs

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -154,7 +154,8 @@ func (e *Marshaler) marshalPackages(metadata types.Metadata, result types.Result
 	// Create package map
 	pkgs := lo.SliceToMap(result.Packages, func(pkg ftypes.Package) (string, Package) {
 		pkgID := lo.Ternary(pkg.ID == "", fmt.Sprintf("%s@%s", pkg.Name, utils.FormatVersion(pkg)), pkg.ID)
-		// To avoid skip same packages with different paths
+		// To avoid merge same packages with different paths.
+		// Only ftypes.NodePkg, ftypes.PythonPkg, ftypes.GemSpec, ftypes.Jar, ftypes.CondaPkg use FilePath.
 		if pkg.FilePath != "" {
 			pkgID = fmt.Sprintf("%s@%s", pkgID, pkg.FilePath)
 		}

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -1190,7 +1190,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path. 2 packages for 1 CVE",
+			name: "happy path. Multiple packages for 1 CVE (2 same packages from different dirs and 1 package with a different name)",
 			inputReport: types.Report{
 				SchemaVersion: report.SchemaVersion,
 				ArtifactName:  "CVE-2023-34468",
@@ -1211,12 +1211,59 @@ func TestMarshaler_Marshal(t *testing.T) {
 								Version:  "1.20.0",
 								FilePath: "nifi-hikari-dbcp-service-1.20.0.jar",
 							},
+							{
+								Name:     "org.apache.nifi:nifi-hikari-dbcp-service",
+								Version:  "1.20.0",
+								FilePath: "dir/nifi-hikari-dbcp-service-1.20.0.jar",
+							},
 						},
 						Vulnerabilities: []types.DetectedVulnerability{
 							{
 								VulnerabilityID:  "CVE-2023-34468",
 								PkgName:          "org.apache.nifi:nifi-dbcp-base",
 								PkgPath:          "nifi-dbcp-base-1.20.0.jar",
+								InstalledVersion: "1.20.0",
+								FixedVersion:     "1.22.0",
+								SeveritySource:   vulnerability.GHSA,
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2023-34468",
+								DataSource: &dtypes.DataSource{
+									ID:   vulnerability.GHSA,
+									Name: "GitHub Security Advisory Maven",
+									URL:  "https://github.com/advisories?query=type%3Areviewed+ecosystem%3Amaven",
+								},
+								Vulnerability: dtypes.Vulnerability{
+									Title:       "Apache NiFi vulnerable to Code Injection",
+									Description: "The DBCPConnectionPool and HikariCPConnectionPool Controller Services in Apache NiFi 0.0.2 through 1.21.0...",
+									Severity:    dtypes.SeverityHigh.String(),
+									CweIDs: []string{
+										"CWE-94",
+									},
+									VendorSeverity: dtypes.VendorSeverity{
+										vulnerability.GHSA: dtypes.SeverityHigh,
+										vulnerability.NVD:  dtypes.SeverityHigh,
+									},
+									CVSS: dtypes.VendorCVSS{
+										vulnerability.GHSA: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+										vulnerability.NVD: dtypes.CVSS{
+											V3Vector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+											V3Score:  8.8,
+										},
+									},
+									References: []string{
+										"http://www.openwall.com/lists/oss-security/2023/06/12/3",
+										"https://github.com/advisories/GHSA-xm2m-2q6h-22jw",
+									},
+									PublishedDate:    lo.ToPtr(time.Date(2023, 6, 12, 16, 15, 0, 0, time.UTC)),
+									LastModifiedDate: lo.ToPtr(time.Date(2023, 6, 21, 02, 20, 0, 0, time.UTC)),
+								},
+							},
+							{
+								VulnerabilityID:  "CVE-2023-34468",
+								PkgName:          "org.apache.nifi:nifi-hikari-dbcp-service",
+								PkgPath:          "dir/nifi-hikari-dbcp-service-1.20.0.jar",
 								InstalledVersion: "1.20.0",
 								FixedVersion:     "1.22.0",
 								SeveritySource:   vulnerability.GHSA,
@@ -1349,6 +1396,24 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
+						BOMRef:     "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=dir%2Fnifi-hikari-dbcp-service-1.20.0.jar",
+						Type:       "library",
+						Name:       "nifi-hikari-dbcp-service",
+						Group:      "org.apache.nifi",
+						Version:    "1.20.0",
+						PackageURL: "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:FilePath",
+								Value: "dir/nifi-hikari-dbcp-service-1.20.0.jar",
+							},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "jar",
+							},
+						},
+					},
+					{
 						BOMRef:     "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
 						Type:       "library",
 						Name:       "nifi-hikari-dbcp-service",
@@ -1372,11 +1437,16 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Ref: "3ff14136-e09f-4df9-80ea-000000000002",
 						Dependencies: &[]string{
 							"pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+							"pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=dir%2Fnifi-hikari-dbcp-service-1.20.0.jar",
 							"pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=nifi-hikari-dbcp-service-1.20.0.jar",
 						},
 					},
 					{
 						Ref:          "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+						Dependencies: lo.ToPtr([]string{}),
+					},
+					{
+						Ref:          "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=dir%2Fnifi-hikari-dbcp-service-1.20.0.jar",
 						Dependencies: lo.ToPtr([]string{}),
 					},
 					{
@@ -1430,6 +1500,15 @@ func TestMarshaler_Marshal(t *testing.T) {
 						Affects: &[]cdx.Affects{
 							{
 								Ref: "pkg:maven/org.apache.nifi/nifi-dbcp-base@1.20.0?file_path=nifi-dbcp-base-1.20.0.jar",
+								Range: &[]cdx.AffectedVersions{
+									{
+										Version: "1.20.0",
+										Status:  cdx.VulnerabilityStatusAffected,
+									},
+								},
+							},
+							{
+								Ref: "pkg:maven/org.apache.nifi/nifi-hikari-dbcp-service@1.20.0?file_path=dir%2Fnifi-hikari-dbcp-service-1.20.0.jar",
 								Range: &[]cdx.AffectedVersions{
 									{
 										Version: "1.20.0",


### PR DESCRIPTION
## Description
Fixes for cases when same packages are found in different directories:
```bash
➜ tree dir
dir
├── dir1
│   └── jackson-databind-2.13.4.jar
└── dir2
    └── jackson-databind-2.13.4.jar
```
1) return all found packages:
    before:
```json
  "components": [
    {
      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir1%2Fjackson-databind-2.13.4.jar",
      "type": "library",
      "group": "com.fasterxml.jackson.core",
      "name": "jackson-databind",
      "version": "2.13.4",
      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4",
      "properties": [
        {
          "name": "aquasecurity:trivy:FilePath",
          "value": "dir1/jackson-databind-2.13.4.jar"
        },
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "jar"
        }
      ]
    }
  ],
```
after:
```json
  "components": [
    {
      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir1%2Fjackson-databind-2.13.4.jar",
      "type": "library",
      "group": "com.fasterxml.jackson.core",
      "name": "jackson-databind",
      "version": "2.13.4",
      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4",
      "properties": [
        {
          "name": "aquasecurity:trivy:FilePath",
          "value": "dir1/jackson-databind-2.13.4.jar"
        },
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "jar"
        }
      ]
    },
    {
      "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir2%2Fjackson-databind-2.13.4.jar",
      "type": "library",
      "group": "com.fasterxml.jackson.core",
      "name": "jackson-databind",
      "version": "2.13.4",
      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4",
      "properties": [
        {
          "name": "aquasecurity:trivy:FilePath",
          "value": "dir2/jackson-databind-2.13.4.jar"
        },
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "jar"
        }
      ]
    }
  ],
```

2) show correct ref's for `vulnerabilities.affects`.
before(dir2 and dir2):
```json
      "affects": [
        {
          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir2%2Fjackson-databind-2.13.4.jar",
          "versions": [
            {
              "version": "2.13.4",
              "status": "affected"
            }
          ]
        },
        {
          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir2%2Fjackson-databind-2.13.4.jar",
          "versions": [
            {
              "version": "2.13.4",
              "status": "affected"
            }
          ]
        }
      ]
```
  after(dir1 + dir2):
```json
      "affects": [
        {
          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir1%2Fjackson-databind-2.13.4.jar",
          "versions": [
            {
              "version": "2.13.4",
              "status": "affected"
            }
          ]
        },
        {
          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4?file_path=dir2%2Fjackson-databind-2.13.4.jar",
          "versions": [
            {
              "version": "2.13.4",
              "status": "affected"
            }
          ]
        }
      ]
```

## Related issues
- Close #5796


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
