### PR TITLE
fix(nodejs): find licenses for packages with slash

### DIFF
--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -87,13 +86,14 @@ func (a npmLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 
 func (a npmLibraryAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	fileName := filepath.Base(filePath)
+	// Don't save package-lock.json from the `node_modules` directory to avoid duplication and mistakes.
 	if fileName == types.NpmPkgLock && !xpath.Contains(filePath, "node_modules") {
 		return true
 	}
-	// The file path to package.json - */node_modules/<package_name>/package.json
-	// The path is slashed in analyzers.
-	dirs := strings.Split(path.Dir(filePath), "/")
-	if len(dirs) > 1 && dirs[len(dirs)-2] == "node_modules" && fileName == types.NpmPkg {
+
+	// Save package.json files only from the `node_modules` directory.
+	// Required to search for licenses.
+	if fileName == types.NpmPkg && xpath.Contains(filePath, "node_modules") {
 		return true
 	}
 	return false

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
@@ -35,6 +35,19 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 						FilePath: "package-lock.json",
 						Libraries: types.Packages{
 							{
+								ID:       "@babel/parser@7.23.6",
+								Name:     "@babel/parser",
+								Version:  "7.23.6",
+								Indirect: true,
+								Licenses: []string{"MIT"},
+								Locations: []types.Location{
+									{
+										StartLine: 6,
+										EndLine:   10,
+									},
+								},
+							},
+							{
 								ID:       "ansi-colors@3.2.3",
 								Name:     "ansi-colors",
 								Version:  "3.2.3",
@@ -42,8 +55,8 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Indirect: true,
 								Locations: []types.Location{
 									{
-										StartLine: 6,
-										EndLine:   11,
+										StartLine: 11,
+										EndLine:   16,
 									},
 								},
 							},
@@ -54,8 +67,8 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Indirect: true,
 								Locations: []types.Location{
 									{
-										StartLine: 12,
-										EndLine:   16,
+										StartLine: 17,
+										EndLine:   21,
 									},
 								},
 							},
@@ -68,8 +81,8 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Licenses:  []string{"MIT"},
 								Locations: []types.Location{
 									{
-										StartLine: 17,
-										EndLine:   39,
+										StartLine: 22,
+										EndLine:   44,
 									},
 								},
 							},
@@ -82,12 +95,12 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Licenses:  []string{"MIT"},
 								Locations: []types.Location{
 									{
-										StartLine: 25,
-										EndLine:   32,
+										StartLine: 30,
+										EndLine:   37,
 									},
 									{
-										StartLine: 48,
-										EndLine:   55,
+										StartLine: 53,
+										EndLine:   60,
 									},
 								},
 							},
@@ -100,8 +113,8 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Licenses:  []string{"MIT"},
 								Locations: []types.Location{
 									{
-										StartLine: 40,
-										EndLine:   62,
+										StartLine: 45,
+										EndLine:   67,
 									},
 								},
 							},
@@ -113,12 +126,12 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Licenses: []string{"MIT"},
 								Locations: []types.Location{
 									{
-										StartLine: 33,
-										EndLine:   37,
+										StartLine: 38,
+										EndLine:   42,
 									},
 									{
-										StartLine: 56,
-										EndLine:   60,
+										StartLine: 61,
+										EndLine:   65,
 									},
 								},
 							},
@@ -130,8 +143,8 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 								Licenses: []string{"MIT"},
 								Locations: []types.Location{
 									{
-										StartLine: 63,
-										EndLine:   67,
+										StartLine: 68,
+										EndLine:   72,
 									},
 								},
 							},

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
@@ -207,8 +207,13 @@ func Test_nodePkgLibraryAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "package.json with `/` in name",
+			filePath: "npm/node_modules/@babel/parser/package.json",
+			want:     true,
+		},
+		{
 			name:     "sad path",
-			filePath: "npm/node_modules/package.json",
+			filePath: "npm/package.json",
 			want:     false,
 		},
 		{

--- a/pkg/fanal/analyzer/language/nodejs/npm/testdata/happy/node_modules/@babel/parser/package.json
+++ b/pkg/fanal/analyzer/language/nodejs/npm/testdata/happy/node_modules/@babel/parser/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@babel/parser",
+  "version": "7.23.6",
+  "description": "A JavaScript parser",
+  "author": "The Babel Team (https://babel.dev/team)",
+  "homepage": "https://babel.dev/docs/en/next/babel-parser",
+  "bugs": "https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22pkg%3A+parser+%28babylon%29%22+is%3Aopen",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "babel",
+    "javascript",
+    "parser",
+    "tc39",
+    "ecmascript",
+    "@babel/parser"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/babel/babel.git",
+    "directory": "packages/babel-parser"
+  },
+  "main": "./lib/index.js",
+  "types": "./typings/babel-parser.d.ts",
+  "files": [
+    "bin",
+    "lib",
+    "typings/babel-parser.d.ts",
+    "index.cjs"
+  ],
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "devDependencies": {
+    "@babel/code-frame": "^7.23.5",
+    "@babel/helper-check-duplicate-nodes": "^7.22.5",
+    "@babel/helper-fixtures": "^7.23.4",
+    "@babel/helper-string-parser": "^7.23.4",
+    "@babel/helper-validator-identifier": "^7.22.20",
+    "charcodes": "^0.2.0"
+  },
+  "bin": "./bin/babel-parser.js",
+  "type": "commonjs"
+}

--- a/pkg/fanal/analyzer/language/nodejs/npm/testdata/happy/package-lock.json
+++ b/pkg/fanal/analyzer/language/nodejs/npm/testdata/happy/package-lock.json
@@ -3,6 +3,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",


### PR DESCRIPTION
## Description
We don't need to skip `package.json` files (when searching for licenses for `package-lock.json` files) if package name contains slash (e.g. `node_modules/@babel/parser/package.json`)


## Related issues
- Close #5835

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
