### PR TITLE
refactor: propagate time through context values

### DIFF
--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/uuid"
 )
@@ -364,8 +363,6 @@ func TestClientServerWithFormat(t *testing.T) {
 	}
 
 	fakeTime := time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC)
-	clock.SetFakeTime(t, fakeTime)
-
 	report.CustomTemplateFuncMap = map[string]interface{}{
 		"now": func() time.Time {
 			return fakeTime
@@ -428,7 +425,6 @@ func TestClientServerWithCycloneDX(t *testing.T) {
 	addr, cacheDir := setup(t, setupOptions{})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			osArgs, outputFile := setupClient(t, tt.args, addr, cacheDir, tt.golden)

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -4,16 +4,13 @@ package integration
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/aquasecurity/trivy/pkg/clock"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/uuid"
@@ -416,12 +413,15 @@ func TestRepository(t *testing.T) {
 
 			osArgs := []string{
 				"-q",
-				"--cache-dir", cacheDir,
+				"--cache-dir",
+				cacheDir,
 				command,
 				"--skip-db-update",
 				"--skip-policy-update",
-				"--format", string(format),
-				"--parallel", fmt.Sprint(tt.args.parallel),
+				"--format",
+				string(format),
+				"--parallel",
+				fmt.Sprint(tt.args.parallel),
 				"--offline-scan",
 			}
 
@@ -499,7 +499,6 @@ func TestRepository(t *testing.T) {
 			osArgs = append(osArgs, "--output", outputFile)
 			osArgs = append(osArgs, tt.args.input)
 
-			clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			// Run "trivy repo"

--- a/integration/testdata/debian-stretch.json.golden
+++ b/integration/testdata/debian-stretch.json.golden
@@ -6,8 +6,7 @@
   "Metadata": {
     "OS": {
       "Family": "debian",
-      "Name": "9.9",
-      "EOSL": true
+      "Name": "9.9"
     },
     "ImageID": "sha256:f26939cc87ef44a6fc554eedd0a976ab30b5bc2769d65d2e986b6c5f1fd4053d",
     "DiffIDs": [

--- a/integration/testdata/distroless-base.json.golden
+++ b/integration/testdata/distroless-base.json.golden
@@ -6,8 +6,7 @@
   "Metadata": {
     "OS": {
       "Family": "debian",
-      "Name": "9.9",
-      "EOSL": true
+      "Name": "9.9"
     },
     "ImageID": "sha256:7f04a8d247173b1f2546d22913af637bbab4e7411e00ae6207da8d94c445750d",
     "DiffIDs": [

--- a/integration/testdata/distroless-python27.json.golden
+++ b/integration/testdata/distroless-python27.json.golden
@@ -6,8 +6,7 @@
   "Metadata": {
     "OS": {
       "Family": "debian",
-      "Name": "9.9",
-      "EOSL": true
+      "Name": "9.9"
     },
     "ImageID": "sha256:6fcac2cc8a710f21577b5bbd534e0bfc841c0cca569b57182ba19054696cddda",
     "DiffIDs": [

--- a/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
+++ b/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
@@ -6,8 +6,7 @@
   "Metadata": {
     "OS": {
       "Family": "ubuntu",
-      "Name": "18.04",
-      "EOSL": true
+      "Name": "18.04"
     },
     "ImageID": "sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12",
     "DiffIDs": [

--- a/integration/testdata/ubuntu-1804.json.golden
+++ b/integration/testdata/ubuntu-1804.json.golden
@@ -6,8 +6,7 @@
   "Metadata": {
     "OS": {
       "Family": "ubuntu",
-      "Name": "18.04",
-      "EOSL": true
+      "Name": "18.04"
     },
     "ImageID": "sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12",
     "DiffIDs": [

--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -1068,8 +1068,11 @@ Summary Report for compliance: my-custom-spec
 				MisconfOptions: flag.MisconfOptions{IncludeNonFailures: true},
 			},
 			cacheContent: "testdata/s3andcloudtrailcache.json",
-			allServices:  []string{"s3", "cloudtrail"},
-			want:         expectedS3AndCloudTrailResult,
+			allServices: []string{
+				"s3",
+				"cloudtrail",
+			},
+			want: expectedS3AndCloudTrailResult,
 		},
 		{
 			name: "skip certain services and include specific services",
@@ -1087,7 +1090,10 @@ Summary Report for compliance: my-custom-spec
 				MisconfOptions: flag.MisconfOptions{IncludeNonFailures: true},
 			},
 			cacheContent: "testdata/s3andcloudtrailcache.json",
-			allServices:  []string{"s3", "cloudtrail"},
+			allServices: []string{
+				"s3",
+				"cloudtrail",
+			},
 			// we skip cloudtrail but still expect results from it as it is cached
 			want: expectedS3AndCloudTrailResult,
 		},
@@ -1096,16 +1102,23 @@ Summary Report for compliance: my-custom-spec
 			options: flag.Options{
 				RegoOptions: flag.RegoOptions{SkipPolicyUpdate: true},
 				AWSOptions: flag.AWSOptions{
-					Region:       "us-east-1",
-					SkipServices: []string{"cloudtrail", "iam"},
-					Account:      "12345678",
+					Region: "us-east-1",
+					SkipServices: []string{
+						"cloudtrail",
+						"iam",
+					},
+					Account: "12345678",
 				},
 				CloudOptions: flag.CloudOptions{
 					MaxCacheAge: time.Hour * 24 * 365 * 100,
 				},
 				MisconfOptions: flag.MisconfOptions{IncludeNonFailures: true},
 			},
-			allServices:  []string{"s3", "cloudtrail", "iam"},
+			allServices: []string{
+				"s3",
+				"cloudtrail",
+				"iam",
+			},
 			cacheContent: "testdata/s3onlycache.json",
 			want:         expectedS3ScanResult,
 		},
@@ -1129,7 +1142,7 @@ Summary Report for compliance: my-custom-spec
 		},
 	}
 
-	clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+	ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.allServices != nil {
@@ -1179,7 +1192,7 @@ Summary Report for compliance: my-custom-spec
 				require.NoError(t, os.WriteFile(cacheFile, cacheData, 0600))
 			}
 
-			err := Run(context.Background(), test.options)
+			err := Run(ctx, test.options)
 			if test.expectErr {
 				assert.Error(t, err)
 				return

--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -67,7 +67,7 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 	defer cleanup()
 
 	if opt.Compliance.Spec.ID != "" {
-		return writeCompliance(rep, opt, output)
+		return writeCompliance(ctx, rep, opt, output)
 	}
 
 	var filtered []types.Result
@@ -93,7 +93,7 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 	})
 
 	base := types.Report{
-		CreatedAt:    clock.Now(),
+		CreatedAt:    clock.Now(ctx),
 		ArtifactName: rep.AccountID,
 		ArtifactType: ftypes.ArtifactAWSAccount,
 		Results:      filtered,
@@ -139,7 +139,7 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 	}
 }
 
-func writeCompliance(rep *Report, opt flag.Options, output io.Writer) error {
+func writeCompliance(ctx context.Context, rep *Report, opt flag.Options, output io.Writer) error {
 	var crr []types.Results
 	for _, r := range rep.Results {
 		crr = append(crr, r.Results)
@@ -150,7 +150,7 @@ func writeCompliance(rep *Report, opt flag.Options, output io.Writer) error {
 		return xerrors.Errorf("compliance report build error: %w", err)
 	}
 
-	return cr.Write(complianceReport, cr.Option{
+	return cr.Write(ctx, complianceReport, cr.Option{
 		Format: opt.Format,
 		Report: opt.ReportFormat,
 		Output: output,

--- a/pkg/cloud/report/service_test.go
+++ b/pkg/cloud/report/service_test.go
@@ -88,7 +88,10 @@ This scan report was loaded from cached results. If you'd like to run a fresh sc
 					},
 				},
 				AWSOptions: flag.AWSOptions{
-					Services: []string{"s3", "ec2"},
+					Services: []string{
+						"s3",
+						"ec2",
+					},
 				},
 			},
 			fromCache: false,
@@ -117,7 +120,11 @@ Scan Overview for AWS Account
 					},
 				},
 				AWSOptions: flag.AWSOptions{
-					Services: []string{"ec2", "s3", "iam"},
+					Services: []string{
+						"ec2",
+						"s3",
+						"iam",
+					},
 				},
 			},
 			fromCache: false,
@@ -310,7 +317,7 @@ Scan Overview for AWS Account
 }`,
 		},
 	}
-	clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+	ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			report := New(
@@ -323,7 +330,7 @@ Scan Overview for AWS Account
 
 			output := bytes.NewBuffer(nil)
 			tt.options.SetOutputWriter(output)
-			require.NoError(t, Write(context.Background(), report, tt.options, tt.fromCache))
+			require.NoError(t, Write(ctx, report, tt.options, tt.fromCache))
 
 			assert.Equal(t, "AWS", report.Provider)
 			assert.Equal(t, tt.options.AWSOptions.Account, report.AccountID)

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -59,5 +59,5 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 
 	server := rpcServer.NewServer(opts.AppVersion, opts.Listen, opts.CacheDir, opts.Token, opts.TokenHeader,
 		opts.DBRepository, opts.RegistryOpts())
-	return server.ListenAndServe(cache, opts.SkipDBUpdate)
+	return server.ListenAndServe(ctx, cache, opts.SkipDBUpdate)
 }

--- a/pkg/compliance/report/report.go
+++ b/pkg/compliance/report/report.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"io"
 
 	"golang.org/x/xerrors"
@@ -63,8 +64,8 @@ type Writer interface {
 	Write(ComplianceReport) error
 }
 
-// Write writes the results in the give format
-func Write(report *ComplianceReport, option Option) error {
+// Write writes the results in the given format
+func Write(ctx context.Context, report *ComplianceReport, option Option) error {
 	switch option.Format {
 	case types.FormatJSON:
 		jwriter := JSONWriter{
@@ -79,7 +80,7 @@ func Write(report *ComplianceReport, option Option) error {
 				Report:     option.Report,
 				Severities: option.Severities,
 			}
-			err := complianceWriter.Write(report)
+			err := complianceWriter.Write(ctx, report)
 			if err != nil {
 				return err
 			}

--- a/pkg/compliance/report/table.go
+++ b/pkg/compliance/report/table.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"io"
 	"sync"
 
@@ -26,7 +27,7 @@ const (
 	IssuesColumn      = "Issues"
 )
 
-func (tw TableWriter) Write(report *ComplianceReport) error {
+func (tw TableWriter) Write(ctx context.Context, report *ComplianceReport) error {
 	switch tw.Report {
 	case allReport:
 		t := pkgReport.Writer{
@@ -36,7 +37,7 @@ func (tw TableWriter) Write(report *ComplianceReport) error {
 		}
 		for _, cr := range report.Results {
 			r := types.Report{Results: cr.Results}
-			err := t.Write(r)
+			err := t.Write(ctx, r)
 			if err != nil {
 				return err
 			}

--- a/pkg/compliance/report/table_test.go
+++ b/pkg/compliance/report/table_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +37,10 @@ func TestTableWriter_Write(t *testing.T) {
 						Results: types.Results{
 							{
 								Misconfigurations: []types.DetectedMisconfiguration{
-									{AVDID: "AVD-KSV012", Status: types.StatusFailure},
+									{
+										AVDID:  "AVD-KSV012",
+										Status: types.StatusFailure,
+									},
 								},
 							},
 						},
@@ -48,7 +52,10 @@ func TestTableWriter_Write(t *testing.T) {
 						Results: types.Results{
 							{
 								Misconfigurations: []types.DetectedMisconfiguration{
-									{AVDID: "AVD-KSV013", Status: types.StatusFailure},
+									{
+										AVDID:  "AVD-KSV013",
+										Status: types.StatusFailure,
+									},
 								},
 							},
 						},
@@ -62,8 +69,11 @@ func TestTableWriter_Write(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
-			tr := report.TableWriter{Report: tt.reportType, Output: buf}
-			err := tr.Write(tt.input)
+			tr := report.TableWriter{
+				Report: tt.reportType,
+				Output: buf,
+			}
+			err := tr.Write(context.Background(), tt.input)
 			require.NoError(t, err)
 
 			want, err := os.ReadFile(tt.want)

--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -1,12 +1,12 @@
 package alma
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alma"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -25,36 +25,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the AlmaLinux scanner
 type Scanner struct {
 	vs *alma.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      alma.NewVulnSrc(),
-		options: o,
+		vs: alma.NewVulnSrc(),
 	}
 }
 
@@ -107,8 +86,8 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Major(osVer))
 }
 
 func addModularNamespace(name, label string) string {

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -1,12 +1,10 @@
 package alma_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,6 +13,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alma"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -215,8 +215,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := alma.NewScanner(alma.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := alma.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -1,12 +1,12 @@
 package alpine
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-apk-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
@@ -50,36 +50,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Alpine scanner
 type Scanner struct {
 	vs alpine.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      alpine.NewVulnSrc(),
-		options: o,
+		vs: alpine.NewVulnSrc(),
 	}
 }
 
@@ -173,8 +152,8 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osver.Minor(osVer))
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Minor(osVer))
 }
 
 func (s *Scanner) repoRelease(repo *ftypes.Repository) string {

--- a/pkg/detector/ospkg/alpine/alpine_test.go
+++ b/pkg/detector/ospkg/alpine/alpine_test.go
@@ -1,21 +1,21 @@
 package alpine_test
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
-
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/dbtest"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alpine"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -326,8 +326,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := alpine.NewScanner(alpine.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := alpine.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -1,12 +1,12 @@
 package amazon
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -27,36 +27,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner to scan amazon vulnerabilities
 type Scanner struct {
 	ac amazon.VulnSrc
-	options
 }
 
 // NewScanner is the factory method to return Amazon scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		ac:      amazon.NewVulnSrc(),
-		options: *o,
+		ac: amazon.NewVulnSrc(),
 	}
 }
 
@@ -116,11 +95,11 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
 	osVer = strings.Fields(osVer)[0]
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {
 		osVer = "1"
 	}
 
-	return osver.Supported(s.clock, eolDates, osFamily, osVer)
+	return osver.Supported(ctx, eolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -1,12 +1,10 @@
 package amazon_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,6 +13,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/amazon"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -248,8 +248,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := amazon.NewScanner(amazon.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := amazon.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/chainguard/chainguard.go
+++ b/pkg/detector/ospkg/chainguard/chainguard.go
@@ -1,9 +1,10 @@
 package chainguard
 
 import (
+	"context"
+
 	version "github.com/knqyf263/go-apk-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/chainguard"
@@ -13,36 +14,15 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Chainguard scanner
 type Scanner struct {
 	vs chainguard.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      chainguard.NewVulnSrc(),
-		options: o,
+		vs: chainguard.NewVulnSrc(),
 	}
 }
 
@@ -103,7 +83,7 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
 	// Chainguard doesn't have versions, so there is no case where a given input yields a
 	// result of an unsupported Chainguard version.
 

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -1,11 +1,11 @@
 package debian
 
 import (
+	"context"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
@@ -41,36 +41,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Debian scanner
 type Scanner struct {
 	vs debian.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method to return Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      debian.NewVulnSrc(),
-		options: o,
+		vs: debian.NewVulnSrc(),
 	}
 }
 
@@ -140,6 +119,6 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Major(osVer))
 }

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -1,13 +1,11 @@
 package debian_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"sort"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -16,6 +14,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -172,8 +172,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := debian.NewScanner(debian.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := debian.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -1,6 +1,7 @@
 package ospkg
 
 import (
+	"context"
 	"time"
 
 	"github.com/samber/lo"
@@ -55,17 +56,17 @@ func RegisterDriver(name ftypes.OSType, driver Driver) {
 // Driver defines operations for OS package scan
 type Driver interface {
 	Detect(string, *ftypes.Repository, []ftypes.Package) ([]types.DetectedVulnerability, error)
-	IsSupportedVersion(ftypes.OSType, string) bool
+	IsSupportedVersion(context.Context, ftypes.OSType, string) bool
 }
 
 // Detect detects the vulnerabilities
-func Detect(_, osFamily ftypes.OSType, osName string, repo *ftypes.Repository, _ time.Time, pkgs []ftypes.Package) ([]types.DetectedVulnerability, bool, error) {
+func Detect(ctx context.Context, _, osFamily ftypes.OSType, osName string, repo *ftypes.Repository, _ time.Time, pkgs []ftypes.Package) ([]types.DetectedVulnerability, bool, error) {
 	driver, err := newDriver(osFamily)
 	if err != nil {
 		return nil, false, ErrUnsupportedOS
 	}
 
-	eosl := !driver.IsSupportedVersion(osFamily, osName)
+	eosl := !driver.IsSupportedVersion(ctx, osFamily, osName)
 
 	// Package `gpg-pubkey` doesn't use the correct version.
 	// We don't need to find vulnerabilities for this package.

--- a/pkg/detector/ospkg/mariner/mariner.go
+++ b/pkg/detector/ospkg/mariner/mariner.go
@@ -1,6 +1,8 @@
 package mariner
 
 import (
+	"context"
+
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
 
@@ -73,7 +75,7 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
 	// EOL is not in public at the moment.
 	return true
 }

--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -1,12 +1,12 @@
 package oracle
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -33,15 +33,13 @@ var (
 
 // Scanner implements oracle vulnerability scanner
 type Scanner struct {
-	vs    *oracleoval.VulnSrc
-	clock clock.Clock
+	vs *oracleoval.VulnSrc
 }
 
 // NewScanner is the factory method to return oracle vulnerabilities
 func NewScanner() *Scanner {
 	return &Scanner{
-		vs:    oracleoval.NewVulnSrc(),
-		clock: clock.RealClock{},
+		vs: oracleoval.NewVulnSrc(),
 	}
 }
 
@@ -101,6 +99,6 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Major(osVer))
 }

--- a/pkg/detector/ospkg/photon/photon.go
+++ b/pkg/detector/ospkg/photon/photon.go
@@ -1,11 +1,11 @@
 package photon
 
 import (
+	"context"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -26,36 +26,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Photon scanner
 type Scanner struct {
 	vs photon.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      photon.NewVulnSrc(),
-		options: o,
+		vs: photon.NewVulnSrc(),
 	}
 }
 
@@ -96,6 +75,6 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osVer)
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -1,12 +1,10 @@
 package photon_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,6 +13,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/photon"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -147,8 +147,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := photon.NewScanner(photon.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := photon.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -1,6 +1,7 @@
 package redhat
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
@@ -64,36 +64,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the RedHat scanner
 type Scanner struct {
 	vs redhat.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      redhat.NewVulnSrc(),
-		options: o,
+		vs: redhat.NewVulnSrc(),
 	}
 }
 
@@ -208,13 +187,13 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 }
 
 // IsSupportedVersion checks is OSFamily can be scanned with Redhat scanner
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
 	osVer = osver.Major(osVer)
 	if osFamily == ftypes.CentOS {
-		return osver.Supported(s.clock, centosEOLDates, osFamily, osVer)
+		return osver.Supported(ctx, centosEOLDates, osFamily, osVer)
 	}
 
-	return osver.Supported(s.clock, redhatEOLDates, osFamily, osVer)
+	return osver.Supported(ctx, redhatEOLDates, osFamily, osVer)
 }
 
 func isFromSupportedVendor(pkg ftypes.Package) bool {

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -1,13 +1,11 @@
 package redhat_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -16,6 +14,8 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -435,8 +435,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := redhat.NewScanner(redhat.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := redhat.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/rocky/rocky.go
+++ b/pkg/detector/ospkg/rocky/rocky.go
@@ -1,11 +1,11 @@
 package rocky
 
 import (
+	"context"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -24,36 +24,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Rocky Linux scanner
 type Scanner struct {
 	vs *rocky.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      rocky.NewVulnSrc(),
-		options: o,
+		vs: rocky.NewVulnSrc(),
 	}
 }
 
@@ -107,8 +86,8 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osver.Major(osVer))
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Major(osVer))
 }
 
 func addModularNamespace(name, label string) string {

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -1,12 +1,10 @@
 package rocky_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,6 +13,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/rocky"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -175,8 +175,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := rocky.NewScanner(rocky.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := rocky.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -1,11 +1,11 @@
 package suse
 
 import (
+	"context"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -58,18 +58,6 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Type defines SUSE type
 type Type int
 
@@ -83,29 +71,18 @@ const (
 // Scanner implements the SUSE scanner
 type Scanner struct {
 	vs susecvrf.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(t Type, opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
-
+func NewScanner(t Type) *Scanner {
 	switch t {
 	case SUSEEnterpriseLinux:
 		return &Scanner{
-			vs:      susecvrf.NewVulnSrc(susecvrf.SUSEEnterpriseLinux),
-			options: o,
+			vs: susecvrf.NewVulnSrc(susecvrf.SUSEEnterpriseLinux),
 		}
 	case OpenSUSE:
 		return &Scanner{
-			vs:      susecvrf.NewVulnSrc(susecvrf.OpenSUSE),
-			options: o,
+			vs: susecvrf.NewVulnSrc(susecvrf.OpenSUSE),
 		}
 	}
 	return nil
@@ -148,9 +125,9 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks if OSFamily can be scanned using SUSE scanner
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
 	if osFamily == ftypes.SLES {
-		return osver.Supported(s.clock, slesEolDates, osFamily, osVer)
+		return osver.Supported(ctx, slesEolDates, osFamily, osVer)
 	}
-	return osver.Supported(s.clock, opensuseEolDates, osFamily, osVer)
+	return osver.Supported(ctx, opensuseEolDates, osFamily, osVer)
 }

--- a/pkg/detector/ospkg/suse/suse_test.go
+++ b/pkg/detector/ospkg/suse/suse_test.go
@@ -1,12 +1,10 @@
 package suse_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -15,6 +13,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/suse"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
@@ -153,8 +153,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := suse.NewScanner(tt.distribution, suse.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := suse.NewScanner(tt.distribution)
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/ubuntu/testdata/fixtures/ubuntu.yaml
+++ b/pkg/detector/ospkg/ubuntu/testdata/fixtures/ubuntu.yaml
@@ -1,3 +1,10 @@
+- bucket: ubuntu 19.04
+  pairs:
+    - bucket: wpa
+      pairs:
+        - key: CVE-2019-9243
+          value:
+            FixedVersion: ""
 - bucket: ubuntu 20.04
   pairs:
     - bucket: wpa

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -1,12 +1,12 @@
 package ubuntu
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -63,36 +63,15 @@ var (
 	}
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Ubuntu scanner
 type Scanner struct {
 	vs ubuntu.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      ubuntu.NewVulnSrc(),
-		options: o,
+		vs: ubuntu.NewVulnSrc(),
 	}
 }
 
@@ -149,8 +128,8 @@ func (s *Scanner) Detect(osVer string, _ *ftypes.Repository, pkgs []ftypes.Packa
 }
 
 // IsSupportedVersion checks is OSFamily can be scanned using Ubuntu scanner
-func (s *Scanner) IsSupportedVersion(osFamily ftypes.OSType, osVer string) bool {
-	return osver.Supported(s.clock, eolDates, osFamily, osVer)
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osVer)
 }
 
 // versionFromEolDates checks if actual (not ESM) version is not outdated
@@ -165,7 +144,7 @@ func (s *Scanner) versionFromEolDates(osVer string) string {
 	// then we need to get vulnerabilities for `18.04`
 	// if `18.04` is outdated - we need to use `18.04-ESM` (we will return error until we add `18.04-ESM` to eolDates)
 	ver := strings.TrimRight(osVer, "-ESM")
-	if eol, ok := eolDates[ver]; ok && s.clock.Now().Before(eol) {
+	if eol, ok := eolDates[ver]; ok && time.Now().Before(eol) { // TODO: time.Now() should be replaced with clock.Now()
 		return ver
 	}
 	return osVer

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -1,13 +1,11 @@
 package ubuntu_test
 
 import (
+	"context"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"sort"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	fake "k8s.io/utils/clock/testing"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -16,12 +14,13 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/ubuntu"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner_Detect(t *testing.T) {
 	type args struct {
 		osVer string
-		now   time.Time
 		pkgs  []ftypes.Package
 	}
 	tests := []struct {
@@ -39,7 +38,6 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			args: args{
 				osVer: "20.04",
-				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
 				pkgs: []ftypes.Package{
 					{
 						Name:       "wpa",
@@ -91,7 +89,6 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			args: args{
 				osVer: "20.04-ESM",
-				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
 				pkgs: []ftypes.Package{
 					{
 						Name:       "wpa",
@@ -136,14 +133,13 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
-			name: "ubuntu 20.04-ESM. 20.04 is outdated",
+			name: "ubuntu 19.04-ESM, 19.04 is outdated", // Use 19.04-ESM for testing, although it doesn't exist
 			fixtures: []string{
 				"testdata/fixtures/ubuntu.yaml",
 				"testdata/fixtures/data-source.yaml",
 			},
 			args: args{
-				osVer: "20.04-ESM",
-				now:   time.Date(2031, 3, 31, 23, 59, 59, 0, time.UTC),
+				osVer: "19.04-ESM",
 				pkgs: []ftypes.Package{
 					{
 						Name:       "wpa",
@@ -165,7 +161,6 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			args: args{
 				osVer: "21.04",
-				now:   time.Date(2019, 3, 31, 23, 59, 59, 0, time.UTC),
 				pkgs: []ftypes.Package{
 					{
 						Name:       "jq",
@@ -183,7 +178,7 @@ func TestScanner_Detect(t *testing.T) {
 			_ = dbtest.InitDB(t, tt.fixtures)
 			defer db.Close()
 
-			s := ubuntu.NewScanner(ubuntu.WithClock(fake.NewFakeClock(tt.args.now)))
+			s := ubuntu.NewScanner()
 			got, err := s.Detect(tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -258,8 +253,9 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := ubuntu.NewScanner(ubuntu.WithClock(fake.NewFakeClock(tt.now)))
-			got := s.IsSupportedVersion(tt.args.osFamily, tt.args.osVer)
+			ctx := clock.With(context.Background(), tt.now)
+			s := ubuntu.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/version/version.go
+++ b/pkg/detector/ospkg/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 import (
+	"context"
 	"strings"
 	"time"
 
-	"k8s.io/utils/clock"
-
+	"github.com/aquasecurity/trivy/pkg/clock"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 )
@@ -28,11 +28,11 @@ func Minor(osVer string) string {
 	return major + "." + minor
 }
 
-func Supported(c clock.Clock, eolDates map[string]time.Time, osFamily ftypes.OSType, osVer string) bool {
+func Supported(ctx context.Context, eolDates map[string]time.Time, osFamily ftypes.OSType, osVer string) bool {
 	eol, ok := eolDates[osVer]
 	if !ok {
 		log.Logger.Warnf("This OS version is not on the EOL list: %s %s", osFamily, osVer)
 		return true // can be the latest version
 	}
-	return c.Now().Before(eol)
+	return clock.Now(ctx).Before(eol)
 }

--- a/pkg/detector/ospkg/wolfi/wolfi.go
+++ b/pkg/detector/ospkg/wolfi/wolfi.go
@@ -1,9 +1,10 @@
 package wolfi
 
 import (
+	"context"
+
 	version "github.com/knqyf263/go-apk-version"
 	"golang.org/x/xerrors"
-	"k8s.io/utils/clock"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
@@ -13,36 +14,15 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-type options struct {
-	clock clock.Clock
-}
-
-type option func(*options)
-
-func WithClock(c clock.Clock) option {
-	return func(opts *options) {
-		opts.clock = c
-	}
-}
-
 // Scanner implements the Wolfi scanner
 type Scanner struct {
 	vs wolfi.VulnSrc
-	*options
 }
 
 // NewScanner is the factory method for Scanner
-func NewScanner(opts ...option) *Scanner {
-	o := &options{
-		clock: clock.RealClock{},
-	}
-
-	for _, opt := range opts {
-		opt(o)
-	}
+func NewScanner() *Scanner {
 	return &Scanner{
-		vs:      wolfi.NewVulnSrc(),
-		options: o,
+		vs: wolfi.NewVulnSrc(),
 	}
 }
 
@@ -103,7 +83,7 @@ func (s *Scanner) isVulnerable(installedVersion version.Version, adv dbTypes.Adv
 }
 
 // IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(_ ftypes.OSType, _ string) bool {
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
 	// Wolfi doesn't have versions, so there is no case where a given input yields a
 	// result of an unsupported Wolfi version.
 

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -116,14 +116,14 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		if err != nil {
 			return xerrors.Errorf("compliance report build error: %w", err)
 		}
-		return cr.Write(complianceReport, cr.Option{
+		return cr.Write(ctx, complianceReport, cr.Option{
 			Format: r.flagOpts.Format,
 			Report: r.flagOpts.ReportFormat,
 			Output: output,
 		})
 	}
 
-	if err := k8sRep.Write(rpt, report.Option{
+	if err := k8sRep.Write(ctx, rpt, report.Option{
 		Format:     r.flagOpts.Format,
 		Report:     r.flagOpts.ReportFormat,
 		Output:     output,

--- a/pkg/k8s/report/cyclonedx.go
+++ b/pkg/k8s/report/cyclonedx.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"io"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -25,7 +26,7 @@ func NewCycloneDXWriter(output io.Writer, format cdx.BOMFileFormat, appVersion s
 	}
 }
 
-func (w CycloneDXWriter) Write(component *core.Component) error {
-	bom := w.marshaler.Marshal(component)
+func (w CycloneDXWriter) Write(ctx context.Context, component *core.Component) error {
+	bom := w.marshaler.Marshal(ctx, component)
 	return w.encoder.Encode(bom)
 }

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"io"
 	"sync"
 
@@ -43,7 +44,7 @@ func InfraColumns() []string {
 	return []string{InfraAssessmentColumn}
 }
 
-func (tw TableWriter) Write(report Report) error {
+func (tw TableWriter) Write(ctx context.Context, report Report) error {
 	switch tw.Report {
 	case AllReport:
 		t := pkgReport.Writer{
@@ -53,7 +54,7 @@ func (tw TableWriter) Write(report Report) error {
 		}
 		for _, r := range report.Resources {
 			if r.Report.Results.Failed() {
-				err := t.Write(nil, r.Report)
+				err := t.Write(ctx, r.Report)
 				if err != nil {
 					return err
 				}

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -28,7 +28,11 @@ const (
 )
 
 func WorkloadColumns() []string {
-	return []string{VulnerabilitiesColumn, MisconfigurationsColumn, SecretsColumn}
+	return []string{
+		VulnerabilitiesColumn,
+		MisconfigurationsColumn,
+		SecretsColumn,
+	}
 }
 
 func RoleColumns() []string {
@@ -42,10 +46,14 @@ func InfraColumns() []string {
 func (tw TableWriter) Write(report Report) error {
 	switch tw.Report {
 	case AllReport:
-		t := pkgReport.Writer{Output: tw.Output, Severities: tw.Severities, ShowMessageOnce: &sync.Once{}}
+		t := pkgReport.Writer{
+			Output:          tw.Output,
+			Severities:      tw.Severities,
+			ShowMessageOnce: &sync.Once{},
+		}
 		for _, r := range report.Resources {
 			if r.Report.Results.Failed() {
-				err := t.Write(r.Report)
+				err := t.Write(nil, r.Report)
 				if err != nil {
 					return err
 				}

--- a/pkg/k8s/writer.go
+++ b/pkg/k8s/writer.go
@@ -38,7 +38,7 @@ func Write(ctx context.Context, k8sreport report.Report, option report.Option) e
 				ColumnHeading: report.ColumnHeading(option.Scanners, option.Components, r.Columns),
 			}
 
-			if err := writer.Write(r.Report); err != nil {
+			if err := writer.Write(ctx, r.Report); err != nil {
 				return err
 			}
 		}

--- a/pkg/k8s/writer.go
+++ b/pkg/k8s/writer.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -10,12 +11,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-type Writer interface {
-	Write(report.Report) error
-}
-
 // Write writes the results in the give format
-func Write(k8sreport report.Report, option report.Option) error {
+func Write(ctx context.Context, k8sreport report.Report, option report.Option) error {
 	k8sreport.PrintErrors()
 
 	switch option.Format {
@@ -49,7 +46,7 @@ func Write(k8sreport report.Report, option report.Option) error {
 		return nil
 	case types.FormatCycloneDX:
 		w := report.NewCycloneDXWriter(option.Output, cdx.BOMFileFormatJSON, option.APIVersion)
-		return w.Write(k8sreport.RootComponent)
+		return w.Write(ctx, k8sreport.RootComponent)
 	}
 	return nil
 }

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"bytes"
+	"context"
+	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
@@ -393,8 +395,8 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				Components: tc.components,
 			}
 
-			Write(tc.report, opt)
-
+			err := Write(context.Background(), tc.report, opt)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, stripAnsi(output.String()), tc.name)
 		})
 	}

--- a/pkg/report/cyclonedx/cyclonedx.go
+++ b/pkg/report/cyclonedx/cyclonedx.go
@@ -1,6 +1,7 @@
 package cyclonedx
 
 import (
+	"context"
 	"io"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -26,8 +27,8 @@ func NewWriter(output io.Writer, appVersion string) Writer {
 }
 
 // Write writes the results in CycloneDX format
-func (w Writer) Write(report types.Report) error {
-	bom, err := w.marshaler.Marshal(report)
+func (w Writer) Write(ctx context.Context, report types.Report) error {
+	bom, err := w.marshaler.Marshal(ctx, report)
 	if err != nil {
 		return xerrors.Errorf("CycloneDX marshal error: %w", err)
 	}

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -71,11 +72,11 @@ type Writer struct {
 	Version string
 }
 
-func (w Writer) Write(report types.Report) error {
+func (w Writer) Write(ctx context.Context, report types.Report) error {
 	snapshot := &DependencySnapshot{}
 
 	// use now() method that can be overwritten while integration tests run
-	snapshot.Scanned = clock.Now().Format(time.RFC3339)
+	snapshot.Scanned = clock.Now(ctx).Format(time.RFC3339)
 	snapshot.Detector = Detector{
 		Name:    "trivy",
 		Version: w.Version,

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -2,6 +2,7 @@ package github_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -174,7 +175,7 @@ func TestWriter_Write(t *testing.T) {
 
 			inputResults := tt.report
 
-			err := w.Write(inputResults)
+			err := w.Write(context.Background(), inputResults)
 			assert.NoError(t, err)
 
 			var got github.DependencySnapshot

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ type JSONWriter struct {
 }
 
 // Write writes the results in JSON format
-func (jw JSONWriter) Write(report types.Report) error {
+func (jw JSONWriter) Write(ctx context.Context, report types.Report) error {
 	output, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return xerrors.Errorf("failed to marshal json: %w", err)

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -85,7 +85,7 @@ func TestReportWriter_JSON(t *testing.T) {
 				},
 			}
 
-			err := jw.Write(inputResults)
+			err := jw.Write(nil, inputResults)
 			assert.NoError(t, err)
 
 			var got types.Report

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestReportWriter_JSON(t *testing.T) {
 				},
 			}
 
-			err := jw.Write(nil, inputResults)
+			err := jw.Write(context.Background(), inputResults)
 			assert.NoError(t, err)
 
 			var got types.Report

--- a/pkg/report/predicate/vuln.go
+++ b/pkg/report/predicate/vuln.go
@@ -1,6 +1,7 @@
 package predicate
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -59,8 +60,7 @@ func NewVulnWriter(output io.Writer, version string) VulnWriter {
 	}
 }
 
-func (w VulnWriter) Write(report types.Report) error {
-
+func (w VulnWriter) Write(ctx context.Context, report types.Report) error {
 	predicate := CosignVulnPredicate{}
 
 	purl := packageurl.NewPackageURL("github", "aquasecurity", "trivy", w.version, nil, "")
@@ -70,7 +70,7 @@ func (w VulnWriter) Write(report types.Report) error {
 		Result:  report,
 	}
 
-	now := clock.Now()
+	now := clock.Now(ctx)
 	predicate.Metadata = Metadata{
 		ScanStartedOn:  now,
 		ScanFinishedOn: now,

--- a/pkg/report/predicate/vuln_test.go
+++ b/pkg/report/predicate/vuln_test.go
@@ -2,6 +2,7 @@ package predicate_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -84,7 +85,6 @@ func TestWriter_Write(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			inputResults := types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "alpine:3.14",
@@ -98,10 +98,10 @@ func TestWriter_Write(t *testing.T) {
 
 			output := bytes.NewBuffer(nil)
 
-			clock.SetFakeTime(t, time.Date(2022, 7, 22, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(context.Background(), time.Date(2022, 7, 22, 12, 20, 30, 5, time.UTC))
 			writer := predicate.NewVulnWriter(output, "dev")
 
-			err := writer.Write(inputResults)
+			err := writer.Write(ctx, inputResults)
 			require.NoError(t, err)
 
 			var got predicate.CosignVulnPredicate

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"fmt"
 	"html"
 	"io"
@@ -121,7 +122,7 @@ func getRuleIndex(id string, indexes map[string]int) int {
 	}
 }
 
-func (sw *SarifWriter) Write(report types.Report) error {
+func (sw *SarifWriter) Write(ctx context.Context, report types.Report) error {
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return xerrors.Errorf("error creating a new sarif template: %w", err)

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -549,7 +549,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 			w := report.SarifWriter{
 				Output: sarifWritten,
 			}
-			err := w.Write(tt.input)
+			err := w.Write(nil, tt.input)
 			assert.NoError(t, err)
 
 			result := &sarif.Report{}

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -1,6 +1,7 @@
 package spdx
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 
@@ -28,8 +29,8 @@ func NewWriter(output io.Writer, version string, spdxFormat types.Format) Writer
 	}
 }
 
-func (w Writer) Write(report types.Report) error {
-	spdxDoc, err := w.marshaler.Marshal(report)
+func (w Writer) Write(ctx context.Context, report types.Report) error {
+	spdxDoc, err := w.marshaler.Marshal(ctx, report)
 	if err != nil {
 		return xerrors.Errorf("failed to marshal spdx: %w", err)
 	}

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -53,7 +53,7 @@ type Renderer interface {
 }
 
 // Write writes the result on standard output
-func (tw Writer) Write(ctx context.Context, report types.Report) error {
+func (tw Writer) Write(_ context.Context, report types.Report) error {
 	for _, result := range report.Results {
 		// Not display a table of custom resources
 		if result.Class == types.ClassCustom {

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -52,7 +53,7 @@ type Renderer interface {
 }
 
 // Write writes the result on standard output
-func (tw Writer) Write(report types.Report) error {
+func (tw Writer) Write(ctx context.Context, report types.Report) error {
 	for _, result := range report.Results {
 		// Not display a table of custom resources
 		if result.Class == types.ClassCustom {

--- a/pkg/report/table/table_test.go
+++ b/pkg/report/table/table_test.go
@@ -354,7 +354,7 @@ package-lock.json
 					dbTypes.SeverityMedium,
 				},
 			}
-			err := writer.Write(types.Report{Results: tc.results})
+			err := writer.Write(nil, types.Report{Results: tc.results})
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, tableWritten.String(), tc.name)
 		})

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"html"
 	"io"
@@ -74,7 +75,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate, appVersion string) (*Te
 }
 
 // Write writes result
-func (tw TemplateWriter) Write(report types.Report) error {
+func (tw TemplateWriter) Write(ctx context.Context, report types.Report) error {
 	err := tw.Template.Execute(tw.Output, report.Results)
 	if err != nil {
 		return xerrors.Errorf("failed to write with template: %w", err)

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -39,7 +40,8 @@ func TestReportWriter_Template(t *testing.T) {
 					VulnerabilityID: "CVE-2019-0000",
 					PkgName:         "bar",
 					Vulnerability: dbTypes.Vulnerability{
-						Severity: dbTypes.SeverityHigh.String()},
+						Severity: dbTypes.SeverityHigh.String(),
+					},
 				},
 				{
 					VulnerabilityID: "CVE-2019-0001",
@@ -164,7 +166,7 @@ func TestReportWriter_Template(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clock.SetFakeTime(t, time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC))
+			ctx := clock.With(context.Background(), time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC))
 
 			os.Setenv("AWS_ACCOUNT_ID", "123456789012")
 			got := bytes.Buffer{}
@@ -180,7 +182,7 @@ func TestReportWriter_Template(t *testing.T) {
 
 			w, err := report.NewTemplateWriter(&got, tc.template, "dev")
 			require.NoError(t, err)
-			err = w.Write(inputReport)
+			err = w.Write(ctx, inputReport)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, got.String())
 		})

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -39,7 +39,7 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 
 	// Compliance report
 	if option.Compliance.Spec.ID != "" {
-		return complianceWrite(report, option, output)
+		return complianceWrite(ctx, report, option, output)
 	}
 
 	var writer Writer
@@ -97,19 +97,19 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 		return xerrors.Errorf("unknown format: %v", option.Format)
 	}
 
-	if err = writer.Write(report); err != nil {
+	if err = writer.Write(ctx, report); err != nil {
 		return xerrors.Errorf("failed to write results: %w", err)
 	}
 
 	return nil
 }
 
-func complianceWrite(report types.Report, opt flag.Options, output io.Writer) error {
+func complianceWrite(ctx context.Context, report types.Report, opt flag.Options, output io.Writer) error {
 	complianceReport, err := cr.BuildComplianceReport([]types.Results{report.Results}, opt.Compliance)
 	if err != nil {
 		return xerrors.Errorf("compliance report build error: %w", err)
 	}
-	return cr.Write(complianceReport, cr.Option{
+	return cr.Write(ctx, complianceReport, cr.Option{
 		Format:     opt.Format,
 		Report:     opt.ReportFormat,
 		Output:     output,
@@ -119,5 +119,5 @@ func complianceWrite(report types.Report, opt flag.Options, output io.Writer) er
 
 // Writer defines the result write operation
 type Writer interface {
-	Write(types.Report) error
+	Write(context.Context, types.Report) error
 }

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -40,7 +40,7 @@ func Filter(ctx context.Context, report types.Report, opt FilterOption) error {
 		return xerrors.Errorf("VEX error: %w", err)
 	}
 
-	ignoreConf, err := getIgnoredFindings(opt.IgnoreFile)
+	ignoreConf, err := getIgnoredFindings(ctx, opt.IgnoreFile)
 	if err != nil {
 		return xerrors.Errorf("%s error: %w", opt.IgnoreFile, err)
 	}

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -1072,9 +1072,9 @@ func TestFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeTime := time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC)
-			clock.SetFakeTime(t, fakeTime)
+			ctx := clock.With(context.Background(), fakeTime)
 
-			err := result.Filter(context.Background(), tt.args.report, result.FilterOption{
+			err := result.Filter(ctx, tt.args.report, result.FilterOption{
 				Severities:     tt.args.severities,
 				VEXPath:        tt.args.vexPath,
 				IgnoreStatuses: tt.args.ignoreStatuses,

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -72,11 +73,11 @@ func pathMatch(path string, patterns []string) bool {
 	return false
 }
 
-func (f *IgnoreFindings) Filter() {
+func (f *IgnoreFindings) Filter(ctx context.Context) {
 	var findings IgnoreFindings
 	for _, finding := range *f {
 		// Filter out expired ignore findings
-		if !finding.ExpiredAt.IsZero() && finding.ExpiredAt.Before(clock.Now()) {
+		if !finding.ExpiredAt.IsZero() && finding.ExpiredAt.Before(clock.Now(ctx)) {
 			continue
 		}
 
@@ -101,7 +102,7 @@ type IgnoreConfig struct {
 	Licenses          IgnoreFindings `yaml:"licenses"`
 }
 
-func getIgnoredFindings(ignoreFile string) (IgnoreConfig, error) {
+func getIgnoredFindings(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {
 	var conf IgnoreConfig
 	if _, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) {
 		// .trivyignore doesn't necessarily exist
@@ -127,10 +128,10 @@ func getIgnoredFindings(ignoreFile string) (IgnoreConfig, error) {
 		}
 	}
 
-	conf.Vulnerabilities.Filter()
-	conf.Misconfigurations.Filter()
-	conf.Secrets.Filter()
-	conf.Licenses.Filter()
+	conf.Vulnerabilities.Filter(ctx)
+	conf.Misconfigurations.Filter(ctx)
+	conf.Secrets.Filter(ctx)
+	conf.Licenses.Filter(ctx)
 
 	return conf, nil
 }

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -253,8 +253,8 @@ func Test_newServeMux(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = c.Close() }()
 
-			ts := httptest.NewServer(newServeMux(
-				c, dbUpdateWg, requestWg, tt.args.token, tt.args.tokenHeader, ""),
+			ts := httptest.NewServer(newServeMux(context.Background(), c, dbUpdateWg, requestWg, tt.args.token,
+				tt.args.tokenHeader, ""),
 			)
 			defer ts.Close()
 
@@ -284,8 +284,8 @@ func Test_VersionEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 
-	ts := httptest.NewServer(newServeMux(
-		c, dbUpdateWg, requestWg, "", "", "testdata/testcache"),
+	ts := httptest.NewServer(newServeMux(context.Background(), c, dbUpdateWg, requestWg, "", "",
+		"testdata/testcache"),
 	)
 	defer ts.Close()
 

--- a/pkg/sbom/cyclonedx/core/cyclonedx.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -60,10 +61,10 @@ func NewCycloneDX(version string) *CycloneDX {
 	}
 }
 
-func (c *CycloneDX) Marshal(root *Component) *cdx.BOM {
+func (c *CycloneDX) Marshal(ctx context.Context, root *Component) *cdx.BOM {
 	bom := cdx.NewBOM()
 	bom.SerialNumber = uuid.New().URN()
-	bom.Metadata = c.Metadata()
+	bom.Metadata = c.Metadata(ctx)
 
 	components := make(map[string]*cdx.Component)
 	dependencies := make(map[string]*[]string)
@@ -180,9 +181,9 @@ func (c *CycloneDX) BOMRef(component *Component) string {
 	return component.PackageURL.BOMRef()
 }
 
-func (c *CycloneDX) Metadata() *cdx.Metadata {
+func (c *CycloneDX) Metadata(ctx context.Context) *cdx.Metadata {
 	return &cdx.Metadata{
-		Timestamp: clock.Now().UTC().Format(timeLayout),
+		Timestamp: clock.Now(ctx).UTC().Format(timeLayout),
 		Tools: &[]cdx.Tool{
 			{
 				Vendor:  ToolVendor,

--- a/pkg/sbom/cyclonedx/core/cyclonedx_test.go
+++ b/pkg/sbom/cyclonedx/core/cyclonedx_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -365,11 +366,11 @@ func TestMarshaler_CoreComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := core.NewCycloneDX("dev")
-			got := marshaler.Marshal(tt.rootComponent)
+			got := marshaler.Marshal(ctx, tt.rootComponent)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -1,6 +1,7 @@
 package cyclonedx
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -57,14 +58,14 @@ func NewMarshaler(version string) *Marshaler {
 }
 
 // Marshal converts the Trivy report to the CycloneDX format
-func (e *Marshaler) Marshal(report types.Report) (*cdx.BOM, error) {
+func (e *Marshaler) Marshal(ctx context.Context, report types.Report) (*cdx.BOM, error) {
 	// Convert
 	root, err := e.MarshalReport(report)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to marshal report: %w", err)
 	}
 
-	return e.core.Marshal(root), nil
+	return e.core.Marshal(ctx, root), nil
 }
 
 func (e *Marshaler) MarshalReport(r types.Report) (*core.Component, error) {

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -1,6 +1,7 @@
 package cyclonedx_test
 
 import (
+	"context"
 	"github.com/package-url/packageurl-go"
 	"testing"
 	"time"
@@ -1825,11 +1826,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := cyclonedx.NewMarshaler("dev")
-			got, err := marshaler.Marshal(tt.inputReport)
+			got, err := marshaler.Marshal(ctx, tt.inputReport)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -1,6 +1,7 @@
 package spdx
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -106,7 +107,7 @@ func NewMarshaler(version string, opts ...marshalOption) *Marshaler {
 	return m
 }
 
-func (m *Marshaler) Marshal(r types.Report) (*spdx.Document, error) {
+func (m *Marshaler) Marshal(ctx context.Context, r types.Report) (*spdx.Document, error) {
 	var relationShips []*spdx.Relationship
 	packages := make(map[spdx.ElementID]*spdx.Package)
 	pkgDownloadLocation := getPackageDownloadLocation(r.ArtifactType, r.ArtifactName)
@@ -186,7 +187,7 @@ func (m *Marshaler) Marshal(r types.Report) (*spdx.Document, error) {
 					CreatorType: "Tool",
 				},
 			},
-			Created: clock.Now().UTC().Format(time.RFC3339),
+			Created: clock.Now(ctx).UTC().Format(time.RFC3339),
 		},
 		Packages:      toPackages(packages),
 		Relationships: relationShips,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1,6 +1,7 @@
 package spdx_test
 
 import (
+	"context"
 	"github.com/package-url/packageurl-go"
 	"hash/fnv"
 	"testing"
@@ -1105,11 +1106,11 @@ func TestMarshaler_Marshal(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := tspdx.NewMarshaler("0.38.1", tspdx.WithHasher(hasher))
-			spdxDoc, err := marshaler.Marshal(tc.inputReport)
+			spdxDoc, err := marshaler.Marshal(ctx, tc.inputReport)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.wantSBOM, spdxDoc)

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -120,7 +120,7 @@ func (s Scanner) ScanTarget(ctx context.Context, target types.ScanTarget, option
 	// Scan packages for vulnerabilities
 	if options.Scanners.Enabled(types.VulnerabilityScanner) {
 		var vulnResults types.Results
-		vulnResults, eosl, err = s.scanVulnerabilities(target, options)
+		vulnResults, eosl, err = s.scanVulnerabilities(ctx, target, options)
 		if err != nil {
 			return nil, ftypes.OS{}, xerrors.Errorf("failed to detect vulnerabilities: %w", err)
 		}
@@ -166,13 +166,13 @@ func (s Scanner) ScanTarget(ctx context.Context, target types.ScanTarget, option
 	return results, target.OS, nil
 }
 
-func (s Scanner) scanVulnerabilities(target types.ScanTarget, options types.ScanOptions) (
+func (s Scanner) scanVulnerabilities(ctx context.Context, target types.ScanTarget, options types.ScanOptions) (
 	types.Results, bool, error) {
 	var eosl bool
 	var results types.Results
 
 	if slices.Contains(options.VulnType, types.VulnTypeOS) {
-		vuln, detectedEOSL, err := s.osPkgScanner.Scan(target, options)
+		vuln, detectedEOSL, err := s.osPkgScanner.Scan(ctx, target, options)
 		if err != nil {
 			return nil, false, xerrors.Errorf("unable to scan OS packages: %w", err)
 		} else if vuln.Target != "" {

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -173,7 +173,7 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 
 	return types.Report{
 		SchemaVersion: report.SchemaVersion,
-		CreatedAt:     clock.Now(),
+		CreatedAt:     clock.Now(ctx),
 		ArtifactName:  artifactInfo.Name,
 		ArtifactType:  artifactInfo.Type,
 		Metadata: types.Metadata{

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -3,13 +3,13 @@ package scanner
 import (
 	"context"
 	"errors"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -19,7 +19,6 @@ func TestScanner_ScanArtifact(t *testing.T) {
 	type args struct {
 		options types.ScanOptions
 	}
-	clock.SetFakeTime(t, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	tests := []struct {
 		name               string
 		args               args
@@ -192,6 +191,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 		t.Run(tt.name, func(t *testing.T) {
 			d := new(MockDriver)
 			d.ApplyScanExpectation(tt.scanExpectation)
@@ -200,7 +200,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 			mockArtifact.ApplyInspectExpectation(tt.inspectExpectation)
 
 			s := NewScanner(d, mockArtifact)
-			got, err := s.ScanArtifact(context.Background(), tt.args.options)
+			got, err := s.ScanArtifact(ctx, tt.args.options)
 			if tt.wantErr != "" {
 				require.NotNil(t, err, tt.name)
 				require.Contains(t, err.Error(), tt.wantErr, tt.name)


### PR DESCRIPTION
## Description
In Trivy, `time.Now()` has been traditionally handled through two methods: 
- Functional Options Pattern ([example](https://github.com/aquasecurity/trivy/blob/1607eee77c1d0cb09d5eda1730b5cd5ac7b627aa/pkg/detector/ospkg/amazon/amazon.go#L30-L61))
- Global variables ([here](https://github.com/aquasecurity/trivy/blob/1607eee77c1d0cb09d5eda1730b5cd5ac7b627aa/pkg/clock/clock.go#L11))

While Functional Options offer advantages in unit testing, they present challenges in integration testing, especially when multiple instances of `time.Now()` need to be mocked with a consistent, fixed time. This approach often requires repetitive coding in multiple places. Conversely, global variables, though convenient, complicate ensuring thread safety.

To address these issues, this PR introduces a new approach: storing and passing `time.Time` within the context. As per the documentation guidelines, context values should be used cautiously and are not meant for every situation. 

>Use context values only for request-scoped data that transits processes and API boundaries, not for passing optional parameters to functions.

However, leveraging context values is a viable solution for data that is integral throughout the entire process flow.

This change allows us to maintain a uniform, fixed time reference throughout a single process while ensuring thread safety. We are open to future improvements and will consider any better methods that may emerge.

This modification enhances our integration testing capabilities. By enabling the fixation of time in tests, we can prevent failures due to End-Of-Life (EOL) related time issues, as was previously encountered in our project, like [this](https://github.com/aquasecurity/trivy/actions/runs/7378072790/job/20072769365?pr=5856).


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
