### PR TITLE
fix(secret): `AWS Secret Access Key` must include only secrets with `aws` text.

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -78,7 +78,7 @@ const (
 	startSecret = `(^|\s+)`
 	endSecret   = `(\s+|$)`
 
-	aws = `(aws)?_?`
+	aws = `aws_?`
 )
 
 // This function is exported for trivy-plugin-aqua purposes only


### PR DESCRIPTION
## Description
AWS Secret Access Key must include only secrets with aws text.

## Related issues
- Close #5900

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
