### PR TITLE
fix(alpine): Add EOL support for alpine 3.19.

### DIFF
--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -46,6 +46,7 @@ var (
 		"3.16": time.Date(2024, 5, 23, 23, 59, 59, 0, time.UTC),
 		"3.17": time.Date(2024, 11, 22, 23, 59, 59, 0, time.UTC),
 		"3.18": time.Date(2025, 5, 9, 23, 59, 59, 0, time.UTC),
+		"3.19": time.Date(2025, 11, 1, 23, 59, 59, 0, time.UTC),
 		"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 )


### PR DESCRIPTION
## Description
Alpine 3.19.x base images are getting falsely flagged as EOL. Alpine 3.19 was released 2023-12-07 and is supported until 2025-11-01. 
https://endoflife.date/alpine

Trivy scan message:
> The operating system version has reached its end of support life and is no longer receiving security updates. Please update to a more recent and supported version.

## Related issues
- Close n/a

## Related PRs
- https://github.com/aquasecurity/trivy/pull/4308


## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
