### PR TITLE
feat(repo): Checksum signature verification

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -129,6 +129,11 @@ The process above can be automated by the following script:
 curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin {{ git.tag }}
 ```
 
+To run signature verfication, pass `-v` command line flag.
+```bash
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin -v {{ git.tag }}
+```
+
 ### Install from source
 
 ```bash


### PR DESCRIPTION
## Description
This PR adds checksum.txt file signature verification before downloading and installing the binary. This optional opt-in feature uses the command line flag -v to the installation script.

The signature verification process depends on 3rd party cosign binary. If the binary is not found, the user is prompted to install the binary. Cosign binary installation is not part of this script.

The overall process with signature verification looks like this:
1. User supplies -v command line flag to the installation script.
2. Script checks for cosign binary terminates execution with a message if not found.
3. The script downloads checksum.txt, checksum.txt.sig, and checksum.txt.pem files.
4. The script runs checksum.txt file signature verification.
5. On successful verification, the script continues to download the actual binary, run checksum verification, and install it.

### Before:
N/A

### After:
#### Successful verification:
```shell
$ ./contrib/install.sh -v -d
aquasecurity/trivy info checking GitHub for latest tag
aquasecurity/trivy info found version: 0.48.3 for v0.48.3/Linux/64bit
aquasecurity/trivy debug downloading files into /tmp/tmp.ZZ6KOpaeAn
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt.pem
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt.sig
aquasecurity/trivy debug Verifying artifact /tmp/tmp.ZZ6KOpaeAn/trivy_0.48.3_checksums.txt
Verified OK
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_Linux-64bit.tar.gz
aquasecurity/trivy info installed ./bin/trivy
```

#### Signature verification failure:
```shell
$ ./contrib/install.sh -v -d
aquasecurity/trivy info checking GitHub for latest tag
aquasecurity/trivy info found version: 0.48.3 for v0.48.3/Linux/64bit
aquasecurity/trivy debug downloading files into /tmp/tmp.CmUO3DgqLT
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt.pem
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.48.3/trivy_0.48.3_checksums.txt.sig
aquasecurity/trivy debug Verifying artifact /tmp/tmp.CmUO3DgqLT/trivy_0.48.3_checksums.txt
Error: none of the expected identities matched what was in the certificate, got subjects [https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v0.48.3] with issuer https://token.actions.githubusercontent.com
main.go:74: error during command execution: none of the expected identities matched what was in the certificate, got subjects [https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v0.48.3] with issuer https://token.actions.githubusercontent.com
```

#### Cosign binary not found:
```shell
$ ./contrib/install.sh -v -d
aquasecurity/trivy err Signature verification is requested but cosign binary is not installed. Follow steps from https://docs.sigstore.dev/system_config/installation/ to install it.
```
## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/5238

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
