### PR TITLE
fix: Added test for golang package that include subpath into the module

### DIFF
--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -180,6 +180,23 @@ func TestNewPackageURL(t *testing.T) {
 			},
 		},
 		{
+			name: "golang package with major version",
+			typ:  ftypes.GoModule,
+			pkg: ftypes.Package{
+				Name:    "github.com/coreos/go-systemd/v22",
+				Version: "v22.1.0",
+			},
+			want: &purl.PackageURL{
+				PackageURL: packageurl.PackageURL{
+					Type:      packageurl.TypeGolang,
+					Namespace: "github.com/coreos/",
+					Name:      "go-systemd",
+					Version:   "v22.1.0",
+					Subpath:   "v22",
+				},
+			},
+		},
+		{
 			name: "golang package with a local path",
 			typ:  ftypes.GoModule,
 			pkg: ftypes.Package{


### PR DESCRIPTION
## Description

Add a test for golang modules that include subpaths (often in the form of the module's major version. i.e. `github.com/coreos/go-systemd/v22`


## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
