### PR TITLE
refactor(report): Replacing `source_location` in `github` report when scanning an image

### DIFF
--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -109,7 +109,7 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 				// `RepoDigests` ~= <registry>/<image_name>@sha256:<image_hash>
 				// `RepoTag` ~= <registry>/<image_name>:<image_tag>
 				// By concatenating the hash from `RepoDigests` at the end of `RepoTag` we get all the information
-				image_reference := strings.Join(report.Metadata.RepoTags, ", ")
+				imageReference := strings.Join(report.Metadata.RepoTags, ", ")
 				image_with_hash := strings.Join(report.Metadata.RepoDigests, ", ")
 				_, image_hash, found := strings.Cut(image_with_hash, "@")
 				if found {

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -106,13 +106,16 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 		// show path for language-specific packages only
 		if result.Class == types.ClassLangPkg {
 			if report.ArtifactType == ftypes.ArtifactContainerImage {
-				// Replacing `source_location` by the image name and tag
+				// `RepoDigests` ~= <registry>/<image_name>@sha256:<image_hash>
+				// `RepoTag` ~= <registry>/<image_name>:<image_tag>
+				// By concatenating the hash from `RepoDigests` at the end of `RepoTag` we get all the information
 				image_reference := strings.Join(report.Metadata.RepoTags, ", ")
 				image_with_hash := strings.Join(report.Metadata.RepoDigests, ", ")
 				_, image_hash, found := strings.Cut(image_with_hash, "@")
 				if found {
 					image_reference += "@" + image_hash
 				}
+				// Replacing `source_location` in manifest by the image name, tag and hash
 				manifest.File = &File{
 					SrcLocation: image_reference,
 				}

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -105,8 +105,17 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 		manifest.Name = string(result.Type)
 		// show path for language-specific packages only
 		if result.Class == types.ClassLangPkg {
-			manifest.File = &File{
-				SrcLocation: result.Target,
+			if report.ArtifactType == "container_image" {
+				// Replacing `source_location` by the image name and tag
+				image_reference := strings.Join(report.Metadata.RepoTags, ", ")
+				manifest.File = &File{
+					SrcLocation: image_reference,
+				}
+
+			} else {
+				manifest.File = &File{
+					SrcLocation: result.Target,
+				}
 			}
 		}
 

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -105,7 +105,7 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 		manifest.Name = string(result.Type)
 		// show path for language-specific packages only
 		if result.Class == types.ClassLangPkg {
-			if report.ArtifactType == "container_image" {
+			if report.ArtifactType == ftypes.ArtifactContainerImage {
 				// Replacing `source_location` by the image name and tag
 				image_reference := strings.Join(report.Metadata.RepoTags, ", ")
 				manifest.File = &File{

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -140,6 +140,10 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 				return xerrors.Errorf("unable to build purl for %s: %w", pkg.Name, err)
 			}
 
+			if pkg.FilePath != "" {
+				githubPkg.Metadata = Metadata{"source_location": pkg.FilePath}
+			}
+
 			resolved[pkg.Name] = githubPkg
 		}
 

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -108,6 +108,11 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 			if report.ArtifactType == ftypes.ArtifactContainerImage {
 				// Replacing `source_location` by the image name and tag
 				image_reference := strings.Join(report.Metadata.RepoTags, ", ")
+				image_with_hash := strings.Join(report.Metadata.RepoDigests, ", ")
+				_, image_hash, found := strings.Cut(image_with_hash, "@")
+				if found {
+					image_reference += "@" + image_hash
+				}
 				manifest.File = &File{
 					SrcLocation: image_reference,
 				}

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -110,14 +110,14 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 				// `RepoTag` ~= <registry>/<image_name>:<image_tag>
 				// By concatenating the hash from `RepoDigests` at the end of `RepoTag` we get all the information
 				imageReference := strings.Join(report.Metadata.RepoTags, ", ")
-				image_with_hash := strings.Join(report.Metadata.RepoDigests, ", ")
-				_, image_hash, found := strings.Cut(image_with_hash, "@")
+				imageWithHash := strings.Join(report.Metadata.RepoDigests, ", ")
+				_, imageHash, found := strings.Cut(imageWithHash, "@")
 				if found {
-					image_reference += "@" + image_hash
+					imageReference += "@" + imageHash
 				}
 				// Replacing `source_location` in manifest by the image name, tag and hash
 				manifest.File = &File{
-					SrcLocation: image_reference,
+					SrcLocation: imageReference,
 				}
 
 			} else {

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -165,7 +165,7 @@ func TestWriter_Write(t *testing.T) {
 			},
 		},
 		{
-			name: "pypi",
+			name: "pypi from image",
 			report: types.Report{
 				SchemaVersion: 2,
 				ArtifactName:  "fake_repo.azurecr.io/image_name",

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -212,7 +212,7 @@ func TestWriter_Write(t *testing.T) {
 				"Python": {
 					Name: "python-pkg",
 					File: &github.File{
-						SrcLocation: "fake_repo.azurecr.io/image_name:latest",
+						SrcLocation: "fake_repo.azurecr.io/image_name:latest@sha256:a7c92cdcb3d010f6edeb37ddcdbacab14981aa31e7f1140e0097dc1b8e834c49",
 					},
 					Resolved: map[string]github.Package{
 						"jwcrypto": {

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -219,11 +219,13 @@ func TestWriter_Write(t *testing.T) {
 							PackageUrl:   "pkg:pypi/jwcrypto@0.7",
 							Relationship: "direct",
 							Scope:        "runtime",
+							Metadata:     github.Metadata{"source_location": "opt/pyenv/versions/3.11.2/lib/python3.11/site-packages/jwcrypto-0.7.dist-info/METADATA"},
 						},
 						"matplotlib": {
 							PackageUrl:   "pkg:pypi/matplotlib@3.5.3",
 							Relationship: "direct",
 							Scope:        "runtime",
+							Metadata:     github.Metadata{"source_location": "opt/pyenv/versions/3.11.2/lib/python3.11/site-packages/matplotlib-3.5.3.dist-info/METADATA"},
 						},
 					},
 				},

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -164,6 +164,71 @@ func TestWriter_Write(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pypi",
+			report: types.Report{
+				SchemaVersion: 2,
+				ArtifactName:  "fake_repo.azurecr.io/image_name",
+				ArtifactType:  "container_image",
+				Metadata: types.Metadata{
+					RepoDigests: []string{"fake_repo.azurecr.io/image_name@sha256:a7c92cdcb3d010f6edeb37ddcdbacab14981aa31e7f1140e0097dc1b8e834c49"},
+					RepoTags:    []string{"fake_repo.azurecr.io/image_name:latest"},
+				},
+				Results: types.Results{
+					{
+						Target: "Python",
+						Class:  "lang-pkgs",
+						Type:   "python-pkg",
+						Packages: []ftypes.Package{
+							{
+								Name:    "jwcrypto",
+								Version: "0.7",
+								Licenses: []string{
+									"LGPLv3+",
+								},
+								Layer: ftypes.Layer{
+									Digest: "sha256:ddc612ba4e74ea5633a93e19e7c32f61f5f230073b21a070302a61ef5eec5c50",
+									DiffID: "sha256:12935ef6ce21a266aef8df75d601cebf7e935edd01e9f19fab16ccb78fbb9a5e",
+								},
+								FilePath: "opt/pyenv/versions/3.11.2/lib/python3.11/site-packages/jwcrypto-0.7.dist-info/METADATA",
+							},
+							{
+								Name:    "matplotlib",
+								Version: "3.5.3",
+								Licenses: []string{
+									"PSF",
+								},
+								Layer: ftypes.Layer{
+									Digest: "sha256:ddc612ba4e74ea5633a93e19e7c32f61f5f230073b21a070302a61ef5eec5c50",
+									DiffID: "sha256:12935ef6ce21a266aef8df75d601cebf7e935edd01e9f19fab16ccb78fbb9a5e",
+								},
+								FilePath: "opt/pyenv/versions/3.11.2/lib/python3.11/site-packages/matplotlib-3.5.3.dist-info/METADATA",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]github.Manifest{
+				"Python": {
+					Name: "python-pkg",
+					File: &github.File{
+						SrcLocation: "fake_repo.azurecr.io/image_name:latest",
+					},
+					Resolved: map[string]github.Package{
+						"jwcrypto": {
+							PackageUrl:   "pkg:pypi/jwcrypto@0.7",
+							Relationship: "direct",
+							Scope:        "runtime",
+						},
+						"matplotlib": {
+							PackageUrl:   "pkg:pypi/matplotlib@3.5.3",
+							Relationship: "direct",
+							Scope:        "runtime",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Relates to https://github.com/aquasecurity/trivy/discussions/5998

Fixes https://github.com/aquasecurity/trivy/issues/6008

The goal is to change the `source_location` of the `manifest` in SBOM report so it provides useful information when displayed in Github Dependency.

The current solution is to use `<image_registry>/<image_name>:<tag>@sha256:<image_hash>` format.

### Before changes

As you can see instead of specifying the image scanned, it only show `Python`.
![Screenshot_20240120_174723](https://github.com/aquasecurity/trivy/assets/72691393/e796bf15-fd85-4d8e-9316-5640efee11df)

### After changes


![Screenshot_20240120_174554](https://github.com/aquasecurity/trivy/assets/72691393/2c0c5ba0-a2dd-4bd5-b0d4-ab6e020a2989)

The report now shows the image name and tag as the `source_location` for all packages.
```
"manifests": {
    "Python": {
      "name": "python-pkg",
      "file": {
        "source_location": "redacted_registry/accesspod:latest"
      },
```


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
