### PR TITLE
fix: check returned error before deferring f.Close()

### DIFF
--- a/pkg/fanal/analyzer/pkg/apk/apk_test.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk_test.go
@@ -408,8 +408,8 @@ func TestParseApkInfo(t *testing.T) {
 		t.Run(testname, func(t *testing.T) {
 			a := alpinePkgAnalyzer{}
 			f, err := os.Open(tt.path)
-			defer f.Close()
 			require.NoError(t, err)
+			defer f.Close()
 			scanner := bufio.NewScanner(f)
 			gotPkgs, gotFiles := a.parseApkInfo(scanner)
 


### PR DESCRIPTION
## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
