### PR TITLE
fix(report): use `AWS_REGION` env for secrets in `asff` template

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -128,7 +128,7 @@
         {
             "SchemaVersion": "2018-10-08",
             "Id": "{{ $target }}",
-            "ProductArn": "arn:aws:securityhub:{{ env "AWS_DEFAULT_REGION" }}::product/aquasecurity/aquasecurity",
+            "ProductArn": "arn:aws:securityhub:{{ env "AWS_REGION" }}::product/aquasecurity/aquasecurity",
             "GeneratorId": "Trivy",
             "AwsAccountId": "{{ env "AWS_ACCOUNT_ID" }}",
             "Types": [ "Sensitive Data Identifications" ],
@@ -145,7 +145,7 @@
                     "Type": "Other",
                     "Id": "{{ $target }}",
                     "Partition": "aws",
-                    "Region": "{{ env "AWS_DEFAULT_REGION" }}",
+                    "Region": "{{ env "AWS_REGION" }}",
                     "Details": {
                         "Other": {
                             "Filename": "{{ $target }}"

--- a/integration/testdata/secrets.asff.golden
+++ b/integration/testdata/secrets.asff.golden
@@ -2,7 +2,7 @@
     "Findings": [{
             "SchemaVersion": "2018-10-08",
             "Id": "deploy.sh",
-            "ProductArn": "arn:aws:securityhub:::product/aquasecurity/aquasecurity",
+            "ProductArn": "arn:aws:securityhub:test-region::product/aquasecurity/aquasecurity",
             "GeneratorId": "Trivy",
             "AwsAccountId": "123456789012",
             "Types": [ "Sensitive Data Identifications" ],
@@ -19,7 +19,7 @@
                     "Type": "Other",
                     "Id": "deploy.sh",
                     "Partition": "aws",
-                    "Region": "",
+                    "Region": "test-region",
                     "Details": {
                         "Other": {
                             "Filename": "deploy.sh"
@@ -31,7 +31,7 @@
         },{
             "SchemaVersion": "2018-10-08",
             "Id": "deploy.sh",
-            "ProductArn": "arn:aws:securityhub:::product/aquasecurity/aquasecurity",
+            "ProductArn": "arn:aws:securityhub:test-region::product/aquasecurity/aquasecurity",
             "GeneratorId": "Trivy",
             "AwsAccountId": "123456789012",
             "Types": [ "Sensitive Data Identifications" ],
@@ -48,7 +48,7 @@
                     "Type": "Other",
                     "Id": "deploy.sh",
                     "Partition": "aws",
-                    "Region": "",
+                    "Region": "test-region",
                     "Details": {
                         "Other": {
                             "Filename": "deploy.sh"


### PR DESCRIPTION
## Description
Use `AWS_REGION` env (https://aquasecurity.github.io/trivy/v0.48/tutorials/integrations/aws-security-hub/) for secrets in `asff` template.

## Related issues
- Close #6010

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
