### PR TITLE
fix: check unescaped `BomRef` when matching `PkgIdentifier`

### DIFF
--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"net/url"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -156,8 +157,16 @@ func (id *PkgIdentifier) Empty() bool {
 }
 
 func (id *PkgIdentifier) Match(s string) bool {
+	// `s` can be an unescaped string
+	// e.g. CycloneDX unescapes BOM Links - https://github.com/CycloneDX/cyclonedx-go/blob/b9654ae9b4705645152d20eb9872b5f3d73eac49/link.go#L136
+	// So we need to match escaped and unescaped BOMRef
+	var unescapedBomRef string
+	if ref, err := url.QueryUnescape(id.BOMRef); err == nil {
+		unescapedBomRef = ref
+	}
+
 	switch {
-	case id.BOMRef == s:
+	case id.BOMRef == s || unescapedBomRef == s:
 		return true
 	case id.PURL != nil && id.PURL.String() == s:
 		return true

--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"encoding/json"
-	"net/url"
+	"strings"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -157,16 +157,15 @@ func (id *PkgIdentifier) Empty() bool {
 }
 
 func (id *PkgIdentifier) Match(s string) bool {
-	// `s` can be an unescaped string
-	// e.g. CycloneDX unescapes BOM Links - https://github.com/CycloneDX/cyclonedx-go/blob/b9654ae9b4705645152d20eb9872b5f3d73eac49/link.go#L136
-	// So we need to match escaped and unescaped BOMRef
-	var unescapedBomRef string
-	if ref, err := url.QueryUnescape(id.BOMRef); err == nil {
-		unescapedBomRef = ref
+	// Encode string as PURL
+	if strings.HasPrefix(s, "pkg:") {
+		if p, err := packageurl.FromString(s); err == nil {
+			s = p.String()
+		}
 	}
 
 	switch {
-	case id.BOMRef == s || unescapedBomRef == s:
+	case id.BOMRef == s:
 		return true
 	case id.PURL != nil && id.PURL.String() == s:
 		return true

--- a/pkg/vex/testdata/cyclonedx.json
+++ b/pkg/vex/testdata/cyclonedx.json
@@ -18,6 +18,27 @@
           "ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.0"
         }
       ]
+    },
+    {
+      "id": "CVE-2022-27943",
+      "source": {
+        "name": "ubuntu",
+        "url": "https://git.launchpad.net/ubuntu-cve-tracker"
+      },
+      "affects": [
+        {
+          "ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:deb/ubuntu/libstdc%2B%2B6@12.3.0-1ubuntu1~22.04?arch=amd64&distro=ubuntu-22.04",
+          "versions": [
+            {
+              "version": "12.3.0-1ubuntu1~22.04",
+              "status": "affected"
+            }
+          ]
+        }
+      ],
+      "analysis": {
+        "state": "not_affected"
+      }
     }
   ]
 }

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -155,7 +155,7 @@ func TestVEX_Filter(t *testing.T) {
 						PkgName:          "libstdc++6",
 						InstalledVersion: "12.3.0-1ubuntu1~22.04",
 						PkgIdentifier: ftypes.PkgIdentifier{
-							BOMRef: "pkg:deb/ubuntu/libstdc%2B%2B6@12.3.0-1ubuntu1~22.04?arch=amd64&distro=ubuntu-22.04",
+							BOMRef: "pkg:deb/ubuntu/libstdc%2B%2B6@12.3.0-1ubuntu1~22.04?distro=ubuntu-22.04&arch=amd64",
 							PURL: &packageurl.PackageURL{
 								Type:      packageurl.TypeDebian,
 								Namespace: "ubuntu",

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -149,6 +149,31 @@ func TestVEX_Filter(t *testing.T) {
 							},
 						},
 					},
+					{
+						VulnerabilityID:  "CVE-2022-27943",
+						PkgID:            "libstdc++6@12.3.0-1ubuntu1~22.04",
+						PkgName:          "libstdc++6",
+						InstalledVersion: "12.3.0-1ubuntu1~22.04",
+						PkgIdentifier: ftypes.PkgIdentifier{
+							BOMRef: "pkg:deb/ubuntu/libstdc%2B%2B6@12.3.0-1ubuntu1~22.04?arch=amd64&distro=ubuntu-22.04",
+							PURL: &packageurl.PackageURL{
+								Type:      packageurl.TypeDebian,
+								Namespace: "ubuntu",
+								Name:      "libstdc++6",
+								Version:   "12.3.0-1ubuntu1~22.04",
+								Qualifiers: []packageurl.Qualifier{
+									{
+										Key:   "arch",
+										Value: "amd64",
+									},
+									{
+										Key:   "distro",
+										Value: "ubuntu-22.04",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			want: []types.DetectedVulnerability{


### PR DESCRIPTION
## Description
When [parsing BomLink]((https://github.com/CycloneDX/cyclonedx-go/blob/master/link.go#L136)), we get an unescaped BomRef.
But we use purl for `BomRef`. So in some cases we may see escaped characters (e.g. `pkg:deb/ubuntu/libstdc%2B%2B6@12.3.0-1ubuntu1~22.04`).
To avoid cases when we don't match refs - we need to compare escaped and unespected BomRef with ref from BomLink.

## Related issues
- Close #6023

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
