### PR TITLE
test: fix flaky `TestDockerEngine`

### DIFF
--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -245,10 +245,10 @@ func TestDockerEngine(t *testing.T) {
 				// load image into docker engine
 				res, err := cli.ImageLoad(ctx, testfile, true)
 				require.NoError(t, err, tt.name)
-				if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-					return err
+				if _, err := io.Copy(io.Discard, res.Body); err != nil {
+					require.NoError(t, err, tt.name)
 				}
-				defer resp.Body.Close()
+				defer res.Body.Close()
 
 				// tag our image to something unique
 				err = cli.ImageTag(ctx, tt.imageTag, tt.input)

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -245,7 +245,10 @@ func TestDockerEngine(t *testing.T) {
 				// load image into docker engine
 				res, err := cli.ImageLoad(ctx, testfile, true)
 				require.NoError(t, err, tt.name)
-				io.Copy(io.Discard, res.Body)
+				if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+					return err
+				}
+				defer resp.Body.Close()
 
 				// tag our image to something unique
 				err = cli.ImageTag(ctx, tt.imageTag, tt.input)
@@ -253,15 +256,14 @@ func TestDockerEngine(t *testing.T) {
 
 				// cleanup
 				t.Cleanup(func() {
-					_, err = cli.ImageRemove(ctx, tt.input, api.ImageRemoveOptions{
+					_, _ = cli.ImageRemove(ctx, tt.input, api.ImageRemoveOptions{
 						Force:         true,
 						PruneChildren: true,
 					})
-					_, err = cli.ImageRemove(ctx, tt.imageTag, api.ImageRemoveOptions{
+					_, _ = cli.ImageRemove(ctx, tt.imageTag, api.ImageRemoveOptions{
 						Force:         true,
 						PruneChildren: true,
 					})
-					assert.NoError(t, err, tt.name)
 				})
 			}
 


### PR DESCRIPTION
## Description
We need to close `ImageLoad` response to avoid a resource leak - https://github.com/moby/moby/blob/71fa3ab079ec13d17257f86fa92db8d7f24802f1/api/types/client.go#L198
We get flaky errors when try to remove image after finish each `TestDockerEngine` testcase:
https://github.com/aquasecurity/trivy/actions/runs/7743024958/job/21113470515?pr=6047#step:5:652
Looks like we don't need to check this error.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
