### PR TITLE
docs: Fix broken link to "pronunciation"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ Contact us about any matter by opening a GitHub Discussion [here][discussions]
 
 [Ecosystem]: ./ecosystem/index.md
 [Installation]: getting-started/installation.md
-[pronunciation]: #how-to-pronounce-the-name-trivy
+[pronunciation]: getting-started/faq.md#how-to-pronounce-the-name-trivy
 [Scanning Coverage]: ./docs/coverage/index.md
 
 [aquasec]: https://aquasec.com


### PR DESCRIPTION
## Description

Trivial documentation issue.
Fixes a broken link: "pronunciation" in the docs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
