### PR TITLE
ci: reduce `root-reserve-mb` size for `maximize-build-space`

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 35840 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
@@ -142,7 +142,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'
@@ -175,7 +175,7 @@ jobs:
     - name: Maximize build space
       uses: easimon/maximize-build-space@v10
       with:
-        root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+        root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
         remove-android: 'true'
         remove-docker-images: 'true'
         remove-dotnet: 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 30720 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,12 +91,11 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 25600 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 30720 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
           remove-haskell: "true"
-          remove-codeql: "true"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 34816 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
@@ -142,7 +142,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 34816 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
@@ -175,7 +175,7 @@ jobs:
     - name: Maximize build space
       uses: easimon/maximize-build-space@v10
       with:
-        root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+        root-reserve-mb: 33792 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
         remove-android: 'true'
         remove-docker-images: 'true'
         remove-dotnet: 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 35840 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: 'true'
           remove-docker-images: 'true'
           remove-dotnet: 'true'
@@ -175,7 +175,7 @@ jobs:
     - name: Maximize build space
       uses: easimon/maximize-build-space@v10
       with:
-        root-reserve-mb: 35840 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+        root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
         remove-android: 'true'
         remove-docker-images: 'true'
         remove-dotnet: 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,11 +91,12 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 35840 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 25600 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
           remove-haskell: "true"
+          remove-codeql: "true"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
## Description
Size of GitHub action ubuntu image has been reduce:
before:
```
Filesystem Size Used Avail Use% Mounted on 
/dev/root 84G 53G 31G 64% /
```

now:
```
Filesystem Size Used Avail Use% Mounted on 
/dev/root 73G 53G 21G 73% /
```
So we can't get [35840MB](https://github.com/aquasecurity/trivy/blob/fc20dfdd804389f82f397707fe641dcf26e2dc98/.github/workflows/test.yaml#L94C28-L94C33) - https://github.com/aquasecurity/trivy/actions/runs/7779351592/job/21210359409
So we need to reduce `root-reserve-mb` value.

Also i [played](https://github.com/DmitriyLewen/trivy/pull/24) with root-reserve-mb. Size equal 32GB doesn't return error.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
