### PR TITLE
fix(misconf): get `user` from `Config.User`

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -104,6 +104,7 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 							Interval: time.Second * 10,
 							Timeout:  time.Second * 3,
 						},
+						User: "1002",
 					},
 					History: []v1.History{
 						{
@@ -125,10 +126,6 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 						{
 							CreatedBy:  "RUN /bin/sh -c ls -hl /foo # buildkit",
 							EmptyLayer: false,
-						},
-						{
-							CreatedBy:  "USER foo",
-							EmptyLayer: true,
 						},
 						{
 							CreatedBy:  `HEALTHCHECK &{["CMD-SHELL" "curl -sS 127.0.0.1 || exit 1"] "10s" "3s" "0s" '\x00'}`,


### PR DESCRIPTION
## Description
Possible cases when `History` doesn't contain information about user.
`Config.User` can contain user information:
```bash
➜  ~ docker image inspect alpine | jq '.[].Config.User'
""
➜  ~ docker history alpine          
IMAGE          CREATED        CREATED BY                                      SIZE      COMMENT
5053b247d78b   7 months ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B        
<missing>      7 months ago   /bin/sh -c #(nop) ADD file:289c2fac17119508c…   7.66MB    
➜  ~ docker run --user 1003 alpine
➜  ~ docker ps -a          
CONTAINER ID   IMAGE     COMMAND     CREATED          STATUS                      PORTS     NAMES
bcbf97a115a5   alpine    "/bin/sh"   28 seconds ago   Exited (0) 27 seconds ago             focused_fermat
➜  ~ docker commit bcbf97a115a5 alpine:test-user
sha256:04babd6fbc5d383e83019b5e3d5a9c37f50158f7f0a3cc19a7d6546ea562dc4d
➜  ~ docker image inspect alpine:test-user | jq '.[].Config.User'
"1003"
➜  ~ docker history alpine:test-user
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
04babd6fbc5d   23 seconds ago   /bin/sh                                         0B        
5053b247d78b   7 months ago     /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B        
<missing>      7 months ago     /bin/sh -c #(nop) ADD file:289c2fac17119508c…   7.66MB 

➜  ~ docker run -it --rm alpine:test-user
~ $ whoami
whoami: unknown uid 1003
~ $ id -u -n
1003id: unknown ID 1003
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
