### PR TITLE
fix(lang): Always include the "Results" section in the output JSON even if no vulnerabilities are detected

### DIFF
--- a/pkg/scanner/langpkg/scan.go
+++ b/pkg/scanner/langpkg/scan.go
@@ -74,8 +74,6 @@ func (s *scanner) Scan(target types.ScanTarget, _ types.ScanOptions) (types.Resu
 		vulns, err := library.Detect(app.Type, app.Libraries)
 		if err != nil {
 			return nil, xerrors.Errorf("failed vulnerability detection of libraries: %w", err)
-		} else if len(vulns) == 0 {
-			continue
 		}
 
 		results = append(results, types.Result{


### PR DESCRIPTION
## Description

When performing a vulnerability scan for language package vulnerabilities with JSON output (eg. `trivy fs ~/project --format json`). The `"Results"` section should always be present, even if no vulnerabilities were found.

## Related issues
- https://github.com/aquasecurity/trivy/discussions/6080

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
