### PR TITLE
fix: add context to target finding on k8s table view

### DIFF
--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -50,8 +50,9 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 			Output:     tw.Output,
 			Severities: tw.Severities,
 		}
-		for _, r := range report.Resources {
+		for i, r := range report.Resources {
 			if r.Report.Results.Failed() {
+				updateTargetContext(&report.Resources[i])
 				err := t.Write(ctx, r.Report)
 				if err != nil {
 					return err
@@ -66,4 +67,11 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 	}
 
 	return nil
+}
+
+// updateTargetContext add context namespace, kind and name to the target
+func updateTargetContext(r *Resource) {
+	for i := range r.Report.Results {
+		r.Report.Results[i].Target = r.fullname()
+	}
 }

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -74,7 +74,7 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 // updateTargetContext add context namespace, kind and name to the target
 func updateTargetContext(r *Resource) {
 	targetName := fmt.Sprintf("namespace: %s, %s: %s", r.Namespace, strings.ToLower(r.Kind), r.Name)
-	if r.Kind == "NodeComponents" {
+	if r.Kind == "NodeComponents" || r.Kind == "NodeInfo" {
 		targetName = fmt.Sprintf("node: %s", r.Name)
 	}
 	for i := range r.Report.Results {

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -2,7 +2,9 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
 
 	"golang.org/x/xerrors"
 
@@ -71,7 +73,11 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 
 // updateTargetContext add context namespace, kind and name to the target
 func updateTargetContext(r *Resource) {
+	targetName := fmt.Sprintf("namespace: %s, %s: %s", r.Namespace, strings.ToLower(r.Kind), r.Name)
+	if r.Kind == "NodeComponents" {
+		targetName = fmt.Sprintf("node: %s", r.Name)
+	}
 	for i := range r.Report.Results {
-		r.Report.Results[i].Target = r.fullname()
+		r.Report.Results[i].Target = targetName
 	}
 }


### PR DESCRIPTION
## Description
add context to Target (`namespace/kind/name`) finding on k8s table view

## Related issues
- Close #6098

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).

example:

### Before
```

k8s.io/apiserver (kubernetes)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌──────────────────┬───────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability │ Severity │ Status │ Installed Version │          Fixed Version           │                           Title                           │
├──────────────────┼───────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ k8s.io/apiserver │ CVE-2022-3162 │ MEDIUM   │ fixed  │ 1.21.1            │ 1.22.16, 1.23.14, 1.24.8, 1.25.4 │ Unauthorized read of Custom Resources                     │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2022-3162                 │
│                  ├───────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2727 │          │        │                   │ 1.24.15, 1.25.11, 1.26.6, 1.27.3 │ Bypassing policies imposed by the ImagePolicyWebhook      │
│                  │               │          │        │                   │                                  │ admission plugin                                          │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2727                 │
│                  ├───────────────┤          │        │                   │                                  ├───────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2728 │          │        │                   │                                  │ Bypassing enforce mountable secrets policy imposed by the │
│                  │               │          │        │                   │                                  │ ServiceAccount admission plugin...                        │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2728                 │
└──────────────────┴───────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────────────┘

kind-control-plane (kubernetes)

Total: 3 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 2, CRITICAL: 0)

┌────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────┐
│    Library     │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                       Title                       │
├────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────┤
│ k8s.io/kubelet │ CVE-2021-25741 │ HIGH     │ fixed  │ 1.21.1            │ 1.19.16, 1.20.11, 1.21.5, 1.22.1 │ Symlink exchange can allow host filesystem access │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2021-25741        │
│                ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────┤
│                │ CVE-2021-25749 │          │        │                   │ 1.22.14, 1.23.11, 1.24.5         │ runAsNonRoot logic bypass for Windows containers  │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2021-25749        │
│                ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────┤
│                │ CVE-2023-2431  │ LOW      │        │                   │ 1.24.14, 1.25.10, 1.26.5, 1.27.2 │ kubernetes: Bypass of seccomp profile enforcement │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2431         │
└────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────┘

kind-control-plane (gobinary)

Total: 10 (UNKNOWN: 0, LOW: 1, MEDIUM: 7, HIGH: 2, CRITICAL: 0)

┌──────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────────────┬──────────────────────────────────────────────────────────────┐
│             Library              │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version     │                            Title                             │
├──────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/containerd/containerd │ CVE-2021-43816      │ HIGH     │ fixed  │ 1.5.2             │ 1.5.9                 │ containerd: Unprivileged pod may bind mount any privileged   │
│                                  │                     │          │        │                   │                       │ regular file on disk...                                      │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-43816                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-23648      │          │        │                   │ 1.4.13, 1.5.10, 1.6.1 │ containerd: insecure handling of image volumes               │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-23648                   │
│                                  ├─────────────────────┼──────────┤        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2021-32760      │ MEDIUM   │        │                   │ 1.4.8, 1.5.4          │ pulling and extracting crafted container image may result in │
│                                  │                     │          │        │                   │                       │ Unix file permission...                                      │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-32760                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2021-41103      │          │        │                   │ 1.4.11, 1.5.7         │ insufficiently restricted permissions on container root and  │
│                                  │                     │          │        │                   │                       │ plugin directories                                           │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-41103                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-23471      │          │        │                   │ 1.5.16, 1.6.12        │ containerd is an open source container runtime. A bug was    │
│                                  │                     │          │        │                   │                       │ found in...                                                  │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-23471                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-31030      │          │        │                   │ 1.5.13, 1.6.6         │ containerd is an open source container runtime. A bug was    │
│                                  │                     │          │        │                   │                       │ found in...                                                  │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-31030                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25153      │          │        │                   │ 1.5.18, 1.6.18        │ containerd: OCI image importer memory exhaustion             │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2023-25153                   │
│                                  ├─────────────────────┤          │        │                   │                       ├──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25173      │          │        │                   │                       │ containerd: Supplementary groups are not set up properly     │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2023-25173                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ GHSA-7ww5-4wqc-m92c │          │        │                   │ 1.6.26, 1.7.11        │ containerd allows RAPL to be accessible to a container       │
│                                  │                     │          │        │                   │                       │ https://github.com/advisories/GHSA-7ww5-4wqc-m92c            │
│                                  ├─────────────────────┼──────────┤        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ GHSA-5j5w-g665-5m35 │ LOW      │        │                   │ 1.4.12, 1.5.8         │ Ambiguous OCI manifest parsing                               │
│                                  │                     │          │        │                   │                       │ https://github.com/advisories/GHSA-5j5w-g665-5m35            │
└──────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────────────┴──────────────────────────────────────────────────────────────┘
```
### After
```
namespace: kube-system, controlplanecomponents: k8s.io/apiserver (kubernetes)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌──────────────────┬───────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability │ Severity │ Status │ Installed Version │          Fixed Version           │                           Title                           │
├──────────────────┼───────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ k8s.io/apiserver │ CVE-2022-3162 │ MEDIUM   │ fixed  │ 1.21.1            │ 1.22.16, 1.23.14, 1.24.8, 1.25.4 │ Unauthorized read of Custom Resources                     │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2022-3162                 │
│                  ├───────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2727 │          │        │                   │ 1.24.15, 1.25.11, 1.26.6, 1.27.3 │ Bypassing policies imposed by the ImagePolicyWebhook      │
│                  │               │          │        │                   │                                  │ admission plugin                                          │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2727                 │
│                  ├───────────────┤          │        │                   │                                  ├───────────────────────────────────────────────────────────┤
│                  │ CVE-2023-2728 │          │        │                   │                                  │ Bypassing enforce mountable secrets policy imposed by the │
│                  │               │          │        │                   │                                  │ ServiceAccount admission plugin...                        │
│                  │               │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2728                 │
└──────────────────┴───────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────────────┘

node: kind-control-plane (kubernetes)

Total: 3 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 2, CRITICAL: 0)

┌────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────┐
│    Library     │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                       Title                       │
├────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────┤
│ k8s.io/kubelet │ CVE-2021-25741 │ HIGH     │ fixed  │ 1.21.1            │ 1.19.16, 1.20.11, 1.21.5, 1.22.1 │ Symlink exchange can allow host filesystem access │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2021-25741        │
│                ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────┤
│                │ CVE-2021-25749 │          │        │                   │ 1.22.14, 1.23.11, 1.24.5         │ runAsNonRoot logic bypass for Windows containers  │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2021-25749        │
│                ├────────────────┼──────────┤        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────┤
│                │ CVE-2023-2431  │ LOW      │        │                   │ 1.24.14, 1.25.10, 1.26.5, 1.27.2 │ kubernetes: Bypass of seccomp profile enforcement │
│                │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-2431         │
└────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────┘

node: kind-control-plane (gobinary)

Total: 10 (UNKNOWN: 0, LOW: 1, MEDIUM: 7, HIGH: 2, CRITICAL: 0)

┌──────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────────────┬──────────────────────────────────────────────────────────────┐
│             Library              │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version     │                            Title                             │
├──────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/containerd/containerd │ CVE-2021-43816      │ HIGH     │ fixed  │ 1.5.2             │ 1.5.9                 │ containerd: Unprivileged pod may bind mount any privileged   │
│                                  │                     │          │        │                   │                       │ regular file on disk...                                      │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-43816                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-23648      │          │        │                   │ 1.4.13, 1.5.10, 1.6.1 │ containerd: insecure handling of image volumes               │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-23648                   │
│                                  ├─────────────────────┼──────────┤        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2021-32760      │ MEDIUM   │        │                   │ 1.4.8, 1.5.4          │ pulling and extracting crafted container image may result in │
│                                  │                     │          │        │                   │                       │ Unix file permission...                                      │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-32760                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2021-41103      │          │        │                   │ 1.4.11, 1.5.7         │ insufficiently restricted permissions on container root and  │
│                                  │                     │          │        │                   │                       │ plugin directories                                           │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2021-41103                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-23471      │          │        │                   │ 1.5.16, 1.6.12        │ containerd is an open source container runtime. A bug was    │
│                                  │                     │          │        │                   │                       │ found in...                                                  │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-23471                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2022-31030      │          │        │                   │ 1.5.13, 1.6.6         │ containerd is an open source container runtime. A bug was    │
│                                  │                     │          │        │                   │                       │ found in...                                                  │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2022-31030                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25153      │          │        │                   │ 1.5.18, 1.6.18        │ containerd: OCI image importer memory exhaustion             │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2023-25153                   │
│                                  ├─────────────────────┤          │        │                   │                       ├──────────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25173      │          │        │                   │                       │ containerd: Supplementary groups are not set up properly     │
│                                  │                     │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2023-25173                   │
│                                  ├─────────────────────┤          │        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ GHSA-7ww5-4wqc-m92c │          │        │                   │ 1.6.26, 1.7.11        │ containerd allows RAPL to be accessible to a container       │
│                                  │                     │          │        │                   │                       │ https://github.com/advisories/GHSA-7ww5-4wqc-m92c            │
│                                  ├─────────────────────┼──────────┤        │                   ├───────────────────────┼──────────────────────────────────────────────────────────────┤
│                                  │ GHSA-5j5w-g665-5m35 │ LOW      │        │                   │ 1.4.12, 1.5.8         │ Ambiguous OCI manifest parsing                               │
│                                  │                     │          │        │                   │                       │ https://github.com/advisories/GHSA-5j5w-g665-5m35            │
└──────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────────────┴──────────────────────────────────────────────────────────────┘
```