### PR TITLE
fix: k8s summary separate infra and user finding results

### DIFF
--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -201,10 +201,7 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 }
 
 func rbacResource(misConfig Resource) bool {
-	return misConfig.Kind == "Role" ||
-		misConfig.Kind == "RoleBinding" ||
-		misConfig.Kind == "ClusterRole" ||
-		misConfig.Kind == "ClusterRoleBinding"
+	return slices.Contains([]string{"Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding"}, misConfig.Kind)
 }
 
 func infraResource(misConfig Resource) bool {

--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -22,6 +22,7 @@ const (
 
 	workloadComponent = "workload"
 	infraComponent    = "infra"
+	infraNamespace    = "kube-system"
 )
 
 type Option struct {
@@ -134,10 +135,14 @@ type reports struct {
 // - infra checks report
 func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, components []string) []reports {
 
-	var workloadMisconfig, infraMisconfig, rbacAssessment, workloadVulnerabilities, workloadResource []Resource
+	var workloadMisconfig, infraMisconfig, rbacAssessment, workloadVulnerabilities, infraVulnerabilities, workloadResource []Resource
 	for _, resource := range k8sReport.Resources {
 		if vulnerabilitiesOrSecretResource(resource) {
-			workloadVulnerabilities = append(workloadVulnerabilities, resource)
+			if resource.Namespace == infraNamespace || nodeInfoResource(resource) {
+				infraVulnerabilities = append(infraVulnerabilities, nodeKind(resource))
+			} else {
+				workloadVulnerabilities = append(workloadVulnerabilities, resource)
+			}
 			continue
 		}
 
@@ -145,15 +150,7 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 		case scanners.Enabled(types.RBACScanner) && rbacResource(resource):
 			rbacAssessment = append(rbacAssessment, resource)
 		case infraResource(resource):
-			workload, infra := splitInfraAndWorkloadResources(resource)
-
-			if slices.Contains(components, infraComponent) {
-				infraMisconfig = append(infraMisconfig, infra)
-			}
-
-			if slices.Contains(components, workloadComponent) {
-				workloadMisconfig = append(workloadMisconfig, workload)
-			}
+			infraMisconfig = append(infraMisconfig, nodeKind(resource))
 
 		case scanners.Enabled(types.MisconfigScanner) && !rbacResource(resource):
 			if slices.Contains(components, workloadComponent) {
@@ -165,7 +162,7 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 	var r []reports
 	workloadResource = append(workloadResource, workloadVulnerabilities...)
 	workloadResource = append(workloadResource, workloadMisconfig...)
-	if shouldAddWorkloadReport(scanners) {
+	if shouldAddToReport(scanners, components, workloadComponent) {
 		workloadReport := Report{
 			SchemaVersion: 0,
 			ClusterName:   k8sReport.ClusterName,
@@ -173,32 +170,15 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 			name:          "Workload Assessment",
 		}
 
-		if (slices.Contains(components, workloadComponent) &&
-			len(workloadMisconfig) > 0) ||
-			len(workloadVulnerabilities) > 0 {
+		if slices.Contains(components, workloadComponent) {
 			r = append(r, reports{
 				Report:  workloadReport,
 				Columns: WorkloadColumns(),
 			})
 		}
 	}
-
-	if scanners.Enabled(types.RBACScanner) && len(rbacAssessment) > 0 {
-		r = append(r, reports{
-			Report: Report{
-				SchemaVersion: 0,
-				ClusterName:   k8sReport.ClusterName,
-				Resources:     rbacAssessment,
-				name:          "RBAC Assessment",
-			},
-			Columns: RoleColumns(),
-		})
-	}
-
-	if scanners.Enabled(types.MisconfigScanner) &&
-		slices.Contains(components, infraComponent) &&
-		len(infraMisconfig) > 0 {
-
+	infraMisconfig = append(infraMisconfig, infraVulnerabilities...)
+	if shouldAddToReport(scanners, components, infraComponent) {
 		r = append(r, reports{
 			Report: Report{
 				SchemaVersion: 0,
@@ -210,15 +190,30 @@ func SeparateMisconfigReports(k8sReport Report, scanners types.Scanners, compone
 		})
 	}
 
+	if scanners.Enabled(types.RBACScanner) {
+		r = append(r, reports{
+			Report: Report{
+				SchemaVersion: 0,
+				ClusterName:   k8sReport.ClusterName,
+				Resources:     rbacAssessment,
+				name:          "RBAC Assessment",
+			},
+			Columns: RoleColumns(),
+		})
+	}
+
 	return r
 }
 
 func rbacResource(misConfig Resource) bool {
-	return misConfig.Kind == "Role" || misConfig.Kind == "RoleBinding" || misConfig.Kind == "ClusterRole" || misConfig.Kind == "ClusterRoleBinding"
+	return misConfig.Kind == "Role" ||
+		misConfig.Kind == "RoleBinding" ||
+		misConfig.Kind == "ClusterRole" ||
+		misConfig.Kind == "ClusterRoleBinding"
 }
 
 func infraResource(misConfig Resource) bool {
-	return (misConfig.Kind == "Pod" && misConfig.Namespace == "kube-system") || misConfig.Kind == "NodeInfo"
+	return !rbacResource(misConfig) && (misConfig.Namespace == infraNamespace) || nodeInfoResource(misConfig)
 }
 
 func CreateResource(artifact *artifacts.Artifact, report types.Report, err error) Resource {
@@ -232,6 +227,10 @@ func CreateResource(artifact *artifacts.Artifact, report types.Report, err error
 	}
 
 	return r
+}
+
+func nodeInfoResource(nodeInfo Resource) bool {
+	return nodeInfo.Kind == "NodeInfo" || nodeInfo.Kind == "NodeComponents"
 }
 
 func createK8sResource(artifact *artifacts.Artifact, scanResults types.Results) Resource {
@@ -269,68 +268,21 @@ func (r Report) PrintErrors() {
 	}
 }
 
-func splitInfraAndWorkloadResources(misconfig Resource) (Resource, Resource) {
-	workload := copyResource(misconfig)
-	infra := copyResource(misconfig)
-
-	workloadResults := make(types.Results, 0)
-	infraResults := make(types.Results, 0)
-
-	for _, result := range misconfig.Results {
-		var workloadMisconfigs, infraMisconfigs []types.DetectedMisconfiguration
-
-		for _, m := range result.Misconfigurations {
-			if strings.HasPrefix(m.ID, "KCV") {
-				infraMisconfigs = append(infraMisconfigs, m)
-				continue
-			}
-
-			workloadMisconfigs = append(workloadMisconfigs, m)
-		}
-
-		if len(workloadMisconfigs) > 0 {
-			workloadResults = append(workloadResults, copyResult(result, workloadMisconfigs))
-		}
-
-		if len(infraMisconfigs) > 0 {
-			infraResults = append(infraResults, copyResult(result, infraMisconfigs))
-		}
-	}
-
-	workload.Results = workloadResults
-	workload.Report.Results = workloadResults
-
-	infra.Results = infraResults
-	infra.Report.Results = infraResults
-
-	return workload, infra
-}
-
-func copyResource(r Resource) Resource {
-	return Resource{
-		Namespace: r.Namespace,
-		Kind:      r.Kind,
-		Name:      r.Name,
-		Metadata:  r.Metadata,
-		Error:     r.Error,
-		Report:    r.Report,
-	}
-}
-
-func copyResult(r types.Result, misconfigs []types.DetectedMisconfiguration) types.Result {
-	return types.Result{
-		Target:            r.Target,
-		Class:             r.Class,
-		Type:              r.Type,
-		MisconfSummary:    r.MisconfSummary,
-		Misconfigurations: misconfigs,
-	}
-}
-
-func shouldAddWorkloadReport(scanners types.Scanners) bool {
-	return scanners.AnyEnabled(types.MisconfigScanner, types.VulnerabilityScanner, types.SecretScanner)
+func shouldAddToReport(scanners types.Scanners, components []string, componentType string) bool {
+	return scanners.AnyEnabled(
+		types.MisconfigScanner,
+		types.VulnerabilityScanner,
+		types.SecretScanner) &&
+		slices.Contains(components, componentType)
 }
 
 func vulnerabilitiesOrSecretResource(resource Resource) bool {
 	return len(resource.Results) > 0 && (len(resource.Results[0].Vulnerabilities) > 0 || len(resource.Results[0].Secrets) > 0)
+}
+
+func nodeKind(resource Resource) Resource {
+	if nodeInfoResource(resource) {
+		resource.Kind = "Node"
+	}
+	return resource
 }

--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -535,11 +535,10 @@ func Test_separateMisconfigReports(t *testing.T) {
 					Resources: []Resource{
 						{Kind: "Deployment"},
 						{Kind: "StatefulSet"},
-						{Kind: "Pod"},
 					},
 				},
-				{Resources: []Resource{{Kind: "Role"}}},
 				{Resources: []Resource{{Kind: "Pod"}}},
+				{Resources: []Resource{{Kind: "Role"}}},
 			},
 		},
 		{
@@ -556,7 +555,6 @@ func Test_separateMisconfigReports(t *testing.T) {
 					Resources: []Resource{
 						{Kind: "Deployment"},
 						{Kind: "StatefulSet"},
-						{Kind: "Pod"},
 					},
 				},
 				{Resources: []Resource{{Kind: "Pod"}}},
@@ -580,7 +578,6 @@ func Test_separateMisconfigReports(t *testing.T) {
 					Resources: []Resource{
 						{Kind: "Deployment"},
 						{Kind: "StatefulSet"},
-						{Kind: "Pod"},
 					},
 				},
 			},

--- a/pkg/k8s/report/summary.go
+++ b/pkg/k8s/report/summary.go
@@ -51,7 +51,7 @@ func ColumnHeading(scanners types.Scanners, components, availableColumns []strin
 				securityOptions[MisconfigurationsColumn] = nil
 			}
 			if slices.Contains(components, infraComponent) {
-				securityOptions[InfraAssessmentColumn] = nil
+				securityOptions[MisconfigurationsColumn] = nil
 			}
 		case types.SecretScanner:
 			securityOptions[SecretsColumn] = nil
@@ -107,8 +107,7 @@ func (s SummaryWriter) Write(report Report) error {
 		}
 
 		if slices.Contains(s.ColumnsHeading, MisconfigurationsColumn) ||
-			slices.Contains(s.ColumnsHeading, RbacAssessmentColumn) ||
-			slices.Contains(s.ColumnsHeading, InfraAssessmentColumn) {
+			slices.Contains(s.ColumnsHeading, RbacAssessmentColumn) {
 			rowParts = append(rowParts, s.generateSummary(mCount)...)
 		}
 

--- a/pkg/k8s/report/summary_test.go
+++ b/pkg/k8s/report/summary_test.go
@@ -62,7 +62,9 @@ func TestReport_ColumnHeading(t *testing.T) {
 			want: []string{
 				NamespaceColumn,
 				ResourceColumn,
-				InfraAssessmentColumn,
+				VulnerabilitiesColumn,
+				MisconfigurationsColumn,
+				SecretsColumn,
 			},
 		},
 		{

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -24,7 +24,6 @@ const (
 	MisconfigurationsColumn = "Misconfigurations"
 	SecretsColumn           = "Secrets"
 	RbacAssessmentColumn    = "RBAC Assessment"
-	InfraAssessmentColumn   = "Kubernetes Infra Assessment"
 )
 
 func WorkloadColumns() []string {
@@ -40,7 +39,11 @@ func RoleColumns() []string {
 }
 
 func InfraColumns() []string {
-	return []string{InfraAssessmentColumn}
+	return []string{
+		VulnerabilitiesColumn,
+		MisconfigurationsColumn,
+		SecretsColumn,
+	}
 }
 
 func (tw TableWriter) Write(ctx context.Context, report Report) error {

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -3,10 +3,11 @@ package k8s
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -234,6 +235,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				Resources:   []report.Resource{deployOrionWithVulns},
 			},
 			scanners:   types.Scanners{types.VulnerabilityScanner},
+			components: []string{workloadComponent},
 			severities: allSeverities,
 			expectedOutput: `Summary Report for test
 =======================
@@ -276,6 +278,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				Resources:   []report.Resource{deployLuaWithSecrets},
 			},
 			scanners:   types.Scanners{types.SecretScanner},
+			components: []string{workloadComponent},
 			severities: allSeverities,
 			expectedOutput: `Summary Report for test
 =======================
@@ -303,13 +306,13 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 =======================
 
 Infra Assessment
-┌─────────────┬────────────────────┬─────────────────────────────┐
-│  Namespace  │      Resource      │ Kubernetes Infra Assessment │
-│             │                    ├─────┬─────┬─────┬─────┬─────┤
-│             │                    │  C  │  H  │  M  │  L  │  U  │
-├─────────────┼────────────────────┼─────┼─────┼─────┼─────┼─────┤
-│ kube-system │ Pod/kube-apiserver │     │     │ 1   │ 1   │     │
-└─────────────┴────────────────────┴─────┴─────┴─────┴─────┴─────┘
+┌─────────────┬────────────────────┬───────────────────┐
+│  Namespace  │      Resource      │ Misconfigurations │
+│             │                    ├───┬───┬───┬───┬───┤
+│             │                    │ C │ H │ M │ L │ U │
+├─────────────┼────────────────────┼───┼───┼───┼───┼───┤
+│ kube-system │ Pod/kube-apiserver │   │ 1 │ 2 │ 2 │   │
+└─────────────┴────────────────────┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
@@ -323,23 +326,23 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				types.MisconfigScanner,
 				types.SecretScanner,
 			},
-			components: []string{workloadComponent},
+			components: []string{infraComponent},
 			severities: allSeverities,
 			expectedOutput: `Summary Report for test
 =======================
 
-Workload Assessment
+Infra Assessment
 ┌─────────────┬────────────────────┬───────────────────┬───────────────────┬───────────────────┐
 │  Namespace  │      Resource      │  Vulnerabilities  │ Misconfigurations │      Secrets      │
 │             │                    ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
 │             │                    │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
 ├─────────────┼────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
-│ kube-system │ Pod/kube-apiserver │   │   │   │   │   │   │ 1 │ 1 │ 1 │   │   │   │   │   │   │
+│ kube-system │ Pod/kube-apiserver │   │   │   │   │   │   │ 1 │ 2 │ 2 │   │   │   │   │   │   │
 └─────────────┴────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
-			name: "apiserver, all scanners and serverities",
+			name: "apiserver, all misconfig and vuln scanners and serverities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{apiseverPodWithMisconfigAndInfra},
@@ -347,8 +350,6 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 			scanners: types.Scanners{
 				types.MisconfigScanner,
 				types.VulnerabilityScanner,
-				types.RBACScanner,
-				types.SecretScanner,
 			},
 			components: []string{
 				workloadComponent,
@@ -359,24 +360,22 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 =======================
 
 Workload Assessment
-┌─────────────┬────────────────────┬───────────────────┬───────────────────┬───────────────────┐
-│  Namespace  │      Resource      │  Vulnerabilities  │ Misconfigurations │      Secrets      │
-│             │                    ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
-│             │                    │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
-├─────────────┼────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
-│ kube-system │ Pod/kube-apiserver │   │   │   │   │   │   │ 1 │ 1 │ 1 │   │   │   │   │   │   │
-└─────────────┴────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+┌───────────┬──────────┬───────────────────┬───────────────────┐
+│ Namespace │ Resource │  Vulnerabilities  │ Misconfigurations │
+│           │          ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
+│           │          │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
+└───────────┴──────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
 
 
 Infra Assessment
-┌─────────────┬────────────────────┬─────────────────────────────┐
-│  Namespace  │      Resource      │ Kubernetes Infra Assessment │
-│             │                    ├─────┬─────┬─────┬─────┬─────┤
-│             │                    │  C  │  H  │  M  │  L  │  U  │
-├─────────────┼────────────────────┼─────┼─────┼─────┼─────┼─────┤
-│ kube-system │ Pod/kube-apiserver │     │     │ 1   │ 1   │     │
-└─────────────┴────────────────────┴─────┴─────┴─────┴─────┴─────┘
+┌─────────────┬────────────────────┬───────────────────┬───────────────────┐
+│  Namespace  │      Resource      │  Vulnerabilities  │ Misconfigurations │
+│             │                    ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
+│             │                    │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
+├─────────────┼────────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
+│ kube-system │ Pod/kube-apiserver │   │   │   │   │   │   │ 1 │ 2 │ 2 │   │
+└─────────────┴────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 	}


### PR DESCRIPTION
## Description
k8s summary separate infra and user finding results

## Related issues
- Close #6121

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).

## Example:
Usage:
- Install [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) cluster
- run : `trivy k8s cluster --report summary`

### Before:
```

Summary Report for kind-kind


Workload Assessment
┌────────────────────┬────────────────────────────────────────────────┬───────────────────────┬───────────────────┬───────────────────┐
│     Namespace      │                    Resource                    │    Vulnerabilities    │ Misconfigurations │      Secrets      │
│                    │                                                ├────┬────┬────┬────┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│                    │                                                │ C  │ H  │ M  │ L  │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├────────────────────┼────────────────────────────────────────────────┼────┼────┼────┼────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ local-path-storage │ Deployment/local-path-provisioner              │ 4  │ 32 │ 10 │ 2  │   │   │ 1 │ 3 │ 9 │   │   │   │   │   │   │
│ kube-system        │ Pod/kube-scheduler-kind-control-plane          │    │    │    │    │ 5 │   │ 2 │ 4 │ 8 │   │   │   │   │   │   │
│ kube-system        │ Pod/kube-apiserver-kind-control-plane          │    │    │    │    │ 5 │   │ 2 │ 4 │ 9 │   │   │   │   │   │   │
│ kube-system        │ DaemonSet/kindnet                              │ 19 │ 56 │ 57 │ 82 │ 2 │   │ 3 │ 5 │ 5 │   │   │   │   │   │   │
│ kube-system        │ ConfigMap/extension-apiserver-authentication   │    │    │    │    │   │   │   │ 1 │   │   │   │   │   │   │   │
│ kube-system        │ Deployment/coredns                             │    │ 13 │ 10 │ 3  │   │   │ 1 │ 3 │ 4 │   │   │   │   │   │   │
│ kube-system        │ DaemonSet/kube-proxy                           │ 19 │ 45 │ 47 │ 82 │ 2 │   │ 3 │ 4 │ 9 │   │   │   │   │   │   │
│ kube-system        │ Pod/etcd-kind-control-plane                    │    │    │    │    │ 6 │   │ 2 │ 4 │ 7 │   │   │   │   │   │   │
│ kube-system        │ Pod/kube-controller-manager-kind-control-plane │    │    │    │    │ 5 │   │ 2 │ 4 │ 8 │   │   │   │   │   │   │
│ kube-system        │ ControlPlaneComponents/k8s.io/apiserver        │    │    │ 3  │    │   │   │   │   │   │   │   │   │   │   │   │
│                    │ NodeComponents/kind-control-plane              │    │ 4  │ 7  │ 2  │   │   │   │   │   │   │   │   │   │   │   │
└────────────────────┴────────────────────────────────────────────────┴────┴────┴────┴────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


RBAC Assessment
┌─────────────┬─────────────────────────────────────────────────────────────────┬───────────────────┐
│  Namespace  │                            Resource                             │  RBAC Assessment  │
│             │                                                                 ├───┬───┬───┬───┬───┤
│             │                                                                 │ C │ H │ M │ L │ U │
├─────────────┼─────────────────────────────────────────────────────────────────┼───┼───┼───┼───┼───┤
│ kube-system │ Role/system:controller:bootstrap-signer                         │   │   │ 1 │   │   │
│ kube-system │ Role/system::leader-locking-kube-scheduler                      │   │   │ 1 │   │   │
│ kube-system │ Role/system:controller:cloud-provider                           │   │   │ 1 │   │   │
│ kube-system │ Role/system::leader-locking-kube-controller-manager             │   │   │ 1 │   │   │
│ kube-system │ Role/system:controller:token-cleaner                            │   │   │ 1 │   │   │
│ kube-public │ Role/system:controller:bootstrap-signer                         │   │   │ 1 │   │   │
│ kube-public │ RoleBinding/kubeadm:bootstrap-signer-clusterinfo                │ 1 │   │   │   │   │
│             │ ClusterRole/admin                                               │ 3 │ 4 │ 6 │   │   │
│             │ ClusterRole/system:controller:node-controller                   │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:resourcequota-controller          │ 1 │   │   │   │   │
│             │ ClusterRole/system:controller:persistent-volume-binder          │ 1 │ 2 │ 1 │   │   │
│             │ ClusterRole/system:controller:replication-controller            │   │   │ 2 │   │   │
│             │ ClusterRole/system:controller:root-ca-cert-publisher            │   │   │ 1 │   │   │
│             │ ClusterRole/local-path-provisioner-role                         │ 1 │ 1 │ 1 │   │   │
│             │ ClusterRole/system:controller:daemon-set-controller             │   │   │ 1 │   │   │
│             │ ClusterRole/edit                                                │ 2 │ 4 │ 6 │   │   │
│             │ ClusterRole/system:controller:job-controller                    │   │   │ 2 │   │   │
│             │ ClusterRole/system:controller:statefulset-controller            │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:endpointslicemirroring-controller │   │ 1 │   │   │   │
│             │ ClusterRole/system:controller:ttl-after-finished-controller     │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:expand-controller                 │ 1 │   │   │   │   │
│             │ ClusterRole/cluster-admin                                       │ 2 │   │   │   │   │
│             │ ClusterRole/system:aggregate-to-admin                           │ 1 │   │   │   │   │
│             │ ClusterRole/system:kube-scheduler                               │   │ 2 │ 1 │   │   │
│             │ ClusterRole/system:aggregate-to-edit                            │ 2 │ 4 │ 6 │   │   │
│             │ ClusterRole/system:controller:cronjob-controller                │   │   │ 3 │   │   │
│             │ ClusterRole/system:controller:horizontal-pod-autoscaler         │ 1 │   │   │   │   │
│             │ ClusterRole/system:node                                         │ 1 │   │ 1 │   │   │
│             │ ClusterRoleBinding/cluster-admin                                │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:pod-garbage-collector             │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:replicaset-controller             │   │   │ 2 │   │   │
│             │ ClusterRole/system:kube-controller-manager                      │ 5 │ 2 │   │   │   │
│             │ ClusterRole/system:controller:generic-garbage-collector         │ 1 │   │   │   │   │
│             │ ClusterRole/system:controller:namespace-controller              │ 1 │   │   │   │   │
│             │ ClusterRole/system:controller:deployment-controller             │   │   │ 3 │   │   │
│             │ ClusterRole/system:controller:endpointslice-controller          │   │ 1 │   │   │   │
│             │ ClusterRole/system:controller:endpoint-controller               │   │ 1 │   │   │   │
└─────────────┴─────────────────────────────────────────────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬────────────────────────────────────────────────┬─────────────────────────────┐
│  Namespace  │                    Resource                    │ Kubernetes Infra Assessment │
│             │                                                ├─────┬─────┬─────┬─────┬─────┤
│             │                                                │  C  │  H  │  M  │  L  │  U  │
├─────────────┼────────────────────────────────────────────────┼─────┼─────┼─────┼─────┼─────┤
│ kube-system │ Pod/kube-controller-manager-kind-control-plane │     │     │     │ 3   │     │
│ kube-system │ Pod/kube-apiserver-kind-control-plane          │     │     │ 1   │ 8   │     │
│ kube-system │ Pod/kube-scheduler-kind-control-plane          │     │     │     │ 1   │     │
│             │ NodeInfo/kind-control-plane                    │  1  │ 4   │     │ 1   │     │
└─────────────┴────────────────────────────────────────────────┴─────┴─────┴─────┴─────┴─────┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

### After:
```

Summary Report for kind-kind


Workload Assessment
┌────────────────────┬───────────────────────────────────┬─────────────────────┬───────────────────┬───────────────────┐
│     Namespace      │             Resource              │   Vulnerabilities   │ Misconfigurations │      Secrets      │
│                    │                                   ├───┬────┬────┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│                    │                                   │ C │ H  │ M  │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├────────────────────┼───────────────────────────────────┼───┼────┼────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ local-path-storage │ Deployment/local-path-provisioner │ 4 │ 32 │ 10 │ 2 │   │   │ 1 │ 3 │ 9 │   │   │   │   │   │   │
└────────────────────┴───────────────────────────────────┴───┴────┴────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬────────────────────────────────────────────────┬───────────────────────┬────────────────────┬───────────────────┐
│  Namespace  │                    Resource                    │    Vulnerabilities    │ Misconfigurations  │      Secrets      │
│             │                                                ├────┬────┬────┬────┬───┼───┬───┬───┬────┬───┼───┬───┬───┬───┬───┤
│             │                                                │ C  │ H  │ M  │ L  │ U │ C │ H │ M │ L  │ U │ C │ H │ M │ L │ U │
├─────────────┼────────────────────────────────────────────────┼────┼────┼────┼────┼───┼───┼───┼───┼────┼───┼───┼───┼───┼───┼───┤
│ kube-system │ DaemonSet/kindnet                              │ 19 │ 56 │ 57 │ 82 │ 2 │   │ 3 │ 5 │ 5  │   │   │   │   │   │   │
│ kube-system │ Pod/kube-scheduler-kind-control-plane          │    │    │    │    │ 5 │   │ 2 │ 4 │ 9  │   │   │   │   │   │   │
│ kube-system │ DaemonSet/kube-proxy                           │ 19 │ 45 │ 47 │ 82 │ 2 │   │ 3 │ 4 │ 9  │   │   │   │   │   │   │
│ kube-system │ ControlPlaneComponents/k8s.io/apiserver        │    │    │ 3  │    │   │   │   │   │    │   │   │   │   │   │   │
│ kube-system │ Pod/etcd-kind-control-plane                    │    │    │    │    │ 6 │   │ 2 │ 4 │ 7  │   │   │   │   │   │   │
│ kube-system │ Deployment/coredns                             │    │ 13 │ 10 │ 3  │   │   │ 1 │ 3 │ 4  │   │   │   │   │   │   │
│ kube-system │ Pod/kube-apiserver-kind-control-plane          │    │    │    │    │ 5 │   │ 2 │ 5 │ 17 │   │   │   │   │   │   │
│ kube-system │ ConfigMap/extension-apiserver-authentication   │    │    │    │    │   │   │   │ 1 │    │   │   │   │   │   │   │
│ kube-system │ Pod/kube-controller-manager-kind-control-plane │    │    │    │    │ 5 │   │ 2 │ 4 │ 11 │   │   │   │   │   │   │
│             │ Node/kind-control-plane                        │    │ 4  │ 7  │ 2  │   │ 1 │ 4 │   │ 1  │   │   │   │   │   │   │
└─────────────┴────────────────────────────────────────────────┴────┴────┴────┴────┴───┴───┴───┴───┴────┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


RBAC Assessment
┌─────────────┬─────────────────────────────────────────────────────────────────┬───────────────────┐
│  Namespace  │                            Resource                             │  RBAC Assessment  │
│             │                                                                 ├───┬───┬───┬───┬───┤
│             │                                                                 │ C │ H │ M │ L │ U │
├─────────────┼─────────────────────────────────────────────────────────────────┼───┼───┼───┼───┼───┤
│ kube-system │ Role/system:controller:cloud-provider                           │   │   │ 1 │   │   │
│ kube-system │ Role/system:controller:token-cleaner                            │   │   │ 1 │   │   │
│ kube-system │ Role/system:controller:bootstrap-signer                         │   │   │ 1 │   │   │
│ kube-system │ Role/system::leader-locking-kube-scheduler                      │   │   │ 1 │   │   │
│ kube-system │ Role/system::leader-locking-kube-controller-manager             │   │   │ 1 │   │   │
│ kube-public │ RoleBinding/kubeadm:bootstrap-signer-clusterinfo                │ 1 │   │   │   │   │
│ kube-public │ Role/system:controller:bootstrap-signer                         │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:replication-controller            │   │   │ 2 │   │   │
│             │ ClusterRole/system:controller:job-controller                    │   │   │ 2 │   │   │
│             │ ClusterRole/system:controller:persistent-volume-binder          │ 1 │ 2 │ 1 │   │   │
│             │ ClusterRole/system:controller:resourcequota-controller          │ 1 │   │   │   │   │
│             │ ClusterRole/system:controller:endpoint-controller               │   │ 1 │   │   │   │
│             │ ClusterRole/system:controller:deployment-controller             │   │   │ 3 │   │   │
│             │ ClusterRole/system:controller:endpointslice-controller          │   │ 1 │   │   │   │
│             │ ClusterRole/admin                                               │ 3 │ 4 │ 6 │   │   │
│             │ ClusterRoleBinding/cluster-admin                                │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:horizontal-pod-autoscaler         │ 1 │   │   │   │   │
│             │ ClusterRole/system:kube-scheduler                               │   │ 2 │ 1 │   │   │
│             │ ClusterRole/system:controller:root-ca-cert-publisher            │   │   │ 1 │   │   │
│             │ ClusterRole/edit                                                │ 2 │ 4 │ 6 │   │   │
│             │ ClusterRole/system:controller:namespace-controller              │ 1 │   │   │   │   │
│             │ ClusterRole/system:node                                         │ 1 │   │ 1 │   │   │
│             │ ClusterRole/cluster-admin                                       │ 2 │   │   │   │   │
│             │ ClusterRole/system:controller:cronjob-controller                │   │   │ 3 │   │   │
│             │ ClusterRole/system:controller:endpointslicemirroring-controller │   │ 1 │   │   │   │
│             │ ClusterRole/system:controller:daemon-set-controller             │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:generic-garbage-collector         │ 1 │   │   │   │   │
│             │ ClusterRole/system:controller:pod-garbage-collector             │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:node-controller                   │   │   │ 1 │   │   │
│             │ ClusterRole/system:kube-controller-manager                      │ 5 │ 2 │   │   │   │
│             │ ClusterRole/system:controller:replicaset-controller             │   │   │ 2 │   │   │
│             │ ClusterRole/system:controller:statefulset-controller            │   │   │ 1 │   │   │
│             │ ClusterRole/system:aggregate-to-edit                            │ 2 │ 4 │ 6 │   │   │
│             │ ClusterRole/system:aggregate-to-admin                           │ 1 │   │   │   │   │
│             │ ClusterRole/local-path-provisioner-role                         │ 1 │ 1 │ 1 │   │   │
│             │ ClusterRole/system:controller:ttl-after-finished-controller     │   │   │ 1 │   │   │
│             │ ClusterRole/system:controller:expand-controller                 │ 1 │   │   │   │   │
└─────────────┴─────────────────────────────────────────────────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

