### PR TITLE
fix(alpine): exclude empty licenses for apk packages

### DIFF
--- a/pkg/fanal/analyzer/pkg/apk/apk.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk.go
@@ -147,6 +147,8 @@ func (a alpinePkgAnalyzer) parseLicense(line string) []string {
 	for i, s := range strings.Fields(line) {
 		s = strings.Trim(s, "()")
 		switch {
+		case s == "":
+			continue
 		case s == "AND" || s == "OR":
 			continue
 		case i > 0 && (s == "1.0" || s == "2.0" || s == "3.0"):

--- a/pkg/fanal/analyzer/pkg/apk/apk_test.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk_test.go
@@ -281,6 +281,24 @@ var pkgs = []types.Package{
 			"usr/include/sqlite3.h",
 		},
 	},
+
+	{
+		ID:         "ada-libs@2.7.4-r0",
+		Name:       "ada-libs",
+		Version:    "2.7.4-r0",
+		SrcName:    "ada",
+		SrcVersion: "2.7.4-r0",
+		Licenses:   []string{"Apache-2.0", "MIT", "MPL-2.0"},
+		Digest:     "sha1:593154f80c440685448e0f52479725d7bc9b678d",
+		DependsOn: []string{
+			"musl@1.1.14-r10",
+		},
+		Arch: "x86_64",
+		InstalledFiles: []string{
+			"usr/lib/libada.so.2",
+			"usr/lib/libada.so.2.7.4",
+		},
+	},
 }
 
 var files = []string{
@@ -385,27 +403,29 @@ var files = []string{
 	"usr/lib/pkgconfig/sqlite3.pc",
 	"usr/include/sqlite3ext.h",
 	"usr/include/sqlite3.h",
+
+	// ada-libs@2.5.1-r0
+	"usr/lib/libada.so.2",
+	"usr/lib/libada.so.2.7.4",
 }
 
 func TestParseApkInfo(t *testing.T) {
-	var tests = map[string]struct {
+	var tests = []struct {
+		name      string
 		path      string
 		wantPkgs  []types.Package
 		wantFiles []string
 	}{
-		"Valid": {
-			path:      "./testdata/apk",
-			wantPkgs:  pkgs,
-			wantFiles: files,
-		},
-		"do not retain pkg installed files": {
+		{
+			name:      "happy path",
 			path:      "./testdata/apk",
 			wantPkgs:  pkgs,
 			wantFiles: files,
 		},
 	}
-	for testname, tt := range tests {
-		t.Run(testname, func(t *testing.T) {
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			a := alpinePkgAnalyzer{}
 			f, err := os.Open(tt.path)
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/pkg/apk/testdata/apk
+++ b/pkg/fanal/analyzer/pkg/apk/testdata/apk
@@ -538,3 +538,27 @@ R:sqlite3ext.h
 Z:Q1riWNHq9ufQzhyMXm7raBW+ZL9z0=
 R:sqlite3.h
 Z:Q11MT2xE8JuMfBRYu6BDTz2PY95Vw=
+
+C:Q1WTFU+AxEBoVEjg9SR5cl17ybZ40=
+P:ada-libs
+V:2.7.4-r0
+A:x86_64
+S:166703
+I:491520
+T:WHATWG-compliant and fast URL parser written in modern C++ (libraries)
+U:https://ada-url.github.io/ada
+L:( Apache-2.0 OR MIT ) AND MPL-2.0
+o:ada
+m:Jakub Jirutka <jakub@jirutka.cz>
+t:1701726025
+c:fa40f3454f9c60870d54115aac4161f9ab7c667f
+D:so:libc.musl-x86_64.so.1
+p:so:libada.so.2=2.7.4
+F:usr
+F:usr/lib
+R:libada.so.2
+a:0:0:777
+Z:Q1qDM97tDEseDtdayU2yr3eJjOl5I=
+R:libada.so.2.7.4
+a:0:0:755
+Z:Q1LUjWSS3wH8zDBHd0pYxED/hWBhk=


### PR DESCRIPTION
## Description
After parsing line of apk package, we can get empty licenses.
e.g.:
```json
"Licenses": [
            "",
            "Apache-2.0",
            "MIT",
            "",
            "MPL-2.0"
          ],
```

## Related issues
- Close #6128

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
