### PR TITLE
docs: add SecObserve in CI/CD and reporting

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -82,7 +82,7 @@ It has capabilities to fail the pipeline, create issues, alert communication cha
 
 
 ## SecObserve GitHub actions and GitLab templates (Community)
-[SecObserve GitHub actions and GitLab templates](https://concourse-ci.org/) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
+[SecObserve GitHub actions and GitLab templates](https://github.com/MaibornWolff/secobserve_actions_templates) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
 
 The Trivy integration supports scanning Docker images and local filesystems for vulnerabilities as well as scanning IaC files for misconfigurations.
 

--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -79,3 +79,11 @@ You can use Trivy Resource in Concourse for scanning containers and introducing 
 It has capabilities to fail the pipeline, create issues, alert communication channels (using respective resources) based on Trivy scan output.
 
 👉 Get it at: <https://github.com/Comcast/trivy-resource/>
+
+
+## SecObserve GitHub actions and GitLab templates (Community)
+[SecObserve GitHub actions and GitLab templates](https://concourse-ci.org/) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
+
+The Trivy integration supports scanning Docker images and local filesystems for vulnerabilities as well as scanning IaC files for misconfigurations.
+
+👉 Get it at: <https://github.com/MaibornWolff/secobserve_actions_templates>

--- a/docs/ecosystem/reporting.md
+++ b/docs/ecosystem/reporting.md
@@ -19,3 +19,8 @@ A Trivy plugin that scans and outputs the results to an interactive html file.
 Trivy-Streamlit is a Streamlit application that allows you to quickly parse the results from a Trivy JSON report.
 
 👉 Get it at: <https://github.com/mfreeman451/trivy-streamlit>
+
+## SecObserve (Community)
+SecObserve can parse Trivy results as CycloneDX reports and provides an unified overview of vulnerabilities from different sources. Vulnerabilities can be evaluated with manual and rule based assessments.
+
+👉 Get it at: <https://github.com/MaibornWolff/SecObserve>


### PR DESCRIPTION
## Description
SecObserve is an open source vulnerability management system that can import and show results of Trivy and has it's own set of GitHub actions and GitLab templates. This shall be shown on the ecosystem pages for CI/CD and reporting.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] *(N/A)* I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] *(N/A)* I've added usage information (if the PR introduces new options)
- [ ] *(N/A)* I've included a "before" and "after" example to the description (if the PR is a user interface change).
