### PR TITLE
docs: update template path for gitlab-ci tutorial

### DIFF
--- a/docs/tutorials/integrations/gitlab-ci.md
+++ b/docs/tutorials/integrations/gitlab-ci.md
@@ -41,7 +41,7 @@ trivy:
     # Build image
     - docker build -t $IMAGE .
     # Build report
-    - ./trivy image --exit-code 0 --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
+    - ./trivy image --exit-code 0 --format template --template "@/contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
     # Print report
     - ./trivy image --exit-code 0 --severity HIGH $IMAGE
     # Fail on severe vulnerabilities
@@ -148,9 +148,9 @@ trivy:
     # Build image
     - docker build -t $IMAGE .
     # Image report
-    - ./trivy image --exit-code 0 --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE
+    - ./trivy image --exit-code 0 --format template --template "@/contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE
     # Filesystem report
-    - ./trivy filesystem --scanners misconfig,vuln --exit-code 0 --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json .
+    - ./trivy filesystem --scanners misconfig,vuln --exit-code 0 --format template --template "@/contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json .
     # Combine report
     - apk update && apk add jq
     - jq -s 'add' gl-codeclimate-image.json gl-codeclimate-fs.json > gl-codeclimate.json


### PR DESCRIPTION
## Description
As written the path to the template file seems to be correct in only one of the script examples for gitlab-ci documentation. This would shore it up for the other examples that are included on that page.

Resolves:
`2024-02-15T18:25:58.494Z	FATAL	report error: unable to write results: failed to initialize template writer: error retrieving template from path: open contrib/gitlab-codequality.tpl: no such file or directory`

## Related issues
- None per [Guideline 1](https://aquasecurity.github.io/trivy/v0.49/community/contribute/pr/#:~:text=Every%20Pull%20Request%20should%20have%20an%20associated%20bug%20or%20feature%20issue%20unless%20you%20are%20fixing%20a%20trivial%20documentation%20issue.) (Trival doc issue)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
