### PR TITLE
docs(report): add remark about `path` to filter licenses using `.trivyignore.yaml` file

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -338,7 +338,7 @@ Available fields:
 | Field      | Required | Type                | Description                                                                                                |
 |------------|:--------:|---------------------|------------------------------------------------------------------------------------------------------------|
 | id         |    ✓     | string              | The identifier of the vulnerability, misconfiguration, secret, or license[^1].                             |
-| paths      |          | string array        | The list of file paths to be ignored. If `paths` is not set, the ignore finding is applied to all files.   |
+| paths[^2]  |          | string array        | The list of file paths to be ignored. If `paths` is not set, the ignore finding is applied to all files.   |
 | expired_at |          | date (`yyyy-mm-dd`) | The expiration date of the ignore finding. If `expired_at` is not set, the ignore finding is always valid. |
 | statement  |          | string              | The reason for ignoring the finding. (This field is not used for filtering.)                               |
 
@@ -489,4 +489,5 @@ You can find more example policies [here](https://github.com/aquasecurity/trivy/
 Please refer to the [VEX documentation](../supply-chain/vex.md) for the details.
 
 
-[^1]: license name is used as id for `.trivyignore.yaml` files
+[^1]: license name is used as id for `.trivyignore.yaml` files.
+[^2]: This doesn't work for package licenses. The `path` field can only be used for license files (licenses obtained using the [--license-full flag](../scanner/license.md#full-scanning)).


### PR DESCRIPTION
## Description
We currently doesn't support using `path` field in `.trivyignore.yaml` file to filter package licenses.
More information - #6117.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
