### PR TITLE
fix(terraform): ensure consistent path handling across OS

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -164,7 +165,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 		return err
 	}
 	p.metrics.Timings.DiskIODuration += time.Since(diskStart)
-	if dir := filepath.Dir(fullPath); p.projectRoot == "" {
+	if dir := path.Dir(fullPath); p.projectRoot == "" {
 		p.debug.Log("Setting project/module root to '%s'", dir)
 		p.projectRoot = dir
 		p.modulePath = dir
@@ -195,7 +196,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 // ParseFS parses a root module, where it exists at the root of the provided filesystem
 func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 
-	dir = filepath.Clean(dir)
+	dir = path.Clean(dir)
 
 	if p.projectRoot == "" {
 		p.debug.Log("Setting project/module root to '%s'", dir)
@@ -212,7 +213,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 
 	var paths []string
 	for _, info := range fileInfos {
-		realPath := filepath.Join(dir, info.Name())
+		realPath := path.Join(dir, info.Name())
 		if info.Type()&os.ModeSymlink != 0 {
 			extra, ok := p.moduleFS.(extrafs.FS)
 			if !ok {

--- a/pkg/iac/scanners/terraform/parser/resolvers/local.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/local.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"io/fs"
+	"path"
 	"path/filepath"
 )
 
@@ -14,13 +15,13 @@ func (r *localResolver) Resolve(_ context.Context, target fs.FS, opt Options) (f
 	if !opt.hasPrefix(".", "..") {
 		return nil, "", "", false, nil
 	}
-	joined := filepath.Clean(filepath.Join(opt.ModulePath, opt.Source))
+	joined := path.Clean(path.Join(opt.ModulePath, opt.Source))
 	if _, err := fs.Stat(target, filepath.ToSlash(joined)); err == nil {
 		opt.Debug("Module '%s' resolved locally to %s", opt.Name, joined)
 		return target, "", joined, true, nil
 	}
 
-	clean := filepath.Clean(opt.Source)
+	clean := path.Clean(opt.Source)
 	opt.Debug("Module '%s' resolved locally to %s", opt.Name, clean)
 	return target, "", clean, true, nil
 }

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -334,7 +335,7 @@ func (s *Scanner) findRootModules(target fs.FS, scanDir string, dirs ...string) 
 			continue
 		}
 		for _, file := range files {
-			realPath := filepath.Join(dir, file.Name())
+			realPath := path.Join(dir, file.Name())
 			if symFS, ok := target.(extrafs.ReadLinkFS); ok {
 				realPath, err = symFS.ResolveSymlink(realPath, scanDir)
 				if err != nil {


### PR DESCRIPTION
## Description

Trivy creates a virtual filesystem for post-analysers, so path handling should not depend on the OS.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
