### PR TITLE
fix(sbom): skip executable file analysis if Rekor isn't a specified SBOM source

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -514,7 +514,8 @@ func disabledAnalyzers(opts flag.Options) []analyzer.Type {
 		analyzers = append(analyzers, analyzer.TypeHistoryDockerfile)
 	}
 
-	if len(opts.SBOMSources) == 0 {
+	// Skip executable file analysis if Rekor isn't a specified SBOM source.
+	if !slices.Contains(opts.SBOMSources, types.SBOMSourceRekor) {
 		analyzers = append(analyzers, analyzer.TypeExecutable)
 	}
 


### PR DESCRIPTION
## Description

Fixed to skip executable analysis if Rekor is not the specified SBOM source.

**before**

Even if only `oci` is specified in the SBOM source, trivy performs a lot of searches for rekor.

```
> trivy version
Version: 0.49.1
Vulnerability DB:
  Version: 2
  UpdatedAt: 2024-02-20 00:16:01.804708429 +0000 UTC
  NextUpdate: 2024-02-20 06:16:01.804708139 +0000 UTC
  DownloadedAt: 2024-02-20 01:34:32.831729 +0000 UTC
Java DB:
  Version: 1
  UpdatedAt: 2024-02-18 00:44:32.669835578 +0000 UTC
  NextUpdate: 2024-02-21 00:44:32.669835368 +0000 UTC
  DownloadedAt: 2024-02-19 16:39:27.048401 +0000 UTC

> trivy -d image --timeout 30m --scanners vuln --severity CRITICAL,HIGH --sbom-sources oci apicurio/apicurio-registry-sql:2.2.5.Final
2024-02-20T12:08:19.513+0900	DEBUG	Severities: ["CRITICAL" "HIGH"]
2024-02-20T12:08:19.513+0900	DEBUG	Ignore statuses	{"statuses": null}
2024-02-20T12:08:19.526+0900	DEBUG	cache dir:  /Users/saso/Library/Caches/trivy
2024-02-20T12:08:19.526+0900	DEBUG	DB update was skipped because the local DB is the latest
2024-02-20T12:08:19.526+0900	DEBUG	DB Schema: 2, UpdatedAt: 2024-02-20 00:16:01.804708429 +0000 UTC, NextUpdate: 2024-02-20 06:16:01.804708139 +0000 UTC, DownloadedAt: 2024-02-20 01:34:32.831729 +0000 UTC
2024-02-20T12:08:19.526+0900	INFO	Vulnerability scanning is enabled
2024-02-20T12:08:19.526+0900	DEBUG	Vulnerability type:  [os library]
2024-02-20T12:08:19.526+0900	DEBUG	Enabling misconfiguration scanners: [azure-arm cloudformation dockerfile helm kubernetes terraform terraformplan]
2024-02-20T12:08:21.431+0900	DEBUG	The nuget packages directory couldn't be found. License search disabled
2024-02-20T12:08:22.234+0900	DEBUG	Image ID: sha256:08023b5ebcfd94fb477635b4636d7c1fbe91e92ac8e3c1fb943c77805a19b8f0
2024-02-20T12:08:22.234+0900	DEBUG	Diff IDs: [sha256:dff9f8de74c048baca326e1d79db28e7615e8e96497c630177c53e61bbd2f906 sha256:e34e3bdec2768c1b351fdcc47094e9e345a7e1c2115d667549e76a02ed282d3c sha256:25ec5befcdd1a4a5560c9e5f2345399612a5dc065be70d7173901ba5e9f087a1 sha256:43e4e0db265565375c091e37ba984f113a90e7424dfbaa6584a4b3a7eb1ad275]
2024-02-20T12:08:24.157+0900	DEBUG	No SBOM found in the source: oci
2024-02-20T12:08:24.158+0900	DEBUG	Base Layers: []
2024-02-20T12:08:24.163+0900	DEBUG	Missing diff ID in cache: sha256:dff9f8de74c048baca326e1d79db28e7615e8e96497c630177c53e61bbd2f906
2024-02-20T12:08:24.163+0900	DEBUG	Missing diff ID in cache: sha256:43e4e0db265565375c091e37ba984f113a90e7424dfbaa6584a4b3a7eb1ad275
2024-02-20T12:08:24.163+0900	DEBUG	Missing diff ID in cache: sha256:25ec5befcdd1a4a5560c9e5f2345399612a5dc065be70d7173901ba5e9f087a1
2024-02-20T12:08:24.568+0900	DEBUG	Skipping directory: dev
2024-02-20T12:08:24.569+0900	DEBUG	Skipping directory: sys
2024-02-20T12:08:24.569+0900	DEBUG	Skipping directory: proc
2024-02-20T12:08:25.464+0900	DEBUG	Search for sha256:e76a82c8ed807533c3d97dea238cfe3ba3ec49a57df643185d2ecbbb7d79a75e in Rekor
2024-02-20T12:08:26.229+0900	DEBUG	Search for sha256:0f586540f4a8c0b4efbc3e2d49874eb96ce8fc550ff40a33732d363649815cd9 in Rekor
2024-02-20T12:08:26.401+0900	DEBUG	Search for sha256:94c763f59c8bc7144b0d5b63f1e9640ec882550a24a3939f1848d50f23515098 in Rekor
2024-02-20T12:08:26.579+0900	DEBUG	Search for sha256:6dfb41e98a1ec75b496352198db1d81b90c9c9e78aed00e67020042045d7917f in Rekor
2024-02-20T12:08:26.744+0900	DEBUG	Search for sha256:28069f3e93c4119cfd5bc8cb86dc86c89e2bd550ebee3ac436ee85c94858bdf3 in Rekor

...

```

**after**

If rekor is not specified, skip analysis of the executable. Therefore, a search for rekor is not performed.

```
> ./trivy -d image --timeout 30m --scanners vuln --severity CRITICAL,HIGH --sbom-sources oci apicurio/apicurio-registry-sql:2.2.5.Final
2024-02-20T12:06:55.054+0900	DEBUG	Severities: ["CRITICAL" "HIGH"]
2024-02-20T12:06:55.054+0900	DEBUG	Ignore statuses	{"statuses": null}
2024-02-20T12:06:55.066+0900	DEBUG	cache dir:  /Users/saso/Library/Caches/trivy
2024-02-20T12:06:55.066+0900	DEBUG	DB update was skipped because the local DB is the latest
2024-02-20T12:06:55.066+0900	DEBUG	DB Schema: 2, UpdatedAt: 2024-02-20 00:16:01.804708429 +0000 UTC, NextUpdate: 2024-02-20 06:16:01.804708139 +0000 UTC, DownloadedAt: 2024-02-20 01:34:32.831729 +0000 UTC
2024-02-20T12:06:55.066+0900	INFO	Vulnerability scanning is enabled
2024-02-20T12:06:55.066+0900	DEBUG	Vulnerability type:  [os library]
2024-02-20T12:06:55.066+0900	DEBUG	Enabling misconfiguration scanners: [azure-arm cloudformation dockerfile helm kubernetes terraform terraformplan]
2024-02-20T12:06:56.996+0900	DEBUG	The nuget packages directory couldn't be found. License search disabled
2024-02-20T12:06:58.081+0900	DEBUG	Image ID: sha256:08023b5ebcfd94fb477635b4636d7c1fbe91e92ac8e3c1fb943c77805a19b8f0
2024-02-20T12:06:58.082+0900	DEBUG	Diff IDs: [sha256:dff9f8de74c048baca326e1d79db28e7615e8e96497c630177c53e61bbd2f906 sha256:e34e3bdec2768c1b351fdcc47094e9e345a7e1c2115d667549e76a02ed282d3c sha256:25ec5befcdd1a4a5560c9e5f2345399612a5dc065be70d7173901ba5e9f087a1 sha256:43e4e0db265565375c091e37ba984f113a90e7424dfbaa6584a4b3a7eb1ad275]
2024-02-20T12:06:59.999+0900	DEBUG	No SBOM found in the source: oci
2024-02-20T12:06:59.999+0900	DEBUG	Base Layers: []
2024-02-20T12:07:00.048+0900	INFO	Detected OS: redhat
2024-02-20T12:07:00.048+0900	INFO	Detecting RHEL/CentOS vulnerabilities...
2024-02-20T12:07:00.048+0900	DEBUG	Red Hat: os version: 8
2024-02-20T12:07:00.048+0900	DEBUG	Red Hat: the number of packages: 234
2024-02-20T12:07:00.108+0900	INFO	Number of language-specific files: 1
2024-02-20T12:07:00.108+0900	INFO	Detecting jar vulnerabilities...
2024-02-20T12:07:00.108+0900	DEBUG	Detecting library vulnerabilities, type: jar, path:
2024-02-20T12:07:00.121+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-22662": no vulnerability details for CVE-2022-22662
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26700": no vulnerability details for CVE-2022-26700
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26709": no vulnerability details for CVE-2022-26709
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26710": no vulnerability details for CVE-2022-26710
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26716": no vulnerability details for CVE-2022-26716
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26717": no vulnerability details for CVE-2022-26717
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-26719": no vulnerability details for CVE-2022-26719
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-30293": no vulnerability details for CVE-2022-30293
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-32792": no vulnerability details for CVE-2022-32792
2024-02-20T12:07:00.122+0900	WARN	Error while getting vulnerability details: failed to get the vulnerability "CVE-2022-32816": no vulnerability details for CVE-2022-32816

apicurio/apicurio-registry-sql:2.2.5.Final (redhat 8.6)

Total: 35 (HIGH: 35, CRITICAL: 0)

...

```

In the case of the `--sbom-sources oci,rekor` option, trivy searches rekor in the same way as before.

```
> ./trivy -d image --timeout 30m --scanners vuln --severity CRITICAL,HIGH --sbom-sources oci,rekor apicurio/apicurio-registry-sql:2.2.5.Final
2024-02-20T12:11:55.122+0900	DEBUG	Severities: ["CRITICAL" "HIGH"]
2024-02-20T12:11:55.122+0900	DEBUG	Ignore statuses	{"statuses": null}
2024-02-20T12:11:55.142+0900	DEBUG	cache dir:  /Users/saso/Library/Caches/trivy
2024-02-20T12:11:55.142+0900	DEBUG	There is no valid metadata file: unable to open a file: open /Users/saso/Library/Caches/trivy/db/metadata.json: no such file or directory
2024-02-20T12:11:55.142+0900	INFO	Need to update DB
2024-02-20T12:11:55.142+0900	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2024-02-20T12:11:55.142+0900	INFO	Downloading DB...
2024-02-20T12:11:55.142+0900	DEBUG	no metadata file
43.02 MiB / 43.02 MiB [------------------------------------------------------------------------------------------------------------] 100.00% 27.21 MiB p/s 1.8s
2024-02-20T12:11:58.030+0900	DEBUG	Updating database metadata...
2024-02-20T12:11:58.030+0900	DEBUG	DB Schema: 2, UpdatedAt: 2024-02-20 00:16:01.804708429 +0000 UTC, NextUpdate: 2024-02-20 06:16:01.804708139 +0000 UTC, DownloadedAt: 2024-02-20 03:11:58.030129 +0000 UTC
2024-02-20T12:11:58.030+0900	INFO	Vulnerability scanning is enabled
2024-02-20T12:11:58.030+0900	DEBUG	Vulnerability type:  [os library]
2024-02-20T12:11:58.030+0900	DEBUG	Enabling misconfiguration scanners: [azure-arm cloudformation dockerfile helm kubernetes terraform terraformplan]
2024-02-20T12:11:59.858+0900	DEBUG	The nuget packages directory couldn't be found. License search disabled
2024-02-20T12:12:00.147+0900	DEBUG	Image ID: sha256:08023b5ebcfd94fb477635b4636d7c1fbe91e92ac8e3c1fb943c77805a19b8f0
2024-02-20T12:12:00.147+0900	DEBUG	Diff IDs: [sha256:dff9f8de74c048baca326e1d79db28e7615e8e96497c630177c53e61bbd2f906 sha256:e34e3bdec2768c1b351fdcc47094e9e345a7e1c2115d667549e76a02ed282d3c sha256:25ec5befcdd1a4a5560c9e5f2345399612a5dc065be70d7173901ba5e9f087a1 sha256:43e4e0db265565375c091e37ba984f113a90e7424dfbaa6584a4b3a7eb1ad275]
2024-02-20T12:12:02.129+0900	DEBUG	No SBOM found in the source: oci
2024-02-20T12:12:02.129+0900	DEBUG	Search for sha256:3b5f03ac430ad5d1e9d623804905bd45ba597a0a31f17f7447b8b0b585b6ec66 in Rekor
2024-02-20T12:12:02.349+0900	DEBUG	No SBOM found in the source: rekor
2024-02-20T12:12:02.349+0900	DEBUG	Base Layers: []
2024-02-20T12:12:02.350+0900	DEBUG	Missing image ID in cache: sha256:08023b5ebcfd94fb477635b4636d7c1fbe91e92ac8e3c1fb943c77805a19b8f0
2024-02-20T12:12:02.350+0900	DEBUG	Missing diff ID in cache: sha256:dff9f8de74c048baca326e1d79db28e7615e8e96497c630177c53e61bbd2f906
2024-02-20T12:12:02.351+0900	DEBUG	Missing diff ID in cache: sha256:e34e3bdec2768c1b351fdcc47094e9e345a7e1c2115d667549e76a02ed282d3c
2024-02-20T12:12:02.352+0900	DEBUG	Missing diff ID in cache: sha256:25ec5befcdd1a4a5560c9e5f2345399612a5dc065be70d7173901ba5e9f087a1
2024-02-20T12:12:02.352+0900	DEBUG	Missing diff ID in cache: sha256:43e4e0db265565375c091e37ba984f113a90e7424dfbaa6584a4b3a7eb1ad275
2024-02-20T12:12:02.714+0900	DEBUG	Skipping directory: dev
2024-02-20T12:12:02.714+0900	DEBUG	Skipping directory: sys
2024-02-20T12:12:02.714+0900	DEBUG	Skipping directory: proc
2024-02-20T12:12:04.215+0900	DEBUG	Search for sha256:6f37f487c2cbdb020d9feeabf6faf7b4cb0d8c1b84ac2904537868cd20df704d in Rekor
2024-02-20T12:12:04.382+0900	DEBUG	Search for sha256:21368a0a11f64142a460198545d9fba8a3474a036cd224798058b316736c1861 in Rekor
2024-02-20T12:12:04.549+0900	DEBUG	Search for sha256:47dcb5bf734944a10d3119737af7a1f6dc2fb266d210d0fd5219d91913095beb in Rekor
2024-02-20T12:12:04.724+0900	DEBUG	Search for sha256:d367fa9b931381a1f9a832e1cde08ef75d2bb56e8c6f5116fc61e70176defe32 in Rekor
2024-02-20T12:12:04.892+0900	DEBUG	Search for sha256:150051476f41c1770bdd00a19ddd0560d5bf88c69aef3ab364018113af4225ad in Rekor
2024-02-20T12:12:05.060+0900	DEBUG	Search for sha256:48421477d0ed2d436c58ef166af25a9f5675fbd239ddb354c8b259f063f9edb8 in Rekor

...

```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6157


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
