### PR TITLE
fix(java): add only valid libs from `pom.properties` files from `jars`

### DIFF
--- a/pkg/dependency/parser/java/jar/parse.go
+++ b/pkg/dependency/parser/java/jar/parse.go
@@ -165,11 +165,14 @@ func (p *Parser) traverseZip(filePath string, size int64, r dio.ReadSeekerAt, fi
 			if err != nil {
 				return nil, manifest{}, false, xerrors.Errorf("failed to parse %s: %w", fileInJar.Name, err)
 			}
-			libs = append(libs, props.Library())
+			// Validation of props to avoid getting libs with empty Name/Version
+			if props.Valid() {
+				libs = append(libs, props.Library())
 
-			// Check if the pom.properties is for the original JAR/WAR/EAR
-			if fileProps.ArtifactID == props.ArtifactID && fileProps.Version == props.Version {
-				foundPomProps = true
+				// Check if the pom.properties is for the original JAR/WAR/EAR
+				if fileProps.ArtifactID == props.ArtifactID && fileProps.Version == props.Version {
+					foundPomProps = true
+				}
 			}
 		case filepath.Base(fileInJar.Name) == "MANIFEST.MF":
 			m, err = parseManifest(fileInJar)


### PR DESCRIPTION
## Description
Add only valid libs from `pom.properties` files from `jars`.

## Related Discussions
- #6148

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
