### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,22 @@
 # Global
 *   @knqyf263
 
+# SBOM/Vulnerability scanning
+pkg/dependency/  @knqyf263 @DmitriyLewen
+pkg/fanal/       @knqyf263 @DmitriyLewen
+pkg/sbom/        @knqyf263 @DmitriyLewen
+pkg/scanner/     @knqyf263 @DmitriyLewen
+
 # Misconfiguration scanning
-docs/docs/scanner/misconfiguration  @knqyf263 @simar7
-docs/docs/target/aws.md             @knqyf263 @simar7
-pkg/fanal/analyzer/config           @knqyf263 @simar7
-pkg/cloud                           @knqyf263 @simar7
-pkg/iac                             @knqyf263 @simar7
+docs/docs/scanner/misconfiguration/  @simar7 @nikpivkin
+docs/docs/target/aws.md              @simar7 @nikpivkin
+pkg/fanal/analyzer/config/           @simar7 @nikpivkin
+pkg/cloud/                           @simar7 @nikpivkin
+pkg/iac/                             @simar7 @nikpivkin
 
 # Helm chart
 helm/trivy/ @chen-keinan
 
 # Kubernetes scanning
-pkg/k8s/                @josedonizetti @chen-keinan @knqyf263
-docs/docs/kubernetes/   @josedonizetti @chen-keinan @knqyf263
+pkg/k8s/                         @chen-keinan
+docs/docs/target/kubernetes.md   @chen-keinan


### PR DESCRIPTION
## Description
This PR includes the following four changes regarding code owners:

- Remove @josedonizetti 
- Add @DmitriyLewen as a code owner for SBOM/vulnerability-related code
- Add @nikpivkin  as a code owner for misconfiguration issues
- Remove @knqyf263  as a code owner for IaC and K8s

@josedonizetti is now maintaining Tracee, while @DmitriyLewen and @nikpivkin have been active in these areas for a long time and are sufficiently knowledgeable.

I originally founded Trivy with philosophy in mind. I've also been a code owner in each domain, like misconfiguration and k8s, to ensure consistency with other features. There have actually been several incidents of accidental breakage of core functions. However, as the project matured and the scope of Trivy expanded, my oversight became broader, leading to a bottleneck and slowing down development. Therefore, I am delegating each area to the respective code owners to prevent delays in development. Of course, I may still participate in discussions about significant feature additions or designs, but ultimately, the code owners can make the final decisions.

If it includes changes outside of each area, I will also review it, otherwise each code owner is free to merge PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
