### PR TITLE
feat: add info log message about dev deps suppression

### DIFF
--- a/pkg/fanal/analyzer/language/analyze.go
+++ b/pkg/fanal/analyzer/language/analyze.go
@@ -1,9 +1,10 @@
 package language
 
 import (
-	"golang.org/x/xerrors"
 	"io"
 	"strings"
+
+	"golang.org/x/xerrors"
 
 	godeptypes "github.com/aquasecurity/trivy/pkg/dependency/parser/types"
 	"github.com/aquasecurity/trivy/pkg/digest"

--- a/pkg/fanal/analyzer/language/analyze.go
+++ b/pkg/fanal/analyzer/language/analyze.go
@@ -1,11 +1,9 @@
 package language
 
 import (
+	"golang.org/x/xerrors"
 	"io"
 	"strings"
-	"sync"
-
-	"golang.org/x/xerrors"
 
 	godeptypes "github.com/aquasecurity/trivy/pkg/dependency/parser/types"
 	"github.com/aquasecurity/trivy/pkg/digest"
@@ -15,8 +13,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
-
-var devDepsInfoOnce sync.Once
 
 // Analyze returns an analysis result of the lock file
 func Analyze(fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser godeptypes.Parser) (*analyzer.AnalysisResult, error) {
@@ -97,13 +93,6 @@ func toApplication(fileType types.LangType, filePath, libFilePath string, r xio.
 
 	var pkgs []types.Package
 	for _, lib := range libs {
-		// By default, we suppress dev deps. Show log info about it.
-		if lib.Dev == true {
-			devDepsInfoOnce.Do(func() {
-				log.Logger.Info("Suppressing dependencies for development and testing. To display them, try '--include-dev-deps'")
-			})
-		}
-
 		var licenses []string
 		if lib.License != "" {
 			licenses = licensing.SplitLicenses(lib.License)

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -430,7 +430,7 @@ func excludeDevDeps(apps []ftypes.Application, include bool) {
 		apps[i].Libraries = lo.Filter(apps[i].Libraries, func(lib ftypes.Package, index int) bool {
 			if lib.Dev {
 				once.Do(func() {
-					log.Logger.Info("Suppressing dependencies for development and testing. To display them, try '--include-dev-deps'")
+					log.Logger.Info("Suppressing dependencies for development and testing. To display them, try the '--include-dev-deps' flag.")
 				})
 			}
 			return !lib.Dev

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -425,13 +425,14 @@ func excludeDevDeps(apps []ftypes.Application, include bool) {
 	if include {
 		return
 	}
-	var once sync.Once
+
+	onceInfo := sync.OnceFunc(func() {
+		log.Logger.Info("Suppressing dependencies for development and testing. To display them, try the '--include-dev-deps' flag.")
+	})
 	for i := range apps {
 		apps[i].Libraries = lo.Filter(apps[i].Libraries, func(lib ftypes.Package, index int) bool {
 			if lib.Dev {
-				once.Do(func() {
-					log.Logger.Info("Suppressing dependencies for development and testing. To display them, try the '--include-dev-deps' flag.")
-				})
+				onceInfo()
 			}
 			return !lib.Dev
 		})

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/google/wire"
 	"github.com/samber/lo"
@@ -424,8 +425,14 @@ func excludeDevDeps(apps []ftypes.Application, include bool) {
 	if include {
 		return
 	}
+	var once sync.Once
 	for i := range apps {
 		apps[i].Libraries = lo.Filter(apps[i].Libraries, func(lib ftypes.Package, index int) bool {
+			if lib.Dev {
+				once.Do(func() {
+					log.Logger.Info("Suppressing dependencies for development and testing. To display them, try '--include-dev-deps'")
+				})
+			}
 			return !lib.Dev
 		})
 	}


### PR DESCRIPTION
## Description
By default, we suppress `Dev` dependencies (npm, yarn is currently support only). 
We need to show info about it.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
