### PR TITLE
feat(java): mark dependencies from `maven-invoker-plugin` integration tests pom.xml files as `Dev`

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -59,7 +59,7 @@ The vulnerability database will be downloaded anyway.
 ### maven-invoker-plugin
 Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin](https://maven.apache.org/plugins/maven-invoker-plugin/usage.html) doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
 
-Trivy marks dependencies from these files as `Dev`. If you need to show them, use `--include-dev-deps` flag.
+Trivy marks dependencies from these files as `Dev`. By default, we skip `Dev` dependencies. If you need to show them, use `--include-dev-deps` flag.
 
 
 ## Gradle.lock

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -55,6 +55,13 @@ The vulnerability database will be downloaded anyway.
 !!! Warning
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
+
+### maven-invoker-plugin
+Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin](https://maven.apache.org/plugins/maven-invoker-plugin/usage.html) doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
+
+Trivy marks dependencies from these files as `Dev`. If you need to show them, use `--include-dev-deps` flag.
+
+
 ## Gradle.lock
 `gradle.lock` files contain all necessary information about used dependencies.
 Trivy simply parses the file, extract dependencies, and finds vulnerabilities for them.

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -57,9 +57,10 @@ The vulnerability database will be downloaded anyway.
 
 
 ### maven-invoker-plugin
-Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin](https://maven.apache.org/plugins/maven-invoker-plugin/usage.html) doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
+Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin][maven-invoker-plugin] doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
 
-Trivy marks dependencies from these files as `Dev`. By default, we skip `Dev` dependencies. If you need to show them, use `--include-dev-deps` flag.
+Trivy marks dependencies from these files as the development dependencies and skip them by default.
+If you need to show them, use the `--include-dev-deps` flag.
 
 
 ## Gradle.lock
@@ -77,3 +78,4 @@ It doesn't require the internet access.
 [^7]: To avoid confusion, Trivy only finds locations for direct dependencies from the base pom.xml file.
 
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
+[maven-invoker-plugin]: https://maven.apache.org/plugins/maven-invoker-plugin/usage.html

--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -62,7 +62,7 @@ func (a pomAnalyzer) Version() int {
 func isIntegrationTestDir(filePath string) bool {
 	dirs := strings.Split(filepath.ToSlash(filePath), "/")
 	// filepath pattern: `**/[src|target]/it/*/pom.xml`
-	if len(dirs) < 5 {
+	if len(dirs) < 4 {
 		return false
 	}
 	return (dirs[len(dirs)-4] == "src" || dirs[len(dirs)-4] == "target") && dirs[len(dirs)-3] == "it"

--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -2,11 +2,11 @@ package pom
 
 import (
 	"context"
-	"github.com/samber/lo"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"

--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
@@ -35,10 +34,9 @@ func (a pomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*
 	// Mark integration test pom files for `maven-invoker-plugin` as Dev to skip them by default.
 	if isIntegrationTestDir(filePath) {
 		for i := range res.Applications {
-			res.Applications[i].Libraries = lo.Map(res.Applications[i].Libraries, func(lib types.Package, _ int) types.Package {
-				lib.Dev = true
-				return lib
-			})
+			for j := range res.Applications[i].Libraries {
+				res.Applications[i].Libraries[j].Dev = true
+			}
 		}
 	}
 

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -90,6 +90,42 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy path for maven-invoker-plugin integration tests",
+			inputFile: "testdata/mark-as-dev/src/it/example/pom.xml",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Pom,
+						FilePath: "testdata/mark-as-dev/src/it/example/pom.xml",
+						Libraries: types.Packages{
+							{
+								ID:      "com.example:example-api:@example.version@",
+								Name:    "com.example:example-api",
+								Version: "@example.version@",
+								Locations: []types.Location{
+									{
+										StartLine: 28,
+										EndLine:   32,
+									},
+								},
+								Dev: true,
+							},
+							{
+								ID:       "com.example:example:1.0.0",
+								Name:     "com.example:example",
+								Version:  "1.0.0",
+								Licenses: []string{"Apache-2.0"},
+								DependsOn: []string{
+									"com.example:example-api:@example.version@",
+								},
+								Dev: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:      "unsupported requirement",
 			inputFile: "testdata/requirements/pom.xml",
 			want: &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/language/java/pom/testdata/mark-as-dev/src/it/example/pom.xml
+++ b/pkg/fanal/analyzer/language/java/pom/testdata/mark-as-dev/src/it/example/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0.0</version>
+
+    <name>example</name>
+    <description>Example</description>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>knqyf263</id>
+            <url>https://github.com/knqyf263</url>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>@example.version@</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description
Mark dependencies from `maven-invoker-plugin` integration tests pom.xml files as `Dev`.
This is necessary to add an option to skip/show these dependencies using `--include-dev-deps` flag.
See more in #5787

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
