### PR TITLE
chore(redhat): handle CentOS Stream releases

### DIFF
--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -38,6 +38,7 @@ var (
 		ftypes.Ubuntu:       ubuntu.NewScanner(),
 		ftypes.RedHat:       redhat.NewScanner(),
 		ftypes.CentOS:       redhat.NewScanner(),
+		ftypes.CentOSStream: redhat.NewScanner(),
 		ftypes.Rocky:        rocky.NewScanner(),
 		ftypes.Oracle:       oracle.NewScanner(),
 		ftypes.OpenSUSELeap: suse.NewScanner(suse.OpenSUSE),

--- a/pkg/fanal/analyzer/os/redhatbase/centos.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos.go
@@ -32,7 +32,7 @@ func (a centOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		}
 
 		switch strings.ToLower(result[1]) {
-		case "centos", "centos linux":
+		case "centos", "centos linux", "centos stream":
 			return &analyzer.AnalysisResult{
 				OS: types.OS{
 					Family: types.CentOS,

--- a/pkg/fanal/analyzer/os/redhatbase/centos.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos.go
@@ -32,10 +32,17 @@ func (a centOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		}
 
 		switch strings.ToLower(result[1]) {
-		case "centos", "centos linux", "centos stream":
+		case "centos", "centos linux":
 			return &analyzer.AnalysisResult{
 				OS: types.OS{
 					Family: types.CentOS,
+					Name:   result[2],
+				},
+			}, nil
+		case "centos stream":
+			return &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.CentOSStream,
 					Name:   result[2],
 				},
 			}, nil

--- a/pkg/fanal/analyzer/os/redhatbase/centos_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos_test.go
@@ -30,7 +30,7 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 			name:      "happy path (CentOS Stream)",
 			inputFile: "testdata/centos/centos-stream-release",
 			want: &analyzer.AnalysisResult{
-				OS: types.OS{Family: "centos", Name: "9"},
+				OS: types.OS{Family: "centos-stream", Name: "9"},
 			},
 		},
 		{

--- a/pkg/fanal/analyzer/os/redhatbase/centos_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos_test.go
@@ -27,6 +27,13 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy path (CentOS Stream)",
+			inputFile: "testdata/centos/centos-stream-release",
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{Family: "centos", Name: "9"},
+			},
+		},
+		{
 			name:      "sad path",
 			inputFile: "testdata/not_redhatbase/empty",
 			wantErr:   "centos: unable to analyze OS information",

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
@@ -52,6 +52,11 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 				Family: types.CentOS,
 				Name:   result[2],
 			}, nil
+		case "centos stream":
+			return types.OS{
+				Family: types.CentOSStream,
+				Name:   result[2],
+			}, nil
 		case "rocky", "rocky linux":
 			return types.OS{
 				Family: types.Rocky,

--- a/pkg/fanal/analyzer/os/redhatbase/testdata/centos/centos-stream-release
+++ b/pkg/fanal/analyzer/os/redhatbase/testdata/centos/centos-stream-release
@@ -1,0 +1,1 @@
+CentOS Stream release 9

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -26,6 +26,7 @@ const (
 	Amazon             OSType = "amazon"
 	CBLMariner         OSType = "cbl-mariner"
 	CentOS             OSType = "centos"
+	CentOSStream       OSType = "centos-stream"
 	Chainguard         OSType = "chainguard"
 	Debian             OSType = "debian"
 	Fedora             OSType = "fedora"

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -499,7 +499,8 @@ func purlType(t ftypes.TargetType) string {
 		return packageurl.TypeDebian
 	case ftypes.RedHat, ftypes.CentOS, ftypes.Rocky, ftypes.Alma,
 		ftypes.Amazon, ftypes.Fedora, ftypes.Oracle, ftypes.OpenSUSE,
-		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.Photon:
+		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.Photon,
+		ftypes.CentOSStream:
 		return packageurl.TypeRPM
 	case TypeOCI:
 		return packageurl.TypeOCI


### PR DESCRIPTION
## Description

This PR adds support for the CentOS Stream OS type family and detects it through the existing CentOS analyzer.
It uses the `CentOS Stream` prefix in the `/etc/centos-release` file to detect this OS type family. 

```
$ cat /etc/centos-release 
CentOS Stream release 9
```

## Related issues
- Close #XXX

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
