### PR TITLE
fix(db): use schema version as tag only for `trivy-db` and `trivy-java-db` registries by default

### DIFF
--- a/docs/docs/configuration/db.md
+++ b/docs/docs/configuration/db.md
@@ -54,9 +54,17 @@ $ trivy image --download-db-only
 $ trivy image --db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-db
 ```
 
+!!!note
+    Trivy automatically adds the `trivy-db` schema version as a tag if the tag is not used:
+
+    `trivy-db-registry:latest` => `trivy-db-registry:latest`, but `trivy-db-registry` => `trivy-db-registry:2`.
+
 ## Java Index Database
 The same options are also available for the Java index DB, which is used for scanning Java applications.
 Skipping an update can be done by using the `--skip-java-db-update` option, while `--download-java-db-only` can be used to only download the Java index DB.
+
+!!! Note
+    In [Client/Server](../references/modes/client-server.md) mode, `Java index DB` is currently only used on the `client` side.
 
 Downloading the Java index DB from an external OCI registry can be done by using the `--java-db-repository` option.
 
@@ -64,8 +72,10 @@ Downloading the Java index DB from an external OCI registry can be done by using
 $ trivy image --java-db-repository registry.gitlab.com/gitlab-org/security-products/dependencies/trivy-java-db --download-java-db-only
 ```
 
-!!! Note
-    In [Client/Server](../references/modes/client-server.md) mode, `Java index DB` is currently only used on the `client` side.
+!!!note
+    Trivy automatically adds the `trivy-java-db` schema version as a tag if the tag is not used:
+
+    `java-db-registry:latest` => `java-db-registry:latest`, but `java-db-registry` => `java-db-registry:1`.
 
 ## Remove DBs
 The `--reset` flag removes all caches and databases.

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -27,7 +27,7 @@ trivy filesystem [flags] PATH
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --custom-headers strings            custom headers in client mode
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -47,7 +47,7 @@ trivy filesystem [flags] PATH
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -41,7 +41,7 @@ trivy image [flags] IMAGE_NAME
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --custom-headers strings            custom headers in client mode
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --docker-host string                unix domain socket path to use for docker scanning
       --download-db-only                  download/update vulnerability database but don't run a scan
@@ -65,7 +65,7 @@ trivy image [flags] IMAGE_NAME
       --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
       --input string                      input file path instead of image name
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -37,7 +37,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --context string                    specify a context to scan
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -57,7 +57,7 @@ trivy kubernetes [flags] { cluster | all | specific resources like kubectl. eg: 
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -27,7 +27,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --custom-headers strings            custom headers in client mode
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -47,7 +47,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -29,7 +29,7 @@ trivy rootfs [flags] ROOTDIR
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --custom-headers strings            custom headers in client mode
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -49,7 +49,7 @@ trivy rootfs [flags] ROOTDIR
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -25,7 +25,7 @@ trivy sbom [flags] SBOM_PATH
       --clear-cache                 clear image caches without scanning
       --compliance string           compliance report to generate
       --custom-headers strings      custom headers in client mode
-      --db-repository string        OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string        OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --download-db-only            download/update vulnerability database but don't run a scan
       --download-java-db-only       download/update Java index database but don't run a scan
       --exit-code int               specify exit code when any security issues are found
@@ -37,7 +37,7 @@ trivy sbom [flags] SBOM_PATH
       --ignore-status strings       comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
       --ignore-unfixed              display only fixed vulnerabilities
       --ignorefile string           specify .trivyignore file (default ".trivyignore")
-      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string   OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --list-all-pkgs               enabling the option will output all packages regardless of vulnerability
       --no-progress                 suppress progress bar
       --offline-scan                do not issue API requests to identify dependencies

--- a/docs/docs/references/configuration/cli/trivy_server.md
+++ b/docs/docs/references/configuration/cli/trivy_server.md
@@ -23,7 +23,7 @@ trivy server [flags]
       --cache-backend string     cache backend (e.g. redis://localhost:6379) (default "fs")
       --cache-ttl duration       cache TTL when using redis as cache backend
       --clear-cache              clear image caches without scanning
-      --db-repository string     OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string     OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --download-db-only         download/update vulnerability database but don't run a scan
       --enable-modules strings   [EXPERIMENTAL] module names to enable
   -h, --help                     help for server

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -26,7 +26,7 @@ trivy vm [flags] VM_IMAGE
       --clear-cache                       clear image caches without scanning
       --compliance string                 compliance report to generate
       --custom-headers strings            custom headers in client mode
-      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db")
+      --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -45,7 +45,7 @@ trivy vm [flags] VM_IMAGE
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-non-failures              include successes and exceptions, available with '--scanners misconfig'
-      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db")
+      --java-db-repository string         OCI repository to retrieve trivy-java-db from (default "ghcr.io/aquasecurity/trivy-java-db:1")
       --list-all-pkgs                     enabling the option will output all packages regardless of vulnerability
       --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -80,6 +80,7 @@ func NewClient(cacheDir string, quiet bool, opts ...Option) *Client {
 	}
 
 	// Add the schema version as a tag if the tag doesn't exist.
+	// This is required for backward compatibility.
 	if !strings.Contains(o.dbRepository, ":") {
 		o.dbRepository = fmt.Sprintf("%s:%d", o.dbRepository, db.SchemaVersion)
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -78,7 +79,10 @@ func NewClient(cacheDir string, quiet bool, opts ...Option) *Client {
 		opt(o)
 	}
 
-	o.dbRepository = fmt.Sprintf("%s:%d", o.dbRepository, db.SchemaVersion)
+	// Add the schema version as a tag if the tag doesn't exist.
+	if !strings.Contains(o.dbRepository, ":") {
+		o.dbRepository = fmt.Sprintf("%s:%d", o.dbRepository, db.SchemaVersion)
+	}
 
 	return &Client{
 		options:  o,

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -78,6 +78,8 @@ func NewClient(cacheDir string, quiet bool, opts ...Option) *Client {
 		opt(o)
 	}
 
+	o.dbRepository = fmt.Sprintf("%s:%d", o.dbRepository, db.SchemaVersion)
+
 	return &Client{
 		options:  o,
 		cacheDir: cacheDir,
@@ -188,8 +190,7 @@ func (c *Client) initOCIArtifact(opt types.RegistryOptions) (*oci.Artifact, erro
 		return c.artifact, nil
 	}
 
-	repo := fmt.Sprintf("%s:%d", c.dbRepository, db.SchemaVersion)
-	art, err := oci.NewArtifact(repo, c.quiet, opt)
+	art, err := oci.NewArtifact(c.dbRepository, c.quiet, opt)
 	if err != nil {
 		var terr *transport.Error
 		if errors.As(err, &terr) {

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -6,8 +6,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-const defaultDBRepository = "ghcr.io/aquasecurity/trivy-db"
-const defaultJavaDBRepository = "ghcr.io/aquasecurity/trivy-java-db"
+const defaultDBRepository = "ghcr.io/aquasecurity/trivy-db:2"
+const defaultJavaDBRepository = "ghcr.io/aquasecurity/trivy-java-db:1"
 
 var (
 	ResetFlag = Flag[bool]{

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -82,8 +83,12 @@ func (u *Updater) Update() error {
 }
 
 func Init(cacheDir, javaDBRepository string, skip, quiet bool, registryOption ftypes.RegistryOptions) {
+	// Add the schema version as a tag if the tag doesn't exist.
+	if !strings.Contains(javaDBRepository, ":") {
+		javaDBRepository = fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion)
+	}
 	updater = &Updater{
-		repo:           fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion),
+		repo:           javaDBRepository,
 		dbDir:          filepath.Join(cacheDir, "java-db"),
 		skip:           skip,
 		quiet:          quiet,

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -84,6 +84,7 @@ func (u *Updater) Update() error {
 
 func Init(cacheDir, javaDBRepository string, skip, quiet bool, registryOption ftypes.RegistryOptions) {
 	// Add the schema version as a tag if the tag doesn't exist.
+	// This is required for backward compatibility.
 	if !strings.Contains(javaDBRepository, ":") {
 		javaDBRepository = fmt.Sprintf("%s:%d", javaDBRepository, db.SchemaVersion)
 	}


### PR DESCRIPTION
## Description
We add schema version as tag only for all registries (both default and external).
To avoid limiting users, we only need to do this for the default registries (`ghcr.io/aquasecurity/trivy-db` and `ghcr.io/aquasecurity/trivy-java-db`).

## Related issues
- Close #6218

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
