### PR TITLE
ci: add maximize-build-space for `Test` job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,15 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          remove-android: "true"
+          remove-docker-images: "true"
+          remove-dotnet: "true"
+          remove-haskell: "true"
+
       - uses: actions/checkout@v4.1.1
 
       - name: Set up Go

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,11 +18,12 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 32768 # The Go cache (`~/.cache/go-build` and `~/go/pkg`) requires a lot of storage space.
+          root-reserve-mb: 32768 # The golangci-lint uses a lot of space.
           remove-android: "true"
           remove-docker-images: "true"
           remove-dotnet: "true"
           remove-haskell: "true"
+        if: matrix.operating-system == 'ubuntu-latest'
 
       - uses: actions/checkout@v4.1.1
 


### PR DESCRIPTION
## Description
We received `no space left on device` errors for [golangci-lint from GH Test action](https://github.com/aquasecurity/trivy/blob/1dfece89d0c7c8dec73b6e3be8e7fabf1fca4a39/.github/workflows/test.yaml#L34-L41)
Add `maximize-build-space` for `Test` job to get more free space.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
