### PR TITLE
test(k8s): use test-db for k8s integration tests

### DIFF
--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -21,11 +21,15 @@ import (
 // "mage test:k8s" will run this test.
 
 func TestK8s(t *testing.T) {
+	// Set up testing DB
+	cacheDir := initDB(t)
 	t.Run("misconfig and vulnerability scan", func(t *testing.T) {
 		// Set up the output file
 		outputFile := filepath.Join(t.TempDir(), "output.json")
 
 		osArgs := []string{
+			"--cache-dir",
+			cacheDir,
 			"k8s",
 			"cluster",
 			"--report",


### PR DESCRIPTION
## Description
We use trivy-db from default cache dir for [k8s integration tests](https://github.com/aquasecurity/trivy/blob/main/integration/k8s_test.go#L23).
To avoid downloading trivy-db each run of CI/CD - we need to use test db.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
