### PR TITLE
fix(java): don't ignore runtime scope for pom.xml files

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -381,7 +381,7 @@ func (p *parser) parseDependencies(deps []pomDependency, props map[string]string
 		// Resolve dependencies
 		d = d.Resolve(props, depManagement, rootDepManagement)
 
-		if (d.Scope != "" && d.Scope != "compile") || d.Optional {
+		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime") || d.Optional {
 			continue
 		}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -47,12 +47,24 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:      "org.example:example-runtime:1.0.0",
+					Name:    "org.example:example-runtime",
+					Version: "1.0.0",
+					Locations: types.Locations{
+						{
+							StartLine: 37,
+							EndLine:   42,
+						},
+					},
+				},
 			},
 			wantDeps: []types.Dependency{
 				{
 					ID: "com.example:happy:1.0.0",
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
+						"org.example:example-runtime:1.0.0",
 					},
 				},
 			},
@@ -80,12 +92,24 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:      "org.example:example-runtime:1.0.0",
+					Name:    "org.example:example-runtime",
+					Version: "1.0.0",
+					Locations: types.Locations{
+						{
+							StartLine: 37,
+							EndLine:   42,
+						},
+					},
+				},
 			},
 			wantDeps: []types.Dependency{
 				{
 					ID: "com.example:happy:1.0.0",
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
+						"org.example:example-runtime:1.0.0",
 					},
 				},
 			},

--- a/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
         <dependency>
             <groupId>org.example</groupId>
+            <artifactId>example-runtime</artifactId>
+            <version>1.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
             <artifactId>example-provided</artifactId>
             <version>999</version>
             <scope>provided</scope>


### PR DESCRIPTION
## Description
We don't need to ignore runtime scope for `pom.xml` files.
See more in #6207

## Related issues
- Close #6207

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
