### PR TITLE
feat(image): customer podman host or socket option

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -78,6 +78,7 @@ trivy image [flags] IMAGE_NAME
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --platform string                   set platform in the form os/arch if image is multi-platform capable
+      --podman-host string                unix podman socket path to use for podman scanning
       --policy-bundle-repository string   OCI registry URL to retrieve policy bundle from (default "ghcr.io/aquasecurity/trivy-policies:0")
       --policy-namespaces strings         Rego namespaces
       --redis-ca string                   redis ca file location, if using redis as cache backend

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -203,6 +203,11 @@ image:
     # Same as '--docker-host'
     # Default is empty
     host: 
+  
+  podman:
+    # Same as '--podman-host'
+    # Default is empty
+    host: 
 ```
 
 ## Vulnerability Options

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -500,3 +500,10 @@ You can configure Docker daemon socket with `DOCKER_HOST` or `--docker-host`.
 ```shell
 $ trivy image --docker-host tcp://127.0.0.1:2375 YOUR_IMAGE
 ```
+
+### Configure Podman daemon socket to connect to.
+You can configure Podman daemon socket with `PODMAN_HOST` or `--podman-host`.
+
+```shell
+$ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE
+```

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -502,7 +502,7 @@ $ trivy image --docker-host tcp://127.0.0.1:2375 YOUR_IMAGE
 ```
 
 ### Configure Podman daemon socket to connect to.
-You can configure Podman daemon socket with `PODMAN_HOST` or `--podman-host`.
+You can configure Podman daemon socket with `--podman-host`.
 
 ```shell
 $ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -670,6 +670,9 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 				DockerOptions: ftypes.DockerOptions{
 					Host: opts.DockerHost,
 				},
+				PodmanOptions: ftypes.PodmanOptions{
+					Host: opts.PodmanHost,
+				},
 				ImageSources: opts.ImageSources,
 			},
 

--- a/pkg/fanal/image/daemon.go
+++ b/pkg/fanal/image/daemon.go
@@ -21,8 +21,8 @@ func tryDockerDaemon(_ context.Context, imageName string, ref name.Reference, op
 
 }
 
-func tryPodmanDaemon(_ context.Context, imageName string, _ name.Reference, _ types.ImageOptions) (types.Image, func(), error) {
-	img, cleanup, err := daemon.PodmanImage(imageName)
+func tryPodmanDaemon(_ context.Context, imageName string, _ name.Reference, opts types.ImageOptions) (types.Image, func(), error) {
+	img, cleanup, err := daemon.PodmanImage(imageName, opts.PodmanOptions.Host)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -115,6 +115,52 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
+
+	ref, err := name.ParseReference("alpine:3.11")
+	require.NoError(t, err)
+
+	eo := engine.Option{
+		APIVersion: opt.APIVersion,
+		ImagePaths: map[string]string{
+			"index.docker.io/library/alpine:3.11": "../../test/testdata/alpine-311.tar.gz",
+		},
+	}
+
+	var podmanSocket string
+
+	if runtime.GOOS != "windows" {
+		runtimeDir, err := os.MkdirTemp("", "daemon")
+		require.NoError(t, err)
+
+		dir := filepath.Join(runtimeDir, "image")
+		err = os.MkdirAll(dir, os.ModePerm)
+		require.NoError(t, err)
+
+		customDockerHost := filepath.Join(dir, "image-test-podman-socket.sock")
+		eo.UnixDomainSocket = customDockerHost
+		podmanSocket = customDockerHost
+	}
+
+	te := engine.NewDockerEngine(eo)
+	defer te.Close()
+
+	if runtime.GOOS == "windows" {
+		podmanSocket = te.Listener.Addr().Network() + "://" + te.Listener.Addr().String()
+	}
+
+	img, cleanup, err := PodmanImage(ref.Name(), podmanSocket)
+	require.NoError(t, err)
+	defer cleanup()
+
+	conf, err := img.ConfigName()
+	assert.Equal(t, v1.Hash{
+		Algorithm: "sha256",
+		Hex:       "a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+	}, conf)
+	assert.Nil(t, err)
+}
+
 func Test_image_ConfigFile(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -116,7 +116,6 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 }
 
 func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
-
 	if runtime.GOOS == "windows" {
 		t.Skip("podman.sock is not available for Windows CI")
 	}
@@ -131,20 +130,15 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 		},
 	}
 
-	var podmanSocket string
+	runtimeDir, err := os.MkdirTemp("", "daemon")
+	require.NoError(t, err)
 
-	if runtime.GOOS != "windows" {
-		runtimeDir, err := os.MkdirTemp("", "daemon")
-		require.NoError(t, err)
+	dir := filepath.Join(runtimeDir, "image")
+	err = os.MkdirAll(dir, os.ModePerm)
+	require.NoError(t, err)
 
-		dir := filepath.Join(runtimeDir, "image")
-		err = os.MkdirAll(dir, os.ModePerm)
-		require.NoError(t, err)
-
-		customDockerHost := filepath.Join(dir, "image-test-podman-socket.sock")
-		eo.UnixDomainSocket = customDockerHost
-		podmanSocket = customDockerHost
-	}
+	podmanSocket := filepath.Join(dir, "image-test-podman-socket.sock")
+	eo.UnixDomainSocket = podmanSocket
 
 	te := engine.NewDockerEngine(eo)
 	defer te.Close()

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -117,6 +117,10 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 
 func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 
+	if runtime.GOOS == "windows" {
+		t.Skip("podman.sock is not available for Windows CI")
+	}
+
 	ref, err := name.ParseReference("alpine:3.11")
 	require.NoError(t, err)
 
@@ -144,10 +148,6 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 
 	te := engine.NewDockerEngine(eo)
 	defer te.Close()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("podman.sock is not available for Windows CI")
-	}
 
 	img, cleanup, err := PodmanImage(ref.Name(), podmanSocket)
 	require.NoError(t, err)

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -146,7 +146,7 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 	defer te.Close()
 
 	if runtime.GOOS == "windows" {
-		podmanSocket = te.Listener.Addr().Network() + "://" + te.Listener.Addr().String()
+		t.Skip("podman.sock is not available for Windows CI")
 	}
 
 	img, cleanup, err := PodmanImage(ref.Name(), podmanSocket)

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -25,10 +25,13 @@ type podmanClient struct {
 	c http.Client
 }
 
-func newPodmanClient() (podmanClient, error) {
+func newPodmanClient(host string) (podmanClient, error) {
 	// Get Podman socket location
 	sockDir := os.Getenv("XDG_RUNTIME_DIR")
 	socket := filepath.Join(sockDir, "podman", "podman.sock")
+	if host != "" {
+		socket = host
+	}
 
 	if _, err := os.Stat(socket); err != nil {
 		return podmanClient{}, xerrors.Errorf("no podman socket found: %w", err)
@@ -109,10 +112,10 @@ func (p podmanClient) imageSave(_ context.Context, imageNames []string) (io.Read
 
 // PodmanImage implements v1.Image by extending daemon.Image.
 // The caller must call cleanup() to remove a temporary file.
-func PodmanImage(ref string) (Image, func(), error) {
+func PodmanImage(ref, host string) (Image, func(), error) {
 	cleanup := func() {}
 
-	c, err := newPodmanClient()
+	c, err := newPodmanClient(host)
 	if err != nil {
 		return nil, cleanup, xerrors.Errorf("unable to initialize Podman client: %w", err)
 	}

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -116,9 +116,7 @@ func (p podmanClient) imageSave(_ context.Context, imageNames []string) (io.Read
 // The caller must call cleanup() to remove a temporary file.
 func PodmanImage(ref, host string) (Image, func(), error) {
 	cleanup := func() {}
-	if host == "" {
-		host = os.Getenv("PODMAN_HOST")
-	}
+
 	c, err := newPodmanClient(host)
 	if err != nil {
 		return nil, cleanup, xerrors.Errorf("unable to initialize Podman client: %w", err)

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -114,7 +114,9 @@ func (p podmanClient) imageSave(_ context.Context, imageNames []string) (io.Read
 // The caller must call cleanup() to remove a temporary file.
 func PodmanImage(ref, host string) (Image, func(), error) {
 	cleanup := func() {}
-
+	if host == "" {
+		host = os.Getenv("PODMAN_HOST")
+	}
 	c, err := newPodmanClient(host)
 	if err != nil {
 		return nil, cleanup, xerrors.Errorf("unable to initialize Podman client: %w", err)

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -31,6 +31,8 @@ func newPodmanClient(host string) (podmanClient, error) {
 	socket := filepath.Join(sockDir, "podman", "podman.sock")
 	if host != "" {
 		socket = host
+	} else if s := os.Getenv("PODMAN_HOST"); s != "" {
+		socket = s
 	}
 
 	if _, err := os.Stat(socket); err != nil {

--- a/pkg/fanal/image/daemon/podman.go
+++ b/pkg/fanal/image/daemon/podman.go
@@ -31,8 +31,6 @@ func newPodmanClient(host string) (podmanClient, error) {
 	socket := filepath.Join(sockDir, "podman", "podman.sock")
 	if host != "" {
 		socket = host
-	} else if s := os.Getenv("PODMAN_HOST"); s != "" {
-		socket = s
 	}
 
 	if _, err := os.Stat(socket); err != nil {

--- a/pkg/fanal/image/daemon/podman_test.go
+++ b/pkg/fanal/image/daemon/podman_test.go
@@ -84,7 +84,7 @@ func TestPodmanImage(t *testing.T) {
 			ref, err := name.ParseReference(tt.imageName)
 			require.NoError(t, err)
 
-			img, cleanup, err := PodmanImage(ref.Name())
+			img, cleanup, err := PodmanImage(ref.Name(), "")
 			defer cleanup()
 
 			if tt.wantErr {

--- a/pkg/fanal/types/image.go
+++ b/pkg/fanal/types/image.go
@@ -60,7 +60,7 @@ type DockerOptions struct {
 }
 
 type PodmanOptions struct {
-	// Add Podman-specific options
+	Host string
 }
 
 type ContainerdOptions struct {

--- a/pkg/flag/image_flags.go
+++ b/pkg/flag/image_flags.go
@@ -45,6 +45,12 @@ var (
 		Default:    "",
 		Usage:      "unix domain socket path to use for docker scanning",
 	}
+	PodmanHostFlag = Flag[string]{
+		Name:       "podman-host",
+		ConfigName: "image.podman.host",
+		Default:    "",
+		Usage:      "unix podman socket path to use for podman scanning",
+	}
 	SourceFlag = Flag[[]string]{
 		Name:       "image-src",
 		ConfigName: "image.source",
@@ -60,6 +66,7 @@ type ImageFlagGroup struct {
 	ScanRemovedPkgs     *Flag[bool]
 	Platform            *Flag[string]
 	DockerHost          *Flag[string]
+	PodmanHost          *Flag[string]
 	ImageSources        *Flag[[]string]
 }
 
@@ -69,6 +76,7 @@ type ImageOptions struct {
 	ScanRemovedPkgs     bool
 	Platform            ftypes.Platform
 	DockerHost          string
+	PodmanHost          string
 	ImageSources        ftypes.ImageSources
 }
 
@@ -79,6 +87,7 @@ func NewImageFlagGroup() *ImageFlagGroup {
 		ScanRemovedPkgs:     ScanRemovedPkgsFlag.Clone(),
 		Platform:            PlatformFlag.Clone(),
 		DockerHost:          DockerHostFlag.Clone(),
+		PodmanHost:          PodmanHostFlag.Clone(),
 		ImageSources:        SourceFlag.Clone(),
 	}
 }
@@ -94,6 +103,7 @@ func (f *ImageFlagGroup) Flags() []Flagger {
 		f.ScanRemovedPkgs,
 		f.Platform,
 		f.DockerHost,
+		f.PodmanHost,
 		f.ImageSources,
 	}
 }
@@ -121,6 +131,7 @@ func (f *ImageFlagGroup) ToOptions() (ImageOptions, error) {
 		ScanRemovedPkgs:     f.ScanRemovedPkgs.Value(),
 		Platform:            platform,
 		DockerHost:          f.DockerHost.Value(),
+		PodmanHost:          f.PodmanHost.Value(),
 		ImageSources:        xstrings.ToTSlice[ftypes.ImageSource](f.ImageSources.Value()),
 	}, nil
 }


### PR DESCRIPTION
## Description
This pull request adds a new feature option `--podman-host` to the image command. This option allows users to specify a custom Podman host.

command output before introducing this feature
```sh
$ trivy image --image-src podman nginx:latest
2024-03-02T16:49:02.943Z	INFO	Need to update DB
2024-03-02T16:49:02.944Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2024-03-02T16:49:02.944Z	INFO	Downloading DB...
43.58 MiB / 43.58 MiB [--------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 7.43 MiB p/s 6.1s
2024-03-02T16:49:10.272Z	INFO	Vulnerability scanning is enabled
2024-03-02T16:49:10.272Z	INFO	Secret scanning is enabled
2024-03-02T16:49:10.272Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-03-02T16:49:10.273Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.49/docs/scanner/secret/#recommendation for faster secret detection
2024-03-02T16:49:10.279Z	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: 1 error occurred:
	* podman error: unable to initialize Podman client: no podman socket found: stat /run/user/1000/snap.trivy/podman/podman.sock: no such file or directory
```
command output after introducing the feature
```sh
$ trivy image --image-src podman --podman-host /run/user/1000/podman/podman.sock docker.io/nginx:latest
2024-03-02T17:03:12.479Z	INFO	Vulnerability scanning is enabled
2024-03-02T17:03:12.479Z	INFO	Secret scanning is enabled
2024-03-02T17:03:12.479Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-03-02T17:03:12.480Z	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret/#recommendation for faster secret detection
2024-03-02T17:03:25.884Z	INFO	Java DB Repository: ghcr.io/aquasecurity/trivy-java-db:1
2024-03-02T17:03:25.884Z	INFO	Downloading the Java DB...
509.15 MiB / 509.15 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 18.21 MiB p/s 28s
2024-03-02T17:03:55.181Z	INFO	The Java DB is cached for 3 days. If you want to update the database more frequently, the '--reset' flag clears the DB cache.
2024-03-02T17:03:55.631Z	INFO	Detected OS: debian
2024-03-02T17:03:55.631Z	INFO	Detecting Debian vulnerabilities...
2024-03-02T17:03:55.730Z	INFO	Number of language-specific files: 0

docker.io/nginx:latest (debian 12.5)

Total: 146 (UNKNOWN: 1, LOW: 84, MEDIUM: 32, HIGH: 27, CRITICAL: 2)

┌────────────────────┬─────────────────────┬──────────┬──────────────┬─────────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│      Library       │    Vulnerability    │ Severity │    Status    │    Installed Version    │ Fixed Version │                            Title                             │
├────────────────────┼─────────────────────┼──────────┼──────────────┼─────────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ apt                │ CVE-2011-3374       │ LOW      │ affected     │ 2.6.1                   │               │ It was found that apt-key in apt, all versions, do not       │
│                    │                     │          │              │                         │               │ correctly...                                                 │
│                    │                     │          │              │                         │               │ https://avd.aquasec.com/nvd/cve-2011-3374                    │
├────────────────────┼─────────────────────┤          │              ├─────────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ bash               │ TEMP-0841856-B18BAF │          │              │ 5.2.15-2+b2             │               │ [Privilege escalation possible to other user than root]      │
│                    │                     │          │              │                         │               │ https://security-tracker.debian.org/tracker/TEMP-0841856-B1- │
│                    │                     │          │              │                         │               │ 8BAF                                                         │
```
## Related issues
- Close #3098 

## Related PRs
- [x] #3599 

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
