### PR TITLE
fix(nodejs): add name validation for package name from `package.json` 

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -43,7 +43,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 		return Package{}, xerrors.Errorf("JSON decode error: %w", err)
 	}
 
-	if IsValidName(pkgJSON.Name) {
+	if !IsValidName(pkgJSON.Name) {
 		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
 	}
 

--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 )
 
-var nameRegexp = regexp.MustCompile(`(?m)^(@[A-Za-z0-9-._]+/)?[A-Za-z0-9-._]+$`)
+var nameRegexp = regexp.MustCompile(`^(@[A-Za-z0-9-._]+/)?[A-Za-z0-9-._]+$`)
 
 type packageJSON struct {
 	Name                 string            `json:"name"`

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -2,7 +2,6 @@ package packagejson_test
 
 import (
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,6 +77,11 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "invalid package name",
+			inputFile: "testdata/invalid_name.json",
+			wantErr:   "Name can only contain URL-friendly characters",
+		},
+		{
 			name:      "sad path",
 			inputFile: "testdata/invalid_package.json",
 
@@ -99,7 +103,7 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, v := range vectors {
-		t.Run(path.Base(v.name), func(t *testing.T) {
+		t.Run(v.name, func(t *testing.T) {
 			f, err := os.Open(v.inputFile)
 			require.NoError(t, err)
 			defer f.Close()
@@ -112,6 +116,56 @@ func TestParse(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, v.want, got)
+		})
+	}
+}
+
+func TestIsValidName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{
+			name: "",
+			want: true,
+		},
+		{
+			name: "test_package",
+			want: true,
+		},
+		{
+			name: "test.package",
+			want: true,
+		},
+		{
+			name: "test-package",
+			want: true,
+		},
+		{
+			name: "@test/package",
+			want: true,
+		},
+		{
+			name: "test@package",
+			want: false,
+		}, {
+			name: "test?package",
+			want: false,
+		},
+		{
+			name: "test/package",
+			want: false,
+		},
+		{
+			name: "package/",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := packagejson.IsValidName(tt.name)
+			require.Equal(t, tt.want, valid)
 		})
 	}
 }

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/invalid_name.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/invalid_name.json
@@ -1,0 +1,11 @@
+{
+  "name": "@invalid/packageName/",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Description
Npm uses some rules for package names - https://docs.npmjs.com/cli/v10/configuring-npm/package-json
We need to reproduce `npm` logic and return error for invalid package names.

## Related Discussions
- https://github.com/aquasecurity/trivy/discussions/6259#discussioncomment-8666078.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
