### PR TITLE
feat: use fs.WalkDir instead of filepath.WalkDir

### DIFF
--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -97,7 +97,13 @@ func (w FS) walkFast(root string, walkFn fastWalkFunc) error {
 
 func (w FS) walkSlow(root string, walkFn fastWalkFunc) error {
 	log.Logger.Debugf("Walk the file tree rooted at '%s' in series", root)
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+
+	relPath, err := filepath.Rel("/", root)
+	if err != nil {
+		return err
+	}
+
+	err = fs.WalkDir(os.DirFS("/"), relPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return w.errCallback(path, err)
 		}
@@ -105,7 +111,7 @@ func (w FS) walkSlow(root string, walkFn fastWalkFunc) error {
 		if err != nil {
 			return xerrors.Errorf("file info error: %w", err)
 		}
-		return walkFn(path, info)
+		return walkFn(string(filepath.Separator)+path, info)
 	})
 	if err != nil {
 		return xerrors.Errorf("walk dir error: %w", err)


### PR DESCRIPTION
## Description

In fs walker, filepath.WalkDir is used when fs.WalkDir is used almost everywhere else.
There are subtle differences, for instance the root directory being a symlink, between
the 2 causing inconsistencies between the fs walk and deb post analyze walk.
This PR switches the fs walker to the newer fs.WalkDir interface. 

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
