### PR TITLE
fix(terraform): fix policy document retrieval

### DIFF
--- a/pkg/iac/adapters/terraform/aws/iam/convert.go
+++ b/pkg/iac/adapters/terraform/aws/iam/convert.go
@@ -208,20 +208,15 @@ func findAllPolicies(modules terraform.Modules, attr *terraform.Attribute) []wra
 
 	policyDocIDs := attr.AsStringValues().AsStrings()
 	for _, policyDocID := range policyDocIDs {
-		policyDoc, err := modules.GetBlockById(policyDocID)
-		if err == nil {
-			document, err := ConvertTerraformDocument(modules, policyDoc)
-			if err == nil {
+		if policyDoc, err := modules.GetBlockById(policyDocID); err == nil {
+			if document, err := ConvertTerraformDocument(modules, policyDoc); err == nil {
 				documents = append(documents, *document)
 			}
-		} else {
-			parsed, err := iamgo.Parse([]byte(unescapeVars(policyDocID)))
-			if err == nil {
-				documents = append(documents, wrappedDocument{
-					Document: *parsed,
-					Source:   attr,
-				})
-			}
+		} else if parsed, err := iamgo.Parse([]byte(unescapeVars(policyDocID))); err == nil {
+			documents = append(documents, wrappedDocument{
+				Document: *parsed,
+				Source:   attr,
+			})
 		}
 	}
 	return documents

--- a/pkg/iac/adapters/terraform/aws/iam/policies_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies_test.go
@@ -384,6 +384,25 @@ data "aws_iam_policy_document" "policy" {
 				},
 			},
 		},
+		{
+			name: "invalid `override_policy_documents` attribute",
+			terraform: `resource "aws_iam_policy" "test_policy" {
+  name   = "test-policy"
+  policy = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+  source_policy_documents = data.aws_iam_policy_document.policy2.json
+}`,
+			expected: []iam.Policy{
+				{
+					Name: iacTypes.String("test-policy", iacTypes.NewTestMetadata()),
+					Document: iam.Document{
+						IsOffset: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/iac/adapters/terraform/aws/iam/policies_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies_test.go
@@ -138,11 +138,10 @@ data "aws_iam_policy_document" "this" {
   }
 }
 
-
 resource "aws_iam_policy" "this" {
   for_each = local.sqs
-  name        = "test-${each.key}"
-  policy      = data.aws_iam_policy_document.this[each.key].json
+  name     = "test-${each.key}"
+  policy   = data.aws_iam_policy_document.this[each.key].json
 }`,
 			expected: []iam.Policy{
 				{
@@ -166,6 +165,176 @@ resource "aws_iam_policy" "this" {
 							return builder.Build()
 						}(),
 					},
+				},
+			},
+		},
+		{
+			name: "policy_document with source_policy_documents",
+			terraform: `
+data "aws_iam_policy_document" "source" {
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "source_document_example" {
+  source_policy_documents = [data.aws_iam_policy_document.source.json]
+
+  statement {
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::somebucket",
+      "arn:aws:s3:::somebucket/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "this" {
+  name   = "test-policy"
+  policy = data.aws_iam_policy_document.source_document_example.json
+}`,
+			expected: []iam.Policy{
+				{
+					Name:    iacTypes.String("test-policy", iacTypes.NewTestMetadata()),
+					Builtin: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+					Document: func() iam.Document {
+						builder := iamgo.NewPolicyBuilder()
+						firstStatement := iamgo.NewStatementBuilder().
+							WithActions([]string{"ec2:*"}).
+							WithResources([]string{"*"}).
+							WithEffect("Allow").
+							Build()
+
+						builder.WithStatement(firstStatement)
+
+						secondStatement := iamgo.NewStatementBuilder().
+							WithActions([]string{"s3:*"}).
+							WithResources([]string{"arn:aws:s3:::somebucket", "arn:aws:s3:::somebucket/*"}).
+							WithEffect("Allow").
+							Build()
+
+						builder.WithStatement(secondStatement)
+
+						return iam.Document{
+							Parsed:   builder.Build(),
+							Metadata: iacTypes.NewTestMetadata(),
+							IsOffset: true,
+							HasRefs:  false,
+						}
+					}(),
+				},
+			},
+		},
+		{
+			name: "source_policy_documents with for-each",
+			terraform: `
+locals {
+  versions = ["2008-10-17", "2012-10-17"]
+}
+
+resource "aws_iam_policy" "test_policy" {
+  name   = "test-policy"
+  policy = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+  source_policy_documents = [for s in data.aws_iam_policy_document.policy_source : s.json if s.version != "2008-10-17"]
+  statement {
+    actions   = ["s3:*"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "policy_source" {
+  for_each = toset(local.versions)
+  version  = each.value
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["*"]
+  }
+}`,
+			expected: []iam.Policy{
+				{
+					Name: iacTypes.String("test-policy", iacTypes.NewTestMetadata()),
+					Document: func() iam.Document {
+						builder := iamgo.NewPolicyBuilder().
+							WithStatement(
+								iamgo.NewStatementBuilder().
+									WithActions([]string{"s3:PutObject"}).
+									WithResources([]string{"*"}).
+									WithEffect("Allow").
+									Build(),
+							).
+							WithStatement(
+								iamgo.NewStatementBuilder().
+									WithActions([]string{"s3:*"}).
+									WithResources([]string{"*"}).
+									WithEffect("Allow").
+									Build(),
+							)
+
+						return iam.Document{
+							Parsed:   builder.Build(),
+							Metadata: iacTypes.NewTestMetadata(),
+							IsOffset: true,
+							HasRefs:  false,
+						}
+					}(),
+				},
+			},
+		},
+		{
+			name: "source_policy_documents with condition",
+			terraform: `
+locals {
+  versions = ["2008-10-17", "2012-10-17"]
+}
+
+resource "aws_iam_policy" "test_policy" {
+  name   = "test-policy"
+  policy = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+  source_policy_documents = true ? [data.aws_iam_policy_document.policy_source.json] : [data.aws_iam_policy_document.policy_source2.json]
+}
+
+data "aws_iam_policy_document" "policy_source" {
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "policy_source2" {
+  statement {
+    actions   = ["s3:PutObject2"]
+    resources = ["*"]
+  }
+}
+`,
+			expected: []iam.Policy{
+				{
+					Name: iacTypes.String("test-policy", iacTypes.NewTestMetadata()),
+					Document: func() iam.Document {
+						builder := iamgo.NewPolicyBuilder().
+							WithStatement(
+								iamgo.NewStatementBuilder().
+									WithActions([]string{"s3:PutObject"}).
+									WithResources([]string{"*"}).
+									WithEffect("Allow").
+									Build(),
+							)
+
+						return iam.Document{
+							Parsed:   builder.Build(),
+							Metadata: iacTypes.NewTestMetadata(),
+							IsOffset: true,
+							HasRefs:  false,
+						}
+					}(),
 				},
 			},
 		},


### PR DESCRIPTION
## Description

If a policy, such as `aws_iam_policy` or `aws_iam_policy_document`, uses a for-each loop to reference policy document resources, those resources are not detected. In the case where a policy references document resources in a condition, only the first resource was selected. It is necessary to search for policy document resources by identifiers (id) rather than by references to fix this.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5686

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
