### PR TITLE
test(terraform): skip cached modules

### DIFF
--- a/pkg/iac/scanners/terraform/module_test.go
+++ b/pkg/iac/scanners/terraform/module_test.go
@@ -600,7 +600,7 @@ variable "group" {
     type = string
 }
 
-resource aws_iam_group_policy mfa {
+resource "aws_iam_group_policy" "mfa" {
   group = var.group
   policy = data.aws_iam_policy_document.policy.json
 }

--- a/pkg/iac/scanners/terraform/options.go
+++ b/pkg/iac/scanners/terraform/options.go
@@ -196,7 +196,7 @@ func ScannerWithDownloadsAllowed(allowed bool) options.ScannerOption {
 func ScannerWithSkipCachedModules(b bool) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if tf, ok := s.(ConfigurableTerraformScanner); ok {
-			tf.AddParserOptions(parser.OptionWithDownloads(b))
+			tf.AddParserOptions(parser.OptionWithSkipCachedModules(b))
 		}
 	}
 }

--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -73,18 +73,19 @@ func newEvaluator(
 	}
 
 	return &evaluator{
-		filesystem:      target,
-		parentParser:    parentParser,
-		modulePath:      modulePath,
-		moduleName:      moduleName,
-		projectRootPath: projectRootPath,
-		ctx:             ctx,
-		blocks:          blocks,
-		inputVars:       inputVars,
-		moduleMetadata:  moduleMetadata,
-		ignores:         ignores,
-		debug:           logger,
-		allowDownloads:  allowDownloads,
+		filesystem:        target,
+		parentParser:      parentParser,
+		modulePath:        modulePath,
+		moduleName:        moduleName,
+		projectRootPath:   projectRootPath,
+		ctx:               ctx,
+		blocks:            blocks,
+		inputVars:         inputVars,
+		moduleMetadata:    moduleMetadata,
+		ignores:           ignores,
+		debug:             logger,
+		allowDownloads:    allowDownloads,
+		skipCachedModules: skipCachedModules,
 	}
 }
 

--- a/pkg/iac/scanners/terraform/scanner_integration_test.go
+++ b/pkg/iac/scanners/terraform/scanner_integration_test.go
@@ -176,6 +176,7 @@ deny[cause] {
 	t.Run("with skip", func(t *testing.T) {
 		scanner := New(
 			ScannerWithSkipDownloaded(true),
+			ScannerWithSkipCachedModules(true),
 			options.ScannerWithPolicyDirs("rules"),
 			options.ScannerWithRegoOnly(true),
 			options.ScannerWithEmbeddedPolicies(false),
@@ -229,6 +230,7 @@ deny[res] {
 
 	scanner := New(
 		ScannerWithSkipDownloaded(true),
+		ScannerWithSkipCachedModules(true),
 		options.ScannerWithPolicyDirs("rules"),
 		options.ScannerWithRegoOnly(true),
 		options.ScannerWithEmbeddedLibraries(true),

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
+	tfscanner "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,8 @@ func initScanner(opts ...options.ScannerOption) *Scanner {
 		options.ScannerWithPolicyNamespaces("user"),
 		options.ScannerWithPolicyDirs("."),
 		options.ScannerWithRegoOnly(true),
+		options.ScannerWithRegoErrorLimits(0),
+		tfscanner.ScannerWithSkipCachedModules(true),
 	}
 
 	opts = append(opts, defaultOpts...)
@@ -110,6 +113,7 @@ func Test_ScanFS(t *testing.T) {
 				options.ScannerWithEmbeddedLibraries(false),
 				options.ScannerWithEmbeddedPolicies(false),
 				options.ScannerWithRegoErrorLimits(0),
+				tfscanner.ScannerWithSkipCachedModules(true),
 			)
 
 			results, err := scanner.ScanFS(context.TODO(), fs, path.Join(tc.dir, "tfplan"))


### PR DESCRIPTION
## Description
Skipping cached modules will avoid fluky tests. See https://github.com/aquasecurity/trivy/pull/6176#discussion_r1510860391

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
