### PR TITLE
fix: increase the default buffer size for scanning dpkg status files by 2 times

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/scanner.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/scanner.go
@@ -15,6 +15,11 @@ type dpkgScanner struct {
 // NewScanner returns a new scanner that splits on empty lines.
 func NewScanner(r io.Reader) *dpkgScanner {
 	s := bufio.NewScanner(r)
+	// Package data may exceed default buffer size
+	// Increase the buffer default size by 2 times
+	buf := make([]byte, 0, 128*1024)
+	s.Buffer(buf, 128*1024)
+
 	s.Split(emptyLineSplit)
 	return &dpkgScanner{Scanner: s}
 }


### PR DESCRIPTION
## Description
There are cases when package data (from dpkg status file) may exceed default buffer size.
Increase the buffer [default size](https://github.com/golang/go/blob/78755f6b8c5f18b0014e9dcac383898047ff14fe/src/bufio/scan.go#L82) by 2 times.

## Related issues
- Close #6297

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
