### PR TITLE
fix(java): parse modules from `pom.xml` files once

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -3,8 +3,6 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/aquasecurity/trivy/pkg/dependency"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"io"
 	"net/http"
 	"net/url"
@@ -20,8 +18,10 @@ import (
 	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 	"github.com/aquasecurity/trivy/pkg/dependency/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -3,6 +3,8 @@ package pom
 import (
 	"encoding/xml"
 	"fmt"
+	"github.com/aquasecurity/trivy/pkg/dependency"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"io"
 	"net/http"
 	"net/url"
@@ -18,10 +20,8 @@ import (
 	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 	"github.com/aquasecurity/trivy/pkg/dependency/types"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
@@ -105,10 +105,10 @@ func (p *parser) Parse(r xio.ReadSeekerAt) ([]types.Library, []types.Dependency,
 	// Cache root POM
 	p.cache.put(result.artifact, result)
 
-	return p.parseRoot(root.artifact())
+	return p.parseRoot(root.artifact(), make(map[string]struct{}))
 }
 
-func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, error) {
+func (p *parser) parseRoot(root artifact, uniqModules map[string]struct{}) ([]types.Library, []types.Dependency, error) {
 	// Prepare a queue for dependencies
 	queue := newArtifactQueue()
 
@@ -132,7 +132,12 @@ func (p *parser) parseRoot(root artifact) ([]types.Library, []types.Dependency, 
 		// Modules should be handled separately so that they can have independent dependencies.
 		// It means multi-module allows for duplicate dependencies.
 		if art.Module {
-			moduleLibs, moduleDeps, err := p.parseRoot(art)
+			if _, ok := uniqModules[art.String()]; ok {
+				continue
+			}
+			uniqModules[art.String()] = struct{}{}
+
+			moduleLibs, moduleDeps, err := p.parseRoot(art, uniqModules)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -960,6 +960,43 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "Infinity loop for modules",
+			inputFile: filepath.Join("testdata", "modules-infinity-loop", "pom.xml"),
+			local:     true,
+			want: []types.Library{
+				// as module
+				{
+					ID:      "org.example:module-1:2.0.0",
+					Name:    "org.example:module-1",
+					Version: "2.0.0",
+				},
+				// as dependency
+				{
+					ID:      "org.example:module-1:2.0.0",
+					Name:    "org.example:module-1",
+					Version: "2.0.0",
+				},
+				{
+					ID:      "org.example:module-2:3.0.0",
+					Name:    "org.example:module-2",
+					Version: "3.0.0",
+				},
+				{
+					ID:      "org.example:root:1.0.0",
+					Name:    "org.example:root",
+					Version: "1.0.0",
+				},
+			},
+			wantDeps: []types.Dependency{
+				{
+					ID: "org.example:module-2:3.0.0",
+					DependsOn: []string{
+						"org.example:module-1:2.0.0",
+					},
+				},
+			},
+		},
+		{
 			name:      "multi module soft requirement",
 			inputFile: filepath.Join("testdata", "multi-module-soft-requirement", "pom.xml"),
 			local:     true,

--- a/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/module-1/module-2/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/module-1/module-2/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-2</artifactId>
+    <groupId>org.example</groupId>
+    <version>3.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>module-1</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/module-1/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/module-1/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-1</artifactId>
+    <groupId>org.example</groupId>
+    <version>2.0.0</version>
+
+    <modules>
+        <module>module-2</module>
+    </modules>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/modules-infinity-loop/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>root</artifactId>
+    <groupId>org.example</groupId>
+    <version>1.0.0</version>
+
+    <modules>
+        <module>module-1</module>
+        <module>module-2</module>
+    </modules>
+</project>


### PR DESCRIPTION
## Description
Possible cases when, when parsing modules, we get an infinite loop.
See examples in https://github.com/aquasecurity/go-dep-parser/issues/297.
To avoid this - we need to parse modules once.


## Related issues
- Close aquasecurity/go-dep-parser/issues/297

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
