### PR TITLE
feat(misconf): Support private registries for misconf check bundle

### DIFF
--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -67,7 +67,7 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	var policyPaths []string
 	var downloadedPolicyPaths []string
 	var err error
-	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate, option.MisconfOptions.PolicyBundleRepository)
+	downloadedPolicyPaths, err = operation.InitBuiltinPolicies(context.Background(), option.CacheDir, option.Quiet, option.SkipPolicyUpdate, option.MisconfOptions.PolicyBundleRepository, option.RegistryOpts())
 	if err != nil {
 		if !option.SkipPolicyUpdate {
 			log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -584,7 +584,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 
 		var downloadedPolicyPaths []string
 		var disableEmbedded bool
-		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate, opts.MisconfOptions.PolicyBundleRepository)
+		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipPolicyUpdate, opts.MisconfOptions.PolicyBundleRepository, opts.RegistryOpts())
 		if err != nil {
 			if !opts.SkipPolicyUpdate {
 				log.Logger.Errorf("Falling back to embedded policies: %s", err)

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -148,7 +148,7 @@ func showDBInfo(cacheDir string) error {
 }
 
 // InitBuiltinPolicies downloads the built-in policies and loads them
-func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleRepository string, registryOptions ftypes.RegistryOptions) ([]string, error) {
+func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleRepository string, registryOpts ftypes.RegistryOptions) ([]string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -159,7 +159,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 
 	needsUpdate := false
 	if !skipUpdate {
-		needsUpdate, err = client.NeedsUpdate(ctx, registryOptions)
+		needsUpdate, err = client.NeedsUpdate(ctx, registryOpts)
 		if err != nil {
 			return nil, xerrors.Errorf("unable to check if built-in policies need to be updated: %w", err)
 		}
@@ -168,7 +168,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	if needsUpdate {
 		log.Logger.Info("Need to update the built-in policies")
 		log.Logger.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx, registryOptions); err != nil {
+		if err = client.DownloadBuiltinPolicies(ctx, registryOpts); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -148,7 +148,7 @@ func showDBInfo(cacheDir string) error {
 }
 
 // InitBuiltinPolicies downloads the built-in policies and loads them
-func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleRepository string) ([]string, error) {
+func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, policyBundleRepository string, registryOptions ftypes.RegistryOptions) ([]string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -159,7 +159,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 
 	needsUpdate := false
 	if !skipUpdate {
-		needsUpdate, err = client.NeedsUpdate(ctx)
+		needsUpdate, err = client.NeedsUpdate(ctx, registryOptions)
 		if err != nil {
 			return nil, xerrors.Errorf("unable to check if built-in policies need to be updated: %w", err)
 		}
@@ -168,7 +168,7 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	if needsUpdate {
 		log.Logger.Info("Need to update the built-in policies")
 		log.Logger.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx); err != nil {
+		if err = client.DownloadBuiltinPolicies(ctx, registryOptions); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -89,10 +89,10 @@ func NewClient(cacheDir string, quiet bool, policyBundleRepo string, opts ...Opt
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact(registryOptions types.RegistryOptions) error {
+func (c *Client) populateOCIArtifact(registryOpts types.RegistryOptions) error {
 	if c.artifact == nil {
 		log.Logger.Debugf("Using URL: %s to load policy bundle", c.policyBundleRepo)
-		art, err := oci.NewArtifact(c.policyBundleRepo, c.quiet, registryOptions)
+		art, err := oci.NewArtifact(c.policyBundleRepo, c.quiet, registryOpts)
 		if err != nil {
 			return xerrors.Errorf("OCI artifact error: %w", err)
 		}
@@ -102,8 +102,8 @@ func (c *Client) populateOCIArtifact(registryOptions types.RegistryOptions) erro
 }
 
 // DownloadBuiltinPolicies download default policies from GitHub Pages
-func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOptions types.RegistryOptions) error {
-	if err := c.populateOCIArtifact(registryOptions); err != nil {
+func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOpts types.RegistryOptions) error {
+	if err := c.populateOCIArtifact(registryOpts); err != nil {
 		return xerrors.Errorf("OPA bundle error: %w", err)
 	}
 
@@ -154,7 +154,7 @@ func (c *Client) LoadBuiltinPolicies() ([]string, error) {
 }
 
 // NeedsUpdate returns if the default policy should be updated
-func (c *Client) NeedsUpdate(ctx context.Context, registryOptions types.RegistryOptions) (bool, error) {
+func (c *Client) NeedsUpdate(ctx context.Context, registryOpts types.RegistryOptions) (bool, error) {
 	meta, err := c.GetMetadata()
 	if err != nil {
 		return true, nil
@@ -165,7 +165,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, registryOptions types.Registry
 		return false, nil
 	}
 
-	if err = c.populateOCIArtifact(registryOptions); err != nil {
+	if err = c.populateOCIArtifact(registryOpts); err != nil {
 		return false, xerrors.Errorf("OPA bundle error: %w", err)
 	}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -89,10 +89,10 @@ func NewClient(cacheDir string, quiet bool, policyBundleRepo string, opts ...Opt
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact() error {
+func (c *Client) populateOCIArtifact(registryOptions types.RegistryOptions) error {
 	if c.artifact == nil {
 		log.Logger.Debugf("Using URL: %s to load policy bundle", c.policyBundleRepo)
-		art, err := oci.NewArtifact(c.policyBundleRepo, c.quiet, types.RegistryOptions{})
+		art, err := oci.NewArtifact(c.policyBundleRepo, c.quiet, registryOptions)
 		if err != nil {
 			return xerrors.Errorf("OCI artifact error: %w", err)
 		}
@@ -102,8 +102,8 @@ func (c *Client) populateOCIArtifact() error {
 }
 
 // DownloadBuiltinPolicies download default policies from GitHub Pages
-func (c *Client) DownloadBuiltinPolicies(ctx context.Context) error {
-	if err := c.populateOCIArtifact(); err != nil {
+func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOptions types.RegistryOptions) error {
+	if err := c.populateOCIArtifact(registryOptions); err != nil {
 		return xerrors.Errorf("OPA bundle error: %w", err)
 	}
 
@@ -154,7 +154,7 @@ func (c *Client) LoadBuiltinPolicies() ([]string, error) {
 }
 
 // NeedsUpdate returns if the default policy should be updated
-func (c *Client) NeedsUpdate(ctx context.Context) (bool, error) {
+func (c *Client) NeedsUpdate(ctx context.Context, registryOptions types.RegistryOptions) (bool, error) {
 	meta, err := c.GetMetadata()
 	if err != nil {
 		return true, nil
@@ -165,7 +165,7 @@ func (c *Client) NeedsUpdate(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	if err = c.populateOCIArtifact(); err != nil {
+	if err = c.populateOCIArtifact(registryOptions); err != nil {
 		return false, xerrors.Errorf("OPA bundle error: %w", err)
 	}
 

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -264,7 +264,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert results
-			got, err := c.NeedsUpdate(context.Background())
+			got, err := c.NeedsUpdate(context.Background(), ftypes.RegistryOptions{})
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 		})
@@ -367,7 +367,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			c, err := policy.NewClient(tempDir, true, "", policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			err = c.DownloadBuiltinPolicies(context.Background())
+			err = c.DownloadBuiltinPolicies(context.Background(), ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)


### PR DESCRIPTION
## Description
This proposed change allows the policy bundle repository specified with `--policy-bundle-repository` to be pulled from a private registry using [specified username and password](https://aquasecurity.github.io/trivy/v0.49/docs/advanced/private-registries/).

## Related issues
- Close #6266 

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
