### PR TITLE
fix(sbom): add check for `CreationInfo` to nil when detecting SPDX created using Trivy

### DIFF
--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -255,6 +255,10 @@ func (s *SPDX) parseExternalReferences(refs []*spdx.PackageExternalReference) (*
 }
 
 func (s *SPDX) isTrivySBOM(spdxDocument *spdx.Document) bool {
+	if spdxDocument == nil || spdxDocument.CreationInfo == nil || spdxDocument.CreationInfo.Creators == nil {
+		return false
+	}
+
 	for _, c := range spdxDocument.CreationInfo.Creators {
 		if c.CreatorType == "Tool" && strings.HasPrefix(c.Creator, "trivy") {
 			return true


### PR DESCRIPTION
## Description
We get panic if `CreationInfo` doesn't exist (see #6344).
add check for `CreationInfo` to nil when detecting SPDX created using Trivy.

## Related issues
- Close #6344

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
