### PR TITLE
fix(report): don't include empty strings in `.vulnerabilities[].identifiers[].url` when `gitlab.tpl` is used

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -72,9 +72,12 @@
         {
 	  {{- /* TODO: Type not extractable - https://github.com/aquasecurity/trivy-db/pull/24 */}}
           "type": "cve",
+          {{- /* cf. https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/e3d280d7f0862ca66a1555ea8b24016a004bb914/dist/container-scanning-report-format.json#L157-179 */}}
+          {{- if .PrimaryURL }}
+          "url": "{{ .PrimaryURL }}",
+          {{- end }}
           "name": "{{ .VulnerabilityID }}",
-          "value": "{{ .VulnerabilityID }}",
-          "url": "{{ .PrimaryURL }}"
+          "value": "{{ .VulnerabilityID }}"
         }
       ],
       "links": [

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -72,12 +72,12 @@
         {
 	  {{- /* TODO: Type not extractable - https://github.com/aquasecurity/trivy-db/pull/24 */}}
           "type": "cve",
-          {{- /* cf. https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/e3d280d7f0862ca66a1555ea8b24016a004bb914/dist/container-scanning-report-format.json#L157-179 */}}
-          {{- if .PrimaryURL }}
-          "url": "{{ .PrimaryURL }}",
-          {{- end }}
           "name": "{{ .VulnerabilityID }}",
           "value": "{{ .VulnerabilityID }}"
+          {{- /* cf. https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/e3d280d7f0862ca66a1555ea8b24016a004bb914/dist/container-scanning-report-format.json#L157-179 */}}
+          {{- if .PrimaryURL -}},
+          "url": "{{ .PrimaryURL }}"
+          {{- end }}
         }
       ],
       "links": [

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -75,7 +75,7 @@
           "name": "{{ .VulnerabilityID }}",
           "value": "{{ .VulnerabilityID }}"
           {{- /* cf. https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/e3d280d7f0862ca66a1555ea8b24016a004bb914/dist/container-scanning-report-format.json#L157-179 */}}
-          {{- if .PrimaryURL -}},
+          {{- if .PrimaryURL | regexMatch "^(https?|ftp)://.+" -}},
           "url": "{{ .PrimaryURL }}"
           {{- end }}
         }
@@ -88,9 +88,13 @@
         {{- else -}}
           ,
         {{- end -}}
+        {{- if . | regexMatch "^(https?|ftp)://.+" -}}
         {
-          "url": "{{ regexFind "[^ ]+" . }}"
+          "url": "{{ . }}"
         }
+        {{- else -}}
+          {{- $l_first = true }}
+        {{- end -}}
         {{- end }}
       ]
     }


### PR DESCRIPTION
## Description
Empty strings in `.vulnerabilities[].identifiers[].url` is not valid value:
- https://gitlab.com/gitlab-org/gitlab/-/issues/443531#note_1803834238
- https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/e3d280d7f0862ca66a1555ea8b24016a004bb914/dist/container-scanning-report-format.json#L157-179 

## Related issues
- Close #6347

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
