### PR TITLE
fix(nodejs): merge `Indirect`, `Dev`, `ExternalReferences` fields for same deps from `package-lock.json` files v2 or later

### DIFF
--- a/pkg/dependency/parser/golang/mod/testdata/replaced-with-local-path-and-version-mismatch/go.sum
+++ b/pkg/dependency/parser/golang/mod/testdata/replaced-with-local-path-and-version-mismatch/go.sum
@@ -50,6 +50,7 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/pkg/dependency/parser/nodejs/npm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_test.go
@@ -42,6 +42,12 @@ func TestParse(t *testing.T) {
 			wantDeps: npmV3WithWorkspaceDeps,
 		},
 		{
+			name:     "lock file v3 contains same dev and non-dev dependencies",
+			file:     "testdata/package-lock_v3_with-same-dev-and-non-dev.json",
+			want:     npmV3WithSameDevAndNonDevLibs,
+			wantDeps: npmV3WithSameDevAndNonDevDeps,
+		},
+		{
 			name:     "lock version v3 with workspace and without direct deps field",
 			file:     "testdata/package-lock_v3_without_root_deps_field.json",
 			want:     npmV3WithoutRootDepsField,

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -1516,4 +1516,89 @@ var (
 			DependsOn: []string{"debug@2.6.9"},
 		},
 	}
+
+	npmV3WithSameDevAndNonDevLibs = []types.Library{
+		{
+			ID:      "fsevents@1.2.9",
+			Name:    "fsevents",
+			Version: "1.2.9",
+			Dev:     true,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefOther,
+					URL:  "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+				},
+			},
+			Locations: []types.Location{
+				{
+					StartLine: 18,
+					EndLine:   37,
+				},
+			},
+		},
+		{
+			ID:       "minimist@0.0.8",
+			Name:     "minimist",
+			Version:  "0.0.8",
+			Indirect: false,
+			Dev:      false,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefOther,
+					URL:  "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+				},
+			},
+			Locations: []types.Location{
+				{
+					StartLine: 38,
+					EndLine:   43,
+				},
+				{
+					StartLine: 68,
+					EndLine:   72,
+				},
+			},
+		},
+		{
+			ID:       "mkdirp@0.5.1",
+			Name:     "mkdirp",
+			Version:  "0.5.1",
+			Indirect: true,
+			Dev:      true,
+			Locations: []types.Location{
+				{
+					StartLine: 44,
+					EndLine:   55,
+				},
+			},
+		},
+		{
+			ID:       "node-pre-gyp@0.12.0",
+			Name:     "node-pre-gyp",
+			Version:  "0.12.0",
+			Indirect: true,
+			Dev:      true,
+			Locations: []types.Location{
+				{
+					StartLine: 56,
+					EndLine:   67,
+				},
+			},
+		},
+	}
+
+	npmV3WithSameDevAndNonDevDeps = []types.Dependency{
+		{
+			ID:        "fsevents@1.2.9",
+			DependsOn: []string{"node-pre-gyp@0.12.0"},
+		},
+		{
+			ID:        "mkdirp@0.5.1",
+			DependsOn: []string{"minimist@0.0.8"},
+		},
+		{
+			ID:        "node-pre-gyp@0.12.0",
+			DependsOn: []string{"mkdirp@0.5.1"},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with-same-dev-and-non-dev.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with-same-dev-and-non-dev.json
@@ -1,0 +1,74 @@
+{
+  "name": "5139",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "5139",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "minimist": "^0.0.8"
+      },
+      "devDependencies": {
+        "fsevents": "^1.2.9"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "bundleDependencies": [
+        "node-pre-gyp"
+      ],
+      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+      "dev": true,
+      "hasInstallScript": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-pre-gyp": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/fsevents/node_modules/minimist": {
+      "version": "0.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fsevents/node_modules/node-pre-gyp": {
+      "version": "0.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
+    }
+  }
+}


### PR DESCRIPTION
## Description
There are times when `package-lock.json` contains 2 (or more) identical dependencies, but
- only one of these dependencies is `Dev`.
- only one of these dependencies is `Indirect`.

We need to combine these dependencies correctly.
Also we need to merge ExternalReferences rather than overwrite them.

## Related issues
- Close #5139

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
