### PR TITLE
docs: add info about support for package license detection in `fs`/`repo` modes

### DIFF
--- a/docs/docs/scanner/license.md
+++ b/docs/docs/scanner/license.md
@@ -22,17 +22,15 @@ Check out [the coverage document][coverage] for details.
 To enable extended license scanning, you can use `--license-full`.
 In addition to package licenses, Trivy scans source code files, Markdown documents, text files and `LICENSE` documents to identify license usage within the image or filesystem.
 
-By default, Trivy only classifies licenses that are matched with a confidence level of 0.9 or more by the classifer.
+By default, Trivy only classifies licenses that are matched with a confidence level of 0.9 or more by the classifier.
 To configure the confidence level, you can use `--license-confidence-level`. This enables us to classify licenses that might be matched with a lower confidence level by the classifer. 
 
 !!! note
     The full license scanning is expensive. It takes a while.
 
-Currently, the standard license scanning doesn't support filesystem and repository scanning.
-
 |   License scanning    | Image | Rootfs | Filesystem | Repository | SBOM |
 |:---------------------:|:-----:|:------:|:----------:|:----------:|:----:|
-|       Standard        |   ✅   |   ✅    |     -      |     -      |  ✅   |
+|       Standard        |   ✅   |   ✅    |   ✅[^1]    |   ✅[^1]    |  ✅   |
 | Full (--license-full) |   ✅   |   ✅    |     ✅      |     ✅      |  -   |
 
 License checking classifies the identified licenses and map the classification to severity.
@@ -344,6 +342,7 @@ license:
   permissive: []
 ```
 
+[^1]: Some lock files require additional files (e.g. files from the cache directory) to detect licenses. Check [coverage][coverage] for more information.
 
 [coverage]: ../coverage/index.md
 [google-license-classification]: https://opensource.google/documentation/reference/thirdparty/licenses

--- a/docs/docs/scanner/license.md
+++ b/docs/docs/scanner/license.md
@@ -30,7 +30,7 @@ To configure the confidence level, you can use `--license-confidence-level`. Thi
 
 |   License scanning    | Image | Rootfs | Filesystem | Repository | SBOM |
 |:---------------------:|:-----:|:------:|:----------:|:----------:|:----:|
-|       Standard        |   ✅   |   ✅    |   ✅[^1]    |   ✅[^1]    |  ✅   |
+|       Standard        |   ✅   |   ✅    | ✅[^1][^2]  | ✅[^1][^2]  |  ✅   |
 | Full (--license-full) |   ✅   |   ✅    |     ✅      |     ✅      |  -   |
 
 License checking classifies the identified licenses and map the classification to severity.
@@ -342,7 +342,8 @@ license:
   permissive: []
 ```
 
-[^1]: Some lock files require additional files (e.g. files from the cache directory) to detect licenses. Check [coverage][coverage] for more information.
+[^1]: Trivy doesn't support license detection for all language files. See the list of supported files [here](../coverage/language/index.md).
+[^2]: Some lock files require additional files (e.g. files from the cache directory) to detect licenses. Check [coverage][coverage] for more information.
 
 [coverage]: ../coverage/index.md
 [google-license-classification]: https://opensource.google/documentation/reference/thirdparty/licenses

--- a/docs/docs/scanner/license.md
+++ b/docs/docs/scanner/license.md
@@ -342,7 +342,7 @@ license:
   permissive: []
 ```
 
-[^1]: Trivy doesn't support license detection for all language files. See the list of supported files [here](../coverage/language/index.md).
+[^1]: See the list of supported language files [here](../coverage/language/index.md).
 [^2]: Some lock files require additional files (e.g. files from the cache directory) to detect licenses. Check [coverage][coverage] for more information.
 
 [coverage]: ../coverage/index.md


### PR DESCRIPTION
## Description
Trivy supports license detection for some lock files.
e.g.:
```
➜  trivy -q fs --scanners license ./integration/testdata/fixtures/repo/yarn

yarn.lock (license)

Total: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬─────────┬────────────────┬──────────┐
│ Package │ License │ Classification │ Severity │
├─────────┼─────────┼────────────────┼──────────┤
│ jquery  │ MIT     │ Notice         │ LOW      │
└─────────┴─────────┴────────────────┴──────────┘
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
