### PR TITLE
perf(helm): load in-memory files

### DIFF
--- a/pkg/iac/scanners/helm/parser/parser.go
+++ b/pkg/iac/scanners/helm/parser/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -192,17 +191,7 @@ func (p *Parser) extractChartName(chartPath string) error {
 }
 
 func (p *Parser) RenderedChartFiles() ([]ChartFile, error) {
-
-	tempDir, err := os.MkdirTemp(os.TempDir(), "defsec")
-	if err != nil {
-		return nil, err
-	}
-
-	if err := p.writeBuildFiles(tempDir); err != nil {
-		return nil, err
-	}
-
-	workingChart, err := loadChart(tempDir)
+	workingChart, err := p.loadChart()
 	if err != nil {
 		return nil, err
 	}
@@ -246,19 +235,36 @@ func (p *Parser) getRelease(chrt *chart.Chart) (*release.Release, error) {
 	return r, nil
 }
 
-func loadChart(tempFs string) (*chart.Chart, error) {
-	loadedChart, err := loader.Load(tempFs)
+func (p *Parser) loadChart() (*chart.Chart, error) {
+
+	var files []*loader.BufferedFile
+
+	for _, filePath := range p.filepaths {
+		b, err := fs.ReadFile(p.workingFS, filePath)
+		if err != nil {
+			return nil, err
+		}
+
+		filePath = strings.TrimPrefix(filePath, p.rootPath+"/")
+		filePath = filepath.ToSlash(filePath)
+		files = append(files, &loader.BufferedFile{
+			Name: filePath,
+			Data: b,
+		})
+	}
+
+	c, err := loader.LoadFiles(files)
 	if err != nil {
 		return nil, err
 	}
 
-	if req := loadedChart.Metadata.Dependencies; req != nil {
-		if err := action.CheckDependencies(loadedChart, req); err != nil {
+	if req := c.Metadata.Dependencies; req != nil {
+		if err := action.CheckDependencies(c, req); err != nil {
 			return nil, err
 		}
 	}
 
-	return loadedChart, nil
+	return c, nil
 }
 
 func (*Parser) getRenderedManifests(manifestsKeys []string, splitManifests map[string]string) []ChartFile {
@@ -288,24 +294,6 @@ func getManifestPath(manifest string) string {
 		return manifestFilePathParts[1]
 	}
 	return manifestFilePathParts[0]
-}
-
-func (p *Parser) writeBuildFiles(tempFs string) error {
-	for _, path := range p.filepaths {
-		content, err := fs.ReadFile(p.workingFS, path)
-		if err != nil {
-			return err
-		}
-		workingPath := strings.TrimPrefix(path, p.rootPath)
-		workingPath = filepath.Join(tempFs, workingPath)
-		if err := os.MkdirAll(filepath.Dir(workingPath), os.ModePerm); err != nil {
-			return err
-		}
-		if err := os.WriteFile(workingPath, content, os.ModePerm); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (p *Parser) required(path string, workingFS fs.FS) bool {

--- a/pkg/iac/scanners/helm/test/parser_test.go
+++ b/pkg/iac/scanners/helm/test/parser_test.go
@@ -32,11 +32,8 @@ func Test_helm_parser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			chartName := test.chartName
-
-			t.Logf("Running test: %s", test.testName)
-
 			helmParser := parser.New(chartName)
-			err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
+			err := helmParser.ParseFS(context.TODO(), os.DirFS("testdata"), chartName)
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

Instead of copying files to a temporary folder, we can pass virutal files to helm, which improves performance.

```bash
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/aquasecurity/trivy/pkg/iac/scanners/helm/test
                    │   old.txt    │               new.txt               │
                    │    sec/op    │   sec/op     vs base                │
_RenderChartFiles-8   2138.1µ ± 2%   978.3µ ± 3%  -54.24% (p=0.000 n=10)

                    │   old.txt    │               new.txt               │
                    │     B/op     │     B/op      vs base               │
_RenderChartFiles-8   570.4Ki ± 0%   532.8Ki ± 0%  -6.59% (p=0.000 n=10)

                    │   old.txt   │              new.txt               │
                    │  allocs/op  │  allocs/op   vs base               │
_RenderChartFiles-8   7.714k ± 0%   7.476k ± 0%  -3.09% (p=0.000 n=10)
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
