### PR TITLE
fix: use `0600` perms for tmp files for post analyzers

### DIFF
--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -55,7 +55,8 @@ func (c *CompositeFS) CopyFileToTemp(opener Opener, info os.FileInfo) (string, e
 		return "", xerrors.Errorf("copy error: %w", err)
 	}
 
-	if err = os.Chmod(f.Name(), info.Mode()); err != nil {
+	// Use 0600 instead of file permissions to avoid errors when a file uses incorrect permissions (e.g. 0044).
+	if err = os.Chmod(f.Name(), 0600); err != nil {
 		return "", xerrors.Errorf("chmod error: %w", err)
 	}
 


### PR DESCRIPTION
## Description
Use `0600` perms for tmp files for post analyzers to avoid errors when file use wrong perms.
e.g.:
- #6373
- https://github.com/goharbor/harbor/issues/18824
- https://github.com/goharbor/harbor/issues/19405

## Related issues
- Close #6373

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
