### PR TITLE
fix(sbom): fix error when parent of SPDX Relationships is not a package.

### DIFF
--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -247,7 +247,11 @@ func (b *BOM) AddRelationship(parent, child *Component, relationshipType Relatio
 	}
 
 	if child == nil {
-		b.relationships[parent.id] = nil // Meaning no dependencies
+		// It is possible that `relationships` already contains this parent.
+		// Check this to avoid overwriting.
+		if _, ok := b.relationships[parent.id]; !ok {
+			b.relationships[parent.id] = nil // Meaning no dependencies
+		}
 		return
 	}
 

--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -238,6 +238,10 @@ func (b *BOM) AddComponent(c *Component) {
 }
 
 func (b *BOM) AddRelationship(parent, child *Component, relationshipType RelationshipType) {
+	// Check the wrong parent to avoid `panic`
+	if parent == nil {
+		return
+	}
 	if parent.id == uuid.Nil {
 		b.AddComponent(parent)
 	}

--- a/pkg/sbom/spdx/testdata/happy/with-file-as-relationship-parent.json
+++ b/pkg/sbom/spdx/testdata/happy/with-file-as-relationship-parent.json
@@ -1,0 +1,54 @@
+{
+  "files": [
+    {
+      "fileName": "./Modules/Microsoft.PowerShell.PSResourceGet/_manifest/spdx_2.2/manifest.spdx.json",
+      "SPDXID": "SPDXRef-File--Modules-Microsoft.PowerShell.PSResourceGet--manifest-spdx-2.2-manifest.spdx.json-2B9FB98F5CA97DC84FD382A8F8E68F663C003362",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "4201b0989938842ef8c11a006184e0b1466bd7f9bb2af61d89a4c8318d43466e"
+        },
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "2b9fb98f5ca97dc84fd382a8f8e68f663c003362"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": "NOASSERTION",
+      "fileTypes": [
+        "SPDX"
+      ]
+    }
+  ],
+  "externalDocumentRefs": [],
+  "relationships": [
+    {
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-RootPackage",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relationshipType": "DESCRIBED_BY",
+      "relatedSpdxElement": "SPDXRef-DOCUMENT",
+      "spdxElementId": "SPDXRef-File--Modules-Microsoft.PowerShell.PSResourceGet--manifest-spdx-2.2-manifest.spdx.json-2B9FB98F5CA97DC84FD382A8F8E68F663C003362"
+    }
+  ],
+  "spdxVersion": "SPDX-2.2",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "PowerShell Linux Arm32 7.5.0-preview.2",
+  "documentNamespace": "https://sbom.microsoft/1:2QSF7qZlbE-F7QrUJlEo7g:pHp_nUFvDUijZ4LrJ4RhoQ/696:458654/PowerShell%20Linux%20Arm32:7.5.0-preview.2:pDkyTHXmgUOdzSXIq9CiqA",
+  "creationInfo": {
+    "created": "2024-02-22T00:43:53Z",
+    "creators": [
+      "Organization: Microsoft",
+      "Tool: Microsoft.SBOMTool-2.2.3"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-RootPackage"
+  ]
+}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -87,13 +87,16 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 			continue
 		}
 
-		compA := components[rel.RefA.ElementRefID]
-		compB := components[rel.RefB.ElementRefID]
-
-		// We only need relationships between packages
-		if compA == nil || compB == nil {
+		compA, ok := components[rel.RefA.ElementRefID]
+		if !ok { // Skip if parent is not Package
 			continue
 		}
+
+		compB, ok := components[rel.RefB.ElementRefID]
+		if !ok { // Skip if child is not Package
+			continue
+		}
+
 		s.BOM.AddRelationship(compA, compB, s.parseRelationshipType(rel.Relationship))
 	}
 

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -89,6 +89,11 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 
 		compA := components[rel.RefA.ElementRefID]
 		compB := components[rel.RefB.ElementRefID]
+
+		// We only need relationships between packages
+		if compA == nil || compB == nil {
+			continue
+		}
 		s.BOM.AddRelationship(compA, compB, s.parseRelationshipType(rel.Relationship))
 	}
 

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -315,6 +315,11 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy path with file as parent of relationship",
+			inputFile: "testdata/happy/with-file-as-relationship-parent.json",
+			want:      types.SBOM{},
+		},
+		{
 			name:      "happy path only os component",
 			inputFile: "testdata/happy/os-only-bom.json",
 			want: types.SBOM{


### PR DESCRIPTION
## Description
When parent from Relationship is not package (e.g. File) - Trivy returns error. (see #6391)
e.g.:
```json
    {
      "relationshipType": "DESCRIBED_BY",
      "relatedSpdxElement": "SPDXRef-DOCUMENT",
      "spdxElementId": "SPDXRef-File--Modules-Microsoft.PowerShell.PSResourceGet--manifest-spdx-2.2-manifest.spdx.json-2B9FB98F5CA97DC84FD382A8F8E68F663C003362"
    }
```
We only need to add to [BOM Relationships](https://github.com/aquasecurity/trivy/blob/f148eb10f25b4daaf97b38ef523e6f16e9b118a1/pkg/sbom/core/bom.go#L63) relationships between packages 

## Related issues
- Close #6391

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
