### PR TITLE
fix(cloudformation): infer type after resolving a function

### DIFF
--- a/pkg/iac/scanners/cloudformation/cftypes/types.go
+++ b/pkg/iac/scanners/cloudformation/cftypes/types.go
@@ -1,5 +1,7 @@
 package cftypes
 
+import "reflect"
+
 type CfType string
 
 const (
@@ -9,4 +11,26 @@ const (
 	Bool    CfType = "bool"
 	Map     CfType = "map"
 	List    CfType = "list"
+	Unknown CfType = "unknown"
 )
+
+func TypeFromGoValue(value interface{}) CfType {
+	switch reflect.TypeOf(value).Kind() {
+	case reflect.String:
+		return String
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return Int
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return Int
+	case reflect.Float32, reflect.Float64:
+		return Float64
+	case reflect.Bool:
+		return Bool
+	case reflect.Map:
+		return Map
+	case reflect.Slice:
+		return List
+	default:
+		return Unknown
+	}
+}

--- a/pkg/iac/scanners/cloudformation/parser/fn_find_in_map_test.go
+++ b/pkg/iac/scanners/cloudformation/parser/fn_find_in_map_test.go
@@ -98,3 +98,26 @@ Resources:
 	nodeTypeProp := testRes.GetStringProperty("CacheNodeType", "")
 	assert.Equal(t, "cache.t2.micro", nodeTypeProp.Value())
 }
+
+func Test_InferType(t *testing.T) {
+	source := `---
+Mappings:
+  ApiDB:
+     MultiAZ:
+        development: False
+Resources:
+  ApiDB:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      MultiAZ: !FindInMap [ApiDB, MultiAZ, development]
+`
+
+	ctx := createTestFileContext(t, source)
+	require.NotNil(t, ctx)
+
+	testRes := ctx.GetResourceByLogicalID("ApiDB")
+	require.NotNil(t, testRes)
+
+	nodeTypeProp := testRes.GetBoolProperty("MultiAZ")
+	assert.False(t, nodeTypeProp.Value())
+}

--- a/pkg/iac/scanners/cloudformation/parser/intrinsics.go
+++ b/pkg/iac/scanners/cloudformation/parser/intrinsics.go
@@ -78,8 +78,13 @@ func ResolveIntrinsicFunc(property *Property) (*Property, bool) {
 
 	for funcName := range property.AsMap() {
 		if fn := intrinsicFuncs[funcName]; fn != nil {
-			//
-			return fn(property)
+			prop, resolved := fn(property)
+			if prop == nil || !resolved {
+				return prop, false
+			}
+
+			prop.inferType()
+			return prop, true
 		}
 	}
 	return property, false

--- a/pkg/iac/scanners/cloudformation/parser/property.go
+++ b/pkg/iac/scanners/cloudformation/parser/property.go
@@ -425,3 +425,11 @@ func convert(input interface{}) interface{} {
 	}
 	return input
 }
+
+func (p *Property) inferType() {
+	typ := cftypes.TypeFromGoValue(p.Inner.Value)
+	if typ == cftypes.Unknown {
+		return
+	}
+	p.Inner.Type = typ
+}

--- a/pkg/iac/scanners/cloudformation/parser/resource.go
+++ b/pkg/iac/scanners/cloudformation/parser/resource.go
@@ -100,11 +100,8 @@ func (r *Resource) GetProperty(path string) *Property {
 	first := pathParts[0]
 	property := &Property{}
 
-	for n, p := range r.properties() {
-		if n == first {
-			property = p
-			break
-		}
+	if p, exists := r.properties()[first]; exists {
+		property = p
 	}
 
 	if len(pathParts) == 1 || property.IsNil() {

--- a/pkg/iac/scanners/cloudformation/parser/util.go
+++ b/pkg/iac/scanners/cloudformation/parser/util.go
@@ -66,13 +66,15 @@ func setPropertyValueFromYaml(node *yaml.Node, propertyData *PropertyInner) erro
 	if node.Content == nil {
 
 		switch node.Tag {
-
 		case "!!int":
 			propertyData.Type = cftypes.Int
 			propertyData.Value, _ = strconv.Atoi(node.Value)
 		case "!!bool":
 			propertyData.Type = cftypes.Bool
 			propertyData.Value, _ = strconv.ParseBool(node.Value)
+		case "!!float":
+			propertyData.Type = cftypes.Float64
+			propertyData.Value, _ = strconv.ParseFloat(node.Value, 64)
 		case "!!str", "!!string":
 			propertyData.Type = cftypes.String
 			propertyData.Value = node.Value


### PR DESCRIPTION
## Description

We need to infer the type after resolving the function because the property with the function is of type `string`.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6404

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
