### PR TITLE
feat(misconf): add support for wildcard ignores

### DIFF
--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -547,4 +547,15 @@ module "s3_bucket" {
   bucket   = each.value
 }
 ```
+
+#### Support for Wildcards
+
+You can use wildcards in the `ws` (workspace) and `ignore` sections of the ignore rules.
+
+```tf
+# trivy:ignore:aws-s3-*:ws:dev-*
+```
+
+This example ignores all checks starting with `aws-s3-` for workspaces matching the pattern `dev-*`.
+
 [custom]: custom/index.md

--- a/pkg/iac/ignore/rule.go
+++ b/pkg/iac/ignore/rule.go
@@ -1,7 +1,9 @@
 package ignore
 
 import (
+	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -88,11 +90,42 @@ func defaultIgnorers(ids []string) map[string]Ignorer {
 	return map[string]Ignorer{
 		"id": func(_ types.Metadata, param any) bool {
 			id, ok := param.(string)
-			return ok && (id == "*" || len(ids) == 0 || slices.Contains(ids, id))
+			if !ok {
+				return false
+			}
+			if id == "*" || len(ids) == 0 {
+				return true
+			}
+
+			return slices.ContainsFunc(ids, func(s string) bool {
+				return MatchPattern(s, id)
+			})
 		},
 		"exp": func(_ types.Metadata, param any) bool {
 			expiry, ok := param.(time.Time)
 			return ok && time.Now().Before(expiry)
 		},
 	}
+}
+
+// MatchPattern checks if the pattern string matches the input pattern.
+// The wildcard '*' in the pattern matches any sequence of characters.
+func MatchPattern(input, pattern string) bool {
+	matched, err := regexp.MatchString(regexpFromPattern(pattern), input)
+	return err == nil && matched
+}
+
+func regexpFromPattern(pattern string) string {
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return "^" + pattern + "$"
+	}
+	var sb strings.Builder
+	for i, literal := range parts {
+		if i > 0 {
+			sb.WriteString(".*")
+		}
+		sb.WriteString(regexp.QuoteMeta(literal))
+	}
+	return "^" + sb.String() + "$"
 }

--- a/pkg/iac/ignore/rule.go
+++ b/pkg/iac/ignore/rule.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Ignorer represents a function that checks if the rule should be ignored.
-type Ignorer func(resultMeta types.Metadata, param any) bool
+type Ignorer func(resultMeta types.Metadata, ignoredParam any) bool
 
 type Rules []Rule
 

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -128,7 +128,7 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, Metrics, er
 					return false
 				}
 
-				return ws == e.workspaceName
+				return ignore.MatchPattern(e.workspaceName, ws)
 			},
 			"ignore": func(resultMeta types.Metadata, param any) bool {
 				params, ok := param.(map[string]string)


### PR DESCRIPTION
## Description

Added wildcard support for `id` and `workspace` sections.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5120

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
