### PR TITLE
BREAKING(aws): change the RESTMethodSettings type to a list of settings

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/sam/sam_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/sam/sam_test.go
@@ -96,6 +96,14 @@ Resources:
 						AccessLogging: sam.AccessLogging{
 							CloudwatchLogGroupARN: types.StringTest("arn:aws:logs:us-east-1:123456789:log-group:my-log-group"),
 						},
+						RESTMethodSettings: []sam.RESTMethodSettings{
+							{
+								LoggingEnabled:     types.BoolTest(true),
+								CacheDataEncrypted: types.BoolTest(true),
+								DataTraceEnabled:   types.BoolTest(true),
+								MetricsEnabled:     types.BoolTest(true),
+							},
+						},
 					},
 				},
 				HttpAPIs: []sam.HttpAPI{

--- a/pkg/iac/providers/aws/sam/api.go
+++ b/pkg/iac/providers/aws/sam/api.go
@@ -10,7 +10,7 @@ type API struct {
 	TracingEnabled      iacTypes.BoolValue
 	DomainConfiguration DomainConfiguration
 	AccessLogging       AccessLogging
-	RESTMethodSettings  RESTMethodSettings
+	RESTMethodSettings  []RESTMethodSettings
 }
 
 type ApiAuth struct {


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6432

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
