### PR TITLE
refactor(terraform): remove metrics collection

### DIFF
--- a/pkg/iac/adapters/terraform/tftestutil/testutil.go
+++ b/pkg/iac/adapters/terraform/tftestutil/testutil.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/trivy/internal/testutil"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 )
 
@@ -13,7 +13,7 @@ func CreateModulesFromSource(t *testing.T, source, ext string) terraform.Modules
 	fs := testutil.CreateFS(t, map[string]string{
 		"source" + ext: source,
 	})
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	if err := p.ParseFS(context.TODO(), "."); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/iac/scanners/helm/test/option_test.go
+++ b/pkg/iac/scanners/helm/test/option_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/helm/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/helm/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 )
 
@@ -37,10 +37,10 @@ func Test_helm_parser_with_options_with_values_file(t *testing.T) {
 			var opts []options.ParserOption
 
 			if test.valuesFile != "" {
-				opts = append(opts, parser2.OptionWithValuesFile(test.valuesFile))
+				opts = append(opts, parser.OptionWithValuesFile(test.valuesFile))
 			}
 
-			helmParser := parser2.New(chartName, opts...)
+			helmParser := parser.New(chartName, opts...)
 			err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()
@@ -87,14 +87,14 @@ func Test_helm_parser_with_options_with_set_value(t *testing.T) {
 			var opts []options.ParserOption
 
 			if test.valuesFile != "" {
-				opts = append(opts, parser2.OptionWithValuesFile(test.valuesFile))
+				opts = append(opts, parser.OptionWithValuesFile(test.valuesFile))
 			}
 
 			if test.values != "" {
-				opts = append(opts, parser2.OptionWithValues(test.values))
+				opts = append(opts, parser.OptionWithValues(test.values))
 			}
 
-			helmParser := parser2.New(chartName, opts...)
+			helmParser := parser.New(chartName, opts...)
 			err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()
@@ -140,10 +140,10 @@ func Test_helm_parser_with_options_with_api_versions(t *testing.T) {
 			var opts []options.ParserOption
 
 			if len(test.apiVersions) > 0 {
-				opts = append(opts, parser2.OptionWithAPIVersions(test.apiVersions...))
+				opts = append(opts, parser.OptionWithAPIVersions(test.apiVersions...))
 			}
 
-			helmParser := parser2.New(chartName, opts...)
+			helmParser := parser.New(chartName, opts...)
 			err := helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()

--- a/pkg/iac/scanners/terraform/deterministic_test.go
+++ b/pkg/iac/scanners/terraform/deterministic_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/executor"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,12 +39,12 @@ locals {
 	})
 
 	for i := 0; i < 100; i++ {
-		p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+		p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 		err := p.ParseFS(context.TODO(), ".")
 		require.NoError(t, err)
 		modules, _, err := p.EvaluateAll(context.TODO())
 		require.NoError(t, err)
-		results, _, _ := executor.New().Execute(modules)
+		results, _ := executor.New().Execute(modules)
 		require.Len(t, results.GetFailed(), 2)
 	}
 }

--- a/pkg/iac/scanners/terraform/executor/executor_test.go
+++ b/pkg/iac/scanners/terraform/executor/executor_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/providers"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/severity"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/stretchr/testify/assert"
@@ -47,12 +47,15 @@ resource "problem" "this" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := New().Execute(modules)
+
+	results, err := New().Execute(modules)
+	assert.Error(t, err)
+
 	assert.Equal(t, len(results.GetFailed()), 0)
 }
 
@@ -69,12 +72,14 @@ resource "problem" "this" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
+
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	_, _, err = New(OptionStopOnErrors(false)).Execute(modules)
+
+	_, err = New(OptionStopOnErrors(false)).Execute(modules)
 	assert.Error(t, err)
 }
 
@@ -91,12 +96,15 @@ resource "problem" "this" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := New().Execute(modules)
+
+	results, _ := New().Execute(modules)
+	require.NoError(t, err)
+
 	assert.Equal(t, len(results.GetFailed()), 0)
 }
 
@@ -113,12 +121,12 @@ resource "problem" "this" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 
-	_, _, err = New(OptionStopOnErrors(false)).Execute(modules)
+	_, err = New(OptionStopOnErrors(false)).Execute(modules)
 	assert.Error(t, err)
 }

--- a/pkg/iac/scanners/terraform/module_test.go
+++ b/pkg/iac/scanners/terraform/module_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/executor"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/severity"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/stretchr/testify/require"
@@ -88,13 +88,15 @@ resource "problem" "uhoh" {
 
 	debug := bytes.NewBuffer([]byte{})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true), options.ParserWithDebug(debug))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true), options.ParserWithDebug(debug))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, err := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
 	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 	if t.Failed() {
 		fmt.Println(debug.String())
@@ -119,12 +121,15 @@ resource "problem" "uhoh" {
 `},
 	)
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -148,12 +153,15 @@ resource "problem" "uhoh" {
 `},
 	)
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleNotFound(t, badRule.LongID(), results, "")
 
 }
@@ -175,12 +183,15 @@ resource "problem" "uhoh" {
 }
 `})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -202,12 +213,15 @@ resource "problem" "uhoh" {
 }
 `})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -238,12 +252,15 @@ resource "problem" "uhoh" {
 }
 `})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -276,12 +293,15 @@ resource "problem" "uhoh" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true), options.ParserWithDebug(os.Stderr))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true), options.ParserWithDebug(os.Stderr))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -331,12 +351,15 @@ resource "problem" "uhoh" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 }
 
@@ -380,12 +403,15 @@ resource "problem" "uhoh" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 }
 
@@ -418,12 +444,15 @@ resource "problem" "uhoh" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -473,12 +502,15 @@ resource "problem" "uhoh" {
 `,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, badRule.LongID(), results, "")
 
 }
@@ -523,12 +555,15 @@ resource "bad" "thing" {
 	reg := rules.Register(r1)
 	defer rules.Deregister(reg)
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleFound(t, r1.LongID(), results, "")
 }
 
@@ -572,12 +607,15 @@ resource "bad" "thing" {
 	reg := rules.Register(r1)
 	defer rules.Deregister(reg)
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleNotFound(t, r1.LongID(), results, "")
 }
 
@@ -621,12 +659,15 @@ data "aws_iam_policy_document" "policy" {
 }
 `})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	err := p.ParseFS(context.TODO(), "project")
 	require.NoError(t, err)
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
-	results, _, _ := executor.New().Execute(modules)
+
+	results, err := executor.New().Execute(modules)
+	require.NoError(t, err)
+
 	testutil.AssertRuleNotFound(t, iam.CheckEnforceGroupMFA.LongID(), results, "")
 
 }

--- a/pkg/iac/scanners/terraform/performance_test.go
+++ b/pkg/iac/scanners/terraform/performance_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/executor"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 )
 
 func BenchmarkCalculate(b *testing.B) {
@@ -21,7 +21,7 @@ func BenchmarkCalculate(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p := parser2.New(f, "", parser2.OptionStopOnHCLError(true))
+		p := parser.New(f, "", parser.OptionStopOnHCLError(true))
 		if err := p.ParseFS(context.TODO(), "project"); err != nil {
 			b.Fatal(err)
 		}
@@ -29,7 +29,7 @@ func BenchmarkCalculate(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, _, _ = executor.New().Execute(modules)
+		executor.New().Execute(modules)
 	}
 }
 

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -63,7 +63,7 @@ func scanWithOptions(t *testing.T, code string, opt ...options.ScannerOption) sc
 	})
 
 	scanner := New(opt...)
-	results, _, err := scanner.ScanFSWithMetrics(context.TODO(), fs, "project")
+	results, err := scanner.ScanFS(context.TODO(), fs, "project")
 	require.NoError(t, err)
 	return results
 }
@@ -338,7 +338,7 @@ cause := bucket.name
 				options.ScannerWithPolicyNamespaces(test.includedNamespaces...),
 			)
 
-			results, _, err := scanner.ScanFSWithMetrics(context.TODO(), fs, "code")
+			results, err := scanner.ScanFS(context.TODO(), fs, "code")
 			require.NoError(t, err)
 
 			var found bool
@@ -376,7 +376,7 @@ resource "aws_s3_bucket" "my-bucket" {
 		}),
 	)
 
-	_, _, err := scanner.ScanFSWithMetrics(context.TODO(), fs, "code")
+	_, err := scanner.ScanFS(context.TODO(), fs, "code")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(actual.AWS.S3.Buckets))

--- a/pkg/iac/scanners/terraform/setup_test.go
+++ b/pkg/iac/scanners/terraform/setup_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
-	parser2 "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +17,7 @@ func createModulesFromSource(t *testing.T, source string, ext string) terraform.
 		"source" + ext: source,
 	})
 
-	p := parser2.New(fs, "", parser2.OptionStopOnHCLError(true))
+	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
 	if err := p.ParseFS(context.TODO(), "."); err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func scanJSON(t *testing.T, source string) scan.Results {
 	})
 
 	s := New(options.ScannerWithEmbeddedPolicies(true), options.ScannerWithEmbeddedLibraries(true))
-	results, _, err := s.ScanFSWithMetrics(context.TODO(), fs, ".")
+	results, err := s.ScanFS(context.TODO(), fs, ".")
 	require.NoError(t, err)
 	return results
 }


### PR DESCRIPTION
## Description
Collecting metrics was relevant for tfsec, in Trivy metrics are not used anywhere.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
