### PR TITLE
feat(report): Include licenses and secrets filtered by rego to ModifiedFindings

### DIFF
--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -303,6 +303,8 @@ func applyPolicy(ctx context.Context, result *types.Result, policyFile string) e
 			return err
 		}
 		if ignored {
+			result.ModifiedFindings = append(result.ModifiedFindings,
+				types.NewModifiedFinding(scrt, types.FindingStatusIgnored, "Filtered by Rego", policyFile))
 			continue
 		}
 		filteredSecrets = append(filteredSecrets, scrt)
@@ -317,6 +319,8 @@ func applyPolicy(ctx context.Context, result *types.Result, policyFile string) e
 			return err
 		}
 		if ignored {
+			result.ModifiedFindings = append(result.ModifiedFindings,
+				types.NewModifiedFinding(lic, types.FindingStatusIgnored, "Filtered by Rego", policyFile))
 			continue
 		}
 		filteredLicenses = append(filteredLicenses, lic)

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -648,65 +648,42 @@ func TestFilter(t *testing.T) {
 					Results: types.Results{
 						{
 							Licenses: []types.DetectedLicense{
-								{
-									Name:       "GPL-3.0",
-									Severity:   dbTypes.SeverityLow.String(),
-									FilePath:   "usr/share/gcc/python/libstdcxx/v6/__init__.py",
-									Category:   "restricted",
-									Confidence: 1,
-								},
-								{
-									Name:       "GPL-3.0",
-									Severity:   dbTypes.SeverityLow.String(),
-									FilePath:   "usr/share/gcc/python/libstdcxx/v6/printers.py",
-									Category:   "restricted",
-									Confidence: 1,
-								},
+								license1,
+								license2,
 							},
 							Secrets: []types.DetectedSecret{
-								{
-									RuleID:    "generic-passed-rule",
-									Severity:  dbTypes.SeverityLow.String(),
-									Title:     "Secret should pass filter",
-									StartLine: 1,
-									EndLine:   2,
-									Match:     "*****",
-								},
-								{
-									RuleID:    "generic-ignored-rule",
-									Severity:  dbTypes.SeverityLow.String(),
-									Title:     "Secret should be ignored",
-									StartLine: 3,
-									EndLine:   4,
-									Match:     "*****",
-								},
+								secret1,
+								secret2,
 							},
 						},
 					},
 				},
-				severities: []dbTypes.Severity{dbTypes.SeverityLow},
+				severities: []dbTypes.Severity{dbTypes.SeverityLow, dbTypes.SeverityHigh},
 				policyFile: "./testdata/test-ignore-policy-licenses-and-secrets.rego",
 			},
 			want: types.Report{
 				Results: types.Results{
 					{
 						Licenses: []types.DetectedLicense{
-							{
-								Name:       "GPL-3.0",
-								Severity:   dbTypes.SeverityLow.String(),
-								FilePath:   "usr/share/gcc/python/libstdcxx/v6/__init__.py",
-								Category:   "restricted",
-								Confidence: 1,
-							},
+							license1,
 						},
 						Secrets: []types.DetectedSecret{
+							secret1,
+						},
+						ModifiedFindings: []types.ModifiedFinding{
+						     {
+								Type:      types.FindingTypeSecret,
+								Status:    types.FindingStatusIgnored,
+								Statement: "Filtered by Rego",
+								Source:    "testdata/test-ignore-policy-licenses-and-secrets.rego",
+								Finding:   secret2,
+							},
 							{
-								RuleID:    "generic-passed-rule",
-								Severity:  dbTypes.SeverityLow.String(),
-								Title:     "Secret should pass filter",
-								StartLine: 1,
-								EndLine:   2,
-								Match:     "*****",
+								Type:      types.FindingTypeLicense,
+								Status:    types.FindingStatusIgnored,
+								Statement: "Filtered by Rego",
+								Source:    "testdata/test-ignore-policy-licenses-and-secrets.rego",
+								Finding:   license2,
 							},
 						},
 					},

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -671,7 +671,7 @@ func TestFilter(t *testing.T) {
 							secret1,
 						},
 						ModifiedFindings: []types.ModifiedFinding{
-						     {
+							 {
 								Type:      types.FindingTypeSecret,
 								Status:    types.FindingStatusIgnored,
 								Statement: "Filtered by Rego",

--- a/pkg/result/testdata/test-ignore-policy-licenses-and-secrets.rego
+++ b/pkg/result/testdata/test-ignore-policy-licenses-and-secrets.rego
@@ -10,6 +10,6 @@ ignore {
 }
 
 ignore {
-	input.RuleID == "generic-ignored-rule"
-	input.Title == "Secret should be ignored"
+	input.RuleID == "generic-unwanted-rule"
+	input.Title == "Secret that should not pass filter on rule id"
 }


### PR DESCRIPTION
## Description

In #6004 rego policy was extended to allow filtering Licenses and Filters, but I somehow overlooked that there’s ModifiedFindings available now, so with this PR I’m trying to fix this and include them, just like it currently includes misconfigurations and vulnerabilities. I’ve updated tests accordingly, and also made them reuse predefined license and secret examples.

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
