### PR TITLE
fix: add color for error inside of log message

### DIFF
--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -129,7 +129,7 @@ func (h *ColorHandler) appendAttr(buf []byte, a slog.Attr, groups []string) []by
 		buf = append(buf, key...)
 		buf = append(buf, '=')
 		if err, ok := a.Value.Any().(error); ok {
-			buf = strconv.AppendQuote(buf, color.HiRedString(err.Error()))
+			buf = append(buf, color.HiRedString(strconv.Quote(err.Error()))...)
 		} else {
 			buf = append(buf, a.Value.String()...)
 		}


### PR DESCRIPTION
## Description
Some log messages (debug, warning, etc.) may contain error message.
We use red for these errors. But decoding updates color symbols and disrupts the coloration.

Before:
![изображение](https://github.com/aquasecurity/trivy/assets/91113035/b83d4221-a6ef-44c6-8623-5fa426ed9a16)

After:
![изображение](https://github.com/aquasecurity/trivy/assets/91113035/d887dc24-b4b4-4bf3-a934-dfe359928cd4)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
