### PR TITLE
fix(secret): convert severity for custom rules

### DIFF
--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -917,6 +917,33 @@ func TestSecretScanner(t *testing.T) {
 			},
 		},
 		{
+			name:          "add unknown severity when rule has no severity",
+			configPath:    filepath.Join("testdata", "config-with-incorrect-severity.yaml"),
+			inputFilePath: filepath.Join("testdata", "secret.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "secret.txt"),
+				Findings: []types.SecretFinding{wantFinding8},
+			},
+		},
+		{
+			name:          "update severity if rule severity is not in uppercase",
+			configPath:    filepath.Join("testdata", "config-with-non-uppercase-severity.yaml"),
+			inputFilePath: filepath.Join("testdata", "secret.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "secret.txt"),
+				Findings: []types.SecretFinding{wantFinding8},
+			},
+		},
+		{
+			name:          "use unknown severity when rule has incorrect severity",
+			configPath:    filepath.Join("testdata", "config-with-incorrect-severity.yaml"),
+			inputFilePath: filepath.Join("testdata", "secret.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "secret.txt"),
+				Findings: []types.SecretFinding{wantFinding8},
+			},
+		},
+		{
 			name:          "invalid aws secrets",
 			configPath:    filepath.Join("testdata", "skip-test.yaml"),
 			inputFilePath: filepath.Join("testdata", "invalid-aws-secrets.txt"),

--- a/pkg/fanal/secret/testdata/config-with-incorrect-severity.yaml
+++ b/pkg/fanal/secret/testdata/config-with-incorrect-severity.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: rule1
+    category: general
+    title: Generic Rule
+    severity: bad
+    regex: (?i)(?P<key>(secret))(=|:).{0,5}['"](?P<secret>somevalue)['"]
+    secret-group-name: secret
+disable-allow-rules:
+  - tests

--- a/pkg/fanal/secret/testdata/config-with-non-uppercase-severity.yaml
+++ b/pkg/fanal/secret/testdata/config-with-non-uppercase-severity.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: rule1
+    category: general
+    title: Generic Rule
+    severity: uNknown
+    regex: (?i)(?P<key>(secret))(=|:).{0,5}['"](?P<secret>somevalue)['"]
+    secret-group-name: secret
+disable-allow-rules:
+  - tests


### PR DESCRIPTION
## Description
By default we [filter all secrets by severity](https://github.com/aquasecurity/trivy/blob/1ba5b59527d161b44830700b678229beb302c0ad/pkg/result/filter.go#L182-L184).
However, there may be cases where user uses wrong severity (wrong name or case (e.g. lower case)) for custom rules.
We need to convert these severity levels to upper case to avoid incorrect filtering.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
