### PR TITLE
feat(misconf): loading embedded checks as a fallback

### DIFF
--- a/pkg/cloud/report/convert.go
+++ b/pkg/cloud/report/convert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
@@ -57,7 +58,7 @@ func ConvertResults(results scan.Results, provider string, scoped []string) map[
 
 				// empty namespace implies a go rule from defsec, "builtin" refers to a built-in rego rule
 				// this ensures we don't generate bad links for custom policies
-				if result.RegoNamespace() == "" || strings.HasPrefix(result.RegoNamespace(), "builtin.") {
+				if result.RegoNamespace() == "" || rego.IsBuiltinNamespace(result.RegoNamespace()) {
 					primaryURL = fmt.Sprintf("https://avd.aquasec.com/misconfig/%s", strings.ToLower(result.Rule().AVDID))
 				}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/javadb"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/misconf"
@@ -49,11 +50,6 @@ const (
 )
 
 var (
-	defaultPolicyNamespaces = []string{
-		"appshield",
-		"defsec",
-		"builtin",
-	}
 	SkipScan = errors.New("skip subsequent processes")
 )
 
@@ -597,7 +593,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		configScannerOptions = misconf.ScannerOption{
 			Debug:                    opts.Debug,
 			Trace:                    opts.Trace,
-			Namespaces:               append(opts.PolicyNamespaces, defaultPolicyNamespaces...),
+			Namespaces:               append(opts.PolicyNamespaces, rego.BuiltinNamespaces()...),
 			PolicyPaths:              append(opts.PolicyPaths, downloadedPolicyPaths...),
 			DataPaths:                opts.DataPaths,
 			HelmValues:               opts.HelmValues,

--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 
-	rules2 "github.com/aquasecurity/trivy-policies"
+	checks "github.com/aquasecurity/trivy-policies"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 )
 
@@ -62,11 +62,11 @@ func RegisterRegoRules(modules map[string]*ast.Module) {
 }
 
 func LoadEmbeddedPolicies() (map[string]*ast.Module, error) {
-	return LoadPoliciesFromDirs(rules2.EmbeddedPolicyFileSystem, ".")
+	return LoadPoliciesFromDirs(checks.EmbeddedPolicyFileSystem, ".")
 }
 
 func LoadEmbeddedLibraries() (map[string]*ast.Module, error) {
-	return LoadPoliciesFromDirs(rules2.EmbeddedLibraryFileSystem, ".")
+	return LoadPoliciesFromDirs(checks.EmbeddedLibraryFileSystem, ".")
 }
 
 func LoadPoliciesFromDirs(target fs.FS, paths ...string) (map[string]*ast.Module, error) {

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -149,10 +149,6 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 	var excludedFiles []string
 
 	for _, e := range compiler.Errors {
-		if _, ok := e.Details.(*ast.RefErrInvalidDetail); !ok {
-			continue
-		}
-
 		loc := e.Location.File
 
 		if lo.Contains(excludedFiles, loc) {

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -89,6 +89,14 @@ func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies b
 		return err
 	}
 
+	if enableEmbeddedPolicies {
+		s.policies = lo.Assign(s.policies, s.embeddedChecks)
+	}
+
+	if enableEmbeddedLibraries {
+		s.policies = lo.Assign(s.policies, s.embeddedLibs)
+	}
+
 	var err error
 	if len(paths) > 0 {
 		loaded, err := LoadPoliciesFromDirs(srcFS, paths...)
@@ -133,14 +141,6 @@ func (s *Scanner) LoadPolicies(enableEmbeddedLibraries, enableEmbeddedPolicies b
 		return fmt.Errorf("unable to load data: %w", err)
 	}
 	s.store = store
-
-	if enableEmbeddedPolicies {
-		s.policies = lo.Assign(s.policies, s.embeddedChecks)
-	}
-
-	if enableEmbeddedLibraries {
-		s.policies = lo.Assign(s.policies, s.embeddedLibs)
-	}
 
 	return s.compilePolicies(srcFS, paths)
 }

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -158,6 +158,22 @@ deny {
 			},
 			expectedErr: "testdata/embedded/bad-check.rego:8: rego_type_error: undefined ref",
 		},
+		{
+			name: "with non existent function",
+			files: map[string]*fstest.MapFile{
+				"policies/my-check2.rego": {
+					Data: []byte(`# METADATA
+# schemas:
+# - input: schema["fooschema"]
+package builtin.test
+
+deny {
+  input.foo == fn.is_foo("foo")
+}`,
+					),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -393,3 +393,16 @@ func (m *MetadataRetriever) queryInputOptions(ctx context.Context, module *ast.M
 func getModuleNamespace(module *ast.Module) string {
 	return strings.TrimPrefix(module.Package.Path.String(), "data.")
 }
+
+func metadataFromRegoModule(module *ast.Module) (*StaticMetadata, error) {
+	meta := new(StaticMetadata)
+	for _, annotation := range module.Annotations {
+		if annotation.Scope == "package" {
+			if err := meta.FromAnnotations(annotation); err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+	return meta, nil
+}

--- a/pkg/iac/rego/testdata/embedded/bad-check.rego
+++ b/pkg/iac/rego/testdata/embedded/bad-check.rego
@@ -1,0 +1,9 @@
+# METADATA
+# schemas:
+# - input: schema["fooschema"]
+
+package builtin.bad.test
+
+deny {
+    input.evil == "foo bar"
+}

--- a/pkg/iac/rego/testdata/embedded/my-check1.rego
+++ b/pkg/iac/rego/testdata/embedded/my-check1.rego
@@ -1,6 +1,8 @@
 # METADATA
 # schemas:
 # - input: schema["fooschema"]
+# custom:
+#   avd_id: test-001
 
 package builtin.test
 

--- a/pkg/iac/rego/testdata/embedded/my-policy1.rego
+++ b/pkg/iac/rego/testdata/embedded/my-policy1.rego
@@ -1,0 +1,9 @@
+# METADATA
+# schemas:
+# - input: schema["fooschema"]
+
+package builtin.test
+
+deny {
+    input.foo == "foo bar"
+}

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/licensing"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/scanner/langpkg"
@@ -383,7 +384,7 @@ func toDetectedMisconfiguration(res ftypes.MisconfResult, defaultSeverity dbType
 
 	// empty namespace implies a go rule from defsec, "builtin" refers to a built-in rego rule
 	// this ensures we don't generate bad links for custom policies
-	if res.Namespace == "" || strings.HasPrefix(res.Namespace, "builtin.") {
+	if res.Namespace == "" || rego.IsBuiltinNamespace(res.Namespace) {
 		primaryURL = fmt.Sprintf("https://avd.aquasec.com/misconfig/%s", strings.ToLower(res.ID))
 		res.References = append(res.References, primaryURL)
 	}


### PR DESCRIPTION
## Description

This PR adds functionality to fallback to embedded checks if an error occurs compiling an built-in check from a bundle. 

`main.tf`
```tf
resource "aws_s3_bucket" "test" {
  bucket = "test"
}

resource "aws_s3_bucket" "log_bucket" {
  bucket = "log_bucket"
}

resource "aws_s3_bucket_logging" "test" {
  bucket = aws_s3_bucket.test.id

  target_bucket = aws_s3_bucket.log_bucket.id
  target_prefix   = "log/"
}
```

1. `rm -rf ~/Library/Caches/trivy/policy`
2. `go run ./cmd/trivy conf main.tf -d --policy-bundle-repository ghcr.io/nikpivkin/trivy-policies:test`
```bash
2024-04-16T17:50:24+07:00       DEBUG   [misconf] 50:24.188902000 terraform.scanner.rego           Error occurred while parsing: Users/nikita/Library/Caches/trivy/policy/content/policies/cloud/policies/aws/s3/enable_logging.rego, Users/nikita/Library/Caches/trivy/policy/content/policies/cloud/policies/aws/s3/enable_logging.rego:33: rego_type_error: undefined ref: bucket.logging.is_enabled.value
        bucket.logging.is_enabled.value
                       ^
                       have: "is_enabled"
                       want (one of): ["enabled" "targetbucket"]. 
Try loading embedded policy.
2024-04-16T17:50:24+07:00       DEBUG   [misconf] 50:24.189063000 terraform.scanner.rego           Found embedded policy: checks/cloud/aws/s3/enable_logging.rego
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6505


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
