### PR TITLE
refactor(misconf): improve error handling in the Rego scanner

### DIFF
--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -241,7 +241,10 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 
 		staticMeta, err := s.retriever.RetrieveMetadata(ctx, module, GetInputsContents(inputs)...)
 		if err != nil {
-			return nil, err
+			s.debug.Log(
+				"Error occurred while retrieving metadata from check %q: %s",
+				module.Package.Location.File, err)
+			continue
 		}
 
 		if isPolicyWithSubtype(s.sourceType) {
@@ -267,7 +270,10 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 			if isEnforcedRule(ruleName) {
 				ruleResults, err := s.applyRule(ctx, namespace, ruleName, inputs, staticMeta.InputOptions.Combined)
 				if err != nil {
-					return nil, err
+					s.debug.Log(
+						"Error occurred while applying rule %q from check %q: %s",
+						ruleName, module.Package.Location.File, err)
+					continue
 				}
 				results = append(results, s.embellishResultsWithRuleMetadata(ruleResults, *staticMeta)...)
 			}


### PR DESCRIPTION
## Description
This PR ensures that Rego checks continue to run even if an error is encountered in one of them, avoiding halting the entire process.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
