### PR TITLE
refactor(misconf): simplify the retrieval of module annotations

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/iac/framework"
 	"github.com/aquasecurity/trivy/pkg/iac/providers"
@@ -15,6 +16,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/severity"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
+
+const annotationScopePackage = "package"
 
 type StaticMetadata struct {
 	ID                 string
@@ -234,17 +237,9 @@ func NewMetadataRetriever(compiler *ast.Compiler) *MetadataRetriever {
 }
 
 func (m *MetadataRetriever) findPackageAnnotations(module *ast.Module) *ast.Annotations {
-	annotationSet := m.compiler.GetAnnotationSet()
-	if annotationSet == nil {
-		return nil
-	}
-	for _, annotation := range annotationSet.Flatten() {
-		if annotation.GetPackage().Path.String() != module.Package.Path.String() || annotation.Annotations.Scope != "package" {
-			continue
-		}
-		return annotation.Annotations
-	}
-	return nil
+	return lo.FindOrElse(module.Annotations, nil, func(a *ast.Annotations) bool {
+		return a.Scope == annotationScopePackage
+	})
 }
 
 func (m *MetadataRetriever) RetrieveMetadata(ctx context.Context, module *ast.Module, contents ...any) (*StaticMetadata, error) {


### PR DESCRIPTION
## Description
Annotations can be retrieved directly from the Rego module.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
