### PR TITLE
ci: use tmp dir inside Trivy repo dir for GoReleaser

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -90,6 +90,11 @@ jobs:
         run: |
           echo "$GPG_KEY" > gpg.key
 
+      # Create tmp dir for GoReleaser
+      - name: "create tmp dir"
+        run: |
+          mkdir tmp    
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -99,10 +104,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FILE: "gpg.key"
+          TMPDIR: "tmp"
 
       - name: "remove gpg key"
         run: |
-          rm gpg.key
+          rm gpg.key      
 
       # Push images to registries (only for canary build)
       # The custom Dockerfile.canary is necessary

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: "remove gpg key"
         run: |
-          rm gpg.key      
+          rm gpg.key
 
       # Push images to registries (only for canary build)
       # The custom Dockerfile.canary is necessary


### PR DESCRIPTION
## Description
`GoReleaser` uses `TMPDIR` during operation.
But we moved all free space to Trivy directory and got error - https://github.com/aquasecurity/trivy/actions/runs/8781316705/job/24095365717#step:14:47

So we also need to move the `GoReleaser` temp directory to Trivy directory.

Test run - https://github.com/DmitriyLewen/trivy/actions/runs/8782979882/job/24098204231#step:14:78

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
