### PR TITLE
fix(vuln): skip empty versions

### DIFF
--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -29,7 +29,8 @@ func detect(ctx context.Context, driver Driver, pkgs []ftypes.Package) ([]types.
 	var vulnerabilities []types.DetectedVulnerability
 	for _, pkg := range pkgs {
 		if pkg.Version == "" {
-			log.DebugContext(ctx, "Skipping package without version", log.String("name", pkg.Name))
+			log.DebugContext(ctx, "Skipping vulnerability scan as no version is detected for the package",
+				log.String("name", pkg.Name))
 			continue
 		}
 		vulns, err := driver.DetectVulnerabilities(pkg.ID, pkg.Name, pkg.Version)

--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -1,20 +1,23 @@
 package library
 
 import (
+	"context"
+
 	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-// Detect scans and returns vulnerabilities of library
-func Detect(libType ftypes.LangType, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+// Detect scans language-specific packages and returns vulnerabilities.
+func Detect(ctx context.Context, libType ftypes.LangType, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	driver, ok := NewDriver(libType)
 	if !ok {
 		return nil, nil
 	}
 
-	vulns, err := detect(driver, pkgs)
+	vulns, err := detect(ctx, driver, pkgs)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to scan %s vulnerabilities: %w", driver.Type(), err)
 	}
@@ -22,18 +25,22 @@ func Detect(libType ftypes.LangType, pkgs []ftypes.Package) ([]types.DetectedVul
 	return vulns, nil
 }
 
-func detect(driver Driver, libs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+func detect(ctx context.Context, driver Driver, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	var vulnerabilities []types.DetectedVulnerability
-	for _, lib := range libs {
-		vulns, err := driver.DetectVulnerabilities(lib.ID, lib.Name, lib.Version)
+	for _, pkg := range pkgs {
+		if pkg.Version == "" {
+			log.DebugContext(ctx, "Skipping package without version", log.String("name", pkg.Name))
+			continue
+		}
+		vulns, err := driver.DetectVulnerabilities(pkg.ID, pkg.Name, pkg.Version)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to detect %s vulnerabilities: %w", driver.Type(), err)
 		}
 
 		for i := range vulns {
-			vulns[i].Layer = lib.Layer
-			vulns[i].PkgPath = lib.FilePath
-			vulns[i].PkgIdentifier = lib.Identifier
+			vulns[i].Layer = pkg.Layer
+			vulns[i].PkgPath = pkg.FilePath
+			vulns[i].PkgIdentifier = pkg.Identifier
 		}
 		vulnerabilities = append(vulnerabilities, vulns...)
 	}

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -186,7 +186,7 @@ func (s Scanner) scanVulnerabilities(ctx context.Context, target types.ScanTarge
 	}
 
 	if slices.Contains(options.VulnType, types.VulnTypeLibrary) {
-		vulns, err := s.langPkgScanner.Scan(target, options)
+		vulns, err := s.langPkgScanner.Scan(ctx, target, options)
 		if err != nil {
 			return nil, false, xerrors.Errorf("failed to scan application libraries: %w", err)
 		}


### PR DESCRIPTION
## Description
It currently shows warnings on empty versions.

```
$ trivy sbom /tmp/sbom-k8s-cluster.json
2024-04-23T13:53:05+04:00       INFO    Vulnerability scanning is enabled
2024-04-23T13:53:05+04:00       INFO    Detected SBOM format    format="cyclonedx-json"
...
2024-04-23T13:53:05+04:00       INFO    [kubernetes] Detecting vulnerabilities...
2024-04-23T13:53:05+04:00       WARN    Version matching error  err="version error (): malformed version: "
2024-04-23T13:53:05+04:00       WARN    Version matching error  err="version error (): malformed version: "
2024-04-23T13:53:05+04:00       WARN    Version matching error  err="version error (): malformed version: "
2024-04-23T13:53:05+04:00       WARN    Version matching error  err="version error (): malformed version: "

```

This PR changed it to skip empty versions and show debug messages.

```
$ trivy sbom /tmp/sbom-k8s-cluster.json -d
...
2024-04-23T13:47:40+04:00       INFO    [kubernetes] Detecting vulnerabilities...
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Scanning packages from the file    file_path=""
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Skipping package without version   name="cilium"
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Skipping package without version   name="hubble-relay"
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Skipping package without version   name="hubble-ui"
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Skipping package without version   name="k8s.io/kube-proxy"
2024-04-23T13:47:40+04:00       DEBUG   [kubernetes] Skipping package without version   name="kube-dns"
```

Also it passes context to the scanner to make logger context-aware.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
