### PR TITLE
fix(terraform): Attribute and fileset fixes

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1631,3 +1631,71 @@ output "test_out" {
 		assert.Equal(t, "test_value", attr.GetRawValue())
 	}
 }
+
+func TestExtractSetValue(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+resource "test" "set-value" {
+	value = toset(["x", "y", "x"])
+}
+`,
+	}
+
+	resources := parse(t, files).GetResourcesByType("test")
+	require.Len(t, resources, 1)
+	attr := resources[0].GetAttribute("value")
+	require.NotNil(t, attr)
+	assert.Equal(t, []string{"x", "y"}, attr.GetRawValue())
+}
+
+func TestFunc_fileset(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+resource "test" "fileset-func" {
+	value = fileset(path.module, "**/*.py")
+}
+`,
+		"a.py":      ``,
+		"path/b.py": ``,
+	}
+
+	resources := parse(t, files).GetResourcesByType("test")
+	require.Len(t, resources, 1)
+	attr := resources[0].GetAttribute("value")
+	require.NotNil(t, attr)
+	assert.Equal(t, []string{"a.py", "path/b.py"}, attr.GetRawValue())
+}
+
+func TestVarTypeShortcut(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+variable "magic_list" {
+	type    = list
+	default = ["x", "y"]
+}
+
+variable "magic_map" {
+	type    = map
+	default = {a = 1, b = 2}
+}
+
+resource "test" "values" {
+	l = var.magic_list
+	m = var.magic_map
+}
+`,
+	}
+
+	resources := parse(t, files).GetResourcesByType("test")
+	require.Len(t, resources, 1)
+
+	list_attr := resources[0].GetAttribute("l")
+	require.NotNil(t, list_attr)
+	assert.Equal(t, []string{"x", "y"}, list_attr.GetRawValue())
+
+	map_attr := resources[0].GetAttribute("m")
+	require.NotNil(t, map_attr)
+	assert.True(t, map_attr.Value().RawEquals(cty.MapVal(map[string]cty.Value{
+		"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2),
+	})))
+}


### PR DESCRIPTION
## Description

* `fileset` function now uses `fs.Stat` instead of `os.Stat` and works more often
* `Attribute.DecodeVarType` now handles the `list` and `map` shortcuts for `list(any)` and `map(any)`
* `Attribute.GetRawValue` now returns data from `set` values

## Related issues
- Close #XXX

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
