### PR TITLE
docs: remove RELEASE_VERSION from trivy.repo

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,11 +10,10 @@ In this section you will find an aggregation of the different ways to install Tr
     Add repository setting to `/etc/yum.repos.d`.
 
     ``` bash
-    RELEASE_VERSION=$(grep -Po '(?<=VERSION_ID=")[0-9]' /etc/os-release)
     cat << EOF | sudo tee -a /etc/yum.repos.d/trivy.repo
     [trivy]
     name=Trivy repository
-    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$RELEASE_VERSION/\$basearch/
+    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/\$basearch/
     gpgcheck=1
     enabled=1
     gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key


### PR DESCRIPTION
## Description
When adding repo configuration to /etc/yum.repos.d/trivy.repo, RELEASE_VERSION should not be added to repo baseurl.

This is also documented in: https://aquasecurity.github.io/trivy-repo/.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
