### PR TITLE
fix(debian): sort dpkg info before parsing due to exclude directories

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
@@ -1423,7 +1423,7 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 			want: &analyzer.AnalysisResult{
 				SystemInstalledFiles: []string{
 					"/bin/tar",
-					"/etc",
+					"/etc/rmt",
 					"/usr/lib/mime/packages/tar",
 					"/usr/sbin/rmt-tar",
 					"/usr/sbin/tarcat",
@@ -1436,7 +1436,6 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 					"/usr/share/man/man1/tar.1.gz",
 					"/usr/share/man/man1/tarcat.1.gz",
 					"/usr/share/man/man8/rmt-tar.8.gz",
-					"/etc/rmt",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Discussed in https://github.com/aquasecurity/trivy/discussions/6543
## Related issues
- Close #6548 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
