### PR TITLE
docs: mention `--show-suppressed` is available in table

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -237,6 +237,9 @@ You can filter the results by
 
 To show the suppressed results, use the `--show-suppressed` flag.
 
+!!! note
+    This flag is currently available only in the table format.
+
 ```bash
 $ trivy image --vex debian11.csaf.vex --ignorefile .trivyignore.yaml --show-suppressed debian:11
 ...


### PR DESCRIPTION
## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6494

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
