### PR TITLE
ci: disable `Go` cache for `reusable-release.yaml`

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false # Don't use cache to avoid `No space left on device ` error in `Post Setup Go` step
 
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@v2

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: false # Don't use cache to avoid `No space left on device ` error in `Post Setup Go` step
+          cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
 
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@v2


### PR DESCRIPTION
## Description
Size of Go cache, Trivy binary, GoReleaser temp files, etc. are getting larger.
We recently started getting an error in `Post Go Setup` step - https://github.com/aquasecurity/trivy/actions/runs/8816024192.
To avoid errors and get stable release run - we disable `Go` cache for `reusable-release.yaml`

Test run - https://github.com/DmitriyLewen/trivy/actions/runs/8845727149

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
