### PR TITLE
feat(go): add main module

### DIFF
--- a/pkg/dependency/parser/golang/mod/parse_testcase.go
+++ b/pkg/dependency/parser/golang/mod/parse_testcase.go
@@ -6,6 +6,17 @@ var (
 	// execute go mod tidy in normal folder
 	GoModNormal = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20211224170007-df43bca6b6ff",
@@ -40,6 +51,17 @@ var (
 	// execute go mod tidy in replaced folder
 	GoModReplaced = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20220406074731-71021a481237",
@@ -61,6 +83,17 @@ var (
 
 	// execute go mod tidy in replaced folder
 	GoModUnreplaced = []types.Library{
+		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
 		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211110174639-8257534ffed3",
 			Name:         "github.com/aquasecurity/go-dep-parser",
@@ -84,6 +117,17 @@ var (
 	// execute go mod tidy in replaced-with-version folder
 	GoModReplacedWithVersion = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20220406074731-71021a481237",
@@ -105,6 +149,17 @@ var (
 
 	// execute go mod tidy in replaced-with-version-mismatch folder
 	GoModReplacedWithVersionMismatch = []types.Library{
+		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
 		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
@@ -140,6 +195,17 @@ var (
 	// execute go mod tidy in replaced-with-local-path folder
 	GoModReplacedWithLocalPath = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20211224170007-df43bca6b6ff",
@@ -168,6 +234,17 @@ var (
 	// execute go mod tidy in replaced-with-local-path-and-version folder
 	GoModReplacedWithLocalPathAndVersion = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20211224170007-df43bca6b6ff",
@@ -195,6 +272,17 @@ var (
 
 	// execute go mod tidy in replaced-with-local-path-and-version-mismatch folder
 	GoModReplacedWithLocalPathAndVersionMismatch = []types.Library{
+		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
 		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
@@ -230,6 +318,17 @@ var (
 	// execute go mod tidy in go116 folder
 	GoMod116 = []types.Library{
 		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
+		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",
 			Version:      "0.0.0-20211224170007-df43bca6b6ff",
@@ -245,6 +344,17 @@ var (
 
 	// execute go mod tidy in no-go-version folder
 	GoModNoGoVersion = []types.Library{
+		{
+			ID:           "github.com/org/repo",
+			Name:         "github.com/org/repo",
+			Relationship: types.RelationshipRoot,
+			ExternalReferences: []types.ExternalRef{
+				{
+					Type: types.RefVCS,
+					URL:  "https://github.com/org/repo",
+				},
+			},
+		},
 		{
 			ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20211224170007-df43bca6b6ff",
 			Name:         "github.com/aquasecurity/go-dep-parser",

--- a/pkg/fanal/analyzer/language/golang/mod/mod_test.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod_test.go
@@ -33,6 +33,11 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 						FilePath: "go.mod",
 						Libraries: types.Packages{
 							{
+								ID:           "github.com/org/repo",
+								Name:         "github.com/org/repo",
+								Relationship: types.RelationshipRoot,
+							},
+							{
 								ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237",
 								Name:         "github.com/aquasecurity/go-dep-parser",
 								Version:      "0.0.0-20220406074731-71021a481237",
@@ -68,6 +73,11 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 						FilePath: "go.mod",
 						Libraries: types.Packages{
 							{
+								ID:           "github.com/org/repo",
+								Name:         "github.com/org/repo",
+								Relationship: types.RelationshipRoot,
+							},
+							{
 								ID:           "github.com/sad/sad@v0.0.1",
 								Name:         "github.com/sad/sad",
 								Version:      "0.0.1",
@@ -90,6 +100,11 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 						Type:     types.GoModule,
 						FilePath: "go.mod",
 						Libraries: types.Packages{
+							{
+								ID:           "github.com/org/repo",
+								Name:         "github.com/org/repo",
+								Relationship: types.RelationshipRoot,
+							},
 							{
 								ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20230219131432-590b1dfb6edd",
 								Name:         "github.com/aquasecurity/go-dep-parser",
@@ -125,6 +140,11 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 						Type:     types.GoModule,
 						FilePath: "go.mod",
 						Libraries: types.Packages{
+							{
+								ID:           "github.com/org/repo",
+								Name:         "github.com/org/repo",
+								Relationship: types.RelationshipRoot,
+							},
 							{
 								ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20230219131432-590b1dfb6edd",
 								Name:         "github.com/aquasecurity/go-dep-parser",


### PR DESCRIPTION
## Description
Extract the main module from go.mod. As far as I know, it should not be possible to get the version, but it is programmatically possible to get it (`Module.Mod` has the version field), so I try to get it just in case.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/6563

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
