### PR TITLE
feat: respect custom exit code from plugin

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"golang.org/x/xerrors"
@@ -9,12 +10,17 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/plugin"
+	"github.com/aquasecurity/trivy/pkg/types"
 
 	_ "modernc.org/sqlite" // sqlite driver for RPM DB and Java DB
 )
 
 func main() {
 	if err := run(); err != nil {
+		var exitError *types.ExitError
+		if errors.As(err, &exitError) {
+			os.Exit(exitError.Code)
+		}
 		log.Fatal("Fatal error", log.Err(err))
 	}
 }

--- a/pkg/cloud/aws/commands/run.go
+++ b/pkg/cloud/aws/commands/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 var allSupportedServicesFunc = awsScanner.AllSupportedServices
@@ -170,6 +171,5 @@ func Run(ctx context.Context, opt flag.Options) error {
 		return xerrors.Errorf("unable to write results: %w", err)
 	}
 
-	operation.Exit(opt, r.Failed())
-	return nil
+	return operation.Exit(opt, r.Failed(), types.Metadata{})
 }

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -130,6 +130,8 @@ func loadPluginCommands() []*cobra.Command {
 				return nil
 			},
 			DisableFlagParsing: true,
+			SilenceUsage:       true,
+			SilenceErrors:      true,
 		}
 		commands = append(commands, cmd)
 	}

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -452,10 +452,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 		return xerrors.Errorf("report error: %w", err)
 	}
 
-	operation.ExitOnEOL(opts, report.Metadata)
-	operation.Exit(opts, report.Results.Failed())
-
-	return nil
+	return operation.Exit(opts, report.Results.Failed(), report.Metadata)
 }
 
 func disabledAnalyzers(opts flag.Options) []analyzer.Type {

--- a/pkg/commands/convert/run.go
+++ b/pkg/commands/convert/run.go
@@ -44,8 +44,5 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 		return xerrors.Errorf("unable to write results: %w", err)
 	}
 
-	operation.ExitOnEOL(opts, r.Metadata)
-	operation.Exit(opts, r.Results.Failed())
-
-	return nil
+	return operation.Exit(opts, r.Results.Failed(), r.Metadata)
 }

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -204,16 +204,15 @@ func GetTLSConfig(caCertPath, certPath, keyPath string) (*x509.CertPool, tls.Cer
 	return caCertPool, cert, nil
 }
 
-func Exit(opts flag.Options, failedResults bool) {
-	if opts.ExitCode != 0 && failedResults {
-		os.Exit(opts.ExitCode)
-	}
-}
-
-func ExitOnEOL(opts flag.Options, m types.Metadata) {
+func Exit(opts flag.Options, failedResults bool, m types.Metadata) error {
 	if opts.ExitOnEOL != 0 && m.OS != nil && m.OS.Eosl {
 		log.Error("Detected EOL OS", log.String("family", string(m.OS.Family)),
 			log.String("version", m.OS.Name))
-		os.Exit(opts.ExitOnEOL)
+		return &types.ExitError{Code: opts.ExitOnEOL}
 	}
+
+	if opts.ExitCode != 0 && failedResults {
+		return &types.ExitError{Code: opts.ExitCode}
+	}
+	return nil
 }

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -122,9 +122,7 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		return xerrors.Errorf("unable to write results: %w", err)
 	}
 
-	operation.Exit(r.flagOpts, rpt.Failed())
-
-	return nil
+	return operation.Exit(r.flagOpts, rpt.Failed(), types.Metadata{})
 }
 
 // Full-cluster scanning with '--format table' without explicit '--report all' is not allowed so that it won't mess up user's terminal.

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -140,7 +140,7 @@ func TestPlugin_Run(t *testing.T) {
 				GOOS:   "linux",
 				GOARCH: "amd64",
 			},
-			wantErr: "plugin exec: exit status 1",
+			wantErr: "exit status 1",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/types/error.go
+++ b/pkg/types/error.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"fmt"
+)
+
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("exit status %d", e.Code)
+}


### PR DESCRIPTION
## Description
Trivy doesn't respect exit codes from plugins now and always exits with 1 if the plugin fails. This PR adds support for it.

### Before
The `testplugin` always exits with 2.

```
$ trivy testplugin; echo $?
Error: plugin error: plugin exec: exit status 2
Usage:
  trivy testplugin [flags]

Flags:
  -h, --help   help for testplugin

Global Flags:
      --cache-dir string          cache directory (default "/Users/teppei/Library/Caches/trivy")
  -c, --config string             config path (default "trivy.yaml")
  -d, --debug                     debug mode
      --generate-default-config   write the default config to trivy-default.yaml
      --insecure                  allow insecure server connections
  -q, --quiet                     suppress progress bar and log output
      --timeout duration          timeout (default 5m0s)
  -v, --version                   show version

2024-04-30T22:56:13+04:00       FATAL   Fatal error     plugin error: plugin exec: exit status 2
1
```

### After
It exits with the code from a plugin and doesn't show usage and error anymore.

```
$ trivy testplugin; echo $?
2
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
