### PR TITLE
feat(misconf): Add `--disable-causes` flag

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_aws.md
+++ b/docs/docs/references/configuration/cli/trivy_aws.md
@@ -73,6 +73,7 @@ trivy aws [flags]
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --endpoint string                   AWS Endpoint override
       --exit-code int                     specify exit code when any security issues are found
   -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -16,6 +16,7 @@ trivy config [flags] DIR
       --compliance string                 compliance report to generate
       --config-data strings               specify paths from which data for the Rego policies will be recursively loaded
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -29,6 +29,7 @@ trivy filesystem [flags] PATH
       --custom-headers strings            custom headers in client mode
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -43,6 +43,7 @@ trivy image [flags] IMAGE_NAME
       --custom-headers strings            custom headers in client mode
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --docker-host string                unix domain socket path to use for docker scanning
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -39,6 +39,7 @@ trivy kubernetes [flags] [CONTEXT]
       --config-policy strings             specify the paths to the Rego policy files or to the directories containing them, applying config files
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --exclude-kinds strings             indicate the kinds exclude from scanning (example: node)

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -29,6 +29,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --custom-headers strings            custom headers in client mode
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -31,6 +31,7 @@ trivy rootfs [flags] ROOTDIR
       --custom-headers strings            custom headers in client mode
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -28,6 +28,7 @@ trivy vm [flags] VM_IMAGE
       --custom-headers strings            custom headers in client mode
       --db-repository string              OCI repository to retrieve trivy-db from (default "ghcr.io/aquasecurity/trivy-db:2")
       --dependency-tree                   [EXPERIMENTAL] show dependency origin tree of vulnerable packages
+      --disable-causes                    disables cause output, useful if scanning large number of files at once
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aquasecurity/table v1.8.0
 	github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da
 	github.com/aquasecurity/tml v0.6.1
-	github.com/aquasecurity/trivy-aws v0.8.0
+	github.com/aquasecurity/trivy-aws v0.8.1-0.20240501011519-21d9fd3732a0
 	github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d
 	github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48
 	github.com/aquasecurity/trivy-kubernetes v0.6.7-0.20240425111126-a549f8de71bb

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gw
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
 github.com/aquasecurity/trivy-aws v0.8.0 h1:4ij8MiZ2sJUH+vWpSeoGVhPr109ZBcNp7LNLfPuv5Cw=
 github.com/aquasecurity/trivy-aws v0.8.0/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
+github.com/aquasecurity/trivy-aws v0.8.1-0.20240501001637-6c1829daf51a/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
+github.com/aquasecurity/trivy-aws v0.8.1-0.20240501011519-21d9fd3732a0/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
 github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d h1:fjI9mkoTUAkbGqpzt9nJsO24RAdfG+ZSiLFj0G2jO8c=
 github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d/go.mod h1:cj9/QmD9N3OZnKQMp+/DvdV+ym3HyIkd4e+F0ZM3ZGs=
 github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48 h1:JVgBIuIYbwG+ekC5lUHUpGJboPYiCcxiz06RCtz8neI=

--- a/go.sum
+++ b/go.sum
@@ -343,9 +343,7 @@ github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da h1:pj/adfN
 github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da/go.mod h1:852lbQLpK2nCwlR4ZLYIccxYCfoQao6q9Nl6tjz54v8=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy-aws v0.8.0 h1:4ij8MiZ2sJUH+vWpSeoGVhPr109ZBcNp7LNLfPuv5Cw=
-github.com/aquasecurity/trivy-aws v0.8.0/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
-github.com/aquasecurity/trivy-aws v0.8.1-0.20240501001637-6c1829daf51a/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
+github.com/aquasecurity/trivy-aws v0.8.1-0.20240501011519-21d9fd3732a0 h1:XxPW1S+kQ6Z3yKBCW9AdYCzW4hYSSq59nlXtTzwoZIU=
 github.com/aquasecurity/trivy-aws v0.8.1-0.20240501011519-21d9fd3732a0/go.mod h1:Pb9xqOuTKMHVgjsnjvudjqZh3nmzdFqFVfRkXnoIZBM=
 github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d h1:fjI9mkoTUAkbGqpzt9nJsO24RAdfG+ZSiLFj0G2jO8c=
 github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d/go.mod h1:cj9/QmD9N3OZnKQMp+/DvdV+ym3HyIkd4e+F0ZM3ZGs=

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -608,6 +608,7 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 			K8sVersion:               opts.K8sVersion,
 			DisableEmbeddedPolicies:  disableEmbedded,
 			DisableEmbeddedLibraries: disableEmbedded,
+			DisableCauses:            opts.DisableCauses,
 			TfExcludeDownloaded:      opts.TfExcludeDownloaded,
 		}
 	}

--- a/pkg/fanal/analyzer/config/config_test.go
+++ b/pkg/fanal/analyzer/config/config_test.go
@@ -72,6 +72,49 @@ func TestAnalyzer_PostAnalyze(t *testing.T) {
 			},
 		},
 		{
+			name: "dockerfile but with causes disabled",
+			fields: fields{
+				typ:        analyzer.TypeDockerfile,
+				newScanner: misconf.NewDockerfileScanner,
+				opts: analyzer.AnalyzerOptions{
+					MisconfScannerOption: misconf.ScannerOption{
+						Namespaces:              []string{"user"},
+						PolicyPaths:             []string{"testdata/rego"},
+						DisableEmbeddedPolicies: true,
+						DisableCauses:           true,
+					},
+				},
+			},
+			dir: "testdata/src",
+			want: &analyzer.AnalysisResult{
+				Misconfigurations: []types.Misconfiguration{
+					{
+						FileType: types.Dockerfile,
+						FilePath: "Dockerfile",
+						Successes: types.MisconfResults{
+							types.MisconfResult{
+								Namespace: "user.something",
+								Query:     "data.user.something.deny",
+								PolicyMetadata: types.PolicyMetadata{
+									ID:                 "TEST001",
+									AVDID:              "AVD-TEST-0001",
+									Type:               "Dockerfile Security Check",
+									Title:              "Test policy",
+									Description:        "This is a test policy.",
+									Severity:           "LOW",
+									RecommendedActions: "Have a cup of tea.",
+									References:         []string{"https://trivy.dev/"},
+								},
+								CauseMetadata: types.CauseMetadata{
+									// this should be empty
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "non-existent dir",
 			fields: fields{
 				typ:        analyzer.TypeDockerfile,

--- a/pkg/flag/misconf_flags.go
+++ b/pkg/flag/misconf_flags.go
@@ -77,6 +77,12 @@ var (
 		Default:    fmt.Sprintf("%s:%d", policy.BundleRepository, policy.BundleVersion),
 		Usage:      "OCI registry URL to retrieve policy bundle from",
 	}
+	DisableCauses = Flag[bool]{
+		Name:       "disable-causes",
+		ConfigName: "misconfiguration.disable-causes",
+		Default:    false,
+		Usage:      "disables cause output, useful if scanning large number of files at once",
+	}
 	MisconfigScannersFlag = Flag[[]string]{
 		Name:       "misconfig-scanners",
 		ConfigName: "misconfiguration.scanners",
@@ -90,6 +96,7 @@ type MisconfFlagGroup struct {
 	IncludeNonFailures     *Flag[bool]
 	ResetPolicyBundle      *Flag[bool]
 	PolicyBundleRepository *Flag[string]
+	DisableCauses          *Flag[bool]
 
 	// Values Files
 	HelmValues                 *Flag[[]string]
@@ -108,6 +115,7 @@ type MisconfOptions struct {
 	IncludeNonFailures     bool
 	ResetPolicyBundle      bool
 	PolicyBundleRepository string
+	DisableCauses          bool
 
 	// Values Files
 	HelmValues              []string
@@ -127,6 +135,7 @@ func NewMisconfFlagGroup() *MisconfFlagGroup {
 		IncludeNonFailures:     IncludeNonFailuresFlag.Clone(),
 		ResetPolicyBundle:      ResetPolicyBundleFlag.Clone(),
 		PolicyBundleRepository: PolicyBundleRepositoryFlag.Clone(),
+		DisableCauses:          DisableCauses.Clone(),
 
 		HelmValues:                 HelmSetFlag.Clone(),
 		HelmFileValues:             HelmSetFileFlag.Clone(),
@@ -160,6 +169,7 @@ func (f *MisconfFlagGroup) Flags() []Flagger {
 		f.TerraformExcludeDownloaded,
 		f.CloudformationParamVars,
 		f.MisconfigScanners,
+		f.DisableCauses,
 	}
 }
 
@@ -172,6 +182,7 @@ func (f *MisconfFlagGroup) ToOptions() (MisconfOptions, error) {
 		IncludeNonFailures:      f.IncludeNonFailures.Value(),
 		ResetPolicyBundle:       f.ResetPolicyBundle.Value(),
 		PolicyBundleRepository:  f.PolicyBundleRepository.Value(),
+		DisableCauses:           f.DisableCauses.Value(),
 		HelmValues:              f.HelmValues.Value(),
 		HelmValueFiles:          f.HelmValueFiles.Value(),
 		HelmFileValues:          f.HelmFileValues.Value(),

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -47,6 +47,8 @@ type Scanner struct {
 	embeddedChecks map[string]*ast.Module
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
 	// handled externally
 }

--- a/pkg/iac/scanners/azure/arm/scanner.go
+++ b/pkg/iac/scanners/azure/arm/scanner.go
@@ -40,6 +40,8 @@ type Scanner struct { // nolint: gocritic
 	sync.Mutex
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetSpec(spec string) {
 	s.spec = spec
 }

--- a/pkg/iac/scanners/cloudformation/scanner.go
+++ b/pkg/iac/scanners/cloudformation/scanner.go
@@ -68,6 +68,8 @@ func (s *Scanner) addParserOptions(opt options.ParserOption) {
 	s.parserOptions = append(s.parserOptions, opt)
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetFrameworks(frameworks []framework.Framework) {
 	s.frameworks = frameworks
 }

--- a/pkg/iac/scanners/dockerfile/scanner.go
+++ b/pkg/iac/scanners/dockerfile/scanner.go
@@ -34,6 +34,8 @@ type Scanner struct { // nolint: gocritic
 	loadEmbeddedPolicies  bool
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetSpec(spec string) {
 	s.spec = spec
 }

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -43,6 +43,8 @@ type Scanner struct {
 	mu                    sync.Mutex
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetSpec(spec string) {
 	s.spec = spec
 }

--- a/pkg/iac/scanners/kubernetes/scanner.go
+++ b/pkg/iac/scanners/kubernetes/scanner.go
@@ -38,6 +38,8 @@ type Scanner struct { // nolint: gocritic
 	loadEmbeddedLibraries bool
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetSpec(spec string) {
 	s.spec = spec
 }

--- a/pkg/iac/scanners/options/scanner.go
+++ b/pkg/iac/scanners/options/scanner.go
@@ -24,6 +24,7 @@ type ConfigurableScanner interface {
 	SetRegoOnly(regoOnly bool)
 	SetRegoErrorLimit(limit int)
 	SetUseEmbeddedLibraries(bool)
+	SetDisableCauses(bool)
 }
 
 type ScannerOption func(s ConfigurableScanner)
@@ -62,6 +63,12 @@ func ScannerWithEmbeddedPolicies(embedded bool) ScannerOption {
 func ScannerWithEmbeddedLibraries(enabled bool) ScannerOption {
 	return func(s ConfigurableScanner) {
 		s.SetUseEmbeddedLibraries(enabled)
+	}
+}
+
+func ScannerWithDisabledCodeHighlighting(disabled bool) ScannerOption {
+	return func(s ConfigurableScanner) {
+		s.SetDisableCauses(disabled)
 	}
 }
 

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -30,20 +30,25 @@ var _ ConfigurableTerraformScanner = (*Scanner)(nil)
 
 type Scanner struct { // nolint: gocritic
 	sync.Mutex
-	options               []options.ScannerOption
-	parserOpt             []options.ParserOption
-	executorOpt           []executor.Option
-	dirs                  map[string]struct{}
-	forceAllDirs          bool
-	policyDirs            []string
-	policyReaders         []io.Reader
-	regoScanner           *rego.Scanner
-	execLock              sync.RWMutex
-	debug                 debug.Logger
-	frameworks            []framework.Framework
-	spec                  string
-	loadEmbeddedLibraries bool
-	loadEmbeddedPolicies  bool
+	options                 []options.ScannerOption
+	parserOpt               []options.ParserOption
+	executorOpt             []executor.Option
+	dirs                    map[string]struct{}
+	forceAllDirs            bool
+	policyDirs              []string
+	policyReaders           []io.Reader
+	regoScanner             *rego.Scanner
+	execLock                sync.RWMutex
+	debug                   debug.Logger
+	frameworks              []framework.Framework
+	spec                    string
+	loadEmbeddedLibraries   bool
+	loadEmbeddedPolicies    bool
+	disableCodeHighlighting bool
+}
+
+func (s *Scanner) SetDisableCauses(b bool) {
+	s.disableCodeHighlighting = b
 }
 
 func (s *Scanner) SetSpec(spec string) {

--- a/pkg/iac/scanners/terraformplan/tfjson/scanner.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/scanner.go
@@ -38,6 +38,8 @@ type Scanner struct {
 	policyReaders           []io.Reader
 }
 
+func (s *Scanner) SetDisableCauses(b bool) {}
+
 func (s *Scanner) SetUseEmbeddedLibraries(b bool) {
 	s.loadEmbeddedLibraries = b
 }


### PR DESCRIPTION
## Description

Adds a new flag `--disable-causes` to disable cause output on demand.

### Before
```
LOW: container should drop all
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Containers must drop ALL capabilities, and are only permitted to add back the NET_BIND_SERVICE capability.

See https://avd.aquasec.com/misconfig/ksv106
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 test/testdata/kubernetes/optional/KSV035/denied.yaml:7-8
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   7 ┌     - name: hello
   8 └       image: blah/something
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```
### After
```
LOW: container should drop all
════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Containers must drop ALL capabilities, and are only permitted to add back the NET_BIND_SERVICE capability.

See https://avd.aquasec.com/misconfig/ksv106
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```



## Related issues
- Partially addresses https://github.com/aquasecurity/trivy/issues/6557


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
