### PR TITLE
perf(misconf): Improve cause performance

### DIFF
--- a/pkg/iac/scan/code.go
+++ b/pkg/iac/scan/code.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -149,7 +151,14 @@ func (r *Result) GetCode(opts ...CodeOption) (*Code, error) {
 		Lines: nil,
 	}
 
-	rawLines := strings.Split(string(content), "\n")
+	var rawLines []string
+	bs := bufio.NewScanner(bytes.NewReader(content))
+	for bs.Scan() {
+		rawLines = append(rawLines, bs.Text())
+	}
+	if bs.Err() != nil {
+		return nil, fmt.Errorf("failed to scan file : %w", err)
+	}
 
 	var highlightedLines []string
 	if settings.includeHighlighted {

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -503,20 +503,26 @@ func NewCauseWithCode(underlying scan.Result) types.CauseMetadata {
 			},
 		})
 	}
-	if code, err := underlying.GetCode(); err == nil {
-		cause.Code = types.Code{
-			Lines: lo.Map(code.Lines, func(l scan.Line, i int) types.Line {
-				return types.Line{
-					Number:      l.Number,
-					Content:     l.Content,
-					IsCause:     l.IsCause,
-					Annotation:  l.Annotation,
-					Truncated:   l.Truncated,
-					Highlighted: l.Highlighted,
-					FirstCause:  l.FirstCause,
-					LastCause:   l.LastCause,
-				}
-			}),
+
+	// only failures have a code cause
+	// failures can happen either due to lack of
+	// OR misconfiguration of something
+	if underlying.Status() == scan.StatusFailed {
+		if code, err := underlying.GetCode(); err == nil {
+			cause.Code = types.Code{
+				Lines: lo.Map(code.Lines, func(l scan.Line, i int) types.Line {
+					return types.Line{
+						Number:      l.Number,
+						Content:     l.Content,
+						IsCause:     l.IsCause,
+						Annotation:  l.Annotation,
+						Truncated:   l.Truncated,
+						Highlighted: l.Highlighted,
+						FirstCause:  l.FirstCause,
+						LastCause:   l.LastCause,
+					}
+				}),
+			}
 		}
 	}
 	return cause


### PR DESCRIPTION
## Description
We only need to get the offending cause if the result is a failure.

Today we end up getting a cause for every single result type, which results in unnecessary compute being done. 

As a side note, I also verified that the JSON output (when including the `--include-non-failures` flag) also does not contain any info on cause (for code excerpts) for results that are a `PASS`. 

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6557

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/6585

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
