### PR TITLE
perf: parse rego input once

### DIFF
--- a/pkg/iac/rego/exceptions.go
+++ b/pkg/iac/rego/exceptions.go
@@ -3,9 +3,11 @@ package rego
 import (
 	"context"
 	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
 )
 
-func (s *Scanner) isIgnored(ctx context.Context, namespace, ruleName string, input interface{}) (bool, error) {
+func (s *Scanner) isIgnored(ctx context.Context, namespace, ruleName string, input ast.Value) (bool, error) {
 	if ignored, err := s.isNamespaceIgnored(ctx, namespace, input); err != nil {
 		return false, err
 	} else if ignored {
@@ -14,7 +16,7 @@ func (s *Scanner) isIgnored(ctx context.Context, namespace, ruleName string, inp
 	return s.isRuleIgnored(ctx, namespace, ruleName, input)
 }
 
-func (s *Scanner) isNamespaceIgnored(ctx context.Context, namespace string, input interface{}) (bool, error) {
+func (s *Scanner) isNamespaceIgnored(ctx context.Context, namespace string, input ast.Value) (bool, error) {
 	exceptionQuery := fmt.Sprintf("data.namespace.exceptions.exception[_] == %q", namespace)
 	result, _, err := s.runQuery(ctx, exceptionQuery, input, true)
 	if err != nil {
@@ -23,7 +25,7 @@ func (s *Scanner) isNamespaceIgnored(ctx context.Context, namespace string, inpu
 	return result.Allowed(), nil
 }
 
-func (s *Scanner) isRuleIgnored(ctx context.Context, namespace, ruleName string, input interface{}) (bool, error) {
+func (s *Scanner) isRuleIgnored(ctx context.Context, namespace, ruleName string, input ast.Value) (bool, error) {
 	exceptionQuery := fmt.Sprintf("endswith(%q, data.%s.exception[_][_])", ruleName, namespace)
 	result, _, err := s.runQuery(ctx, exceptionQuery, input, true)
 	if err != nil {


### PR DESCRIPTION
## Description

We can pass Rego ast types instead of raw input, which will reduce the time cost of parsing as we apply Rego to the same input data multiple times.

Tested on https://github.com/kubernetes/minikube.

before: `time go run ./cmd/trivy conf ~/projects/minikube -q  261.24s user 7.95s system 167% cpu 2:41.04 total`
after: `time go run ./cmd/trivy conf ~/projects/minikube -q  127.74s user 6.90s system 151% cpu 1:28.74 total`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
