### PR TITLE
docs: remove mention of GitLab Gold because it doesn't exist anymore

### DIFF
--- a/docs/tutorials/integrations/gitlab-ci.md
+++ b/docs/tutorials/integrations/gitlab-ci.md
@@ -49,7 +49,7 @@ trivy:
   cache:
     paths:
       - .trivycache/
-  # Enables https://docs.gitlab.com/ee/user/application_security/container_scanning/ (Container Scanning report is available on GitLab EE Ultimate or GitLab.com Gold)
+  # Enables https://docs.gitlab.com/ee/user/application_security/container_scanning/ (Container Scanning report is available on GitLab Ultimate)
   artifacts:
     reports:
       container_scanning: gl-container-scanning-report.json


### PR DESCRIPTION
## Description

This PR removes the mention of GitLab Gold in the `gitlab-ci` docs because GitLab renamed their SaaS offerings to match the names of the on-prem offerings.

## Related issues
There is no issue because this only fixes a trivial documentation issue.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
~~- [ ] I've added tests that prove my fix is effective or that my feature works.~~
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
