### PR TITLE
fix(misconf): do not use semver for parsing tf module versions

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_integration_test.go
@@ -49,3 +49,26 @@ module "registry" {
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
+
+func Test_ModuleWithPessimisticVersionConstraint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	fs := testutil.CreateFS(t, map[string]string{
+		"code/test.tf": `
+module "registry" {
+	source = "registry.terraform.io/terraform-aws-modules/s3-bucket/aws"
+	bucket = "my-s3-bucket"
+	version = "~> 3.1"
+}
+`,
+	})
+
+	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
+	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
+		t.Fatal(err)
+	}
+	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+}

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/net/idna"
 
-	"github.com/aquasecurity/go-version/pkg/semver"
+	"github.com/aquasecurity/go-version/pkg/version"
 )
 
 type registryResolver struct {
@@ -167,13 +167,13 @@ func resolveVersion(input string, versions moduleVersions) (string, error) {
 		return "", fmt.Errorf("no available versions for module")
 	}
 
-	constraints, err := semver.NewConstraints(input)
+	constraints, err := version.NewConstraints(input)
 	if err != nil {
 		return "", err
 	}
-	var realVersions semver.Collection
+	var realVersions version.Collection
 	for _, rawVersion := range versions.Modules[0].Versions {
-		realVersion, err := semver.Parse(rawVersion.Version)
+		realVersion, err := version.Parse(rawVersion.Version)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Description

Terraform does [not use](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraints) semantic module versioning, so we must use the `github.com/aquasecurity/go-version/pkg/version` package to parsing module versions.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6537

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
