### PR TITLE
refactor: move setting scanners when using compliance reports to flag parsing

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -172,6 +172,7 @@ func TestFlags(t *testing.T) {
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity
+		scanners   types.Scanners
 	}
 	tests := []struct {
 		name      string
@@ -193,6 +194,10 @@ func TestFlags(t *testing.T) {
 					dbTypes.SeverityHigh,
 					dbTypes.SeverityCritical,
 				},
+				scanners: types.Scanners{
+					types.VulnerabilityScanner,
+					types.SecretScanner,
+				},
 			},
 		},
 		{
@@ -207,6 +212,10 @@ func TestFlags(t *testing.T) {
 				severities: []dbTypes.Severity{
 					dbTypes.SeverityLow,
 					dbTypes.SeverityMedium,
+				},
+				scanners: types.Scanners{
+					types.VulnerabilityScanner,
+					types.SecretScanner,
 				},
 			},
 		},
@@ -225,6 +234,10 @@ func TestFlags(t *testing.T) {
 					dbTypes.SeverityLow,
 					dbTypes.SeverityHigh,
 				},
+				scanners: types.Scanners{
+					types.VulnerabilityScanner,
+					types.SecretScanner,
+				},
 			},
 		},
 		{
@@ -240,6 +253,33 @@ func TestFlags(t *testing.T) {
 				format: types.FormatJSON,
 				severities: []dbTypes.Severity{
 					dbTypes.SeverityCritical,
+				},
+				scanners: types.Scanners{
+					types.VulnerabilityScanner,
+					types.SecretScanner,
+				},
+			},
+		},
+		{
+			name: "happy path with scanners for compliance report",
+			arguments: []string{
+				"test",
+				"--scanners",
+				"license",
+				"--compliance",
+				"docker-cis",
+			},
+			want: want{
+				format: types.FormatTable,
+				severities: []dbTypes.Severity{
+					dbTypes.SeverityUnknown,
+					dbTypes.SeverityLow,
+					dbTypes.SeverityMedium,
+					dbTypes.SeverityHigh,
+					dbTypes.SeverityCritical,
+				},
+				scanners: types.Scanners{
+					types.VulnerabilityScanner,
 				},
 			},
 		},
@@ -264,6 +304,7 @@ func TestFlags(t *testing.T) {
 			flags := &flag.Flags{
 				GlobalFlagGroup: globalFlags,
 				ReportFlagGroup: flag.NewReportFlagGroup(),
+				ScanFlagGroup:   flag.NewScanFlagGroup(),
 			}
 			cmd := &cobra.Command{
 				Use: "test",
@@ -280,6 +321,7 @@ func TestFlags(t *testing.T) {
 
 					assert.Equal(t, tt.want.format, options.Format)
 					assert.Equal(t, tt.want.severities, options.Severities)
+					assert.Equal(t, tt.want.scanners, options.Scanners)
 					return nil
 				},
 			}

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -533,25 +533,6 @@ func initScannerConfig(opts flag.Options, cacheClient cache.Cache) (ScannerConfi
 		target = opts.Input
 	}
 
-	if opts.Compliance.Spec.ID != "" {
-		// set scanners types by spec
-		scanners, err := opts.Compliance.Scanners()
-		if err != nil {
-			return ScannerConfig{}, types.ScanOptions{}, xerrors.Errorf("scanner error: %w", err)
-		}
-
-		opts.Scanners = scanners
-		opts.ImageConfigScanners = nil
-		// TODO: define image-config-scanners in the spec
-		if opts.Compliance.Spec.ID == "docker-cis" {
-			opts.Scanners = types.Scanners{types.VulnerabilityScanner}
-			opts.ImageConfigScanners = types.Scanners{
-				types.MisconfigScanner,
-				types.SecretScanner,
-			}
-		}
-	}
-
 	scanOptions := types.ScanOptions{
 		VulnType:            opts.VulnType,
 		Scanners:            opts.Scanners,


### PR DESCRIPTION
## Description
when using compliance reports, we init some options before configuring the scanners (e.g. init trivy-db).
To avoid panic, we need to set up scanners when parsing flags.

## Related issues
- Close #6613

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
