### PR TITLE
docs: link warning to both timeout config options

### DIFF
--- a/pkg/cloud/aws/commands/run.go
+++ b/pkg/cloud/aws/commands/run.go
@@ -140,7 +140,7 @@ func Run(ctx context.Context, opt flag.Options) error {
 	var err error
 	defer func() {
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Warn("Increase --timeout value")
+			log.Warn("Provide a higher timeout value, see https://aquasecurity.github.io/trivy/latest/docs/configuration/")
 		}
 	}()
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -397,7 +397,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 
 	defer func() {
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Warn("Increase --timeout value")
+			log.Warn("Provide a higher timeout value, see https://aquasecurity.github.io/trivy/latest/docs/configuration/")
 		}
 	}()
 

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -39,7 +39,7 @@ func Run(ctx context.Context, args []string, opts flag.Options) error {
 	defer func() {
 		cancel()
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.WarnContext(ctx, "Increase --timeout value")
+			log.WarnContext(ctx, "Provide a higher timeout value, see https://aquasecurity.github.io/trivy/latest/docs/configuration/")
 		}
 	}()
 	opts.K8sVersion = cluster.GetClusterVersion()


### PR DESCRIPTION
## Description

Should these warnings only mention the CLI flag? How about instead linking to a docs page 1 level higher, so that users who encounter these warnings can then pick the relevant way to set their higher timeout?

## (Semi-)Related issues

- https://github.com/aquasecurity/trivy/issues/2054
- https://github.com/aquasecurity/trivy/issues/3421

## ~~Related PRs~~

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
   - The exact strings don't seem to be tested for, so is this needed?
   - … double-checking locally …
- [~] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [~] I've added usage information (if the PR introduces new options)
- [~] I've included a "before" and "after" example to the description (if the PR is a user interface change).
