### PR TITLE
fix(fs): handle default skip dirs properly

### DIFF
--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -23,8 +23,8 @@ func NewFS() *FS {
 // Walk walks the filesystem rooted at root, calling fn for each unfiltered file.
 func (w *FS) Walk(root string, opt Option, fn WalkFunc) error {
 	opt.SkipFiles = w.BuildSkipPaths(root, opt.SkipFiles)
-	opt.SkipDirs = append(opt.SkipDirs, defaultSkipDirs...)
 	opt.SkipDirs = w.BuildSkipPaths(root, opt.SkipDirs)
+	opt.SkipDirs = append(opt.SkipDirs, defaultSkipDirs...)
 
 	walkDirFunc := w.WalkDirFunc(root, fn, opt)
 	walkDirFunc = w.onError(walkDirFunc)
@@ -50,22 +50,22 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 		}
 		relPath = filepath.ToSlash(relPath)
 
-		info, err := d.Info()
-		if err != nil {
-			return xerrors.Errorf("file info error: %w", err)
-		}
-
 		// Skip unnecessary files
 		switch {
-		case info.IsDir():
+		case d.IsDir():
 			if SkipPath(relPath, opt.SkipDirs) {
 				return filepath.SkipDir
 			}
 			return nil
-		case !info.Mode().IsRegular():
+		case !d.Type().IsRegular():
 			return nil
 		case SkipPath(relPath, opt.SkipFiles):
 			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return xerrors.Errorf("file info error: %w", err)
 		}
 
 		if err = fn(relPath, info, fileOpener(filePath)); err != nil {
@@ -83,8 +83,11 @@ func (w *FS) onError(wrapped fs.WalkDirFunc) fs.WalkDirFunc {
 		// Unwrap fs.SkipDir error
 		case errors.Is(err, fs.SkipDir):
 			return fs.SkipDir
-		// ignore permission errors
+		// Ignore permission errors
 		case os.IsPermission(err):
+			return nil
+		// Ignore "file does not exist" errors: it happens with special files like /proc/.
+		case errors.Is(err, fs.ErrNotExist):
 			return nil
 		case err != nil:
 			// halt traversal on any other error

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -86,9 +86,6 @@ func (w *FS) onError(wrapped fs.WalkDirFunc) fs.WalkDirFunc {
 		// Ignore permission errors
 		case os.IsPermission(err):
 			return nil
-		// Ignore "file does not exist" errors: it happens with special files like /proc/.
-		case errors.Is(err, fs.ErrNotExist):
-			return nil
 		case err != nil:
 			// halt traversal on any other error
 			return xerrors.Errorf("unknown error with %s: %w", filePath, err)


### PR DESCRIPTION
## Description
There are two problems. First, `d.Info()` could return an error on system files, like `/proc`. It is currently called before skipping dirs. File walking exits before processing skipping dirs. Second, user-specified skipping dirs are pre-processed, but the default skipping dirs are also processed by mistake. This PR fixes these two problems.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6627

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
