### PR TITLE
chore(deps): bump `knqyf263/trivy-issue-action` to v0.0.6

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4.1.4
 
       - name: Run Trivy vulnerability scanner and create GitHub issues
-        uses: knqyf263/trivy-issue-action@v0.0.5
+        uses: knqyf263/trivy-issue-action@v0.0.6
         with:
           assignee: knqyf263
           severity: CRITICAL


### PR DESCRIPTION
## Description
We use old Trivy in [Scan vulnerabilities](https://github.com/aquasecurity/trivy/actions/workflows/scan.yaml) and get errors - https://github.com/aquasecurity/trivy/actions/runs/8962160517/job/24610643339

Bump `knqyf263/trivy-issue-action` to v0.0.6

Test run - https://github.com/DmitriyLewen/trivy/actions/runs/8964744455/job/24617010006

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
