### PR TITLE
ci: add `generic` dir to deb deploy script

### DIFF
--- a/ci/deploy-deb.sh
+++ b/ci/deploy-deb.sh
@@ -5,14 +5,14 @@ UBUNTU_RELEASES=$(sort -u <(ubuntu-distro-info --supported-esm) <(ubuntu-distro-
 
 cd trivy-repo/deb
 
-for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Removing deb package of $release"
   reprepro -A i386 remove $release trivy
   reprepro -A amd64 remove $release trivy
   reprepro -A arm64 remove $release trivy
 done
 
-for release in ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
+for release in generic ${DEBIAN_RELEASES[@]} ${UBUNTU_RELEASES[@]}; do
   echo "Adding deb package to $release"
   reprepro includedeb $release ../../dist/*Linux-32bit.deb
   reprepro includedeb $release ../../dist/*Linux-64bit.deb


### PR DESCRIPTION
## Description
Add `generic` dir to deb deploy script.

## Related PRs
- [x] aquasecurity/trivy-repo/pull/37
- [x] #6606

Test:
 - https://github.com/DmitriyLewen/trivy/actions/runs/8965411083/job/24620153662
 - https://github.com/DmitriyLewen/trivy-repo/tree/main/deb/dists/generic

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
