### PR TITLE
fix(misconf): skip Rego errors with a nil location

### DIFF
--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -149,6 +149,10 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 	var excludedFiles []string
 
 	for _, e := range compiler.Errors {
+		if e.Location == nil {
+			continue
+		}
+
 		loc := e.Location.File
 
 		if lo.Contains(excludedFiles, loc) {


### PR DESCRIPTION
## Description

We have to skip errors without locations.

https://github.com/aquasecurity/trivy/pull/6502#discussion_r1591042149

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
