### PR TITLE
fix: skip only absolute filesystem dirs

### DIFF
--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -16,9 +16,9 @@ const defaultSizeThreshold = int64(100) << 20 // 200MB
 
 var defaultSkipDirs = []string{
 	"**/.git",
-	"proc",
-	"sys",
-	"dev",
+	"/proc",
+	"/sys",
+	"/dev",
 }
 
 type Option struct {


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6651

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
