### PR TITLE
fix(misconf): skip Rego errors with a nil location

### DIFF
--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -184,7 +184,7 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 	}
 
 	compiler.Errors = lo.Filter(compiler.Errors, func(e *ast.Error, _ int) bool {
-		return !lo.Contains(excludedFiles, e.Location.File)
+		return e.Location == nil || !lo.Contains(excludedFiles, e.Location.File)
 	})
 }
 
@@ -219,6 +219,9 @@ func (s *Scanner) prunePoliciesWithError(compiler *ast.Compiler) error {
 	}
 
 	for _, e := range compiler.Errors {
+		if e.Location == nil {
+			continue
+		}
 		s.debug.Log("Error occurred while parsing: %s, %s", e.Location.File, e.Error())
 		delete(s.policies, e.Location.File)
 	}


### PR DESCRIPTION
## Description

Fixes https://github.com/aquasecurity/trivy/pull/6638#issuecomment-2099813132

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
