### PR TITLE
chore(deps): use errors instead of golang.org/x/xerrors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,22 +70,23 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - unused
-    - ineffassign
-    - typecheck
-    - govet
-    - revive
-    - gosec
-    - unconvert
+    - bodyclose
+    - errorlint
+    - gci
     - goconst
+    - gocritic
     - gocyclo
     - gofmt
-    - misspell
-    - bodyclose
-    - gci
     - gomodguard
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - revive
     - tenv
-    - gocritic
+    - typecheck
+    - unconvert
+    - unused
 
 run:
   go: '1.22'

--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -3,9 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/commands"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -29,10 +28,10 @@ func run() error {
 	// Trivy behaves as the specified plugin.
 	if runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN"); runAsPlugin != "" {
 		if !plugin.IsPredefined(runAsPlugin) {
-			return xerrors.Errorf("unknown plugin: %s", runAsPlugin)
+			return fmt.Errorf("unknown plugin: %s", runAsPlugin)
 		}
 		if err := plugin.RunWithURL(context.Background(), runAsPlugin, plugin.RunOptions{Args: os.Args[1:]}); err != nil {
-			return xerrors.Errorf("plugin error: %w", err)
+			return fmt.Errorf("plugin error: %w", err)
 		}
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,10 @@ require (
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/alecthomas/chroma v0.10.0
 	github.com/alicebob/miniredis/v2 v2.31.1
+	github.com/antchfx/htmlquery v1.3.0
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -36,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
+	github.com/aws/smithy-go v1.20.2
 	github.com/bitnami/go-version v0.0.0-20231130084017-bb00604d650c
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -58,7 +62,12 @@ require (
 	github.com/hashicorp/go-getter v1.7.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
+	github.com/hashicorp/go-uuid v1.0.3
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hashicorp/hc-install v0.6.3
+	github.com/hashicorp/hcl/v2 v2.19.1
+	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f
 	github.com/knqyf263/go-deb-version v0.0.0-20230223133812-3ed183d23422
@@ -66,7 +75,9 @@ require (
 	github.com/knqyf263/go-rpmdb v0.0.0-20231008124120-ac49267ab4e1
 	github.com/knqyf263/nested v0.0.1
 	github.com/kylelemons/godebug v1.1.0
+	github.com/liamg/iamgo v0.0.9
 	github.com/liamg/jfather v0.0.7
+	github.com/liamg/memoryfs v1.6.0
 	github.com/magefile/mage v1.15.0
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/masahiro331/go-disk v0.0.0-20220919035250-c8da316f91ac
@@ -77,6 +88,7 @@ require (
 	github.com/masahiro331/go-xfs-filesystem v0.0.0-20230608043311-a335f4599b70
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/microsoft/go-rustaudit v0.0.0-20220808201409-204dfee52032
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/buildkit v0.12.5
@@ -85,6 +97,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/openvex/go-vex v0.2.5
 	github.com/owenrumney/go-sarif/v2 v2.3.0
+	github.com/owenrumney/squealer v1.2.2
 	github.com/package-url/packageurl-go v0.1.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/samber/lo v1.39.0
@@ -104,40 +117,24 @@ require (
 	github.com/twitchtv/twirp v8.1.2+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xlab/treeprint v1.2.0
+	github.com/zclconf/go-cty v1.14.4
+	github.com/zclconf/go-cty-yaml v1.0.3
 	go.etcd.io/bbolt v1.3.9
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/mod v0.16.0
 	golang.org/x/net v0.24.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/term v0.19.0
 	golang.org/x/text v0.14.0
-	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
+	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/protobuf v1.34.0
 	gopkg.in/yaml.v3 v3.0.1
+	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.3
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	modernc.org/sqlite v1.29.7
-)
-
-require (
-	github.com/alecthomas/chroma v0.10.0
-	github.com/antchfx/htmlquery v1.3.0
-	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/aws/smithy-go v1.20.2
-	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hc-install v0.6.3
-	github.com/hashicorp/hcl/v2 v2.19.1
-	github.com/hashicorp/terraform-exec v0.20.0
-	github.com/liamg/iamgo v0.0.9
-	github.com/liamg/memoryfs v1.6.0
-	github.com/mitchellh/go-homedir v1.1.0
-	github.com/owenrumney/squealer v1.2.2
-	github.com/zclconf/go-cty v1.14.4
-	github.com/zclconf/go-cty-yaml v1.0.3
-	golang.org/x/crypto v0.22.0
-	helm.sh/helm/v3 v3.14.2
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-	"golang.org/x/xerrors"
 )
 
 // CosignPredicate specifies the format of the Custom Predicate.
@@ -24,20 +24,20 @@ func (s *Statement) UnmarshalJSON(b []byte) error {
 	var envelope dsse.Envelope
 	err := json.NewDecoder(bytes.NewReader(b)).Decode(&envelope)
 	if err != nil {
-		return xerrors.Errorf("failed to decode as a dsse envelope: %w", err)
+		return fmt.Errorf("failed to decode as a dsse envelope: %w", err)
 	}
 	if envelope.PayloadType != in_toto.PayloadType {
-		return xerrors.Errorf("invalid attestation payload type: %s", envelope.PayloadType)
+		return fmt.Errorf("invalid attestation payload type: %s", envelope.PayloadType)
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(envelope.Payload)
 	if err != nil {
-		return xerrors.Errorf("failed to decode attestation payload: %w", err)
+		return fmt.Errorf("failed to decode attestation payload: %w", err)
 	}
 
 	statement := (*in_toto.Statement)(s)
 	if err = json.NewDecoder(bytes.NewReader(decoded)).Decode(statement); err != nil {
-		return xerrors.Errorf("failed to decode attestation payload as in-toto statement: %w", err)
+		return fmt.Errorf("failed to decode attestation payload as in-toto statement: %w", err)
 	}
 
 	return nil

--- a/pkg/cache/remote.go
+++ b/pkg/cache/remote.go
@@ -3,9 +3,8 @@ package cache
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -44,7 +43,7 @@ func (c RemoteCache) PutArtifact(imageID string, artifactInfo types.ArtifactInfo
 		return err
 	})
 	if err != nil {
-		return xerrors.Errorf("unable to store cache on the server: %w", err)
+		return fmt.Errorf("unable to store cache on the server: %w", err)
 	}
 	return nil
 }
@@ -57,7 +56,7 @@ func (c RemoteCache) PutBlob(diffID string, blobInfo types.BlobInfo) error {
 		return err
 	})
 	if err != nil {
-		return xerrors.Errorf("unable to store cache on the server: %w", err)
+		return fmt.Errorf("unable to store cache on the server: %w", err)
 	}
 	return nil
 }
@@ -71,7 +70,7 @@ func (c RemoteCache) MissingBlobs(imageID string, layerIDs []string) (bool, []st
 		return err
 	})
 	if err != nil {
-		return false, nil, xerrors.Errorf("unable to fetch missing layers: %w", err)
+		return false, nil, fmt.Errorf("unable to fetch missing layers: %w", err)
 	}
 	return layers.MissingArtifact, layers.MissingBlobIds, nil
 }
@@ -84,7 +83,7 @@ func (c RemoteCache) DeleteBlobs(blobIDs []string) error {
 		return err
 	})
 	if err != nil {
-		return xerrors.Errorf("unable to delete blobs on the server: %w", err)
+		return fmt.Errorf("unable to delete blobs on the server: %w", err)
 	}
 	return nil
 }

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -2,6 +2,7 @@ package cache_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twitchtv/twirp"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/cache"
 	fcache "github.com/aquasecurity/trivy/pkg/fanal/cache"
@@ -27,14 +27,14 @@ type mockCacheServer struct {
 
 func (s *mockCacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
 	if strings.Contains(in.ArtifactId, "invalid") {
-		return &google_protobuf.Empty{}, xerrors.New("invalid image ID")
+		return &google_protobuf.Empty{}, errors.New("invalid image ID")
 	}
 	return &google_protobuf.Empty{}, nil
 }
 
 func (s *mockCacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
 	if strings.Contains(in.DiffId, "invalid") {
-		return &google_protobuf.Empty{}, xerrors.New("invalid layer ID")
+		return &google_protobuf.Empty{}, errors.New("invalid layer ID")
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -43,7 +43,7 @@ func (s *mockCacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBl
 	var layerIDs []string
 	for _, layerID := range in.BlobIds[:len(in.BlobIds)-1] {
 		if strings.Contains(layerID, "invalid") {
-			return nil, xerrors.New("invalid layer ID")
+			return nil, errors.New("invalid layer ID")
 		}
 		layerIDs = append(layerIDs, layerID)
 	}
@@ -53,7 +53,7 @@ func (s *mockCacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBl
 func (s *mockCacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
 	for _, blobId := range in.GetBlobIds() {
 		if strings.Contains(blobId, "invalid") {
-			return &google_protobuf.Empty{}, xerrors.New("invalid layer ID")
+			return &google_protobuf.Empty{}, errors.New("invalid layer ID")
 		}
 	}
 	return &google_protobuf.Empty{}, nil

--- a/pkg/cloud/aws/config/config.go
+++ b/pkg/cloud/aws/config/config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"golang.org/x/xerrors"
 )
 
 func EndpointResolver(endpoint string) aws.EndpointResolverWithOptionsFunc {
@@ -36,11 +37,11 @@ func MakeAWSOptions(region, endpoint string) []func(*awsconfig.LoadOptions) erro
 func LoadDefaultAWSConfig(ctx context.Context, region, endpoint string) (aws.Config, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, MakeAWSOptions(region, endpoint)...)
 	if err != nil {
-		return aws.Config{}, xerrors.Errorf("aws config load error: %w", err)
+		return aws.Config{}, fmt.Errorf("aws config load error: %w", err)
 	}
 
 	if cfg.Region == "" {
-		return aws.Config{}, xerrors.New("aws region is required")
+		return aws.Config{}, errors.New("aws region is required")
 	}
 
 	return cfg, nil

--- a/pkg/cloud/aws/scanner/scanner.go
+++ b/pkg/cloud/aws/scanner/scanner.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 
-	"golang.org/x/xerrors"
-
 	aws "github.com/aquasecurity/trivy-aws/pkg/scanner"
 	"github.com/aquasecurity/trivy/pkg/cloud/aws/cache"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
@@ -89,7 +87,7 @@ func (s *AWSScanner) Scan(ctx context.Context, option flag.Options) (scan.Result
 	var policyFS fs.FS
 	policyFS, policyPaths, err = misconf.CreatePolicyFS(append(policyPaths, option.RegoOptions.CheckPaths...))
 	if err != nil {
-		return nil, false, xerrors.Errorf("unable to create policyfs: %w", err)
+		return nil, false, fmt.Errorf("unable to create policyfs: %w", err)
 	}
 
 	scannerOpts = append(scannerOpts,

--- a/pkg/cloud/report/report.go
+++ b/pkg/cloud/report/report.go
@@ -2,12 +2,11 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sort"
 	"time"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/tml"
 	"github.com/aquasecurity/trivy/pkg/clock"
@@ -62,7 +61,7 @@ func (r *Report) Failed() bool {
 func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) error {
 	output, cleanup, err := opt.OutputWriter(ctx)
 	if err != nil {
-		return xerrors.Errorf("failed to create output file: %w", err)
+		return fmt.Errorf("failed to create output file: %w", err)
 	}
 	defer cleanup()
 
@@ -72,7 +71,7 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 
 	ignoreConf, err := result.ParseIgnoreFile(ctx, opt.IgnoreFile)
 	if err != nil {
-		return xerrors.Errorf("%s error: %w", opt.IgnoreFile, err)
+		return fmt.Errorf("%s error: %w", opt.IgnoreFile, err)
 	}
 
 	var filtered []types.Result
@@ -149,7 +148,7 @@ func writeCompliance(ctx context.Context, rep *Report, opt flag.Options, output 
 
 	complianceReport, err := cr.BuildComplianceReport(crr, opt.Compliance)
 	if err != nil {
-		return xerrors.Errorf("compliance report build error: %w", err)
+		return fmt.Errorf("compliance report build error: %w", err)
 	}
 
 	return cr.Write(ctx, complianceReport, cr.Option{

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/xerrors"
 
 	awsScanner "github.com/aquasecurity/trivy-aws/pkg/scanner"
 	awscommands "github.com/aquasecurity/trivy/pkg/cloud/aws/commands"
@@ -125,7 +124,7 @@ func loadPluginCommands() []*cobra.Command {
 			GroupID: groupPlugin,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if err = p.Run(cmd.Context(), plugin.RunOptions{Args: args}); err != nil {
-					return xerrors.Errorf("plugin error: %w", err)
+					return fmt.Errorf("plugin error: %w", err)
 				}
 				return nil
 			},
@@ -147,7 +146,7 @@ func initConfig(configFile string) error {
 			log.Debug("Config file not found", log.String("file_path", configFile))
 			return nil
 		}
-		return xerrors.Errorf("config file %q loading error: %s", configFile, err)
+		return fmt.Errorf("config file %q loading error: %s", configFile, err)
 	}
 	log.Info("Loaded", log.String("file_path", configFile))
 	return nil
@@ -179,7 +178,7 @@ func NewRootCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			// cf. https://github.com/spf13/cobra/issues/875
 			//     https://github.com/spf13/viper/issues/233
 			if err := globalFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 
 			// The config path is needed for config initialization.
@@ -295,14 +294,14 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			// cf. https://github.com/spf13/cobra/issues/875
 			//     https://github.com/spf13/viper/issues/233
 			if err := imageFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options, err := imageFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return artifact.Run(cmd.Context(), options, artifact.TargetContainerImage)
 		},
@@ -352,17 +351,17 @@ func NewFilesystemCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
   $ trivy fs ./trivy-ci-test/Pipfile.lock`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := fsFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := fsFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := fsFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return artifact.Run(cmd.Context(), options, artifact.TargetFilesystem)
 		},
@@ -412,17 +411,17 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
   / # trivy rootfs /`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := rootfsFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := rootfsFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := rootfsFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return artifact.Run(cmd.Context(), options, artifact.TargetRootfs)
 		},
@@ -468,17 +467,17 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
   $ trivy repo /path/to/your/repository`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := repoFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := repoFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := repoFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return artifact.Run(cmd.Context(), options, artifact.TargetRepository)
 		},
@@ -509,17 +508,17 @@ func NewConvertCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := convertFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := convertFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			opts, err := convertFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 
 			return convert.Run(cmd.Context(), opts)
@@ -565,7 +564,7 @@ func NewClientCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		Hidden:  true, // 'client' command is deprecated
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := clientFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
@@ -573,11 +572,11 @@ func NewClientCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			log.Warn("'client' subcommand is deprecated now. See https://github.com/aquasecurity/trivy/discussions/2119")
 
 			if err := clientFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := clientFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return artifact.Run(cmd.Context(), options, artifact.TargetContainerImage)
 		},
@@ -620,11 +619,11 @@ func NewServerCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := serverFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := serverFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			return server.Run(cmd.Context(), options)
 		},
@@ -677,17 +676,17 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		Short:   "Scan config files for misconfigurations",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := configFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := configFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := configFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 
 			// Disable OS and language analyzers
@@ -727,7 +726,7 @@ func NewPluginCommand() *cobra.Command {
 			Args:                  cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if _, err := plugin.Install(cmd.Context(), args[0], true); err != nil {
-					return xerrors.Errorf("plugin install error: %w", err)
+					return fmt.Errorf("plugin install error: %w", err)
 				}
 				return nil
 			},
@@ -741,7 +740,7 @@ func NewPluginCommand() *cobra.Command {
 			Args:                  cobra.ExactArgs(1),
 			RunE: func(_ *cobra.Command, args []string) error {
 				if err := plugin.Uninstall(args[0]); err != nil {
-					return xerrors.Errorf("plugin uninstall error: %w", err)
+					return fmt.Errorf("plugin uninstall error: %w", err)
 				}
 				return nil
 			},
@@ -756,10 +755,10 @@ func NewPluginCommand() *cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				info, err := plugin.List()
 				if err != nil {
-					return xerrors.Errorf("plugin list display error: %w", err)
+					return fmt.Errorf("plugin list display error: %w", err)
 				}
 				if _, err := fmt.Fprint(os.Stdout, info); err != nil {
-					return xerrors.Errorf("print error: %w", err)
+					return fmt.Errorf("print error: %w", err)
 				}
 				return nil
 			},
@@ -773,10 +772,10 @@ func NewPluginCommand() *cobra.Command {
 			RunE: func(_ *cobra.Command, args []string) error {
 				info, err := plugin.Information(args[0])
 				if err != nil {
-					return xerrors.Errorf("plugin information display error: %w", err)
+					return fmt.Errorf("plugin information display error: %w", err)
 				}
 				if _, err := fmt.Fprint(os.Stdout, info); err != nil {
-					return xerrors.Errorf("print error: %w", err)
+					return fmt.Errorf("print error: %w", err)
 				}
 				return nil
 			},
@@ -800,7 +799,7 @@ func NewPluginCommand() *cobra.Command {
 			Args:                  cobra.ExactArgs(1),
 			RunE: func(_ *cobra.Command, args []string) error {
 				if err := plugin.Update(args[0]); err != nil {
-					return xerrors.Errorf("plugin update error: %w", err)
+					return fmt.Errorf("plugin update error: %w", err)
 				}
 				return nil
 			},
@@ -834,7 +833,7 @@ func NewModuleCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			Args:    cobra.ExactArgs(1),
 			PreRunE: func(cmd *cobra.Command, args []string) error {
 				if err := moduleFlags.Bind(cmd); err != nil {
-					return xerrors.Errorf("flag bind error: %w", err)
+					return fmt.Errorf("flag bind error: %w", err)
 				}
 				return nil
 			},
@@ -846,7 +845,7 @@ func NewModuleCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 				repo := args[0]
 				opts, err := moduleFlags.ToOptions(args)
 				if err != nil {
-					return xerrors.Errorf("flag error: %w", err)
+					return fmt.Errorf("flag error: %w", err)
 				}
 				return module.Install(cmd.Context(), opts.ModuleDir, repo, opts.Quiet, opts.RegistryOpts())
 			},
@@ -858,7 +857,7 @@ func NewModuleCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			Args:    cobra.ExactArgs(1),
 			PreRunE: func(cmd *cobra.Command, args []string) error {
 				if err := moduleFlags.Bind(cmd); err != nil {
-					return xerrors.Errorf("flag bind error: %w", err)
+					return fmt.Errorf("flag bind error: %w", err)
 				}
 				return nil
 			},
@@ -870,7 +869,7 @@ func NewModuleCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 				repo := args[0]
 				opts, err := moduleFlags.ToOptions(args)
 				if err != nil {
-					return xerrors.Errorf("flag error: %w", err)
+					return fmt.Errorf("flag error: %w", err)
 				}
 				return module.Uninstall(cmd.Context(), opts.ModuleDir, repo)
 			},
@@ -954,17 +953,17 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := k8sFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := k8sFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			opts, err := k8sFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 
 			return k8scommands.Run(cmd.Context(), args, opts)
@@ -1028,14 +1027,14 @@ The following services are supported:
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := awsFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts, err := awsFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			if opts.Timeout < time.Hour {
 				opts.Timeout = time.Hour
@@ -1091,17 +1090,17 @@ func NewVMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := vmFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := vmFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := vmFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 			if options.Timeout < time.Minute*30 {
 				options.Timeout = time.Minute * 30
@@ -1166,17 +1165,17 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := sbomFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			return validateArgs(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := sbomFlags.Bind(cmd); err != nil {
-				return xerrors.Errorf("flag bind error: %w", err)
+				return fmt.Errorf("flag bind error: %w", err)
 			}
 			options, err := sbomFlags.ToOptions(args)
 			if err != nil {
-				return xerrors.Errorf("flag error: %w", err)
+				return fmt.Errorf("flag error: %w", err)
 			}
 
 			return artifact.Run(cmd.Context(), options, artifact.TargetSBOM)
@@ -1221,7 +1220,7 @@ func showVersion(cacheDir, outputFormat string, w io.Writer) error {
 	switch outputFormat {
 	case "json":
 		if err := json.NewEncoder(w).Encode(versionInfo); err != nil {
-			return xerrors.Errorf("json encode error: %w", err)
+			return fmt.Errorf("json encode error: %w", err)
 		}
 	default:
 		fmt.Fprint(w, versionInfo.String())
@@ -1243,14 +1242,14 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 		}
 
 		if f := cmd.Flags().Lookup(flag.InputFlag.ConfigName); f != nil {
-			return xerrors.New(`Require at least 1 argument or --input option`)
+			return errors.New(`Require at least 1 argument or --input option`)
 		}
-		return xerrors.New(`Require at least 1 argument`)
+		return errors.New(`Require at least 1 argument`)
 	} else if cmd.Name() != "kubernetes" && len(args) > 1 {
 		if err := cmd.Help(); err != nil {
 			return err
 		}
-		return xerrors.New(`multiple targets cannot be specified`)
+		return errors.New(`multiple targets cannot be specified`)
 	}
 
 	return nil

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -2,8 +2,7 @@ package artifact
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy/pkg/scanner"
 )
@@ -14,7 +13,7 @@ func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Sc
 	s, cleanup, err := initializeImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
 		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize an image scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize an image scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -24,7 +23,7 @@ func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Sc
 func archiveStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, err := initializeArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize the archive scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize the archive scanner: %w", err)
 	}
 	return s, func() {}, nil
 }
@@ -36,7 +35,7 @@ func imageRemoteScanner(ctx context.Context, conf ScannerConfig) (
 	s, cleanup, err := initializeRemoteImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
 		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize a remote image scanner: %w", err)
+		return scanner.Scanner{}, nil, fmt.Errorf("unable to initialize a remote image scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -47,7 +46,7 @@ func archiveRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scan
 	// Scan tar file
 	s, err := initializeRemoteArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize the remote archive scanner: %w", err)
+		return scanner.Scanner{}, nil, fmt.Errorf("unable to initialize the remote archive scanner: %w", err)
 	}
 	return s, func() {}, nil
 }
@@ -56,7 +55,7 @@ func archiveRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scan
 func filesystemStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a filesystem scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -65,7 +64,7 @@ func filesystemStandaloneScanner(ctx context.Context, conf ScannerConfig) (scann
 func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRemoteFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote filesystem scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a remote filesystem scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -74,7 +73,7 @@ func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 func repositoryStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a repository scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a repository scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -84,7 +83,7 @@ func repositoryRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 	s, cleanup, err := initializeRemoteRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
 		conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote repository scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a remote repository scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -93,7 +92,7 @@ func repositoryRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 func sbomStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeSBOMScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a cycloneDX scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a cycloneDX scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -102,7 +101,7 @@ func sbomStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Sca
 func sbomRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRemoteSBOMScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote cycloneDX scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a remote cycloneDX scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -111,7 +110,7 @@ func sbomRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner
 func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeVMScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a vm scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a vm scanner: %w", err)
 	}
 	return s, cleanup, nil
 }
@@ -120,7 +119,7 @@ func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scann
 func vmRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	s, cleanup, err := initializeRemoteVMScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
-		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote vm scanner: %w", err)
+		return scanner.Scanner{}, func() {}, fmt.Errorf("unable to initialize a remote vm scanner: %w", err)
 	}
 	return s, cleanup, nil
 }

--- a/pkg/commands/convert/run.go
+++ b/pkg/commands/convert/run.go
@@ -3,9 +3,9 @@ package convert
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
 	"github.com/aquasecurity/trivy/pkg/flag"
@@ -21,27 +21,27 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 
 	f, err := os.Open(opts.Target)
 	if err != nil {
-		return xerrors.Errorf("file open error: %w", err)
+		return fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 
 	var r types.Report
 	if err = json.NewDecoder(f).Decode(&r); err != nil {
-		return xerrors.Errorf("json decode error: %w", err)
+		return fmt.Errorf("json decode error: %w", err)
 	}
 
 	// "convert" supports JSON results produced by Trivy scanning other than AWS and Kubernetes
 	if r.ArtifactName == "" && r.ArtifactType == "" {
-		return xerrors.New("AWS and Kubernetes scanning reports are not yet supported")
+		return errors.New("AWS and Kubernetes scanning reports are not yet supported")
 	}
 
 	if err = result.Filter(ctx, r, opts.FilterOpts()); err != nil {
-		return xerrors.Errorf("unable to filter results: %w", err)
+		return fmt.Errorf("unable to filter results: %w", err)
 	}
 
 	log.Debug("Writing report to output...")
 	if err = report.Write(ctx, r, opts); err != nil {
-		return xerrors.Errorf("unable to write results: %w", err)
+		return fmt.Errorf("unable to write results: %w", err)
 	}
 
 	return operation.Exit(opts, r.Results.Failed(), r.Metadata)

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -2,8 +2,7 @@ package server
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
@@ -22,7 +21,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	fsutils.SetCacheDir(opts.CacheDir)
 	cache, err := operation.NewCache(opts.CacheOptions)
 	if err != nil {
-		return xerrors.Errorf("server cache error: %w", err)
+		return fmt.Errorf("server cache error: %w", err)
 	}
 	defer cache.Close()
 	log.Debug("Cache", log.String("dir", fsutils.CacheDir()))
@@ -42,7 +41,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	}
 
 	if err = db.Init(opts.CacheDir); err != nil {
-		return xerrors.Errorf("error in vulnerability DB initialize: %w", err)
+		return fmt.Errorf("error in vulnerability DB initialize: %w", err)
 	}
 
 	// Initialize WASM modules
@@ -51,7 +50,7 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 		EnabledModules: opts.EnabledModules,
 	})
 	if err != nil {
-		return xerrors.Errorf("WASM module error: %w", err)
+		return fmt.Errorf("WASM module error: %w", err)
 	}
 	m.Register()
 

--- a/pkg/compliance/report/json.go
+++ b/pkg/compliance/report/json.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 )
 
 type JSONWriter struct {
@@ -25,16 +23,16 @@ func (jw JSONWriter) Write(report *ComplianceReport) error {
 	case summaryReport:
 		v = BuildSummary(report)
 	default:
-		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, jw.Report)
+		return fmt.Errorf(`report %q not supported. Use "summary" or "all"`, jw.Report)
 	}
 
 	output, err = json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return xerrors.Errorf("failed to marshal json: %w", err)
+		return fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	if _, err = fmt.Fprintln(jw.Output, string(output)); err != nil {
-		return xerrors.Errorf("failed to write json: %w", err)
+		return fmt.Errorf("failed to write json: %w", err)
 	}
 
 	return nil

--- a/pkg/compliance/report/report.go
+++ b/pkg/compliance/report/report.go
@@ -2,9 +2,8 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/compliance/spec"
@@ -87,7 +86,7 @@ func Write(ctx context.Context, report *ComplianceReport, option Option) error {
 		}
 		return nil
 	default:
-		return xerrors.Errorf(`unknown format %q. Use "json" or "table"`, option.Format)
+		return fmt.Errorf(`unknown format %q. Use "json" or "table"`, option.Format)
 	}
 }
 

--- a/pkg/compliance/report/summary.go
+++ b/pkg/compliance/report/summary.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/table"
 )
@@ -45,11 +44,11 @@ func NewSummaryWriter(output io.Writer) SummaryWriter {
 // Write writes the results in a summarized table format
 func (s SummaryWriter) Write(report *ComplianceReport) error {
 	if _, err := fmt.Fprintln(s.Output); err != nil {
-		return xerrors.Errorf("failed to write summary report: %w", err)
+		return fmt.Errorf("failed to write summary report: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(s.Output, "Summary Report for compliance: %s\n", report.Title); err != nil {
-		return xerrors.Errorf("failed to write summary report: %w", err)
+		return fmt.Errorf("failed to write summary report: %w", err)
 	}
 	sr := BuildSummary(report)
 	t := table.New(s.Output)

--- a/pkg/compliance/report/table.go
+++ b/pkg/compliance/report/table.go
@@ -2,9 +2,8 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	pkgReport "github.com/aquasecurity/trivy/pkg/report/table"
@@ -44,7 +43,7 @@ func (tw TableWriter) Write(ctx context.Context, report *ComplianceReport) error
 		writer := NewSummaryWriter(tw.Output)
 		return writer.Write(report)
 	default:
-		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)
+		return fmt.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)
 	}
 
 	return nil

--- a/pkg/compliance/spec/compliance.go
+++ b/pkg/compliance/spec/compliance.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	sp "github.com/aquasecurity/trivy-checks/pkg/spec"
@@ -34,7 +34,7 @@ func (cs *ComplianceSpec) Scanners() (types.Scanners, error) {
 		for _, check := range control.Checks {
 			scannerType := scannerByCheckID(check.ID)
 			if scannerType == types.UnknownScanner {
-				return nil, xerrors.Errorf("unsupported check ID: %s", check.ID)
+				return nil, fmt.Errorf("unsupported check ID: %s", check.ID)
 			}
 			scannerTypes[scannerType] = struct{}{}
 		}
@@ -86,7 +86,7 @@ func GetComplianceSpec(specNameOrPath string) (ComplianceSpec, error) {
 
 	var complianceSpec ComplianceSpec
 	if err = yaml.Unmarshal(b, &complianceSpec); err != nil {
-		return ComplianceSpec{}, xerrors.Errorf("spec yaml decode error: %w", err)
+		return ComplianceSpec{}, fmt.Errorf("spec yaml decode error: %w", err)
 	}
 	return complianceSpec, nil
 

--- a/pkg/dependency/parser/c/conan/parse.go
+++ b/pkg/dependency/parser/c/conan/parse.go
@@ -1,13 +1,13 @@
 package conan
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/liamg/jfather"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -121,10 +121,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to read conan lock file: %w", err)
+		return nil, nil, fmt.Errorf("failed to read conan lock file: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &lock); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode conan lock file: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode conan lock file: %w", err)
 	}
 
 	// try to parse requirements as conan v1.x
@@ -147,7 +147,7 @@ func parsePackage(text string) (string, string, error) {
 	// 'pkgd/0.1.0#7dcb50c43a5a50d984c2e8fa5898bf18'
 	ss := strings.Split(strings.Split(strings.Split(text, "@")[0], "#")[0], "/")
 	if len(ss) != 2 {
-		return "", "", xerrors.Errorf("Unable to determine conan dependency: %q", text)
+		return "", "", fmt.Errorf("Unable to determine conan dependency: %q", text)
 	}
 	return ss[0], ss[1], nil
 }

--- a/pkg/dependency/parser/conda/environment/parse.go
+++ b/pkg/dependency/parser/conda/environment/parse.go
@@ -1,11 +1,11 @@
 package environment
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
 
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/go-version/pkg/version"
@@ -42,7 +42,7 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	var env environment
 	if err := yaml.NewDecoder(r).Decode(&env); err != nil {
-		return nil, nil, xerrors.Errorf("unable to decode conda environment.yml file: %w", err)
+		return nil, nil, fmt.Errorf("unable to decode conda environment.yml file: %w", err)
 	}
 
 	var pkgs ftypes.Packages
@@ -118,12 +118,12 @@ func (e *Entry) UnmarshalYAML(node *yaml.Node) error {
 			//  	  - pip:
 			//     	    - pandas==2.1.4
 			if node.Content[1].Tag != "!!seq" { // Conda supports only map[string][]string format.
-				return xerrors.Errorf("unsupported dependency type %q on line %d", node.Content[1].Tag, node.Content[1].Line)
+				return fmt.Errorf("unsupported dependency type %q on line %d", node.Content[1].Tag, node.Content[1].Line)
 			}
 
 			for _, depContent := range node.Content[1].Content {
 				if depContent.Tag != "!!str" {
-					return xerrors.Errorf("unsupported dependency type %q on line %d", depContent.Tag, depContent.Line)
+					return fmt.Errorf("unsupported dependency type %q on line %d", depContent.Tag, depContent.Line)
 				}
 
 				dependencies = append(dependencies, Dependency{
@@ -133,7 +133,7 @@ func (e *Entry) UnmarshalYAML(node *yaml.Node) error {
 			}
 		}
 	default:
-		return xerrors.Errorf("unsupported dependency type %q on line %d", node.Tag, node.Line)
+		return fmt.Errorf("unsupported dependency type %q on line %d", node.Tag, node.Line)
 	}
 
 	e.Dependencies = dependencies

--- a/pkg/dependency/parser/conda/meta/parse.go
+++ b/pkg/dependency/parser/conda/meta/parse.go
@@ -2,9 +2,9 @@ package meta
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -29,11 +29,11 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var data packageJSON
 	err := json.NewDecoder(r).Decode(&data)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("JSON decode error: %w", err)
+		return nil, nil, fmt.Errorf("JSON decode error: %w", err)
 	}
 
 	if data.Name == "" || data.Version == "" {
-		return nil, nil, xerrors.Errorf("unable to parse conda package")
+		return nil, nil, fmt.Errorf("unable to parse conda package")
 	}
 
 	return []ftypes.Package{

--- a/pkg/dependency/parser/dart/pub/parse.go
+++ b/pkg/dependency/parser/dart/pub/parse.go
@@ -1,7 +1,8 @@
 package pub
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
@@ -34,7 +35,7 @@ type Dep struct {
 func (p Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	l := &lock{}
 	if err := yaml.NewDecoder(r).Decode(&l); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode pubspec.lock: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode pubspec.lock: %w", err)
 	}
 	var pkgs []ftypes.Package
 	for name, dep := range l.Packages {

--- a/pkg/dependency/parser/dotnet/core_deps/parse.go
+++ b/pkg/dependency/parser/dotnet/core_deps/parse.go
@@ -1,11 +1,11 @@
 package core_deps
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/liamg/jfather"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -27,10 +27,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("read error: %w", err)
+		return nil, nil, fmt.Errorf("read error: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &depsFile); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode .deps.json file: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode .deps.json file: %w", err)
 	}
 
 	var pkgs []ftypes.Package

--- a/pkg/dependency/parser/frameworks/wordpress/parse.go
+++ b/pkg/dependency/parser/frameworks/wordpress/parse.go
@@ -2,10 +2,9 @@ package wordpress
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -68,7 +67,7 @@ func Parse(r io.Reader) (lib ftypes.Package, err error) {
 	}
 
 	if err = scanner.Err(); err != nil || version == "" {
-		return ftypes.Package{}, xerrors.New("version.php could not be parsed")
+		return ftypes.Package{}, errors.New("version.php could not be parsed")
 	}
 
 	return ftypes.Package{

--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -3,13 +3,13 @@ package binary
 import (
 	"cmp"
 	"debug/buildinfo"
+	"errors"
 	"runtime/debug"
 	"sort"
 	"strings"
 
 	"github.com/spf13/pflag"
 	"golang.org/x/mod/semver"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	ErrUnrecognizedExe = xerrors.New("unrecognized executable format")
-	ErrNonGoBinary     = xerrors.New("non go binary")
+	ErrUnrecognizedExe = errors.New("unrecognized executable format")
+	ErrNonGoBinary     = errors.New("non go binary")
 )
 
 // convertError detects buildinfo.errUnrecognizedFormat and convert to

--- a/pkg/dependency/parser/golang/mod/parse.go
+++ b/pkg/dependency/parser/golang/mod/parse.go
@@ -1,6 +1,7 @@
 package mod
 
 import (
+	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -9,7 +10,6 @@ import (
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"golang.org/x/mod/modfile"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -71,12 +71,12 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 	goModData, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("file read error: %w", err)
+		return nil, nil, fmt.Errorf("file read error: %w", err)
 	}
 
 	modFileParsed, err := modfile.Parse("go.mod", goModData, nil)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("go.mod parse error: %w", err)
+		return nil, nil, fmt.Errorf("go.mod parse error: %w", err)
 	}
 
 	skipIndirect := true

--- a/pkg/dependency/parser/golang/sum/parse.go
+++ b/pkg/dependency/parser/golang/sum/parse.go
@@ -2,9 +2,8 @@ package sum
 
 import (
 	"bufio"
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -35,7 +34,7 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 		uniquePkgs[s[0]] = strings.TrimSuffix(strings.TrimPrefix(s[1], "v"), "/go.mod")
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, nil, xerrors.Errorf("scan error: %w", err)
+		return nil, nil, fmt.Errorf("scan error: %w", err)
 	}
 
 	for k, v := range uniquePkgs {

--- a/pkg/dependency/parser/java/jar/sonatype/sonatype.go
+++ b/pkg/dependency/parser/java/jar/sonatype/sonatype.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/jar"
 )
@@ -85,7 +84,7 @@ func New(opts ...Option) Sonatype {
 func (s Sonatype) Exists(groupID, artifactID string) (bool, error) {
 	req, err := http.NewRequest(http.MethodGet, s.baseURL, http.NoBody)
 	if err != nil {
-		return false, xerrors.Errorf("unable to initialize HTTP client: %w", err)
+		return false, fmt.Errorf("unable to initialize HTTP client: %w", err)
 	}
 
 	q := req.URL.Query()
@@ -95,13 +94,13 @@ func (s Sonatype) Exists(groupID, artifactID string) (bool, error) {
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return false, xerrors.Errorf("http error: %w", err)
+		return false, fmt.Errorf("http error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	var res apiResponse
 	if err = json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return false, xerrors.Errorf("json decode error: %w", err)
+		return false, fmt.Errorf("json decode error: %w", err)
 	}
 	return res.Response.NumFound > 0, nil
 }
@@ -110,7 +109,7 @@ func (s Sonatype) SearchBySHA1(sha1 string) (jar.Properties, error) {
 
 	req, err := http.NewRequest(http.MethodGet, s.baseURL, http.NoBody)
 	if err != nil {
-		return jar.Properties{}, xerrors.Errorf("unable to initialize HTTP client: %w", err)
+		return jar.Properties{}, fmt.Errorf("unable to initialize HTTP client: %w", err)
 	}
 
 	q := req.URL.Query()
@@ -121,21 +120,21 @@ func (s Sonatype) SearchBySHA1(sha1 string) (jar.Properties, error) {
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return jar.Properties{}, xerrors.Errorf("sha1 search error: %w", err)
+		return jar.Properties{}, fmt.Errorf("sha1 search error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return jar.Properties{}, xerrors.Errorf("status %s from %s", resp.Status, req.URL.String())
+		return jar.Properties{}, fmt.Errorf("status %s from %s", resp.Status, req.URL.String())
 	}
 
 	var res apiResponse
 	if err = json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return jar.Properties{}, xerrors.Errorf("json decode error: %w", err)
+		return jar.Properties{}, fmt.Errorf("json decode error: %w", err)
 	}
 
 	if len(res.Response.Docs) == 0 {
-		return jar.Properties{}, xerrors.Errorf("digest %s: %w", sha1, jar.ArtifactNotFoundErr)
+		return jar.Properties{}, fmt.Errorf("digest %s: %w", sha1, jar.ArtifactNotFoundErr)
 	}
 
 	// Some artifacts might have the same SHA-1 digests.
@@ -156,7 +155,7 @@ func (s Sonatype) SearchBySHA1(sha1 string) (jar.Properties, error) {
 func (s Sonatype) SearchByArtifactID(artifactID, _ string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, s.baseURL, http.NoBody)
 	if err != nil {
-		return "", xerrors.Errorf("unable to initialize HTTP client: %w", err)
+		return "", fmt.Errorf("unable to initialize HTTP client: %w", err)
 	}
 
 	q := req.URL.Query()
@@ -167,21 +166,21 @@ func (s Sonatype) SearchByArtifactID(artifactID, _ string) (string, error) {
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return "", xerrors.Errorf("artifactID search error: %w", err)
+		return "", fmt.Errorf("artifactID search error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", xerrors.Errorf("status %s from %s", resp.Status, req.URL.String())
+		return "", fmt.Errorf("status %s from %s", resp.Status, req.URL.String())
 	}
 
 	var res apiResponse
 	if err = json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return "", xerrors.Errorf("json decode error: %w", err)
+		return "", fmt.Errorf("json decode error: %w", err)
 	}
 
 	if len(res.Response.Docs) == 0 {
-		return "", xerrors.Errorf("artifactID %s: %w", artifactID, jar.ArtifactNotFoundErr)
+		return "", fmt.Errorf("artifactID %s: %w", artifactID, jar.ArtifactNotFoundErr)
 	}
 
 	// Some artifacts might have the same artifactId.

--- a/pkg/dependency/parser/java/jar/types.go
+++ b/pkg/dependency/parser/java/jar/types.go
@@ -1,14 +1,13 @@
 package jar
 
 import (
+	"errors"
 	"fmt"
-
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
-var ArtifactNotFoundErr = xerrors.New("no artifact found")
+var ArtifactNotFoundErr = errors.New("no artifact found")
 
 type Properties struct {
 	GroupID    string

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -322,7 +321,7 @@ func (props *properties) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error 
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return xerrors.Errorf("XML decode error: %w", err)
+			return fmt.Errorf("XML decode error: %w", err)
 		}
 
 		(*props)[p.XMLName.Local] = p.Value
@@ -336,7 +335,7 @@ func (deps *pomDependencies) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) er
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return xerrors.Errorf("XML decode error: %w", err)
+			return fmt.Errorf("XML decode error: %w", err)
 		}
 
 		t, ok := token.(xml.StartElement)
@@ -351,7 +350,7 @@ func (deps *pomDependencies) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) er
 			// Decode the <dependency> element
 			err = d.DecodeElement(&dep, &t)
 			if err != nil {
-				return xerrors.Errorf("Error decoding dependency: %w", err)
+				return fmt.Errorf("Error decoding dependency: %w", err)
 			}
 
 			dep.EndLine, _ = d.InputPos() // <dependency> tag ends

--- a/pkg/dependency/parser/julia/manifest/parse.go
+++ b/pkg/dependency/parser/julia/manifest/parse.go
@@ -1,12 +1,12 @@
 package julia
 
 import (
+	"fmt"
 	"io"
 	"sort"
 
 	"github.com/BurntSushi/toml"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -39,10 +39,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	// Try to read the old Manifest format. If that fails, try the new format.
 	if _, err := decoder.Decode(&oldDeps); err != nil {
 		if _, err = r.Seek(0, io.SeekStart); err != nil {
-			return nil, nil, xerrors.Errorf("seek error: %w", err)
+			return nil, nil, fmt.Errorf("seek error: %w", err)
 		}
 		if manMetadata, err = decoder.Decode(&primMan); err != nil {
-			return nil, nil, xerrors.Errorf("decode error: %w", err)
+			return nil, nil, fmt.Errorf("decode error: %w", err)
 		}
 	}
 
@@ -57,11 +57,11 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 	man, err := decodeManifest(&primMan, &manMetadata)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("unable to decode manifest dependencies: %w", err)
+		return nil, nil, fmt.Errorf("unable to decode manifest dependencies: %w", err)
 	}
 
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("seek error: %w", err)
+		return nil, nil, fmt.Errorf("seek error: %w", err)
 	}
 
 	// naive parser to get line numbers
@@ -140,7 +140,7 @@ func decodeDependency(man *primitiveManifest, dep primitiveDependency, metadata 
 		for _, depName := range possibleDeps {
 			primDep := man.Dependencies[depName]
 			if len(primDep) > 1 {
-				return primitiveDependency{}, xerrors.Errorf("Dependency %q has invalid format (parsed multiple deps): %s", depName, primDep)
+				return primitiveDependency{}, fmt.Errorf("Dependency %q has invalid format (parsed multiple deps): %s", depName, primDep)
 			}
 			possibleUuids = append(possibleUuids, primDep[0].UUID)
 		}

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -11,7 +11,6 @@ import (
 	"github.com/liamg/jfather"
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
@@ -65,10 +64,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockFile LockFile
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("read error: %w", err)
+		return nil, nil, fmt.Errorf("read error: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+		return nil, nil, fmt.Errorf("decode error: %w", err)
 	}
 
 	var pkgs []ftypes.Package
@@ -267,7 +266,7 @@ func findDependsOn(pkgPath, depName string, packages map[string]Package) (string
 	}
 
 	// It should not reach here.
-	return "", xerrors.Errorf("can't find dependsOn for %s", depName)
+	return "", fmt.Errorf("can't find dependsOn for %s", depName)
 }
 
 func (p *Parser) parseV1(dependencies map[string]Dependency, versions map[string]string) ([]ftypes.Package, []ftypes.Dependency) {

--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -2,11 +2,11 @@ package packagejson
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"regexp"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -41,11 +41,11 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r io.Reader) (Package, error) {
 	var pkgJSON packageJSON
 	if err := json.NewDecoder(r).Decode(&pkgJSON); err != nil {
-		return Package{}, xerrors.Errorf("JSON decode error: %w", err)
+		return Package{}, fmt.Errorf("JSON decode error: %w", err)
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, fmt.Errorf("Name can only contain URL-friendly characters")
 	}
 
 	var id string

--- a/pkg/dependency/parser/nodejs/pnpm/parse.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/go-version/pkg/semver"
@@ -49,7 +49,7 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	var lockFile LockFile
 	if err := yaml.NewDecoder(r).Decode(&lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+		return nil, nil, fmt.Errorf("decode error: %w", err)
 	}
 
 	lockVer := p.parseLockfileVersion(lockFile)

--- a/pkg/dependency/parser/nuget/config/parse.go
+++ b/pkg/dependency/parser/nuget/config/parse.go
@@ -2,8 +2,7 @@ package config
 
 import (
 	"encoding/xml"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -32,7 +31,7 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	var cfgData config
 	if err := xml.NewDecoder(r).Decode(&cfgData); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode .config file: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode .config file: %w", err)
 	}
 
 	var pkgs []ftypes.Package

--- a/pkg/dependency/parser/nuget/lock/parse.go
+++ b/pkg/dependency/parser/nuget/lock/parse.go
@@ -1,11 +1,11 @@
 package lock
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/liamg/jfather"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
@@ -38,10 +38,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockFile LockFile
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to read packages.lock.json: %w", err)
+		return nil, nil, fmt.Errorf("failed to read packages.lock.json: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode packages.lock.json: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode packages.lock.json: %w", err)
 	}
 
 	var pkgs []ftypes.Package

--- a/pkg/dependency/parser/nuget/packagesprops/parse.go
+++ b/pkg/dependency/parser/nuget/packagesprops/parse.go
@@ -2,9 +2,8 @@ package packagesprops
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
@@ -70,7 +69,7 @@ func isVariable(s string) bool {
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	var configData project
 	if err := xml.NewDecoder(r).Decode(&configData); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode '*.packages.props' file: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode '*.packages.props' file: %w", err)
 	}
 
 	var pkgs []ftypes.Package

--- a/pkg/dependency/parser/php/composer/parse.go
+++ b/pkg/dependency/parser/php/composer/parse.go
@@ -1,13 +1,13 @@
 package composer
 
 import (
+	"fmt"
 	"io"
 	"sort"
 	"strings"
 
 	"github.com/liamg/jfather"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -41,10 +41,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockFile LockFile
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("read error: %w", err)
+		return nil, nil, fmt.Errorf("read error: %w", err)
 	}
 	if err = jfather.Unmarshal(input, &lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+		return nil, nil, fmt.Errorf("decode error: %w", err)
 	}
 
 	pkgs := make(map[string]ftypes.Package)

--- a/pkg/dependency/parser/python/packaging/parse.go
+++ b/pkg/dependency/parser/python/packaging/parse.go
@@ -3,12 +3,12 @@ package packaging
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"net/textproto"
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -37,12 +37,12 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 		// so we continue with the subsequent process.
 		p.logger.Debug("MIME protocol error", log.Err(err))
 	} else if err != nil && err != io.EOF {
-		return nil, nil, xerrors.Errorf("read MIME error: %w", err)
+		return nil, nil, fmt.Errorf("read MIME error: %w", err)
 	}
 
 	name, version := h.Get("name"), h.Get("version")
 	if name == "" || version == "" {
-		return nil, nil, xerrors.New("name or version is empty")
+		return nil, nil, errors.New("name or version is empty")
 	}
 
 	// "License-Expression" takes precedence in accordance with https://peps.python.org/pep-0639/#deprecate-license-field

--- a/pkg/dependency/parser/python/pip/parse.go
+++ b/pkg/dependency/parser/python/pip/parse.go
@@ -2,13 +2,13 @@ package pip
 
 import (
 	"bufio"
+	"fmt"
 	"strings"
 	"unicode"
 
 	"golang.org/x/text/encoding"
 	u "golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -55,7 +55,7 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 		})
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, nil, xerrors.Errorf("scan error: %w", err)
+		return nil, nil, fmt.Errorf("scan error: %w", err)
 	}
 	return pkgs, nil, nil
 }

--- a/pkg/dependency/parser/python/pipenv/parse.go
+++ b/pkg/dependency/parser/python/pipenv/parse.go
@@ -1,11 +1,11 @@
 package pipenv
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/liamg/jfather"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -30,10 +30,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockFile lockFile
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to read packages.lock.json: %w", err)
+		return nil, nil, fmt.Errorf("failed to read packages.lock.json: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode Pipenv.lock: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode Pipenv.lock: %w", err)
 	}
 
 	var pkgs []ftypes.Package

--- a/pkg/dependency/parser/python/poetry/parse.go
+++ b/pkg/dependency/parser/python/poetry/parse.go
@@ -1,11 +1,11 @@
 package poetry
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"golang.org/x/xerrors"
 
 	version "github.com/aquasecurity/go-pep440-version"
 	"github.com/aquasecurity/trivy/pkg/dependency"
@@ -41,7 +41,7 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	var lockfile Lockfile
 	if _, err := toml.NewDecoder(r).Decode(&lockfile); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode poetry.lock: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode poetry.lock: %w", err)
 	}
 
 	// Keep all installed versions
@@ -108,7 +108,7 @@ func (p *Parser) parseDependency(name string, versRange any, pkgVersions map[str
 	name = normalizePkgName(name)
 	vers, ok := pkgVersions[name]
 	if !ok {
-		return "", xerrors.Errorf("no version found for %q", name)
+		return "", fmt.Errorf("no version found for %q", name)
 	}
 
 	for _, ver := range vers {
@@ -126,24 +126,24 @@ func (p *Parser) parseDependency(name string, versRange any, pkgVersions map[str
 		}
 
 		if matched, err := matchVersion(ver, vRange); err != nil {
-			return "", xerrors.Errorf("failed to match version for %s: %w", name, err)
+			return "", fmt.Errorf("failed to match version for %s: %w", name, err)
 		} else if matched {
 			return packageID(name, ver), nil
 		}
 	}
-	return "", xerrors.Errorf("no matched version found for %q", name)
+	return "", fmt.Errorf("no matched version found for %q", name)
 }
 
 // matchVersion checks if the package version satisfies the given constraint.
 func matchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := version.Parse(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("python version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("python version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := version.NewSpecifiers(constraint, version.WithPreRelease(true))
 	if err != nil {
-		return false, xerrors.Errorf("python constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("python constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -1,10 +1,10 @@
 package pyproject
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/BurntSushi/toml"
-	"golang.org/x/xerrors"
 )
 
 type PyProject struct {
@@ -31,7 +31,7 @@ func NewParser() *Parser {
 func (p *Parser) Parse(r io.Reader) (map[string]interface{}, error) {
 	var conf PyProject
 	if _, err := toml.NewDecoder(r).Decode(&conf); err != nil {
-		return nil, xerrors.Errorf("toml decode error: %w", err)
+		return nil, fmt.Errorf("toml decode error: %w", err)
 	}
 	return conf.Tool.Poetry.Dependencies, nil
 }

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -2,11 +2,11 @@ package bundler
 
 import (
 	"bufio"
+	"fmt"
 	"sort"
 	"strings"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -100,7 +100,7 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 		deps[i].DependsOn = dependsOn
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, nil, xerrors.Errorf("scan error: %w", err)
+		return nil, nil, fmt.Errorf("scan error: %w", err)
 	}
 
 	pkgSlice := maps.Values(pkgs)

--- a/pkg/dependency/parser/ruby/gemspec/parse.go
+++ b/pkg/dependency/parser/ruby/gemspec/parse.go
@@ -2,11 +2,10 @@ package gemspec
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/licensing"
@@ -88,11 +87,11 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) (pkgs []ftypes.Package, deps []ftypes
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, nil, xerrors.Errorf("failed to parse gemspec: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse gemspec: %w", err)
 	}
 
 	if name == "" || version == "" {
-		return nil, nil, xerrors.New("failed to parse gemspec")
+		return nil, nil, errors.New("failed to parse gemspec")
 	}
 
 	return []ftypes.Package{

--- a/pkg/dependency/parser/rust/binary/parse.go
+++ b/pkg/dependency/parser/rust/binary/parse.go
@@ -2,9 +2,10 @@
 package binary
 
 import (
+	"errors"
+
 	rustaudit "github.com/microsoft/go-rustaudit"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -12,8 +13,8 @@ import (
 )
 
 var (
-	ErrUnrecognizedExe = xerrors.New("unrecognized executable format")
-	ErrNonRustBinary   = xerrors.New("non Rust auditable binary")
+	ErrUnrecognizedExe = errors.New("unrecognized executable format")
+	ErrNonRustBinary   = errors.New("non Rust auditable binary")
 )
 
 // convertError detects rustaudit.ErrUnknownFileFormat and convert to

--- a/pkg/dependency/parser/rust/cargo/parse.go
+++ b/pkg/dependency/parser/rust/cargo/parse.go
@@ -1,13 +1,13 @@
 package cargo
 
 import (
+	"fmt"
 	"io"
 	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -39,11 +39,11 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockfile Lockfile
 	decoder := toml.NewDecoder(r)
 	if _, err := decoder.Decode(&lockfile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+		return nil, nil, fmt.Errorf("decode error: %w", err)
 	}
 
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("seek error: %w", err)
+		return nil, nil, fmt.Errorf("seek error: %w", err)
 	}
 
 	// naive parser to get line numbers by package from lock file

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -1,11 +1,12 @@
 package cocoapods
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
@@ -33,7 +34,7 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	lock := &lockFile{}
 	decoder := yaml.NewDecoder(r)
 	if err := decoder.Decode(&lock); err != nil {
-		return nil, nil, xerrors.Errorf("failed to decode cocoapods lock file: %s", err.Error())
+		return nil, nil, fmt.Errorf("failed to decode cocoapods lock file: %s", err.Error())
 	}
 
 	parsedDeps := make(map[string]ftypes.Package) // dependency name => Package
@@ -58,13 +59,13 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 				children, ok := childDeps.([]interface{})
 				if !ok {
-					return nil, nil, xerrors.Errorf("invalid value of cocoapods direct dependency: %q", childDeps)
+					return nil, nil, fmt.Errorf("invalid value of cocoapods direct dependency: %q", childDeps)
 				}
 
 				for _, childDep := range children {
 					s, ok := childDep.(string)
 					if !ok {
-						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
+						return nil, nil, fmt.Errorf("must be string: %q", childDep)
 					}
 					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
 				}
@@ -98,7 +99,7 @@ func parseDep(dep string) (ftypes.Package, error) {
 	// 'AppCenter/Analytics (-> 4.2.0)'
 	ss := strings.Split(dep, " (")
 	if len(ss) != 2 {
-		return ftypes.Package{}, xerrors.Errorf("Unable to determine cocoapods dependency: %q", dep)
+		return ftypes.Package{}, fmt.Errorf("Unable to determine cocoapods dependency: %q", dep)
 	}
 
 	name := ss[0]

--- a/pkg/dependency/parser/swift/swift/parse.go
+++ b/pkg/dependency/parser/swift/swift/parse.go
@@ -1,13 +1,13 @@
 package swift
 
 import (
+	"fmt"
 	"io"
 	"sort"
 	"strings"
 
 	"github.com/liamg/jfather"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -30,10 +30,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	var lockFile LockFile
 	input, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("read error: %w", err)
+		return nil, nil, fmt.Errorf("read error: %w", err)
 	}
 	if err := jfather.Unmarshal(input, &lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+		return nil, nil, fmt.Errorf("decode error: %w", err)
 	}
 
 	var pkgs ftypes.Packages

--- a/pkg/detector/library/compare/bitnami/compare.go
+++ b/pkg/detector/library/compare/bitnami/compare.go
@@ -1,8 +1,9 @@
 package bitnami
 
 import (
+	"fmt"
+
 	version "github.com/bitnami/go-version/pkg/version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
@@ -20,12 +21,12 @@ func (n Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 func (n Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := version.Parse(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("bitnami version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("bitnami version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := version.NewConstraints(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("bitnami constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("bitnami constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/detector/library/compare/compare.go
+++ b/pkg/detector/library/compare/compare.go
@@ -1,9 +1,8 @@
 package compare
 
 import (
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/go-version/pkg/version"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -66,12 +65,12 @@ func (v GenericComparer) IsVulnerable(ver string, advisory dbTypes.Advisory) boo
 func (v GenericComparer) matchVersion(currentVersion, constraint string) (bool, error) {
 	ver, err := version.Parse(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := version.NewConstraints(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("constraint error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("constraint error (%s): %s", currentVersion, err)
 	}
 
 	return c.Check(ver), nil

--- a/pkg/detector/library/compare/maven/compare.go
+++ b/pkg/detector/library/compare/maven/compare.go
@@ -1,8 +1,9 @@
 package maven
 
 import (
+	"fmt"
+
 	version "github.com/masahiro331/go-mvn-version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
@@ -20,12 +21,12 @@ func (n Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 func (n Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := version.NewVersion(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("maven version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("maven version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := version.NewComparer(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("maven constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("maven constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/detector/library/compare/npm/compare.go
+++ b/pkg/detector/library/compare/npm/compare.go
@@ -1,7 +1,7 @@
 package npm
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	npm "github.com/aquasecurity/go-npm-version/pkg"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -20,12 +20,12 @@ func (n Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 func (n Comparer) MatchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := npm.NewVersion(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("npm version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("npm version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := npm.NewConstraints(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("npm constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("npm constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/detector/library/compare/pep440/compare.go
+++ b/pkg/detector/library/compare/pep440/compare.go
@@ -1,7 +1,7 @@
 package pep440
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	version "github.com/aquasecurity/go-pep440-version"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -20,12 +20,12 @@ func (n Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 func (n Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := version.Parse(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("python version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("python version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := version.NewSpecifiers(constraint, version.WithPreRelease(true))
 	if err != nil {
-		return false, xerrors.Errorf("python constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("python constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/detector/library/compare/rubygems/compare.go
+++ b/pkg/detector/library/compare/rubygems/compare.go
@@ -1,7 +1,7 @@
 package rubygems
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/go-gem-version"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -20,12 +20,12 @@ func (r Comparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
 func (r Comparer) matchVersion(currentVersion, constraint string) (bool, error) {
 	v, err := gem.NewVersion(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("RubyGems version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("RubyGems version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := gem.NewConstraints(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("RubyGems constraint error (%s): %s", constraint, err)
+		return false, fmt.Errorf("RubyGems constraint error (%s): %s", constraint, err)
 	}
 
 	return c.Check(v), nil

--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -2,8 +2,7 @@ package library
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -19,7 +18,7 @@ func Detect(ctx context.Context, libType ftypes.LangType, pkgs []ftypes.Package)
 
 	vulns, err := detect(ctx, driver, pkgs)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to scan %s vulnerabilities: %w", driver.Type(), err)
+		return nil, fmt.Errorf("failed to scan %s vulnerabilities: %w", driver.Type(), err)
 	}
 
 	return vulns, nil
@@ -35,7 +34,7 @@ func detect(ctx context.Context, driver Driver, pkgs []ftypes.Package) ([]types.
 		}
 		vulns, err := driver.DetectVulnerabilities(pkg.ID, pkg.Name, pkg.Version)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to detect %s vulnerabilities: %w", driver.Type(), err)
+			return nil, fmt.Errorf("failed to detect %s vulnerabilities: %w", driver.Type(), err)
 		}
 
 		for i := range vulns {

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -114,7 +113,7 @@ func (d *Driver) DetectVulnerabilities(pkgID, pkgName, pkgVer string) ([]types.D
 	prefix := fmt.Sprintf("%s::", d.ecosystem)
 	advisories, err := d.dbc.GetAdvisories(prefix, vulnerability.NormalizePkgName(d.ecosystem, pkgName))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get %s advisories: %w", d.ecosystem, err)
+		return nil, fmt.Errorf("failed to get %s advisories: %w", d.ecosystem, err)
 	}
 
 	var vulns []types.DetectedVulnerability

--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -2,11 +2,11 @@ package alma
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alma"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -53,7 +53,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 		pkgName := addModularNamespace(pkg.Name, pkg.Modularitylabel)
 		advisories, err := s.vs.Get(osVer, pkgName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get AlmaLinux advisories: %w", err)
+			return nil, fmt.Errorf("failed to get AlmaLinux advisories: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -2,11 +2,11 @@ package alpine
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-apk-version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/alpine"
@@ -89,7 +89,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, repo *ftypes.Reposit
 		}
 		advisories, err := s.vs.Get(stream, srcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get alpine advisories: %w", err)
+			return nil, fmt.Errorf("failed to get alpine advisories: %w", err)
 		}
 
 		sourceVersion, err := version.NewVersion(utils.FormatSrcVersion(pkg))

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -2,11 +2,11 @@ package amazon
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/amazon"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -55,7 +55,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	for _, pkg := range pkgs {
 		advisories, err := s.ac.Get(osVer, pkg.Name)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get amazon advisories: %w", err)
+			return nil, fmt.Errorf("failed to get amazon advisories: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/chainguard/chainguard.go
+++ b/pkg/detector/ospkg/chainguard/chainguard.go
@@ -2,9 +2,9 @@ package chainguard
 
 import (
 	"context"
+	"fmt"
 
 	version "github.com/knqyf263/go-apk-version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/chainguard"
@@ -38,7 +38,7 @@ func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pk
 		}
 		advisories, err := s.vs.Get("", srcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Chainguard advisories: %w", err)
+			return nil, fmt.Errorf("failed to get Chainguard advisories: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -2,10 +2,10 @@ package debian
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/debian"
@@ -70,7 +70,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 		advisories, err := s.vs.Get(osVer, pkg.SrcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get debian advisories: %w", err)
+			return nil, fmt.Errorf("failed to get debian advisories: %w", err)
 		}
 
 		for _, adv := range advisories {

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -2,10 +2,11 @@ package ospkg
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alma"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alpine"
@@ -27,7 +28,7 @@ import (
 
 var (
 	// ErrUnsupportedOS defines error for unsupported OS
-	ErrUnsupportedOS = xerrors.New("unsupported os")
+	ErrUnsupportedOS = errors.New("unsupported os")
 
 	drivers = map[ftypes.OSType]Driver{
 		ftypes.Alpine:       alpine.NewScanner(),
@@ -77,7 +78,7 @@ func Detect(ctx context.Context, _, osFamily ftypes.OSType, osName string, repo 
 	})
 	vulns, err := driver.Detect(ctx, osName, repo, filteredPkgs)
 	if err != nil {
-		return nil, false, xerrors.Errorf("failed detection: %w", err)
+		return nil, false, fmt.Errorf("failed detection: %w", err)
 	}
 
 	return vulns, eosl, nil

--- a/pkg/detector/ospkg/mariner/mariner.go
+++ b/pkg/detector/ospkg/mariner/mariner.go
@@ -2,9 +2,9 @@ package mariner
 
 import (
 	"context"
+	"fmt"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/mariner"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -39,7 +39,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 		// CBL Mariner OVAL contains source package names only.
 		advisories, err := s.vs.Get(osVer, pkg.SrcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get CBL-Mariner advisories: %w", err)
+			return nil, fmt.Errorf("failed to get CBL-Mariner advisories: %w", err)
 		}
 
 		sourceVersion := version.NewVersion(utils.FormatSrcVersion(pkg))

--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -2,11 +2,11 @@ package oracle
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	oracleoval "github.com/aquasecurity/trivy-db/pkg/vulnsrc/oracle-oval"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -63,7 +63,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	for _, pkg := range pkgs {
 		advisories, err := s.vs.Get(osVer, pkg.Name)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Oracle Linux advisory: %w", err)
+			return nil, fmt.Errorf("failed to get Oracle Linux advisory: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/photon/photon.go
+++ b/pkg/detector/ospkg/photon/photon.go
@@ -2,10 +2,10 @@ package photon
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/photon"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -47,7 +47,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	for _, pkg := range pkgs {
 		advisories, err := s.vs.Get(osVer, pkg.SrcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Photon Linux advisory: %w", err)
+			return nil, fmt.Errorf("failed to get Photon Linux advisory: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -10,7 +10,6 @@ import (
 	version "github.com/knqyf263/go-rpm-version"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	ustrings "github.com/aquasecurity/trivy-db/pkg/utils/strings"
@@ -91,7 +90,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 		detectedVulns, err := s.detect(osVer, pkg)
 		if err != nil {
-			return nil, xerrors.Errorf("redhat vulnerability detection error: %w", err)
+			return nil, fmt.Errorf("redhat vulnerability detection error: %w", err)
 		}
 		vulns = append(vulns, detectedVulns...)
 	}
@@ -113,7 +112,7 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 
 	advisories, err := s.vs.Get(pkgName, contentSets, []string{nvr})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get Red Hat advisories: %w", err)
+		return nil, fmt.Errorf("failed to get Red Hat advisories: %w", err)
 	}
 
 	installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/rocky/rocky.go
+++ b/pkg/detector/ospkg/rocky/rocky.go
@@ -2,10 +2,10 @@ package rocky
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/rocky"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -52,7 +52,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 		pkgName := addModularNamespace(pkg.Name, pkg.Modularitylabel)
 		advisories, err := s.vs.Get(osVer, pkgName, pkg.Arch)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Rocky Linux advisories: %w", err)
+			return nil, fmt.Errorf("failed to get Rocky Linux advisories: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -2,10 +2,10 @@ package suse
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"golang.org/x/xerrors"
 
 	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -97,7 +97,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	for _, pkg := range pkgs {
 		advisories, err := s.vs.Get(osVer, pkg.Name)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get SUSE advisory: %w", err)
+			return nil, fmt.Errorf("failed to get SUSE advisory: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -2,11 +2,11 @@ package ubuntu
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-deb-version"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
@@ -87,7 +87,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 		osVer = s.versionFromEolDates(osVer)
 		advisories, err := s.vs.Get(osVer, pkg.SrcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Ubuntu advisories: %w", err)
+			return nil, fmt.Errorf("failed to get Ubuntu advisories: %w", err)
 		}
 
 		sourceVersion, err := version.NewVersion(utils.FormatSrcVersion(pkg))

--- a/pkg/detector/ospkg/wolfi/wolfi.go
+++ b/pkg/detector/ospkg/wolfi/wolfi.go
@@ -2,9 +2,9 @@ package wolfi
 
 import (
 	"context"
+	"fmt"
 
 	version "github.com/knqyf263/go-apk-version"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
@@ -38,7 +38,7 @@ func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pk
 		}
 		advisories, err := s.vs.Get("", srcName)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to get Wolfi advisories: %w", err)
+			return nil, fmt.Errorf("failed to get Wolfi advisories: %w", err)
 		}
 
 		installed := utils.FormatVersion(pkg)

--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -7,8 +7,6 @@ import (
 	"hash"
 	"io"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 type Algorithm string
@@ -66,7 +64,7 @@ func CalcSHA1(r io.ReadSeeker) (Digest, error) {
 
 	h := sha1.New() // nolint
 	if _, err := io.Copy(h, r); err != nil {
-		return "", xerrors.Errorf("unable to calculate sha1 digest: %w", err)
+		return "", fmt.Errorf("unable to calculate sha1 digest: %w", err)
 	}
 
 	return NewDigest(SHA1, h), nil
@@ -77,7 +75,7 @@ func CalcSHA256(r io.ReadSeeker) (Digest, error) {
 
 	h := sha256.New()
 	if _, err := io.Copy(h, r); err != nil {
-		return "", xerrors.Errorf("unable to calculate sha256 digest: %w", err)
+		return "", fmt.Errorf("unable to calculate sha256 digest: %w", err)
 	}
 
 	return NewDigest(SHA256, h), nil

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -2,27 +2,27 @@ package downloader
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	getter "github.com/hashicorp/go-getter"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 )
 
 // DownloadToTempDir downloads the configured source to a temp dir.
 func DownloadToTempDir(ctx context.Context, url string) (string, error) {
 	tempDir, err := os.MkdirTemp("", "trivy-plugin")
 	if err != nil {
-		return "", xerrors.Errorf("failed to create a temp dir: %w", err)
+		return "", fmt.Errorf("failed to create a temp dir: %w", err)
 	}
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		return "", xerrors.Errorf("unable to get the current dir: %w", err)
+		return "", fmt.Errorf("unable to get the current dir: %w", err)
 	}
 
 	if err = Download(ctx, url, tempDir, pwd); err != nil {
-		return "", xerrors.Errorf("download error: %w", err)
+		return "", fmt.Errorf("download error: %w", err)
 	}
 
 	return tempDir, nil
@@ -53,7 +53,7 @@ func Download(ctx context.Context, src, dst, pwd string) error {
 	}
 
 	if err := client.Get(); err != nil {
-		return xerrors.Errorf("failed to download: %w", err)
+		return fmt.Errorf("failed to download: %w", err)
 	}
 
 	return nil

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -2,16 +2,17 @@ package analyzer_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/name"
 	"os"
 	"sync"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -535,7 +536,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 			err = a.AnalyzeFile(ctx, &wg, limit, got, "", tt.args.filePath, info,
 				func() (xio.ReadSeekCloserAt, error) {
 					if tt.args.testFilePath == "testdata/error" {
-						return nil, xerrors.New("error")
+						return nil, errors.New("error")
 					} else if tt.args.testFilePath == "testdata/no-permission" {
 						os.Chmod(tt.args.testFilePath, 0000)
 						t.Cleanup(func() {

--- a/pkg/fanal/analyzer/buildinfo/content_manifest.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest.go
@@ -3,10 +3,9 @@ package buildinfo
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -28,7 +27,7 @@ type contentManifestAnalyzer struct{}
 func (a contentManifestAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	var manifest contentManifest
 	if err := json.NewDecoder(target.Content).Decode(&manifest); err != nil {
-		return nil, xerrors.Errorf("invalid content manifest: %w", err)
+		return nil, fmt.Errorf("invalid content manifest: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/config/config.go
+++ b/pkg/fanal/analyzer/config/config.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"golang.org/x/xerrors"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -31,7 +31,7 @@ type NewScanner func([]string, misconf.ScannerOption) (*misconf.Scanner, error)
 func NewAnalyzer(t analyzer.Type, version int, newScanner NewScanner, opts analyzer.AnalyzerOptions) (*Analyzer, error) {
 	s, err := newScanner(opts.FilePatterns, opts.MisconfScannerOption)
 	if err != nil {
-		return nil, xerrors.Errorf("%s scanner init error: %w", t, err)
+		return nil, fmt.Errorf("%s scanner init error: %w", t, err)
 	}
 	return &Analyzer{
 		typ:     t,
@@ -44,7 +44,7 @@ func NewAnalyzer(t analyzer.Type, version int, newScanner NewScanner, opts analy
 func (a *Analyzer) PostAnalyze(ctx context.Context, input analyzer.PostAnalysisInput) (*analyzer.AnalysisResult, error) {
 	misconfs, err := a.scanner.Scan(ctx, input.FS)
 	if err != nil {
-		return nil, xerrors.Errorf("%s scan error: %w", a.typ, err)
+		return nil, fmt.Errorf("%s scan error: %w", a.typ, err)
 	}
 	return &analyzer.AnalysisResult{Misconfigurations: misconfs}, nil
 }

--- a/pkg/fanal/analyzer/config_analyzer.go
+++ b/pkg/fanal/analyzer/config_analyzer.go
@@ -2,10 +2,10 @@ package analyzer
 
 import (
 	"context"
+	"fmt"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -81,7 +81,7 @@ func NewConfigAnalyzerGroup(opts ConfigAnalyzerOptions) (ConfigAnalyzerGroup, er
 		}
 		a, err := newConfigAnalyzer(opts)
 		if err != nil {
-			return ConfigAnalyzerGroup{}, xerrors.Errorf("config analyzer %s initialize error: %w", t, err)
+			return ConfigAnalyzerGroup{}, fmt.Errorf("config analyzer %s initialize error: %w", t, err)
 		}
 
 		g.configAnalyzers = append(g.configAnalyzers, a)

--- a/pkg/fanal/analyzer/executable/executable.go
+++ b/pkg/fanal/analyzer/executable/executable.go
@@ -2,9 +2,8 @@ package executable
 
 import (
 	"context"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -30,7 +29,7 @@ func (a executableAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisIn
 
 	dig, err := digest.CalcSHA256(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("sha256 error: %w", err)
+		return nil, fmt.Errorf("sha256 error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -14,7 +14,6 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -76,7 +75,7 @@ func (a alpineCmdAnalyzer) Analyze(_ context.Context, input analyzer.ConfigAnaly
 	var err error
 	if apkIndexArchive, err = a.fetchApkIndexArchive(input.OS); err != nil {
 		log.Println(err)
-		return nil, xerrors.Errorf("failed to fetch apk index archive: %w", err)
+		return nil, fmt.Errorf("failed to fetch apk index archive: %w", err)
 	}
 
 	pkgs := a.parseConfig(apkIndexArchive, input.Config)
@@ -101,21 +100,21 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 		var err error
 		reader, err = builtinos.Open(strings.TrimPrefix(url, "file://"))
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read APKINDEX archive file: %w", err)
+			return nil, fmt.Errorf("failed to read APKINDEX archive file: %w", err)
 		}
 		defer reader.(*builtinos.File).Close()
 	} else {
 		// nolint
 		resp, err := http.Get(url)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to fetch APKINDEX archive: %w", err)
+			return nil, fmt.Errorf("failed to fetch APKINDEX archive: %w", err)
 		}
 		defer resp.Body.Close()
 		reader = resp.Body
 	}
 	apkIndexArchive := &apkIndex{}
 	if err := json.NewDecoder(reader).Decode(apkIndexArchive); err != nil {
-		return nil, xerrors.Errorf("failed to decode APKINDEX JSON: %w", err)
+		return nil, fmt.Errorf("failed to decode APKINDEX JSON: %w", err)
 	}
 
 	return apkIndexArchive, nil

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/xerrors"
+	
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/image"
@@ -28,7 +28,7 @@ type historyAnalyzer struct {
 func newHistoryAnalyzer(opts analyzer.ConfigAnalyzerOptions) (analyzer.ConfigAnalyzer, error) {
 	s, err := misconf.NewDockerfileScanner(opts.FilePatterns, opts.MisconfScannerOption)
 	if err != nil {
-		return nil, xerrors.Errorf("misconfiguration scanner error: %w", err)
+		return nil, fmt.Errorf("misconfiguration scanner error: %w", err)
 	}
 	return &historyAnalyzer{
 		scanner: s,
@@ -95,12 +95,12 @@ func (a *historyAnalyzer) Analyze(ctx context.Context, input analyzer.ConfigAnal
 
 	fsys := mapfs.New()
 	if err := fsys.WriteVirtualFile("Dockerfile", dockerfile.Bytes(), 0600); err != nil {
-		return nil, xerrors.Errorf("mapfs write error: %w", err)
+		return nil, fmt.Errorf("mapfs write error: %w", err)
 	}
 
 	misconfs, err := a.scanner.Scan(ctx, fsys)
 	if err != nil {
-		return nil, xerrors.Errorf("history scan error: %w", err)
+		return nil, fmt.Errorf("history scan error: %w", err)
 	}
 	// The result should be a single element as it passes one Dockerfile.
 	if len(misconfs) != 1 {

--- a/pkg/fanal/analyzer/imgconf/secret/secret.go
+++ b/pkg/fanal/analyzer/imgconf/secret/secret.go
@@ -3,8 +3,7 @@ package secret
 import (
 	"context"
 	"encoding/json"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/secret"
@@ -27,7 +26,7 @@ func newSecretAnalyzer(opts analyzer.ConfigAnalyzerOptions) (analyzer.ConfigAnal
 	configPath := opts.SecretScannerOption.ConfigPath
 	c, err := secret.ParseConfig(configPath)
 	if err != nil {
-		return nil, xerrors.Errorf("secret config error: %w", err)
+		return nil, fmt.Errorf("secret config error: %w", err)
 	}
 	scanner := secret.NewScanner(c)
 
@@ -43,7 +42,7 @@ func (a *secretAnalyzer) Analyze(_ context.Context, input analyzer.ConfigAnalysi
 	}
 	b, err := json.MarshalIndent(input.Config, "  ", "")
 	if err != nil {
-		return nil, xerrors.Errorf("json marshal error: %w", err)
+		return nil, fmt.Errorf("json marshal error: %w", err)
 	}
 
 	result := a.scanner.Scan(secret.ScanArgs{

--- a/pkg/fanal/analyzer/language/analyze.go
+++ b/pkg/fanal/analyzer/language/analyze.go
@@ -1,9 +1,8 @@
 package language
 
 import (
+	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -22,7 +21,7 @@ type Parser interface {
 func Analyze(fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser) (*analyzer.AnalysisResult, error) {
 	app, err := Parse(fileType, filePath, r, parser)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
 	}
 
 	if app == nil {
@@ -36,7 +35,7 @@ func Analyze(fileType types.LangType, filePath string, r xio.ReadSeekerAt, parse
 func AnalyzePackage(fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser, checksum bool) (*analyzer.AnalysisResult, error) {
 	app, err := ParsePackage(fileType, filePath, r, parser, checksum)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
 	}
 
 	if app == nil {
@@ -50,11 +49,11 @@ func AnalyzePackage(fileType types.LangType, filePath string, r xio.ReadSeekerAt
 func Parse(fileType types.LangType, filePath string, r io.Reader, parser Parser) (*types.Application, error) {
 	rr, err := xio.NewReadSeekerAt(r)
 	if err != nil {
-		return nil, xerrors.Errorf("reader error: %w", err)
+		return nil, fmt.Errorf("reader error: %w", err)
 	}
 	parsedPkgs, parsedDependencies, err := parser.Parse(rr)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
 	}
 
 	// The file path of each library should be empty in case of dependency list such as lock file
@@ -66,7 +65,7 @@ func Parse(fileType types.LangType, filePath string, r io.Reader, parser Parser)
 func ParsePackage(fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser, checksum bool) (*types.Application, error) {
 	parsedPkgs, parsedDependencies, err := parser.Parse(r)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to parse %s: %w", filePath, err)
 	}
 
 	// The reader is not passed if the checksum is not necessarily calculated.
@@ -122,7 +121,7 @@ func calculateDigest(r xio.ReadSeekerAt) (digest.Digest, error) {
 	}
 	// return reader to start after it has been read in analyzer
 	if _, err := r.Seek(0, io.SeekStart); err != nil {
-		return "", xerrors.Errorf("unable to seek: %w", err)
+		return "", fmt.Errorf("unable to seek: %w", err)
 	}
 
 	return digest.CalcSHA1(r)

--- a/pkg/fanal/analyzer/language/analyze_test.go
+++ b/pkg/fanal/analyzer/language/analyze_test.go
@@ -1,13 +1,13 @@
 package language_test
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/language"
@@ -32,7 +32,7 @@ func (p *mockParser) Parse(r xio.ReadSeekerAt) ([]types.Package, []types.Depende
 			},
 		}, nil, nil
 	case "sad":
-		return nil, nil, xerrors.New("unexpected error")
+		return nil, nil, errors.New("unexpected error")
 	}
 
 	return nil, nil, nil

--- a/pkg/fanal/analyzer/language/c/conan/conan.go
+++ b/pkg/fanal/analyzer/language/c/conan/conan.go
@@ -3,6 +3,7 @@ package conan
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -10,8 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/c/conan"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -56,7 +55,7 @@ func (a conanLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 	if err = fsutils.WalkDir(input.FS, ".", required, func(filePath string, _ fs.DirEntry, r io.Reader) error {
 		app, err := language.Parse(types.Conan, filePath, r, a.parser)
 		if err != nil {
-			return xerrors.Errorf("%s parse error: %w", filePath, err)
+			return fmt.Errorf("%s parse error: %w", filePath, err)
 		}
 
 		if app == nil {
@@ -76,7 +75,7 @@ func (a conanLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 		apps = append(apps, *app)
 		return nil
 	}); err != nil {
-		return nil, xerrors.Errorf("unable to parse conan lock file: %w", err)
+		return nil, fmt.Errorf("unable to parse conan lock file: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -97,7 +96,7 @@ func licensesFromCache() (map[string]string, error) {
 	cacheDir = path.Join(cacheDir, ".conan", "data")
 
 	if !fsutils.DirExists(cacheDir) {
-		return nil, xerrors.Errorf("the Conan cache directory (%s) was not found.", cacheDir)
+		return nil, fmt.Errorf("the Conan cache directory (%s) was not found.", cacheDir)
 	}
 
 	licenses := make(map[string]string)
@@ -133,7 +132,7 @@ func licensesFromCache() (map[string]string, error) {
 		licenses[name] = license
 		return nil
 	}); err != nil {
-		return nil, xerrors.Errorf("the Conan cache dir (%s) walk error: %w", cacheDir, err)
+		return nil, fmt.Errorf("the Conan cache dir (%s) walk error: %w", cacheDir, err)
 	}
 	return licenses, nil
 }

--- a/pkg/fanal/analyzer/language/conda/environment/environment.go
+++ b/pkg/fanal/analyzer/language/conda/environment/environment.go
@@ -2,10 +2,9 @@ package environment
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/conda/environment"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -24,7 +23,7 @@ type environmentAnalyzer struct{}
 func (a environmentAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.CondaEnv, input.FilePath, input.Content, environment.NewParser())
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse environment.yaml: %w", err)
+		return nil, fmt.Errorf("unable to parse environment.yaml: %w", err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/dart/pub/pubspec.go
+++ b/pkg/fanal/analyzer/language/dart/pub/pubspec.go
@@ -2,6 +2,7 @@ package pub
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
@@ -62,7 +63,7 @@ func (a pubSpecLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostA
 	err = fsutils.WalkDir(input.FS, ".", required, func(path string, _ fs.DirEntry, r io.Reader) error {
 		app, err := language.Parse(types.Pub, path, r, a.parser)
 		if err != nil {
-			return xerrors.Errorf("unable to parse %q: %w", path, err)
+			return fmt.Errorf("unable to parse %q: %w", path, err)
 		}
 
 		if app == nil {
@@ -91,7 +92,7 @@ func (a pubSpecLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostA
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("walk error: %w", err)
+		return nil, fmt.Errorf("walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -124,7 +125,7 @@ func (a pubSpecLockAnalyzer) findDependsOn() (map[string][]string, error) {
 		return nil
 
 	}); err != nil {
-		return nil, xerrors.Errorf("walk error: %w", err)
+		return nil, fmt.Errorf("walk error: %w", err)
 	}
 	return deps, nil
 }
@@ -153,7 +154,7 @@ type pubSpecYaml struct {
 func parsePubSpecYaml(r io.Reader) (string, []string, error) {
 	var spec pubSpecYaml
 	if err := yaml.NewDecoder(r).Decode(&spec); err != nil {
-		return "", nil, xerrors.Errorf("unable to decode: %w", err)
+		return "", nil, fmt.Errorf("unable to decode: %w", err)
 	}
 
 	// Version is a required field only for packages from pub.dev:

--- a/pkg/fanal/analyzer/language/dotnet/deps/deps.go
+++ b/pkg/fanal/analyzer/language/dotnet/deps/deps.go
@@ -2,10 +2,9 @@ package deps
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	core "github.com/aquasecurity/trivy/pkg/dependency/parser/dotnet/core_deps"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a depsLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisI
 	parser := core.NewParser()
 	res, err := language.Analyze(types.DotNetCore, input.FilePath, input.Content, parser)
 	if err != nil {
-		return nil, xerrors.Errorf(".Net Core dependencies analysis error: %w", err)
+		return nil, fmt.Errorf(".Net Core dependencies analysis error: %w", err)
 	}
 
 	return res, nil

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget.go
@@ -3,6 +3,7 @@ package nuget
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"sort"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nuget/config"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nuget/lock"
@@ -70,7 +70,7 @@ func (a *nugetLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.Pos
 
 		app, err := language.Parse(types.NuGet, path, r, parser)
 		if err != nil {
-			return xerrors.Errorf("NuGet parse error: %w", err)
+			return fmt.Errorf("NuGet parse error: %w", err)
 		}
 
 		// nuget file doesn't contain dependencies
@@ -83,7 +83,7 @@ func (a *nugetLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.Pos
 			if !ok {
 				license, err = a.licenseParser.findLicense(lib.Name, lib.Version)
 				if err != nil && !errors.Is(err, fs.ErrNotExist) {
-					return xerrors.Errorf("license find error: %w", err)
+					return fmt.Errorf("license find error: %w", err)
 				}
 				foundLicenses[lib.ID] = license
 			}
@@ -96,7 +96,7 @@ func (a *nugetLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.Pos
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("NuGet walk error: %w", err)
+		return nil, fmt.Errorf("NuGet walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuspec.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuspec.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/utils/fsutils"
 )
@@ -70,13 +68,13 @@ func (p nuspecParser) findLicense(name, version string) ([]string, error) {
 
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to open %q file: %w", path, err)
+		return nil, fmt.Errorf("unable to open %q file: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	var pkg Package
 	if err = xml.NewDecoder(f).Decode(&pkg); err != nil {
-		return nil, xerrors.Errorf("unable to decode %q file: %w", path, err)
+		return nil, fmt.Errorf("unable to decode %q file: %w", path, err)
 	}
 
 	if license := pkg.Metadata.License; license.Type != "expression" || license.Text == "" {

--- a/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops.go
+++ b/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops.go
@@ -2,10 +2,9 @@ package packagesprops
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	props "github.com/aquasecurity/trivy/pkg/dependency/parser/nuget/packagesprops"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a packagesPropsAnalyzer) Analyze(_ context.Context, input analyzer.Analysi
 	parser := props.NewParser()
 	res, err := language.Analyze(types.PackagesProps, input.FilePath, input.Content, parser)
 	if err != nil {
-		return nil, xerrors.Errorf("*Packages.props dependencies analysis error: %w", err)
+		return nil, fmt.Errorf("*Packages.props dependencies analysis error: %w", err)
 	}
 
 	return res, nil

--- a/pkg/fanal/analyzer/language/elixir/mix/mix.go
+++ b/pkg/fanal/analyzer/language/elixir/mix/mix.go
@@ -2,10 +2,9 @@ package mix
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/hex/mix"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a mixLockAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 	p := mix.NewParser()
 	res, err := language.Analyze(types.Hex, input.FilePath, input.Content, p)
 	if err != nil {
-		return nil, xerrors.Errorf("%s parse error: %w", input.FilePath, err)
+		return nil, fmt.Errorf("%s parse error: %w", input.FilePath, err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/golang/binary/binary.go
+++ b/pkg/fanal/analyzer/language/golang/binary/binary.go
@@ -3,9 +3,8 @@ package binary
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/golang/binary"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a gobinaryLibraryAnalyzer) Analyze(_ context.Context, input analyzer.Analy
 	if errors.Is(err, binary.ErrUnrecognizedExe) || errors.Is(err, binary.ErrNonGoBinary) {
 		return nil, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("go binary (filepath: %s) parse error: %w", input.FilePath, err)
+		return nil, fmt.Errorf("go binary (filepath: %s) parse error: %w", input.FilePath, err)
 	}
 
 	return res, nil

--- a/pkg/fanal/analyzer/language/java/gradle/lockfile.go
+++ b/pkg/fanal/analyzer/language/java/gradle/lockfile.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/gradle/lockfile"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -57,7 +56,7 @@ func (a gradleLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 		var app *types.Application
 		app, err = language.Parse(types.Gradle, filePath, r, a.parser)
 		if err != nil {
-			return xerrors.Errorf("%s parse error: %w", filePath, err)
+			return fmt.Errorf("%s parse error: %w", filePath, err)
 		}
 
 		if app == nil {
@@ -95,7 +94,7 @@ func (a gradleLockAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("walk error: %w", err)
+		return nil, fmt.Errorf("walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/language/java/gradle/pom.go
+++ b/pkg/fanal/analyzer/language/java/gradle/pom.go
@@ -2,6 +2,7 @@ package gradle
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"golang.org/x/net/html/charset"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/utils/fsutils"
@@ -57,7 +57,7 @@ func (props *Properties) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error 
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return xerrors.Errorf("XML decode error: %w", err)
+			return fmt.Errorf("XML decode error: %w", err)
 		}
 
 		(*props)[p.XMLName.Local] = p.Value
@@ -90,7 +90,7 @@ func (a gradleLockAnalyzer) parsePoms() (map[string]pomXML, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("gradle licenses walk error: %w", err)
+		return nil, fmt.Errorf("gradle licenses walk error: %w", err)
 	}
 
 	return poms, nil
@@ -101,7 +101,7 @@ func parsePom(r io.Reader, path string) (pomXML, error) {
 	decoder := xml.NewDecoder(r)
 	decoder.CharsetReader = charset.NewReaderLabel
 	if err := decoder.Decode(&pom); err != nil {
-		return pomXML{}, xerrors.Errorf("xml decode error: %w", err)
+		return pomXML{}, fmt.Errorf("xml decode error: %w", err)
 	}
 
 	// We only need pom's with licenses or dependencies
@@ -121,7 +121,7 @@ func parsePom(r io.Reader, path string) (pomXML, error) {
 	}
 
 	if err := pom.resolveDependencyVersions(); err != nil {
-		return pomXML{}, xerrors.Errorf("unable to resolve dependency version: %w", err)
+		return pomXML{}, fmt.Errorf("unable to resolve dependency version: %w", err)
 	}
 
 	return pom, nil
@@ -139,7 +139,7 @@ func (pom *pomXML) resolveDependencyVersions() error {
 			} else {
 				// We use simplified logic to resolve properties.
 				// If necessary, update and use the logic for maven pom's
-				return xerrors.Errorf("Unable to resolve %q version. Please open a new discussion to update the Trivy logic.", dep.Version)
+				return fmt.Errorf("Unable to resolve %q version. Please open a new discussion to update the Trivy logic.", dep.Version)
 			}
 		}
 	}

--- a/pkg/fanal/analyzer/language/java/jar/jar.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar.go
@@ -2,12 +2,11 @@ package jar
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/jar"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -46,7 +45,7 @@ func (a *javaLibraryAnalyzer) PostAnalyze(ctx context.Context, input analyzer.Po
 	// TODO: think about the sonatype API and "--offline"
 	client, err := javadb.NewClient()
 	if err != nil {
-		return nil, xerrors.Errorf("Unable to initialize the Java DB: %s", err)
+		return nil, fmt.Errorf("Unable to initialize the Java DB: %s", err)
 	}
 	defer func() { _ = client.Close() }()
 
@@ -71,7 +70,7 @@ func (a *javaLibraryAnalyzer) PostAnalyze(ctx context.Context, input analyzer.Po
 	}
 
 	if err = parallel.WalkDir(ctx, input.FS, ".", a.parallel, onFile, onResult); err != nil {
-		return nil, xerrors.Errorf("walk dir error: %w", err)
+		return nil, fmt.Errorf("walk dir error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -2,11 +2,10 @@ package pom
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a pomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*
 	p := pom.NewParser(filePath, pom.WithOffline(input.Options.Offline))
 	res, err := language.Analyze(types.Pom, input.FilePath, input.Content, p)
 	if err != nil {
-		return nil, xerrors.Errorf("%s parse error: %w", input.FilePath, err)
+		return nil, fmt.Errorf("%s parse error: %w", input.FilePath, err)
 	}
 
 	// Mark integration test pom files for `maven-invoker-plugin` as Dev to skip them by default.

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm.go
@@ -3,13 +3,12 @@ package npm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/npm"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/packagejson"
@@ -61,7 +60,7 @@ func (a npmLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 
 		app, err := a.parseNpmPkgLock(input.FS, filePath)
 		if err != nil {
-			return xerrors.Errorf("parse error: %w", err)
+			return fmt.Errorf("parse error: %w", err)
 		} else if app == nil {
 			return nil
 		}
@@ -77,7 +76,7 @@ func (a npmLibraryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAn
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("package-lock.json/package.json walk error: %w", err)
+		return nil, fmt.Errorf("package-lock.json/package.json walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -111,13 +110,13 @@ func (a npmLibraryAnalyzer) Version() int {
 func (a npmLibraryAnalyzer) parseNpmPkgLock(fsys fs.FS, filePath string) (*types.Application, error) {
 	f, err := fsys.Open(filePath)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
 	file, ok := f.(xio.ReadSeekCloserAt)
 	if !ok {
-		return nil, xerrors.Errorf("type assertion error: %w", err)
+		return nil, fmt.Errorf("type assertion error: %w", err)
 	}
 
 	// parse package-lock.json file
@@ -145,14 +144,14 @@ func (a npmLibraryAnalyzer) findLicenses(fsys fs.FS, lockPath string) (map[strin
 	err := fsutils.WalkDir(fsys, root, required, func(filePath string, d fs.DirEntry, r io.Reader) error {
 		pkg, err := a.packageParser.Parse(r)
 		if err != nil {
-			return xerrors.Errorf("unable to parse %q: %w", filePath, err)
+			return fmt.Errorf("unable to parse %q: %w", filePath, err)
 		}
 
 		licenses[pkg.ID] = pkg.Licenses
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("walk error: %w", err)
+		return nil, fmt.Errorf("walk error: %w", err)
 	}
 	return licenses, nil
 }

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm.go
@@ -2,10 +2,9 @@ package pnpm
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/pnpm"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -27,7 +26,7 @@ type pnpmLibraryAnalyzer struct{}
 func (a pnpmLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Pnpm, input.FilePath, input.Content, pnpm.NewParser())
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse %s: %w", input.FilePath, err)
+		return nil, fmt.Errorf("unable to parse %s: %w", input.FilePath, err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/php/composer/composer.go
+++ b/pkg/fanal/analyzer/language/php/composer/composer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/php/composer"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -54,7 +54,7 @@ func (a composerAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnal
 		// Parse composer.lock
 		app, err := a.parseComposerLock(path, r)
 		if err != nil {
-			return xerrors.Errorf("parse error: %w", err)
+			return fmt.Errorf("parse error: %w", err)
 		} else if app == nil {
 			return nil
 		}
@@ -70,7 +70,7 @@ func (a composerAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnal
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("composer walk error: %w", err)
+		return nil, fmt.Errorf("composer walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -112,7 +112,7 @@ func (a composerAnalyzer) mergeComposerJson(fsys fs.FS, dir string, app *types.A
 		log.Debug("Unable to determine the direct dependencies, composer.json not found", log.String("path", path))
 		return nil
 	} else if err != nil {
-		return xerrors.Errorf("unable to parse %s: %w", path, err)
+		return fmt.Errorf("unable to parse %s: %w", path, err)
 	}
 
 	for i, pkg := range app.Packages {
@@ -136,14 +136,14 @@ func (a composerAnalyzer) parseComposerJson(fsys fs.FS, path string) (map[string
 	// Parse composer.json
 	f, err := fsys.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
 	jsonFile := composerJson{}
 	err = json.NewDecoder(f).Decode(&jsonFile)
 	if err != nil {
-		return nil, xerrors.Errorf("json decode error: %w", err)
+		return nil, fmt.Errorf("json decode error: %w", err)
 	}
 	return jsonFile.Require, nil
 }

--- a/pkg/fanal/analyzer/language/python/packaging/packaging.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/packaging"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -71,18 +71,18 @@ func (a packagingAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 	err := fsutils.WalkDir(input.FS, ".", required, func(path string, d fs.DirEntry, r io.Reader) error {
 		rsa, ok := r.(xio.ReadSeekerAt)
 		if !ok {
-			return xerrors.New("invalid reader")
+			return errors.New("invalid reader")
 		}
 
 		// .egg file is zip format and PKG-INFO needs to be extracted from the zip file.
 		if strings.HasSuffix(path, ".egg") {
 			info, err := d.Info()
 			if err != nil {
-				return xerrors.Errorf("egg file error: %w", err)
+				return fmt.Errorf("egg file error: %w", err)
 			}
 			pkginfoInZip, err := a.analyzeEggZip(rsa, info.Size())
 			if err != nil {
-				return xerrors.Errorf("egg analysis error: %w", err)
+				return fmt.Errorf("egg analysis error: %w", err)
 			}
 
 			// Egg archive may not contain required files, then we will get nil. Skip this archives
@@ -94,7 +94,7 @@ func (a packagingAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 
 		app, err := a.parse(path, rsa, input.Options.FileChecksum)
 		if err != nil {
-			return xerrors.Errorf("parse error: %w", err)
+			return fmt.Errorf("parse error: %w", err)
 		} else if app == nil {
 			return nil
 		}
@@ -108,7 +108,7 @@ func (a packagingAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAna
 	})
 
 	if err != nil {
-		return nil, xerrors.Errorf("python package walk error: %w", err)
+		return nil, fmt.Errorf("python package walk error: %w", err)
 	}
 	return &analyzer.AnalysisResult{
 		Applications: apps,
@@ -154,13 +154,13 @@ func classifyLicense(dir, licPath string, classifierConfidenceLevel float64, fsy
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 
 	l, err := licensing.Classify(licPath, f, classifierConfidenceLevel)
 	if err != nil {
-		return nil, xerrors.Errorf("license classify error: %w", err)
+		return nil, fmt.Errorf("license classify error: %w", err)
 	} else if l == nil {
 		return nil, nil
 	}
@@ -175,7 +175,7 @@ func (a packagingAnalyzer) parse(filePath string, r xio.ReadSeekerAt, checksum b
 func (a packagingAnalyzer) analyzeEggZip(r io.ReaderAt, size int64) (xio.ReadSeekerAt, error) {
 	zr, err := zip.NewReader(r, size)
 	if err != nil {
-		return nil, xerrors.Errorf("zip reader error: %w", err)
+		return nil, fmt.Errorf("zip reader error: %w", err)
 	}
 
 	found, ok := lo.Find(zr.File, func(f *zip.File) bool {
@@ -197,7 +197,7 @@ func (a packagingAnalyzer) open(file *zip.File) (xio.ReadSeekerAt, error) {
 
 	b, err := io.ReadAll(f)
 	if err != nil {
-		return nil, xerrors.Errorf("file %s open error: %w", file.Name, err)
+		return nil, fmt.Errorf("file %s open error: %w", file.Name, err)
 	}
 
 	return bytes.NewReader(b), nil

--- a/pkg/fanal/analyzer/language/python/pip/pip.go
+++ b/pkg/fanal/analyzer/language/python/pip/pip.go
@@ -2,10 +2,9 @@ package pip
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pip"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -24,7 +23,7 @@ type pipLibraryAnalyzer struct{}
 func (a pipLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Pip, input.FilePath, input.Content, pip.NewParser())
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse requirements.txt: %w", err)
+		return nil, fmt.Errorf("unable to parse requirements.txt: %w", err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/python/pipenv/pipenv.go
+++ b/pkg/fanal/analyzer/language/python/pipenv/pipenv.go
@@ -2,10 +2,9 @@ package pipenv
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pipenv"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -27,7 +26,7 @@ type pipenvLibraryAnalyzer struct{}
 func (a pipenvLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Pipenv, input.FilePath, input.Content, pipenv.NewParser())
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse Pipfile.lock: %w", err)
+		return nil, fmt.Errorf("unable to parse Pipfile.lock: %w", err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/python/poetry/poetry.go
+++ b/pkg/fanal/analyzer/language/python/poetry/poetry.go
@@ -3,12 +3,11 @@ package poetry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/poetry"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pyproject"
@@ -50,7 +49,7 @@ func (a poetryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalys
 		// Parse poetry.lock
 		app, err := a.parsePoetryLock(path, r)
 		if err != nil {
-			return xerrors.Errorf("parse error: %w", err)
+			return fmt.Errorf("parse error: %w", err)
 		} else if app == nil {
 			return nil
 		}
@@ -65,7 +64,7 @@ func (a poetryAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalys
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("poetry walk error: %w", err)
+		return nil, fmt.Errorf("poetry walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -99,7 +98,7 @@ func (a poetryAnalyzer) mergePyProject(fsys fs.FS, dir string, app *types.Applic
 		a.logger.Debug("pyproject.toml not found", log.String("path", path))
 		return nil
 	} else if err != nil {
-		return xerrors.Errorf("unable to parse %s: %w", path, err)
+		return fmt.Errorf("unable to parse %s: %w", path, err)
 	}
 
 	for i, pkg := range app.Packages {
@@ -119,7 +118,7 @@ func (a poetryAnalyzer) parsePyProject(fsys fs.FS, path string) (map[string]inte
 	// Parse pyproject.toml
 	f, err := fsys.Open(path)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 

--- a/pkg/fanal/analyzer/language/ruby/bundler/bundler.go
+++ b/pkg/fanal/analyzer/language/ruby/bundler/bundler.go
@@ -2,10 +2,9 @@ package bundler
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/ruby/bundler"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -24,7 +23,7 @@ type bundlerLibraryAnalyzer struct{}
 func (a bundlerLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Bundler, input.FilePath, input.Content, bundler.NewParser())
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse Gemfile.lock: %w", err)
+		return nil, fmt.Errorf("unable to parse Gemfile.lock: %w", err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/rust/binary/binary.go
+++ b/pkg/fanal/analyzer/language/rust/binary/binary.go
@@ -3,9 +3,8 @@ package binary
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/rust/binary"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -27,7 +26,7 @@ func (a rustBinaryLibraryAnalyzer) Analyze(_ context.Context, input analyzer.Ana
 	if errors.Is(err, binary.ErrUnrecognizedExe) || errors.Is(err, binary.ErrNonRustBinary) {
 		return nil, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("rust binary parse error: %w", err)
+		return nil, fmt.Errorf("rust binary parse error: %w", err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo.go
@@ -15,7 +15,6 @@ import (
 	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/go-version/pkg/semver"
 	goversion "github.com/aquasecurity/go-version/pkg/version"
@@ -64,7 +63,7 @@ func (a cargoAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysi
 		// Parse Cargo.lock
 		app, err := a.parseCargoLock(filePath, r)
 		if err != nil {
-			return xerrors.Errorf("parse error: %w", err)
+			return fmt.Errorf("parse error: %w", err)
 		} else if app == nil {
 			return nil
 		}
@@ -80,7 +79,7 @@ func (a cargoAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysi
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("cargo walk error: %w", err)
+		return nil, fmt.Errorf("cargo walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{
@@ -112,7 +111,7 @@ func (a cargoAnalyzer) removeDevDependencies(fsys fs.FS, dir string, app *types.
 		a.logger.Debug("Cargo.toml not found", log.String("path", cargoTOMLPath))
 		return nil
 	} else if err != nil {
-		return xerrors.Errorf("unable to parse %s: %w", cargoTOMLPath, err)
+		return fmt.Errorf("unable to parse %s: %w", cargoTOMLPath, err)
 	}
 
 	// Cargo.toml file can contain same packages with different versions.
@@ -174,7 +173,7 @@ type Dependencies map[string]interface{}
 func (a cargoAnalyzer) parseRootCargoTOML(fsys fs.FS, filePath string) (map[string]string, error) {
 	dependencies, members, err := parseCargoTOML(fsys, filePath)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse %s: %w", filePath, err)
+		return nil, fmt.Errorf("unable to parse %s: %w", filePath, err)
 	}
 	// According to Cargo workspace RFC, workspaces can't be nested:
 	// https://github.com/nox/rust-rfcs/blob/master/text/1525-cargo-workspace.md#validating-a-workspace
@@ -243,12 +242,12 @@ func (a cargoAnalyzer) matchVersion(currentVersion, constraint string) (bool, er
 
 	ver, err := semver.Parse(currentVersion)
 	if err != nil {
-		return false, xerrors.Errorf("version error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("version error (%s): %s", currentVersion, err)
 	}
 
 	c, err := semver.NewConstraints(constraint)
 	if err != nil {
-		return false, xerrors.Errorf("constraint error (%s): %s", currentVersion, err)
+		return false, fmt.Errorf("constraint error (%s): %s", currentVersion, err)
 	}
 
 	return c.Check(ver), nil
@@ -258,7 +257,7 @@ func parseCargoTOML(fsys fs.FS, filePath string) (Dependencies, []string, error)
 	// Parse Cargo.toml
 	f, err := fsys.Open(filePath)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("file open error: %w", err)
+		return nil, nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -268,7 +267,7 @@ func parseCargoTOML(fsys fs.FS, filePath string) (Dependencies, []string, error)
 	// declare `dependencies` to avoid panic
 	dependencies := Dependencies{}
 	if _, err = toml.NewDecoder(f).Decode(&tomlFile); err != nil {
-		return nil, nil, xerrors.Errorf("toml decode error: %w", err)
+		return nil, nil, fmt.Errorf("toml decode error: %w", err)
 	}
 
 	maps.Copy(dependencies, tomlFile.Dependencies)

--- a/pkg/fanal/analyzer/language/swift/cocoapods/cocoapods.go
+++ b/pkg/fanal/analyzer/language/swift/cocoapods/cocoapods.go
@@ -2,9 +2,8 @@ package cocoapods
 
 import (
 	"context"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/swift/cocoapods"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -27,7 +26,7 @@ func (a cocoaPodsLockAnalyzer) Analyze(_ context.Context, input analyzer.Analysi
 	p := cocoapods.NewParser()
 	res, err := language.Analyze(types.Cocoapods, input.FilePath, input.Content, p)
 	if err != nil {
-		return nil, xerrors.Errorf("%s parse error: %w", input.FilePath, err)
+		return nil, fmt.Errorf("%s parse error: %w", input.FilePath, err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/language/swift/swift/swift.go
+++ b/pkg/fanal/analyzer/language/swift/swift/swift.go
@@ -2,10 +2,9 @@ package swift
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/swift/swift"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -28,7 +27,7 @@ func (a swiftLockAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInp
 	p := swift.NewParser()
 	res, err := language.Analyze(types.Swift, input.FilePath, input.Content, p)
 	if err != nil {
-		return nil, xerrors.Errorf("%s parse error: %w", input.FilePath, err)
+		return nil, fmt.Errorf("%s parse error: %w", input.FilePath, err)
 	}
 	return res, nil
 }

--- a/pkg/fanal/analyzer/licensing/license.go
+++ b/pkg/fanal/analyzer/licensing/license.go
@@ -2,6 +2,7 @@ package licensing
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -101,7 +101,7 @@ func (a *licenseFileAnalyzer) Analyze(ctx context.Context, input analyzer.Analys
 	}
 	lf, err := licensing.Classify(input.FilePath, input.Content, a.classifierConfidenceLevel)
 	if err != nil {
-		return nil, xerrors.Errorf("license classification error: %w", err)
+		return nil, fmt.Errorf("license classification error: %w", err)
 	} else if len(lf.Findings) == 0 {
 		return nil, nil
 	}

--- a/pkg/fanal/analyzer/os/alpine/alpine.go
+++ b/pkg/fanal/analyzer/os/alpine/alpine.go
@@ -3,10 +3,10 @@ package alpine
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -34,7 +34,7 @@ func (a alpineOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 			},
 		}, nil
 	}
-	return nil, xerrors.Errorf("alpine: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("alpine: %w", fos.AnalyzeOSError)
 }
 
 func (a alpineOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
@@ -3,11 +3,10 @@ package amazonlinux
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -59,7 +58,7 @@ func (a amazonlinuxOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 			}, nil
 		}
 	}
-	return types.OS{}, xerrors.Errorf("amazon: %w", fos.AnalyzeOSError)
+	return types.OS{}, fmt.Errorf("amazon: %w", fos.AnalyzeOSError)
 }
 
 func (a amazonlinuxOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/const.go
+++ b/pkg/fanal/analyzer/os/const.go
@@ -1,5 +1,5 @@
 package os
 
-import "golang.org/x/xerrors"
+import "errors"
 
-var AnalyzeOSError = xerrors.New("unable to analyze OS information")
+var AnalyzeOSError = errors.New("unable to analyze OS information")

--- a/pkg/fanal/analyzer/os/debian/debian.go
+++ b/pkg/fanal/analyzer/os/debian/debian.go
@@ -3,9 +3,8 @@ package debian
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -34,7 +33,7 @@ func (a debianOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 			},
 		}, nil
 	}
-	return nil, xerrors.Errorf("debian: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("debian: %w", fos.AnalyzeOSError)
 }
 
 func (a debianOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/mariner/mariner.go
+++ b/pkg/fanal/analyzer/os/mariner/mariner.go
@@ -3,12 +3,11 @@ package mariner
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -29,7 +28,7 @@ type marinerOSAnalyzer struct{}
 func (a marinerOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	foundOS, err := a.parseRelease(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("release parse error: %w", err)
+		return nil, fmt.Errorf("release parse error: %w", err)
 	}
 	return &analyzer.AnalysisResult{
 		OS: foundOS,
@@ -51,7 +50,7 @@ func (a marinerOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 			}, nil
 		}
 	}
-	return types.OS{}, xerrors.Errorf("cbl-mariner: %w", fos.AnalyzeOSError)
+	return types.OS{}, fmt.Errorf("cbl-mariner: %w", fos.AnalyzeOSError)
 }
 
 func (a marinerOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/alma.go
+++ b/pkg/fanal/analyzer/os/redhatbase/alma.go
@@ -3,10 +3,10 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -28,7 +28,7 @@ func (a almaOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return nil, xerrors.New("alma: invalid almalinux-release")
+			return nil, errors.New("alma: invalid almalinux-release")
 		}
 
 		switch strings.ToLower(result[1]) {
@@ -42,7 +42,7 @@ func (a almaOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		}
 	}
 
-	return nil, xerrors.Errorf("alma: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("alma: %w", fos.AnalyzeOSError)
 }
 
 func (a almaOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/centos.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos.go
@@ -3,10 +3,10 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -28,7 +28,7 @@ func (a centOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return nil, xerrors.New("centos: invalid centos-release")
+			return nil, errors.New("centos: invalid centos-release")
 		}
 
 		switch strings.ToLower(result[1]) {
@@ -42,7 +42,7 @@ func (a centOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 		}
 	}
 
-	return nil, xerrors.Errorf("centos: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("centos: %w", fos.AnalyzeOSError)
 }
 
 func (a centOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/fedora.go
+++ b/pkg/fanal/analyzer/os/redhatbase/fedora.go
@@ -3,10 +3,10 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -28,7 +28,7 @@ func (a fedoraOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return nil, xerrors.New("fedora: Invalid fedora-release")
+			return nil, errors.New("fedora: Invalid fedora-release")
 		}
 
 		switch strings.ToLower(result[1]) {
@@ -41,7 +41,7 @@ func (a fedoraOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 			}, nil
 		}
 	}
-	return nil, xerrors.Errorf("fedora: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("fedora: %w", fos.AnalyzeOSError)
 }
 
 func (a fedoraOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/oracle.go
+++ b/pkg/fanal/analyzer/os/redhatbase/oracle.go
@@ -3,10 +3,10 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -28,7 +28,7 @@ func (a oracleOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return nil, xerrors.New("oracle: invalid oracle-release")
+			return nil, errors.New("oracle: invalid oracle-release")
 		}
 		return &analyzer.AnalysisResult{
 			OS: types.OS{
@@ -38,7 +38,7 @@ func (a oracleOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 		}, nil
 	}
 
-	return nil, xerrors.Errorf("oracle: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("oracle: %w", fos.AnalyzeOSError)
 }
 
 func (a oracleOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
@@ -3,12 +3,12 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -43,7 +43,7 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return types.OS{}, xerrors.New("redhat: invalid redhat-release")
+			return types.OS{}, errors.New("redhat: invalid redhat-release")
 		}
 
 		switch strings.ToLower(result[1]) {
@@ -79,7 +79,7 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 			}, nil
 		}
 	}
-	return types.OS{}, xerrors.Errorf("redhatbase: %w", fos.AnalyzeOSError)
+	return types.OS{}, fmt.Errorf("redhatbase: %w", fos.AnalyzeOSError)
 }
 
 func (a redhatOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/redhatbase/rocky.go
+++ b/pkg/fanal/analyzer/os/redhatbase/rocky.go
@@ -3,10 +3,10 @@ package redhatbase
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -28,7 +28,7 @@ func (a rockyOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))
 		if len(result) != 3 {
-			return nil, xerrors.New("rocky: invalid rocky-release")
+			return nil, errors.New("rocky: invalid rocky-release")
 		}
 
 		switch strings.ToLower(result[1]) {
@@ -42,7 +42,7 @@ func (a rockyOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 		}
 	}
 
-	return nil, xerrors.Errorf("rocky: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("rocky: %w", fos.AnalyzeOSError)
 }
 
 func (a rockyOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/os/ubuntu/esm.go
+++ b/pkg/fanal/analyzer/os/ubuntu/esm.go
@@ -3,10 +3,10 @@ package ubuntu
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -33,7 +33,7 @@ func (a ubuntuESMAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInp
 	st := status{}
 	err := json.NewDecoder(input.Content).Decode(&st)
 	if err != nil {
-		return nil, xerrors.Errorf("ubuntu ESM analyze error: %w", err)
+		return nil, fmt.Errorf("ubuntu ESM analyze error: %w", err)
 	}
 	if esmEnabled(st) {
 		return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/os/ubuntu/ubuntu.go
+++ b/pkg/fanal/analyzer/os/ubuntu/ubuntu.go
@@ -3,11 +3,11 @@ package ubuntu
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
@@ -48,7 +48,7 @@ func (a ubuntuOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInpu
 			}, nil
 		}
 	}
-	return nil, xerrors.Errorf("ubuntu: %w", fos.AnalyzeOSError)
+	return nil, fmt.Errorf("ubuntu: %w", fos.AnalyzeOSError)
 }
 
 func (a ubuntuOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -3,6 +3,7 @@ package dpkg
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -39,18 +39,18 @@ type dpkgLicenseAnalyzer struct {
 func (a *dpkgLicenseAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	findings, err := a.parseCopyright(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("parse copyright %s: %w", input.FilePath, err)
+		return nil, fmt.Errorf("parse copyright %s: %w", input.FilePath, err)
 	}
 
 	// If licenses are not found, fallback to the classifier
 	if len(findings) == 0 && a.licenseFull {
 		// Rewind the reader to the beginning of the stream after saving
 		if _, err = input.Content.Seek(0, io.SeekStart); err != nil {
-			return nil, xerrors.Errorf("seek error: %w", err)
+			return nil, fmt.Errorf("seek error: %w", err)
 		}
 		licenseFile, err := licensing.Classify(input.FilePath, input.Content, a.classifierConfidenceLevel)
 		if err != nil {
-			return nil, xerrors.Errorf("license classification error: %w", err)
+			return nil, fmt.Errorf("license classification error: %w", err)
 		}
 		findings = licenseFile.Findings
 	}

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg.go
@@ -17,7 +17,6 @@ import (
 	debVersion "github.com/knqyf263/go-deb-version"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -92,7 +91,7 @@ func (a dpkgAnalyzer) PostAnalyze(_ context.Context, input analyzer.PostAnalysis
 		return nil
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("dpkg walk error: %w", err)
+		return nil, fmt.Errorf("dpkg walk error: %w", err)
 	}
 
 	// map the packages to their respective files
@@ -130,7 +129,7 @@ func (a dpkgAnalyzer) parseDpkgInfoList(scanner *bufio.Scanner) ([]string, error
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, xerrors.Errorf("scan error: %w", err)
+		return nil, fmt.Errorf("scan error: %w", err)
 	}
 
 	// Add the file if it is not directory.
@@ -160,7 +159,7 @@ func (a dpkgAnalyzer) parseDpkgInfoList(scanner *bufio.Scanner) ([]string, error
 func (a dpkgAnalyzer) parseDpkgAvailable(fsys fs.FS) (map[string]digest.Digest, error) {
 	f, err := fsys.Open(availableFile)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 
@@ -179,7 +178,7 @@ func (a dpkgAnalyzer) parseDpkgAvailable(fsys fs.FS) (map[string]digest.Digest, 
 		}
 	}
 	if err = scanner.Err(); err != nil {
-		return nil, xerrors.Errorf("scan error: %w", err)
+		return nil, fmt.Errorf("scan error: %w", err)
 	}
 
 	return pkgs, nil
@@ -208,7 +207,7 @@ func (a dpkgAnalyzer) parseDpkgStatus(filePath string, r io.Reader, digests map[
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, xerrors.Errorf("scan error: %w", err)
+		return nil, fmt.Errorf("scan error: %w", err)
 	}
 
 	a.consolidateDependencies(pkgs, pkgIDs)

--- a/pkg/fanal/analyzer/pkg/rpm/rpmqa.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpmqa.go
@@ -3,11 +3,11 @@ package rpm
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -32,7 +32,7 @@ type rpmqaPkgAnalyzer struct{}
 func (a rpmqaPkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	pkgs, err := a.parseRpmqaManifest(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rpmqa manifest: %w", err)
+		return nil, fmt.Errorf("failed to parse rpmqa manifest: %w", err)
 	}
 	return &analyzer.AnalysisResult{
 		PackageInfos: []types.PackageInfo{
@@ -53,7 +53,7 @@ func (a rpmqaPkgAnalyzer) parseRpmqaManifest(r xio.ReadSeekerAt) ([]types.Packag
 		// %{NAME}\t%{VERSION}-%{RELEASE}\t%{INSTALLTIME}\t%{BUILDTIME}\t%{VENDOR}\t(none)\t%{SIZE}\t%{ARCH}\t%{EPOCHNUM}\t%{SOURCERPM}
 		s := strings.Split(line, "\t")
 		if len(s) != 10 {
-			return nil, xerrors.Errorf("failed to parse a line (%s)", line)
+			return nil, fmt.Errorf("failed to parse a line (%s)", line)
 		}
 		name = s[0]
 		arch = s[7]
@@ -62,11 +62,11 @@ func (a rpmqaPkgAnalyzer) parseRpmqaManifest(r xio.ReadSeekerAt) ([]types.Packag
 			ver = verRel[0]
 			rel = verRel[1]
 		} else {
-			return nil, xerrors.Errorf("failed to split a version (%s)", s[1])
+			return nil, fmt.Errorf("failed to split a version (%s)", s[1])
 		}
 		srcName, srcVer, srcRel, err := splitFileName(sourceRpm)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to split source rpm: %w", err)
+			return nil, fmt.Errorf("failed to split source rpm: %w", err)
 		}
 		pkgs = append(pkgs, types.Package{
 			Name:       name,

--- a/pkg/fanal/analyzer/repo/apk/apk.go
+++ b/pkg/fanal/analyzer/repo/apk/apk.go
@@ -3,11 +3,11 @@ package apk
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	ver "github.com/aquasecurity/go-version/pkg/version"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -45,7 +45,7 @@ func (a apkRepoAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 
 		// Find OS Family
 		if osFamily != "" && osFamily != newOSFamily {
-			return nil, xerrors.Errorf("mixing different distributions in etc/apk/repositories: %s != %s", osFamily, newOSFamily)
+			return nil, fmt.Errorf("mixing different distributions in etc/apk/repositories: %s != %s", osFamily, newOSFamily)
 		}
 		osFamily = newOSFamily
 

--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -2,11 +2,10 @@ package sbom
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -33,12 +32,12 @@ func (a sbomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (
 	// Format auto-detection
 	format, err := sbom.DetectFormat(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to detect SBOM format: %w", err)
+		return nil, fmt.Errorf("failed to detect SBOM format: %w", err)
 	}
 
 	bom, err := sbom.Decode(input.Content, format)
 	if err != nil {
-		return nil, xerrors.Errorf("SBOM decode error: %w", err)
+		return nil, fmt.Errorf("SBOM decode error: %w", err)
 	}
 
 	// Bitnami images

--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/secret"
@@ -69,7 +68,7 @@ func (a *SecretAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
 	configPath := opt.SecretScannerOption.ConfigPath
 	c, err := secret.ParseConfig(configPath)
 	if err != nil {
-		return xerrors.Errorf("secret config error: %w", err)
+		return fmt.Errorf("secret config error: %w", err)
 	}
 	a.scanner = secret.NewScanner(c)
 	a.configPath = configPath
@@ -85,7 +84,7 @@ func (a *SecretAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 
 	content, err := io.ReadAll(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("read error %s: %w", input.FilePath, err)
+		return nil, fmt.Errorf("read error %s: %w", input.FilePath, err)
 	}
 
 	content = bytes.ReplaceAll(content, []byte("\r"), []byte(""))

--- a/pkg/fanal/applier/applier.go
+++ b/pkg/fanal/applier/applier.go
@@ -1,7 +1,7 @@
 package applier
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
@@ -26,7 +26,7 @@ func (a *applier) ApplyLayers(imageID string, layerKeys []string) (ftypes.Artifa
 	for _, key := range layerKeys {
 		blob, _ := a.cache.GetBlob(key) // nolint
 		if blob.SchemaVersion == 0 {
-			return ftypes.ArtifactDetail{}, xerrors.Errorf("layer cache missing: %s", key)
+			return ftypes.ArtifactDetail{}, fmt.Errorf("layer cache missing: %s", key)
 		}
 		layers = append(layers, blob)
 	}

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -12,7 +13,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -47,17 +47,17 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, opt artifact.Option) (a
 	// Initialize handlers
 	handlerManager, err := handler.NewManager(opt)
 	if err != nil {
-		return nil, xerrors.Errorf("handler init error: %w", err)
+		return nil, fmt.Errorf("handler init error: %w", err)
 	}
 
 	a, err := analyzer.NewAnalyzerGroup(opt.AnalyzerOptions())
 	if err != nil {
-		return nil, xerrors.Errorf("analyzer group error: %w", err)
+		return nil, fmt.Errorf("analyzer group error: %w", err)
 	}
 
 	ca, err := analyzer.NewConfigAnalyzerGroup(opt.ConfigAnalyzerOptions())
 	if err != nil {
-		return nil, xerrors.Errorf("config analyzer group error: %w", err)
+		return nil, fmt.Errorf("config analyzer group error: %w", err)
 	}
 
 	return Artifact{
@@ -76,13 +76,13 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, opt artifact.Option) (a
 func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	imageID, err := a.image.ID()
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("unable to get the image ID: %w", err)
+		return artifact.Reference{}, fmt.Errorf("unable to get the image ID: %w", err)
 	}
 	a.logger.Debug("Detected image ID", log.String("image_id", imageID))
 
 	configFile, err := a.image.ConfigFile()
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("unable to get the image's config file: %w", err)
+		return artifact.Reference{}, fmt.Errorf("unable to get the image's config file: %w", err)
 	}
 
 	diffIDs := a.diffIDs(configFile)
@@ -94,7 +94,7 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 		return res, nil
 	} else if !errors.Is(err, errNoSBOMFound) {
 		// Fail on unexpected error, otherwise it falls into the usual scanning.
-		return artifact.Reference{}, xerrors.Errorf("remote SBOM fetching error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("remote SBOM fetching error: %w", err)
 	}
 
 	// Try to detect base layers.
@@ -112,7 +112,7 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 
 	missingImage, missingLayers, err := a.cache.MissingBlobs(imageKey, layerKeys)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("unable to get missing layers: %w", err)
+		return artifact.Reference{}, fmt.Errorf("unable to get missing layers: %w", err)
 	}
 
 	missingImageKey := imageKey
@@ -123,7 +123,7 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	}
 
 	if err = a.inspect(ctx, missingImageKey, missingLayers, baseDiffIDs, layerKeyMap, configFile); err != nil {
-		return artifact.Reference{}, xerrors.Errorf("analyze error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("analyze error: %w", err)
 	}
 
 	return artifact.Reference{
@@ -214,10 +214,10 @@ func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys, b
 
 		layerInfo, err := a.inspectLayer(ctx, layer, disabledAnalyzers)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to analyze layer (%s): %w", layer.DiffID, err)
+			return nil, fmt.Errorf("failed to analyze layer (%s): %w", layer.DiffID, err)
 		}
 		if err = a.cache.PutBlob(layerKey, layerInfo); err != nil {
-			return nil, xerrors.Errorf("failed to store layer: %s in cache: %w", layerKey, err)
+			return nil, fmt.Errorf("failed to store layer: %s in cache: %w", layerKey, err)
 		}
 		if lo.IsNotEmpty(layerInfo.OS) {
 			osFound = layerInfo.OS
@@ -227,12 +227,12 @@ func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys, b
 	}, nil)
 
 	if err := p.Do(ctx); err != nil {
-		return xerrors.Errorf("pipeline error: %w", err)
+		return fmt.Errorf("pipeline error: %w", err)
 	}
 
 	if missingImage != "" {
 		if err := a.inspectConfig(ctx, missingImage, osFound, configFile); err != nil {
-			return xerrors.Errorf("unable to analyze config: %w", err)
+			return fmt.Errorf("unable to analyze config: %w", err)
 		}
 	}
 
@@ -244,7 +244,7 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 
 	layerDigest, rc, err := a.uncompressedLayer(layerInfo.DiffID)
 	if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("unable to get uncompressed layer %s: %w", layerInfo.DiffID, err)
+		return types.BlobInfo{}, fmt.Errorf("unable to get uncompressed layer %s: %w", layerInfo.DiffID, err)
 	}
 	defer rc.Close()
 
@@ -260,14 +260,14 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 	// Prepare filesystem for post analysis
 	composite, err := a.analyzer.PostAnalyzerFS()
 	if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("unable to get post analysis filesystem: %w", err)
+		return types.BlobInfo{}, fmt.Errorf("unable to get post analysis filesystem: %w", err)
 	}
 	defer composite.Cleanup()
 
 	// Walk a tar layer
 	opqDirs, whFiles, err := a.walker.Walk(rc, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
 		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, "", filePath, info, opener, disabled, opts); err != nil {
-			return xerrors.Errorf("failed to analyze %s: %w", filePath, err)
+			return fmt.Errorf("failed to analyze %s: %w", filePath, err)
 		}
 
 		// Skip post analysis if the file is not required
@@ -279,16 +279,16 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 		// Build filesystem for post analysis
 		tmpFilePath, err := composite.CopyFileToTemp(opener, info)
 		if err != nil {
-			return xerrors.Errorf("failed to copy file to temp: %w", err)
+			return fmt.Errorf("failed to copy file to temp: %w", err)
 		}
 		if err = composite.CreateLink(analyzerTypes, "", filePath, tmpFilePath); err != nil {
-			return xerrors.Errorf("failed to write a file: %w", err)
+			return fmt.Errorf("failed to write a file: %w", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("walk error: %w", err)
+		return types.BlobInfo{}, fmt.Errorf("walk error: %w", err)
 	}
 
 	// Wait for all the goroutine to finish.
@@ -296,7 +296,7 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 
 	// Post-analysis
 	if err = a.analyzer.PostAnalyze(ctx, composite, result, opts); err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("post analysis error: %w", err)
+		return types.BlobInfo{}, fmt.Errorf("post analysis error: %w", err)
 	}
 
 	// Sort the analysis result for consistent results
@@ -324,7 +324,7 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 
 	// Call post handlers to modify blob info
 	if err = a.handlerManager.PostHandle(ctx, result, &blobInfo); err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("post handler error: %w", err)
+		return types.BlobInfo{}, fmt.Errorf("post handler error: %w", err)
 	}
 
 	return blobInfo, nil
@@ -343,12 +343,12 @@ func (a Artifact) uncompressedLayer(diffID string) (string, io.ReadCloser, error
 	// diffID is a hash of the uncompressed layer
 	h, err := v1.NewHash(diffID)
 	if err != nil {
-		return "", nil, xerrors.Errorf("invalid layer ID (%s): %w", diffID, err)
+		return "", nil, fmt.Errorf("invalid layer ID (%s): %w", diffID, err)
 	}
 
 	layer, err := a.image.LayerByDiffID(h)
 	if err != nil {
-		return "", nil, xerrors.Errorf("failed to get the layer (%s): %w", diffID, err)
+		return "", nil, fmt.Errorf("failed to get the layer (%s): %w", diffID, err)
 	}
 
 	// digest is a hash of the compressed layer
@@ -356,14 +356,14 @@ func (a Artifact) uncompressedLayer(diffID string) (string, io.ReadCloser, error
 	if a.isCompressed(layer) {
 		d, err := layer.Digest()
 		if err != nil {
-			return "", nil, xerrors.Errorf("failed to get the digest (%s): %w", diffID, err)
+			return "", nil, fmt.Errorf("failed to get the digest (%s): %w", diffID, err)
 		}
 		digest = d.String()
 	}
 
 	rc, err := layer.Uncompressed()
 	if err != nil {
-		return "", nil, xerrors.Errorf("failed to get the layer content (%s): %w", diffID, err)
+		return "", nil, fmt.Errorf("failed to get the layer content (%s): %w", diffID, err)
 	}
 	return digest, rc, nil
 }
@@ -389,7 +389,7 @@ func (a Artifact) inspectConfig(ctx context.Context, imageID string, osFound typ
 	}
 
 	if err := a.cache.PutArtifact(imageID, info); err != nil {
-		return xerrors.Errorf("failed to put image info into the cache: %w", err)
+		return fmt.Errorf("failed to put image info into the cache: %w", err)
 	}
 
 	return nil

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -2015,7 +2014,7 @@ func TestArtifact_Inspect(t *testing.T) {
 					BlobIDs:    []string{"sha256:1fd280c63e1416a2261e76454caa19a5b77c6bddedd48309c9687c4fe72b34c0"},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
-					Err: xerrors.New("MissingBlobs failed"),
+					Err: errors.New("MissingBlobs failed"),
 				},
 			},
 			wantErr: "MissingBlobs failed",

--- a/pkg/fanal/artifact/image/remote_sbom.go
+++ b/pkg/fanal/artifact/image/remote_sbom.go
@@ -11,7 +11,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	sbomatt "github.com/aquasecurity/trivy/pkg/attestation/sbom"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -23,7 +22,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-var errNoSBOMFound = xerrors.New("remote SBOM not found")
+var errNoSBOMFound = errors.New("remote SBOM not found")
 
 type inspectRemoteSBOM func(context.Context) (artifact.Reference, error)
 
@@ -46,7 +45,7 @@ func (a Artifact) retrieveRemoteSBOM(ctx context.Context) (artifact.Reference, e
 			a.logger.Debug("No SBOM found in the source", log.String("source", sbomSource))
 			continue
 		} else if err != nil {
-			return artifact.Reference{}, xerrors.Errorf("SBOM searching error: %w", err)
+			return artifact.Reference{}, fmt.Errorf("SBOM searching error: %w", err)
 		}
 		return ref, nil
 	}
@@ -56,17 +55,17 @@ func (a Artifact) retrieveRemoteSBOM(ctx context.Context) (artifact.Reference, e
 func (a Artifact) inspectOCIReferrerSBOM(ctx context.Context) (artifact.Reference, error) {
 	digest, err := repoDigest(a.image, a.artifactOption.Insecure)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("repo digest error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("repo digest error: %w", err)
 	}
 
 	// Fetch referrers
 	index, err := remote.Referrers(ctx, digest, a.artifactOption.ImageOption.RegistryOptions)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("unable to fetch referrers: %w", err)
+		return artifact.Reference{}, fmt.Errorf("unable to fetch referrers: %w", err)
 	}
 	manifest, err := index.IndexManifest()
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("unable to get manifest: %w", err)
+		return artifact.Reference{}, fmt.Errorf("unable to get manifest: %w", err)
 	}
 	for _, m := range lo.FromPtr(manifest).Manifests {
 		// Unsupported artifact type
@@ -89,12 +88,12 @@ func (a Artifact) parseReferrer(ctx context.Context, repo string, desc v1.Descri
 	repoName := fmt.Sprintf("%s@%s", repo, desc.Digest)
 	referrer, err := oci.NewArtifact(repoName, true, a.artifactOption.ImageOption.RegistryOptions)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("OCI error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("OCI error: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "trivy-sbom-*")
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("mkdir temp error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("mkdir temp error: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
@@ -103,12 +102,12 @@ func (a Artifact) parseReferrer(ctx context.Context, repo string, desc v1.Descri
 		MediaType: desc.ArtifactType,
 		Filename:  fileName,
 	}); err != nil {
-		return artifact.Reference{}, xerrors.Errorf("SBOM download error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("SBOM download error: %w", err)
 	}
 
 	res, err := a.inspectSBOMFile(ctx, filepath.Join(tmpDir, fileName))
 	if err != nil {
-		return res, xerrors.Errorf("SBOM error: %w", err)
+		return res, fmt.Errorf("SBOM error: %w", err)
 	}
 
 	// Found SBOM
@@ -120,36 +119,36 @@ func (a Artifact) parseReferrer(ctx context.Context, repo string, desc v1.Descri
 func (a Artifact) inspectRekorSBOMAttestation(ctx context.Context) (artifact.Reference, error) {
 	digest, err := repoDigest(a.image, a.artifactOption.Insecure)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("repo digest error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("repo digest error: %w", err)
 	}
 
 	client, err := sbomatt.NewRekor(a.artifactOption.RekorURL)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to create rekor client: %w", err)
+		return artifact.Reference{}, fmt.Errorf("failed to create rekor client: %w", err)
 	}
 
 	raw, err := client.RetrieveSBOM(ctx, digest.DigestStr())
 	if errors.Is(err, sbomatt.ErrNoSBOMAttestation) {
 		return artifact.Reference{}, errNoSBOMFound
 	} else if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to retrieve SBOM attestation: %w", err)
+		return artifact.Reference{}, fmt.Errorf("failed to retrieve SBOM attestation: %w", err)
 	}
 
 	f, err := os.CreateTemp("", "sbom-*")
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to create a temporary file: %w", err)
+		return artifact.Reference{}, fmt.Errorf("failed to create a temporary file: %w", err)
 	}
 	defer os.Remove(f.Name())
 
 	if _, err = f.Write(raw); err != nil {
-		return artifact.Reference{}, xerrors.Errorf("copy error: %w", err)
+		return artifact.Reference{}, fmt.Errorf("copy error: %w", err)
 	}
 	if err = f.Close(); err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to close %s: %w", f.Name(), err)
+		return artifact.Reference{}, fmt.Errorf("failed to close %s: %w", f.Name(), err)
 	}
 	res, err := a.inspectSBOMFile(ctx, f.Name())
 	if err != nil {
-		return res, xerrors.Errorf("SBOM error: %w", err)
+		return res, fmt.Errorf("SBOM error: %w", err)
 	}
 
 	// Found SBOM
@@ -162,12 +161,12 @@ func (a Artifact) inspectRekorSBOMAttestation(ctx context.Context) (artifact.Ref
 func (a Artifact) inspectSBOMFile(ctx context.Context, filePath string) (artifact.Reference, error) {
 	ar, err := sbom.NewArtifact(filePath, a.cache, a.artifactOption)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to new artifact: %w", err)
+		return artifact.Reference{}, fmt.Errorf("failed to new artifact: %w", err)
 	}
 
 	results, err := ar.Inspect(ctx)
 	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("failed to inspect: %w", err)
+		return artifact.Reference{}, fmt.Errorf("failed to inspect: %w", err)
 	}
 	results.Name = a.image.Name()
 
@@ -178,7 +177,7 @@ func repoDigest(img ftypes.Image, insecure bool) (name.Digest, error) {
 	repoNameFull := img.Name()
 	ref, err := name.ParseReference(repoNameFull)
 	if err != nil {
-		return name.Digest{}, xerrors.Errorf("image name parse error: %w", err)
+		return name.Digest{}, fmt.Errorf("image name parse error: %w", err)
 	}
 
 	for _, rd := range img.RepoDigests() {
@@ -191,5 +190,5 @@ func repoDigest(img ftypes.Image, insecure bool) (name.Digest, error) {
 			return digest, nil
 		}
 	}
-	return name.Digest{}, xerrors.Errorf("no repo digest found: %w", errNoSBOMFound)
+	return name.Digest{}, fmt.Errorf("no repo digest found: %w", errNoSBOMFound)
 }

--- a/pkg/fanal/cache/key.go
+++ b/pkg/fanal/cache/key.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"golang.org/x/mod/sumdb/dirhash"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -33,7 +32,7 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 	}{id, analyzerVersions, hookVersions, artifactOpt.WalkerOption.SkipFiles, artifactOpt.WalkerOption.SkipDirs, artifactOpt.FilePatterns}
 
 	if err := json.NewEncoder(h).Encode(keyBase); err != nil {
-		return "", xerrors.Errorf("json encode error: %w", err)
+		return "", fmt.Errorf("json encode error: %w", err)
 	}
 
 	// Write check, data contents and secret config file
@@ -51,7 +50,7 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 		}
 
 		if _, err := h.Write([]byte(hash)); err != nil {
-			return "", xerrors.Errorf("sha256 write error: %w", err)
+			return "", fmt.Errorf("sha256 write error: %w", err)
 		}
 	}
 
@@ -61,7 +60,7 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 func hashContents(path string) (string, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
-		return "", xerrors.Errorf("file %q stat error: %w", path, err)
+		return "", fmt.Errorf("file %q stat error: %w", path, err)
 	}
 
 	var hash string
@@ -69,14 +68,14 @@ func hashContents(path string) (string, error) {
 	if fi.IsDir() {
 		hash, err = dirhash.HashDir(path, "", dirhash.DefaultHash)
 		if err != nil {
-			return "", xerrors.Errorf("hash dir error (%s): %w", path, err)
+			return "", fmt.Errorf("hash dir error (%s): %w", path, err)
 		}
 	} else {
 		hash, err = dirhash.DefaultHash([]string{filepath.Base(path)}, func(_ string) (io.ReadCloser, error) {
 			return os.Open(path)
 		})
 		if err != nil {
-			return "", xerrors.Errorf("hash file error (%s): %w", path, err)
+			return "", fmt.Errorf("hash file error (%s): %w", path, err)
 		}
 	}
 	return hash, nil

--- a/pkg/fanal/cache/redis.go
+++ b/pkg/fanal/cache/redis.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -35,10 +34,10 @@ func (c RedisCache) PutArtifact(artifactID string, artifactConfig types.Artifact
 	key := fmt.Sprintf("%s::%s::%s", redisPrefix, artifactBucket, artifactID)
 	b, err := json.Marshal(artifactConfig)
 	if err != nil {
-		return xerrors.Errorf("failed to marshal artifact JSON: %w", err)
+		return fmt.Errorf("failed to marshal artifact JSON: %w", err)
 	}
 	if err := c.client.Set(context.TODO(), key, string(b), c.expiration).Err(); err != nil {
-		return xerrors.Errorf("unable to store artifact information in Redis cache (%s): %w", artifactID, err)
+		return fmt.Errorf("unable to store artifact information in Redis cache (%s): %w", artifactID, err)
 	}
 	return nil
 }
@@ -46,11 +45,11 @@ func (c RedisCache) PutArtifact(artifactID string, artifactConfig types.Artifact
 func (c RedisCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 	b, err := json.Marshal(blobInfo)
 	if err != nil {
-		return xerrors.Errorf("failed to marshal blob JSON: %w", err)
+		return fmt.Errorf("failed to marshal blob JSON: %w", err)
 	}
 	key := fmt.Sprintf("%s::%s::%s", redisPrefix, blobBucket, blobID)
 	if err := c.client.Set(context.TODO(), key, string(b), c.expiration).Err(); err != nil {
-		return xerrors.Errorf("unable to store blob information in Redis cache (%s): %w", blobID, err)
+		return fmt.Errorf("unable to store blob information in Redis cache (%s): %w", blobID, err)
 	}
 	return nil
 }
@@ -59,7 +58,7 @@ func (c RedisCache) DeleteBlobs(blobIDs []string) error {
 	for _, blobID := range blobIDs {
 		key := fmt.Sprintf("%s::%s::%s", redisPrefix, artifactBucket, blobID)
 		if err := c.client.Del(context.TODO(), key).Err(); err != nil {
-			errs = multierror.Append(errs, xerrors.Errorf("unable to delete blob %s: %w", blobID, err))
+			errs = multierror.Append(errs, fmt.Errorf("unable to delete blob %s: %w", blobID, err))
 		}
 	}
 	return errs
@@ -69,15 +68,15 @@ func (c RedisCache) GetArtifact(artifactID string) (types.ArtifactInfo, error) {
 	key := fmt.Sprintf("%s::%s::%s", redisPrefix, artifactBucket, artifactID)
 	val, err := c.client.Get(context.TODO(), key).Bytes()
 	if err == redis.Nil {
-		return types.ArtifactInfo{}, xerrors.Errorf("artifact (%s) is missing in Redis cache", artifactID)
+		return types.ArtifactInfo{}, fmt.Errorf("artifact (%s) is missing in Redis cache", artifactID)
 	} else if err != nil {
-		return types.ArtifactInfo{}, xerrors.Errorf("failed to get artifact from the Redis cache: %w", err)
+		return types.ArtifactInfo{}, fmt.Errorf("failed to get artifact from the Redis cache: %w", err)
 	}
 
 	var info types.ArtifactInfo
 	err = json.Unmarshal(val, &info)
 	if err != nil {
-		return types.ArtifactInfo{}, xerrors.Errorf("failed to unmarshal artifact (%s) from Redis value: %w", artifactID, err)
+		return types.ArtifactInfo{}, fmt.Errorf("failed to unmarshal artifact (%s) from Redis value: %w", artifactID, err)
 	}
 	return info, nil
 }
@@ -86,14 +85,14 @@ func (c RedisCache) GetBlob(blobID string) (types.BlobInfo, error) {
 	key := fmt.Sprintf("%s::%s::%s", redisPrefix, blobBucket, blobID)
 	val, err := c.client.Get(context.TODO(), key).Bytes()
 	if err == redis.Nil {
-		return types.BlobInfo{}, xerrors.Errorf("blob (%s) is missing in Redis cache", blobID)
+		return types.BlobInfo{}, fmt.Errorf("blob (%s) is missing in Redis cache", blobID)
 	} else if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("failed to get blob from the Redis cache: %w", err)
+		return types.BlobInfo{}, fmt.Errorf("failed to get blob from the Redis cache: %w", err)
 	}
 
 	var blobInfo types.BlobInfo
 	if err = json.Unmarshal(val, &blobInfo); err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("failed to unmarshal blob (%s) from Redis value: %w", blobID, err)
+		return types.BlobInfo{}, fmt.Errorf("failed to unmarshal blob (%s) from Redis value: %w", blobID, err)
 	}
 	return blobInfo, nil
 }
@@ -134,10 +133,10 @@ func (c RedisCache) Clear() error {
 	for {
 		keys, cursor, err := c.client.Scan(ctx, 0, redisPrefix+"::*", 100).Result()
 		if err != nil {
-			return xerrors.Errorf("failed to perform prefix scanning: %w", err)
+			return fmt.Errorf("failed to perform prefix scanning: %w", err)
 		}
 		if err = c.client.Unlink(ctx, keys...).Err(); err != nil {
-			return xerrors.Errorf("failed to unlink redis keys: %w", err)
+			return fmt.Errorf("failed to unlink redis keys: %w", err)
 		}
 		if cursor == 0 { // We cleared all keys
 			break

--- a/pkg/fanal/cache/s3_test.go
+++ b/pkg/fanal/cache/s3_test.go
@@ -3,13 +3,13 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -189,7 +189,7 @@ func (m *mockS3ClientMissingBlobs) PutObject(ctx context.Context, in *s3.PutObje
 }
 
 func (m *mockS3ClientMissingBlobs) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
-	return &s3.HeadObjectOutput{}, xerrors.Errorf("the object doesn't exist in S3")
+	return &s3.HeadObjectOutput{}, fmt.Errorf("the object doesn't exist in S3")
 }
 
 func TestS3Cache_MissingBlobs(t *testing.T) {

--- a/pkg/fanal/handler/handler.go
+++ b/pkg/fanal/handler/handler.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -47,7 +47,7 @@ func NewManager(artifactOpt artifact.Option) (Manager, error) {
 		}
 		handler, err := handlerInit(artifactOpt)
 		if err != nil {
-			return Manager{}, xerrors.Errorf("post handler %s initialize error: %w", t, err)
+			return Manager{}, fmt.Errorf("post handler %s initialize error: %w", t, err)
 		}
 
 		m.postHandlers = append(m.postHandlers, handler)
@@ -72,7 +72,7 @@ func (m Manager) Versions() map[string]int {
 func (m Manager) PostHandle(ctx context.Context, result *analyzer.AnalysisResult, blob *types.BlobInfo) error {
 	for _, h := range m.postHandlers {
 		if err := h.Handle(ctx, result, blob); err != nil {
-			return xerrors.Errorf("post handler error: %w", err)
+			return fmt.Errorf("post handler error: %w", err)
 		}
 	}
 	return nil

--- a/pkg/fanal/handler/unpackaged/unpackaged.go
+++ b/pkg/fanal/handler/unpackaged/unpackaged.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	sbomatt "github.com/aquasecurity/trivy/pkg/attestation/sbom"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -31,7 +31,7 @@ type unpackagedHook struct {
 func NewUnpackagedHandler(opt artifact.Option) (handler.PostHandler, error) {
 	c, err := sbomatt.NewRekor(opt.RekorURL)
 	if err != nil {
-		return nil, xerrors.Errorf("rekor client error: %w", err)
+		return nil, fmt.Errorf("rekor client error: %w", err)
 	}
 	return unpackagedHook{
 		logger: log.WithPrefix("unpackaged"),

--- a/pkg/fanal/image/daemon/docker.go
+++ b/pkg/fanal/image/daemon/docker.go
@@ -2,11 +2,11 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
-	"golang.org/x/xerrors"
 )
 
 // DockerImage implements v1.Image by extending daemon.Image.
@@ -25,7 +25,7 @@ func DockerImage(ref name.Reference, host string) (Image, func(), error) {
 	c, err := client.NewClientWithOpts(opts...)
 
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to initialize a docker client: %w", err)
+		return nil, cleanup, fmt.Errorf("failed to initialize a docker client: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -42,18 +42,18 @@ func DockerImage(ref name.Reference, host string) (Image, func(), error) {
 		imageID = ref.String() // <image_id> pattern like `5ac716b05a9c`
 		inspect, _, err = c.ImageInspectWithRaw(context.Background(), imageID)
 		if err != nil {
-			return nil, cleanup, xerrors.Errorf("unable to inspect the image (%s): %w", imageID, err)
+			return nil, cleanup, fmt.Errorf("unable to inspect the image (%s): %w", imageID, err)
 		}
 	}
 
 	history, err := c.ImageHistory(context.Background(), imageID)
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("unable to get history (%s): %w", imageID, err)
+		return nil, cleanup, fmt.Errorf("unable to get history (%s): %w", imageID, err)
 	}
 
 	f, err := os.CreateTemp("", "fanal-*")
 	if err != nil {
-		return nil, cleanup, xerrors.Errorf("failed to create a temporary file: %w", err)
+		return nil, cleanup, fmt.Errorf("failed to create a temporary file: %w", err)
 	}
 
 	cleanup = func() {

--- a/pkg/fanal/image/docker.go
+++ b/pkg/fanal/image/docker.go
@@ -3,12 +3,12 @@ package image
 import (
 	"bufio"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/utils"
 )
@@ -16,7 +16,7 @@ import (
 func tryDockerArchive(fileName string) (v1.Image, error) {
 	img, err := tarball.Image(fileOpener(fileName), nil)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to open %s as a Docker image: %w", fileName, err)
+		return nil, fmt.Errorf("unable to open %s as a Docker image: %w", fileName, err)
 	}
 	return img, nil
 }
@@ -25,7 +25,7 @@ func fileOpener(fileName string) func() (io.ReadCloser, error) {
 	return func() (io.ReadCloser, error) {
 		f, err := os.Open(fileName)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to open the file: %w", err)
+			return nil, fmt.Errorf("unable to open the file: %w", err)
 		}
 
 		var r io.Reader
@@ -35,7 +35,7 @@ func fileOpener(fileName string) func() (io.ReadCloser, error) {
 		if utils.IsGzip(br) {
 			r, err = gzip.NewReader(br)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to open gzip: %w", err)
+				return nil, fmt.Errorf("failed to open gzip: %w", err)
 			}
 		}
 		return io.NopCloser(r), nil

--- a/pkg/fanal/image/image.go
+++ b/pkg/fanal/image/image.go
@@ -2,13 +2,13 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	multierror "github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -25,7 +25,7 @@ var imageSourceFuncs = map[types.ImageSource]imageSourceFunc{
 
 func NewContainerImage(ctx context.Context, imageName string, opt types.ImageOptions) (types.Image, func(), error) {
 	if len(opt.ImageSources) == 0 {
-		return nil, func() {}, xerrors.New("no image sources supplied")
+		return nil, func() {}, errors.New("no image sources supplied")
 	}
 
 	var errs error
@@ -36,7 +36,7 @@ func NewContainerImage(ctx context.Context, imageName string, opt types.ImageOpt
 
 	ref, err := name.ParseReference(imageName, nameOpts...)
 	if err != nil {
-		return nil, func() {}, xerrors.Errorf("failed to parse the image name: %w", err)
+		return nil, func() {}, fmt.Errorf("failed to parse the image name: %w", err)
 	}
 
 	for _, src := range opt.ImageSources {
@@ -61,7 +61,7 @@ func NewContainerImage(ctx context.Context, imageName string, opt types.ImageOpt
 func ID(img v1.Image) (string, error) {
 	h, err := img.ConfigName()
 	if err != nil {
-		return "", xerrors.Errorf("unable to get the image ID: %w", err)
+		return "", fmt.Errorf("unable to get the image ID: %w", err)
 	}
 	return h.String(), nil
 }
@@ -69,7 +69,7 @@ func ID(img v1.Image) (string, error) {
 func LayerIDs(img v1.Image) ([]string, error) {
 	conf, err := img.ConfigFile()
 	if err != nil {
-		return nil, xerrors.Errorf("unable to get the config file: %w", err)
+		return nil, fmt.Errorf("unable to get the config file: %w", err)
 	}
 
 	var layerIDs []string

--- a/pkg/fanal/image/oci.go
+++ b/pkg/fanal/image/oci.go
@@ -1,12 +1,13 @@
 package image
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"golang.org/x/xerrors"
 )
 
 func tryOCI(fileName string) (v1.Image, error) {
@@ -28,21 +29,21 @@ func tryOCI(fileName string) (v1.Image, error) {
 
 	lp, err := layout.FromPath(inputFileName)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to open %s as an OCI Image: %w", fileName, err)
+		return nil, fmt.Errorf("unable to open %s as an OCI Image: %w", fileName, err)
 	}
 
 	index, err := lp.ImageIndex()
 	if err != nil {
-		return nil, xerrors.Errorf("unable to retrieve index.json: %w", err)
+		return nil, fmt.Errorf("unable to retrieve index.json: %w", err)
 	}
 
 	m, err := index.IndexManifest()
 	if err != nil {
-		return nil, xerrors.Errorf("invalid index.json: %w", err)
+		return nil, fmt.Errorf("invalid index.json: %w", err)
 	}
 
 	if len(m.Manifests) == 0 {
-		return nil, xerrors.New("no valid manifest")
+		return nil, errors.New("no valid manifest")
 	}
 
 	// Support image having tag separated by : , otherwise support first image
@@ -60,23 +61,23 @@ func getOCIImage(m *v1.IndexManifest, index v1.ImageIndex, inputRef string) (v1.
 			if manifest.MediaType.IsIndex() {
 				childIndex, err := index.ImageIndex(h)
 				if err != nil {
-					return nil, xerrors.Errorf("unable to retrieve a child image %q: %w", h.String(), err)
+					return nil, fmt.Errorf("unable to retrieve a child image %q: %w", h.String(), err)
 				}
 				childManifest, err := childIndex.IndexManifest()
 				if err != nil {
-					return nil, xerrors.Errorf("invalid a child manifest for %q: %w", h.String(), err)
+					return nil, fmt.Errorf("invalid a child manifest for %q: %w", h.String(), err)
 				}
 				return getOCIImage(childManifest, childIndex, "")
 			}
 
 			img, err := index.Image(h)
 			if err != nil {
-				return nil, xerrors.Errorf("invalid OCI image: %w", err)
+				return nil, fmt.Errorf("invalid OCI image: %w", err)
 			}
 
 			return img, nil
 		}
 	}
 
-	return nil, xerrors.New("invalid OCI image ref")
+	return nil, errors.New("invalid OCI image ref")
 }

--- a/pkg/fanal/image/registry/azure/azure.go
+++ b/pkg/fanal/image/registry/azure/azure.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/containerregistry/runtime/containerregistry"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -27,7 +26,7 @@ const (
 
 func (r *Registry) CheckOptions(domain string, _ types.RegistryOptions) error {
 	if !strings.HasSuffix(domain, azureURL) {
-		return xerrors.Errorf("Azure registry: %w", types.InvalidURLPattern)
+		return fmt.Errorf("Azure registry: %w", types.InvalidURLPattern)
 	}
 	r.domain = domain
 	return nil
@@ -36,15 +35,15 @@ func (r *Registry) CheckOptions(domain string, _ types.RegistryOptions) error {
 func (r *Registry) GetCredential(ctx context.Context) (string, string, error) {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
-		return "", "", xerrors.Errorf("unable to generate acr credential error: %w", err)
+		return "", "", fmt.Errorf("unable to generate acr credential error: %w", err)
 	}
 	aadToken, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{scope}})
 	if err != nil {
-		return "", "", xerrors.Errorf("unable to get an access token: %w", err)
+		return "", "", fmt.Errorf("unable to get an access token: %w", err)
 	}
 	rt, err := refreshToken(ctx, aadToken.Token, r.domain)
 	if err != nil {
-		return "", "", xerrors.Errorf("unable to refresh token: %w", err)
+		return "", "", fmt.Errorf("unable to refresh token: %w", err)
 	}
 	return "00000000-0000-0000-0000-000000000000", *rt.RefreshToken, err
 }

--- a/pkg/fanal/image/registry/ecr/ecr.go
+++ b/pkg/fanal/image/registry/ecr/ecr.go
@@ -3,13 +3,13 @@ package ecr
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -38,7 +38,7 @@ func getSession(option types.RegistryOptions) (aws.Config, error) {
 
 func (e *ECR) CheckOptions(domain string, option types.RegistryOptions) error {
 	if !strings.HasSuffix(domain, ecrURL) {
-		return xerrors.Errorf("ECR : %w", types.InvalidURLPattern)
+		return fmt.Errorf("ECR : %w", types.InvalidURLPattern)
 	}
 
 	cfg, err := getSession(option)
@@ -55,12 +55,12 @@ func (e *ECR) GetCredential(ctx context.Context) (username, password string, err
 	input := &ecr.GetAuthorizationTokenInput{}
 	result, err := e.Client.GetAuthorizationToken(ctx, input)
 	if err != nil {
-		return "", "", xerrors.Errorf("failed to get authorization token: %w", err)
+		return "", "", fmt.Errorf("failed to get authorization token: %w", err)
 	}
 	for _, data := range result.AuthorizationData {
 		b, err := base64.StdEncoding.DecodeString(*data.AuthorizationToken)
 		if err != nil {
-			return "", "", xerrors.Errorf("base64 decode failed: %w", err)
+			return "", "", fmt.Errorf("base64 decode failed: %w", err)
 		}
 		// e.g. AWS:eyJwYXlsb2...
 		split := strings.SplitN(string(b), ":", 2)

--- a/pkg/fanal/image/registry/google/google.go
+++ b/pkg/fanal/image/registry/google/google.go
@@ -2,12 +2,12 @@ package google
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/config"
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/credhelper"
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -25,7 +25,7 @@ const garURL = "docker.pkg.dev"
 
 func (g *Registry) CheckOptions(domain string, option types.RegistryOptions) error {
 	if !strings.HasSuffix(domain, gcrURL) && !strings.HasSuffix(domain, garURL) {
-		return xerrors.Errorf("Google registry: %w", types.InvalidURLPattern)
+		return fmt.Errorf("Google registry: %w", types.InvalidURLPattern)
 	}
 	g.domain = domain
 	if option.GCPCredPath != "" {
@@ -39,14 +39,14 @@ func (g *Registry) GetCredential(_ context.Context) (username, password string, 
 	if g.Store == nil {
 		credStore, err = store.DefaultGCRCredStore()
 		if err != nil {
-			return "", "", xerrors.Errorf("failed to get GCRCredStore: %w", err)
+			return "", "", fmt.Errorf("failed to get GCRCredStore: %w", err)
 		}
 	} else {
 		credStore = g.Store
 	}
 	userCfg, err := config.LoadUserConfig()
 	if err != nil {
-		return "", "", xerrors.Errorf("failed to load user config: %w", err)
+		return "", "", fmt.Errorf("failed to load user config: %w", err)
 	}
 	helper := credhelper.NewGCRCredentialHelper(credStore, userCfg)
 	return helper.Get(g.domain)

--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"sort"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -74,7 +75,7 @@ func (r *Regexp) UnmarshalYAML(value *yaml.Node) error {
 	}
 	regex, err := regexp.Compile(v)
 	if err != nil {
-		return xerrors.Errorf("regexp compile error: %w", err)
+		return fmt.Errorf("regexp compile error: %w", err)
 	}
 
 	r.Regexp = regex
@@ -282,7 +283,7 @@ func ParseConfig(configPath string) (*Config, error) {
 		logger.Debug("No secret config detected")
 		return nil, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("file open error %s: %w", configPath, err)
+		return nil, fmt.Errorf("file open error %s: %w", configPath, err)
 	}
 	defer f.Close()
 
@@ -290,7 +291,7 @@ func ParseConfig(configPath string) (*Config, error) {
 
 	var config Config
 	if err = yaml.NewDecoder(f).Decode(&config); err != nil {
-		return nil, xerrors.Errorf("secrets config decode error: %w", err)
+		return nil, fmt.Errorf("secrets config decode error: %w", err)
 	}
 
 	// Update severity for custom rules

--- a/pkg/fanal/types/error.go
+++ b/pkg/fanal/types/error.go
@@ -1,8 +1,8 @@
 package types
 
-import "golang.org/x/xerrors"
+import "errors"
 
 var (
-	InvalidURLPattern = xerrors.New("invalid url pattern")
-	ErrNoRpmCmd       = xerrors.New("no rpm command")
+	InvalidURLPattern = errors.New("invalid url pattern")
+	ErrNoRpmCmd       = errors.New("no rpm command")
 )

--- a/pkg/fanal/types/package.go
+++ b/pkg/fanal/types/package.go
@@ -2,11 +2,11 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
 )
@@ -49,7 +49,7 @@ func (r *Relationship) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 	}
-	return xerrors.Errorf("invalid relationship (%s)", s)
+	return fmt.Errorf("invalid relationship (%s)", s)
 }
 
 // PkgIdentifier represents a software identifiers in one of more of the supported formats.

--- a/pkg/fanal/vm/disk/disk.go
+++ b/pkg/fanal/vm/disk/disk.go
@@ -2,9 +2,8 @@ package disk
 
 import (
 	"errors"
+	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/vm"
 )
@@ -28,10 +27,10 @@ func New(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.SectionReader, e
 			if errors.Is(err, vm.ErrInvalidSignature) {
 				continue
 			}
-			return nil, xerrors.Errorf("open virtual machine error: %w", err)
+			return nil, fmt.Errorf("open virtual machine error: %w", err)
 		}
 
 		return vreader, nil
 	}
-	return nil, xerrors.New("virtual machine can not be detected")
+	return nil, errors.New("virtual machine can not be detected")
 }

--- a/pkg/fanal/vm/disk/vmdk.go
+++ b/pkg/fanal/vm/disk/vmdk.go
@@ -2,10 +2,10 @@ package disk
 
 import (
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/masahiro331/go-vmdk-parser/pkg/virtualization/vmdk"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/vm"
 )
@@ -14,7 +14,7 @@ type VMDK struct{}
 
 func (VMDK) NewReader(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.SectionReader, error) {
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return nil, xerrors.Errorf("seek error: %w", err)
+		return nil, fmt.Errorf("seek error: %w", err)
 	}
 
 	if _, err := vmdk.Check(rs); err != nil {
@@ -22,15 +22,15 @@ func (VMDK) NewReader(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.Sec
 	}
 
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return nil, xerrors.Errorf("seek error: %w", err)
+		return nil, fmt.Errorf("seek error: %w", err)
 	}
 
 	reader, err := vmdk.Open(rs, cache)
 	if err != nil {
 		if errors.Is(err, vmdk.ErrUnSupportedType) {
-			return nil, xerrors.Errorf("%s: %w", err.Error(), vm.ErrUnsupportedType)
+			return nil, fmt.Errorf("%s: %w", err.Error(), vm.ErrUnsupportedType)
 		}
-		return nil, xerrors.Errorf("failed to open vmdk: %w", err)
+		return nil, fmt.Errorf("failed to open vmdk: %w", err)
 	}
 	return reader, nil
 }

--- a/pkg/fanal/vm/filesystem/ext4.go
+++ b/pkg/fanal/vm/filesystem/ext4.go
@@ -1,11 +1,11 @@
 package filesystem
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 
 	"github.com/masahiro331/go-ext4-filesystem/ext4"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/vm"
 )
@@ -15,7 +15,7 @@ type EXT4 struct{}
 func (e EXT4) New(sr io.SectionReader, cache vm.Cache[string, any]) (fs.FS, error) {
 	_, err := sr.Seek(0, io.SeekStart)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to seek offset error: %w", err)
+		return nil, fmt.Errorf("failed to seek offset error: %w", err)
 	}
 	ok := ext4.Check(&sr)
 	if !ok {
@@ -24,11 +24,11 @@ func (e EXT4) New(sr io.SectionReader, cache vm.Cache[string, any]) (fs.FS, erro
 
 	_, err = sr.Seek(0, io.SeekStart)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to seek offset error: %w", err)
+		return nil, fmt.Errorf("failed to seek offset error: %w", err)
 	}
 	f, err := ext4.NewFS(sr, cache)
 	if err != nil {
-		return nil, xerrors.Errorf("new ext4 filesystem error: %w", err)
+		return nil, fmt.Errorf("new ext4 filesystem error: %w", err)
 	}
 	return f, nil
 }

--- a/pkg/fanal/vm/filesystem/filesystem.go
+++ b/pkg/fanal/vm/filesystem/filesystem.go
@@ -2,11 +2,11 @@ package filesystem
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/vm"
 )
@@ -14,7 +14,7 @@ import (
 const cacheSize = 2048
 
 var (
-	ErrInvalidHeader = xerrors.New("invalid Header error")
+	ErrInvalidHeader = errors.New("invalid Header error")
 	filesystems      = []Filesystem{
 		EXT4{},
 		XFS{},
@@ -31,7 +31,7 @@ func New(sr io.SectionReader) (fs.FS, func(), error) {
 	// Initialize LRU cache for filesystem walking
 	lruCache, err := lru.New[string, any](cacheSize)
 	if err != nil {
-		return nil, clean, xerrors.Errorf("failed to create a LRU cache: %w", err)
+		return nil, clean, fmt.Errorf("failed to create a LRU cache: %w", err)
 	}
 	clean = lruCache.Purge
 
@@ -42,9 +42,9 @@ func New(sr io.SectionReader) (fs.FS, func(), error) {
 			if errors.Is(err, ErrInvalidHeader) {
 				continue
 			}
-			return nil, clean, xerrors.Errorf("unexpected fs error: %w", err)
+			return nil, clean, fmt.Errorf("unexpected fs error: %w", err)
 		}
 		return fsys, clean, nil
 	}
-	return nil, clean, xerrors.New("unable to detect filesystem")
+	return nil, clean, errors.New("unable to detect filesystem")
 }

--- a/pkg/fanal/vm/filesystem/xfs.go
+++ b/pkg/fanal/vm/filesystem/xfs.go
@@ -1,11 +1,11 @@
 package filesystem
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 
 	"github.com/masahiro331/go-xfs-filesystem/xfs"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/vm"
 )
@@ -15,7 +15,7 @@ type XFS struct{}
 func (x XFS) New(sr io.SectionReader, cache vm.Cache[string, any]) (fs.FS, error) {
 	_, err := sr.Seek(0, io.SeekStart)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to seek offset error: %w", err)
+		return nil, fmt.Errorf("failed to seek offset error: %w", err)
 	}
 	ok := xfs.Check(&sr)
 	if !ok {
@@ -24,11 +24,11 @@ func (x XFS) New(sr io.SectionReader, cache vm.Cache[string, any]) (fs.FS, error
 
 	_, err = sr.Seek(0, io.SeekStart)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to seek offset error: %w", err)
+		return nil, fmt.Errorf("failed to seek offset error: %w", err)
 	}
 	f, err := xfs.NewFS(sr, cache)
 	if err != nil {
-		return nil, xerrors.Errorf("new xfs filesystem error: %w", err)
+		return nil, fmt.Errorf("new xfs filesystem error: %w", err)
 	}
 	return f, nil
 }

--- a/pkg/fanal/vm/vm.go
+++ b/pkg/fanal/vm/vm.go
@@ -1,12 +1,10 @@
 package vm
 
-import (
-	"golang.org/x/xerrors"
-)
+import "errors"
 
 var (
-	ErrInvalidSignature = xerrors.New("invalid signature error")
-	ErrUnsupportedType  = xerrors.New("unsupported type error")
+	ErrInvalidSignature = errors.New("invalid signature error")
+	ErrUnsupportedType  = errors.New("unsupported type error")
 )
 
 type Cache[K comparable, V any] interface {

--- a/pkg/fanal/walker/cached_file.go
+++ b/pkg/fanal/walker/cached_file.go
@@ -2,11 +2,10 @@ package walker
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"sync"
-
-	"golang.org/x/xerrors"
 
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
@@ -39,12 +38,12 @@ func (o *cachedFile) Open() (xio.ReadSeekCloserAt, error) {
 		if o.size >= defaultSizeThreshold {
 			f, err := os.CreateTemp("", "fanal-*")
 			if err != nil {
-				o.err = xerrors.Errorf("failed to create the temp file: %w", err)
+				o.err = fmt.Errorf("failed to create the temp file: %w", err)
 				return
 			}
 
 			if _, err = io.Copy(f, o.reader); err != nil {
-				o.err = xerrors.Errorf("failed to copy: %w", err)
+				o.err = fmt.Errorf("failed to copy: %w", err)
 				return
 			}
 
@@ -52,14 +51,14 @@ func (o *cachedFile) Open() (xio.ReadSeekCloserAt, error) {
 		} else {
 			b, err := io.ReadAll(o.reader)
 			if err != nil {
-				o.err = xerrors.Errorf("unable to read the file: %w", err)
+				o.err = fmt.Errorf("unable to read the file: %w", err)
 				return
 			}
 			o.content = b
 		}
 	})
 	if o.err != nil {
-		return nil, xerrors.Errorf("failed to open: %w", o.err)
+		return nil, fmt.Errorf("failed to open: %w", o.err)
 	}
 
 	return o.open()
@@ -69,7 +68,7 @@ func (o *cachedFile) open() (xio.ReadSeekCloserAt, error) {
 	if o.filePath != "" {
 		f, err := os.Open(o.filePath)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to open the temp file: %w", err)
+			return nil, fmt.Errorf("failed to open the temp file: %w", err)
 		}
 		return f, nil
 	}

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -2,12 +2,11 @@ package walker
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -31,7 +30,7 @@ func (w *FS) Walk(root string, opt Option, fn WalkFunc) error {
 
 	// Walk the filesystem
 	if err := filepath.WalkDir(root, walkDirFunc); err != nil {
-		return xerrors.Errorf("walk dir error: %w", err)
+		return fmt.Errorf("walk dir error: %w", err)
 	}
 
 	return nil
@@ -46,7 +45,7 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 		// For exported rootfs (e.g. images/alpine/etc/alpine-release)
 		relPath, err := filepath.Rel(root, filePath)
 		if err != nil {
-			return xerrors.Errorf("filepath rel (%s): %w", relPath, err)
+			return fmt.Errorf("filepath rel (%s): %w", relPath, err)
 		}
 		relPath = filepath.ToSlash(relPath)
 
@@ -65,11 +64,11 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 
 		info, err := d.Info()
 		if err != nil {
-			return xerrors.Errorf("file info error: %w", err)
+			return fmt.Errorf("file info error: %w", err)
 		}
 
 		if err = fn(relPath, info, fileOpener(filePath)); err != nil {
-			return xerrors.Errorf("failed to analyze file: %w", err)
+			return fmt.Errorf("failed to analyze file: %w", err)
 		}
 
 		return nil
@@ -88,7 +87,7 @@ func (w *FS) onError(wrapped fs.WalkDirFunc) fs.WalkDirFunc {
 			return nil
 		case err != nil:
 			// halt traversal on any other error
-			return xerrors.Errorf("unknown error with %s: %w", filePath, err)
+			return fmt.Errorf("unknown error with %s: %w", filePath, err)
 		}
 		return nil
 	}

--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -2,13 +2,12 @@ package walker
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/utils"
 )
@@ -40,7 +39,7 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return nil, nil, xerrors.Errorf("failed to extract the archive: %w", err)
+			return nil, nil, fmt.Errorf("failed to extract the archive: %w", err)
 		}
 
 		// filepath.Clean cannot be used since tar file paths should be OS-agnostic.
@@ -82,7 +81,7 @@ func (w LayerTar) Walk(layer io.Reader, analyzeFn WalkFunc) ([]string, []string,
 
 		// A regular file will reach here.
 		if err = w.processFile(filePath, tr, hdr.FileInfo(), analyzeFn); err != nil {
-			return nil, nil, xerrors.Errorf("failed to process the file: %w", err)
+			return nil, nil, fmt.Errorf("failed to process the file: %w", err)
 		}
 	}
 	return opqDirs, whFiles, nil
@@ -96,7 +95,7 @@ func (w LayerTar) processFile(filePath string, tr *tar.Reader, fi fs.FileInfo, a
 	}()
 
 	if err := analyzeFn(filePath, fi, cf.Open); err != nil {
-		return xerrors.Errorf("failed to analyze file: %w", err)
+		return fmt.Errorf("failed to analyze file: %w", err)
 	}
 
 	return nil

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 )
 
 // e.g. config yaml:
@@ -129,12 +128,12 @@ func (fg *CacheFlagGroup) ToOptions() (CacheOptions, error) {
 	// An empty value is also allowed for testability
 	if !strings.HasPrefix(cacheBackend, "redis://") &&
 		cacheBackend != "fs" && cacheBackend != "" {
-		return CacheOptions{}, xerrors.Errorf("unsupported cache backend: %s", cacheBackend)
+		return CacheOptions{}, fmt.Errorf("unsupported cache backend: %s", cacheBackend)
 	}
 	// if one of redis option not nil, make sure CA, cert, and key provided
 	if !lo.IsEmpty(redisOptions) {
 		if redisOptions.RedisCACert == "" || redisOptions.RedisCert == "" || redisOptions.RedisKey == "" {
-			return CacheOptions{}, xerrors.Errorf("you must provide Redis CA, cert and key file path when using TLS")
+			return CacheOptions{}, fmt.Errorf("you must provide Redis CA, cert and key file path when using TLS")
 		}
 	}
 

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -1,10 +1,10 @@
 package flag
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/javadb"
@@ -138,10 +138,10 @@ func (f *DBFlagGroup) ToOptions() (DBOptions, error) {
 	light := f.Light.Value()
 
 	if downloadDBOnly && skipDBUpdate {
-		return DBOptions{}, xerrors.New("--skip-db-update and --download-db-only options can not be specified both")
+		return DBOptions{}, errors.New("--skip-db-update and --download-db-only options can not be specified both")
 	}
 	if downloadJavaDBOnly && skipJavaDBUpdate {
-		return DBOptions{}, xerrors.New("--skip-java-db-update and --download-java-db-only options can not be specified both")
+		return DBOptions{}, errors.New("--skip-java-db-update and --download-java-db-only options can not be specified both")
 	}
 	if light {
 		log.Warn("'--light' option is deprecated and will be removed. See also: https://github.com/aquasecurity/trivy/discussions/1649")
@@ -151,7 +151,7 @@ func (f *DBFlagGroup) ToOptions() (DBOptions, error) {
 	var err error
 	if f.DBRepository != nil {
 		if dbRepository, err = name.ParseReference(f.DBRepository.Value(), name.WithDefaultTag("")); err != nil {
-			return DBOptions{}, xerrors.Errorf("invalid db repository: %w", err)
+			return DBOptions{}, fmt.Errorf("invalid db repository: %w", err)
 		}
 		// Add the schema version if the tag is not specified for backward compatibility.
 		if t, ok := dbRepository.(name.Tag); ok && t.TagStr() == "" {
@@ -163,7 +163,7 @@ func (f *DBFlagGroup) ToOptions() (DBOptions, error) {
 
 	if f.JavaDBRepository != nil {
 		if javaDBRepository, err = name.ParseReference(f.JavaDBRepository.Value(), name.WithDefaultTag("")); err != nil {
-			return DBOptions{}, xerrors.Errorf("invalid javadb repository: %w", err)
+			return DBOptions{}, fmt.Errorf("invalid javadb repository: %w", err)
 		}
 		// Add the schema version if the tag is not specified for backward compatibility.
 		if t, ok := javaDBRepository.(name.Tag); ok && t.TagStr() == "" {

--- a/pkg/flag/image_flags.go
+++ b/pkg/flag/image_flags.go
@@ -1,8 +1,9 @@
 package flag
 
 import (
+	"fmt"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -117,7 +118,7 @@ func (f *ImageFlagGroup) ToOptions() (ImageOptions, error) {
 	if p := f.Platform.Value(); p != "" {
 		pl, err := v1.ParsePlatform(p)
 		if err != nil {
-			return ImageOptions{}, xerrors.Errorf("unable to parse platform: %w", err)
+			return ImageOptions{}, fmt.Errorf("unable to parse platform: %w", err)
 		}
 		if pl.OS == "*" {
 			pl.OS = "" // Empty OS means any OS

--- a/pkg/flag/registry_flags.go
+++ b/pkg/flag/registry_flags.go
@@ -1,9 +1,8 @@
 package flag
 
 import (
+	"errors"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -66,7 +65,7 @@ func (f *RegistryFlagGroup) ToOptions() (RegistryOptions, error) {
 	users := f.Username.Value()
 	passwords := f.Password.Value()
 	if len(users) != len(passwords) {
-		return RegistryOptions{}, xerrors.New("the length of usernames and passwords must match")
+		return RegistryOptions{}, errors.New("the length of usernames and passwords must match")
 	}
 	for i, user := range users {
 		credentials = append(credentials, types.Credential{

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -1,12 +1,12 @@
 package flag
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/mattn/go-shellwords"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/compliance/spec"
@@ -231,14 +231,14 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 
 	cs, err := loadComplianceTypes(f.Compliance.Value())
 	if err != nil {
-		return ReportOptions{}, xerrors.Errorf("unable to load compliance spec: %w", err)
+		return ReportOptions{}, fmt.Errorf("unable to load compliance spec: %w", err)
 	}
 
 	var outputPluginArgs []string
 	if arg := f.OutputPluginArg.Value(); arg != "" {
 		outputPluginArgs, err = shellwords.Parse(arg)
 		if err != nil {
-			return ReportOptions{}, xerrors.Errorf("unable to parse output plugin argument: %w", err)
+			return ReportOptions{}, fmt.Errorf("unable to parse output plugin argument: %w", err)
 		}
 	}
 
@@ -262,12 +262,12 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 
 func loadComplianceTypes(compliance string) (spec.ComplianceSpec, error) {
 	if compliance != "" && !slices.Contains(types.SupportedCompliances, compliance) && !strings.HasPrefix(compliance, "@") {
-		return spec.ComplianceSpec{}, xerrors.Errorf("unknown compliance : %v", compliance)
+		return spec.ComplianceSpec{}, fmt.Errorf("unknown compliance : %v", compliance)
 	}
 
 	cs, err := spec.GetComplianceSpec(compliance)
 	if err != nil {
-		return spec.ComplianceSpec{}, xerrors.Errorf("spec loading from file system error: %w", err)
+		return spec.ComplianceSpec{}, fmt.Errorf("spec loading from file system error: %w", err)
 	}
 
 	return cs, nil

--- a/pkg/flag/sbom_flags.go
+++ b/pkg/flag/sbom_flags.go
@@ -1,7 +1,7 @@
 package flag
 
 import (
-	"golang.org/x/xerrors"
+	"errors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 )
@@ -58,7 +58,7 @@ func (f *SBOMFlagGroup) ToOptions() (SBOMOptions, error) {
 	if artifactType != "" || sbomFormat != "" {
 		log.Error("'trivy sbom' is now for scanning SBOM. " +
 			"See https://github.com/aquasecurity/trivy/discussions/2407 for the detail")
-		return SBOMOptions{}, xerrors.New("'--artifact-type' and '--sbom-format' are no longer available")
+		return SBOMOptions{}, errors.New("'--artifact-type' and '--sbom-format' are no longer available")
 	}
 
 	return SBOMOptions{}, nil

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -2,8 +2,7 @@ package commands
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	k8sArtifacts "github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/k8s"
@@ -24,7 +23,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	case types.FormatCycloneDX:
 		artifacts, err = trivyk8s.New(cluster).ListClusterBomInfo(ctx)
 		if err != nil {
-			return xerrors.Errorf("get k8s artifacts with node info error: %w", err)
+			return fmt.Errorf("get k8s artifacts with node info error: %w", err)
 		}
 	case types.FormatJSON, types.FormatTable:
 		k8sOpts := []trivyk8s.K8sOption{
@@ -41,16 +40,16 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 				trivyk8s.WithScanJobImageRef(opts.NodeCollectorImageRef),
 				trivyk8s.WithTolerations(opts.Tolerations))
 			if err != nil {
-				return xerrors.Errorf("get k8s artifacts with node info error: %w", err)
+				return fmt.Errorf("get k8s artifacts with node info error: %w", err)
 			}
 		} else {
 			artifacts, err = trivyk8s.New(cluster, k8sOpts...).ListArtifacts(ctx)
 			if err != nil {
-				return xerrors.Errorf("get k8s artifacts error: %w", err)
+				return fmt.Errorf("get k8s artifacts error: %w", err)
 			}
 		}
 	default:
-		return xerrors.Errorf(`unknown format %q. Use "json" or "table" or "cyclonedx"`, opts.Format)
+		return fmt.Errorf(`unknown format %q. Use "json" or "table" or "cyclonedx"`, opts.Format)
 	}
 
 	if !opts.DisableNodeCollector && !opts.Quiet {

--- a/pkg/k8s/report/cyclonedx.go
+++ b/pkg/k8s/report/cyclonedx.go
@@ -2,10 +2,10 @@ package report
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
@@ -31,7 +31,7 @@ func NewCycloneDXWriter(output io.Writer, format cdx.BOMFileFormat, appVersion s
 func (w CycloneDXWriter) Write(ctx context.Context, component *core.BOM) error {
 	bom, err := w.marshaler.Marshal(ctx, component)
 	if err != nil {
-		return xerrors.Errorf("CycloneDX marshal error: %w", err)
+		return fmt.Errorf("CycloneDX marshal error: %w", err)
 	}
 	return w.encoder.Encode(bom)
 }

--- a/pkg/k8s/report/json.go
+++ b/pkg/k8s/report/json.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 )
 
 type JSONWriter struct {
@@ -22,18 +20,18 @@ func (jw JSONWriter) Write(report Report) error {
 	case AllReport:
 		output, err = json.MarshalIndent(report, "", "  ")
 		if err != nil {
-			return xerrors.Errorf("failed to write json: %w", err)
+			return fmt.Errorf("failed to write json: %w", err)
 		}
 	case SummaryReport:
 		output, err = json.MarshalIndent(report.consolidate(), "", "  ")
 		if err != nil {
-			return xerrors.Errorf("failed to write json: %w", err)
+			return fmt.Errorf("failed to write json: %w", err)
 		}
 	default:
-		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, jw.Report)
+		return fmt.Errorf(`report %q not supported. Use "summary" or "all"`, jw.Report)
 	}
 	if _, err = fmt.Fprintln(jw.Output, string(output)); err != nil {
-		return xerrors.Errorf("failed to write json: %w", err)
+		return fmt.Errorf("failed to write json: %w", err)
 	}
 
 	return nil

--- a/pkg/k8s/report/summary.go
+++ b/pkg/k8s/report/summary.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/table"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -71,11 +70,11 @@ func (s SummaryWriter) Write(report Report) error {
 	consolidated := report.consolidate()
 
 	if _, err := fmt.Fprintln(s.Output); err != nil {
-		return xerrors.Errorf("failed to write summary report: %w", err)
+		return fmt.Errorf("failed to write summary report: %w", err)
 	}
 
 	if _, err := fmt.Fprintln(s.Output, report.name); err != nil {
-		return xerrors.Errorf("failed to write summary report title: %w", err)
+		return fmt.Errorf("failed to write summary report title: %w", err)
 	}
 
 	t := table.New(s.Output)

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	pkgReport "github.com/aquasecurity/trivy/pkg/report/table"
 )
@@ -68,7 +66,7 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 		writer := NewSummaryWriter(tw.Output, tw.Severities, tw.ColumnHeading)
 		return writer.Write(report)
 	default:
-		return xerrors.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)
+		return fmt.Errorf(`report %q not supported. Use "summary" or "all"`, tw.Report)
 	}
 
 	return nil

--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"runtime"
 
-	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
@@ -24,7 +23,7 @@ func createTempFile(artifact *artifacts.Artifact) (string, error) {
 	}
 	file, err := os.CreateTemp("", filename)
 	if err != nil {
-		return "", xerrors.Errorf("creating tmp file error: %w", err)
+		return "", fmt.Errorf("creating tmp file error: %w", err)
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
@@ -34,7 +33,7 @@ func createTempFile(artifact *artifacts.Artifact) (string, error) {
 
 	if err := yaml.NewEncoder(file).Encode(artifact.RawResource); err != nil {
 		removeFile(filename)
-		return "", xerrors.Errorf("marshaling resource error: %w", err)
+		return "", fmt.Errorf("marshaling resource error: %w", err)
 	}
 
 	return file.Name(), nil

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -10,7 +10,6 @@ import (
 	ms "github.com/mitchellh/mapstructure"
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/go-version/pkg/version"
 	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
@@ -106,14 +105,14 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 			}
 			vulns, err := s.scanVulns(ctx, artifact, opts)
 			if err != nil {
-				return scanResult{}, xerrors.Errorf("scanning vulnerabilities error: %w", err)
+				return scanResult{}, fmt.Errorf("scanning vulnerabilities error: %w", err)
 			}
 			scanResults.vulns = vulns
 		}
 		if local.ShouldScanMisconfigOrRbac(s.opts.Scanners) {
 			misconfig, err := s.scanMisconfigs(ctx, artifact)
 			if err != nil {
-				return scanResult{}, xerrors.Errorf("scanning misconfigurations error: %w", err)
+				return scanResult{}, fmt.Errorf("scanning misconfigurations error: %w", err)
 			}
 			scanResults.misconfig = misconfig
 		}
@@ -164,7 +163,7 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 
 		resource, err := s.filter(ctx, imageReport, artifact)
 		if err != nil {
-			return nil, xerrors.Errorf("filter error: %w", err)
+			return nil, fmt.Errorf("filter error: %w", err)
 		}
 
 		resources = append(resources, resource)
@@ -176,7 +175,7 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 func (s *Scanner) scanMisconfigs(ctx context.Context, artifact *artifacts.Artifact) (report.Resource, error) {
 	configFile, err := createTempFile(artifact)
 	if err != nil {
-		return report.Resource{}, xerrors.Errorf("scan error: %w", err)
+		return report.Resource{}, fmt.Errorf("scan error: %w", err)
 	}
 
 	s.opts.Target = configFile
@@ -194,7 +193,7 @@ func (s *Scanner) filter(ctx context.Context, r types.Report, artifact *artifact
 	var err error
 	r, err = s.runner.Filter(ctx, s.opts, r)
 	if err != nil {
-		return report.Resource{}, xerrors.Errorf("filter error: %w", err)
+		return report.Resource{}, fmt.Errorf("filter error: %w", err)
 	}
 	return report.CreateResource(artifact, r, nil), nil
 }
@@ -399,7 +398,7 @@ func (s *Scanner) clusterInfoToReportResources(allArtifact []*artifacts.Artifact
 					},
 				}, ftypes.Package{})
 				if err != nil {
-					return nil, xerrors.Errorf("failed to create PURL: %w", err)
+					return nil, fmt.Errorf("failed to create PURL: %w", err)
 				}
 
 				imageComponent := &core.Component{

--- a/pkg/licensing/classifier.go
+++ b/pkg/licensing/classifier.go
@@ -8,7 +8,6 @@ import (
 
 	classifier "github.com/google/licenseclassifier/v2"
 	"github.com/google/licenseclassifier/v2/assets"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -35,7 +34,7 @@ func initGoogleClassifier() error {
 func Classify(filePath string, r io.Reader, confidenceLevel float64) (*types.LicenseFile, error) {
 	content, err := io.ReadAll(r)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to read a license file %q: %w", filePath, err)
+		return nil, fmt.Errorf("unable to read a license file %q: %w", filePath, err)
 	}
 	if err = initGoogleClassifier(); err != nil {
 		return nil, err

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -1,14 +1,14 @@
 package expression
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"unicode"
-
-	"golang.org/x/xerrors"
 )
 
 var (
-	ErrInvalidExpression = xerrors.New("invalid expression error")
+	ErrInvalidExpression = errors.New("invalid expression error")
 )
 
 type NormalizeFunc func(license string) string
@@ -16,7 +16,7 @@ type NormalizeFunc func(license string) string
 func parse(license string) (Expression, error) {
 	l := NewLexer(strings.NewReader(license))
 	if yyParse(l) != 0 {
-		return nil, xerrors.Errorf("license parse error: %w", l.Err())
+		return nil, fmt.Errorf("license parse error: %w", l.Err())
 	} else if err := l.Err(); err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func parse(license string) (Expression, error) {
 func Normalize(license string, fn ...NormalizeFunc) (string, error) {
 	expr, err := parse(license)
 	if err != nil {
-		return "", xerrors.Errorf("license (%s) parse error: %w", license, err)
+		return "", fmt.Errorf("license (%s) parse error: %w", license, err)
 	}
 	expr = normalize(expr, fn...)
 

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -151,7 +150,7 @@ func (h *ColorHandler) Handle(ctx context.Context, r slog.Record) error {
 	defer h.mu.Unlock()
 
 	if _, err := h.out.Write(buf); err != nil {
-		return xerrors.Errorf("failed to write log: %w", err)
+		return fmt.Errorf("failed to write log: %w", err)
 	}
 
 	return nil

--- a/pkg/mapfs/file.go
+++ b/pkg/mapfs/file.go
@@ -1,6 +1,7 @@
 package mapfs
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -8,8 +9,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"golang.org/x/xerrors"
 
 	xsync "github.com/aquasecurity/trivy/pkg/x/sync"
 )
@@ -52,7 +51,7 @@ func (f *file) open() (fs.File, error) {
 	case f.stat.IsDir(): // Directory
 		entries, err := f.ReadDir(".")
 		if err != nil {
-			return nil, xerrors.Errorf("read dir error: %w", err)
+			return nil, fmt.Errorf("read dir error: %w", err)
 		}
 		return &mapDir{
 			path:     f.underlyingPath,
@@ -155,7 +154,7 @@ func (f *file) ReadDir(name string) ([]fs.DirEntry, error) {
 			return true
 		})
 		if err != nil {
-			return nil, xerrors.Errorf("range error: %w", err)
+			return nil, fmt.Errorf("range error: %w", err)
 		}
 		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 		return entries, nil
@@ -223,7 +222,7 @@ func (f *file) WriteFile(path, underlyingPath string) error {
 
 func (f *file) WriteVirtualFile(path string, data []byte, mode fs.FileMode) error {
 	if mode&fs.ModeDir != 0 {
-		return xerrors.Errorf("invalid perm: %v", mode)
+		return fmt.Errorf("invalid perm: %v", mode)
 	}
 	parts := strings.Split(path, separator)
 
@@ -272,7 +271,7 @@ func (f *file) glob(pattern string) ([]string, error) {
 		return true
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("range error: %w", err)
+		return nil, fmt.Errorf("range error: %w", err)
 	}
 
 	sort.Strings(entries)

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	xsync "github.com/aquasecurity/trivy/pkg/x/sync"
 )
@@ -95,7 +94,7 @@ func (m *FS) FilterFunc(fn func(path string, d fs.DirEntry) (bool, error)) (*FS,
 
 		f, err := m.root.getFile(path)
 		if err != nil {
-			return xerrors.Errorf("unable to get %s: %w", path, err)
+			return fmt.Errorf("unable to get %s: %w", path, err)
 		}
 		// Virtual file
 		if f.underlyingPath == "" {
@@ -104,7 +103,7 @@ func (m *FS) FilterFunc(fn func(path string, d fs.DirEntry) (bool, error)) (*FS,
 		return newFS.WriteFile(path, f.underlyingPath)
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("walk error %w", err)
+		return nil, fmt.Errorf("walk error %w", err)
 	}
 
 	return newFS, nil

--- a/pkg/module/command.go
+++ b/pkg/module/command.go
@@ -2,11 +2,11 @@ package module
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -19,20 +19,20 @@ const mediaType = "application/vnd.module.wasm.content.layer.v1+wasm"
 func Install(ctx context.Context, dir, repo string, quiet bool, opt types.RegistryOptions) error {
 	ref, err := name.ParseReference(repo)
 	if err != nil {
-		return xerrors.Errorf("repository parse error: %w", err)
+		return fmt.Errorf("repository parse error: %w", err)
 	}
 
 	log.Info("Installing the module from the repository...", log.String("repo", repo))
 	artifact, err := oci.NewArtifact(repo, quiet, opt)
 	if err != nil {
-		return xerrors.Errorf("module initialize error: %w", err)
+		return fmt.Errorf("module initialize error: %w", err)
 	}
 
 	dst := filepath.Join(dir, ref.Context().Name())
 	log.Debug("Installing the module...", log.String("dst", dst))
 
 	if err = artifact.Download(ctx, dst, oci.DownloadOption{MediaType: mediaType}); err != nil {
-		return xerrors.Errorf("module download error: %w", err)
+		return fmt.Errorf("module download error: %w", err)
 	}
 
 	return nil
@@ -42,13 +42,13 @@ func Install(ctx context.Context, dir, repo string, quiet bool, opt types.Regist
 func Uninstall(_ context.Context, dir, repo string) error {
 	ref, err := name.ParseReference(repo)
 	if err != nil {
-		return xerrors.Errorf("repository parse error: %w", err)
+		return fmt.Errorf("repository parse error: %w", err)
 	}
 
 	log.Info("Uninstalling the module ...", log.String("module", repo))
 	dst := filepath.Join(dir, ref.Context().Name())
 	if err = os.RemoveAll(dst); err != nil {
-		return xerrors.Errorf("remove error: %w", err)
+		return fmt.Errorf("remove error: %w", err)
 	}
 
 	return nil

--- a/pkg/module/memfs.go
+++ b/pkg/module/memfs.go
@@ -1,12 +1,11 @@
 package module
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
 	"time"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/mapfs"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -37,15 +36,15 @@ func (m *memFS) Open(name string) (fs.File, error) {
 func (m *memFS) initialize(filePath string, content xio.ReadSeekerAt) error {
 	mfs := mapfs.New()
 	if err := mfs.MkdirAll(filepath.Dir(filePath), fs.ModePerm); err != nil {
-		return xerrors.Errorf("mapfs mkdir error: %w", err)
+		return fmt.Errorf("mapfs mkdir error: %w", err)
 	}
 	b, err := io.ReadAll(content)
 	if err != nil {
-		return xerrors.Errorf("read error: %w", err)
+		return fmt.Errorf("read error: %w", err)
 	}
 	err = mfs.WriteVirtualFile(filePath, b, fs.ModePerm)
 	if err != nil {
-		return xerrors.Errorf("mapfs write error: %w", err)
+		return fmt.Errorf("mapfs write error: %w", err)
 	}
 
 	m.current = mfs

--- a/pkg/parallel/walk.go
+++ b/pkg/parallel/walk.go
@@ -2,10 +2,11 @@ package parallel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io/fs"
 
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -51,7 +52,7 @@ func WalkDir[T any](ctx context.Context, fsys fs.FS, root string, parallel int,
 			return nil
 		})
 		if err != nil {
-			return xerrors.Errorf("walk error: %w", err)
+			return fmt.Errorf("walk error: %w", err)
 		}
 		return nil
 	})
@@ -90,18 +91,18 @@ func WalkDir[T any](ctx context.Context, fsys fs.FS, root string, parallel int,
 func walk[T any](ctx context.Context, fsys fs.FS, path string, c chan T, onFile onFile[T]) error {
 	f, err := fsys.Open(path)
 	if err != nil {
-		return xerrors.Errorf("file open error: %w", err)
+		return fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 
 	info, err := f.Stat()
 	if err != nil {
-		return xerrors.Errorf("stat error: %w", err)
+		return fmt.Errorf("stat error: %w", err)
 	}
 
 	rsa, ok := f.(xio.ReadSeekerAt)
 	if !ok {
-		return xerrors.New("type assertion failed")
+		return errors.New("type assertion failed")
 	}
 	res, err := onFile(path, info, rsa)
 	if err != nil {

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -9,7 +9,6 @@ import (
 	version "github.com/knqyf263/go-rpm-version"
 	packageurl "github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -49,7 +48,7 @@ type PackageURL packageurl.PackageURL
 func FromString(s string) (*PackageURL, error) {
 	p, err := packageurl.FromString(s)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse purl(%s): %w", s, err)
+		return nil, fmt.Errorf("failed to parse purl(%s): %w", s, err)
 	}
 
 	if len(p.Qualifiers) == 0 {
@@ -285,7 +284,7 @@ func parseOCI(metadata types.Metadata) (*packageurl.PackageURL, error) {
 
 	digest, err := cn.NewDigest(metadata.RepoDigests[0])
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse digest: %w", err)
+		return nil, fmt.Errorf("failed to parse digest: %w", err)
 	}
 
 	name := strings.ToLower(digest.RepositoryStr())

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -14,7 +15,6 @@ import (
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/image/registry"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -28,7 +28,7 @@ type Descriptor = remote.Descriptor
 func Get(ctx context.Context, ref name.Reference, option types.RegistryOptions) (*Descriptor, error) {
 	transport, err := httpTransport(option)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create http transport: %w", err)
+		return nil, fmt.Errorf("failed to create http transport: %w", err)
 	}
 
 	var errs error
@@ -42,7 +42,7 @@ func Get(ctx context.Context, ref name.Reference, option types.RegistryOptions) 
 		if option.Platform.Platform != nil {
 			p, err := resolvePlatform(ref, option.Platform, remoteOpts)
 			if err != nil {
-				return nil, xerrors.Errorf("platform error: %w", err)
+				return nil, fmt.Errorf("platform error: %w", err)
 			}
 			// Don't pass platform when the specified image is single-arch.
 			if p.Platform != nil {
@@ -73,7 +73,7 @@ func Get(ctx context.Context, ref name.Reference, option types.RegistryOptions) 
 func Image(ctx context.Context, ref name.Reference, option types.RegistryOptions) (v1.Image, error) {
 	transport, err := httpTransport(option)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create http transport: %w", err)
+		return nil, fmt.Errorf("failed to create http transport: %w", err)
 	}
 
 	var errs error
@@ -100,7 +100,7 @@ func Image(ctx context.Context, ref name.Reference, option types.RegistryOptions
 func Referrers(ctx context.Context, d name.Digest, option types.RegistryOptions) (v1.ImageIndex, error) {
 	transport, err := httpTransport(option)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create http transport: %w", err)
+		return nil, fmt.Errorf("failed to create http transport: %w", err)
 	}
 
 	var errs error
@@ -180,7 +180,7 @@ func resolvePlatform(ref name.Reference, p types.Platform, options []remote.Opti
 	// e.g. */amd64
 	d, err := remote.Get(ref, options...)
 	if err != nil {
-		return types.Platform{}, xerrors.Errorf("image get error: %w", err)
+		return types.Platform{}, fmt.Errorf("image get error: %w", err)
 	}
 	switch d.MediaType {
 	case v1types.OCIManifestSchema1, v1types.DockerManifestSchema2:
@@ -193,12 +193,12 @@ func resolvePlatform(ref name.Reference, p types.Platform, options []remote.Opti
 
 	index, err := d.ImageIndex()
 	if err != nil {
-		return types.Platform{}, xerrors.Errorf("image index error: %w", err)
+		return types.Platform{}, fmt.Errorf("image index error: %w", err)
 	}
 
 	m, err := index.IndexManifest()
 	if err != nil {
-		return types.Platform{}, xerrors.Errorf("remote index manifest error: %w", err)
+		return types.Platform{}, fmt.Errorf("remote index manifest error: %w", err)
 	}
 	if len(m.Manifests) == 0 {
 		log.Debug("Ignore '--platform' as the image is not multi-arch")
@@ -229,7 +229,7 @@ func satisfyPlatform(desc *remote.Descriptor, platform v1.Platform) error {
 		return err
 	}
 	if !lo.FromPtr(c.Platform()).Satisfies(platform) {
-		return xerrors.Errorf("the specified platform not found")
+		return fmt.Errorf("the specified platform not found")
 	}
 	return nil
 }

--- a/pkg/report/cyclonedx/cyclonedx.go
+++ b/pkg/report/cyclonedx/cyclonedx.go
@@ -2,10 +2,10 @@ package cyclonedx
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -30,14 +30,14 @@ func NewWriter(output io.Writer, appVersion string) Writer {
 func (w Writer) Write(ctx context.Context, report types.Report) error {
 	bom, err := w.marshaler.MarshalReport(ctx, report)
 	if err != nil {
-		return xerrors.Errorf("CycloneDX marshal error: %w", err)
+		return fmt.Errorf("CycloneDX marshal error: %w", err)
 	}
 
 	encoder := cdx.NewBOMEncoder(w.output, w.format)
 	encoder.SetPretty(true)
 	encoder.SetEscapeHTML(false)
 	if err = encoder.Encode(bom); err != nil {
-		return xerrors.Errorf("failed to encode bom: %w", err)
+		return fmt.Errorf("failed to encode bom: %w", err)
 	}
 
 	return nil

--- a/pkg/report/github/github.go
+++ b/pkg/report/github/github.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -138,7 +136,7 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 			githubPkg.Dependencies = pkg.DependsOn // TODO: replace with PURL
 			githubPkg.PackageUrl, err = buildPurl(result.Type, report.Metadata, pkg)
 			if err != nil {
-				return xerrors.Errorf("unable to build purl for %s: %w", pkg.Name, err)
+				return fmt.Errorf("unable to build purl for %s: %w", pkg.Name, err)
 			}
 
 			if pkg.FilePath != "" {
@@ -156,11 +154,11 @@ func (w Writer) Write(ctx context.Context, report types.Report) error {
 
 	output, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
-		return xerrors.Errorf("failed to marshal github dependency snapshots: %w", err)
+		return fmt.Errorf("failed to marshal github dependency snapshots: %w", err)
 	}
 
 	if _, err = fmt.Fprint(w.Output, string(output)); err != nil {
-		return xerrors.Errorf("failed to write github dependency snapshots: %w", err)
+		return fmt.Errorf("failed to write github dependency snapshots: %w", err)
 	}
 	return nil
 }
@@ -186,7 +184,7 @@ func getPkgRelationshipType(pkg ftypes.Package) string {
 func buildPurl(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (string, error) {
 	packageUrl, err := purl.New(t, metadata, pkg)
 	if err != nil {
-		return "", xerrors.Errorf("purl error: %w", err)
+		return "", fmt.Errorf("purl error: %w", err)
 	}
 	if packageUrl == nil {
 		return "", nil

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/xerrors"
-
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
@@ -20,11 +18,11 @@ type JSONWriter struct {
 func (jw JSONWriter) Write(ctx context.Context, report types.Report) error {
 	output, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
-		return xerrors.Errorf("failed to marshal json: %w", err)
+		return fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	if _, err = fmt.Fprintln(jw.Output, string(output)); err != nil {
-		return xerrors.Errorf("failed to write json: %w", err)
+		return fmt.Errorf("failed to write json: %w", err)
 	}
 	return nil
 }

--- a/pkg/report/predicate/vuln.go
+++ b/pkg/report/predicate/vuln.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/package-url/packageurl-go"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -78,11 +77,11 @@ func (w VulnWriter) Write(ctx context.Context, report types.Report) error {
 
 	output, err := json.MarshalIndent(predicate, "", "  ")
 	if err != nil {
-		return xerrors.Errorf("failed to marshal cosign vulnerability predicate: %w", err)
+		return fmt.Errorf("failed to marshal cosign vulnerability predicate: %w", err)
 	}
 
 	if _, err = fmt.Fprint(w.output, string(output)); err != nil {
-		return xerrors.Errorf("failed to write cosign vulnerability predicate: %w", err)
+		return fmt.Errorf("failed to write cosign vulnerability predicate: %w", err)
 	}
 	return nil
 

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -11,7 +11,6 @@ import (
 
 	containerName "github.com/google/go-containerregistry/pkg/name"
 	"github.com/owenrumney/go-sarif/v2/sarif"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -126,7 +125,7 @@ func getRuleIndex(id string, indexes map[string]int) int {
 func (sw *SarifWriter) Write(ctx context.Context, report types.Report) error {
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
-		return xerrors.Errorf("error creating a new sarif template: %w", err)
+		return fmt.Errorf("error creating a new sarif template: %w", err)
 	}
 	sw.run = sarif.NewRunWithInformationURI("Trivy", "https://github.com/aquasecurity/trivy")
 	sw.run.Tool.Driver.WithVersion(sw.Version)

--- a/pkg/report/spdx/spdx.go
+++ b/pkg/report/spdx/spdx.go
@@ -3,11 +3,11 @@ package spdx
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 	"github.com/spdx/tools-golang/tagvalue"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -32,16 +32,16 @@ func NewWriter(output io.Writer, version string, spdxFormat types.Format) Writer
 func (w Writer) Write(ctx context.Context, report types.Report) error {
 	spdxDoc, err := w.marshaler.MarshalReport(ctx, report)
 	if err != nil {
-		return xerrors.Errorf("failed to marshal spdx: %w", err)
+		return fmt.Errorf("failed to marshal spdx: %w", err)
 	}
 
 	if w.format == "spdx-json" {
 		if err := writeSPDXJson(spdxDoc, w.output); err != nil {
-			return xerrors.Errorf("failed to save spdx json: %w", err)
+			return fmt.Errorf("failed to save spdx json: %w", err)
 		}
 	} else {
 		if err := tagvalue.Write(spdxDoc, w.output); err != nil {
-			return xerrors.Errorf("failed to save spdx tag-value: %w", err)
+			return fmt.Errorf("failed to save spdx tag-value: %w", err)
 		}
 	}
 

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"fmt"
 	"html"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -32,7 +32,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate, appVersion string) (*Te
 	if strings.HasPrefix(outputTemplate, "@") {
 		buf, err := os.ReadFile(strings.TrimPrefix(outputTemplate, "@"))
 		if err != nil {
-			return nil, xerrors.Errorf("error retrieving template from path: %w", err)
+			return nil, fmt.Errorf("error retrieving template from path: %w", err)
 		}
 		outputTemplate = string(buf)
 	}
@@ -66,7 +66,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate, appVersion string) (*Te
 
 	tmpl, err := template.New("output template").Funcs(templateFuncMap).Parse(outputTemplate)
 	if err != nil {
-		return nil, xerrors.Errorf("error parsing template: %w", err)
+		return nil, fmt.Errorf("error parsing template: %w", err)
 	}
 	return &TemplateWriter{
 		Output:   output,
@@ -78,7 +78,7 @@ func NewTemplateWriter(output io.Writer, outputTemplate, appVersion string) (*Te
 func (tw TemplateWriter) Write(ctx context.Context, report types.Report) error {
 	err := tw.Template.Execute(tw.Output, report.Results)
 	if err != nil {
-		return xerrors.Errorf("failed to write with template: %w", err)
+		return fmt.Errorf("failed to write with template: %w", err)
 	}
 	return nil
 }

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -3,10 +3,9 @@ package report
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	cr "github.com/aquasecurity/trivy/pkg/compliance/report"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -28,7 +27,7 @@ const (
 func Write(ctx context.Context, report types.Report, option flag.Options) (err error) {
 	output, cleanup, err := option.OutputWriter(ctx)
 	if err != nil {
-		return xerrors.Errorf("failed to create a file: %w", err)
+		return fmt.Errorf("failed to create a file: %w", err)
 	}
 	defer func() {
 		if cerr := cleanup(); cerr != nil {
@@ -78,7 +77,7 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 		}
 		var err error
 		if writer, err = NewTemplateWriter(output, option.Template, option.AppVersion); err != nil {
-			return xerrors.Errorf("failed to initialize template writer: %w", err)
+			return fmt.Errorf("failed to initialize template writer: %w", err)
 		}
 	case types.FormatSarif:
 		target := ""
@@ -93,11 +92,11 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 	case types.FormatCosignVuln:
 		writer = predicate.NewVulnWriter(output, option.AppVersion)
 	default:
-		return xerrors.Errorf("unknown format: %v", option.Format)
+		return fmt.Errorf("unknown format: %v", option.Format)
 	}
 
 	if err = writer.Write(ctx, report); err != nil {
-		return xerrors.Errorf("failed to write results: %w", err)
+		return fmt.Errorf("failed to write results: %w", err)
 	}
 
 	return nil
@@ -106,7 +105,7 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 func complianceWrite(ctx context.Context, report types.Report, opt flag.Options, output io.Writer) error {
 	complianceReport, err := cr.BuildComplianceReport([]types.Results{report.Results}, opt.Compliance)
 	if err != nil {
-		return xerrors.Errorf("compliance report build error: %w", err)
+		return fmt.Errorf("compliance report build error: %w", err)
 	}
 	return cr.Write(ctx, complianceReport, cr.Option{
 		Format:     opt.Format,

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/package-url/packageurl-go"
-	"golang.org/x/xerrors"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/clock"
@@ -65,7 +66,7 @@ func (i *IgnoreFinding) UnmarshalYAML(value *yaml.Node) error {
 
 	for _, pattern := range i.Paths {
 		if !doublestar.ValidatePattern(pattern) {
-			return xerrors.Errorf("invalid path pattern in the ignore file, id: %s, path: %s", i.ID, pattern)
+			return fmt.Errorf("invalid path pattern in the ignore file, id: %s, path: %s", i.ID, pattern)
 		}
 	}
 
@@ -73,7 +74,7 @@ func (i *IgnoreFinding) UnmarshalYAML(value *yaml.Node) error {
 	for _, purlStr := range tmp.PURLs {
 		parsedPURL, err := purl.FromString(purlStr)
 		if err != nil {
-			return xerrors.Errorf("purl error in the ignore file: %w", err)
+			return fmt.Errorf("purl error in the ignore file: %w", err)
 		}
 		i.PURLs = append(i.PURLs, parsedPURL)
 	}
@@ -189,12 +190,12 @@ func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, erro
 	} else if filepath.Ext(ignoreFile) == ".yml" || filepath.Ext(ignoreFile) == ".yaml" {
 		conf, err = parseIgnoreYAML(ignoreFile)
 		if err != nil {
-			return IgnoreConfig{}, xerrors.Errorf("%s parse error: %w", ignoreFile, err)
+			return IgnoreConfig{}, fmt.Errorf("%s parse error: %w", ignoreFile, err)
 		}
 	} else {
 		ignoredFindings, err := parseIgnore(ignoreFile)
 		if err != nil {
-			return IgnoreConfig{}, xerrors.Errorf("%s parse error: %w", ignoreFile, err)
+			return IgnoreConfig{}, fmt.Errorf("%s parse error: %w", ignoreFile, err)
 		}
 
 		// IDs in .trivyignore are treated as IDs for all scanners
@@ -220,7 +221,7 @@ func parseIgnoreYAML(ignoreFile string) (IgnoreConfig, error) {
 	// Read .trivyignore.yaml
 	f, err := os.Open(ignoreFile)
 	if err != nil {
-		return IgnoreConfig{}, xerrors.Errorf("file open error: %w", err)
+		return IgnoreConfig{}, fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 	log.Debug("Found an ignore yaml", log.String("path", ignoreFile))
@@ -228,7 +229,7 @@ func parseIgnoreYAML(ignoreFile string) (IgnoreConfig, error) {
 	// Parse the YAML content
 	var ignoreConfig IgnoreConfig
 	if err = yaml.NewDecoder(f).Decode(&ignoreConfig); err != nil {
-		return IgnoreConfig{}, xerrors.Errorf("yaml decode error: %w", err)
+		return IgnoreConfig{}, fmt.Errorf("yaml decode error: %w", err)
 	}
 	return ignoreConfig, nil
 }
@@ -236,7 +237,7 @@ func parseIgnoreYAML(ignoreFile string) (IgnoreConfig, error) {
 func parseIgnore(ignoreFile string) (IgnoreFindings, error) {
 	f, err := os.Open(ignoreFile)
 	if err != nil {
-		return nil, xerrors.Errorf("file open error: %w", err)
+		return nil, fmt.Errorf("file open error: %w", err)
 	}
 	defer f.Close()
 	log.Debug("Found an ignore file", log.String("path", ignoreFile))

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -3,9 +3,8 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
-
-	"golang.org/x/xerrors"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	r "github.com/aquasecurity/trivy/pkg/rpc"
@@ -92,7 +91,7 @@ func (s Scanner) Scan(ctx context.Context, target, artifactKey string, blobKeys 
 		return err
 	})
 	if err != nil {
-		return nil, ftypes.OS{}, xerrors.Errorf("failed to detect vulnerabilities via RPC: %w", err)
+		return nil, ftypes.OS{}, fmt.Errorf("failed to detect vulnerabilities via RPC: %w", err)
 	}
 
 	return r.ConvertFromRPCResults(res.Results), r.ConvertFromRPCOS(res.Os), nil

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy-db/pkg/metadata"
@@ -108,7 +108,7 @@ func Test_dbWorker_update(t *testing.T) {
 					appVersion: "1",
 					skip:       false,
 				},
-				output: needsUpdateOutput{err: xerrors.New("fail")},
+				output: needsUpdateOutput{err: errors.New("fail")},
 			},
 			args:    args{appVersion: "1"},
 			wantErr: "failed to check if db needs an update",
@@ -124,7 +124,7 @@ func Test_dbWorker_update(t *testing.T) {
 			},
 			download: download{
 				call: true,
-				err:  xerrors.New("fail"),
+				err:  errors.New("fail"),
 			},
 			args:    args{appVersion: "1"},
 			wantErr: "failed DB hot update",

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/wire"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -54,7 +54,7 @@ func (s *ScanServer) Scan(ctx context.Context, in *rpcScanner.ScanRequest) (*rpc
 	}
 	results, os, err := s.localScanner.Scan(ctx, in.Target, in.ArtifactId, in.BlobIds, options)
 	if err != nil {
-		return nil, teeError(xerrors.Errorf("failed scan, %s: %w", in.Target, err))
+		return nil, teeError(fmt.Errorf("failed scan, %s: %w", in.Target, err))
 	}
 
 	return rpc.ConvertToRPCScanResponse(results, os), nil
@@ -73,11 +73,11 @@ func NewCacheServer(c cache.Cache) *CacheServer {
 // PutArtifact puts the artifacts in cache
 func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
 	if in.ArtifactInfo == nil {
-		return nil, teeError(xerrors.Errorf("empty image info"))
+		return nil, teeError(fmt.Errorf("empty image info"))
 	}
 	imageInfo := rpc.ConvertFromRPCPutArtifactRequest(in)
 	if err := s.cache.PutArtifact(in.ArtifactId, imageInfo); err != nil {
-		return nil, teeError(xerrors.Errorf("unable to store image info in cache: %w", err))
+		return nil, teeError(fmt.Errorf("unable to store image info in cache: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -85,11 +85,11 @@ func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactReq
 // PutBlob puts the blobs in cache
 func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
 	if in.BlobInfo == nil {
-		return nil, teeError(xerrors.Errorf("empty layer info"))
+		return nil, teeError(fmt.Errorf("empty layer info"))
 	}
 	layerInfo := rpc.ConvertFromRPCPutBlobRequest(in)
 	if err := s.cache.PutBlob(in.DiffId, layerInfo); err != nil {
-		return nil, teeError(xerrors.Errorf("unable to store layer info in cache: %w", err))
+		return nil, teeError(fmt.Errorf("unable to store layer info in cache: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }
@@ -98,7 +98,7 @@ func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*
 func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsRequest) (*rpcCache.MissingBlobsResponse, error) {
 	missingArtifact, blobIDs, err := s.cache.MissingBlobs(in.ArtifactId, in.BlobIds)
 	if err != nil {
-		return nil, teeError(xerrors.Errorf("failed to get missing blobs: %w", err))
+		return nil, teeError(fmt.Errorf("failed to get missing blobs: %w", err))
 	}
 	return &rpcCache.MissingBlobsResponse{
 		MissingArtifact: missingArtifact,
@@ -110,7 +110,7 @@ func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsR
 func (s *CacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
 	blobIDs := rpc.ConvertFromDeleteBlobsRequest(in)
 	if err := s.cache.DeleteBlobs(blobIDs); err != nil {
-		return nil, teeError(xerrors.Errorf("failed to remove a blobs: %w", err))
+		return nil, teeError(fmt.Errorf("failed to remove a blobs: %w", err))
 	}
 	return &google_protobuf.Empty{}, nil
 }

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -252,7 +251,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 					},
 				},
 				Returns: cache.ArtifactCachePutArtifactReturns{
-					Err: xerrors.New("error"),
+					Err: errors.New("error"),
 				},
 			},
 			wantErr: "unable to store image info in cache",
@@ -478,7 +477,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 					BlobInfoAnything: true,
 				},
 				Returns: cache.ArtifactCachePutBlobReturns{
-					Err: xerrors.New("error"),
+					Err: errors.New("error"),
 				},
 			},
 			wantErr: "unable to store layer info in cache",
@@ -494,7 +493,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 					BlobInfoAnything: true,
 				},
 				Returns: cache.ArtifactCachePutBlobReturns{
-					Err: xerrors.New("error"),
+					Err: errors.New("error"),
 				},
 			},
 			wantErr: "empty layer info",

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -11,7 +11,6 @@ import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	dtypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -51,7 +50,7 @@ func (m *Marshaler) MarshalReport(ctx context.Context, report types.Report) (*cd
 	opts := core.Options{GenerateBOMRef: true}
 	bom, err := sbomio.NewEncoder(opts).Encode(report)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal report: %w", err)
+		return nil, fmt.Errorf("failed to marshal report: %w", err)
 	}
 
 	return m.Marshal(ctx, bom)
@@ -68,11 +67,11 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*cdx.BOM, error
 
 	var err error
 	if cdxBOM.Metadata.Component, err = m.MarshalRoot(); err != nil {
-		return nil, xerrors.Errorf("failed to marshal component: %w", err)
+		return nil, fmt.Errorf("failed to marshal component: %w", err)
 	}
 
 	if cdxBOM.Components, err = m.marshalComponents(); err != nil {
-		return nil, xerrors.Errorf("failed to marshal components: %w", err)
+		return nil, fmt.Errorf("failed to marshal components: %w", err)
 	}
 
 	cdxBOM.Dependencies = m.marshalDependencies()
@@ -104,7 +103,7 @@ func (m *Marshaler) MarshalRoot() (*cdx.Component, error) {
 func (m *Marshaler) MarshalComponent(component *core.Component) (*cdx.Component, error) {
 	componentType, err := m.componentType(component.Type)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get cdx component type: %w", err)
+		return nil, fmt.Errorf("failed to get cdx component type: %w", err)
 	}
 
 	cdxComponent := &cdx.Component{
@@ -132,7 +131,7 @@ func (m *Marshaler) marshalComponents() (*[]cdx.Component, error) {
 		}
 		c, err := m.MarshalComponent(component)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to marshal component: %w", err)
+			return nil, fmt.Errorf("failed to marshal component: %w", err)
 		}
 		cdxComponents = append(cdxComponents, *c)
 	}
@@ -230,7 +229,7 @@ func (*Marshaler) componentType(t core.ComponentType) (cdx.ComponentType, error)
 	case core.TypePlatform:
 		return cdx.ComponentTypePlatform, nil
 	}
-	return "", xerrors.Errorf("unknown component type: %s", t)
+	return "", fmt.Errorf("unknown component type: %s", t)
 }
 
 func (*Marshaler) PackageURL(p *packageurl.PackageURL) string {

--- a/pkg/sbom/io/encode.go
+++ b/pkg/sbom/io/encode.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -31,7 +30,7 @@ func (e *Encoder) Encode(report types.Report) (*core.BOM, error) {
 	// Metadata component
 	root, err := e.rootComponent(report)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create root component: %w", err)
+		return nil, fmt.Errorf("failed to create root component: %w", err)
 	}
 
 	e.bom = core.NewBOM(e.opts)
@@ -71,7 +70,7 @@ func (e *Encoder) rootComponent(r types.Report) (*core.Component, error) {
 
 		p, err := purl.New(purl.TypeOCI, r.Metadata, ftypes.Package{})
 		if err != nil {
-			return nil, xerrors.Errorf("failed to new package url for oci: %w", err)
+			return nil, fmt.Errorf("failed to new package url for oci: %w", err)
 		}
 		if p != nil {
 			root.PkgIdentifier.PURL = p.Unwrap()

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	"github.com/spdx/tools-golang/tagvalue"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
@@ -35,15 +34,15 @@ type TVDecoder struct {
 func (tv *TVDecoder) Decode(v interface{}) error {
 	spdxDocument, err := tagvalue.Read(tv.r)
 	if err != nil {
-		return xerrors.Errorf("failed to load tag-value spdx: %w", err)
+		return fmt.Errorf("failed to load tag-value spdx: %w", err)
 	}
 
 	a, ok := v.(*SPDX)
 	if !ok {
-		return xerrors.Errorf("invalid struct type tag-value decoder needed SPDX struct")
+		return fmt.Errorf("invalid struct type tag-value decoder needed SPDX struct")
 	}
 	if err = a.unmarshal(spdxDocument); err != nil {
-		return xerrors.Errorf("failed to unmarshal spdx: %w", err)
+		return fmt.Errorf("failed to unmarshal spdx: %w", err)
 	}
 
 	return nil
@@ -59,11 +58,11 @@ func (s *SPDX) UnmarshalJSON(b []byte) error {
 
 	spdxDocument, err := json.Read(bytes.NewReader(b))
 	if err != nil {
-		return xerrors.Errorf("failed to load spdx json: %w", err)
+		return fmt.Errorf("failed to load spdx json: %w", err)
 	}
 
 	if err = s.unmarshal(spdxDocument); err != nil {
-		return xerrors.Errorf("failed to unmarshal spdx: %w", err)
+		return fmt.Errorf("failed to unmarshal spdx: %w", err)
 	}
 	return nil
 }
@@ -77,7 +76,7 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 	// Convert all SPDX packages into Trivy components
 	components, err := s.parsePackages(spdxDocument)
 	if err != nil {
-		return xerrors.Errorf("package parse error: %w", err)
+		return fmt.Errorf("package parse error: %w", err)
 	}
 
 	// Parse relationships and build the dependency graph
@@ -146,7 +145,7 @@ func (s *SPDX) parsePackages(spdxDocument *spdx.Document) (map[common.ElementID]
 	for _, pkg := range spdxDocument.Packages {
 		component, err := s.parsePackage(*pkg)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse package: %w", err)
+			return nil, fmt.Errorf("failed to parse package: %w", err)
 		}
 		components[pkg.PackageSPDXIdentifier] = component
 
@@ -168,7 +167,7 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 
 	// PURL
 	if component.PkgIdentifier.PURL, err = s.parseExternalReferences(spdxPkg.PackageExternalReferences); err != nil {
-		return nil, xerrors.Errorf("external references error: %w", err)
+		return nil, fmt.Errorf("external references error: %w", err)
 	}
 
 	// License
@@ -255,7 +254,7 @@ func (s *SPDX) parseExternalReferences(refs []*spdx.PackageExternalReference) (*
 
 		packageURL, err := packageurl.FromString(ref.Locator)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse purl from string: %w", err)
+			return nil, fmt.Errorf("failed to parse purl from string: %w", err)
 		}
 		return &packageURL, nil
 	}

--- a/pkg/scanner/langpkg/scan.go
+++ b/pkg/scanner/langpkg/scan.go
@@ -2,9 +2,8 @@ package langpkg
 
 import (
 	"context"
+	"fmt"
 	"sort"
-
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/detector/library"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -76,7 +75,7 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, _ types.Sca
 		log.DebugContext(ctx, "Scanning packages from the file", log.String("file_path", app.FilePath))
 		vulns, err := library.Detect(ctx, app.Type, app.Packages)
 		if err != nil {
-			return nil, xerrors.Errorf("failed vulnerability detection of packages: %w", err)
+			return nil, fmt.Errorf("failed vulnerability detection of packages: %w", err)
 		} else if len(vulns) == 0 {
 			continue
 		}

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/wire"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -86,7 +85,7 @@ func (s Scanner) Scan(ctx context.Context, targetName, artifactKey string, blobK
 		log.Warn("No OS package is detected. Make sure you haven't deleted any files that contain information about the installed packages.")
 		log.Warn(`e.g. files under "/lib/apk/db/", "/var/lib/dpkg/" and "/var/lib/rpm"`)
 	case err != nil:
-		return nil, ftypes.OS{}, xerrors.Errorf("failed to apply layers: %w", err)
+		return nil, ftypes.OS{}, fmt.Errorf("failed to apply layers: %w", err)
 	}
 
 	target := types.ScanTarget{
@@ -126,7 +125,7 @@ func (s Scanner) ScanTarget(ctx context.Context, target types.ScanTarget, option
 		var vulnResults types.Results
 		vulnResults, eosl, err = s.scanVulnerabilities(ctx, target, options)
 		if err != nil {
-			return nil, ftypes.OS{}, xerrors.Errorf("failed to detect vulnerabilities: %w", err)
+			return nil, ftypes.OS{}, fmt.Errorf("failed to detect vulnerabilities: %w", err)
 		}
 		target.OS.Eosl = eosl
 
@@ -164,7 +163,7 @@ func (s Scanner) ScanTarget(ctx context.Context, target types.ScanTarget, option
 	// Post scanning
 	results, err = post.Scan(ctx, results)
 	if err != nil {
-		return nil, ftypes.OS{}, xerrors.Errorf("post scan error: %w", err)
+		return nil, ftypes.OS{}, fmt.Errorf("post scan error: %w", err)
 	}
 
 	return results, target.OS, nil
@@ -178,7 +177,7 @@ func (s Scanner) scanVulnerabilities(ctx context.Context, target types.ScanTarge
 	if slices.Contains(options.VulnType, types.VulnTypeOS) {
 		vuln, detectedEOSL, err := s.osPkgScanner.Scan(ctx, target, options)
 		if err != nil {
-			return nil, false, xerrors.Errorf("unable to scan OS packages: %w", err)
+			return nil, false, fmt.Errorf("unable to scan OS packages: %w", err)
 		} else if vuln.Target != "" {
 			results = append(results, vuln)
 		}
@@ -188,7 +187,7 @@ func (s Scanner) scanVulnerabilities(ctx context.Context, target types.ScanTarge
 	if slices.Contains(options.VulnType, types.VulnTypeLibrary) {
 		vulns, err := s.langPkgScanner.Scan(ctx, target, options)
 		if err != nil {
-			return nil, false, xerrors.Errorf("failed to scan application libraries: %w", err)
+			return nil, false, fmt.Errorf("failed to scan application libraries: %w", err)
 		}
 		results = append(results, vulns...)
 	}

--- a/pkg/scanner/ospkg/scan.go
+++ b/pkg/scanner/ospkg/scan.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"golang.org/x/xerrors"
-
 	ospkgDetector "github.com/aquasecurity/trivy/pkg/detector/ospkg"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -57,7 +55,7 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, _ types.Sca
 	if errors.Is(err, ospkgDetector.ErrUnsupportedOS) {
 		return types.Result{}, false, nil
 	} else if err != nil {
-		return types.Result{}, false, xerrors.Errorf("failed vulnerability detection of OS packages: %w", err)
+		return types.Result{}, false, fmt.Errorf("failed vulnerability detection of OS packages: %w", err)
 	}
 
 	artifactDetail := fmt.Sprintf("%s (%s %s)", target.Name, target.OS.Family, target.OS.Name)

--- a/pkg/scanner/post/post_scan.go
+++ b/pkg/scanner/post/post_scan.go
@@ -2,8 +2,7 @@ package post
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"github.com/aquasecurity/trivy/pkg/types"
 )
@@ -38,7 +37,7 @@ func Scan(ctx context.Context, results types.Results) (types.Results, error) {
 	for _, s := range postScanners {
 		results, err = s.PostScan(ctx, results)
 		if err != nil {
-			return nil, xerrors.Errorf("%s post scan error: %w", s.Name(), err)
+			return nil, fmt.Errorf("%s post scan error: %w", s.Name(), err)
 		}
 	}
 	return results, nil

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -2,9 +2,9 @@ package scanner
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/wire"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -145,7 +145,7 @@ func NewScanner(driver Driver, ar artifact.Artifact) Scanner {
 func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (types.Report, error) {
 	artifactInfo, err := s.artifact.Inspect(ctx)
 	if err != nil {
-		return types.Report{}, xerrors.Errorf("failed analysis: %w", err)
+		return types.Report{}, fmt.Errorf("failed analysis: %w", err)
 	}
 	defer func() {
 		if err := s.artifact.Clean(artifactInfo); err != nil {
@@ -156,7 +156,7 @@ func (s Scanner) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 
 	results, osFound, err := s.driver.Scan(ctx, artifactInfo.Name, artifactInfo.ID, artifactInfo.BlobIDs, options)
 	if err != nil {
-		return types.Report{}, xerrors.Errorf("scan failed: %w", err)
+		return types.Report{}, fmt.Errorf("scan failed: %w", err)
 	}
 
 	ptros := &osFound

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 )
@@ -55,7 +54,7 @@ func HomeDir() string {
 func CopyFile(src, dst string) (int64, error) {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
-		return 0, xerrors.Errorf("file (%s) stat error: %w", src, err)
+		return 0, fmt.Errorf("file (%s) stat error: %w", src, err)
 	}
 
 	if !sourceFileStat.Mode().IsRegular() {
@@ -98,7 +97,7 @@ func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, fn WalkDirFu
 
 		f, err := fsys.Open(path)
 		if err != nil {
-			return xerrors.Errorf("file open error: %w", err)
+			return fmt.Errorf("file open error: %w", err)
 		}
 		defer f.Close()
 

--- a/pkg/x/io/io.go
+++ b/pkg/x/io/io.go
@@ -2,9 +2,8 @@ package io
 
 import (
 	"bytes"
+	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 )
 
 type ReadSeekerAt interface {
@@ -24,7 +23,7 @@ func NewReadSeekerAt(r io.Reader) (ReadSeekerAt, error) {
 
 	buff := bytes.NewBuffer([]byte{})
 	if _, err := io.Copy(buff, r); err != nil {
-		return nil, xerrors.Errorf("copy error: %w", err)
+		return nil, fmt.Errorf("copy error: %w", err)
 	}
 
 	return bytes.NewReader(buff.Bytes()), nil
@@ -43,7 +42,7 @@ func NewReadSeekerAtWithSize(r io.Reader) (ReadSeekerAt, int64, error) {
 
 	size, err := getSeekerSize(rsa)
 	if err != nil {
-		return nil, 0, xerrors.Errorf("get size error: %w", err)
+		return nil, 0, fmt.Errorf("get size error: %w", err)
 	}
 	return rsa, size, nil
 }
@@ -51,11 +50,11 @@ func NewReadSeekerAtWithSize(r io.Reader) (ReadSeekerAt, int64, error) {
 func getSeekerSize(s io.Seeker) (int64, error) {
 	size, err := s.Seek(0, io.SeekEnd)
 	if err != nil {
-		return 0, xerrors.Errorf("seek error: %w", err)
+		return 0, fmt.Errorf("seek error: %w", err)
 	}
 
 	if _, err = s.Seek(0, io.SeekStart); err != nil {
-		return 0, xerrors.Errorf("seek error: %w", err)
+		return 0, fmt.Errorf("seek error: %w", err)
 	}
 	return size, nil
 }


### PR DESCRIPTION
## Description

use errors instead of golang.org/x/xerrors

* replace xerrors.Errorf with fmt.Errorf
* replace xerrors.New with errors.New
* enable errorlint 

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
