### PR TITLE
chore(deps): use `google.golang.org/protobuf/types/known` instead of `github.com/golang/protobuf/ptypes`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,10 @@ require (
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/alecthomas/chroma v0.10.0
 	github.com/alicebob/miniredis/v2 v2.31.1
+	github.com/antchfx/htmlquery v1.3.0
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
@@ -36,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.27.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
+	github.com/aws/smithy-go v1.20.2
 	github.com/bitnami/go-version v0.0.0-20231130084017-bb00604d650c
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -50,7 +54,6 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-containerregistry v0.19.1
 	github.com/google/licenseclassifier/v2 v2.0.0
 	github.com/google/uuid v1.6.0
@@ -58,7 +61,12 @@ require (
 	github.com/hashicorp/go-getter v1.7.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
+	github.com/hashicorp/go-uuid v1.0.3
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hashicorp/hc-install v0.6.3
+	github.com/hashicorp/hcl/v2 v2.19.1
+	github.com/hashicorp/terraform-exec v0.20.0
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f
 	github.com/knqyf263/go-deb-version v0.0.0-20230223133812-3ed183d23422
@@ -66,9 +74,10 @@ require (
 	github.com/knqyf263/go-rpmdb v0.0.0-20231008124120-ac49267ab4e1
 	github.com/knqyf263/nested v0.0.1
 	github.com/kylelemons/godebug v1.1.0
+	github.com/liamg/iamgo v0.0.9
 	github.com/liamg/jfather v0.0.7
+	github.com/liamg/memoryfs v1.6.0
 	github.com/magefile/mage v1.15.0
-	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/masahiro331/go-disk v0.0.0-20220919035250-c8da316f91ac
 	github.com/masahiro331/go-ebs-file v0.0.0-20240112135404-d5fbb1d46323
 	github.com/masahiro331/go-ext4-filesystem v0.0.0-20231208112839-4339555a0cd4
@@ -77,6 +86,7 @@ require (
 	github.com/masahiro331/go-xfs-filesystem v0.0.0-20230608043311-a335f4599b70
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/microsoft/go-rustaudit v0.0.0-20220808201409-204dfee52032
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/buildkit v0.12.5
@@ -85,6 +95,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/openvex/go-vex v0.2.5
 	github.com/owenrumney/go-sarif/v2 v2.3.0
+	github.com/owenrumney/squealer v1.2.2
 	github.com/package-url/packageurl-go v0.1.2
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/samber/lo v1.39.0
@@ -104,8 +115,10 @@ require (
 	github.com/twitchtv/twirp v8.1.2+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xlab/treeprint v1.2.0
+	github.com/zclconf/go-cty v1.14.4
+	github.com/zclconf/go-cty-yaml v1.0.3
 	go.etcd.io/bbolt v1.3.9
-	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/mod v0.16.0
 	golang.org/x/net v0.24.0
@@ -115,29 +128,10 @@ require (
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	google.golang.org/protobuf v1.34.0
 	gopkg.in/yaml.v3 v3.0.1
+	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.3
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	modernc.org/sqlite v1.29.7
-)
-
-require (
-	github.com/alecthomas/chroma v0.10.0
-	github.com/antchfx/htmlquery v1.3.0
-	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/aws/smithy-go v1.20.2
-	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hc-install v0.6.3
-	github.com/hashicorp/hcl/v2 v2.19.1
-	github.com/hashicorp/terraform-exec v0.20.0
-	github.com/liamg/iamgo v0.0.9
-	github.com/liamg/memoryfs v1.6.0
-	github.com/mitchellh/go-homedir v1.1.0
-	github.com/owenrumney/squealer v1.2.2
-	github.com/zclconf/go-cty v1.14.4
-	github.com/zclconf/go-cty-yaml v1.0.3
-	golang.org/x/crypto v0.22.0
-	helm.sh/helm/v3 v3.14.2
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -282,6 +276,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -317,6 +312,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
@@ -394,6 +390,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twitchtv/twirp"
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/aquasecurity/trivy/pkg/cache"
 	fcache "github.com/aquasecurity/trivy/pkg/fanal/cache"
@@ -25,18 +25,18 @@ type mockCacheServer struct {
 	cache fcache.Cache
 }
 
-func (s *mockCacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
+func (s *mockCacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*emptypb.Empty, error) {
 	if strings.Contains(in.ArtifactId, "invalid") {
-		return &google_protobuf.Empty{}, xerrors.New("invalid image ID")
+		return &emptypb.Empty{}, xerrors.New("invalid image ID")
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
-func (s *mockCacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
+func (s *mockCacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*emptypb.Empty, error) {
 	if strings.Contains(in.DiffId, "invalid") {
-		return &google_protobuf.Empty{}, xerrors.New("invalid layer ID")
+		return &emptypb.Empty{}, xerrors.New("invalid layer ID")
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func (s *mockCacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsRequest) (*rpcCache.MissingBlobsResponse, error) {
@@ -50,13 +50,13 @@ func (s *mockCacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBl
 	return &rpcCache.MissingBlobsResponse{MissingArtifact: true, MissingBlobIds: layerIDs}, nil
 }
 
-func (s *mockCacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
+func (s *mockCacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*emptypb.Empty, error) {
 	for _, blobId := range in.GetBlobIds() {
 		if strings.Contains(blobId, "invalid") {
-			return &google_protobuf.Empty{}, xerrors.New("invalid layer ID")
+			return &emptypb.Empty{}, xerrors.New("invalid layer ID")
 		}
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func withToken(base http.Handler, token, tokenHeader string) http.Handler {

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -9,10 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/utils"
@@ -95,10 +95,10 @@ func TestScanner_Scan(t *testing.T) {
 								Layer: &common.Layer{
 									DiffId: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 								},
-								LastModifiedDate: &timestamp.Timestamp{
+								LastModifiedDate: &timestamppb.Timestamp{
 									Seconds: 1577840460,
 								},
-								PublishedDate: &timestamp.Timestamp{
+								PublishedDate: &timestamppb.Timestamp{
 									Seconds: 978310860,
 								},
 							},

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -3,10 +3,10 @@ package server
 import (
 	"context"
 
-	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/wire"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -71,7 +71,7 @@ func NewCacheServer(c cache.Cache) *CacheServer {
 }
 
 // PutArtifact puts the artifacts in cache
-func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*google_protobuf.Empty, error) {
+func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactRequest) (*emptypb.Empty, error) {
 	if in.ArtifactInfo == nil {
 		return nil, teeError(xerrors.Errorf("empty image info"))
 	}
@@ -79,11 +79,11 @@ func (s *CacheServer) PutArtifact(_ context.Context, in *rpcCache.PutArtifactReq
 	if err := s.cache.PutArtifact(in.ArtifactId, imageInfo); err != nil {
 		return nil, teeError(xerrors.Errorf("unable to store image info in cache: %w", err))
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 // PutBlob puts the blobs in cache
-func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*google_protobuf.Empty, error) {
+func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*emptypb.Empty, error) {
 	if in.BlobInfo == nil {
 		return nil, teeError(xerrors.Errorf("empty layer info"))
 	}
@@ -91,7 +91,7 @@ func (s *CacheServer) PutBlob(_ context.Context, in *rpcCache.PutBlobRequest) (*
 	if err := s.cache.PutBlob(in.DiffId, layerInfo); err != nil {
 		return nil, teeError(xerrors.Errorf("unable to store layer info in cache: %w", err))
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 // MissingBlobs returns missing blobs from cache
@@ -107,10 +107,10 @@ func (s *CacheServer) MissingBlobs(_ context.Context, in *rpcCache.MissingBlobsR
 }
 
 // DeleteBlobs removes blobs by IDs
-func (s *CacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*google_protobuf.Empty, error) {
+func (s *CacheServer) DeleteBlobs(_ context.Context, in *rpcCache.DeleteBlobsRequest) (*emptypb.Empty, error) {
 	blobIDs := rpc.ConvertFromDeleteBlobsRequest(in)
 	if err := s.cache.DeleteBlobs(blobIDs); err != nil {
 		return nil, teeError(xerrors.Errorf("failed to remove a blobs: %w", err))
 	}
-	return &google_protobuf.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 	"time"
 
-	google_protobuf "github.com/golang/protobuf/ptypes/empty"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -124,10 +123,10 @@ func TestScanServer_Scan(t *testing.T) {
 								Title:       "dos",
 								Description: "dos vulnerability",
 								References:  []string{"http://example.com"},
-								LastModifiedDate: &timestamp.Timestamp{
+								LastModifiedDate: &timestamppb.Timestamp{
 									Seconds: 1577840460,
 								},
-								PublishedDate: &timestamp.Timestamp{
+								PublishedDate: &timestamppb.Timestamp{
 									Seconds: 978310860,
 								},
 								DataSource: &common.DataSource{
@@ -193,7 +192,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 		name     string
 		args     args
 		putImage cache.ArtifactCachePutArtifactExpectation
-		want     *google_protobuf.Empty
+		want     *emptypb.Empty
 		wantErr  string
 	}{
 		{
@@ -204,7 +203,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 					ArtifactInfo: &rpcCache.ArtifactInfo{
 						SchemaVersion: 1,
 						Architecture:  "amd64",
-						Created: func() *timestamp.Timestamp {
+						Created: func() *timestamppb.Timestamp {
 							d := time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC)
 							t := timestamppb.New(d)
 							return t
@@ -226,7 +225,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 					},
 				},
 			},
-			want: &google_protobuf.Empty{},
+			want: &emptypb.Empty{},
 		},
 		{
 			name: "sad path",
@@ -235,7 +234,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 					ArtifactId: "sha256:e7d92cdc71feacf90708cb59182d0df1b911f8ae022d29e8e95d75ca6a99776a",
 					ArtifactInfo: &rpcCache.ArtifactInfo{
 						SchemaVersion: 1,
-						Created: func() *timestamp.Timestamp {
+						Created: func() *timestamppb.Timestamp {
 							d := time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC)
 							t := timestamppb.New(d)
 							return t
@@ -294,7 +293,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 		name     string
 		args     args
 		putLayer cache.ArtifactCachePutBlobExpectation
-		want     *google_protobuf.Empty
+		want     *emptypb.Empty
 		wantErr  string
 	}{
 		{
@@ -461,7 +460,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 					},
 				},
 			},
-			want: &google_protobuf.Empty{},
+			want: &emptypb.Empty{},
 		},
 		{
 			name: "sad path",


### PR DESCRIPTION
## Description

use `google.golang.org/protobuf/types/known` instead of `github.com/golang/protobuf/ptypes`
this also removes `github.com/golang/protobuf` from the list of direct dependencies to use the recommanded `google.golang.org/protobuf`
