### PR TITLE
ci(deps): enable testifylint linter on .*_test.go$

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,26 +66,35 @@ linters-settings:
       ruleguard:
         failOn: all
         rules: '${configDir}/misc/lint/rules.go'
+  testifylint:
+    enable-all: true
+    disable:
+      - bool-compare
+      - expected-actual
+      - float-compare
+      - len
+      - require-error
 
 linters:
   disable-all: true
   enable:
-    - unused
-    - ineffassign
-    - typecheck
-    - govet
-    - revive
-    - gosec
-    - unconvert
-    - goconst
-    - gocyclo
-    - gofmt
-    - misspell
     - bodyclose
     - gci
-    - gomodguard
-    - tenv
+    - goconst
     - gocritic
+    - gocyclo
+    - gofmt
+    - gomodguard
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - tenv
+    - testifylint
+    - typecheck
+    - unconvert
+    - unused
 
 run:
   go: '1.22'
@@ -93,12 +102,24 @@ run:
 issues:
   exclude-files:
     - ".*_mock.go$"
-    - ".*_test.go$"
     - "integration/*"
     - "examples/*"
   exclude-dirs:
     - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions
   exclude-rules:
+    - path: ".*_test.go$"
+      linters:
+        - bodyclose
+        - gci
+        - gocritic
+        - goconst
+        - gofmt
+        - gosec
+        - govet
+        - ineffassign
+        - misspell
+        - tenv
+        - unused
     - linters:
         - gosec
       text: "G304: Potential file inclusion"

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -146,7 +146,7 @@ func TestRemoteCache_PutArtifact(t *testing.T) {
 			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
 			err := c.PutArtifact(tt.args.imageID, tt.args.imageInfo)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
@@ -207,7 +207,7 @@ func TestRemoteCache_PutBlob(t *testing.T) {
 			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
 			err := c.PutBlob(tt.args.diffID, tt.args.layerInfo)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
@@ -285,7 +285,7 @@ func TestRemoteCache_MissingBlobs(t *testing.T) {
 			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
 			gotMissingImage, gotMissingLayerIDs, err := c.MissingBlobs(tt.args.imageID, tt.args.layerIDs)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {

--- a/pkg/dependency/parser/dotnet/core_deps/parse_test.go
+++ b/pkg/dependency/parser/dotnet/core_deps/parse_test.go
@@ -41,7 +41,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 			} else {
 				require.NoError(t, err)

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -128,7 +128,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := binary.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1408,7 +1408,7 @@ func TestPom_Parse(t *testing.T) {
 
 			gotPkgs, gotDeps, err := p.Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/dependency/parser/nuget/config/parse_test.go
+++ b/pkg/dependency/parser/nuget/config/parse_test.go
@@ -46,7 +46,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := config.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/dependency/parser/nuget/packagesprops/parse_test.go
+++ b/pkg/dependency/parser/nuget/packagesprops/parse_test.go
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := config.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/dependency/parser/ruby/gemspec/parse_test.go
+++ b/pkg/dependency/parser/ruby/gemspec/parse_test.go
@@ -83,7 +83,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := gemspec.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/dependency/parser/rust/binary/parse_test.go
+++ b/pkg/dependency/parser/rust/binary/parse_test.go
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 
 			got, gotDeps, err := binary.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -252,7 +252,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -522,7 +522,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 				DisabledAnalyzers: tt.args.disabledAnalyzers,
 			})
 			if err != nil && tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
@@ -549,7 +549,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 
 			wg.Wait()
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/analyze_test.go
+++ b/pkg/fanal/analyzer/language/analyze_test.go
@@ -97,7 +97,7 @@ func TestAnalyze(t *testing.T) {
 
 			got, err := language.Analyze(tt.args.fileType, tt.args.filePath, tt.args.content, mp)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
@@ -63,7 +63,7 @@ func Test_depsLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -180,7 +180,7 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 				},
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
@@ -89,7 +89,7 @@ func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
@@ -54,7 +54,7 @@ func Test_pnpmPkgLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
@@ -168,7 +168,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/python/pip/pip_test.go
+++ b/pkg/fanal/analyzer/language/python/pip/pip_test.go
@@ -65,7 +65,7 @@ func Test_pipAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
+++ b/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
@@ -92,7 +92,7 @@ func Test_gemspecLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/analyzer/os/alpine/alpine_test.go
+++ b/pkg/fanal/analyzer/os/alpine/alpine_test.go
@@ -39,10 +39,10 @@ func TestAlpineReleaseOSAnalyzer_Required(t *testing.T) {
 			res, err := a.Analyze(context.Background(), test.input)
 
 			if test.wantError != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Equal(t, test.wantError, err.Error())
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.wantResult, res)
 			}
 		})

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -95,7 +95,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, tt.input)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/debian/debian_test.go
+++ b/pkg/fanal/analyzer/os/debian/debian_test.go
@@ -59,7 +59,7 @@ func Test_debianOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/redhatbase/centos_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos_test.go
@@ -45,7 +45,7 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
@@ -45,7 +45,7 @@ func Test_fedoraOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
@@ -45,7 +45,7 @@ func Test_oracleOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
@@ -45,7 +45,7 @@ func Test_redhatOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
+++ b/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
@@ -45,7 +45,7 @@ func Test_ubuntuOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
@@ -63,7 +63,7 @@ glibc	2.35-2.cm2	1653816591	1653628955	Microsoft Corporation	(none)	10855265	x86
 			a := rpmqaPkgAnalyzer{}
 			result, err := a.parseRpmqaManifest(strings.NewReader(test.content))
 			if test.wantErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Equal(t, test.wantErr, err.Error())
 			} else {
 				assert.NoError(t, err)

--- a/pkg/fanal/applier/applier_test.go
+++ b/pkg/fanal/applier/applier_test.go
@@ -972,7 +972,7 @@ func TestApplier_ApplyLayers(t *testing.T) {
 
 			got, err := a.ApplyLayers(tt.args.imageID, tt.args.layerIDs)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 			} else {
 				require.NoError(t, err, tt.name)

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -248,7 +248,7 @@ func TestArtifact_Inspect(t *testing.T) {
 
 			got, err := a.Inspect(context.Background())
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -253,7 +253,7 @@ func Test_newURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newURL(tt.args.rawurl)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {

--- a/pkg/fanal/artifact/sbom/sbom_test.go
+++ b/pkg/fanal/artifact/sbom/sbom_test.go
@@ -408,7 +408,7 @@ func TestArtifact_Inspect(t *testing.T) {
 
 			got, err := a.Inspect(context.Background())
 			if len(tt.wantErr) > 0 {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				found := false
 				for _, wantErr := range tt.wantErr {
 					if strings.Contains(err.Error(), wantErr) {

--- a/pkg/fanal/cache/fs_test.go
+++ b/pkg/fanal/cache/fs_test.go
@@ -286,7 +286,7 @@ func TestFSCache_PutBlob(t *testing.T) {
 
 			err = fs.PutBlob(tt.args.diffID, tt.args.layerInfo)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
@@ -366,7 +366,7 @@ func TestFSCache_PutArtifact(t *testing.T) {
 
 			err = fs.PutArtifact(tt.args.imageID, tt.args.imageConfig)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {

--- a/pkg/fanal/cache/redis_test.go
+++ b/pkg/fanal/cache/redis_test.go
@@ -73,7 +73,7 @@ func TestRedisCache_PutArtifact(t *testing.T) {
 
 			err = c.PutArtifact(tt.args.artifactID, tt.args.artifactConfig)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
@@ -162,7 +162,7 @@ func TestRedisCache_PutBlob(t *testing.T) {
 
 			err = c.PutBlob(tt.args.blobID, tt.args.blobConfig)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
@@ -247,7 +247,7 @@ func TestRedisCache_GetArtifact(t *testing.T) {
 
 			got, err := c.GetArtifact(tt.artifactID)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
@@ -340,7 +340,7 @@ func TestRedisCache_GetBlob(t *testing.T) {
 
 			got, err := c.GetBlob(tt.blobID)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
@@ -451,7 +451,7 @@ func TestRedisCache_MissingBlobs(t *testing.T) {
 
 			missingArtifact, missingBlobIDs, err := c.MissingBlobs(tt.args.artifactID, tt.args.blobIDs)
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -112,7 +112,7 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 		Algorithm: "sha256",
 		Hex:       "a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 	}, conf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
@@ -152,7 +152,7 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 		Algorithm: "sha256",
 		Hex:       "a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 	}, conf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func Test_image_ConfigFile(t *testing.T) {

--- a/pkg/fanal/image/daemon/podman_test.go
+++ b/pkg/fanal/image/daemon/podman_test.go
@@ -88,7 +88,7 @@ func TestPodmanImage(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -281,7 +281,7 @@ func TestNewDockerImage(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
@@ -399,7 +399,7 @@ func TestNewDockerImageWithPrivateRegistry(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, err)
 			} else {
 				assert.NoError(t, err)
@@ -490,7 +490,7 @@ func TestNewArchiveImage(t *testing.T) {
 			img, err := NewArchiveImage(tt.args.fileName)
 			switch {
 			case tt.wantErr != "":
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			default:

--- a/pkg/fanal/image/oci_test.go
+++ b/pkg/fanal/image/oci_test.go
@@ -61,7 +61,7 @@ func TestTryOCI(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := tryOCI(test.ociImagePath)
 			if test.wantErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.wantErr, err)
 			} else {
 				assert.NoError(t, err)

--- a/pkg/iac/adapters/arm/compute/adapt_test.go
+++ b/pkg/iac/adapters/arm/compute/adapt_test.go
@@ -30,7 +30,7 @@ func Test_AdaptLinuxVM(t *testing.T) {
 	output := Adapt(input)
 
 	require.Len(t, output.LinuxVirtualMachines, 1)
-	require.Len(t, output.WindowsVirtualMachines, 0)
+	require.Empty(t, output.WindowsVirtualMachines)
 
 	linuxVM := output.LinuxVirtualMachines[0]
 	assert.True(t, linuxVM.OSProfileLinuxConfig.DisablePasswordAuthentication.IsTrue())
@@ -54,6 +54,6 @@ func Test_AdaptWindowsVM(t *testing.T) {
 
 	output := Adapt(input)
 
-	require.Len(t, output.LinuxVirtualMachines, 0)
+	require.Empty(t, output.LinuxVirtualMachines)
 	require.Len(t, output.WindowsVirtualMachines, 1)
 }

--- a/pkg/iac/adapters/terraform/aws/dynamodb/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/dynamodb/adapt_test.go
@@ -154,7 +154,7 @@ func TestLines(t *testing.T) {
 	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
 	adapted := Adapt(modules)
 
-	require.Len(t, adapted.DAXClusters, 0)
+	require.Empty(t, adapted.DAXClusters)
 	require.Len(t, adapted.Tables, 1)
 	table := adapted.Tables[0]
 

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -389,7 +389,7 @@ rules:
 
 func BenchmarkIsType_SmallFile(b *testing.B) {
 	data, err := os.ReadFile(fmt.Sprintf("./testdata/%s", "small.file"))
-	assert.Nil(b, err)
+	assert.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -400,7 +400,7 @@ func BenchmarkIsType_SmallFile(b *testing.B) {
 
 func BenchmarkIsType_BigFile(b *testing.B) {
 	data, err := os.ReadFile(fmt.Sprintf("./testdata/%s", "big.file"))
-	assert.Nil(b, err)
+	assert.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -59,8 +59,8 @@ deny {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
 	assert.False(t, results.GetFailed()[0].IsWarning())
@@ -94,8 +94,8 @@ deny {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
 	assert.False(t, results.GetFailed()[0].IsWarning())
@@ -128,8 +128,8 @@ warn {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	require.Equal(t, 0, len(results.GetPassed()))
-	require.Equal(t, 0, len(results.GetIgnored()))
+	require.Empty(t, results.GetPassed())
+	require.Empty(t, results.GetIgnored())
 
 	assert.True(t, results.GetFailed()[0].IsWarning())
 }
@@ -159,9 +159,9 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(results.GetFailed()))
+	assert.Empty(t, results.GetFailed())
 	require.Equal(t, 1, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetPassed()[0].Metadata().Range().GetFilename())
 }
@@ -202,8 +202,8 @@ exception[ns] {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
+	assert.Empty(t, results.GetFailed())
+	assert.Empty(t, results.GetPassed())
 	assert.Equal(t, 1, len(results.GetIgnored()))
 
 }
@@ -251,7 +251,7 @@ exception[ns] {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
+	assert.Empty(t, results.GetPassed())
 	assert.Equal(t, 1, len(results.GetIgnored()))
 
 }
@@ -287,8 +287,8 @@ exception[rules] {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
+	assert.Empty(t, results.GetFailed())
+	assert.Empty(t, results.GetPassed())
 	assert.Equal(t, 1, len(results.GetIgnored()))
 }
 
@@ -324,8 +324,8 @@ exception[rules] {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_RegoScanning_WithRuntimeValues(t *testing.T) {
@@ -358,8 +358,8 @@ deny_evil {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_RegoScanning_WithDenyMessage(t *testing.T) {
@@ -389,8 +389,8 @@ deny[msg] {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "oh no", results.GetFailed()[0].Description())
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
@@ -427,8 +427,8 @@ deny[res] {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "oh no", results.GetFailed()[0].Description())
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
@@ -469,8 +469,8 @@ deny[res] {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "oh no", results.GetFailed()[0].Description())
 	assert.Equal(t, "/blah.txt", results.GetFailed()[0].Metadata().Range().GetFilename())
@@ -523,8 +523,8 @@ deny[res] {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
 	failure := results.GetFailed()[0]
 
@@ -572,8 +572,8 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_RegoScanning_WithNonMatchingInputSelector(t *testing.T) {
@@ -605,9 +605,9 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetFailed())
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_RegoScanning_NoTracingByDefault(t *testing.T) {
@@ -637,10 +637,10 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
-	assert.Len(t, results.GetFailed()[0].Traces(), 0)
+	assert.Empty(t, results.GetFailed()[0].Traces())
 }
 
 func Test_RegoScanning_GlobalTracingEnabled(t *testing.T) {
@@ -672,11 +672,11 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
-	assert.Len(t, results.GetFailed()[0].Traces(), 0)
-	assert.Greater(t, len(traceBuffer.Bytes()), 0)
+	assert.Empty(t, results.GetFailed()[0].Traces())
+	assert.NotEmpty(t, traceBuffer.Bytes())
 }
 
 func Test_RegoScanning_PerResultTracingEnabled(t *testing.T) {
@@ -706,10 +706,10 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 
-	assert.Greater(t, len(results.GetFailed()[0].Traces()), 0)
+	assert.NotEmpty(t, results.GetFailed()[0].Traces())
 }
 
 func Test_dynamicMetadata(t *testing.T) {
@@ -934,8 +934,8 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_RegoScanning_InvalidFS(t *testing.T) {
@@ -974,8 +974,8 @@ deny {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(results.GetFailed()))
-	assert.Equal(t, 0, len(results.GetPassed()))
-	assert.Equal(t, 0, len(results.GetIgnored()))
+	assert.Empty(t, results.GetPassed())
+	assert.Empty(t, results.GetIgnored())
 }
 
 func Test_NoErrorsWhenUsingBadRegoCheck(t *testing.T) {

--- a/pkg/iac/rules/register_test.go
+++ b/pkg/iac/rules/register_test.go
@@ -16,7 +16,7 @@ func Test_Reset(t *testing.T) {
 	_ = Register(rule)
 	assert.Equal(t, 1, len(GetFrameworkRules()))
 	Reset()
-	assert.Equal(t, 0, len(GetFrameworkRules()))
+	assert.Empty(t, GetFrameworkRules())
 }
 
 func Test_Registration(t *testing.T) {
@@ -112,7 +112,7 @@ func Test_Deregistration(t *testing.T) {
 	require.Equal(t, 1, len(actual))
 	assert.Equal(t, "B", actual[0].GetRule().AVDID)
 	Deregister(registrationB)
-	assert.Equal(t, 0, len(GetFrameworkRules()))
+	assert.Empty(t, GetFrameworkRules())
 }
 
 func Test_DeregistrationMultipleFrameworks(t *testing.T) {
@@ -135,5 +135,5 @@ func Test_DeregistrationMultipleFrameworks(t *testing.T) {
 	require.Equal(t, 1, len(actual))
 	assert.Equal(t, "B", actual[0].GetRule().AVDID)
 	Deregister(registrationB)
-	assert.Equal(t, 0, len(GetFrameworkRules()))
+	assert.Empty(t, GetFrameworkRules())
 }

--- a/pkg/iac/scanners/azure/arm/parser/armjson/parse_array_test.go
+++ b/pkg/iac/scanners/azure/arm/parser/armjson/parse_array_test.go
@@ -14,7 +14,7 @@ func Test_Array_Empty(t *testing.T) {
 	target := []int{}
 	metadata := types.NewTestMetadata()
 	require.NoError(t, Unmarshal(example, &target, &metadata))
-	assert.Len(t, target, 0)
+	assert.Empty(t, target)
 }
 
 func Test_Array_ToSlice(t *testing.T) {

--- a/pkg/iac/scanners/azure/arm/parser/parser_test.go
+++ b/pkg/iac/scanners/azure/arm/parser/parser_test.go
@@ -215,7 +215,7 @@ func TestParser_Parse(t *testing.T) {
 			require.NoError(t, err)
 
 			if !tt.wantDeployment {
-				assert.Len(t, got, 0)
+				assert.Empty(t, got)
 				return
 			}
 

--- a/pkg/iac/scanners/cloudformation/parser/fn_builtin_test.go
+++ b/pkg/iac/scanners/cloudformation/parser/fn_builtin_test.go
@@ -20,7 +20,7 @@ func Test_cidr_generator(t *testing.T) {
 	}
 
 	ranges, err := calculateCidrs("10.1.0.0/16", 4, 4, original)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, ranges, 4)
 
 	results := make(map[int]string)
@@ -47,7 +47,7 @@ func Test_cidr_generator_8_bits(t *testing.T) {
 	}
 
 	ranges, err := calculateCidrs("10.1.0.0/16", 4, 8, original)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, ranges, 4)
 
 	results := make(map[int]string)

--- a/pkg/iac/scanners/cloudformation/test/cf_scanning_test.go
+++ b/pkg/iac/scanners/cloudformation/test/cf_scanning_test.go
@@ -19,7 +19,7 @@ func Test_basic_cloudformation_scanning(t *testing.T) {
 	results, err := cfScanner.ScanFS(context.TODO(), os.DirFS("./examples/bucket"), ".")
 	require.NoError(t, err)
 
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 }
 
 func Test_cloudformation_scanning_has_expected_errors(t *testing.T) {
@@ -28,7 +28,7 @@ func Test_cloudformation_scanning_has_expected_errors(t *testing.T) {
 	results, err := cfScanner.ScanFS(context.TODO(), os.DirFS("./examples/bucket"), ".")
 	require.NoError(t, err)
 
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 }
 
 func Test_cloudformation_scanning_with_debug(t *testing.T) {
@@ -44,5 +44,5 @@ func Test_cloudformation_scanning_with_debug(t *testing.T) {
 	require.NoError(t, err)
 
 	// check debug is as expected
-	assert.Greater(t, len(debugWriter.String()), 0)
+	assert.NotEmpty(t, debugWriter.String())
 }

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -357,5 +357,5 @@ deny[res] {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
-	assert.Len(t, results.GetFailed(), 0)
+	assert.Empty(t, results.GetFailed())
 }

--- a/pkg/iac/scanners/kubernetes/scanner_test.go
+++ b/pkg/iac/scanners/kubernetes/scanner_test.go
@@ -338,7 +338,7 @@ spec:
 `))
 	require.NoError(t, err)
 
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 }
 
 func Test_FileScan_WithSeparator(t *testing.T) {
@@ -358,7 +358,7 @@ spec:
 `))
 	require.NoError(t, err)
 
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 }
 
 func Test_FileScan_MultiManifests(t *testing.T) {
@@ -396,7 +396,7 @@ spec:
 	for _, failure := range results.GetFailed() {
 		actualCode, err := failure.GetCode()
 		require.NoError(t, err)
-		assert.Greater(t, len(actualCode.Lines), 0)
+		assert.NotEmpty(t, actualCode.Lines)
 		for _, line := range actualCode.Lines {
 			assert.Greater(t, len(fileLines), line.Number)
 			assert.Equal(t, line.Content, fileLines[line.Number-1])
@@ -514,7 +514,7 @@ spec:
 `))
 	require.NoError(t, err)
 
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 
 	firstResult := results.GetFailed()[0]
 	assert.Equal(t, 2, firstResult.Metadata().Range().GetStartLine())
@@ -592,7 +592,7 @@ spec:
 `))
 	require.NoError(t, err)
 
-	require.Greater(t, len(results.GetFailed()), 0)
+	require.NotEmpty(t, results.GetFailed())
 
 	firstResult := results.GetFailed()[0]
 	assert.Equal(t, 8, firstResult.Metadata().Range().GetStartLine())

--- a/pkg/iac/scanners/terraform/executor/executor_test.go
+++ b/pkg/iac/scanners/terraform/executor/executor_test.go
@@ -56,7 +56,7 @@ resource "problem" "this" {
 	results, err := New().Execute(modules)
 	assert.Error(t, err)
 
-	assert.Equal(t, len(results.GetFailed()), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_PanicInCheckAllowed(t *testing.T) {
@@ -104,7 +104,7 @@ resource "problem" "this" {
 	results, _ := New().Execute(modules)
 	require.NoError(t, err)
 
-	assert.Equal(t, len(results.GetFailed()), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_PanicNotInCheckNotIncludePassedStopOnError(t *testing.T) {

--- a/pkg/iac/scanners/terraform/fs_test.go
+++ b/pkg/iac/scanners/terraform/fs_test.go
@@ -18,5 +18,5 @@ func Test_OS_FS(t *testing.T) {
 	)
 	results, err := s.ScanFS(context.TODO(), os.DirFS("testdata"), "fail")
 	require.NoError(t, err)
-	assert.Greater(t, len(results.GetFailed()), 0)
+	assert.NotEmpty(t, results.GetFailed())
 }

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -673,7 +673,7 @@ func Test_IgnoreInline(t *testing.T) {
 		  secure = false # tfsec:ignore:%s
 	}
 	  `, exampleRule.LongID()))
-	assert.Len(t, results.GetFailed(), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_IgnoreWithAliasCodeStillIgnored(t *testing.T) {
@@ -686,7 +686,7 @@ resource "bad" "my-rule" {
 	
 }
 `, "testworkspace")
-	assert.Len(t, results.GetFailed(), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_TrivyIgnoreWithAliasCodeStillIgnored(t *testing.T) {
@@ -699,7 +699,7 @@ resource "bad" "my-rule" {
 	
 }
 `, "testworkspace")
-	assert.Len(t, results.GetFailed(), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_TrivyIgnoreInline(t *testing.T) {
@@ -711,7 +711,7 @@ func Test_TrivyIgnoreInline(t *testing.T) {
 		  secure = false # trivy:ignore:%s
 	}
 	  `, exampleRule.LongID()))
-	assert.Len(t, results.GetFailed(), 0)
+	assert.Empty(t, results.GetFailed())
 }
 
 func Test_IgnoreInlineByAVDID(t *testing.T) {
@@ -742,7 +742,7 @@ func Test_IgnoreInlineByAVDID(t *testing.T) {
 				reg := rules.Register(exampleRule)
 				defer rules.Deregister(reg)
 				results := scanHCL(t, fmt.Sprintf(tc.input, id))
-				assert.Len(t, results.GetFailed(), 0)
+				assert.Empty(t, results.GetFailed())
 			})
 		}
 	}

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry_test.go
@@ -50,7 +50,7 @@ func Test_getPrivateRegistryTokenFromEnvVars_ConvertsSiteNameToEnvVar(t *testing
 			t.Setenv(tt.tokenName, "abcd")
 			token, err := getPrivateRegistryTokenFromEnvVars(tt.siteName)
 			assert.Equal(t, "abcd", token)
-			assert.Equal(t, nil, err)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/module/memfs_test.go
+++ b/pkg/module/memfs_test.go
@@ -1,7 +1,6 @@
 package module
 
 import (
-	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -54,6 +53,6 @@ func TestMemFS_NilIsDirectory(t *testing.T) {
 	t.Run("read invalid", func(t *testing.T) {
 		buf := make([]byte, 4)
 		_, err = f.Read(buf)
-		require.True(t, errors.Is(err, fs.ErrInvalid))
+		require.ErrorIs(t, err, fs.ErrInvalid)
 	})
 }

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -124,7 +124,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 
 			got, err := c.LoadBuiltinPolicies()
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
@@ -369,7 +369,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 
 			err = c.DownloadBuiltinPolicies(context.Background(), ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -201,7 +201,7 @@ func TestScanner_Scan(t *testing.T) {
 			gotResults, gotOS, err := s.Scan(context.Background(), tt.args.target, tt.args.imageID, tt.args.layerIDs, tt.args.options)
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				require.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -166,7 +166,7 @@ func Test_dbWorker_update(t *testing.T) {
 			err := w.update(context.Background(), tt.args.appVersion, cacheDir,
 				tt.needsUpdate.input.skip, &dbUpdateWg, &requestWg, ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -175,7 +175,7 @@ func TestScanServer_Scan(t *testing.T) {
 			s := NewScanServer(mockDriver)
 			got, err := s.Scan(context.Background(), tt.args.in)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}
@@ -274,7 +274,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 			got, err := s.PutArtifact(context.Background(), tt.args.in)
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
@@ -509,7 +509,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 			got, err := s.PutBlob(context.Background(), tt.args.in)
 
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
@@ -574,7 +574,7 @@ func TestCacheServer_MissingBlobs(t *testing.T) {
 			s := NewCacheServer(mockCache)
 			got, err := s.MissingBlobs(tt.args.ctx, tt.args.in)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -1371,7 +1371,7 @@ func TestScanner_Scan(t *testing.T) {
 			s := NewScanner(applier, ospkg.NewScanner(), langpkg.NewScanner(), vulnerability.NewClient(db.Config{}))
 			gotResults, gotOS, err := s.Scan(context.Background(), tt.args.target, "", tt.args.layerIDs, tt.args.options)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				require.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -202,7 +202,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 			s := NewScanner(d, mockArtifact)
 			got, err := s.ScanArtifact(ctx, tt.args.options)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				require.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -64,7 +64,7 @@ func TestCopyFile(t *testing.T) {
 
 			_, err := CopyFile(src, dst)
 			if tt.wantErr != "" {
-				require.NotNil(t, err, tt.name)
+				require.Error(t, err, tt.name)
 				assert.Equal(t, err.Error(), tt.wantErr, tt.name)
 			} else {
 				assert.NoError(t, err, tt.name)


### PR DESCRIPTION
## Description

enable [testifylint](https://github.com/Antonboom/testifylint) linter on .*_test.go$

It helps applying the best practices with testify use

It applies `empty`, `error-nil` and `error-is-as` rules. Several are excluded to avoid having a too big PR.

The `.*_test.go$` has been removed from `exclude-files` and moved to `exclude-rules`
