### PR TITLE
chore: enforce golangci-lint version

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -16,6 +16,8 @@ import (
 	"github.com/magefile/mage/sh"
 	"github.com/magefile/mage/target"
 
+	// Trivy packages should not be imported in Mage (see https://github.com/aquasecurity/trivy/pull/4242),
+	// but this package doesn't have so many dependencies, and Mage is still fast.
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +15,8 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/magefile/mage/target"
+
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 var (
@@ -23,6 +27,10 @@ var (
 		"CGO_ENABLED": "0",
 	}
 )
+
+func init() {
+	slog.SetDefault(log.New(log.NewHandler(os.Stderr, nil))) // stdout is suppressed in mage
+}
 
 func version() (string, error) {
 	if ver, err := sh.Output("git", "describe", "--tags", "--always"); err != nil {
@@ -60,13 +68,36 @@ func (Tool) Wire() error {
 }
 
 // GolangciLint installs golangci-lint
-func (Tool) GolangciLint() error {
+func (t Tool) GolangciLint() error {
 	const version = "v1.57.2"
-	if exists(filepath.Join(GOBIN, "golangci-lint")) {
+	bin := filepath.Join(GOBIN, "golangci-lint")
+	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil
 	}
 	command := fmt.Sprintf("curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b %s %s", GOBIN, version)
 	return sh.Run("bash", "-c", command)
+}
+
+func (Tool) matchGolangciLintVersion(bin, version string) bool {
+	out, err := sh.Output(bin, "version", "--format", "json")
+	if err != nil {
+		slog.Error("Unable to get golangci-lint version", slog.Any("err", err))
+		return false
+	}
+	var output struct {
+		Version string `json:"Version"`
+	}
+	if err = json.Unmarshal([]byte(out), &output); err != nil {
+		slog.Error("Unable to parse golangci-lint version", slog.Any("err", err))
+		return false
+	}
+
+	version = strings.TrimPrefix(version, "v")
+	if output.Version != version {
+		slog.Info("golangci-lint version mismatch", slog.String("expected", version), slog.String("actual", output.Version))
+		return false
+	}
+	return true
 }
 
 // Labeler installs labeler


### PR DESCRIPTION
## Description
Install golangci-lint if the installed version doesn't match.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/6639

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
