### PR TITLE
fix(go): include only `.version`|`.ver` (no prefixes) ldflags for `gobinaries`

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -159,7 +159,7 @@ func (p *Parser) ParseLDFlags(name string, flags []string) string {
 func isValidXKey(key string) bool {
 	key = strings.ToLower(key)
 	// The check for a 'ver' prefix enables the parser to pick up Trivy's own version value that's set.
-	return strings.HasSuffix(key, "version") || strings.HasSuffix(key, "ver")
+	return strings.HasSuffix(key, ".version") || strings.HasSuffix(key, ".ver")
 }
 
 func isValidSemVer(ver string) bool {

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -228,6 +228,18 @@ func TestParser_ParseLDFlags(t *testing.T) {
 			want: "0.50.1",
 		},
 		{
+			name: "with version with extra prefix",
+			args: args{
+				name: "github.com/argoproj/argo-cd/v2",
+				flags: []string{
+					"-s",
+					"-w",
+					"-X='github.com/argoproj/argo-cd/v2/common.kubectlVersion=v0.26.11'",
+				},
+			},
+			want: "",
+		},
+		{
 			name: "with no flags",
 			args: args{
 				name:  "github.com/aquasecurity/test",


### PR DESCRIPTION
## Description
There are cases when ldflags contain `version` with prefix (e.g. `github.com/argoproj/argo-cd/v2/common.kubectlVersion=v0.26.11`).
We don't need to take these versions.

## Related issues
- Close #6702

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
