### PR TITLE
ci(deps): update golangci-lint-action and enable testifylint linter on "integration/*"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,11 +43,10 @@ jobs:
 
       - name: Lint
         id: lint
-        uses: golangci/golangci-lint-action@v4.0.0
+        uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: v1.57
-          args: --timeout=30m --out-format=line-number
-          skip-cache: true # https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052197778
+          args: --verbose --out-format=line-number
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,10 +69,7 @@ linters-settings:
   testifylint:
     enable-all: true
     disable:
-      - bool-compare
-      - expected-actual
       - float-compare
-      - len
       - require-error
 
 linters:
@@ -98,11 +95,11 @@ linters:
 
 run:
   go: '1.22'
+  timeout: 30m
 
 issues:
   exclude-files:
     - ".*_mock.go$"
-    - "integration/*"
     - "examples/*"
   exclude-dirs:
     - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions

--- a/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
+++ b/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
@@ -59,7 +59,7 @@ func Test_dockerfileAnalyzer_Analyze(t *testing.T) {
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
-				assert.Equal(t, err.Error(), tt.wantErr)
+				assert.Equal(t, tt.wantErr, err.Error())
 				return
 			}
 			assert.NoError(t, err)

--- a/pkg/fanal/analyzer/language/nodejs/license/license_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/license/license_test.go
@@ -91,7 +91,7 @@ func Test_IsLicenseRefToFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ok, licenseFileName := license.IsLicenseRefToFile(tt.input)
-			assert.Equal(t, ok, tt.wantOk)
+			assert.Equal(t, tt.wantOk, ok)
 			assert.Equal(t, tt.wantFileName, licenseFileName)
 		})
 	}

--- a/pkg/flag/kubernetes_flags_test.go
+++ b/pkg/flag/kubernetes_flags_test.go
@@ -45,7 +45,7 @@ func TestOptionToToleration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := optionToTolerations(tt.tolerationsOptions)
 			assert.NoError(t, err)
-			assert.Equal(t, got, tt.want)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/iac/adapters/arm/storage/adapt_test.go
+++ b/pkg/iac/adapters/arm/storage/adapt_test.go
@@ -28,7 +28,7 @@ func Test_AdaptStorageDefaults(t *testing.T) {
 
 	account := output.Accounts[0]
 	assert.Equal(t, "TLS1_0", account.MinimumTLSVersion.Value())
-	assert.Equal(t, false, account.EnforceHTTPS.Value())
+	assert.False(t, account.EnforceHTTPS.Value())
 
 }
 
@@ -53,6 +53,6 @@ func Test_AdaptStorage(t *testing.T) {
 
 	account := output.Accounts[0]
 	assert.Equal(t, "TLS1_2", account.MinimumTLSVersion.Value())
-	assert.Equal(t, true, account.EnforceHTTPS.Value())
+	assert.True(t, account.EnforceHTTPS.Value())
 
 }

--- a/pkg/iac/adapters/terraform/aws/s3/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/s3/adapt_test.go
@@ -56,7 +56,7 @@ resource "aws_s3_bucket_public_access_block" "example_access_block"{
 			modules := tftestutil.CreateModulesFromSource(t, tC.source, ".tf")
 			s3Ctx := Adapt(modules)
 
-			assert.Equal(t, tC.expectedBuckets, len(s3Ctx.Buckets))
+			assert.Len(t, s3Ctx.Buckets, tC.expectedBuckets)
 
 			for _, bucket := range s3Ctx.Buckets {
 				if tC.hasPublicAccess {

--- a/pkg/iac/adapters/terraform/aws/s3/bucket_test.go
+++ b/pkg/iac/adapters/terraform/aws/s3/bucket_test.go
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "bucket1" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 
 }
 
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.Equal(t, "authenticated-read", s3.Buckets[0].ACL.Value())
 
 }
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_acl" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.Equal(t, "authenticated-read", s3.Buckets[0].ACL.Value())
 
 }
@@ -80,7 +80,7 @@ resource "aws_s3_bucket" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Logging.Enabled.Value())
 
 }
@@ -110,7 +110,7 @@ resource "aws_s3_bucket_logging" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 2, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 2)
 	for _, bucket := range s3.Buckets {
 		switch bucket.Name.Value() {
 		case "yournamehere":
@@ -135,7 +135,7 @@ resource "aws_s3_bucket" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Versioning.Enabled.Value())
 }
 
@@ -157,7 +157,7 @@ resource "aws_s3_bucket_versioning" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Versioning.Enabled.Value())
 }
 
@@ -174,7 +174,7 @@ resource "aws_s3_bucket" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Versioning.Enabled.Value())
 
 }
@@ -194,7 +194,7 @@ resource "aws_s3_bucket_object_lock_configuration" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Versioning.Enabled.Value())
 
 }
@@ -220,7 +220,7 @@ resource "aws_s3_bucket_versioning" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Versioning.Enabled.Value())
 
 }
@@ -245,7 +245,7 @@ func Test_BucketGetEncryption(t *testing.T) {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Encryption.Enabled.Value())
 }
 
@@ -273,7 +273,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
 
 	s3 := Adapt(modules)
 
-	assert.Equal(t, 1, len(s3.Buckets))
+	assert.Len(t, s3.Buckets, 1)
 	assert.True(t, s3.Buckets[0].Encryption.Enabled.Value())
 }
 
@@ -312,19 +312,19 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 
 	s3 := Adapt(modules)
 
-	require.Equal(t, 1, len(s3.Buckets))
-	require.Equal(t, 1, len(s3.Buckets[0].BucketPolicies))
+	require.Len(t, s3.Buckets, 1)
+	require.Len(t, s3.Buckets[0].BucketPolicies, 1)
 
 	policy := s3.Buckets[0].BucketPolicies[0]
 
 	statements, _ := policy.Document.Parsed.Statements()
-	require.Equal(t, 1, len(statements))
+	require.Len(t, statements, 1)
 
 	principals, _ := statements[0].Principals()
 	actions, _ := statements[0].Actions()
 
 	awsPrincipals, _ := principals.AWS()
-	require.Equal(t, 1, len(awsPrincipals))
-	require.Equal(t, 2, len(actions))
+	require.Len(t, awsPrincipals, 1)
+	require.Len(t, actions, 2)
 
 }

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -58,7 +58,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -93,7 +93,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -127,7 +127,7 @@ warn {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	require.Empty(t, results.GetPassed())
 	require.Empty(t, results.GetIgnored())
 
@@ -160,7 +160,7 @@ deny {
 	require.NoError(t, err)
 
 	assert.Empty(t, results.GetFailed())
-	require.Equal(t, 1, len(results.GetPassed()))
+	require.Len(t, results.GetPassed(), 1)
 	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetPassed()[0].Metadata().Range().GetFilename())
@@ -204,7 +204,7 @@ exception[ns] {
 
 	assert.Empty(t, results.GetFailed())
 	assert.Empty(t, results.GetPassed())
-	assert.Equal(t, 1, len(results.GetIgnored()))
+	assert.Len(t, results.GetIgnored(), 1)
 
 }
 
@@ -250,9 +250,9 @@ exception[ns] {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
-	assert.Equal(t, 1, len(results.GetIgnored()))
+	assert.Len(t, results.GetIgnored(), 1)
 
 }
 
@@ -289,7 +289,7 @@ exception[rules] {
 
 	assert.Empty(t, results.GetFailed())
 	assert.Empty(t, results.GetPassed())
-	assert.Equal(t, 1, len(results.GetIgnored()))
+	assert.Len(t, results.GetIgnored(), 1)
 }
 
 func Test_RegoScanning_Rule_Exception_WithoutMatch(t *testing.T) {
@@ -323,7 +323,7 @@ exception[rules] {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 }
@@ -357,7 +357,7 @@ deny_evil {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 }
@@ -388,7 +388,7 @@ deny[msg] {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -426,7 +426,7 @@ deny[res] {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -468,7 +468,7 @@ deny[res] {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -522,7 +522,7 @@ deny[res] {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(results.GetFailed()))
+	require.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -571,7 +571,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 }
@@ -636,7 +636,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -671,7 +671,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -705,7 +705,7 @@ deny {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 
@@ -742,7 +742,7 @@ deny {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, results[0].Rule().Summary, "i am dynamic")
+	assert.Equal(t, "i am dynamic", results[0].Rule().Summary)
 }
 
 func Test_staticMetadata(t *testing.T) {
@@ -775,7 +775,7 @@ deny {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, results[0].Rule().Summary, "i am static")
+	assert.Equal(t, "i am static", results[0].Rule().Summary)
 }
 
 func Test_annotationMetadata(t *testing.T) {
@@ -933,7 +933,7 @@ deny {
 	results, err := scanner.ScanInput(context.TODO(), Input{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 }
@@ -973,7 +973,7 @@ deny {
 	results, err := scanner.ScanInput(context.TODO(), Input{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 	assert.Empty(t, results.GetPassed())
 	assert.Empty(t, results.GetIgnored())
 }

--- a/pkg/iac/rules/register_test.go
+++ b/pkg/iac/rules/register_test.go
@@ -14,7 +14,7 @@ func Test_Reset(t *testing.T) {
 	Reset()
 	rule := scan.Rule{}
 	_ = Register(rule)
-	assert.Equal(t, 1, len(GetFrameworkRules()))
+	assert.Len(t, GetFrameworkRules(), 1)
 	Reset()
 	assert.Empty(t, GetFrameworkRules())
 }
@@ -106,10 +106,10 @@ func Test_Deregistration(t *testing.T) {
 	registrationB := Register(scan.Rule{
 		AVDID: "B",
 	})
-	assert.Equal(t, 2, len(GetFrameworkRules()))
+	assert.Len(t, GetFrameworkRules(), 2)
 	Deregister(registrationA)
 	actual := GetFrameworkRules()
-	require.Equal(t, 1, len(actual))
+	require.Len(t, actual, 1)
 	assert.Equal(t, "B", actual[0].GetRule().AVDID)
 	Deregister(registrationB)
 	assert.Empty(t, GetFrameworkRules())
@@ -129,10 +129,10 @@ func Test_DeregistrationMultipleFrameworks(t *testing.T) {
 			framework.Default: nil,
 		},
 	})
-	assert.Equal(t, 2, len(GetFrameworkRules()))
+	assert.Len(t, GetFrameworkRules(), 2)
 	Deregister(registrationA)
 	actual := GetFrameworkRules()
-	require.Equal(t, 1, len(actual))
+	require.Len(t, actual, 1)
 	assert.Equal(t, "B", actual[0].GetRule().AVDID)
 	Deregister(registrationB)
 	assert.Empty(t, GetFrameworkRules())

--- a/pkg/iac/scanners/dockerfile/parser/parser_test.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser_test.go
@@ -18,13 +18,13 @@ CMD python /app/app.py
 	df, err := New().parse("Dockerfile", strings.NewReader(input))
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(df.Stages))
+	assert.Len(t, df.Stages, 1)
 
 	require.Len(t, df.Stages, 1)
 
 	assert.Equal(t, "ubuntu:18.04", df.Stages[0].Name)
 	commands := df.Stages[0].Commands
-	assert.Equal(t, 4, len(commands))
+	assert.Len(t, commands, 4)
 
 	// FROM ubuntu:18.04
 	assert.Equal(t, "from", commands[0].Cmd)

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -51,7 +51,7 @@ func Test_helm_scanner_with_archive(t *testing.T) {
 		require.NotNil(t, results)
 
 		failed := results.GetFailed()
-		assert.Equal(t, 13, len(failed))
+		assert.Len(t, failed, 13)
 
 		visited := make(map[string]bool)
 		var errorCodes []string
@@ -135,7 +135,7 @@ func Test_helm_scanner_with_dir(t *testing.T) {
 		require.NotNil(t, results)
 
 		failed := results.GetFailed()
-		assert.Equal(t, 14, len(failed))
+		assert.Len(t, failed, 14)
 
 		visited := make(map[string]bool)
 		var errorCodes []string
@@ -227,7 +227,7 @@ deny[res] {
 			require.NotNil(t, results)
 
 			failed := results.GetFailed()
-			assert.Equal(t, 15, len(failed))
+			assert.Len(t, failed, 15)
 
 			visited := make(map[string]bool)
 			var errorCodes []string

--- a/pkg/iac/scanners/kubernetes/scanner_test.go
+++ b/pkg/iac/scanners/kubernetes/scanner_test.go
@@ -424,7 +424,7 @@ spec:
 `))
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 }
 
 func Test_FileScanJSON(t *testing.T) {
@@ -479,7 +479,7 @@ deny[msg] {
 `))
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(results.GetFailed()))
+	assert.Len(t, results.GetFailed(), 1)
 }
 
 func Test_FileScanWithMetadata(t *testing.T) {

--- a/pkg/iac/scanners/terraform/block_test.go
+++ b/pkg/iac/scanners/terraform/block_test.go
@@ -49,8 +49,8 @@ resource "aws_s3_bucket" "my-bucket" {
 			modules := createModulesFromSource(t, test.source, ".tf")
 			for _, module := range modules {
 				for _, block := range module.GetBlocks() {
-					assert.Equal(t, block.HasChild(test.expectedAttribute), true)
-					assert.Equal(t, !block.HasChild(test.expectedAttribute), false)
+					assert.True(t, block.HasChild(test.expectedAttribute))
+					assert.True(t, block.HasChild(test.expectedAttribute))
 				}
 			}
 		})
@@ -89,8 +89,8 @@ resource "aws_s3_bucket" "my-bucket" {
 			modules := createModulesFromSource(t, test.source, ".tf")
 			for _, module := range modules {
 				for _, block := range module.GetBlocks() {
-					assert.Equal(t, block.HasChild(test.expectedAttribute), false)
-					assert.Equal(t, !block.HasChild(test.expectedAttribute), true)
+					assert.False(t, block.HasChild(test.expectedAttribute))
+					assert.False(t, block.HasChild(test.expectedAttribute))
 				}
 			}
 		})
@@ -129,8 +129,8 @@ resource "aws_s3_bucket" "my-bucket" {
 			modules := createModulesFromSource(t, test.source, ".tf")
 			for _, module := range modules {
 				for _, block := range module.GetBlocks() {
-					assert.Equal(t, block.MissingChild(test.expectedAttribute), true)
-					assert.Equal(t, !block.HasChild(test.expectedAttribute), true)
+					assert.True(t, block.MissingChild(test.expectedAttribute))
+					assert.False(t, block.HasChild(test.expectedAttribute))
 				}
 			}
 		})

--- a/pkg/iac/scanners/terraform/count_test.go
+++ b/pkg/iac/scanners/terraform/count_test.go
@@ -181,7 +181,7 @@ variable "things" {
 			} else {
 				exclude = r1.LongID()
 			}
-			assert.Equal(t, test.expectedResults, len(results.GetFailed()))
+			assert.Len(t, results.GetFailed(), test.expectedResults)
 			if include != "" {
 				testutil.AssertRuleFound(t, include, results, "false negative found")
 			}

--- a/pkg/iac/scanners/terraform/parser/load_vars_test.go
+++ b/pkg/iac/scanners/terraform/parser/load_vars_test.go
@@ -39,7 +39,7 @@ func Test_TFVarsFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "bar", vars["variable"].GetAttr("foo").GetAttr("default").AsString())
 		assert.Equal(t, "qux", vars["variable"].GetAttr("baz").AsString())
-		assert.Equal(t, true, vars["foo2"].True())
-		assert.Equal(t, true, vars["foo3"].Equals(cty.NumberIntVal(3)).True())
+		assert.True(t, vars["foo2"].True())
+		assert.True(t, vars["foo3"].Equals(cty.NumberIntVal(3)).True())
 	})
 }

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -291,7 +291,7 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, false, attr.IsResolvable())
+	assert.False(t, attr.IsResolvable())
 }
 
 func Test_UndefinedModuleOutputReferenceInSlice(t *testing.T) {
@@ -318,18 +318,18 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 3)
 
 	assert.Equal(t, "first", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
-	assert.Equal(t, false, values[1].GetMetadata().IsResolvable())
+	assert.False(t, values[1].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "last", values[2].Value())
-	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
+	assert.True(t, values[2].GetMetadata().IsResolvable())
 }
 
 func Test_TemplatedSliceValue(t *testing.T) {
@@ -361,19 +361,19 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 3)
 
 	assert.Equal(t, "first", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "hello-hello", values[1].Value())
-	assert.Equal(t, true, values[1].GetMetadata().IsResolvable())
+	assert.True(t, values[1].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "last", values[2].Value())
-	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
+	assert.True(t, values[2].GetMetadata().IsResolvable())
 }
 
 func Test_SliceOfVars(t *testing.T) {
@@ -409,16 +409,16 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 2)
 
 	assert.Equal(t, "1", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "2", values[1].Value())
-	assert.Equal(t, true, values[1].GetMetadata().IsResolvable())
+	assert.True(t, values[1].GetMetadata().IsResolvable())
 }
 
 func Test_VarSlice(t *testing.T) {
@@ -450,19 +450,19 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 3)
 
 	assert.Equal(t, "a", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "b", values[1].Value())
-	assert.Equal(t, true, values[1].GetMetadata().IsResolvable())
+	assert.True(t, values[1].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "c", values[2].Value())
-	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
+	assert.True(t, values[2].GetMetadata().IsResolvable())
 }
 
 func Test_LocalSliceNested(t *testing.T) {
@@ -498,19 +498,19 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 3)
 
 	assert.Equal(t, "a", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "b", values[1].Value())
-	assert.Equal(t, true, values[1].GetMetadata().IsResolvable())
+	assert.True(t, values[1].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "c", values[2].Value())
-	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
+	assert.True(t, values[2].GetMetadata().IsResolvable())
 }
 
 func Test_FunctionCall(t *testing.T) {
@@ -543,19 +543,19 @@ resource "something" "blah" {
 	attr := block.GetAttribute("value")
 	require.NotNil(t, attr)
 
-	assert.Equal(t, true, attr.IsResolvable())
+	assert.True(t, attr.IsResolvable())
 
 	values := attr.AsStringValueSliceOrEmpty()
 	require.Len(t, values, 3)
 
 	assert.Equal(t, "a", values[0].Value())
-	assert.Equal(t, true, values[0].GetMetadata().IsResolvable())
+	assert.True(t, values[0].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "b", values[1].Value())
-	assert.Equal(t, true, values[1].GetMetadata().IsResolvable())
+	assert.True(t, values[1].GetMetadata().IsResolvable())
 
 	assert.Equal(t, "c", values[2].Value())
-	assert.Equal(t, true, values[2].GetMetadata().IsResolvable())
+	assert.True(t, values[2].GetMetadata().IsResolvable())
 }
 
 func Test_NullDefaultValueForVar(t *testing.T) {
@@ -802,7 +802,7 @@ policy_rules = {
 	block := blocks[0]
 
 	assert.Equal(t, "secure-tag-1", block.GetAttribute("name").AsStringValueOrDefault("", block).Value())
-	assert.Equal(t, true, block.GetAttribute("enabled").AsBoolValueOrDefault(false, block).Value())
+	assert.True(t, block.GetAttribute("enabled").AsBoolValueOrDefault(false, block).Value())
 	assert.Equal(t, "host() != 'google.com'", block.GetAttribute("session_matcher").AsStringValueOrDefault("", block).Value())
 	assert.Equal(t, 1001, block.GetAttribute("priority").AsIntValueOrDefault(0, block).Value())
 }

--- a/pkg/k8s/report/summary_test.go
+++ b/pkg/k8s/report/summary_test.go
@@ -92,7 +92,7 @@ func TestReport_ColumnHeading(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			column := ColumnHeading(tt.scanners, tt.availableColumns)
-			if !assert.Equal(t, column, tt.want) {
+			if !assert.Equal(t, tt.want, column) {
 				t.Error(fmt.Errorf("TestReport_ColumnHeading want %v got %v", tt.want, column))
 			}
 		})

--- a/pkg/licensing/expression/parser_test.go
+++ b/pkg/licensing/expression/parser_test.go
@@ -144,7 +144,7 @@ func TestParse(t *testing.T) {
 			ret := yyParse(l)
 			err := l.Err()
 			if tt.wantErr != "" {
-				assert.Equal(t, ret, 1)
+				assert.Equal(t, 1, ret)
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}

--- a/pkg/misconf/scanner_test.go
+++ b/pkg/misconf/scanner_test.go
@@ -159,7 +159,7 @@ func TestScanner_Scan(t *testing.T) {
 
 			misconfs, err := s.Scan(context.Background(), fsys)
 			require.NoError(t, err)
-			require.Equal(t, tt.misconfsExpected, len(misconfs), "wrong number of misconfigurations found")
+			require.Len(t, misconfs, tt.misconfsExpected, "wrong number of misconfigurations found")
 			if tt.misconfsExpected == 1 {
 				assert.Equal(t, tt.wantFilePath, misconfs[0].FilePath, "filePaths don't equal")
 				assert.Equal(t, tt.wantFileType, misconfs[0].FileType, "fileTypes don't equal")

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -102,7 +102,7 @@ func TestManager_Register(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// WASM modules must be generated before running the tests.
-	require.Equal(t, count, 3, "missing WASM modules, try 'mage test:unit' or 'mage test:generateModules'")
+	require.Equal(t, 3, count, "missing WASM modules, try 'mage test:unit' or 'mage test:generateModules'")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scanner/post/post_scan_test.go
+++ b/pkg/scanner/post/post_scan_test.go
@@ -96,8 +96,8 @@ func TestScan(t *testing.T) {
 			}()
 
 			results, err := post.Scan(context.Background(), tt.results)
-			require.Equal(t, err != nil, tt.wantErr)
-			assert.Equal(t, results, tt.want)
+			require.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, results)
 		})
 	}
 }

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -65,7 +65,7 @@ func TestCopyFile(t *testing.T) {
 			_, err := CopyFile(src, dst)
 			if tt.wantErr != "" {
 				require.Error(t, err, tt.name)
-				assert.Equal(t, err.Error(), tt.wantErr, tt.name)
+				assert.Equal(t, tt.wantErr, err.Error(), tt.name)
 			} else {
 				assert.NoError(t, err, tt.name)
 			}


### PR DESCRIPTION
## Description 

Update golangci-lint-action to v6.0.1 which doesn’t cache go package dependencies anymore 

Move the timeout configuration in the config file so it is mutualise for any use case.

enable [testifylint](https://github.com/Antonboom/testifylint) linter on integration/*

It helps applying the best practices with testify use

It applies `bool-compare`, `expected-actual` and `len` rules. 

The `integration/*` has been removed from `exclude-files`.