### PR TITLE
fix(go): add only non-empty root modules for `gobinaries`

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -58,8 +58,17 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 	ldflags := p.ldFlags(info.Settings)
 	pkgs := make(ftypes.Packages, 0, len(info.Deps)+2)
-	pkgs = append(pkgs, []ftypes.Package{
-		{
+	pkgs = append(pkgs, ftypes.Package{
+		// Add the Go version used to build this binary.
+		Name:         "stdlib",
+		Version:      stdlibVersion,
+		Relationship: ftypes.RelationshipDirect, // Considered a direct dependency as the main module depends on the standard packages.
+	})
+
+	// There are times when gobinaries don't contain Main information.
+	// e.g. `Go` binaries (e.g. `go`, `gofmt`, etc.)
+	if info.Main.Path != "" {
+		pkgs = append(pkgs, ftypes.Package{
 			// Add main module
 			Name: info.Main.Path,
 			// Only binaries installed with `go install` contain semver version of the main module.
@@ -69,14 +78,8 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 			// See https://github.com/aquasecurity/trivy/issues/1837#issuecomment-1832523477.
 			Version:      cmp.Or(p.checkVersion(info.Main.Path, info.Main.Version), p.ParseLDFlags(info.Main.Path, ldflags)),
 			Relationship: ftypes.RelationshipRoot,
-		},
-		{
-			// Add the Go version used to build this binary.
-			Name:         "stdlib",
-			Version:      stdlibVersion,
-			Relationship: ftypes.RelationshipDirect, // Considered a direct dependency as the main module depends on the standard packages.
-		},
-	}...)
+		})
+	}
 
 	for _, dep := range info.Deps {
 		// binaries with old go version may incorrectly add module in Deps

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -119,11 +119,6 @@ func TestParse(t *testing.T) {
 			inputFile: "testdata/goexperiment",
 			want: []ftypes.Package{
 				{
-					Name:         "",
-					Version:      "",
-					Relationship: ftypes.RelationshipRoot,
-				},
-				{
 					Name:         "stdlib",
 					Version:      "1.22.1",
 					Relationship: ftypes.RelationshipDirect,


### PR DESCRIPTION
## Description
Add only non-empty root modules for `gobinaries`.
See #6709

## Related issues
- Close #6709

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
