### PR TITLE
chore: auto-bump golang patch versions

### DIFF
--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -5,7 +5,8 @@ on:
       - 'misc/triage/labels.yaml'
     branches:
       - main
-
+env:
+  GO_VERSION: '1.22'
 jobs:
   deploy:
     name: Auto-update labels
@@ -17,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install aqua tools
         uses: aquaproj/aqua-installer@v3.0.0

--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
+          # cf. https://github.com/aquasecurity/trivy/pull/6711
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install aqua tools

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -14,6 +14,7 @@ on:
 
 env:
   GH_USER: "aqua-bot"
+  GO_VERSION: '1.22'
 
 jobs:
   release:
@@ -76,7 +77,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
 
       - name: Generate SBOM

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
       - 'mkdocs.yml'
       - 'LICENSE'
   merge_group:
+env:
+  GO_VERSION: '1.22'
 jobs:
   test:
     name: Test
@@ -30,8 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-
+          go-version: ${{ env.GO_VERSION }}
       - name: go mod tidy
         run: |
           go mod tidy
@@ -84,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.0
@@ -113,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.0
@@ -133,7 +134,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.0
@@ -164,7 +165,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.0
         with:
@@ -198,7 +199,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Determine GoReleaser ID
       id: goreleaser_id


### PR DESCRIPTION
## Description
The following change will help to solve an issue of auto-bump golang patch versions.

## Current behaviour 
up to now that auto-bump golang patch versions was using the:
```
- uses: actions/setup-go@v5
    with:
      go-version-file: 'go.mod'
```
This setting assumes that the go.mod file of Trivy is configured with a partial Go version `<major>.<minor>` for instance, `go 1.22`.

## The Problem
It has been observed that if a go.mod file includes a dependency like `github.com/aquasecurity/trivy-kubernetes`, and that dependency's go.mod file specifies a full Go version `<major>.<minor>.<patch>` such as `go 1.22.0`, then the Go version of this dependency will replace the Go version specified in trivy go.mod file.

therefore the above `actions/setup-go` cannot be used with `go-version-file: 'go.mod'` param.

## Workaround
The workaround will be to use the following  `go-version` param with partial version, which will auto bump patch version without relating to go mod file.
```
- uses: actions/setup-go@v5
    with:
      go-version: '1.22'
```
