### PR TITLE
ci(deps): enable `require-error` rule from `testifylint` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,7 +70,6 @@ linters-settings:
     enable-all: true
     disable:
       - float-compare
-      - require-error
 
 linters:
   disable-all: true
@@ -99,7 +98,7 @@ run:
 
 issues:
   exclude-files:
-    - ".*_mock.go$"
+    - "mock_*.go$"
     - "examples/*"
   exclude-dirs:
     - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions

--- a/integration/aws_cloud_test.go
+++ b/integration/aws_cloud_test.go
@@ -71,7 +71,7 @@ func TestAwsCommandRun(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -5,16 +5,16 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/aquasecurity/trivy/pkg/types"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aquasecurity/trivy/pkg/types"
+
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
@@ -542,7 +542,7 @@ func setup(t *testing.T, options setupOptions) (string, string) {
 	t.Setenv("XDG_DATA_HOME", cacheDir)
 
 	port, err := getFreePort()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	addr := fmt.Sprintf("localhost:%d", port)
 
 	go func() {
@@ -554,7 +554,7 @@ func setup(t *testing.T, options setupOptions) (string, string) {
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	err = waitPort(ctx, addr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return addr, cacheDir
 }

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -5,15 +5,15 @@ package integration
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/types"
 	"io"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/aquasecurity/trivy/pkg/types"
+
 	api "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -298,7 +298,7 @@ func TestDockerEngine(t *testing.T) {
 			if len(tt.ignoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
 				err = os.WriteFile(trivyIgnore, []byte(strings.Join(tt.ignoreIDs, "\n")), 0444)
-				assert.NoError(t, err, "failed to write .trivyignore")
+				require.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
 			osArgs = append(osArgs, tt.input)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -289,7 +289,7 @@ func compareSPDXJson(t *testing.T, wantFile, gotFile string) {
 	SPDXVersion, ok := strings.CutPrefix(want.SPDXVersion, "SPDX-")
 	assert.True(t, ok)
 
-	assert.NoError(t, spdxlib.ValidateDocument(got))
+	require.NoError(t, spdxlib.ValidateDocument(got))
 
 	// Validate SPDX output against the JSON schema
 	validateReport(t, fmt.Sprintf(SPDXSchema, SPDXVersion), got)

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 // TestRepository tests `trivy repo` with the local code repositories
@@ -460,7 +459,7 @@ func TestRepository(t *testing.T) {
 			if len(tt.args.ignoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
 				err := os.WriteFile(trivyIgnore, []byte(strings.Join(tt.args.ignoreIDs, "\n")), 0444)
-				assert.NoError(t, err, "failed to write .trivyignore")
+				require.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
 

--- a/integration/standalone_tar_test.go
+++ b/integration/standalone_tar_test.go
@@ -3,13 +3,13 @@
 package integration
 
 import (
-	"github.com/aquasecurity/trivy/pkg/types"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/aquasecurity/trivy/pkg/types"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -384,7 +384,7 @@ func TestTar(t *testing.T) {
 			if len(tt.args.IgnoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
 				err := os.WriteFile(trivyIgnore, []byte(strings.Join(tt.args.IgnoreIDs, "\n")), 0444)
-				assert.NoError(t, err, "failed to write .trivyignore")
+				require.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
 			if tt.args.Input != "" {

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -150,7 +150,7 @@ func TestRemoteCache_PutArtifact(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 		})
 	}
@@ -211,7 +211,7 @@ func TestRemoteCache_PutBlob(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 		})
 	}
@@ -339,7 +339,7 @@ func TestRemoteCache_PutArtifactInsecure(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err, tt.name)
+			require.NoError(t, err, tt.name)
 		})
 	}
 }

--- a/pkg/cloud/aws/commands/run_test.go
+++ b/pkg/cloud/aws/commands/run_test.go
@@ -1275,10 +1275,10 @@ Summary Report for compliance: my-custom-spec
 
 			err := Run(ctx, test.options)
 			if test.expectErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.want, output.String())
 		})
 	}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -161,7 +161,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 			default:
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 
 			assert.Equal(t, tt.want, needsUpdate)
@@ -232,7 +232,7 @@ func TestClient_Download(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			meta := metadata.NewClient(cacheDir)
 			got, err := meta.Get()

--- a/pkg/dependency/parser/conda/environment/parse_test.go
+++ b/pkg/dependency/parser/conda/environment/parse_test.go
@@ -220,7 +220,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/conda/meta/parse_test.go
+++ b/pkg/dependency/parser/conda/meta/parse_test.go
@@ -63,7 +63,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -144,7 +144,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/gradle/lockfile/parse_test.go
+++ b/pkg/dependency/parser/gradle/lockfile/parse_test.go
@@ -7,6 +7,7 @@ import (
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser_Parse(t *testing.T) {
@@ -65,7 +66,7 @@ func TestParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewParser()
 			f, err := os.Open(tt.inputFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			pkgs, _, _ := parser.Parse(f)
 			sort.Sort(ftypes.Packages(pkgs))

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -7,6 +7,7 @@ import (
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser_Parse(t *testing.T) {
@@ -76,7 +77,7 @@ func TestParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewParser()
 			f, err := os.Open(tt.inputFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			pkgs, _, _ := parser.Parse(f)
 			sort.Sort(ftypes.Packages(pkgs))

--- a/pkg/dependency/parser/nuget/config/parse_test.go
+++ b/pkg/dependency/parser/nuget/config/parse_test.go
@@ -51,7 +51,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/nuget/packagesprops/parse_test.go
+++ b/pkg/dependency/parser/nuget/packagesprops/parse_test.go
@@ -75,7 +75,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/python/poetry/parse_test.go
+++ b/pkg/dependency/parser/python/poetry/parse_test.go
@@ -122,7 +122,7 @@ func TestParseDependency(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/dependency/parser/rust/binary/parse_test.go
+++ b/pkg/dependency/parser/rust/binary/parse_test.go
@@ -82,7 +82,7 @@ func TestParse(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantDeps, gotDeps)
 		})

--- a/pkg/dependency/parser/swift/swift/parse_test.go
+++ b/pkg/dependency/parser/swift/swift/parse_test.go
@@ -1,10 +1,12 @@
 package swift
 
 import (
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser_Parse(t *testing.T) {
@@ -90,10 +92,10 @@ func TestParser_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewParser()
 			f, err := os.Open(tt.inputFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			gotPkgs, _, err := parser.Parse(f)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, gotPkgs)
 		})
 	}

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -200,7 +200,7 @@ func TestDriver_Detect(t *testing.T) {
 			}
 
 			// Compare
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -2,9 +2,10 @@ package alma_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -168,7 +169,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/alpine/alpine_test.go
+++ b/pkg/detector/ospkg/alpine/alpine_test.go
@@ -261,7 +261,7 @@ func TestScanner_Detect(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].VulnerabilityID < got[j].VulnerabilityID
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -2,9 +2,10 @@ package amazon_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -183,7 +184,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/chainguard/chainguard_test.go
+++ b/pkg/detector/ospkg/chainguard/chainguard_test.go
@@ -204,7 +204,7 @@ func TestScanner_Detect(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].VulnerabilityID < got[j].VulnerabilityID
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -2,10 +2,11 @@ package debian_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -125,7 +126,7 @@ func TestScanner_Detect(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].VulnerabilityID < got[j].VulnerabilityID
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/mariner/mariner_test.go
+++ b/pkg/detector/ospkg/mariner/mariner_test.go
@@ -143,7 +143,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -2,9 +2,10 @@ package oracle
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -256,7 +257,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -2,9 +2,10 @@ package photon_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -100,7 +101,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -2,9 +2,10 @@ package rocky_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -128,7 +129,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/suse/suse_test.go
+++ b/pkg/detector/ospkg/suse/suse_test.go
@@ -2,9 +2,10 @@ package suse_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -103,7 +104,7 @@ func TestScanner_Detect(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -2,10 +2,11 @@ package ubuntu_test
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy/pkg/clock"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -188,7 +189,7 @@ func TestScanner_Detect(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].VulnerabilityID < got[j].VulnerabilityID
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/detector/ospkg/wolfi/wolfi_test.go
+++ b/pkg/detector/ospkg/wolfi/wolfi_test.go
@@ -204,7 +204,7 @@ func TestScanner_Detect(t *testing.T) {
 			sort.Slice(got, func(i, j int) bool {
 				return got[i].VulnerabilityID < got[j].VulnerabilityID
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
+++ b/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
@@ -62,7 +62,7 @@ func Test_dockerfileAnalyzer_Analyze(t *testing.T) {
 				assert.Equal(t, tt.wantErr, err.Error())
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -291,7 +291,7 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			got, err := a.Analyze(context.Background(), tt.input)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 			if got != nil && got.Misconfiguration != nil {

--- a/pkg/fanal/analyzer/imgconf/secret/secret_test.go
+++ b/pkg/fanal/analyzer/imgconf/secret/secret_test.go
@@ -99,7 +99,7 @@ func Test_secretAnalyzer_Analyze(t *testing.T) {
 				Config: tt.config,
 			})
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/language/conda/meta/meta_test.go
+++ b/pkg/fanal/analyzer/language/conda/meta/meta_test.go
@@ -67,7 +67,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/dart/pub/pubspec_test.go
+++ b/pkg/fanal/analyzer/language/dart/pub/pubspec_test.go
@@ -137,7 +137,7 @@ func Test_pubSpecLockAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
@@ -68,7 +68,7 @@ func Test_depsLibraryAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
@@ -201,7 +201,7 @@ func Test_nugetibraryAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops_test.go
@@ -91,7 +91,7 @@ func Test_packagesPropsAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/elixir/mix/mix_test.go
+++ b/pkg/fanal/analyzer/language/elixir/mix/mix_test.go
@@ -54,7 +54,7 @@ func Test_mixLockAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer func() {
 				err = f.Close()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}()
 
 			a := mixLockAnalyzer{}
@@ -63,7 +63,7 @@ func Test_mixLockAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/golang/binary/binary_test.go
+++ b/pkg/fanal/analyzer/language/golang/binary/binary_test.go
@@ -78,7 +78,7 @@ func Test_gobinaryLibraryAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/golang/mod/mod_test.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod_test.go
@@ -231,13 +231,13 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 			got, err := a.PostAnalyze(ctx, analyzer.PostAnalysisInput{
 				FS: mfs,
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if len(got.Applications) > 0 {
 				sort.Sort(got.Applications[0].Packages)
 				sort.Sort(tt.want.Applications[0].Packages)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/java/gradle/lockfile_test.go
+++ b/pkg/fanal/analyzer/language/java/gradle/lockfile_test.go
@@ -122,7 +122,7 @@ func Test_gradleLockAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/java/jar/jar_test.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar_test.go
@@ -2,11 +2,12 @@ package jar
 
 import (
 	"context"
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -141,16 +142,16 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 
 			mfs := mapfs.New()
 			err = mfs.MkdirAll(filepath.Dir(tt.inputFile), os.ModePerm)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = mfs.WriteFile(tt.inputFile, tt.inputFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			got, err := a.PostAnalyze(ctx, analyzer.PostAnalysisInput{
 				FS:      mfs,
 				Options: analyzer.AnalysisOptions{FileChecksum: tt.includeChecksum},
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -184,7 +184,7 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/julia/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/julia/pkg/pkg_test.go
@@ -202,7 +202,7 @@ func Test_juliaAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
@@ -239,7 +239,7 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if len(got.Applications) > 0 {
 				sort.Sort(got.Applications[0].Packages)
 			}

--- a/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
@@ -94,7 +94,7 @@ func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
@@ -59,7 +59,7 @@ func Test_pnpmPkgLibraryAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn_test.go
@@ -771,7 +771,7 @@ func Test_yarnLibraryAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/php/composer/composer_test.go
+++ b/pkg/fanal/analyzer/language/php/composer/composer_test.go
@@ -163,7 +163,7 @@ func Test_composerAnalyzer_PostAnalyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
@@ -172,7 +172,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/python/pip/pip_test.go
+++ b/pkg/fanal/analyzer/language/python/pip/pip_test.go
@@ -69,7 +69,7 @@ func Test_pipAnalyzer_Analyze(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/python/poetry/poetry_test.go
+++ b/pkg/fanal/analyzer/language/python/poetry/poetry_test.go
@@ -192,7 +192,7 @@ func Test_poetryLibraryAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
+++ b/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
@@ -96,7 +96,7 @@ func Test_gemspecLibraryAnalyzer_Analyze(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/rust/binary/binary_test.go
+++ b/pkg/fanal/analyzer/language/rust/binary/binary_test.go
@@ -69,7 +69,7 @@ func Test_rustBinaryLibraryAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
@@ -550,7 +550,7 @@ func Test_cargoAnalyzer_Analyze(t *testing.T) {
 				FS: os.DirFS(tt.dir),
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/swift/cocoapods/cocoapods_test.go
+++ b/pkg/fanal/analyzer/language/swift/cocoapods/cocoapods_test.go
@@ -91,7 +91,7 @@ func Test_cocoaPodsLockAnalyzer_Analyze(t *testing.T) {
 				}
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/language/swift/swift/swift_test.go
+++ b/pkg/fanal/analyzer/language/swift/swift/swift_test.go
@@ -83,7 +83,7 @@ func Test_swiftLockAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/os/alpine/alpine_test.go
+++ b/pkg/fanal/analyzer/os/alpine/alpine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -39,10 +40,10 @@ func TestAlpineReleaseOSAnalyzer_Required(t *testing.T) {
 			res, err := a.Analyze(context.Background(), test.input)
 
 			if test.wantError != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.wantError, err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.wantResult, res)
 			}
 		})

--- a/pkg/fanal/analyzer/os/release/release_test.go
+++ b/pkg/fanal/analyzer/os/release/release_test.go
@@ -120,12 +120,12 @@ func Test_osReleaseAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, tt.wantErr, err.Error())
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, res)
 		})
 	}

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -1443,21 +1444,21 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a, err := newDpkgAnalyzer(analyzer.AnalyzerOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			ctx := context.Background()
 
 			mfs := mapfs.New()
 			for testPath, osPath := range tt.testFiles {
 				err = mfs.MkdirAll(filepath.Dir(osPath), os.ModePerm)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				err = mfs.WriteFile(osPath, testPath)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			got, err := a.PostAnalyze(ctx, analyzer.PostAnalysisInput{
 				FS: mfs,
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Sort the result for consistency
 			for i := range got.PackageInfos {
@@ -1509,7 +1510,7 @@ func Test_dpkgAnalyzer_Required(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a, err := newDpkgAnalyzer(analyzer.AnalyzerOptions{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			got := a.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/fanal/analyzer/pkg/rpm/rpm_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm_test.go
@@ -97,9 +97,9 @@ func Test_splitFileName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotName, gotVer, gotRel, err := splitFileName(tt.filename)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantName, gotName)
 			assert.Equal(t, tt.wantVer, gotVer)

--- a/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -63,10 +64,10 @@ glibc	2.35-2.cm2	1653816591	1653628955	Microsoft Corporation	(none)	10855265	x86
 			a := rpmqaPkgAnalyzer{}
 			result, err := a.parseRpmqaManifest(strings.NewReader(test.content))
 			if test.wantErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.wantErr, err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.wantPkgs, result)
 			}
 		})

--- a/pkg/fanal/analyzer/repo/apk/apk_test.go
+++ b/pkg/fanal/analyzer/repo/apk/apk_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -152,11 +153,11 @@ https://dl-cdn.alpinelinux.org/alpine/v3.10/main
 			got, err := a.Analyze(context.Background(), test.input)
 
 			if test.wantErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.wantErr, err.Error())
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -211,7 +211,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			defer cleanup()
 
 			ref, err := art.Inspect(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, ref)
 		})
 	}

--- a/pkg/fanal/cache/key_test.go
+++ b/pkg/fanal/cache/key_test.go
@@ -1,8 +1,9 @@
 package cache
 
 import (
-	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,7 +254,7 @@ func TestCalcKey(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/cache/redis_test.go
+++ b/pkg/fanal/cache/redis_test.go
@@ -77,7 +77,7 @@ func TestRedisCache_PutArtifact(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			got, err := s.Get(tt.wantKey)
@@ -166,7 +166,7 @@ func TestRedisCache_PutBlob(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			got, err := s.Get(tt.wantKey)
@@ -251,7 +251,7 @@ func TestRedisCache_GetArtifact(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			assert.Equal(t, tt.want, got)
@@ -345,7 +345,7 @@ func TestRedisCache_GetBlob(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -456,7 +456,7 @@ func TestRedisCache_MissingBlobs(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantMissingArtifact, missingArtifact)
 			assert.Equal(t, tt.wantMissingBlobIDs, missingBlobIDs)
 		})
@@ -556,7 +556,7 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -112,7 +112,7 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 		Algorithm: "sha256",
 		Hex:       "a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 	}, conf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
@@ -152,7 +152,7 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 		Algorithm: "sha256",
 		Hex:       "a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 	}, conf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func Test_image_ConfigFile(t *testing.T) {

--- a/pkg/fanal/image/daemon/podman_test.go
+++ b/pkg/fanal/image/daemon/podman_test.go
@@ -88,10 +88,10 @@ func TestPodmanImage(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			confName, err := img.ConfigName()
 			require.NoError(t, err)

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -281,10 +281,10 @@ func TestNewDockerImage(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			gotID, err := img.ID()
 			require.NoError(t, err)
@@ -399,10 +399,10 @@ func TestNewDockerImageWithPrivateRegistry(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -494,7 +494,7 @@ func TestNewArchiveImage(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			default:
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 
 			// archive doesn't support RepoTags and RepoDigests
@@ -552,7 +552,7 @@ func TestDockerPlatformArguments(t *testing.T) {
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/fanal/image/oci_test.go
+++ b/pkg/fanal/image/oci_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTryOCI(t *testing.T) {
@@ -61,10 +62,10 @@ func TestTryOCI(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := tryOCI(test.ociImagePath)
 			if test.wantErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.wantErr, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/fanal/image/registry/azure/azure_test.go
+++ b/pkg/fanal/image/registry/azure/azure_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/image/registry/azure"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -37,7 +38,7 @@ func TestRegistry_CheckOptions(t *testing.T) {
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -63,7 +63,7 @@ func setupContainerd(t *testing.T, ctx context.Context, namespace string) *conta
 			return err, true
 		}
 		t.Cleanup(func() {
-			assert.NoError(t, client.Close())
+			require.NoError(t, client.Close())
 		})
 		return nil, false
 	})
@@ -105,7 +105,7 @@ func startContainerd(t *testing.T, ctx context.Context, hostPath string) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		assert.NoError(t, containerdC.Terminate(ctx))
+		require.NoError(t, containerdC.Terminate(ctx))
 	})
 }
 

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -2,13 +2,14 @@ package walker_test
 
 import (
 	"errors"
-	"golang.org/x/exp/slices"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,7 @@ func TestFS_Walk(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/fanal/walker/tar_test.go
+++ b/pkg/fanal/walker/tar_test.go
@@ -84,7 +84,7 @@ func TestLayerTar_Walk(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantOpqDirs, gotOpqDirs)
 			assert.Equal(t, tt.wantWhFiles, gotWhFiles)
 		})

--- a/pkg/flag/kubernetes_flags_test.go
+++ b/pkg/flag/kubernetes_flags_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -44,7 +45,7 @@ func TestOptionToToleration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := optionToTolerations(tt.tolerationsOptions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -1,8 +1,9 @@
 package flag_test
 
 import (
-	"github.com/aquasecurity/trivy/pkg/log"
 	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/log"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/compliance/spec"
@@ -11,6 +12,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReportFlagGroup_ToOptions(t *testing.T) {
@@ -221,7 +223,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			}
 
 			got, err := f.ToOptions()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equalf(t, tt.want, got, "ToOptions()")
 
 			// Assert log messages

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Detection(t *testing.T) {
@@ -389,7 +390,7 @@ rules:
 
 func BenchmarkIsType_SmallFile(b *testing.B) {
 	data, err := os.ReadFile(fmt.Sprintf("./testdata/%s", "small.file"))
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -400,7 +401,7 @@ func BenchmarkIsType_SmallFile(b *testing.B) {
 
 func BenchmarkIsType_BigFile(b *testing.B) {
 	data, err := os.ReadFile(fmt.Sprintf("./testdata/%s", "big.file"))
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -97,7 +97,7 @@ deny {
 }`
 		scanner := rego.NewScanner(types.SourceJSON)
 		err := scanner.LoadPolicies(false, false, fstest.MapFS{}, []string{"."}, []io.Reader{strings.NewReader(check)})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 }
@@ -205,7 +205,7 @@ deny {
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -245,5 +245,5 @@ deny {
 		options.ScannerWithEmbeddedPolicies(false),
 	)
 	err := scanner.LoadPolicies(false, false, fsys, []string{"."}, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/iac/rego/metadata_test.go
+++ b/pkg/iac/rego/metadata_test.go
@@ -201,7 +201,7 @@ Resources:
 	for _, tc := range testCases {
 		t.Run(tc.schema, func(t *testing.T) {
 			em, err := NewEngineMetadata(tc.schema, inputSchema)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, em.GoodExamples[0])
 		})
 	}

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -871,7 +871,7 @@ deny {
 	})
 
 	scanner := NewScanner(types.SourceDockerfile)
-	assert.NoError(
+	require.NoError(
 		t,
 		scanner.LoadPolicies(false, false, srcFS, []string{"policies"}, nil),
 	)
@@ -1007,7 +1007,7 @@ deny {
 		scanner.LoadPolicies(false, false, fsys, []string{"checks"}, nil),
 	)
 	_, err := scanner.ScanInput(context.TODO(), Input{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, buf.String(),
 		`Error occurred while applying rule "deny" from check "checks/bad.rego"`)
 }

--- a/pkg/iac/scanners/terraform/executor/executor_test.go
+++ b/pkg/iac/scanners/terraform/executor/executor_test.go
@@ -54,7 +54,7 @@ resource "problem" "this" {
 	require.NoError(t, err)
 
 	results, err := New().Execute(modules)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	assert.Empty(t, results.GetFailed())
 }
@@ -79,7 +79,7 @@ resource "problem" "this" {
 	modules, _, err := p.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 	_, err = New().Execute(modules)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func Test_PanicNotInCheckNotIncludePassed(t *testing.T) {
@@ -127,5 +127,5 @@ resource "problem" "this" {
 	require.NoError(t, err)
 
 	_, err = New().Execute(modules)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -174,7 +174,7 @@ output "mod_result" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	require.Len(t, modules, 2)
 	rootModule := modules[0]
@@ -235,7 +235,7 @@ output "mod_result" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 2)
 	rootModule := modules[0]
 	childModule := modules[1]
@@ -280,7 +280,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -307,7 +307,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -350,7 +350,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -398,7 +398,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -439,7 +439,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -487,7 +487,7 @@ resource "something" "blah" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
 
@@ -635,7 +635,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this2" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -670,7 +670,7 @@ resource "aws_s3_bucket" "main" {
 
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -703,7 +703,7 @@ resource "aws_s3_bucket" "this" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -737,7 +737,7 @@ resource "aws_s3_bucket" "this" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -791,7 +791,7 @@ policy_rules = {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -827,7 +827,7 @@ resource "aws_s3_bucket" "this" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	bucketBlocks := modules.GetResourcesByType("aws_s3_bucket")
@@ -859,7 +859,7 @@ data "http" "example" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -896,7 +896,7 @@ data "http" "example" {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
 	rootModule := modules[0]
@@ -1268,7 +1268,7 @@ func TestForEachWithObjectsOfDifferentTypes(t *testing.T) {
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 }
 

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getPrivateRegistryTokenFromEnvVars_ErrorsWithNoEnvVarSet(t *testing.T) {
@@ -50,7 +51,7 @@ func Test_getPrivateRegistryTokenFromEnvVars_ConvertsSiteNameToEnvVar(t *testing
 			t.Setenv(tt.tokenName, "abcd")
 			token, err := getPrivateRegistryTokenFromEnvVars(tt.siteName)
 			assert.Equal(t, "abcd", token)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/iac/terraform/reference_test.go
+++ b/pkg/iac/terraform/reference_test.go
@@ -46,7 +46,7 @@ func Test_ReferenceParsing(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.expected, func(t *testing.T) {
 			ref, err := newReference(test.input, "")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, ref.String())
 		})
 	}

--- a/pkg/k8s/scanner/scanner_test.go
+++ b/pkg/k8s/scanner/scanner_test.go
@@ -2,13 +2,14 @@ package scanner
 
 import (
 	"context"
+	"sort"
+	"testing"
+
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	"github.com/aquasecurity/trivy/pkg/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"sort"
-	"testing"
 
 	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
@@ -278,7 +279,7 @@ func TestScanner_Scan(t *testing.T) {
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			runner, err := cmd.NewRunner(ctx, flagOpts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			scanner := NewScanner(tt.clusterName, runner, flagOpts)
 			got, err := scanner.Scan(ctx, tt.artifacts)

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -206,7 +206,7 @@ func TestManager_Run(t *testing.T) {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -230,7 +230,7 @@ func TestManager_Uninstall(t *testing.T) {
 
 		// Uninstall the plugin
 		err = plugin.NewManager().Uninstall(ctx, pluginName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NoDirExists(t, pluginDir)
 	})
 
@@ -240,7 +240,7 @@ func TestManager_Uninstall(t *testing.T) {
 		slog.SetDefault(slog.New(log.NewHandler(buf, &log.Options{Level: log.LevelInfo})))
 
 		err := plugin.NewManager().Uninstall(ctx, pluginName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "2021-08-25T12:20:30Z\tERROR\t[plugin] No such plugin\n", buf.String())
 	})
 }
@@ -332,7 +332,7 @@ func TestManager_LoadAll(t *testing.T) {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.Len(t, got, len(tt.want))
 			for i := range tt.want {
 				assert.EqualExportedValues(t, tt.want[i], got[i])

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -191,7 +191,7 @@ func TestManager_Install(t *testing.T) {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.EqualExportedValues(t, tt.want, got)
 			if tt.wantFile != "" {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -128,7 +128,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -373,7 +373,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Assert metadata.json
 			metadata := filepath.Join(tempDir, "policy", "metadata.json")

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -436,7 +436,7 @@ func TestNewPackageURL(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, packageURL, tc.name)
 		})
 	}
@@ -554,7 +554,7 @@ func TestFromString(t *testing.T) {
 				assert.ErrorContains(t, err, tc.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, *pkg, tc.name)
 		})
 	}

--- a/pkg/rekor/client_test.go
+++ b/pkg/rekor/client_test.go
@@ -69,7 +69,7 @@ func TestClient_Search(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -202,7 +202,7 @@ func TestGet(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -245,11 +246,11 @@ func TestWriter_Write(t *testing.T) {
 			inputResults := tt.report
 
 			err := w.Write(context.Background(), inputResults)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var got github.DependencySnapshot
 			err = json.Unmarshal(written.Bytes(), &got)
-			assert.NoError(t, err, "invalid github written")
+			require.NoError(t, err, "invalid github written")
 			assert.Equal(t, tt.want, got.Manifests, tt.name)
 		})
 	}

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -87,11 +88,11 @@ func TestReportWriter_JSON(t *testing.T) {
 			}
 
 			err := jw.Write(context.Background(), inputResults)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var got types.Report
 			err = json.Unmarshal(jsonWritten.Bytes(), &got)
-			assert.NoError(t, err, "invalid json written")
+			require.NoError(t, err, "invalid json written")
 
 			assert.Equal(t, tc.want, got, tc.name)
 		})

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -672,11 +673,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 				Output: sarifWritten,
 			}
 			err := w.Write(context.TODO(), tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			result := &sarif.Report{}
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/report/table/table_test.go
+++ b/pkg/report/table/table_test.go
@@ -2,10 +2,12 @@ package table_test
 
 import (
 	"bytes"
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"testing"
 
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/report/table"
@@ -85,7 +87,7 @@ Total: 1 (MEDIUM: 0, HIGH: 1)
 				},
 			}
 			err := writer.Write(nil, types.Report{Results: tc.results})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, tableWritten.String(), tc.name)
 		})
 	}

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -183,7 +183,7 @@ func TestReportWriter_Template(t *testing.T) {
 			w, err := report.NewTemplateWriter(&got, tc.template, "dev")
 			require.NoError(t, err)
 			err = w.Write(ctx, inputReport)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, got.String())
 		})
 	}

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -178,7 +178,7 @@ func Test_dbWorker_update(t *testing.T) {
 
 			mc := metadata.NewClient(cacheDir)
 			got, err := mc.Get()
-			assert.NoError(t, err, tt.name)
+			require.NoError(t, err, tt.name)
 			assert.Equal(t, tt.want, got, tt.name)
 
 			mockDBClient.AssertExpectations(t)

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -178,7 +178,7 @@ func TestScanServer_Scan(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			}
-			assert.NoError(t, err, tt.name)
+			require.NoError(t, err, tt.name)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -277,7 +277,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 
 			assert.Equal(t, tt.want, got)
@@ -512,7 +512,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 
 			assert.Equal(t, tt.want, got)
@@ -577,7 +577,7 @@ func TestCacheServer_MissingBlobs(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
 				return
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 
 			assert.Equal(t, tt.want, got)

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -67,7 +67,7 @@ func TestCopyFile(t *testing.T) {
 				require.Error(t, err, tt.name)
 				assert.Equal(t, tt.wantErr, err.Error(), tt.name)
 			} else {
-				assert.NoError(t, err, tt.name)
+				require.NoError(t, err, tt.name)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

enable `require-error` rule from `testifylint` linter

It also replaces `.*_mock.go$` with `mock_*.go$` from excluded files for golangci-lint