### PR TITLE
feat(vex): support non-root components for products in OpenVEX

### DIFF
--- a/integration/testdata/conda-spdx.json.golden
+++ b/integration/testdata/conda-spdx.json.golden
@@ -14,7 +14,7 @@
   "packages": [
     {
       "name": "openssl",
-      "SPDXID": "SPDXRef-Package-32b6b37a6fa2e57f",
+      "SPDXID": "SPDXRef-Package-22a178da112ac20a",
       "versionInfo": "1.1.1q",
       "supplier": "NOASSERTION",
       "downloadLocation": "NONE",
@@ -38,7 +38,7 @@
     },
     {
       "name": "pip",
-      "SPDXID": "SPDXRef-Package-e260029d0b6fd07b",
+      "SPDXID": "SPDXRef-Package-c22b9ee9a601ba6",
       "versionInfo": "22.2.2",
       "supplier": "NOASSERTION",
       "downloadLocation": "NONE",
@@ -103,21 +103,21 @@
     },
     {
       "spdxElementId": "SPDXRef-Filesystem-2e2426fd0f2580ef",
-      "relatedSpdxElement": "SPDXRef-Package-32b6b37a6fa2e57f",
+      "relatedSpdxElement": "SPDXRef-Package-22a178da112ac20a",
       "relationshipType": "CONTAINS"
     },
     {
       "spdxElementId": "SPDXRef-Filesystem-2e2426fd0f2580ef",
-      "relatedSpdxElement": "SPDXRef-Package-e260029d0b6fd07b",
+      "relatedSpdxElement": "SPDXRef-Package-c22b9ee9a601ba6",
       "relationshipType": "CONTAINS"
     },
     {
-      "spdxElementId": "SPDXRef-Package-32b6b37a6fa2e57f",
+      "spdxElementId": "SPDXRef-Package-22a178da112ac20a",
       "relatedSpdxElement": "SPDXRef-File-600e5e0110a84891",
       "relationshipType": "CONTAINS"
     },
     {
-      "spdxElementId": "SPDXRef-Package-e260029d0b6fd07b",
+      "spdxElementId": "SPDXRef-Package-c22b9ee9a601ba6",
       "relatedSpdxElement": "SPDXRef-File-7eb62e2a3edddc0a",
       "relationshipType": "CONTAINS"
     }

--- a/integration/testdata/julia-spdx.json.golden
+++ b/integration/testdata/julia-spdx.json.golden
@@ -25,7 +25,7 @@
     },
     {
       "name": "A",
-      "SPDXID": "SPDXRef-Package-2a46714189f3b9de",
+      "SPDXID": "SPDXRef-Package-7784b00da0cb0cb0",
       "versionInfo": "1.9.0",
       "supplier": "NOASSERTION",
       "downloadLocation": "NONE",
@@ -48,30 +48,7 @@
     },
     {
       "name": "B",
-      "SPDXID": "SPDXRef-Package-4a8e351c4c9b7318",
-      "versionInfo": "1.9.0",
-      "supplier": "NOASSERTION",
-      "downloadLocation": "NONE",
-      "filesAnalyzed": false,
-      "sourceInfo": "package found in: Manifest.toml",
-      "licenseConcluded": "NONE",
-      "licenseDeclared": "NONE",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:julia/B@1.9.0?uuid=edca9bc6-334e-11e9-3554-9595dbb4349c"
-        }
-      ],
-      "attributionTexts": [
-        "PkgID: edca9bc6-334e-11e9-3554-9595dbb4349c",
-        "PkgType: julia"
-      ],
-      "primaryPackagePurpose": "LIBRARY"
-    },
-    {
-      "name": "B",
-      "SPDXID": "SPDXRef-Package-d10d5e4a30a43fff",
+      "SPDXID": "SPDXRef-Package-960543ac5c5f7e10",
       "versionInfo": "1.9.0",
       "supplier": "NOASSERTION",
       "downloadLocation": "NONE",
@@ -93,6 +70,29 @@
       "primaryPackagePurpose": "LIBRARY"
     },
     {
+      "name": "B",
+      "SPDXID": "SPDXRef-Package-a4705eb108e4f15c",
+      "versionInfo": "1.9.0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "sourceInfo": "package found in: Manifest.toml",
+      "licenseConcluded": "NONE",
+      "licenseDeclared": "NONE",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:julia/B@1.9.0?uuid=edca9bc6-334e-11e9-3554-9595dbb4349c"
+        }
+      ],
+      "attributionTexts": [
+        "PkgID: edca9bc6-334e-11e9-3554-9595dbb4349c",
+        "PkgType: julia"
+      ],
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
       "name": "testdata/fixtures/repo/julia",
       "SPDXID": "SPDXRef-Filesystem-1be792dd0077c431",
       "downloadLocation": "NONE",
@@ -106,17 +106,17 @@
   "relationships": [
     {
       "spdxElementId": "SPDXRef-Application-18fc3597717a3e56",
-      "relatedSpdxElement": "SPDXRef-Package-2a46714189f3b9de",
+      "relatedSpdxElement": "SPDXRef-Package-7784b00da0cb0cb0",
       "relationshipType": "CONTAINS"
     },
     {
       "spdxElementId": "SPDXRef-Application-18fc3597717a3e56",
-      "relatedSpdxElement": "SPDXRef-Package-4a8e351c4c9b7318",
+      "relatedSpdxElement": "SPDXRef-Package-960543ac5c5f7e10",
       "relationshipType": "CONTAINS"
     },
     {
       "spdxElementId": "SPDXRef-Application-18fc3597717a3e56",
-      "relatedSpdxElement": "SPDXRef-Package-d10d5e4a30a43fff",
+      "relatedSpdxElement": "SPDXRef-Package-a4705eb108e4f15c",
       "relationshipType": "CONTAINS"
     },
     {
@@ -130,8 +130,8 @@
       "relationshipType": "CONTAINS"
     },
     {
-      "spdxElementId": "SPDXRef-Package-2a46714189f3b9de",
-      "relatedSpdxElement": "SPDXRef-Package-d10d5e4a30a43fff",
+      "spdxElementId": "SPDXRef-Package-7784b00da0cb0cb0",
+      "relatedSpdxElement": "SPDXRef-Package-960543ac5c5f7e10",
       "relationshipType": "DEPENDS_ON"
     }
   ]

--- a/pkg/fanal/applier/applier_test.go
+++ b/pkg/fanal/applier/applier_test.go
@@ -1,10 +1,10 @@
 package applier_test
 
 import (
-	"github.com/package-url/packageurl-go"
 	"sort"
 	"testing"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -89,7 +89,7 @@ func filterByVEX(report types.Report, opt FilterOption) error {
 		return nil
 	}
 
-	bom, err := sbomio.NewEncoder(core.Options{}).Encode(report)
+	bom, err := sbomio.NewEncoder(core.Options{Parents: true}).Encode(report)
 	if err != nil {
 		return xerrors.Errorf("unable to encode the SBOM: %w", err)
 	}

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -18,10 +18,12 @@ import (
 
 func TestFilter(t *testing.T) {
 	var (
-		vuln1 = types.DetectedVulnerability{
-			VulnerabilityID: "CVE-2019-0001",
-			PkgName:         "foo",
-			PkgIdentifier: ftypes.PkgIdentifier{
+		pkg1 = ftypes.Package{
+			ID:      "foo@1.2.3",
+			Name:    "foo",
+			Version: "1.2.3",
+			Identifier: ftypes.PkgIdentifier{
+				Hash: "01",
 				PURL: &packageurl.PackageURL{
 					Type:      packageurl.TypeGolang,
 					Namespace: "github.com/aquasecurity",
@@ -29,25 +31,29 @@ func TestFilter(t *testing.T) {
 					Version:   "1.2.3",
 				},
 			},
-			InstalledVersion: "1.2.3",
+		}
+		vuln1 = types.DetectedVulnerability{
+			VulnerabilityID:  "CVE-2019-0001",
+			PkgName:          pkg1.Name,
+			InstalledVersion: pkg1.Version,
 			FixedVersion:     "1.2.4",
+			PkgIdentifier: ftypes.PkgIdentifier{
+				Hash: pkg1.Identifier.Hash,
+				PURL: pkg1.Identifier.PURL,
+			},
 			Vulnerability: dbTypes.Vulnerability{
 				Severity: dbTypes.SeverityLow.String(),
 			},
 		}
 		vuln2 = types.DetectedVulnerability{
-			VulnerabilityID: "CVE-2019-0002",
-			PkgName:         "foo",
-			PkgIdentifier: ftypes.PkgIdentifier{
-				PURL: &packageurl.PackageURL{
-					Type:      packageurl.TypeGolang,
-					Namespace: "github.com/aquasecurity",
-					Name:      "foo",
-					Version:   "4.5.6",
-				},
-			},
-			InstalledVersion: "1.2.3",
+			VulnerabilityID:  "CVE-2019-0002",
+			PkgName:          pkg1.Name,
+			InstalledVersion: pkg1.Version,
 			FixedVersion:     "1.2.4",
+			PkgIdentifier: ftypes.PkgIdentifier{
+				Hash: pkg1.Identifier.Hash,
+				PURL: pkg1.Identifier.PURL,
+			},
 			Vulnerability: dbTypes.Vulnerability{
 				Severity: dbTypes.SeverityCritical.String(),
 			},
@@ -243,8 +249,14 @@ func TestFilter(t *testing.T) {
 			name: "filter by VEX",
 			args: args{
 				report: types.Report{
+					ArtifactName: ".",
+					ArtifactType: ftypes.ArtifactFilesystem,
 					Results: types.Results{
 						types.Result{
+							Target:   "gobinary",
+							Class:    types.ClassLangPkg,
+							Type:     ftypes.GoBinary,
+							Packages: []ftypes.Package{pkg1},
 							Vulnerabilities: []types.DetectedVulnerability{
 								vuln1,
 								vuln2,
@@ -262,8 +274,14 @@ func TestFilter(t *testing.T) {
 				vexPath: "testdata/openvex.json",
 			},
 			want: types.Report{
+				ArtifactName: ".",
+				ArtifactType: ftypes.ArtifactFilesystem,
 				Results: types.Results{
 					types.Result{
+						Target:   "gobinary",
+						Class:    types.ClassLangPkg,
+						Type:     ftypes.GoBinary,
+						Packages: []ftypes.Package{pkg1},
 						Vulnerabilities: []types.DetectedVulnerability{
 							vuln2,
 						},

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -2,6 +2,7 @@ package result_test
 
 import (
 	"context"
+	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	"github.com/package-url/packageurl-go"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ func TestFilter(t *testing.T) {
 			Name:    "foo",
 			Version: "1.2.3",
 			Identifier: ftypes.PkgIdentifier{
-				Hash: "01",
+				UID: "01",
 				PURL: &packageurl.PackageURL{
 					Type:      packageurl.TypeGolang,
 					Namespace: "github.com/aquasecurity",
@@ -38,7 +39,7 @@ func TestFilter(t *testing.T) {
 			InstalledVersion: pkg1.Version,
 			FixedVersion:     "1.2.4",
 			PkgIdentifier: ftypes.PkgIdentifier{
-				Hash: pkg1.Identifier.Hash,
+				UID:  pkg1.Identifier.UID,
 				PURL: pkg1.Identifier.PURL,
 			},
 			Vulnerability: dbTypes.Vulnerability{
@@ -51,7 +52,7 @@ func TestFilter(t *testing.T) {
 			InstalledVersion: pkg1.Version,
 			FixedVersion:     "1.2.4",
 			PkgIdentifier: ftypes.PkgIdentifier{
-				Hash: pkg1.Identifier.Hash,
+				UID:  pkg1.Identifier.UID,
 				PURL: pkg1.Identifier.PURL,
 			},
 			Vulnerability: dbTypes.Vulnerability{
@@ -250,7 +251,7 @@ func TestFilter(t *testing.T) {
 			args: args{
 				report: types.Report{
 					ArtifactName: ".",
-					ArtifactType: ftypes.ArtifactFilesystem,
+					ArtifactType: artifact.TypeFilesystem,
 					Results: types.Results{
 						types.Result{
 							Target:   "gobinary",
@@ -275,7 +276,7 @@ func TestFilter(t *testing.T) {
 			},
 			want: types.Report{
 				ArtifactName: ".",
-				ArtifactType: ftypes.ArtifactFilesystem,
+				ArtifactType: artifact.TypeFilesystem,
 				Results: types.Results{
 					types.Result{
 						Target:   "gobinary",
@@ -676,7 +677,10 @@ func TestFilter(t *testing.T) {
 						},
 					},
 				},
-				severities: []dbTypes.Severity{dbTypes.SeverityLow, dbTypes.SeverityHigh},
+				severities: []dbTypes.Severity{
+					dbTypes.SeverityLow,
+					dbTypes.SeverityHigh,
+				},
 				policyFile: "./testdata/test-ignore-policy-licenses-and-secrets.rego",
 			},
 			want: types.Report{
@@ -689,7 +693,7 @@ func TestFilter(t *testing.T) {
 							secret1,
 						},
 						ModifiedFindings: []types.ModifiedFinding{
-							 {
+							{
 								Type:      types.FindingTypeSecret,
 								Status:    types.FindingStatusIgnored,
 								Statement: "Filtered by Rego",

--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -70,6 +70,10 @@ type BOM struct {
 	// This is used to ensure that each package URL is only represented once in the BOM.
 	purls map[string][]uuid.UUID
 
+	// parents is a map of parent components to their children
+	// This field is populated when Options.Parents is set to true.
+	parents map[uuid.UUID][]uuid.UUID
+
 	// opts is a set of options for the BOM.
 	opts Options
 }
@@ -199,7 +203,8 @@ type Vulnerability struct {
 }
 
 type Options struct {
-	GenerateBOMRef bool
+	GenerateBOMRef bool // Generate BOMRef for CycloneDX
+	Parents        bool // Hold parent maps
 }
 
 func NewBOM(opts Options) *BOM {
@@ -208,6 +213,7 @@ func NewBOM(opts Options) *BOM {
 		relationships:   make(map[uuid.UUID][]Relationship),
 		vulnerabilities: make(map[uuid.UUID][]Vulnerability),
 		purls:           make(map[string][]uuid.UUID),
+		parents:         make(map[uuid.UUID][]uuid.UUID),
 		opts:            opts,
 	}
 }
@@ -257,6 +263,10 @@ func (b *BOM) AddRelationship(parent, child *Component, relationshipType Relatio
 		Type:       relationshipType,
 		Dependency: child.id,
 	})
+
+	if b.opts.Parents {
+		b.parents[child.id] = append(b.parents[child.id], parent.id)
+	}
 }
 
 func (b *BOM) AddVulnerabilities(c *Component, vulns []Vulnerability) {
@@ -298,8 +308,8 @@ func (b *BOM) Vulnerabilities() map[uuid.UUID][]Vulnerability {
 	return b.vulnerabilities
 }
 
-func (b *BOM) NumComponents() int {
-	return len(b.components) + 1 // +1 for the root component
+func (b *BOM) Parents() map[uuid.UUID][]uuid.UUID {
+	return b.parents
 }
 
 // bomRef returns BOMRef for CycloneDX

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -60,7 +60,7 @@ func (m *Marshaler) MarshalReport(ctx context.Context, report types.Report) (*cd
 // Marshal converts the Trivy component to the CycloneDX format
 func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*cdx.BOM, error) {
 	m.bom = bom
-	m.componentIDs = make(map[uuid.UUID]string, m.bom.NumComponents())
+	m.componentIDs = make(map[uuid.UUID]string, len(m.bom.Components()))
 
 	cdxBOM := cdx.NewBOM()
 	cdxBOM.SerialNumber = uuid.New().URN()

--- a/pkg/sbom/io/encode.go
+++ b/pkg/sbom/io/encode.go
@@ -348,6 +348,7 @@ func (*Encoder) component(result types.Result, pkg ftypes.Package) *core.Compone
 		SrcVersion: utils.FormatSrcVersion(pkg),
 		SrcFile:    srcFile,
 		PkgIdentifier: ftypes.PkgIdentifier{
+			UID:  pkg.Identifier.UID,
 			PURL: pkg.Identifier.PURL,
 		},
 		Supplier:   pkg.Maintainer,

--- a/pkg/vex/csaf.go
+++ b/pkg/vex/csaf.go
@@ -1,7 +1,7 @@
 package vex
 
 import (
-	csaf "github.com/csaf-poc/csaf_distribution/v3/csaf"
+	"github.com/csaf-poc/csaf_distribution/v3/csaf"
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
 

--- a/pkg/vex/openvex.go
+++ b/pkg/vex/openvex.go
@@ -1,9 +1,10 @@
 package vex
 
 import (
+	openvex "github.com/openvex/go-vex/pkg/vex"
+
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	"github.com/aquasecurity/trivy/pkg/types"
-	openvex "github.com/openvex/go-vex/pkg/vex"
 )
 
 type OpenVEX struct {

--- a/pkg/vex/openvex.go
+++ b/pkg/vex/openvex.go
@@ -1,11 +1,9 @@
 package vex
 
 import (
-	openvex "github.com/openvex/go-vex/pkg/vex"
-	"github.com/samber/lo"
-
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	"github.com/aquasecurity/trivy/pkg/types"
+	openvex "github.com/openvex/go-vex/pkg/vex"
 )
 
 type OpenVEX struct {
@@ -19,38 +17,36 @@ func newOpenVEX(vex openvex.VEX) VEX {
 }
 
 func (v *OpenVEX) Filter(result *types.Result, bom *core.BOM) {
-	result.Vulnerabilities = lo.Filter(result.Vulnerabilities, func(vuln types.DetectedVulnerability, _ int) bool {
-		if vuln.PkgIdentifier.PURL == nil {
-			return true
-		}
-
-		stmts := v.Matches(vuln, bom)
-		if len(stmts) == 0 {
-			return true
-		}
-
-		// Take the latest statement for a given vulnerability and product
-		// as a sequence of statements can be overridden by the newer one.
-		// cf. https://github.com/openvex/spec/blob/fa5ba0c0afedb008dc5ebad418548cacf16a3ca7/OPENVEX-SPEC.md#the-vex-statement
-		stmt := stmts[len(stmts)-1]
-		if stmt.Status == openvex.StatusNotAffected || stmt.Status == openvex.StatusFixed {
-			result.ModifiedFindings = append(result.ModifiedFindings,
-				types.NewModifiedFinding(vuln, findingStatus(stmt.Status), string(stmt.Justification), "OpenVEX"))
-			return false
-		}
-		return true
-	})
+	filterVulnerabilities(result, bom, v.NotAffected)
 }
 
-func (v *OpenVEX) Matches(vuln types.DetectedVulnerability, bom *core.BOM) []openvex.Statement {
-	root := bom.Root()
-	if root != nil && root.PkgIdentifier.PURL != nil {
-		stmts := v.vex.Matches(vuln.VulnerabilityID, root.PkgIdentifier.PURL.String(), []string{vuln.PkgIdentifier.PURL.String()})
-		if len(stmts) != 0 {
-			return stmts
-		}
+func (v *OpenVEX) NotAffected(vuln types.DetectedVulnerability, product, subComponent *core.Component) (types.ModifiedFinding, bool) {
+	stmts := v.Matches(vuln, product, subComponent)
+	if len(stmts) == 0 {
+		return types.ModifiedFinding{}, false
 	}
-	return v.vex.Matches(vuln.VulnerabilityID, vuln.PkgIdentifier.PURL.String(), nil)
+
+	// Take the latest statement for a given vulnerability and product
+	// as a sequence of statements can be overridden by the newer one.
+	// cf. https://github.com/openvex/spec/blob/fa5ba0c0afedb008dc5ebad418548cacf16a3ca7/OPENVEX-SPEC.md#the-vex-statement
+	stmt := stmts[len(stmts)-1]
+	if stmt.Status == openvex.StatusNotAffected || stmt.Status == openvex.StatusFixed {
+		modifiedFindings := types.NewModifiedFinding(vuln, findingStatus(stmt.Status), string(stmt.Justification), "OpenVEX")
+		return modifiedFindings, true
+	}
+	return types.ModifiedFinding{}, false
+}
+
+func (v *OpenVEX) Matches(vuln types.DetectedVulnerability, product, subComponent *core.Component) []openvex.Statement {
+	if product == nil || product.PkgIdentifier.PURL == nil {
+		return nil
+	}
+
+	var subComponentPURL string
+	if subComponent != nil && subComponent.PkgIdentifier.PURL != nil {
+		subComponentPURL = subComponent.PkgIdentifier.PURL.String()
+	}
+	return v.vex.Matches(vuln.VulnerabilityID, product.PkgIdentifier.PURL.String(), []string{subComponentPURL})
 }
 
 func findingStatus(status openvex.Status) types.FindingStatus {

--- a/pkg/vex/testdata/openvex-nested.json
+++ b/pkg/vex/testdata/openvex-nested.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "author": "Aqua Security",
+  "role": "Project Release Bot",
+  "timestamp": "2023-01-16T19:07:16.853479631-06:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-0001"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aquasecurity/go-direct1@2.0.0",
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/github.com/aquasecurity/go-transitive@4.0.0"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -137,6 +137,7 @@ func filterVulnerabilities(result *types.Result, bom *core.BOM, fn NotAffected) 
 	})
 }
 
+// reachRoot traverses the component tree from the leaf to the root and returns true if the leaf reaches the root.
 func reachRoot(leaf *core.Component, components map[uuid.UUID]*core.Component, parents map[uuid.UUID][]uuid.UUID,
 	notAffected func(c, leaf *core.Component) bool) bool {
 
@@ -146,8 +147,10 @@ func reachRoot(leaf *core.Component, components map[uuid.UUID]*core.Component, p
 
 	visited := make(map[uuid.UUID]bool)
 
+	// Use Depth First Search (DFS)
 	var dfs func(c *core.Component) bool
 	dfs = func(c *core.Component) bool {
+		// Call the function with the current component and the leaf component
 		if notAffected(c, leaf) {
 			return false
 		} else if c.Root {

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -111,7 +111,7 @@ type NotAffected func(vuln types.DetectedVulnerability, product, subComponent *c
 
 func filterVulnerabilities(result *types.Result, bom *core.BOM, fn NotAffected) {
 	components := lo.MapEntries(bom.Components(), func(id uuid.UUID, component *core.Component) (string, *core.Component) {
-		return component.PkgID.Hash, component
+		return component.PkgIdentifier.UID, component
 	})
 
 	result.Vulnerabilities = lo.Filter(result.Vulnerabilities, func(vuln types.DetectedVulnerability, _ int) bool {
@@ -119,7 +119,7 @@ func filterVulnerabilities(result *types.Result, bom *core.BOM, fn NotAffected) 
 			return true
 		}
 
-		c, ok := components[vuln.PkgIdentifier.Hash]
+		c, ok := components[vuln.PkgIdentifier.UID]
 		if !ok {
 			return true // Should never reach here
 		}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	csaf "github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/google/uuid"
+	"github.com/aquasecurity/trivy/pkg/uuid"
 	"github.com/hashicorp/go-multierror"
 	openvex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/samber/lo"

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -5,8 +5,7 @@ import (
 	"io"
 	"os"
 
-	csaf "github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/aquasecurity/trivy/pkg/uuid"
+	"github.com/csaf-poc/csaf_distribution/v3/csaf"
 	"github.com/hashicorp/go-multierror"
 	openvex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/samber/lo"
@@ -14,10 +13,12 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/sbom"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/uuid"
 )
 
 // VEX represents Vulnerability Exploitability eXchange. It abstracts multiple VEX formats.
@@ -121,6 +122,7 @@ func filterVulnerabilities(result *types.Result, bom *core.BOM, fn NotAffected) 
 
 		c, ok := components[vuln.PkgIdentifier.UID]
 		if !ok {
+			log.Error("Component not found", log.String("uid", vuln.PkgIdentifier.UID))
 			return true // Should never reach here
 		}
 

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -18,11 +18,40 @@ import (
 )
 
 var (
-	vuln1 = types.DetectedVulnerability{
-		VulnerabilityID:  "CVE-2021-44228",
-		PkgName:          "spring-boot",
-		InstalledVersion: "2.6.0",
+	ociComponent = core.Component{
+		Root: true,
+		Type: core.TypeContainerImage,
+		Name: "debian:12",
 		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:    packageurl.TypeOCI,
+				Name:    "debian",
+				Version: "sha256:4482958b4461ff7d9fabc24b3a9ab1e9a2c85ece07b2db1840c7cbc01d053e90",
+				Qualifiers: packageurl.Qualifiers{
+					{
+						Key:   "tag",
+						Value: "12",
+					},
+					{
+						Key:   "repository_url",
+						Value: "docker.io/library/debian",
+					},
+				},
+			},
+		},
+	}
+	fsComponent = core.Component{
+		Root: true,
+		Type: core.TypeFilesystem,
+		Name: ".",
+	}
+	springComponent = core.Component{
+		Type:    core.TypeLibrary,
+		Group:   "org.springframework.boot",
+		Name:    "spring-boot",
+		Version: "2.6.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "01",
 			PURL: &packageurl.PackageURL{
 				Type:      packageurl.TypeMaven,
 				Namespace: "org.springframework.boot",
@@ -31,30 +60,110 @@ var (
 			},
 		},
 	}
-	vuln2 = types.DetectedVulnerability{
-		VulnerabilityID:  "CVE-2021-0001",
-		PkgName:          "spring-boot",
-		InstalledVersion: "2.6.0",
+	bashComponent = core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "bash",
+		Version: "5.3",
 		PkgIdentifier: ftypes.PkgIdentifier{
-			PURL: &packageurl.PackageURL{
-				Type:      packageurl.TypeMaven,
-				Namespace: "org.springframework.boot",
-				Name:      "spring-boot",
-				Version:   "2.6.0",
-			},
-		},
-	}
-	vuln3 = types.DetectedVulnerability{
-		VulnerabilityID:  "CVE-2022-3715",
-		PkgName:          "bash",
-		InstalledVersion: "5.2.15",
-		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "02",
 			PURL: &packageurl.PackageURL{
 				Type:      packageurl.TypeDebian,
 				Namespace: "debian",
 				Name:      "bash",
 				Version:   "5.2.15",
 			},
+		},
+	}
+	goModuleComponent = core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "github.com/aquasecurity/go-module",
+		Version: "1.0.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "03",
+			PURL: &packageurl.PackageURL{
+				Type:      packageurl.TypeGolang,
+				Namespace: "github.com/aquasecurity",
+				Name:      "go-module",
+				Version:   "1.0.0",
+			},
+		},
+	}
+	goDirectComponent1 = core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "github.com/aquasecurity/go-direct1",
+		Version: "2.0.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "04",
+			PURL: &packageurl.PackageURL{
+				Type:      packageurl.TypeGolang,
+				Namespace: "github.com/aquasecurity",
+				Name:      "go-direct1",
+				Version:   "2.0.0",
+			},
+		},
+	}
+	goDirectComponent2 = core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "github.com/aquasecurity/go-direct2",
+		Version: "3.0.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "05",
+			PURL: &packageurl.PackageURL{
+				Type:      packageurl.TypeGolang,
+				Namespace: "github.com/aquasecurity",
+				Name:      "go-direct2",
+				Version:   "3.0.0",
+			},
+		},
+	}
+	goTransitiveComponent = core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "github.com/aquasecurity/go-transitive",
+		Version: "4.0.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID: "06",
+			PURL: &packageurl.PackageURL{
+				Type:      packageurl.TypeGolang,
+				Namespace: "github.com/aquasecurity",
+				Name:      "go-transitive",
+				Version:   "4.0.0",
+			},
+		},
+	}
+	vuln1 = types.DetectedVulnerability{
+		VulnerabilityID:  "CVE-2021-44228",
+		PkgName:          springComponent.Name,
+		InstalledVersion: springComponent.Version,
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID:  springComponent.PkgIdentifier.UID,
+			PURL: springComponent.PkgIdentifier.PURL,
+		},
+	}
+	vuln2 = types.DetectedVulnerability{
+		VulnerabilityID:  "CVE-2021-0001",
+		PkgName:          springComponent.Name,
+		InstalledVersion: springComponent.Version,
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID:  springComponent.PkgIdentifier.UID,
+			PURL: springComponent.PkgIdentifier.PURL,
+		},
+	}
+	vuln3 = types.DetectedVulnerability{
+		VulnerabilityID:  "CVE-2022-3715",
+		PkgName:          bashComponent.Name,
+		InstalledVersion: bashComponent.Version,
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID:  bashComponent.PkgIdentifier.UID,
+			PURL: bashComponent.PkgIdentifier.PURL,
+		},
+	}
+	vuln4 = types.DetectedVulnerability{
+		VulnerabilityID:  "CVE-2024-0001",
+		PkgName:          goTransitiveComponent.Name,
+		InstalledVersion: goTransitiveComponent.Version,
+		PkgIdentifier: ftypes.PkgIdentifier{
+			UID:  goTransitiveComponent.PkgIdentifier.UID,
+			PURL: goTransitiveComponent.PkgIdentifier.PURL,
 		},
 	}
 )
@@ -87,7 +196,7 @@ func TestVEX_Filter(t *testing.T) {
 			},
 			args: args{
 				vulns: []types.DetectedVulnerability{vuln1},
-				bom:   newTestBOM(),
+				bom:   newTestBOM1(),
 			},
 			want: []types.DetectedVulnerability{},
 		},
@@ -101,7 +210,7 @@ func TestVEX_Filter(t *testing.T) {
 					vuln1, // filtered by VEX
 					vuln2,
 				},
-				bom: newTestBOM(),
+				bom: newTestBOM1(),
 			},
 			want: []types.DetectedVulnerability{
 				vuln2,
@@ -116,7 +225,7 @@ func TestVEX_Filter(t *testing.T) {
 				vulns: []types.DetectedVulnerability{
 					vuln3,
 				},
-				bom: newTestBOM(),
+				bom: newTestBOM1(),
 			},
 			want: []types.DetectedVulnerability{},
 		},
@@ -130,6 +239,28 @@ func TestVEX_Filter(t *testing.T) {
 				bom:   newTestBOM2(),
 			},
 			want: []types.DetectedVulnerability{vuln3},
+		},
+		{
+			name: "OpenVEX, single path between product and subcomponent",
+			fields: fields{
+				filePath: "testdata/openvex-nested.json",
+			},
+			args: args{
+				vulns: []types.DetectedVulnerability{vuln4},
+				bom:   newTestBOM3(),
+			},
+			want: []types.DetectedVulnerability{},
+		},
+		{
+			name: "OpenVEX, multi paths between product and subcomponent",
+			fields: fields{
+				filePath: "testdata/openvex-nested.json",
+			},
+			args: args{
+				vulns: []types.DetectedVulnerability{vuln4},
+				bom:   newTestBOM4(),
+			},
+			want: []types.DetectedVulnerability{vuln4}, // Will not be filtered because of multi paths
 		},
 		{
 			name: "CycloneDX SBOM with CycloneDX VEX",
@@ -373,30 +504,16 @@ func TestVEX_Filter(t *testing.T) {
 	}
 }
 
-func newTestBOM() *core.BOM {
-	bom := core.NewBOM(core.Options{})
-	bom.AddComponent(&core.Component{
-		Root: true,
-		Type: core.TypeContainerImage,
-		Name: "debian:12",
-		PkgIdentifier: ftypes.PkgIdentifier{
-			PURL: &packageurl.PackageURL{
-				Type:    packageurl.TypeOCI,
-				Name:    "debian",
-				Version: "sha256:4482958b4461ff7d9fabc24b3a9ab1e9a2c85ece07b2db1840c7cbc01d053e90",
-				Qualifiers: packageurl.Qualifiers{
-					{
-						Key:   "tag",
-						Value: "12",
-					},
-					{
-						Key:   "repository_url",
-						Value: "docker.io/library/debian",
-					},
-				},
-			},
-		},
-	})
+func newTestBOM1() *core.BOM {
+	// - oci:debian?tag=12
+	//     - pkg:maven/org.springframework.boot/spring-boot@2.6.0
+	//     - pkg:deb/debian/bash@5.3
+	bom := core.NewBOM(core.Options{Parents: true})
+	bom.AddComponent(&ociComponent)
+	bom.AddComponent(&springComponent)
+	bom.AddComponent(&bashComponent)
+	bom.AddRelationship(&ociComponent, &springComponent, core.RelationshipContains)
+	bom.AddRelationship(&ociComponent, &bashComponent, core.RelationshipContains)
 	return bom
 }
 
@@ -424,5 +541,42 @@ func newTestBOM2() *core.BOM {
 			},
 		},
 	})
+	return bom
+}
+
+func newTestBOM3() *core.BOM {
+	// - filesystem
+	//     - pkg:golang/github.com/aquasecurity/go-module@1.0.0
+	//         - pkg:golang/github.com/aquasecurity/go-direct1@2.0.0
+	//             - pkg:golang/github.com/aquasecurity/go-transitive@4.0.0
+	bom := core.NewBOM(core.Options{Parents: true})
+	bom.AddComponent(&fsComponent)
+	bom.AddComponent(&goModuleComponent)
+	bom.AddComponent(&goDirectComponent1)
+	bom.AddComponent(&goTransitiveComponent)
+	bom.AddRelationship(&fsComponent, &goModuleComponent, core.RelationshipContains)
+	bom.AddRelationship(&goModuleComponent, &goDirectComponent1, core.RelationshipDependsOn)
+	bom.AddRelationship(&goDirectComponent1, &goTransitiveComponent, core.RelationshipDependsOn)
+	return bom
+}
+
+func newTestBOM4() *core.BOM {
+	// - filesystem
+	//     - pkg:golang/github.com/aquasecurity/go-module@2.0.0
+	//         - pkg:golang/github.com/aquasecurity/go-direct1@3.0.0
+	//             - pkg:golang/github.com/aquasecurity/go-transitive@5.0.0
+	//         - pkg:golang/github.com/aquasecurity/go-direct2@4.0.0
+	//             - pkg:golang/github.com/aquasecurity/go-transitive@5.0.0
+	bom := core.NewBOM(core.Options{Parents: true})
+	bom.AddComponent(&fsComponent)
+	bom.AddComponent(&goModuleComponent)
+	bom.AddComponent(&goDirectComponent1)
+	bom.AddComponent(&goDirectComponent2)
+	bom.AddComponent(&goTransitiveComponent)
+	bom.AddRelationship(&fsComponent, &goModuleComponent, core.RelationshipContains)
+	bom.AddRelationship(&goModuleComponent, &goDirectComponent1, core.RelationshipDependsOn)
+	bom.AddRelationship(&goModuleComponent, &goDirectComponent2, core.RelationshipDependsOn)
+	bom.AddRelationship(&goDirectComponent1, &goTransitiveComponent, core.RelationshipDependsOn)
+	bom.AddRelationship(&goDirectComponent2, &goTransitiveComponent, core.RelationshipDependsOn)
 	return bom
 }


### PR DESCRIPTION
## Background

Currently, Trivy uses VEX statements with `fixed` and `not_affected` statuses to filter out vulnerabilities.

## Current Implementation

In [this PR](https://github.com/aquasecurity/trivy/pull/6313), we added limited support for OpenVEX subcomponents. With this change, VEX can be applied to scans when the product is the root component and the subcomponent is the leaf component, i.e., the component with the vulnerability. For container image scans, if the product ID is the scan subject, the PURL of the image, the VEX is applicable as the image is a root component.

![image](https://github.com/aquasecurity/trivy/assets/2253692/1db360b7-284e-4289-8124-09fba7f135e6)

However, it does not work with VEX for non-root components within that container image. In the following example, a VEX document for Application B doesn't work since it is a non-root component.

![image](https://github.com/aquasecurity/trivy/assets/2253692/e6730447-80f2-4890-a30e-1c410e289fe5)

## Enhancement
This PR extends that functionality to allow VEX with non-root components as the product ID to be applied as well. This means that when scanning a container image like `ghcr.io/aquasecurity/trivy:0.51.1`, the following VEX can be passed:

```
{
  "@context": "https://openvex.dev/ns/v0.2.0",
  "author": "Aqua Security",
  "role": "Maintainer",
  "timestamp": "2024-05-20T19:07:16.853479631-06:00",
  "version": 1,
  "statements": [
    {
      "vulnerability": {
        "name": "CVE-2024-21626"
      },
      "products": [
        {
          "@id": "pkg:golang/github.com/aquasecurity/trivy",
          "subcomponents": [
            {
              "@id": "pkg:golang/github.com/opencontainers/runc"
            }
          ]
        }
      ],
      "status": "not_affected",
      "justification": "vulnerable_code_not_in_execute_path"
    }
  ]
}
```

With this extension, there is no longer a need to issue VEX for all container images to suppress this vulnerability, and VEX for applications can be reused. In the example above, the same VEX can be applied to all container images, including the `pkg:golang/github.com/aquasecurity/trivy` binary.

## Implementation

Applying VEX to components in the middle of the dependency tree is not straightforward because the vulnerable component may also be used by other components. This means that all possible paths must be explored to ensure that all paths are unaffected.

1. Single path
If Library C is used only by Library B and Library B has a VEX statement declaring "not affected", we can consider Container Image A is also not affected.

![image](https://github.com/aquasecurity/trivy/assets/2253692/f223b6d8-b8b0-463b-8c11-22205e6f1714)

The VEX statement would be as follows:

```
  "statements": [
    {
      "vulnerability": {
        "name": "CVE-XXXX-YYYY"
      },
      "products": [
        {
          "@id": "pkg:golang/library-b",
          "subcomponents": [
            {
              "@id": "pkg:golang/library-c"
            }
          ]
        }
      ],
      "status": "not_affected",
      "justification": "vulnerable_code_not_in_execute_path"
    }
```

2. Multi paths

However, consider a scenario where Application A depends on Library B and Library D, and both Library B and D depend on Library C. In other words, there are multiple paths from Library C to the root component, which is Application A in this example.

In this case, even if there is a VEX statement for Library B declaring that it is not affected by the vulnerability in Library C, we cannot definitively say that Application A is not vulnerable to the vulnerability in Library C. This is because Library D might be using Library C in a vulnerable way. Therefore, we also need to check the VEX for Library D, and if it is "affected" or if no VEX exists (default is considered affected), Application A is still considered affected.

![image](https://github.com/aquasecurity/trivy/assets/2253692/e2459555-d9a5-4351-beb5-c1ab7be5a347)

On the other hand, if Library D also has a VEX statement declaring it as not affected, Application A is deemed not affected.

![image](https://github.com/aquasecurity/trivy/assets/2253692/b330e018-4dab-4b56-aad6-7daf8847e3ef)

In this PR, Trivy generates as complete a dependency tree as possible, performs a full path exploration, and filters out the vulnerability only when all paths to the root component are unreachable.

## Note
CSAF relationship support will be implemented in another PR.

## Related issues
- https://github.com/aquasecurity/trivy/issues/6077
 
## Related PRs
- https://github.com/aquasecurity/trivy/pull/6313

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
