### PR TITLE
ci: add groups for `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,3 @@ updates:
       common:
         patterns:
           - "*"
-        exclude-patterns:
-          - "github.com/aws/*"
-          - "github.com/testcontainers/*"
-          - "github.com/docker/*"
-          - "github.com/moby/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     open-pull-requests-limit: 10
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     groups:
       aws:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,39 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: monthly
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: gomod
     open-pull-requests-limit: 10
     directory: /
     schedule:
       interval: monthly
+    groups:
+      aws:
+        patterns:
+          - "github.com/aws/*"
+      docker:
+        patterns:
+          - "github.com/docker/*"
+          - "github.com/moby/*"
+      testcontainers:
+        patterns:
+          - "github.com/testcontainers/*"
+      common:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/aws/*"
+          - "github.com/testcontainers/*"
+          - "github.com/docker/*"
+          - "github.com/moby/*"


### PR DESCRIPTION
## Description
`Dependabot` PRs [grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-updates-into-one-pull-request):
- GH actions
- Docker files
- `github.com/docker/*` from `go.mod`.
- `github.com/aws/*` from `go.mod`.
- `github.com/testcontainers-go/*` from `go.mod`.
- others

Example:
![изображение](https://github.com/aquasecurity/trivy/assets/91113035/bd5df2c4-c922-48b8-b3e6-d97f5a1edd4d)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
