### PR TITLE
feat(misconf): add support for AWS::EC2::SecurityGroupIngress/Egress

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
@@ -272,6 +272,57 @@ Resources:
 				},
 			},
 		},
+		{
+			name: "security group with ingress and egress rules",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: MySecurityGroup
+      GroupDescription: MySecurityGroup
+  InboundRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref MySecurityGroup
+      Description: Inbound
+      CidrIp: 0.0.0.0/0
+  OutboundRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !GetAtt MySecurityGroup.GroupId
+      Description: Outbound
+      CidrIp: 0.0.0.0/0
+  RuleWithoutGroup:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      CidrIpv6: ::/0
+      Description: Inbound
+`,
+			expected: ec2.EC2{
+				SecurityGroups: []ec2.SecurityGroup{
+					{
+						Description: types.StringTest("MySecurityGroup"),
+						IngressRules: []ec2.SecurityGroupRule{
+							{
+								Description: types.StringTest("Inbound"),
+								CIDRs: []types.StringValue{
+									types.StringTest("0.0.0.0/0"),
+								},
+							},
+						},
+						EgressRules: []ec2.SecurityGroupRule{
+							{
+								Description: types.StringTest("Outbound"),
+								CIDRs: []types.StringValue{
+									types.StringTest("0.0.0.0/0"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
Added support for `AWS::EC2::SecurityGroupIngress` and `AWS::EC2::SecurityGroupEgress` resources.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6754


```sh
2024-05-23T17:28:41+06:00	INFO	Misconfiguration scanning is enabled
2024-05-23T17:29:09+06:00	INFO	Detected config files	num=1

templ.yaml (cloudformation)

Tests: 8 (SUCCESSES: 6, FAILURES: 2, EXCEPTIONS: 0)
Failures: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 1)

CRITICAL: Security group rule allows ingress from public internet.
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Opening up ports to the public internet is generally to be avoided. You should restrict access to IP addresses or ranges that explicitly require it where possible.

See https://avd.aquasec.com/misconfig/avd-aws-0107
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 templ.yaml:17
   via templ.yaml:10-17 (SecurityGroupIngress)
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  10     SecurityGroupIngress:
  11       Type: 'AWS::EC2::SecurityGroupIngress'
  12       Properties:
  13         GroupId: !Ref SecurityGroup
  14         IpProtocol: tcp
  15         FromPort: '22'
  16         ToPort: '22'
  17 [       CidrIp: 0.0.0.0/0
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
