### PR TITLE
build: use main package instead of main.go

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: trivy
 builds:
   - id: build-linux
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w
@@ -21,7 +21,7 @@ builds:
     goarm:
       - 7
   - id: build-bsd
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w
@@ -36,7 +36,7 @@ builds:
       - 386
       - amd64
   - id: build-macos
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w
@@ -52,7 +52,7 @@ builds:
     goarm:
       - 7
   - id: build-windows
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w


### PR DESCRIPTION
## Description
Our release binaries don't include the main module information now, and our gobinary analyzer doesn't work on them.

```
$ docker run --rm -it --entrypoint "sh" ghcr.io/aquasecurity/trivy:0.51.2 -c "apk add go && go version -m /usr/local/bin/trivy" | grep "/usr/local/bin/trivy" -A 5
/usr/local/bin/trivy: go1.22.3
        path    command-line-arguments
        dep     cloud.google.com/go     v0.112.1        h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
        dep     cloud.google.com/go/compute/metadata    v0.2.3  h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
        dep     cloud.google.com/go/iam v1.1.6  h1:bEa06k05IO4f4uJonbB5iAgKTPpABy1ayxaIZV/GHVc=
        dep     cloud.google.com/go/storage     v1.39.1 h1:MvraqHKhogCOTXTlct/9C3K3+Uy2jBmFYb3/Sp6dVtY=
```

A binary built by Mage includes it.

```
$ mage build && go version -m ./trivy | head -n 5
./trivy: go1.22.3
        path    github.com/aquasecurity/trivy/cmd/trivy
        mod     github.com/aquasecurity/trivy   (devel)
        dep     cloud.google.com/go     v0.112.1        h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
        dep     cloud.google.com/go/compute/metadata    v0.2.3  h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
```

This is because GoRelease uses main.go, `cmd/trivy/main.go`, while Mage uses the main package, `./cmd/trivy`. This PR fixes it.



### Before

```
$ goreleaser build -f goreleaser.yml --skip-validate --id build-macos --clean && go version -m dist/build-macos_darwin_amd64_v1/trivy | head -n 5
dist/build-macos_darwin_amd64_v1/trivy: go1.22.3
        path    command-line-arguments
        dep     cloud.google.com/go     v0.112.1        h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
        dep     cloud.google.com/go/compute/metadata    v0.2.3  h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
        dep     cloud.google.com/go/iam v1.1.6  h1:bEa06k05IO4f4uJonbB5iAgKTPpABy1ayxaIZV/GHVc=
```


### After

```
$ goreleaser build -f goreleaser.yml --skip-validate --id build-macos --clean && go version -m dist/build-macos_darwin_amd64_v1/trivy | head -n 5
dist/build-macos_darwin_amd64_v1/trivy: go1.22.3
        path    github.com/aquasecurity/trivy/cmd/trivy
        mod     github.com/aquasecurity/trivy   (devel)
        dep     cloud.google.com/go     v0.112.1        h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
        dep     cloud.google.com/go/compute/metadata    v0.2.3  h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
