### PR TITLE
fix: clean up golangci lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,35 +1,9 @@
 linters-settings:
+  dupl:
+    threshold: 100
   errcheck:
     check-type-assertions: true
     check-blank: true
-  govet:
-    check-shadowing: false
-  gofmt:
-    simplify: false
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-  revive:
-    ignore-generated-header: true
-  gocyclo:
-    min-complexity: 20
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  misspell:
-    locale: US
-    ignore-words:
-      - licence
-      - optimise
-  gosec:
-    excludes:
-      - G101
-      - G114
-      - G204
-      - G304
-      - G402
   gci:
     sections:
       - standard
@@ -37,17 +11,9 @@ linters-settings:
       - prefix(github.com/aquasecurity/)
       - blank
       - dot
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/hashicorp/go-version:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
-        - github.com/Masterminds/semver:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
+  goconst:
+    min-len: 3
+    min-occurrences: 3
   gocritic:
     disabled-checks:
       - appendAssign
@@ -70,6 +36,42 @@ linters-settings:
       ruleguard:
         failOn: all
         rules: '${configDir}/misc/lint/rules.go'
+  gocyclo:
+    min-complexity: 20
+  gofmt:
+    simplify: false
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/hashicorp/go-version:
+            recommendations:
+              - github.com/aquasecurity/go-version
+            reason: "`aquasecurity/go-version` is designed for our use-cases"
+        - github.com/Masterminds/semver:
+            recommendations:
+              - github.com/aquasecurity/go-version
+            reason: "`aquasecurity/go-version` is designed for our use-cases"
+  gosec:
+    excludes:
+      - G101
+      - G114
+      - G204
+      - G304
+      - G402
+  govet:
+    check-shadowing: false
+  misspell:
+    locale: US
+    ignore-words:
+      - behaviour
+      - licence
+      - optimise
+      - simmilar
+  revive:
+    ignore-generated-header: true
   testifylint:
     enable-all: true
     disable:
@@ -111,7 +113,6 @@ issues:
       linters:
         - goconst
         - gosec
-        - misspell
         - unused
     - path: ".*_test.go$"
       linters:
@@ -129,16 +130,5 @@ issues:
       linters:
         - gocritic
       text: "importShadow:"
-    - linters:
-        - errcheck
-      text: "Close` is not checked"
-    - linters:
-        - errcheck
-      text: "os.*` is not checked"
-    - linters:
-        - golint
-      text: "a blank import should be only in a main or test package"
-  exclude:
-    - "should have a package comment, unless it's in another file for this package"
   exclude-use-default: false
   max-same-issues: 0


### PR DESCRIPTION
## Description

Sort linter-settings alphabetically.
Enable misspell in test.go
Remove unused exclusions