### PR TITLE
docs(plugin): add missed `plugin` section

### DIFF
--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -399,7 +399,7 @@ $ trivy <target> [--format <format>] --output plugin=<plugin_name> [--output-plu
 ```
 
 This is useful for cases where you want to convert the output into a custom format, or when you want to send the output somewhere.
-For more details, please check [here](../plugin/plugins.md#output-plugins).
+For more details, please check [here](../plugin/user-guide.md#output-mode-support).
 
 ## Converting
 To generate multiple reports, you can generate the JSON report first and convert it to other formats with the `convert` subcommand.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,10 @@ nav:
       - Compliance:
           - Built-in Compliance:  docs/compliance/compliance.md
           - Custom Compliance: docs/compliance/contrib-compliance.md
+      - Plugins:
+          - Overview: docs/plugin/index.md
+          - User guide: docs/plugin/user-guide.md
+          - Developer guide: docs/plugin/developer-guide.md
       - Advanced:
           - Modules: docs/advanced/modules.md
           - Air-Gapped Environment: docs/advanced/air-gap.md


### PR DESCRIPTION
## Description
Add missed `plugin` section.

<img src="https://github.com/aquasecurity/trivy/assets/91113035/4af46eaa-9f87-498c-aec2-d85266132984" width="170" />


## Related PRs
- [x] #6674

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
