### PR TITLE
fix(python): add package name and version validation for `requirements.txt` files.

### DIFF
--- a/pkg/dependency/parser/python/pip/parse_test.go
+++ b/pkg/dependency/parser/python/pip/parse_test.go
@@ -2,7 +2,6 @@ package pip
 
 import (
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,57 +11,72 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	vectors := []struct {
-		file string
-		want []ftypes.Package
+	tests := []struct {
+		name     string
+		filePath string
+		want     []ftypes.Package
 	}{
 		{
-			file: "testdata/requirements_flask.txt",
-			want: requirementsFlask,
+			name:     "happy path",
+			filePath: "testdata/requirements_flask.txt",
+			want:     requirementsFlask,
 		},
 		{
-			file: "testdata/requirements_comments.txt",
-			want: requirementsComments,
+			name:     "happy path with comments",
+			filePath: "testdata/requirements_comments.txt",
+			want:     requirementsComments,
 		},
 		{
-			file: "testdata/requirements_spaces.txt",
-			want: requirementsSpaces,
+			name:     "happy path with spaces",
+			filePath: "testdata/requirements_spaces.txt",
+			want:     requirementsSpaces,
 		},
 		{
-			file: "testdata/requirements_no_version.txt",
-			want: requirementsNoVersion,
+			name:     "happy path with dependency without version",
+			filePath: "testdata/requirements_no_version.txt",
+			want:     requirementsNoVersion,
 		},
 		{
-			file: "testdata/requirements_operator.txt",
-			want: requirementsOperator,
+			name:     "happy path with operator",
+			filePath: "testdata/requirements_operator.txt",
+			want:     requirementsOperator,
 		},
 		{
-			file: "testdata/requirements_hash.txt",
-			want: requirementsHash,
+			name:     "happy path with hash",
+			filePath: "testdata/requirements_hash.txt",
+			want:     requirementsHash,
 		},
 		{
-			file: "testdata/requirements_hyphens.txt",
-			want: requirementsHyphens,
+			name:     "happy path with hyphens",
+			filePath: "testdata/requirements_hyphens.txt",
+			want:     requirementsHyphens,
 		},
 		{
-			file: "testdata/requirement_exstras.txt",
-			want: requirementsExtras,
+			name:     "happy path with exstras",
+			filePath: "testdata/requirement_exstras.txt",
+			want:     requirementsExtras,
 		},
 		{
-			file: "testdata/requirements_utf16le.txt",
-			want: requirementsUtf16le,
+			name:     "happy path. File uses utf16le",
+			filePath: "testdata/requirements_utf16le.txt",
+			want:     requirementsUtf16le,
+		},
+		{
+			name:     "happy path with templating engine",
+			filePath: "testdata/requirements_with_templating_engine.txt",
+			want:     nil,
 		},
 	}
 
-	for _, v := range vectors {
-		t.Run(path.Base(v.file), func(t *testing.T) {
-			f, err := os.Open(v.file)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.Open(tt.filePath)
 			require.NoError(t, err)
 
 			got, _, err := NewParser().Parse(f)
 			require.NoError(t, err)
 
-			assert.Equal(t, v.want, got)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/dependency/parser/python/pip/testdata/requirements_with_templating_engine.txt
+++ b/pkg/dependency/parser/python/pip/testdata/requirements_with_templating_engine.txt
@@ -1,0 +1,5 @@
+%ifcookiecutter.command_line_interface|lower=='click'-%}
+foo|bar=='1.2.4'
+foo{bar}==%%
+foo,bar&&foobar==1.2.3
+foo=='invalid-version'


### PR DESCRIPTION
## Description
Add package name and version validation for `requirements.txt` files.

## Related issues
- Close #6750

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
