### PR TITLE
ci: replace PAT with ORG_REPO_TOKEN

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,7 +21,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.ORG_REPO_TOKEN }}
           target-branch: ${{ github.ref_name }}
 
   manual-release-please:
@@ -34,7 +34,7 @@ jobs:
       - name: Release Please
         run: |
           release-please release-pr --repo-url=${{ github.server_url }}/${{ github.repository }} \
-            --token=${{ secrets.PAT }} \
+            --token=${{ secrets.ORG_REPO_TOKEN }} \
             --release-as=${{ github.event.inputs.version }} \
             --target-branch=${{ github.ref_name }}
 
@@ -55,7 +55,7 @@ jobs:
         if: ${{ steps.extract_info.outputs.version }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.ORG_REPO_TOKEN }}
           script: |
             await github.rest.git.createRef({
               owner: context.repo.owner,
@@ -71,7 +71,7 @@ jobs:
         if: ${{ steps.extract_info.outputs.pr_number }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT }}
+          github-token: ${{ secrets.ORG_REPO_TOKEN }}
           script: |
             const prNumber = parseInt('${{ steps.extract_info.outputs.pr_number }}', 10);
             github.rest.issues.removeLabel({


### PR DESCRIPTION
## Description
I used `secrets.PAT` in my fork and forgot to replace it with `ORG_REPO_TOKEN` 😔 

## Related PRs
- https://github.com/aquasecurity/trivy/pull/6795

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
