### PR TITLE
fix(sbom): fix panic for `convert` mode when scanning json file derived from sbom file

### DIFF
--- a/pkg/sbom/io/encode.go
+++ b/pkg/sbom/io/encode.go
@@ -83,8 +83,15 @@ func (e *Encoder) rootComponent(r types.Report) (*core.Component, error) {
 		root.Type = core.TypeFilesystem
 	case artifact.TypeRepository:
 		root.Type = core.TypeRepository
-	case artifact.TypeCycloneDX:
-		return r.BOM.Root(), nil
+	case artifact.TypeCycloneDX, artifact.TypeSPDX:
+		// When we scan SBOM file
+		if r.BOM != nil {
+			return r.BOM.Root(), nil
+		}
+		// When we scan a `json` file (meaning a file in `json` format) which was created from the SBOM file.
+		// e.g. for use in `convert` mode.
+		// See https://github.com/aquasecurity/trivy/issues/6780
+		root.Type = core.TypeFilesystem
 	}
 
 	if r.Metadata.Size != 0 {


### PR DESCRIPTION
## Description
See #6780

## Related issues
- Close #6780

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
