### PR TITLE
fix(misconf): fix caching of modules in subdirectories

### DIFF
--- a/pkg/iac/scanners/terraform/parser/module_retrieval.go
+++ b/pkg/iac/scanners/terraform/parser/module_retrieval.go
@@ -13,8 +13,8 @@ type ModuleResolver interface {
 }
 
 var defaultResolvers = []ModuleResolver{
-	resolvers.Cache,
 	resolvers.Local,
+	resolvers.Cache,
 	resolvers.Remote,
 	resolvers.Registry,
 }

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -232,17 +232,19 @@ func (p *Parser) Load(ctx context.Context) (*evaluator, error) {
 	}
 
 	modulesMetadata, metadataPath, err := loadModuleMetadata(p.moduleFS, p.projectRoot)
-	if err != nil {
+
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		p.debug.Log("Error loading module metadata: %s.", err)
-	} else {
-		p.debug.Log("Loaded module metadata for %d module(s) from '%s'.", len(modulesMetadata.Modules), metadataPath)
+	} else if err == nil {
+		p.debug.Log("Loaded module metadata for %d module(s) from %q.", len(modulesMetadata.Modules), metadataPath)
 	}
 
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
-	p.debug.Log("Working directory for module evaluation is '%s'", workingDir)
+
+	p.debug.Log("Working directory for module evaluation is %q", workingDir)
 	return newEvaluator(
 		p.moduleFS,
 		p,

--- a/pkg/iac/scanners/terraform/parser/parser_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_integration_test.go
@@ -13,7 +13,8 @@ func Test_DefaultRegistry(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	fs := testutil.CreateFS(t, map[string]string{
+
+	fsys := testutil.CreateFS(t, map[string]string{
 		"code/test.tf": `
 module "registry" {
 	source = "terraform-aws-modules/vpc/aws"
@@ -21,10 +22,9 @@ module "registry" {
 `,
 	})
 
-	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
-		t.Fatal(err)
-	}
+	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
+	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+
 	modules, _, err := parser.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
@@ -34,7 +34,8 @@ func Test_SpecificRegistry(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	fs := testutil.CreateFS(t, map[string]string{
+
+	fsys := testutil.CreateFS(t, map[string]string{
 		"code/test.tf": `
 module "registry" {
 	source = "registry.terraform.io/terraform-aws-modules/vpc/aws"
@@ -42,10 +43,9 @@ module "registry" {
 `,
 	})
 
-	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
-		t.Fatal(err)
-	}
+	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
+	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+
 	modules, _, err := parser.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
@@ -55,7 +55,8 @@ func Test_ModuleWithPessimisticVersionConstraint(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	fs := testutil.CreateFS(t, map[string]string{
+
+	fsys := testutil.CreateFS(t, map[string]string{
 		"code/test.tf": `
 module "registry" {
 	source = "registry.terraform.io/terraform-aws-modules/s3-bucket/aws"
@@ -65,10 +66,30 @@ module "registry" {
 `,
 	})
 
-	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
-		t.Fatal(err)
+	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
+	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+
+	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, err)
+	require.Len(t, modules, 2)
+}
+
+func Test_ModuleInSubdir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
 	}
+
+	fsys := testutil.CreateFS(t, map[string]string{
+		"code/test.tf": `
+module "object" {
+	source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/object?ref=v4.1.2"
+
+}`,
+	})
+
+	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
+	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+
 	modules, _, err := parser.EvaluateAll(context.TODO())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)

--- a/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
@@ -1,0 +1,114 @@
+package resolvers_test
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser/resolvers"
+)
+
+type moduleResolver interface {
+	Resolve(context.Context, fs.FS, resolvers.Options) (fs.FS, string, string, bool, error)
+}
+
+func TestResolveModuleFromCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		name          string
+		opts          resolvers.Options
+		firstResolver moduleResolver
+	}{
+		{
+			name: "registry",
+			opts: resolvers.Options{
+				Name:    "bucket",
+				Source:  "terraform-aws-modules/s3-bucket/aws",
+				Version: "4.1.2",
+			},
+			firstResolver: resolvers.Registry,
+		},
+		{
+			name: "registry with subdir",
+			opts: resolvers.Options{
+				Name:    "object",
+				Source:  "terraform-aws-modules/s3-bucket/aws//modules/object",
+				Version: "4.1.2",
+			},
+			firstResolver: resolvers.Registry,
+		},
+		{
+			name: "remote",
+			opts: resolvers.Options{
+				Name:   "bucket",
+				Source: "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.1.2",
+			},
+			firstResolver: resolvers.Remote,
+		},
+		{
+			name: "remote with subdir",
+			opts: resolvers.Options{
+				Name:   "object",
+				Source: "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/object?ref=v4.1.2",
+			},
+			firstResolver: resolvers.Remote,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			tt.opts.AllowDownloads = true
+			tt.opts.OriginalSource = tt.opts.Source
+			tt.opts.OriginalVersion = tt.opts.Version
+			tt.opts.CacheDir = t.TempDir()
+
+			fsys, _, _, applies, err := tt.firstResolver.Resolve(context.Background(), nil, tt.opts)
+			require.NoError(t, err)
+			assert.True(t, applies)
+
+			_, err = fs.Stat(fsys, "main.tf")
+			require.NoError(t, err)
+
+			_, _, _, applies, err = resolvers.Cache.Resolve(context.Background(), fsys, tt.opts)
+			require.NoError(t, err)
+			assert.True(t, applies)
+		})
+	}
+}
+
+func TestResolveModuleFromCacheWithDifferentSubdir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cacheDir := t.TempDir()
+
+	fsys, _, _, applies, err := resolvers.Remote.Resolve(context.Background(), nil, resolvers.Options{
+		Name:           "object",
+		Source:         "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/object?ref=v4.1.2",
+		OriginalSource: "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/object?ref=v4.1.2",
+		AllowDownloads: true,
+		CacheDir:       cacheDir,
+	})
+	require.NoError(t, err)
+	assert.True(t, applies)
+
+	_, err = fs.Stat(fsys, "main.tf")
+	require.NoError(t, err)
+
+	_, _, _, applies, err = resolvers.Cache.Resolve(context.Background(), nil, resolvers.Options{
+		Name:           "notification",
+		Source:         "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/notification?ref=v4.1.2",
+		OriginalSource: "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git//modules/notification?ref=v4.1.2",
+		CacheDir:       cacheDir,
+	})
+	require.NoError(t, err)
+	assert.True(t, applies)
+}

--- a/pkg/iac/scanners/terraform/parser/resolvers/options.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	AllowDownloads                                                                 bool
 	SkipCache                                                                      bool
 	RelativePath                                                                   string
+	CacheDir                                                                       string
 }
 
 func (o *Options) hasPrefix(prefixes ...string) bool {

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry.go
@@ -45,7 +45,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 	}
 
 	inputVersion := opt.Version
-	source, relativePath, _ := strings.Cut(opt.Source, "//")
+	source := removeSubdirFromSource(opt.Source)
 	parts := strings.Split(source, "/")
 	if len(parts) < 3 || len(parts) > 4 {
 		return
@@ -146,7 +146,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 	}
 
 	opt.Debug("Module '%s' resolved via registry to new source: '%s'", opt.Name, opt.Source)
-	opt.RelativePath = relativePath
+
 	filesystem, prefix, downloadPath, _, err = Remote.Resolve(ctx, target, opt)
 	if err != nil {
 		return nil, "", "", true, err

--- a/pkg/iac/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/remote.go
@@ -38,10 +38,11 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 		return nil, "", "", false, nil
 	}
 
-	key := cacheKey(opt.OriginalSource, opt.OriginalVersion, opt.RelativePath)
+	src := removeSubdirFromSource(opt.OriginalSource)
+	key := cacheKey(src, opt.OriginalVersion)
 	opt.Debug("Storing with cache key %s", key)
 
-	baseCacheDir, err := locateCacheDir()
+	baseCacheDir, err := locateCacheDir(opt.CacheDir)
 	if err != nil {
 		return nil, "", "", true, fmt.Errorf("failed to locate cache directory: %w", err)
 	}

--- a/pkg/iac/scanners/terraform/parser/resolvers/source.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/source.go
@@ -1,0 +1,36 @@
+package resolvers
+
+import "strings"
+
+func removeSubdirFromSource(src string) string {
+	stop := len(src)
+	if idx := strings.Index(src, "?"); idx > -1 {
+		stop = idx
+	}
+
+	// Calculate an offset to avoid accidentally marking the scheme
+	// as the dir.
+	var offset int
+	if idx := strings.Index(src[:stop], "://"); idx > -1 {
+		offset = idx + 3
+	}
+
+	// First see if we even have an explicit subdir
+	idx := strings.Index(src[offset:stop], "//")
+	if idx == -1 {
+		return src
+	}
+
+	idx += offset
+	subdir := src[idx+2:]
+	src = src[:idx]
+
+	// Next, check if we have query parameters and push them onto the
+	// URL.
+	if idx = strings.Index(subdir, "?"); idx > -1 {
+		query := subdir[idx:]
+		src += query
+	}
+
+	return src
+}

--- a/pkg/iac/scanners/terraform/parser/resolvers/source_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/source_test.go
@@ -1,0 +1,44 @@
+package resolvers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveSubdirFromSource(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name:     "address with scheme and query string",
+			source:   "git::https://github.com/aquasecurity/terraform-modules.git//modules/ecs-service?ref=v0.1.0",
+			expected: "git::https://github.com/aquasecurity/terraform-modules.git?ref=v0.1.0",
+		},
+		{
+			name:     "address with scheme",
+			source:   "git::https://github.com/aquasecurity/terraform-modules.git//modules/ecs-service",
+			expected: "git::https://github.com/aquasecurity/terraform-modules.git",
+		},
+		{
+			name:     "registry address",
+			source:   "hashicorp/consul/aws//modules/consul-cluster",
+			expected: "hashicorp/consul/aws",
+		},
+		{
+			name:     "without subdir",
+			source:   `hashicorp/consul/aws`,
+			expected: `hashicorp/consul/aws`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := removeSubdirFromSource(test.source)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Modules are saved and retrieved from the cache by a key, which is built from the module source and version. But when caching a module from a package subdirectory, the relative path of that module is added to the key, which is not taken into account when loading the module from the cache. This leads to two problems:
- The cache is bloated because a separate directory is created for each module in the package that contains the entire package. For example, two directories would be created for `terraform-aws-modules/s3-bucket/aws//modules/object` and `terraform-aws-modules/s3-bucket/aws//modules/object`, each containing a `terraform-aws-modules/s3-bucket/aws` module.
- Trivy does not load modules from the cache that are in subdirectories, such as `terraform-aws-modules/s3-bucket/aws//modules/object`.

This PR removes subdirectories from the module source when creating a key, since the package is cached completely.

[Doc](https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories):
> Terraform will still extract the entire package to local disk, but will read the module from the subdirectory. As a result, it is safe for a module in a sub-directory of a package to use [a local path](https://developer.hashicorp.com/terraform/language/modules/sources#local-paths) to another module as long as it is in the same package.

Steps to reproduce:
```sh
❯ rm -rf $TMPDIR/.aqua
❯ cat main.tf
module "object" {
  source = "terraform-aws-modules/s3-bucket/aws//modules/object"
  version = "4.1.2"
}

module "notification" {
  source = "terraform-aws-modules/s3-bucket/aws//modules/notification"
  version = "4.1.2"
}% 
❯ trivy conf -d .
...
2024-05-29T18:41:04+07:00       DEBUG    [misconf] 41:04.727053000 terraform.parser.<root>.evaluator.resolver Downloading git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket?ref=8a0b697adfbc673e6135c70246cff7f8052ad95a...
2024-05-29T18:41:06+07:00       DEBUG    [misconf] 41:06.590482000 terraform.parser.<root>.evaluator.resolver Incrementing the download counter
2024-05-29T18:41:06+07:00       DEBUG    [misconf] 41:06.590545000 terraform.parser.<root>.evaluator.resolver Download counter is now 1
2024-05-29T18:41:06+07:00       DEBUG    [misconf] 41:06.590557000 terraform.parser.<root>.evaluator.resolver Successfully downloaded module.notification from git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket?ref=8a0b697adfbc673e6135c70246cff7f8052ad95a
...
2024-05-29T18:41:06+07:00       DEBUG    [misconf] 41:06.815826000 terraform.parser.<root>.evaluator.resolver Downloading git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket?ref=8a0b697adfbc673e6135c70246cff7f8052ad95a...
2024-05-29T18:41:08+07:00       DEBUG    [misconf] 41:08.477748000 terraform.parser.<root>.evaluator.resolver Incrementing the download counter
2024-05-29T18:41:08+07:00       DEBUG    [misconf] 41:08.477798000 terraform.parser.<root>.evaluator.resolver Download counter is now 2
2024-05-29T18:41:08+07:00       DEBUG    [misconf] 41:08.477811000 terraform.parser.<root>.evaluator.resolver Successfully downloaded module.object from git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket?ref=8a0b697adfbc673e6135c70246cff7f8052ad95a
...
❯ ll $TMPDIR/.aqua/cache/
total 0
drwxr-xr-x  19 tososomaru  staff   608B 29 май 18:41 979bacd596feccb476850d8603ea9fdb
drwxr-xr-x  19 tososomaru  staff   608B 29 май 18:41 b61a3243ae53f2bd060603f7a03bb76d
❯ cat $TMPDIR/.aqua/cache/979bacd596feccb476850d8603ea9fdb/README.md |grep "AWS S3 bucket Terraform module"
# AWS S3 bucket Terraform module
❯ cat $TMPDIR/.aqua/cache/b61a3243ae53f2bd060603f7a03bb76d/README.md |grep "AWS S3 bucket Terraform module"
# AWS S3 bucket Terraform module
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
