### PR TITLE
docs: add more workarounds for out-of-disk

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -154,13 +154,35 @@ $ TMPDIR=/my/custom/path trivy repo ...
     write /tmp/fanal-3323732142: no space left on device
     ```
 
-Trivy uses the `/tmp` directory during image scan, if the image is large or `/tmp` is of insufficient size then the scan fails You can set the `TMPDIR` environment variable to use redirect trivy to use a directory with adequate storage.
+Trivy uses the `$TMPDIR` directory during image scans.
+If the image is large or `$TMPDIR` has insufficient space, the scan will fail.
+You can set the `$TMPDIR` environment variable to redirect Trivy to a directory with adequate storage.
 
 Try:
 
 ```
 $ TMPDIR=/my/custom/path trivy image ...
 ```
+
+When scanning images from a container registry, Trivy processes each layer by streaming, loading only the necessary files for the scan into memory and discarding unnecessary files.
+If a layer contains large files that are necessary for the scan (such as JAR files or binary files), Trivy saves them to a temporary directory ($TMPDIR) on local storage to avoid increased memory consumption.
+Although these files are deleted after the scan is complete, they can temporarily increase disk consumption and potentially exhaust storage.
+In such cases, there are currently three workarounds:
+
+1. Specify `$TMPDIR` with sufficient capacity
+ 
+    This is the same as explained above.
+ 
+2. Specify a small value for `--parallel`
+ 
+    By default, multiple layers are processed in parallel.
+    If each layer contains large files, disk space may be consumed rapidly.
+    By specifying a small value such as `--parallel 1`, parallelism is reduced, which can mitigate the issue.
+
+3. Specify `--skip-files` or `--skip-dirs`
+ 
+    If the container image contains large files that do not need to be scanned, you can skip their processing by specifying --skip-files or --skip-dirs. 
+    For more details, please refer to [this documentation](../configuration/skipping.md).
 
 ## DB
 ### Old DB schema

--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -160,6 +160,8 @@ The directory path would be determined as follows:
 - On Unix systems: Use `$TMPDIR` if non-empty, else `/tmp`.
 - On Windows: Uses GetTempPath, returning the first non-empty value from `%TMP%`, `%TEMP%`, `%USERPROFILE%`, or the Windows directory.
 
+See [this documentation](https://golang.org/pkg/os/#TempDir) for more details.
+
 If the image is large or the temporary directory has insufficient space, the scan will fail.
 You can configure the directory path to redirect Trivy to a directory with adequate storage.
 On Unix systems, you can set the `$TMPDIR` environment variable.

--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -154,22 +154,26 @@ $ TMPDIR=/my/custom/path trivy repo ...
     write /tmp/fanal-3323732142: no space left on device
     ```
 
-Trivy uses the `$TMPDIR` directory during image scans.
-If the image is large or `$TMPDIR` has insufficient space, the scan will fail.
-You can set the `$TMPDIR` environment variable to redirect Trivy to a directory with adequate storage.
+Trivy uses a temporary directory during image scans.
+The directory path would be determined as follows:
 
-Try:
+- On Unix systems: Use `$TMPDIR` if non-empty, else `/tmp`.
+- On Windows: Uses GetTempPath, returning the first non-empty value from `%TMP%`, `%TEMP%`, `%USERPROFILE%`, or the Windows directory.
+
+If the image is large or the temporary directory has insufficient space, the scan will fail.
+You can configure the directory path to redirect Trivy to a directory with adequate storage.
+On Unix systems, you can set the `$TMPDIR` environment variable.
 
 ```
 $ TMPDIR=/my/custom/path trivy image ...
 ```
 
 When scanning images from a container registry, Trivy processes each layer by streaming, loading only the necessary files for the scan into memory and discarding unnecessary files.
-If a layer contains large files that are necessary for the scan (such as JAR files or binary files), Trivy saves them to a temporary directory ($TMPDIR) on local storage to avoid increased memory consumption.
+If a layer contains large files that are necessary for the scan (such as JAR files or binary files), Trivy saves them to a temporary directory (e.g. $TMPDIR) on local storage to avoid increased memory consumption.
 Although these files are deleted after the scan is complete, they can temporarily increase disk consumption and potentially exhaust storage.
 In such cases, there are currently three workarounds:
 
-1. Specify `$TMPDIR` with sufficient capacity
+1. Use a temporary directory with sufficient capacity
  
     This is the same as explained above.
  


### PR DESCRIPTION
## Description
Add several workarounds besides `$TMPDIR` with a large capacity,

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
