### PR TITLE
docs(julia): add scanner table

### DIFF
--- a/docs/docs/coverage/language/julia.md
+++ b/docs/docs/coverage/language/julia.md
@@ -3,6 +3,12 @@
 ## Features
 
 Trivy supports [Pkg.jl](https://pkgdocs.julialang.org/v1/), which is the Julia package manager.
+The following scanners are supported.
+
+| Package manager | SBOM | Vulnerability | License |
+|-----------------|:----:|:-------------:|:-------:|
+| Pkg.jl          |  ✓   |       -       |    -    |
+
 The following table provides an outline of the features Trivy offers.
 
 | Package manager | File          | Transitive dependencies | Dev dependencies | License | Dependency graph | Position |


### PR DESCRIPTION
## Description
Add a missing table of supported scanners.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/5635

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
