### PR TITLE
fix(cli): always output fatal errors to stderr

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -67,7 +67,8 @@ func Errorf(format string, args ...any) { slog.Default().Error(fmt.Sprintf(forma
 
 // Fatal for logging fatal errors
 func Fatal(msg string, args ...any) {
-	slog.Default().Log(context.Background(), LevelFatal, msg, args...)
+	// Fatal errors should be logged to stderr even if the logger is disabled.
+	New(NewHandler(os.Stderr, &Options{})).Log(context.Background(), LevelFatal, msg, args...)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
## Description
`--quiet` currently suppresses even fatal errors.

### Before

```
$ trivy image unknown --quiet 
```

### After

```
$ trivy image unknown --quiet
2024-05-30T16:16:14+04:00        FATAL   Fatal error     image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: unable to find the specified image "unknown" in ["docker" "containerd" "podman" "remote"]: 4 errors occurred:
        * docker error: unable to inspect the image (unknown): Error response from daemon: No such image: unknown:latest
        * containerd error: containerd socket not found: /run/containerd/containerd.sock
        * podman error: unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
        * remote error: GET https://index.docker.io/v2/library/unknown/manifests/latest: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:library/unknown Type:repository]]
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
