### PR TITLE
fix(misconf): parsing numbers without fraction as int

### DIFF
--- a/pkg/iac/scanners/cloudformation/parser/intrinsics.go
+++ b/pkg/iac/scanners/cloudformation/parser/intrinsics.go
@@ -100,7 +100,7 @@ func getIntrinsicTag(tag string) string {
 	}
 }
 
-func abortIntrinsic(property *Property, msg string, components ...string) (*Property, bool) {
+func abortIntrinsic(property *Property, _ string, _ ...string) (*Property, bool) {
 	//
 	return property, false
 }

--- a/pkg/iac/scanners/cloudformation/parser/parameter.go
+++ b/pkg/iac/scanners/cloudformation/parser/parameter.go
@@ -27,7 +27,24 @@ func (p *Parameter) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func (p *Parameter) UnmarshalJSONWithMetadata(node jfather.Node) error {
-	return node.Decode(&p.inner)
+
+	var inner parameterInner
+
+	if err := node.Decode(&inner); err != nil {
+		return err
+	}
+
+	// jfather parses Number without fraction as int64
+	// https://github.com/liamg/jfather/blob/4ef05d70c05af167226d3333a4ec7d8ac3c9c281/parse_number.go#L33-L42
+	switch v := inner.Default.(type) {
+	case int64:
+		inner.Default = int(v)
+	default:
+		inner.Default = v
+	}
+
+	p.inner = inner
+	return nil
 }
 
 func (p *Parameter) Type() cftypes.CfType {

--- a/pkg/iac/scanners/cloudformation/parser/util.go
+++ b/pkg/iac/scanners/cloudformation/parser/util.go
@@ -13,10 +13,20 @@ import (
 func setPropertyValueFromJson(node jfather.Node, propertyData *PropertyInner) error {
 
 	switch node.Kind() {
-
 	case jfather.KindNumber:
-		propertyData.Type = cftypes.Float64
-		return node.Decode(&propertyData.Value)
+		var val any
+		if err := node.Decode(&val); err != nil {
+			return err
+		}
+		switch v := val.(type) {
+		case float64:
+			propertyData.Type = cftypes.Float64
+			propertyData.Value = v
+		case int64:
+			propertyData.Type = cftypes.Int
+			propertyData.Value = int(v)
+		}
+		return nil
 	case jfather.KindBoolean:
 		propertyData.Type = cftypes.Bool
 		return node.Decode(&propertyData.Value)


### PR DESCRIPTION
## Description

`jfather` parses Number without fractional part as int64, but in our types we use int, which causes type casting error.

```json
{
    "AWSTemplateFormatVersion": "2010-09-09",
    "Parameters": {
        "ContainerMemory": {
            "Type": "Number",
            "Default": 512
        }
    },
    "Resources": {
        "TaskDefinition": {
            "Type": "AWS::ECS::TaskDefinition",
            "Properties": {
                "ContainerDefinitions": [
                    {
                        "Memory": {
                            "Ref": "ContainerMemory"
                        }
                    }
                ]
            }
        }
    }
}

```

```sh
trivy conf -d /Users/nikita/projects/aws-cloudformation-templates/ECS/FargateLaunchType/services/private-subnet-private-service.json
2024-05-31T22:01:39+07:00       DEBUG   Parsed severities       severities=[UNKNOWN LOW MEDIUM HIGH CRITICAL]
2024-05-31T22:01:39+07:00       DEBUG   Cache dir       dir="/Users/nikita/Library/Caches/trivy"
2024-05-31T22:01:39+07:00       INFO    Misconfiguration scanning is enabled
2024-05-31T22:01:39+07:00       DEBUG   Policies successfully loaded from disk
2024-05-31T22:01:39+07:00       DEBUG   Enabling misconfiguration scanners      scanners=[azure-arm cloudformation dockerfile helm kubernetes terraform terraformplan-json terraformplan-snapshot]
2024-05-31T22:01:39+07:00       DEBUG   Scanning files for misconfigurations... scanner="CloudFormation"
2024-05-31T22:01:39+07:00       DEBUG   [misconf] 01:39.922532000 cloudformation.scanner.rego      Overriding filesystem for checks!
2024-05-31T22:01:39+07:00       DEBUG   [misconf] 01:39.923069000 cloudformation.scanner.rego      Loaded 3 embedded libraries.
2024-05-31T22:01:39+07:00       DEBUG   [misconf] 01:39.950123000 cloudformation.scanner.rego      Loaded 191 embedded policies.
2024-05-31T22:01:39+07:00       DEBUG   [misconf] 01:39.987149000 cloudformation.scanner.rego      Loaded 194 policies from disk.
2024-05-31T22:01:39+07:00       DEBUG   [misconf] 01:39.987436000 cloudformation.scanner.rego      Overriding filesystem for data!
2024-05-31T22:01:40+07:00       DEBUG   [misconf] 01:40.037709000 cloudformation.scanner.rego      Error occurred while parsing: Users/nikita/Library/Caches/trivy/policy/content/policies/docker/policies/update_instruction_alone.rego, Users/nikita/Library/Caches/trivy/policy/content/policies/docker/policies/update_instruction_alone.rego:48: rego_type_error: undefined function sh.parse_commands. Trying to fallback to embedded check.
2024-05-31T22:01:40+07:00       DEBUG   [misconf] 01:40.037922000 cloudformation.scanner.rego      Found embedded check: checks/docker/update_instruction_alone.rego
2024-05-31T22:01:40+07:00       DEBUG   [misconf] 01:40.037929000 cloudformation.scanner.rego      Error occurred while parsing: Users/nikita/Library/Caches/trivy/policy/content/policies/docker/policies/yum_clean_all_missing.rego, Users/nikita/Library/Caches/trivy/policy/content/policies/docker/policies/yum_clean_all_missing.rego:27: rego_type_error: undefined function sh.parse_commands. Trying to fallback to embedded check.
2024-05-31T22:01:40+07:00       DEBUG   [misconf] 01:40.038135000 cloudformation.scanner.rego      Found embedded check: checks/docker/yum_clean_all_missing.rego
panic: interface conversion: interface {} is int64, not int

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).AsInt(0x140036be7e0)
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property_helpers.go:116 +0x1cc
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).AsInt(0x14003243c20)
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property_helpers.go:105 +0x1a0
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).AsIntValue(0x14003243c20)
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property_helpers.go:123 +0x2a0
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).GetIntProperty(0x140032439e0, {0x106521795?, 0x106517f54?}, {0x0?, 0x0?, 0x14002201700?})
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property.go:216 +0x2ec
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation/aws/ecs.getContainerDefinitions(0x140011f9c20)
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/aws/ecs/task_definition.go:49 +0x470
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation/aws/ecs.getTaskDefinitions({{0x14002f66f30, 0x23}, {0x14002c92000, 0x18, 0x18}, {0x106514bc7, 0x4}, {0x0, 0x0, 0x0}, ...})
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/aws/ecs/task_definition.go:14 +0x174
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation/aws/ecs.Adapt({{0x14002f66f30, 0x23}, {0x14002c92000, 0x18, 0x18}, {0x106514bc7, 0x4}, {0x0, 0x0, 0x0}, ...})
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/aws/ecs/ecs.go:12 +0xfc
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation/aws.Adapt({{_, _}, {_, _, _}, {_, _}, {_, _, _}, ...})
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/aws/adapt.go:53 +0x6d0
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation.Adapt(...)
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/adapt.go:12
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation.(*Scanner).scanFileContext(0x140034628f0, {0x1090bd5f0, 0x14001237810}, 0x14000a37e60, 0x14001221400, {0x10900d6c0, 0x14000e67560})
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/scanner.go:210 +0xe0
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation.(*Scanner).ScanFS(0x140034628f0, {0x1090bd5f0, 0x14001237810}, {0x10900d6c0, 0x14000e67560}, {0x107c96ba0?, 0x14003a68908?})
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/scanner.go:173 +0x124
github.com/aquasecurity/trivy/pkg/misconf.(*Scanner).Scan(0x140026b34d0, {0x1090bd5f0, 0x14001237810}, {0x10900d6c0?, 0x14000e67488?})
        /home/runner/work/trivy/trivy/pkg/misconf/scanner.go:157 +0x1bc
github.com/aquasecurity/trivy/pkg/fanal/analyzer/config.(*Analyzer).PostAnalyze(0x14003471f40, {0x1090bd5f0?, 0x14001237810?}, {{0x10900d6c0?, 0x14000e67488?}, {0xe?, 0x0?}})
        /home/runner/work/trivy/trivy/pkg/fanal/analyzer/config/config.go:45 +0x38
github.com/aquasecurity/trivy/pkg/fanal/analyzer.AnalyzerGroup.PostAnalyze({0x14003590860, {0x1400313b680, 0x3, 0x4}, {0x14000e47800, 0x8, 0x8}, 0x14003846b10}, {0x1090bd5f0, 0x14001237810}, ...)
        /home/runner/work/trivy/trivy/pkg/fanal/analyzer/analyzer.go:493 +0x228
github.com/aquasecurity/trivy/pkg/fanal/artifact/local.Artifact.Inspect({{0x16f9aaade, 0x76}, {0x134421a90, 0x14003590330}, {0x10900d600, 0x10ca35b60}, {0x14003590860, {0x1400313b680, 0x3, 0x4}, ...}, ...}, ...)
        /home/runner/work/trivy/trivy/pkg/fanal/artifact/local/fs.go:120 +0x37c
github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact({{_, _}, {_, _}}, {_, _}, {{0x0, 0x0, 0x0}, {0x14003590210, ...}, ...})
        /home/runner/work/trivy/trivy/pkg/scanner/scan.go:146 +0xa4
github.com/aquasecurity/trivy/pkg/commands/artifact.scan({_, _}, {{{0x10653b08b, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, {0x140006434d0, ...}, ...}, ...}, ...)
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:691 +0x32c
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact(_, {_, _}, {{{0x10653b08b, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...}, ...)
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:264 +0xa8
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanFS(_, {_, _}, {{{0x10653b08b, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...})
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:212 +0xac
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).ScanFilesystem(_, {_, _}, {{{0x10653b08b, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...})
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:192 +0x1b8
github.com/aquasecurity/trivy/pkg/commands/artifact.Run({_, _}, {{{0x10653b08b, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, {0x140006434d0, ...}, ...}, ...}, ...)
        /home/runner/work/trivy/trivy/pkg/commands/artifact/run.go:425 +0x408
github.com/aquasecurity/trivy/pkg/commands.NewConfigCommand.func2(0x1400061f208, {0x140035faee0, 0x1, 0x2})
        /home/runner/work/trivy/trivy/pkg/commands/app.go:699 +0x294
github.com/spf13/cobra.(*Command).execute(0x1400061f208, {0x140035faec0, 0x2, 0x2})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14000b47508)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(0x1065a3ed5?)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
main.run()
        /home/runner/work/trivy/trivy/cmd/trivy/main.go:41 +0x158
main.main()
        /home/runner/work/trivy/trivy/cmd/trivy/main.go:19 +0x20
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
