### PR TITLE
fix(plugin): initialize logger

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -28,7 +28,8 @@ func main() {
 func run() error {
 	// Trivy behaves as the specified plugin.
 	if runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN"); runAsPlugin != "" {
-		if err := plugin.RunWithURL(context.Background(), runAsPlugin, plugin.Options{Args: os.Args[1:]}); err != nil {
+		log.InitLogger(false, false)
+		if err := plugin.Run(context.Background(), runAsPlugin, plugin.Options{Args: os.Args[1:]}); err != nil {
 			return xerrors.Errorf("plugin error: %w", err)
 		}
 		return nil

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -799,7 +799,7 @@ func NewPluginCommand() *cobra.Command {
 			Short:                 "Run a plugin on the fly",
 			Args:                  cobra.MinimumNArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return plugin.RunWithURL(cmd.Context(), args[0], plugin.Options{Args: args[1:]})
+				return plugin.Run(cmd.Context(), args[0], plugin.Options{Args: args[1:]})
 			},
 		},
 		&cobra.Command{

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -84,8 +84,8 @@ func Install(ctx context.Context, name string, opts Options) (Plugin, error) {
 func Start(ctx context.Context, name string, opts Options) (Wait, error) {
 	return defaultManager().Start(ctx, name, opts)
 }
-func RunWithURL(ctx context.Context, name string, opts Options) error {
-	return defaultManager().RunWithURL(ctx, name, opts)
+func Run(ctx context.Context, name string, opts Options) error {
+	return defaultManager().Run(ctx, name, opts)
 }
 func Upgrade(ctx context.Context, names []string) error { return defaultManager().Upgrade(ctx, names) }
 func Uninstall(ctx context.Context, name string) error  { return defaultManager().Uninstall(ctx, name) }
@@ -291,8 +291,8 @@ func (m *Manager) Start(ctx context.Context, name string, opts Options) (Wait, e
 	return wait, nil
 }
 
-// RunWithURL runs the plugin
-func (m *Manager) RunWithURL(ctx context.Context, name string, opts Options) error {
+// Run installs and runs the plugin
+func (m *Manager) Run(ctx context.Context, name string, opts Options) error {
 	plugin, err := m.Install(ctx, name, opts)
 	if err != nil {
 		return xerrors.Errorf("plugin install error: %w", err)


### PR DESCRIPTION
## Description
Need to initialize a logger before running a plugin. Also, renamed `RunWithURL` with `Run` as it also takes a plugin name as an argument now.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
