### PR TITLE
chore(misconf): remove recursion from the cloud schema

### DIFF
--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -2334,13 +2334,6 @@
             "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.aws.iam.AccessKey"
           }
         },
-        "groups": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.aws.iam.Group"
-          }
-        },
         "lastaccess": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.TimeValue"
@@ -5643,13 +5636,6 @@
           "items": {
             "type": "object",
             "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Binding"
-          }
-        },
-        "folders": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Folder"
           }
         },
         "members": {


### PR DESCRIPTION
## Description

Rego does not support recursion, so we can break recursion in the schema to avoid panic and allow the schema to be used in testing.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/5866

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
