### PR TITLE
fix(python): compare pkg names from `poetry.lock` and `pyproject.toml` in lowercase

### DIFF
--- a/pkg/dependency/parser/python/poetry/parse.go
+++ b/pkg/dependency/parser/python/poetry/parse.go
@@ -105,7 +105,7 @@ func (p *Parser) parseDependencies(deps map[string]any, pkgVersions map[string][
 }
 
 func (p *Parser) parseDependency(name string, versRange any, pkgVersions map[string][]string) (string, error) {
-	name = normalizePkgName(name)
+	name = NormalizePkgName(name)
 	vers, ok := pkgVersions[name]
 	if !ok {
 		return "", xerrors.Errorf("no version found for %q", name)
@@ -149,9 +149,11 @@ func matchVersion(currentVersion, constraint string) (bool, error) {
 	return c.Check(v), nil
 }
 
-func normalizePkgName(name string) string {
+// NormalizePkgName normalizes the package name based on pep-0426
+func NormalizePkgName(name string) string {
 	// The package names don't use `_`, `.` or upper case, but dependency names can contain them.
 	// We need to normalize those names.
+	// cf. https://peps.python.org/pep-0426/#name
 	name = strings.ToLower(name)              // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L819
 	name = strings.ReplaceAll(name, "_", "-") // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L50
 	name = strings.ReplaceAll(name, ".", "-") // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L816

--- a/pkg/fanal/analyzer/language/python/poetry/testdata/happy/pyproject.toml
+++ b/pkg/fanal/analyzer/language/python/poetry/testdata/happy/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Trivy"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-flask = "^1.0"
+Flask = "^1.0"
 requests = {version = "2.28.1", optional = true}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Description
There are cases where package names from `poetry.lock` and `pyproject.toml` use different case.
e.g. `pyproject.toml` uses `Flask`, but `poetry.lock` uses `flask`
So we need to compare lowercase package names.

## Related issues
- Close #6817

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
