### PR TITLE
fix(nodejs): fix infinite loop when package link from `package-lock.json` file is broken

### DIFF
--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -194,9 +194,16 @@ func (p *Parser) parseV2(packages map[string]Package) ([]ftypes.Package, []ftype
 // node_modules/func1 -> link to target
 // see `package-lock_v3_with_workspace.json` to better understanding
 func (p *Parser) resolveLinks(packages map[string]Package) {
-	links := lo.PickBy(packages, func(_ string, pkg Package) bool {
-		// Checking pkg.Resolved is necessary to avoid memory leaks for corrupt package-lock.json files
-		return pkg.Link && pkg.Resolved != ""
+	links := lo.PickBy(packages, func(pkgPath string, pkg Package) bool {
+		if !pkg.Link {
+			return false
+		}
+		if pkg.Resolved == "" {
+			p.logger.Warn("`package-lock.json` contains broken link with empty `resolved` field. This package will be skipped to avoid receiving an empty package", log.String("pkg", pkgPath))
+			delete(packages, pkgPath)
+			return false
+		}
+		return true
 	})
 	// Early return
 	if len(links) == 0 {

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -216,7 +216,8 @@ func (p *Parser) resolveLinks(packages map[string]Package) {
 	}
 
 	workspaces := rootPkg.Workspaces
-	// Clone packages to avoid cases when we check already updated packages
+	// Changing the map during the map iteration causes unexpected behavior,
+	// so we need to iterate over the cloned `packages` map, but change the original `packages` map.
 	for pkgPath, pkg := range maps.Clone(packages) {
 		for linkPath, link := range links {
 			if !strings.HasPrefix(pkgPath, link.Resolved) {

--- a/pkg/dependency/parser/nodejs/npm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_test.go
@@ -53,6 +53,12 @@ func TestParse(t *testing.T) {
 			want:     npmV3WithoutRootDepsField,
 			wantDeps: npmV3WithoutRootDepsFieldDeps,
 		},
+		{
+			name:     "lock version v3 with broken link",
+			file:     "testdata/package-lock_v3_broken_link.json",
+			want:     nil,
+			wantDeps: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_broken_link.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_broken_link.json
@@ -1,0 +1,24 @@
+{
+  "name": "node_v3_without_direct_deps",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_v3_without_direct_deps",
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "functions/func1": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^2.6.9"
+      }
+    },
+    "node_modules/func1": {
+      "resolved": "",
+      "link": true
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR fixes 2 cases:
1. When `Packages[x].resolved` is empty for link - we don't need to resolve this link.
2. Don't overwrite `packages` map when resolving links to avoid cases when we updated package is parsed.

## Related issues
- Close #6854


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
