### PR TITLE
ci: create release branch

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,12 +55,29 @@ jobs:
         if: ${{ steps.extract_info.outputs.version }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ORG_REPO_TOKEN }}
+          github-token: ${{ secrets.ORG_REPO_TOKEN }} # To trigger another workflow
           script: |
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `refs/tags/v${{ steps.extract_info.outputs.version }}`,
+              sha: context.sha
+            });
+
+      # When v0.50.0 is released, a release branch "release/v0.50" is created.
+      - name: Create release branch for patch versions
+        if: ${{ endsWith(steps.extract_info.outputs.version, '.0') }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Should not trigger the workflow again
+          script: |
+            const version = '${{ steps.extract_info.outputs.version }}';
+            const minorVersion = version.slice(0, version.lastIndexOf('.'));
+            const releaseBranch = `release/v${minorVersion}`;
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${releaseBranch}`,
               sha: context.sha
             });
 
@@ -71,7 +88,7 @@ jobs:
         if: ${{ steps.extract_info.outputs.pr_number }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.ORG_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const prNumber = parseInt('${{ steps.extract_info.outputs.pr_number }}', 10);
             github.rest.issues.removeLabel({


### PR DESCRIPTION
## Description
Automatically create a release branch `release/vX.Y` when `vX.Y.0` is released. This branch is for patch versions, such as `vX.Y.1` and `vX.Y.2`.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/6781

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
