### PR TITLE
fix(sbom): don't overwrite `srcEpoch` when decoding SBOM files

### DIFF
--- a/pkg/sbom/io/decode.go
+++ b/pkg/sbom/io/decode.go
@@ -2,7 +2,6 @@ package io
 
 import (
 	"errors"
-	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -201,9 +200,6 @@ func (m *Decoder) decodeLibrary(c *core.Component) (*ftypes.Package, error) {
 	pkg.Name = m.pkgName(pkg, c)
 	pkg.ID = dependency.ID(p.LangType(), pkg.Name, p.Version) // Re-generate ID with the updated name
 
-	if pkg.Name == "bsdutils" {
-		fmt.Println()
-	}
 	var err error
 	for _, prop := range c.Properties {
 		switch prop.Name {

--- a/pkg/sbom/io/decode.go
+++ b/pkg/sbom/io/decode.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -200,6 +201,9 @@ func (m *Decoder) decodeLibrary(c *core.Component) (*ftypes.Package, error) {
 	pkg.Name = m.pkgName(pkg, c)
 	pkg.ID = dependency.ID(p.LangType(), pkg.Name, p.Version) // Re-generate ID with the updated name
 
+	if pkg.Name == "bsdutils" {
+		fmt.Println()
+	}
 	var err error
 	for _, prop := range c.Properties {
 		switch prop.Name {
@@ -270,6 +274,11 @@ func (m *Decoder) fillSrcPkg(c *core.Component, pkg *ftypes.Package) {
 		pkg.SrcName = c.SrcName
 	}
 	m.parseSrcVersion(pkg, c.SrcVersion)
+
+	// Source info was added from component or properties
+	if pkg.SrcName != "" && pkg.SrcVersion != "" {
+		return
+	}
 
 	// Fill source package information for components in third-party SBOMs .
 	if pkg.SrcName == "" {


### PR DESCRIPTION
## Description
Trivy stores source information in `properties`.
So, we only need to overwrite the source information if `srcName` and `srcVersion` are not found (it means that we decoding  third-party SBOMs).

## Related issues
- Close #6865

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
