### PR TITLE
ci: use author permission check instead of `author_association` field for backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,13 +5,33 @@ on:
     types: [created]
 
 jobs:
+  check_permission:
+    name: Check comment author permissions
+    runs-on: ubuntu-latest
+    outputs:
+      is_maintainer: ${{ steps.check_permission.outputs.is_maintainer }}
+    steps:
+      - name: Check permission
+        id: check_permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [ "$PERMISSION" == "admin" ] || [ "$PERMISSION" == "write" ]; then
+           echo "is_maintainer=true" >> $GITHUB_OUTPUT
+          else
+           echo "is_maintainer=false" >> $GITHUB_OUTPUT
+          fi
+  
+
   backport:
     name: Backport PR
+    needs: check_permission # run this job after checking permissions
     if: |
+      needs.check_permission.outputs.is_maintainer == 'true' &&      
       github.event.issue.pull_request &&
       github.event.issue.pull_request.merged_at != null &&
-      startsWith(github.event.comment.body, '@aqua-bot backport release/') &&
-      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
+      startsWith(github.event.comment.body, '@aqua-bot backport release/')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
Due to organization visibility, the `author_association` field is always NONE for maintainers  - https://github.com/orgs/community/discussions/18690
Therefore, we need to check the permissions of the comment author to run `backport`.

Test runs:
https://github.com/aquasecurity/trivy-backport-test/pull/5#issuecomment-2153893422 + https://github.com/aquasecurity/trivy-backport-test/actions/runs/9411582941
https://github.com/aquasecurity/trivy-backport-test/pull/5#issuecomment-2153896517 + https://github.com/aquasecurity/trivy-backport-test/actions/runs/9411592649

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
