### PR TITLE
ci: bump `github.com/goreleaser/goreleaser` to `v2.0.0`

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -98,9 +98,9 @@ jobs:
           mkdir tmp    
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: v1.20.0
+          version: v2.0.0
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,7 +213,7 @@ jobs:
         fi
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v6
       with:
-        version: v1.20.0
+        version: v2.0.0
         args: build --snapshot --clean --timeout 90m ${{ steps.goreleaser_id.outputs.id }}

--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: trivy_canary_build
 builds:
   -

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: trivy
 builds:
   - id: build-linux


### PR DESCRIPTION
## Description
- Bump `goreleaser/goreleaser-action` to `v6`
- Bump `github.com/goreleaser/goreleaser` to `v2.0.0`
- Add `version` field to config files

config file validations:
```bash
➜  goreleaser check goreleaser.yml       
  • checking                                 path=goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
➜  goreleaser check goreleaser-canary.yml
  • checking                                 path=goreleaser-canary.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

## Related issues
- Close #6885

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
