### PR TITLE
feat(misconf): support of selectors for all providers for Rego

### DIFF
--- a/pkg/iac/providers/provider.go
+++ b/pkg/iac/providers/provider.go
@@ -26,6 +26,13 @@ const (
 	CloudStackProvider   Provider = "cloudstack"
 )
 
+func AllProviders() []Provider {
+	return []Provider{
+		AWSProvider, AzureProvider, DigitalOceanProvider, GitHubProvider, GoogleProvider,
+		KubernetesProvider, OracleProvider, OpenStackProvider, NifcloudProvider, CloudStackProvider,
+	}
+}
+
 func RuleProviderToString(provider Provider) string {
 	return strings.ToUpper(string(provider))
 }

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -30,14 +30,15 @@ var checkTypesWithSubtype = map[types.Source]struct{}{
 	types.SourceKubernetes: {},
 }
 
-var supportedProviders map[string]struct{}
+var supportedProviders = makeSupportedProviders()
 
-func init() {
-	supportedProviders = make(map[string]struct{})
+func makeSupportedProviders() map[string]struct{} {
+	m := make(map[string]struct{})
 	for _, p := range providers.AllProviders() {
-		supportedProviders[string(p)] = struct{}{}
+		m[string(p)] = struct{}{}
 	}
-	supportedProviders["kind"] = struct{}{} // kubernetes
+	m["kind"] = struct{}{} // kubernetes
+	return m
 }
 
 var _ options.ConfigurableScanner = (*Scanner)(nil)

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -17,11 +17,28 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/iac/debug"
 	"github.com/aquasecurity/trivy/pkg/iac/framework"
+	"github.com/aquasecurity/trivy/pkg/iac/providers"
 	"github.com/aquasecurity/trivy/pkg/iac/rego/schemas"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
+
+var checkTypesWithSubtype = map[types.Source]struct{}{
+	types.SourceCloud:      {},
+	types.SourceDefsec:     {},
+	types.SourceKubernetes: {},
+}
+
+var supportedProviders map[string]struct{}
+
+func init() {
+	supportedProviders = make(map[string]struct{})
+	for _, p := range providers.AllProviders() {
+		supportedProviders[string(p)] = struct{}{}
+	}
+	supportedProviders["kind"] = struct{}{} // kubernetes
+}
 
 var _ options.ConfigurableScanner = (*Scanner)(nil)
 
@@ -295,12 +312,8 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 }
 
 func isPolicyWithSubtype(sourceType types.Source) bool {
-	for _, s := range []types.Source{types.SourceCloud, types.SourceDefsec, types.SourceKubernetes} {
-		if sourceType == s {
-			return true
-		}
-	}
-	return false
+	_, exists := checkTypesWithSubtype[sourceType]
+	return exists
 }
 
 func checkSubtype(ii map[string]any, provider string, subTypes []SubType) bool {
@@ -311,10 +324,11 @@ func checkSubtype(ii map[string]any, provider string, subTypes []SubType) bool {
 	for _, st := range subTypes {
 		switch services := ii[provider].(type) {
 		case map[string]any:
-			for service := range services {
-				if (service == st.Service) && (st.Provider == provider) {
-					return true
-				}
+			if st.Provider != provider {
+				continue
+			}
+			if _, exists := services[st.Service]; exists {
+				return true
 			}
 		case string: // k8s - logic can be improved
 			if strings.EqualFold(services, st.Group) ||
@@ -331,8 +345,7 @@ func isPolicyApplicable(staticMetadata *StaticMetadata, inputs ...Input) bool {
 	for _, input := range inputs {
 		if ii, ok := input.Contents.(map[string]any); ok {
 			for provider := range ii {
-				// TODO(simar): Add other providers
-				if !strings.Contains(strings.Join([]string{"kind", "aws", "azure"}, ","), provider) {
+				if _, exists := supportedProviders[provider]; !exists {
 					continue
 				}
 


### PR DESCRIPTION
## Description
This will allow specifying selectors for all providers.

Fixes https://github.com/aquasecurity/trivy/issues/6911


For example:
```rego
# METADATA
# title: "Test"
# scope: package
# schemas:
# - input: schema["cloud"]
# custom:
#   id: TEST001
#   avd_id: TEST001
#   severity: LOW
#   input:
#     selector:
#     - type: cloud
#       subtypes:
#         - service: compute
#           provider: google

package user.test001

import rego.v1

deny contains res if {
    some instance in input.google.compute.instances
    instance.name.value == "my-instance"
    res := result.new("deny", instance.name)
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
