### PR TITLE
ci: don't run `tests` for `release-please` PRs

### DIFF
--- a/.github/workflows/bypass-test.yaml
+++ b/.github/workflows/bypass-test.yaml
@@ -8,14 +8,14 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'LICENSE'
-      - '.release-please-manifest.json' ## don't run tests for release-please PRs
+      - '.release-please-manifest.json'
   pull_request:
     paths:
       - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
       - 'LICENSE'
-      - '.release-please-manifest.json' ## don't run tests for release-please PRs
+      - '.release-please-manifest.json'
 jobs:
   test:
     name: Test

--- a/.github/workflows/bypass-test.yaml
+++ b/.github/workflows/bypass-test.yaml
@@ -8,12 +8,14 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'LICENSE'
+      - '.release-please-manifest.json' ## don't run tests for release-please PRs
   pull_request:
     paths:
       - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
       - 'LICENSE'
+      - '.release-please-manifest.json' ## don't run tests for release-please PRs
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,6 @@ on:
       - 'mkdocs.yml'
       - 'LICENSE'
       - '.release-please-manifest.json' ## don't run tests for release-please PRs
-      - 'CHANGELOG.md'
   merge_group:
 env:
   GO_VERSION: '1.22'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - 'LICENSE'
+      - '.release-please-manifest.json' ## don't run tests for release-please PRs
+      - 'CHANGELOG.md'
   merge_group:
 env:
   GO_VERSION: '1.22'


### PR DESCRIPTION
## Description
Release please PRs contain information only about created changes and don't affect source code.
To avoid running `tests` after every commit to `main` branch - we need to disable `tests` workflow for these PRs.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
