### PR TITLE
fix(cyclonedx): trim non-URL info for `advisory.url`

### DIFF
--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -847,8 +847,8 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 										},
 									},
 									References: []string{
-										"http://www.openwall.com/lists/oss-security/2022/02/11/5",
-										"https://access.redhat.com/security/cve/CVE-2022-23633",
+										"  extraPrefix http://www.openwall.com/lists/oss-security/2022/02/11/5",
+										"https://access.redhat.com/security/cve/CVE-2022-23633 (extra suffix)",
 									},
 									PublishedDate:    lo.ToPtr(time.Date(2022, 2, 11, 21, 15, 0, 0, time.UTC)),
 									LastModifiedDate: lo.ToPtr(time.Date(2022, 2, 22, 21, 47, 0, 0, time.UTC)),


### PR DESCRIPTION
## Description
trim non-URL info for [advisory.url](https://cyclonedx.org/docs/1.6/json/#vulnerabilities_items_advisories_items_url)
more info #6801

## Related issues
- Close #6801

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
