### PR TITLE
fix(purl): add missed os types

### DIFF
--- a/integration/testdata/mariner-1.0.json.golden
+++ b/integration/testdata/mariner-1.0.json.golden
@@ -42,7 +42,7 @@
           "VulnerabilityID": "CVE-2022-0261",
           "PkgName": "vim",
           "PkgIdentifier": {
-            "PURL": "pkg:cbl-mariner/vim@8.2.4081-1.cm1?arch=x86_64",
+            "PURL": "pkg:rpm/cbl-mariner/vim@8.2.4081-1.cm1?arch=x86_64\u0026distro=cbl-mariner-1.0.20220122",
             "UID": "3f08cd76fa5ba73d"
           },
           "InstalledVersion": "8.2.4081-1.cm1",
@@ -79,7 +79,7 @@
           "VulnerabilityID": "CVE-2022-0158",
           "PkgName": "vim",
           "PkgIdentifier": {
-            "PURL": "pkg:cbl-mariner/vim@8.2.4081-1.cm1?arch=x86_64",
+            "PURL": "pkg:rpm/cbl-mariner/vim@8.2.4081-1.cm1?arch=x86_64\u0026distro=cbl-mariner-1.0.20220122",
             "UID": "3f08cd76fa5ba73d"
           },
           "InstalledVersion": "8.2.4081-1.cm1",

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -468,13 +468,14 @@ func purlType(t ftypes.TargetType) string {
 		return packageurl.TypePub
 	case ftypes.RustBinary, ftypes.Cargo:
 		return packageurl.TypeCargo
-	case ftypes.Alpine:
+	case ftypes.Alpine, ftypes.Chainguard, ftypes.Wolfi:
 		return packageurl.TypeApk
 	case ftypes.Debian, ftypes.Ubuntu:
 		return packageurl.TypeDebian
 	case ftypes.RedHat, ftypes.CentOS, ftypes.Rocky, ftypes.Alma,
 		ftypes.Amazon, ftypes.Fedora, ftypes.Oracle, ftypes.OpenSUSE,
-		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.Photon:
+		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.Photon,
+		ftypes.CBLMariner:
 		return packageurl.TypeRPM
 	case TypeOCI:
 		return packageurl.TypeOCI


### PR DESCRIPTION
## Description
Use correct `purl` types for some OS pkgs (e.g. `pkg:cbl-mariner/bash@5.1.8-4.cm2` -> `pkg:rpm/cbl-mariner/bash@5.1.8-4.cm2`).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
