### PR TITLE
fix(suse): Add SLES 15.6 and Leap 15.6

### DIFF
--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -39,9 +39,10 @@ var (
 		"15.2": time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.3": time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.4": time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
-		"15.5": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
+		"15.5": time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC),
+		"15.6": time.Date(2031, 7, 31, 23, 59, 59, 0, time.UTC),
 		// 6 months after SLES 15 SP7 release
-		// "15.6": time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC),
+		// "15.7": time.Date(2031, 7, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{
@@ -55,6 +56,7 @@ var (
 		"15.3": time.Date(2022, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.4": time.Date(2023, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.5": time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC),
+		"15.6": time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION

## Description

There are three changes here:

* openSUSE Leap 15.6 got released and will be maintained at least until end of Dec 2025.
* SLES 15.6 is going to be announced shortly and hence the overlapping lifecycle for 15.5 shortens its lifecycle to the end of calendar year 2024.
* SLES 15 got a lifecycle extension. General support got 3 more years post-initial release added, hence end of life moves from 2028 to 2031.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
