### PR TITLE
perf(misconf): optimize work with context

### DIFF
--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -85,7 +85,7 @@ func NewBlock(hclBlock *hcl.Block, ctx *context.Context, moduleBlock *Block, par
 	}
 
 	b := Block{
-		id:           uuid.New().String(),
+		id:           uuid.NewString(),
 		context:      ctx,
 		hclBlock:     hclBlock,
 		moduleBlock:  moduleBlock,
@@ -446,6 +446,9 @@ func (b *Block) Attributes() map[string]*Attribute {
 func (b *Block) Values() cty.Value {
 	values := createPresetValues(b)
 	for _, attribute := range b.GetAttributes() {
+		if attribute.Name() == "for_each" {
+			continue
+		}
 		values[attribute.Name()] = attribute.Value()
 	}
 	return cty.ObjectVal(postProcessValues(b, values))

--- a/pkg/iac/terraform/context/context_test.go
+++ b/pkg/iac/terraform/context/context_test.go
@@ -52,6 +52,43 @@ func Test_ContextVariablesPreservation(t *testing.T) {
 
 }
 
+func Test_SetWithMerge(t *testing.T) {
+	hctx := hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"my": cty.ObjectVal(map[string]cty.Value{
+				"someValue": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("test"),
+					"bar": cty.ObjectVal(map[string]cty.Value{
+						"foo": cty.StringVal("test"),
+					}),
+				}),
+			}),
+		},
+	}
+
+	ctx := NewContext(&hctx, nil)
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		"foo2": cty.StringVal("test2"),
+		"bar": cty.ObjectVal(map[string]cty.Value{
+			"foo2": cty.StringVal("test2"),
+		}),
+	})
+
+	ctx.Set(val, "my", "someValue")
+	got := ctx.Get("my", "someValue")
+	expected := cty.ObjectVal(map[string]cty.Value{
+		"foo":  cty.StringVal("test"),
+		"foo2": cty.StringVal("test2"),
+		"bar": cty.ObjectVal(map[string]cty.Value{
+			"foo":  cty.StringVal("test"),
+			"foo2": cty.StringVal("test2"),
+		}),
+	})
+
+	assert.Equal(t, expected, got)
+}
+
 func Test_ContextVariablesPreservationByDot(t *testing.T) {
 
 	underlying := &hcl.EvalContext{}


### PR DESCRIPTION
## Description

- The `for_each` resource attribute is not added to the context because it cannot be accessed, but it can take up a lot of memory.
- If possible, use the `GetAttr` method to access `cty.Object` attributes, instead of converting the object to a map.

Unfortunately there is still the [mergeVars](https://github.com/aquasecurity/trivy/pull/6968/files#diff-8544850e0d901aac3f77abe4fb9e6e9430043f6f2dbadd5a66a79f25c4140db6L90) function, which cannot be optimised due to some limitations. Because of the [impossibility to modify](https://github.com/zclconf/go-cty/issues/57) `cty.Object` directly, it is necessary to convert `cty.Object` into a map, modify it and create the object from the map again. With a large number of resources, such actions generate a large number of objects and take a decent amount of time due to checks and conversions inside the `cty` package.

Test config:
```hcl
locals {
  team_repos = [ for i in range(1000): "repo-${i}"]
  teams = [ for i in range(10): "team-${i}"]
  repositories = merge([for team_id in local.teams : { for repo in local.team_repos : "${team_id}-${repo}" => team_id}]...)
}

resource "aws_ecr_repository" "ecr-repository" {
  for_each = local.repositories

  name                 = each.key
  image_tag_mutability = "IMMUTABLE"
  tags = {
    "Team" : each.value
  }
}
```

Before:
Memory usage is increasing, scans are not completed in a reasonable amount of time.

After:
```sh
/usr/bin/time -al ./trivy conf -q -f json -o report.json /Users/nikita/projects/trivy-test/diss-6958
       29.68 real        40.85 user         0.69 sys
          1221738496  maximum resident set size
```

## Related issues:
- Close https://github.com/aquasecurity/trivy/issues/6959

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
