### PR TITLE
fix: Add dependencyManagement exclusions to the child exclusions

### DIFF
--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -980,6 +980,52 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "exclusions in child and parent dependency management",
+			inputFile: filepath.Join("testdata", "exclusions-parent-dependency-management", "child", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:child:3.0.0",
+					Name:         "com.example:child",
+					Version:      "3.0.0",
+					Licenses:     []string{"Apache 2.0"},
+					Relationship: ftypes.RelationshipRoot,
+				},
+				{
+					ID:           "org.example:example-nested:3.3.3",
+					Name:         "org.example:example-nested",
+					Version:      "3.3.3",
+					Relationship: ftypes.RelationshipDirect,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 26,
+							EndLine:   35,
+						},
+					},
+				},
+				{
+					ID:           "org.example:example-dependency:1.2.3",
+					Name:         "org.example:example-dependency",
+					Version:      "1.2.3",
+					Relationship: ftypes.RelationshipIndirect,
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:child:3.0.0",
+					DependsOn: []string{
+						"org.example:example-nested:3.3.3",
+					},
+				},
+				{
+					ID: "org.example:example-nested:3.3.3",
+					DependsOn: []string{
+						"org.example:example-dependency:1.2.3",
+					},
+				},
+			},
+		},
+		{
 			name:      "exclusions with wildcards",
 			inputFile: filepath.Join("testdata", "wildcard-exclusions", "pom.xml"),
 			local:     true,

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -979,6 +979,14 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
+		// ➜ mvn dependency:tree
+		// ...
+		// [INFO]
+		// [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ child ---
+		// [INFO] com.example:child:jar:3.0.0
+		// [INFO] \- org.example:example-exclusions:jar:3.0.0:compile
+		// [INFO]    \- org.example:example-nested:jar:3.3.3:compile
+		// [INFO] ------------------------------------------------------------------------
 		{
 			name:      "exclusions in child and parent dependency management",
 			inputFile: filepath.Join("testdata", "exclusions-parent-dependency-management", "child", "pom.xml"),
@@ -992,9 +1000,9 @@ func TestPom_Parse(t *testing.T) {
 					Relationship: ftypes.RelationshipRoot,
 				},
 				{
-					ID:           "org.example:example-nested:3.3.3",
-					Name:         "org.example:example-nested",
-					Version:      "3.3.3",
+					ID:           "org.example:example-exclusions:3.0.0",
+					Name:         "org.example:example-exclusions",
+					Version:      "3.0.0",
 					Relationship: ftypes.RelationshipDirect,
 					Locations: ftypes.Locations{
 						{
@@ -1004,9 +1012,9 @@ func TestPom_Parse(t *testing.T) {
 					},
 				},
 				{
-					ID:           "org.example:example-dependency:1.2.3",
-					Name:         "org.example:example-dependency",
-					Version:      "1.2.3",
+					ID:           "org.example:example-nested:3.3.3",
+					Name:         "org.example:example-nested",
+					Version:      "3.3.3",
 					Relationship: ftypes.RelationshipIndirect,
 				},
 			},
@@ -1014,13 +1022,13 @@ func TestPom_Parse(t *testing.T) {
 				{
 					ID: "com.example:child:3.0.0",
 					DependsOn: []string{
-						"org.example:example-nested:3.3.3",
+						"org.example:example-exclusions:3.0.0",
 					},
 				},
 				{
-					ID: "org.example:example-nested:3.3.3",
+					ID: "org.example:example-exclusions:3.0.0",
 					DependsOn: []string{
-						"org.example:example-dependency:1.2.3",
+						"org.example:example-nested:3.3.3",
 					},
 				},
 			},

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -266,9 +266,8 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 		if !dep.Optional {
 			dep.Optional = managed.Optional
 		}
-		if len(dep.Exclusions.Exclusion) == 0 {
-			dep.Exclusions = managed.Exclusions
-		}
+		// `mvn` always merges exceptions for pom and parent
+		dep.Exclusions.Exclusion = append(dep.Exclusions.Exclusion, managed.Exclusions.Exclusion...)
 	}
 	return dep
 }

--- a/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/child/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/child/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>child</artifactId>
+    <version>3.0.0</version>
+
+    <name>child</name>
+    <description>Child</description>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example-api-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/child/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/child/pom.xml
@@ -25,11 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.example</groupId>
-            <artifactId>example-nested</artifactId>
+            <artifactId>example-exclusions</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.example</groupId>
-                    <artifactId>example-api-common</artifactId>
+                    <artifactId>example-dependency</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/pom.xml
@@ -22,12 +22,12 @@
         <dependencies>
             <dependency>
                 <groupId>org.example</groupId>
-                <artifactId>example-nested</artifactId>
-                <version>3.3.3</version>
+                <artifactId>example-exclusions</artifactId>
+                <version>3.0.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.example</groupId>
-                        <artifactId>example-api</artifactId>
+                        <artifactId>example-dependency2</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/exclusions-parent-dependency-management/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.0.0</version>
+
+    <packaging>pom</packaging>
+    <name>parent</name>
+    <description>Parent</description>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested</artifactId>
+                <version>3.3.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.example</groupId>
+                        <artifactId>example-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-exclusions/3.0.0/example-exclusions-3.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-exclusions/3.0.0/example-exclusions-3.0.0.pom
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-exclusions</artifactId>
+    <version>3.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency2</artifactId>
+            <version>2.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
I noticed that if I have a child pom with a dependency with some exclusions, and a parent pom with a dependencyManagement section with the same dependency with different exclusions, then Trivy only uses the child exclusions.

This is not the behaviour that the maven command line uses, the mvn dependency:tree combines the set of exclusions in this case.

To reproduce unzip "trivy.zip" attached and run:
```
 mvn dependency:tree | grep jettison
```
This will return nothing as jettison is excluded in the parent pom. Now run:
```
 trivy fs . | grep jettison
```
and see it returns findings in jettison even though it's not on the classpath