### PR TITLE
chore: use `!` for breaking changes

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -29,7 +29,6 @@ jobs:
             chore
             revert
             release
-            BREAKING
 
           scopes: |
             vuln

--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -185,10 +185,18 @@ others:
 
 The `<scope>` can be empty (e.g. if the change is a global or difficult to assign to a single component), in which case the parentheses are omitted.
 
+**Breaking changes**
+
+A PR, introducing a breaking API change, needs to append a `!` after the type/scope.
+
 ### Example titles
 
 ```
 feat(alma): add support for AlmaLinux
+```
+
+```
+feat(vuln)!: delete the existing CLI flag
 ```
 
 ```


### PR DESCRIPTION
## Description
For clarity, we added the type `BREAKING` to the existing type of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), but [Release Please](https://github.com/googleapis/release-please) recognizes only breaking changes indicated by the `! `.

>feat!:, or fix!:, refactor!:, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.

https://github.com/googleapis/release-please/blob/ace2bd5dc778f83c33ad5dee6807db5d0afdba36/README.md?plain=1#L52-L53

Now, it's better to follow Conventional Commits.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
