### PR TITLE
chore(k8s): enhance k8s scan log

### DIFF
--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -86,6 +86,7 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		r.flagOpts.ScanOptions.Scanners = scanners
 	}
 	var rpt report.Report
+	log.Info("Scanning K8s(nextline show the progress)...", log.String("K8s", r.cluster))
 	rpt, err = s.Scan(ctx, artifacts)
 	if err != nil {
 		return xerrors.Errorf("k8s scan error: %w", err)

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -86,7 +86,7 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		r.flagOpts.ScanOptions.Scanners = scanners
 	}
 	var rpt report.Report
-	log.Info("Scanning K8s(nextline show the progress)...", log.String("K8s", r.cluster))
+	log.Info("Scanning K8s...", log.String("K8s", r.cluster))
 	rpt, err = s.Scan(ctx, artifacts)
 	if err != nil {
 		return xerrors.Errorf("k8s scan error: %w", err)


### PR DESCRIPTION
## Description
Discussed in #6932 

In short, progress bar may lead someone(like me) confused. It show the download progress or scan image progress or scan K8s progress.

## Related issues
- Close #6996

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
