### PR TITLE
docs: Add sudo on commands, chmod before mv on install docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -165,8 +165,8 @@ The plugin used by both tools is developped [here](https://github.com/zufardhiya
 
 1. Download the file for your operating system/architecture from [GitHub Release assets](https://github.com/aquasecurity/trivy/releases/tag/{{ git.tag }}).  
 2. Unpack the downloaded archive (`tar -xzf ./trivy.tar.gz`).
-3. Put the binary somewhere in your `$PATH` (e.g `sudo mv ./trivy /usr/local/bin/`).
-4. Make sure the binary has execution bit turned on (`chmod +x ./trivy`).
+3. Make sure the binary has execution bit turned on (`chmod +x ./trivy`).
+4. Put the binary somewhere in your `$PATH` (e.g `sudo mv ./trivy /usr/local/bin/`).
 
 ### Install Script
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,7 +61,7 @@ brew install trivy
 Arch Linux Package Repository.
 
 ```bash
-pacman -S trivy
+sudo pacman -S trivy
 ```
 
 References: 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -165,7 +165,7 @@ The plugin used by both tools is developped [here](https://github.com/zufardhiya
 
 1. Download the file for your operating system/architecture from [GitHub Release assets](https://github.com/aquasecurity/trivy/releases/tag/{{ git.tag }}).  
 2. Unpack the downloaded archive (`tar -xzf ./trivy.tar.gz`).
-3. Put the binary somewhere in your `$PATH` (e.g `mv ./trivy /usr/local/bin/`).
+3. Put the binary somewhere in your `$PATH` (e.g `sudo mv ./trivy /usr/local/bin/`).
 4. Make sure the binary has execution bit turned on (`chmod +x ./trivy`).
 
 ### Install Script

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -173,7 +173,7 @@ The plugin used by both tools is developped [here](https://github.com/zufardhiya
 The process above can be automated by the following script:
 
 ```bash
-curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin {{ git.tag }}
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin {{ git.tag }}
 ```
 
 ### Install from source


### PR DESCRIPTION
## Description

This PR changes installation docs as mentioned below:
* Add sudo on pacman
* Add sudo on sh -s
* Run chmod before mv

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
