### PR TITLE
Docker build: copy repo dir error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20.0
 RUN apk --no-cache add ca-certificates git
-COPY trivy /usr/local/bin/trivy
+COPY . /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
## Description

When we build docker image from repo directory there is an errror:

```
#0 building with "default" instance using docker driver
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 182B done
#1 DONE 0.1s
#2 [internal] load metadata for docker.io/library/alpine:3.20.0
#2 DONE 1.9s
#3 [internal] load .dockerignore
#3 transferring context: 87B done
#3 DONE 0.0s
#4 [internal] load build context
#4 transferring context: 20.60kB 0.0s done
#4 DONE 0.1s
#5 [1/4] FROM docker.io/library/alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
#5 resolve docker.io/library/alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd 0.0s done
#5 sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd 1.85kB / 1.85kB done
#5 sha256:216266c86fc4dcef56930bd394245824c2af52fd21ba7c6fa0e618657d4c3b 528B / 528B done
#5 sha256:1d34ffeaf190be23d3de5a8de0a436676b758f48f835c3a2d4768b798c15a7f1 1.47kB / 1.47kB done
#5 CANCELED
#6 [2/4] RUN apk --no-cache add ca-certificates git
#6 CACHED
#7 [3/4] COPY trivy /usr/local/bin/trivy
#7 ERROR: failed to calculate checksum of ref 739e7ff0-7215-49f4-a0a7-db45724445cc::0ctst17cs2gaqf6zbimg4n6td: "/trivy": not found
------
 > [3/4] COPY trivy /usr/local/bin/trivy:
------
WARNING: buildx: git was not found in the system. Current commit information was not captured by the build
Dockerfile:3
--------------------
   1 |     FROM alpine:3..0
   2 |     RUN apk --no-cache add ca-certificates git
   3 | >>> COPY trivy /usr/local/bin/trivy
   4 |     COPY contrib/*.tpl contrib/
   5 |     ENTRYPOINT ["trivy"]
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref 739e7ff0-75-49f4-a0a7-db45724445cc::0ctst17cs2gaqf6zbimg4n6td: "/trivy": not found
```