### PR TITLE
fix(sbom): exclude duplicate vulnerabilities

### DIFF
--- a/pkg/sbom/io/encode_test.go
+++ b/pkg/sbom/io/encode_test.go
@@ -97,17 +97,55 @@ func TestEncoder_Encode(t *testing.T) {
 						Class:  types.ClassLangPkg,
 						Packages: []ftypes.Package{
 							{
-								ID:       "org.apache.xmlgraphics/batik-anim:1.9.1",
-								Name:     "org.apache.xmlgraphics/batik-anim",
-								Version:  "1.9.1",
-								FilePath: "/app/batik-anim-1.9.1.jar",
+								ID:       "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+								Name:     "com.fasterxml.jackson.core:jackson-databind",
+								Version:  "2.13.4",
+								FilePath: "/foo/jackson-databind-2.13.4.jar",
 								Identifier: ftypes.PkgIdentifier{
 									PURL: &packageurl.PackageURL{
 										Type:      packageurl.TypeMaven,
-										Namespace: "org.apache.xmlgraphics",
-										Name:      "batik-anim",
-										Version:   "1.9.1",
+										Namespace: "com.fasterxml.jackson.core",
+										Name:      "jackson-databind",
+										Version:   "2.13.4",
 									},
+								},
+							},
+							{
+								ID:       "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+								Name:     "com.fasterxml.jackson.core:jackson-databind",
+								Version:  "2.13.4",
+								FilePath: "/bar/jackson-databind-2.13.4.jar",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeMaven,
+										Namespace: "com.fasterxml.jackson.core",
+										Name:      "jackson-databind",
+										Version:   "2.13.4",
+									},
+								},
+							},
+						},
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								PkgName:          "com.fasterxml.jackson.core:jackson-databind",
+								PkgID:            "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+								VulnerabilityID:  "CVE-2022-42003",
+								InstalledVersion: "2.13.4",
+								FixedVersion:     "2.12.7.1, 2.13.4.2",
+								PkgPath:          "/foo/jackson-databind-2.13.4.jar",
+								Vulnerability: dtypes.Vulnerability{
+									Severity: "HIGH",
+								},
+							},
+							{
+								PkgName:          "com.fasterxml.jackson.core:jackson-databind",
+								PkgID:            "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+								VulnerabilityID:  "CVE-2022-42003",
+								InstalledVersion: "2.13.4",
+								FixedVersion:     "2.12.7.1, 2.13.4.2",
+								PkgPath:          "/bar/jackson-databind-2.13.4.jar",
+								Vulnerability: dtypes.Vulnerability{
+									Severity: "HIGH",
 								},
 							},
 						},
@@ -218,22 +256,22 @@ func TestEncoder_Encode(t *testing.T) {
 				},
 				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000005"): {
 					Type:    core.TypeLibrary,
-					Group:   "org.apache.xmlgraphics",
-					Name:    "batik-anim",
-					Version: "1.9.1",
+					Group:   "com.fasterxml.jackson.core",
+					Name:    "jackson-databind",
+					Version: "2.13.4",
 					Files: []core.File{
 						{
-							Path: "/app/batik-anim-1.9.1.jar",
+							Path: "/foo/jackson-databind-2.13.4.jar",
 						},
 					},
 					Properties: []core.Property{
 						{
 							Name:  core.PropertyFilePath,
-							Value: "/app/batik-anim-1.9.1.jar",
+							Value: "/foo/jackson-databind-2.13.4.jar",
 						},
 						{
 							Name:  core.PropertyPkgID,
-							Value: "org.apache.xmlgraphics/batik-anim:1.9.1",
+							Value: "com.fasterxml.jackson.core:jackson-databind:2.13.4",
 						},
 						{
 							Name:  core.PropertyPkgType,
@@ -243,11 +281,45 @@ func TestEncoder_Encode(t *testing.T) {
 					PkgIdentifier: ftypes.PkgIdentifier{
 						PURL: &packageurl.PackageURL{
 							Type:      packageurl.TypeMaven,
-							Namespace: "org.apache.xmlgraphics",
-							Name:      "batik-anim",
-							Version:   "1.9.1",
+							Namespace: "com.fasterxml.jackson.core",
+							Name:      "jackson-databind",
+							Version:   "2.13.4",
 						},
-						BOMRef: "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1",
+						BOMRef: "3ff14136-e09f-4df9-80ea-000000000005",
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000006"): {
+					Type:    core.TypeLibrary,
+					Group:   "com.fasterxml.jackson.core",
+					Name:    "jackson-databind",
+					Version: "2.13.4",
+					Files: []core.File{
+						{
+							Path: "/bar/jackson-databind-2.13.4.jar",
+						},
+					},
+					Properties: []core.Property{
+						{
+							Name:  core.PropertyFilePath,
+							Value: "/bar/jackson-databind-2.13.4.jar",
+						},
+						{
+							Name:  core.PropertyPkgID,
+							Value: "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+						},
+						{
+							Name:  core.PropertyPkgType,
+							Value: "jar",
+						},
+					},
+					PkgIdentifier: ftypes.PkgIdentifier{
+						PURL: &packageurl.PackageURL{
+							Type:      packageurl.TypeMaven,
+							Namespace: "com.fasterxml.jackson.core",
+							Name:      "jackson-databind",
+							Version:   "2.13.4",
+						},
+						BOMRef: "3ff14136-e09f-4df9-80ea-000000000006",
 					},
 				},
 			},
@@ -259,6 +331,10 @@ func TestEncoder_Encode(t *testing.T) {
 					},
 					{
 						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000005"),
+						Type:       core.RelationshipContains,
+					},
+					{
+						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000006"),
 						Type:       core.RelationshipContains,
 					},
 				},
@@ -280,6 +356,7 @@ func TestEncoder_Encode(t *testing.T) {
 					},
 				},
 				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000005"): nil,
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000006"): nil,
 			},
 			wantVulns: map[uuid.UUID][]core.Vulnerability{
 				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000004"): {
@@ -289,6 +366,30 @@ func TestEncoder_Encode(t *testing.T) {
 						PkgName:          "curl",
 						InstalledVersion: "7.50.3-1",
 						FixedVersion:     "7.50.3-1+deb9u1",
+						Vulnerability: dtypes.Vulnerability{
+							Severity: "HIGH",
+						},
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000005"): {
+					{
+						ID:               "CVE-2022-42003",
+						PkgID:            "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+						PkgName:          "com.fasterxml.jackson.core:jackson-databind",
+						InstalledVersion: "2.13.4",
+						FixedVersion:     "2.12.7.1, 2.13.4.2",
+						Vulnerability: dtypes.Vulnerability{
+							Severity: "HIGH",
+						},
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000006"): {
+					{
+						ID:               "CVE-2022-42003",
+						PkgID:            "com.fasterxml.jackson.core:jackson-databind:2.13.4",
+						PkgName:          "com.fasterxml.jackson.core:jackson-databind",
+						InstalledVersion: "2.13.4",
+						FixedVersion:     "2.12.7.1, 2.13.4.2",
 						Vulnerability: dtypes.Vulnerability{
 							Severity: "HIGH",
 						},


### PR DESCRIPTION
## Description
We [aggregated](https://github.com/aquasecurity/trivy/blob/8d618e48a2f1b60c2e4c49cdd9deb8eb45c972b0/pkg/fanal/applier/docker.go#L283-L308) `pip/gem/npm/jar/conda` packages.
Therefore, there are cases when `Result` contains the same vulnerabilities for the same packages but with different file paths.
We show duplicates in [vulnerabilities[].affects[]](https://cyclonedx.org/docs/1.6/json/#vulnerabilities_items_affects) for these cases.
But [vulnerabilities[].affects[]](https://cyclonedx.org/docs/1.6/json/#vulnerabilities_items_affects) should be uniq.
To avoid this we don't need to include vulns with same `CVE` for same `pkgID`. 

Example:
```bash
➜  tree

.
├── bar
│   └── jackson-databind-2.13.4.jar
├── foo
│   ├── bar
│   └── jackson-databind-2.13.4.jar
```

Before:
```bash
➜  trivy -q rootfs -f cyclonedx --scanners vuln . | jq '.vulnerabilities[0].affects'
[
  {
    "ref": "7d55fb4f-cd6d-426a-9103-9e3b0e784f16",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  },
  {
    "ref": "7d55fb4f-cd6d-426a-9103-9e3b0e784f16",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  },
  {
    "ref": "b8a8670f-c668-46cb-b8a4-2160040f77dd",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  },
  {
    "ref": "b8a8670f-c668-46cb-b8a4-2160040f77dd",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  }
]

```
after:
```bash
➜  ./trivy -q rootfs -f cyclonedx --scanners vuln . | jq '.vulnerabilities[0].affects'
[
  {
    "ref": "5ced2014-adb3-4bae-a81d-64a767c5de81",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  },
  {
    "ref": "6ca42da4-583f-42a3-b689-18a5b54dcfc3",
    "versions": [
      {
        "version": "2.13.4",
        "status": "affected"
      }
    ]
  }
]

```

## Related issues
- Close #5796

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
