### PR TITLE
refactor: use google/wire for cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	cacheDirName = "fanal"
+	scanCacheDirName = "fanal"
 
 	// artifactBucket stores artifact information with artifact ID such as image ID
 	artifactBucket = "artifact"

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -1,9 +1,6 @@
 package cache
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"strings"
 	"time"
 
@@ -65,22 +62,4 @@ func New(opts Options) (Cache, func(), error) {
 		return nil, cleanup, xerrors.Errorf("unknown cache type: %s", t)
 	}
 	return cache, func() { _ = cache.Close() }, nil
-}
-
-// GetTLSConfig gets tls config from CA, Cert and Key file
-func GetTLSConfig(caCertPath, certPath, keyPath string) (*x509.CertPool, tls.Certificate, error) {
-	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
-	if err != nil {
-		return nil, tls.Certificate{}, err
-	}
-
-	caCert, err := os.ReadFile(caCertPath)
-	if err != nil {
-		return nil, tls.Certificate{}, err
-	}
-
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-
-	return caCertPool, cert, nil
 }

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -3,148 +3,68 @@ package cache
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis/v8"
-	"github.com/samber/lo"
 	"golang.org/x/xerrors"
-
-	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 const (
-	TypeFS    Type = "fs"
-	TypeRedis Type = "redis"
+	TypeUnknown Type = "unknown"
+	TypeFS      Type = "fs"
+	TypeRedis   Type = "redis"
 )
 
 type Type string
 
 type Options struct {
-	Type  Type
-	TTL   time.Duration
-	Redis RedisOptions
+	Backend     string
+	CacheDir    string
+	RedisCACert string
+	RedisCert   string
+	RedisKey    string
+	RedisTLS    bool
+	TTL         time.Duration
 }
 
-func NewOptions(backend, redisCACert, redisCert, redisKey string, redisTLS bool, ttl time.Duration) (Options, error) {
-	t, err := NewType(backend)
-	if err != nil {
-		return Options{}, xerrors.Errorf("cache type error: %w", err)
-	}
-
-	var redisOpts RedisOptions
-	if t == TypeRedis {
-		redisTLSOpts, err := NewRedisTLSOptions(redisCACert, redisCert, redisKey)
-		if err != nil {
-			return Options{}, xerrors.Errorf("redis TLS option error: %w", err)
-		}
-		redisOpts = RedisOptions{
-			Backend:    backend,
-			TLS:        redisTLS,
-			TLSOptions: redisTLSOpts,
-		}
-	} else if ttl != 0 {
-		log.Warn("'--cache-ttl' is only available with Redis cache backend")
-	}
-
-	return Options{
-		Type:  t,
-		TTL:   ttl,
-		Redis: redisOpts,
-	}, nil
-}
-
-type RedisOptions struct {
-	Backend    string
-	TLS        bool
-	TLSOptions RedisTLSOptions
-}
-
-// BackendMasked returns the redis connection string masking credentials
-func (o *RedisOptions) BackendMasked() string {
-	endIndex := strings.Index(o.Backend, "@")
-	if endIndex == -1 {
-		return o.Backend
-	}
-
-	startIndex := strings.Index(o.Backend, "//")
-
-	return fmt.Sprintf("%s****%s", o.Backend[:startIndex+2], o.Backend[endIndex:])
-}
-
-// RedisTLSOptions holds the options for redis cache
-type RedisTLSOptions struct {
-	CACert string
-	Cert   string
-	Key    string
-}
-
-func NewRedisTLSOptions(caCert, cert, key string) (RedisTLSOptions, error) {
-	opts := RedisTLSOptions{
-		CACert: caCert,
-		Cert:   cert,
-		Key:    key,
-	}
-
-	// If one of redis option not nil, make sure CA, cert, and key provided
-	if !lo.IsEmpty(opts) {
-		if opts.CACert == "" || opts.Cert == "" || opts.Key == "" {
-			return RedisTLSOptions{}, xerrors.Errorf("you must provide Redis CA, cert and key file path when using TLS")
-		}
-	}
-	return opts, nil
-}
-
-func NewType(backend string) (Type, error) {
+func NewType(backend string) Type {
 	// "redis://" or "fs" are allowed for now
 	// An empty value is also allowed for testability
 	switch {
 	case strings.HasPrefix(backend, "redis://"):
-		return TypeRedis, nil
+		return TypeRedis
 	case backend == "fs", backend == "":
-		return TypeFS, nil
+		return TypeFS
 	default:
-		return "", xerrors.Errorf("unknown cache backend: %s", backend)
+		return TypeUnknown
 	}
 }
 
 // New returns a new cache client
-func New(dir string, opts Options) (Cache, error) {
-	if opts.Type == TypeRedis {
-		log.Info("Redis cache", log.String("url", opts.Redis.BackendMasked()))
-		options, err := redis.ParseURL(opts.Redis.Backend)
+func New(opts Options) (Cache, func(), error) {
+	cleanup := func() {} // To avoid panic
+
+	var cache Cache
+	t := NewType(opts.Backend)
+	switch t {
+	case TypeRedis:
+		redisCache, err := NewRedisCache(opts.Backend, opts.RedisCACert, opts.RedisCert, opts.RedisKey, opts.RedisTLS, opts.TTL)
 		if err != nil {
-			return nil, err
+			return nil, cleanup, xerrors.Errorf("unable to initialize redis cache: %w", err)
 		}
-
-		if tlsOpts := opts.Redis.TLSOptions; !lo.IsEmpty(tlsOpts) {
-			caCert, cert, err := GetTLSConfig(tlsOpts.CACert, tlsOpts.Cert, tlsOpts.Key)
-			if err != nil {
-				return nil, err
-			}
-
-			options.TLSConfig = &tls.Config{
-				RootCAs:      caCert,
-				Certificates: []tls.Certificate{cert},
-				MinVersion:   tls.VersionTLS12,
-			}
-		} else if opts.Redis.TLS {
-			options.TLSConfig = &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			}
+		cache = redisCache
+	case TypeFS:
+		// standalone mode
+		fsCache, err := NewFSCache(opts.CacheDir)
+		if err != nil {
+			return nil, cleanup, xerrors.Errorf("unable to initialize fs cache: %w", err)
 		}
-
-		return NewRedisCache(options, opts.TTL), nil
+		cache = fsCache
+	default:
+		return nil, cleanup, xerrors.Errorf("unknown cache type: %s", t)
 	}
-
-	// standalone mode
-	fsCache, err := NewFSCache(dir)
-	if err != nil {
-		return nil, xerrors.Errorf("unable to initialize fs cache: %w", err)
-	}
-	return fsCache, nil
+	return cache, func() { _ = cache.Close() }, nil
 }
 
 // GetTLSConfig gets tls config from CA, Cert and Key file

--- a/pkg/cache/fs.go
+++ b/pkg/cache/fs.go
@@ -20,7 +20,7 @@ type FSCache struct {
 }
 
 func NewFSCache(cacheDir string) (FSCache, error) {
-	dir := filepath.Join(cacheDir, cacheDirName)
+	dir := filepath.Join(cacheDir, scanCacheDirName)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return FSCache{}, xerrors.Errorf("failed to create cache dir: %w", err)
 	}
@@ -31,7 +31,10 @@ func NewFSCache(cacheDir string) (FSCache, error) {
 	}
 
 	err = db.Update(func(tx *bolt.Tx) error {
-		for _, bucket := range []string{artifactBucket, blobBucket} {
+		for _, bucket := range []string{
+			artifactBucket,
+			blobBucket,
+		} {
 			if _, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
 				return xerrors.Errorf("unable to create %s bucket: %w", bucket, err)
 			}

--- a/pkg/cache/fs_test.go
+++ b/pkg/cache/fs_test.go
@@ -373,7 +373,7 @@ func TestFSCache_PutArtifact(t *testing.T) {
 				require.NoError(t, err, tt.name)
 			}
 
-			fs.db.View(func(tx *bolt.Tx) error {
+			err = fs.db.View(func(tx *bolt.Tx) error {
 				// check decompressedDigestBucket
 				imageBucket := tx.Bucket([]byte(artifactBucket))
 				b := imageBucket.Get([]byte(tt.args.imageID))
@@ -381,6 +381,7 @@ func TestFSCache_PutArtifact(t *testing.T) {
 
 				return nil
 			})
+			require.NoError(t, err)
 		})
 	}
 }

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -3,8 +3,10 @@ package cache
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -227,4 +229,22 @@ func (c RedisCache) Clear() error {
 		}
 	}
 	return nil
+}
+
+// GetTLSConfig gets tls config from CA, Cert and Key file
+func GetTLSConfig(caCertPath, certPath, keyPath string) (*x509.CertPool, tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, tls.Certificate{}, err
+	}
+
+	caCert, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, tls.Certificate{}, err
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	return caCertPool, cert, nil
 }

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -88,7 +88,7 @@ func NewRedisCache(backend, caCertPath, certPath, keyPath string, enableTLS bool
 		return RedisCache{}, xerrors.Errorf("failed to create Redis options: %w", err)
 	}
 
-	log.Info("Redis cache", log.String("url", opts.BackendMasked()))
+	log.Info("Redis scan cache", log.String("url", opts.BackendMasked()))
 	options, err := redis.ParseURL(opts.Backend)
 	if err != nil {
 		return RedisCache{}, xerrors.Errorf("failed to parse Redis URL: %w", err)

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -2,33 +2,116 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/hashicorp/go-multierror"
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-var _ Cache = &RedisCache{}
+var _ Cache = (*RedisCache)(nil)
 
-const (
-	redisPrefix = "fanal"
-)
+const redisPrefix = "fanal"
+
+type RedisOptions struct {
+	Backend    string
+	TLS        bool
+	TLSOptions RedisTLSOptions
+}
+
+func NewRedisOptions(backend, caCert, cert, key string, enableTLS bool) (RedisOptions, error) {
+	tlsOpts, err := NewRedisTLSOptions(caCert, cert, key)
+	if err != nil {
+		return RedisOptions{}, xerrors.Errorf("redis TLS option error: %w", err)
+	}
+
+	return RedisOptions{
+		Backend:    backend,
+		TLS:        enableTLS,
+		TLSOptions: tlsOpts,
+	}, nil
+}
+
+// BackendMasked returns the redis connection string masking credentials
+func (o *RedisOptions) BackendMasked() string {
+	endIndex := strings.Index(o.Backend, "@")
+	if endIndex == -1 {
+		return o.Backend
+	}
+
+	startIndex := strings.Index(o.Backend, "//")
+
+	return fmt.Sprintf("%s****%s", o.Backend[:startIndex+2], o.Backend[endIndex:])
+}
+
+// RedisTLSOptions holds the options for redis cache
+type RedisTLSOptions struct {
+	CACert string
+	Cert   string
+	Key    string
+}
+
+func NewRedisTLSOptions(caCert, cert, key string) (RedisTLSOptions, error) {
+	opts := RedisTLSOptions{
+		CACert: caCert,
+		Cert:   cert,
+		Key:    key,
+	}
+
+	// If one of redis option not nil, make sure CA, cert, and key provided
+	if !lo.IsEmpty(opts) {
+		if opts.CACert == "" || opts.Cert == "" || opts.Key == "" {
+			return RedisTLSOptions{}, xerrors.Errorf("you must provide Redis CA, cert and key file path when using TLS")
+		}
+	}
+	return opts, nil
+}
 
 type RedisCache struct {
 	client     *redis.Client
 	expiration time.Duration
 }
 
-func NewRedisCache(options *redis.Options, expiration time.Duration) RedisCache {
+func NewRedisCache(backend, caCertPath, certPath, keyPath string, enableTLS bool, ttl time.Duration) (RedisCache, error) {
+	opts, err := NewRedisOptions(backend, caCertPath, certPath, keyPath, enableTLS)
+	if err != nil {
+		return RedisCache{}, xerrors.Errorf("failed to create Redis options: %w", err)
+	}
+
+	log.Info("Redis cache", log.String("url", opts.BackendMasked()))
+	options, err := redis.ParseURL(opts.Backend)
+	if err != nil {
+		return RedisCache{}, xerrors.Errorf("failed to parse Redis URL: %w", err)
+	}
+
+	if tlsOpts := opts.TLSOptions; !lo.IsEmpty(tlsOpts) {
+		caCert, cert, err := GetTLSConfig(tlsOpts.CACert, tlsOpts.Cert, tlsOpts.Key)
+		if err != nil {
+			return RedisCache{}, xerrors.Errorf("failed to get TLS config: %w", err)
+		}
+
+		options.TLSConfig = &tls.Config{
+			RootCAs:      caCert,
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}
+	} else if opts.TLS {
+		options.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
 	return RedisCache{
 		client:     redis.NewClient(options),
-		expiration: expiration,
-	}
+		expiration: ttl,
+	}, nil
 }
 
 func (c RedisCache) PutArtifact(artifactID string, artifactConfig types.ArtifactInfo) error {

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -67,18 +66,15 @@ func TestRedisCache_PutArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			err = c.PutArtifact(tt.args.artifactID, tt.args.artifactConfig)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
 			got, err := s.Get(tt.wantKey)
 			require.NoError(t, err)
@@ -156,18 +152,15 @@ func TestRedisCache_PutBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			err = c.PutBlob(tt.args.blobID, tt.args.blobConfig)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
 			got, err := s.Get(tt.wantKey)
 			require.NoError(t, err)
@@ -241,18 +234,15 @@ func TestRedisCache_GetArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			got, err := c.GetArtifact(tt.artifactID)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.want, got)
 		})
@@ -334,14 +324,12 @@ func TestRedisCache_GetBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			got, err := c.GetBlob(tt.blobID)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 
@@ -445,14 +433,12 @@ func TestRedisCache_MissingBlobs(t *testing.T) {
 				addr = "dummy:6379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			missingArtifact, missingBlobIDs, err := c.MissingBlobs(tt.args.artifactID, tt.args.blobIDs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 
@@ -470,9 +456,9 @@ func TestRedisCache_Close(t *testing.T) {
 	defer s.Close()
 
 	t.Run("close", func(t *testing.T) {
-		c := cache.NewRedisCache(&redis.Options{
-			Addr: s.Addr(),
-		}, 0)
+		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", false, 0)
+		require.NoError(t, err)
+
 		closeErr := c.Close()
 		require.NoError(t, closeErr)
 		time.Sleep(3 * time.Second) // give it some time
@@ -492,9 +478,9 @@ func TestRedisCache_Clear(t *testing.T) {
 	s.Set("foo", "bar")
 
 	t.Run("clear", func(t *testing.T) {
-		c := cache.NewRedisCache(&redis.Options{
-			Addr: s.Addr(),
-		}, 0)
+		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", false, 0)
+		require.NoError(t, err)
+
 		require.NoError(t, c.Clear())
 		for i := 0; i < 200; i++ {
 			assert.False(t, s.Exists(fmt.Sprintf("fanal::key%d", i)))
@@ -546,9 +532,8 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c := cache.NewRedisCache(&redis.Options{
-				Addr: addr,
-			}, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			require.NoError(t, err)
 
 			err = c.DeleteBlobs(tt.args.blobIDs)
 			if tt.wantErr != "" {
@@ -557,6 +542,30 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRedisOptions_BackendMasked(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields cache.RedisOptions
+		want   string
+	}{
+		{
+			name:   "redis cache backend masked",
+			fields: cache.RedisOptions{Backend: "redis://root:password@localhost:6379"},
+			want:   "redis://****@localhost:6379",
+		},
+		{
+			name:   "redis cache backend masked does nothing",
+			fields: cache.RedisOptions{Backend: "redis://localhost:6379"},
+			want:   "redis://localhost:6379",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.fields.BackendMasked())
 		})
 	}
 }

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -145,7 +145,11 @@ func TestRemoteCache_PutArtifact(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
+			c := cache.NewRemoteCache(cache.RemoteOptions{
+				ServerAddr:    ts.URL,
+				CustomHeaders: tt.args.customHeaders,
+				Insecure:      false,
+			})
 			err := c.PutArtifact(tt.args.imageID, tt.args.imageInfo)
 			if tt.wantErr != "" {
 				require.Error(t, err, tt.name)
@@ -206,7 +210,11 @@ func TestRemoteCache_PutBlob(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
+			c := cache.NewRemoteCache(cache.RemoteOptions{
+				ServerAddr:    ts.URL,
+				CustomHeaders: tt.args.customHeaders,
+				Insecure:      false,
+			})
 			err := c.PutBlob(tt.args.diffID, tt.args.layerInfo)
 			if tt.wantErr != "" {
 				require.Error(t, err, tt.name)
@@ -284,7 +292,11 @@ func TestRemoteCache_MissingBlobs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := cache.NewRemoteCache(ts.URL, tt.args.customHeaders, false)
+			c := cache.NewRemoteCache(cache.RemoteOptions{
+				ServerAddr:    ts.URL,
+				CustomHeaders: tt.args.customHeaders,
+				Insecure:      false,
+			})
 			gotMissingImage, gotMissingLayerIDs, err := c.MissingBlobs(tt.args.imageID, tt.args.layerIDs)
 			if tt.wantErr != "" {
 				require.Error(t, err, tt.name)
@@ -334,7 +346,11 @@ func TestRemoteCache_PutArtifactInsecure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := cache.NewRemoteCache(ts.URL, nil, tt.args.insecure)
+			c := cache.NewRemoteCache(cache.RemoteOptions{
+				ServerAddr:    ts.URL,
+				CustomHeaders: nil,
+				Insecure:      tt.args.insecure,
+			})
 			err := c.PutArtifact(tt.args.imageID, tt.args.imageInfo)
 			if tt.wantErr != "" {
 				require.Error(t, err)

--- a/pkg/commands/artifact/inject.go
+++ b/pkg/commands/artifact/inject.go
@@ -21,8 +21,7 @@ import (
 
 // initializeImageScanner is for container image scanning in standalone mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, imageOpt types.ImageOptions, artifactOption artifact.Option) (
+func initializeImageScanner(ctx context.Context, imageName string, imageOpt types.ImageOptions, cacheOptions cache.Options, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneDockerSet)
 	return scanner.Scanner{}, nil, nil
@@ -30,33 +29,29 @@ func initializeImageScanner(ctx context.Context, imageName string, artifactCache
 
 // initializeArchiveScanner is for container image archive scanning in standalone mode
 // e.g. docker save -o alpine.tar alpine:3.15
-func initializeArchiveScanner(ctx context.Context, filePath string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, artifactOption artifact.Option) (scanner.Scanner, error) {
+func initializeArchiveScanner(ctx context.Context, filePath string, cacheOptions cache.Options, artifactOption artifact.Option) (
+	scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneArchiveSet)
-	return scanner.Scanner{}, nil
+	return scanner.Scanner{}, nil, nil
 }
 
 // initializeFilesystemScanner is for filesystem scanning in standalone mode
-func initializeFilesystemScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+func initializeFilesystemScanner(ctx context.Context, path string, cacheOptions cache.Options, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneFilesystemSet)
 	return scanner.Scanner{}, nil, nil
 }
 
-func initializeRepositoryScanner(ctx context.Context, url string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+func initializeRepositoryScanner(ctx context.Context, url string, cacheOptions cache.Options, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneRepositorySet)
 	return scanner.Scanner{}, nil, nil
 }
 
-func initializeSBOMScanner(ctx context.Context, filePath string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
+func initializeSBOMScanner(ctx context.Context, filePath string, cacheOptions cache.Options, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneSBOMSet)
 	return scanner.Scanner{}, nil, nil
 }
 
-func initializeVMScanner(ctx context.Context, filePath string, artifactCache cache.ArtifactCache,
-	localArtifactCache cache.LocalArtifactCache, artifactOption artifact.Option) (
+func initializeVMScanner(ctx context.Context, filePath string, cacheOptions cache.Options, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.StandaloneVMSet)
 	return scanner.Scanner{}, nil, nil
@@ -68,7 +63,7 @@ func initializeVMScanner(ctx context.Context, filePath string, artifactCache cac
 
 // initializeRemoteImageScanner is for container image scanning in client/server mode
 // e.g. dockerd, container registry, podman, etc.
-func initializeRemoteImageScanner(ctx context.Context, imageName string, artifactCache cache.ArtifactCache,
+func initializeRemoteImageScanner(ctx context.Context, imageName string, remoteCacheOptions cache.RemoteOptions,
 	remoteScanOptions client.ScannerOption, imageOpt types.ImageOptions, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteDockerSet)
@@ -77,21 +72,21 @@ func initializeRemoteImageScanner(ctx context.Context, imageName string, artifac
 
 // initializeRemoteArchiveScanner is for container image archive scanning in client/server mode
 // e.g. docker save -o alpine.tar alpine:3.15
-func initializeRemoteArchiveScanner(ctx context.Context, filePath string, artifactCache cache.ArtifactCache,
-	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, error) {
+func initializeRemoteArchiveScanner(ctx context.Context, filePath string, remoteCacheOptions cache.RemoteOptions,
+	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteArchiveSet)
-	return scanner.Scanner{}, nil
+	return scanner.Scanner{}, nil, nil
 }
 
 // initializeRemoteFilesystemScanner is for filesystem scanning in client/server mode
-func initializeRemoteFilesystemScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
+func initializeRemoteFilesystemScanner(ctx context.Context, path string, remoteCacheOptions cache.RemoteOptions,
 	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteFilesystemSet)
 	return scanner.Scanner{}, nil, nil
 }
 
 // initializeRemoteRepositoryScanner is for repository scanning in client/server mode
-func initializeRemoteRepositoryScanner(ctx context.Context, url string, artifactCache cache.ArtifactCache,
+func initializeRemoteRepositoryScanner(ctx context.Context, url string, remoteCacheOptions cache.RemoteOptions,
 	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (
 	scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteRepositorySet)
@@ -99,14 +94,14 @@ func initializeRemoteRepositoryScanner(ctx context.Context, url string, artifact
 }
 
 // initializeRemoteSBOMScanner is for sbom scanning in client/server mode
-func initializeRemoteSBOMScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
+func initializeRemoteSBOMScanner(ctx context.Context, path string, remoteCacheOptions cache.RemoteOptions,
 	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteSBOMSet)
 	return scanner.Scanner{}, nil, nil
 }
 
 // initializeRemoteVMScanner is for vm scanning in client/server mode
-func initializeRemoteVMScanner(ctx context.Context, path string, artifactCache cache.ArtifactCache,
+func initializeRemoteVMScanner(ctx context.Context, path string, remoteCacheOptions cache.RemoteOptions,
 	remoteScanOptions client.ScannerOption, artifactOption artifact.Option) (scanner.Scanner, func(), error) {
 	wire.Build(scanner.RemoteVMSet)
 	return scanner.Scanner{}, nil, nil

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -248,10 +248,10 @@ func (r *runner) ScanVM(ctx context.Context, opts flag.Options) (types.Report, e
 }
 
 func (r *runner) scanArtifact(ctx context.Context, opts flag.Options, initializeScanner InitializeScanner) (types.Report, error) {
-	if r.initializeScanner == nil {
-		r.initializeScanner = initializeScanner
+	if r.initializeScanner != nil {
+		initializeScanner = r.initializeScanner
 	}
-	report, err := r.scan(ctx, opts)
+	report, err := r.scan(ctx, opts, initializeScanner)
 	if err != nil {
 		return types.Report{}, xerrors.Errorf("scan error: %w", err)
 	}
@@ -614,12 +614,12 @@ func (r *runner) initScannerConfig(opts flag.Options) (ScannerConfig, types.Scan
 	}, scanOptions, nil
 }
 
-func (r *runner) scan(ctx context.Context, opts flag.Options) (types.Report, error) {
+func (r *runner) scan(ctx context.Context, opts flag.Options, initializeScanner InitializeScanner) (types.Report, error) {
 	scannerConfig, scanOptions, err := r.initScannerConfig(opts)
 	if err != nil {
 		return types.Report{}, err
 	}
-	s, cleanup, err := r.initializeScanner(ctx, scannerConfig)
+	s, cleanup, err := initializeScanner(ctx, scannerConfig)
 	if err != nil {
 		return types.Report{}, xerrors.Errorf("unable to initialize a scanner: %w", err)
 	}

--- a/pkg/commands/artifact/scanner.go
+++ b/pkg/commands/artifact/scanner.go
@@ -11,8 +11,7 @@ import (
 // imageStandaloneScanner initializes a container image scanner in standalone mode
 // $ trivy image alpine:3.15
 func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache,
-		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
+	s, cleanup, err := initializeImageScanner(ctx, conf.Target, conf.ArtifactOption.ImageOption, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize an image scanner: %w", err)
 	}
@@ -22,18 +21,18 @@ func imageStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Sc
 // archiveStandaloneScanner initializes an image archive scanner in standalone mode
 // $ trivy image --input alpine.tar
 func archiveStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, err := initializeArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
+	s, cleanup, err := initializeArchiveScanner(ctx, conf.Target, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize the archive scanner: %w", err)
 	}
-	return s, func() {}, nil
+	return s, cleanup, nil
 }
 
 // imageRemoteScanner initializes a container image scanner in client/server mode
 // $ trivy image --server localhost:4954 alpine:3.15
 func imageRemoteScanner(ctx context.Context, conf ScannerConfig) (
 	scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteImageScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
+	s, cleanup, err := initializeRemoteImageScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption,
 		conf.ArtifactOption.ImageOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize a remote image scanner: %w", err)
@@ -45,16 +44,16 @@ func imageRemoteScanner(ctx context.Context, conf ScannerConfig) (
 // $ trivy image --server localhost:4954 --input alpine.tar
 func archiveRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
 	// Scan tar file
-	s, err := initializeRemoteArchiveScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
+	s, cleanup, err := initializeRemoteArchiveScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, nil, xerrors.Errorf("unable to initialize the remote archive scanner: %w", err)
 	}
-	return s, func() {}, nil
+	return s, cleanup, nil
 }
 
 // filesystemStandaloneScanner initializes a filesystem scanner in standalone mode
 func filesystemStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
+	s, cleanup, err := initializeFilesystemScanner(ctx, conf.Target, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a filesystem scanner: %w", err)
 	}
@@ -63,7 +62,7 @@ func filesystemStandaloneScanner(ctx context.Context, conf ScannerConfig) (scann
 
 // filesystemRemoteScanner initializes a filesystem scanner in client/server mode
 func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteFilesystemScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
+	s, cleanup, err := initializeRemoteFilesystemScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote filesystem scanner: %w", err)
 	}
@@ -72,7 +71,7 @@ func filesystemRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 
 // repositoryStandaloneScanner initializes a repository scanner in standalone mode
 func repositoryStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
+	s, cleanup, err := initializeRepositoryScanner(ctx, conf.Target, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a repository scanner: %w", err)
 	}
@@ -81,7 +80,7 @@ func repositoryStandaloneScanner(ctx context.Context, conf ScannerConfig) (scann
 
 // repositoryRemoteScanner initializes a repository scanner in client/server mode
 func repositoryRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteRepositoryScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption,
+	s, cleanup, err := initializeRemoteRepositoryScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption,
 		conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote repository scanner: %w", err)
@@ -91,7 +90,7 @@ func repositoryRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.S
 
 // sbomStandaloneScanner initializes a SBOM scanner in standalone mode
 func sbomStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeSBOMScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
+	s, cleanup, err := initializeSBOMScanner(ctx, conf.Target, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a cycloneDX scanner: %w", err)
 	}
@@ -100,7 +99,7 @@ func sbomStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Sca
 
 // sbomRemoteScanner initializes a SBOM scanner in client/server mode
 func sbomRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteSBOMScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
+	s, cleanup, err := initializeRemoteSBOMScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote cycloneDX scanner: %w", err)
 	}
@@ -109,7 +108,7 @@ func sbomRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner
 
 // vmStandaloneScanner initializes a VM scanner in standalone mode
 func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeVMScanner(ctx, conf.Target, conf.ArtifactCache, conf.LocalArtifactCache, conf.ArtifactOption)
+	s, cleanup, err := initializeVMScanner(ctx, conf.Target, conf.CacheOptions, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a vm scanner: %w", err)
 	}
@@ -118,7 +117,7 @@ func vmStandaloneScanner(ctx context.Context, conf ScannerConfig) (scanner.Scann
 
 // vmRemoteScanner initializes a VM scanner in client/server mode
 func vmRemoteScanner(ctx context.Context, conf ScannerConfig) (scanner.Scanner, func(), error) {
-	s, cleanup, err := initializeRemoteVMScanner(ctx, conf.Target, conf.ArtifactCache, conf.ServerOption, conf.ArtifactOption)
+	s, cleanup, err := initializeRemoteVMScanner(ctx, conf.Target, conf.RemoteCacheOptions, conf.ServerOption, conf.ArtifactOption)
 	if err != nil {
 		return scanner.Scanner{}, func() {}, xerrors.Errorf("unable to initialize a remote vm scanner: %w", err)
 	}

--- a/pkg/commands/clean/run.go
+++ b/pkg/commands/clean/run.go
@@ -62,10 +62,12 @@ func cleanAll(ctx context.Context, opts flag.Options) error {
 
 func cleanScanCache(ctx context.Context, opts flag.Options) error {
 	log.InfoContext(ctx, "Removing scan cache...")
-	c, err := cache.New(opts.CacheDir, opts.CacheBackendOptions)
+	c, cleanup, err := cache.New(opts.CacheOpts())
 	if err != nil {
 		return xerrors.Errorf("failed to instantiate cache client: %w", err)
 	}
+	defer cleanup()
+
 	if err = c.Clear(); err != nil {
 		return xerrors.Errorf("clear scan cache: %w", err)
 	}

--- a/pkg/commands/clean/run_test.go
+++ b/pkg/commands/clean/run_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/commands/clean"
 	"github.com/aquasecurity/trivy/pkg/flag"
 )
@@ -99,6 +100,9 @@ func TestRun(t *testing.T) {
 			opts := flag.Options{
 				GlobalOptions: flag.GlobalOptions{
 					CacheDir: tempDir,
+				},
+				CacheOptions: flag.CacheOptions{
+					CacheBackend: string(cache.TypeFS),
 				},
 				CleanOptions: tt.cleanOpts,
 			}

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -24,7 +24,6 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 		return xerrors.Errorf("server cache error: %w", err)
 	}
 	defer cleanup()
-	log.Debug("Cache", log.String("dir", opts.CacheDir))
 
 	// download the database file
 	if err = operation.DownloadDB(ctx, opts.AppVersion, opts.CacheDir, opts.DBRepository,

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -19,11 +19,11 @@ func Run(ctx context.Context, opts flag.Options) (err error) {
 	log.InitLogger(opts.Debug, opts.Quiet)
 
 	// configure cache dir
-	cacheClient, err := cache.New(opts.CacheDir, opts.CacheOptions.CacheBackendOptions)
+	cacheClient, cleanup, err := cache.New(opts.CacheOpts())
 	if err != nil {
 		return xerrors.Errorf("server cache error: %w", err)
 	}
-	defer cacheClient.Close()
+	defer cleanup()
 	log.Debug("Cache", log.String("dir", opts.CacheDir))
 
 	// download the database file

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -80,7 +80,6 @@ type CacheOptions struct {
 // NewCacheFlagGroup returns a default CacheFlagGroup
 func NewCacheFlagGroup() *CacheFlagGroup {
 	return &CacheFlagGroup{
-		ClearCache:   ClearCacheFlag.Clone(),
 		CacheBackend: CacheBackendFlag.Clone(),
 		CacheTTL:     CacheTTLFlag.Clone(),
 		RedisTLS:     RedisTLSFlag.Clone(),
@@ -112,7 +111,6 @@ func (fg *CacheFlagGroup) ToOptions() (CacheOptions, error) {
 	}
 
 	return CacheOptions{
-		ClearCache:   fg.ClearCache.Value(),
 		CacheBackend: fg.CacheBackend.Value(),
 		CacheTTL:     fg.CacheTTL.Value(),
 		RedisTLS:     fg.RedisTLS.Value(),

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -2,10 +2,6 @@ package flag
 
 import (
 	"time"
-
-	"golang.org/x/xerrors"
-
-	"github.com/aquasecurity/trivy/pkg/cache"
 )
 
 // e.g. config yaml:
@@ -71,8 +67,14 @@ type CacheFlagGroup struct {
 }
 
 type CacheOptions struct {
-	ClearCache          bool
-	CacheBackendOptions cache.Options
+	ClearCache bool
+
+	CacheBackend string
+	CacheTTL     time.Duration
+	RedisTLS     bool
+	RedisCACert  string
+	RedisCert    string
+	RedisKey     string
 }
 
 // NewCacheFlagGroup returns a default CacheFlagGroup
@@ -109,14 +111,13 @@ func (fg *CacheFlagGroup) ToOptions() (CacheOptions, error) {
 		return CacheOptions{}, err
 	}
 
-	backendOpts, err := cache.NewOptions(fg.CacheBackend.Value(), fg.RedisCACert.Value(), fg.RedisCert.Value(),
-		fg.RedisKey.Value(), fg.RedisTLS.Value(), fg.CacheTTL.Value())
-	if err != nil {
-		return CacheOptions{}, xerrors.Errorf("failed to initialize cache options: %w", err)
-	}
-
 	return CacheOptions{
-		ClearCache:          fg.ClearCache.Value(),
-		CacheBackendOptions: backendOpts,
+		ClearCache:   fg.ClearCache.Value(),
+		CacheBackend: fg.CacheBackend.Value(),
+		CacheTTL:     fg.CacheTTL.Value(),
+		RedisTLS:     fg.RedisTLS.Value(),
+		RedisCACert:  fg.RedisCACert.Value(),
+		RedisCert:    fg.RedisCert.Value(),
+		RedisKey:     fg.RedisKey.Value(),
 	}, nil
 }

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aquasecurity/trivy/pkg/cache"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 var (
@@ -143,6 +144,8 @@ func (f *GlobalFlagGroup) ToOptions() (GlobalOptions, error) {
 
 	// Keep TRIVY_NON_SSL for backward compatibility
 	insecure := f.Insecure.Value() || os.Getenv("TRIVY_NON_SSL") != ""
+
+	log.Debug("Cache dir", log.String("dir", f.CacheDir.Value()))
 
 	return GlobalOptions{
 		ConfigFile:            f.ConfigFile.Value(),

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -443,6 +444,28 @@ func (o *Options) FilterOpts() result.FilterOption {
 		PolicyFile:         o.IgnorePolicy,
 		IgnoreLicenses:     o.IgnoredLicenses,
 		VEXPath:            o.VEXPath,
+	}
+}
+
+// CacheOpts returns options for scan cache
+func (o *Options) CacheOpts() cache.Options {
+	return cache.Options{
+		Backend:     o.CacheBackend,
+		CacheDir:    o.CacheDir,
+		RedisCACert: o.RedisCACert,
+		RedisCert:   o.RedisCert,
+		RedisKey:    o.RedisKey,
+		RedisTLS:    o.RedisTLS,
+		TTL:         o.CacheTTL,
+	}
+}
+
+// RemoteCacheOpts returns options for remote scan cache
+func (o *Options) RemoteCacheOpts() cache.RemoteOptions {
+	return cache.RemoteOptions{
+		ServerAddr:    o.ServerAddr,
+		CustomHeaders: o.CustomHeaders,
+		Insecure:      o.Insecure,
 	}
 }
 

--- a/pkg/k8s/wire_gen.go
+++ b/pkg/k8s/wire_gen.go
@@ -8,8 +8,8 @@ package k8s
 
 import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
-	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/cache"
+	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/scanner/langpkg"
 	"github.com/aquasecurity/trivy/pkg/scanner/local"
 	"github.com/aquasecurity/trivy/pkg/scanner/ospkg"

--- a/pkg/rpc/server/wire_gen.go
+++ b/pkg/rpc/server/wire_gen.go
@@ -8,8 +8,8 @@ package server
 
 import (
 	"github.com/aquasecurity/trivy-db/pkg/db"
-	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/cache"
+	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/scanner/langpkg"
 	"github.com/aquasecurity/trivy/pkg/scanner/local"
 	"github.com/aquasecurity/trivy/pkg/scanner/ospkg"

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/wire"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	aimage "github.com/aquasecurity/trivy/pkg/fanal/artifact/image"
@@ -28,6 +29,11 @@ import (
 
 // StandaloneSuperSet is used in the standalone mode
 var StandaloneSuperSet = wire.NewSet(
+	// Cache
+	cache.New,
+	wire.Bind(new(cache.ArtifactCache), new(cache.Cache)),
+	wire.Bind(new(cache.LocalArtifactCache), new(cache.Cache)),
+
 	local.SuperSet,
 	wire.Bind(new(Driver), new(local.Scanner)),
 	NewScanner,
@@ -77,6 +83,10 @@ var StandaloneVMSet = wire.NewSet(
 
 // RemoteSuperSet is used in the client mode
 var RemoteSuperSet = wire.NewSet(
+	// Cache
+	cache.NewRemoteCache,
+	wire.Bind(new(cache.ArtifactCache), new(*cache.RemoteCache)), // No need for LocalArtifactCache
+
 	client.NewScanner,
 	wire.Value([]client.Option(nil)),
 	wire.Bind(new(Driver), new(client.Scanner)),


### PR DESCRIPTION
## Description

This PR simplifies the cache initialization process in the artifact scanning. Previously, we [initialized](https://github.com/aquasecurity/trivy/blob/3d02a31b44924f9e2495aae087f7ca9de3314db4/pkg/commands/artifact/run.go#L338-L361) the `cache.Cache` instance within `pkg/commands/artifact/run.go` to support `--clear-cache` and `--reset` operations. However, these operations have been [moved to the `trivy clean` command](https://github.com/aquasecurity/trivy/pull/6993).

With this change, we can now generate the `cache.Cache` instance through [google/wire](https://github.com/google/wire), which is consistent with other instances in the project. 

## Changes

- Remove the `initCache` function from `pkg/commands/artifact/run.go`
- Update the wire injection to include `cache.Cache` generation
- Adjust the artifact scanning initialization process to use the wire-generated cache instance

## Benefits

- Improved consistency in scanner initialization across the project
- Simplified code structure in the artifact scanning module
- Better alignment with the project's dependency injection pattern using wire

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
