### PR TITLE
fix(cli): show info message only when --scanners is available

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -353,8 +353,10 @@ type Options struct {
 }
 
 // Align takes consistency of options
-func (o *Options) Align() error {
-	o.enableSBOM()
+func (o *Options) Align(f *Flags) error {
+	if f.ScanFlagGroup != nil && f.ScanFlagGroup.Scanners != nil {
+		o.enableSBOM()
+	}
 
 	if o.Compliance.Spec.ID != "" {
 		if viper.IsSet(ScannersFlag.ConfigName) {
@@ -738,7 +740,7 @@ func (f *Flags) ToOptions(args []string) (Options, error) {
 		}
 	}
 
-	if err := opts.Align(); err != nil {
+	if err := opts.Align(f); err != nil {
 		return Options{}, xerrors.Errorf("align options error: %w", err)
 	}
 


### PR DESCRIPTION
## Description
`trivy convert` shows the following message even though it doesn't have `--scanners` flag.

### Before

```
$ trivy convert -f cyclonedx /tmp/with_vulns.json -o /dev/null
2024-06-27T07:33:52+04:00       INFO    "--format cyclonedx" disables security scanning. Specify "--scanners vuln" explicitly if you want to include vulnerabilities in the CycloneDX report.
```

### After

```
$ trivy convert -f cyclonedx /tmp/with_vulns.json -o /dev/null
```

## Related issues
- Discussion: https://github.com/aquasecurity/trivy/discussions/7016

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
