### PR TITLE
docs: ✨ Updated ecosystem docs with reference to new community app

### DIFF
--- a/docs/ecosystem/prod.md
+++ b/docs/ecosystem/prod.md
@@ -29,3 +29,11 @@ You can use Kyverno to ensure and enforce that deployed workloads' images are sc
 Trivy is integrated into Zora as a vulnerability scanner plugin.
 
 👉 Get it at: <https://zora-docs.undistro.io/latest/plugins/trivy/>
+
+## Helmper (Community)
+
+[Helmper](https://christoffernissen.github.io/helmper/) is a go program that reads Helm Charts from remote OCI registries and pushes the Helm Charts and the Helm Charts container images to your OCI registries with optional OS level vulnerability patching
+
+Trivy is integrated into Helmper as a vulnerability scanner in combination with Copacetic to fix detected vulnerabilities.
+
+👉 Get it at: <https://github.com/ChristofferNissen/helmper>


### PR DESCRIPTION
## Description

This PR updates the docs/ecosystem/prod. documentation to include a new additional reference to a community-supported  tool to import Helm Charts and container images to OCI registries, with Security Scanning (trivy) and Copacetic (patching based on trivy reports)

## Related issues
- N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
