### PR TITLE
fix: Allow commas in passwords so long as only one username is passed

### DIFF
--- a/pkg/flag/registry_flags.go
+++ b/pkg/flag/registry_flags.go
@@ -65,7 +65,10 @@ func (f *RegistryFlagGroup) ToOptions() (RegistryOptions, error) {
 	var credentials []types.Credential
 	users := f.Username.Value()
 	passwords := f.Password.Value()
-	if len(users) != len(passwords) {
+	switch {
+	case len(users) == 1 && len(passwords) > 1:
+		passwords = []string{strings.Join(passwords, ",")}
+	case len(users) != len(passwords):
 		return RegistryOptions{}, xerrors.New("the length of usernames and passwords must match")
 	}
 	for i, user := range users {


### PR DESCRIPTION
## Description

It's a bit tricky to use Trivy with the Fly.io registry because Fly.io tokens often contain commas. Trivy allows multiple, comma separated passwords to be sent and complains if the number of usernames doesn't match the number of passwords.

In the case where one username and multiple passwords is set, this PR rejoins the passwords with commas. This seems like a good balance between allowing for multiple credentials to be specified and allowing for commas in passwords.

## Related issues

https://github.com/aquasecurity/trivy/discussions/7043

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
