### PR TITLE
fix(misconf): allow frameworks without versions

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -128,16 +128,19 @@ func (sm *StaticMetadata) updateFrameworks(meta map[string]any) error {
 			return fmt.Errorf("frameworks metadata is not an object, got %T", raw)
 		}
 		for fw, rawIDs := range frameworks {
-			ids, ok := rawIDs.([]any)
-			if !ok {
-				return fmt.Errorf("framework ids is not an array, got %T", rawIDs)
-			}
 			fr := framework.Framework(fw)
-			for _, id := range ids {
-				if str, ok := id.(string); ok {
-					sm.Frameworks[fr] = append(sm.Frameworks[fr], str)
+
+			switch ids := rawIDs.(type) {
+			case []any:
+				for _, id := range ids {
+					if str, ok := id.(string); ok {
+						sm.Frameworks[fr] = append(sm.Frameworks[fr], str)
+					}
 				}
+			case nil:
+				sm.Frameworks[fr] = []string{}
 			}
+
 		}
 	}
 	return nil

--- a/pkg/iac/rego/metadata_test.go
+++ b/pkg/iac/rego/metadata_test.go
@@ -28,7 +28,7 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			Service:            "srvc",
 			Library:            false,
 			Frameworks: map[framework.Framework][]string{
-				framework.Default: {"dd"},
+				framework.CIS_AWS_1_2: {"dd"},
 			},
 		}
 
@@ -47,7 +47,8 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 				"library":             true,
 				"url":                 "r_n",
 				"frameworks": map[string]any{
-					"all": []any{"aa"},
+					"all":     []any{"aa"},
+					"default": nil,
 				},
 			},
 		))
@@ -68,8 +69,9 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			Service:            "srvc_n",
 			Library:            true,
 			Frameworks: map[framework.Framework][]string{
-				framework.Default: {"dd"},
-				framework.ALL:     {"aa"},
+				framework.CIS_AWS_1_2: {"dd"},
+				framework.ALL:         {"aa"},
+				framework.Default:     {},
 			},
 			CloudFormation: &scan.EngineMetadata{},
 			Terraform:      &scan.EngineMetadata{},


### PR DESCRIPTION
## Description

Trivy [has](https://github.com/aquasecurity/trivy/blob/main/pkg/iac/framework/frameworks.go#L6) `Default` and `All` frameworks that do not match any CIS Benchamrks, so they have no versions. Such a framework can be detected in Go check, but not in Rego.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
