### PR TITLE
fix(sbom): fix panic when scanning SBOM file without root component into SBOM format

### DIFF
--- a/pkg/sbom/io/encode.go
+++ b/pkg/sbom/io/encode.go
@@ -86,7 +86,10 @@ func (e *Encoder) rootComponent(r types.Report) (*core.Component, error) {
 	case artifact.TypeCycloneDX, artifact.TypeSPDX:
 		// When we scan SBOM file
 		if r.BOM != nil {
-			return r.BOM.Root(), nil
+			// If SBOM file doesn't contain root component - use filesystem
+			if bomRoot := r.BOM.Root(); bomRoot != nil {
+				return bomRoot, nil
+			}
 		}
 		// When we scan a `json` file (meaning a file in `json` format) which was created from the SBOM file.
 		// e.g. for use in `convert` mode.


### PR DESCRIPTION
## Description
See #7050

## Related issues
- Close #7050

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
