### PR TITLE
perf(debian): use `bytes.Index` in `emptyLineSplit` to cut allocation

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/scanner.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/scanner.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io"
 	"net/textproto"
-	"strings"
 )
 
 type dpkgScanner struct {
@@ -42,7 +41,7 @@ func emptyLineSplit(data []byte, atEOF bool) (advance int, token []byte, err err
 		return 0, nil, nil
 	}
 
-	if i := strings.Index(string(data), "\n\n"); i >= 0 {
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
 		// We have a full empty line terminated block.
 		return i + 2, data[0:i], nil
 	}


### PR DESCRIPTION
## Description

This PR makes use of `bytes.Index` in `emptyLineSplit` instead of `strings.Index` to remove the extra allocation caused by the bytes to string cast.

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/7064

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
