### PR TITLE
chore: bump golangci-lint from v1.58 to v1.59

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         id: lint
         uses: golangci/golangci-lint-action@v6.0.1
         with:
-          version: v1.58
+          version: v1.59
           args: --verbose --out-format=line-number
         if: matrix.operating-system == 'ubuntu-latest-m'
 

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -23,8 +23,8 @@ func AssertRuleFound(t *testing.T, ruleID string, results scan.Results, message 
 			meta := &m
 			for meta != nil {
 				assert.NotNil(t, meta.Range(), 0)
-				assert.Greater(t, meta.Range().GetStartLine(), 0)
-				assert.Greater(t, meta.Range().GetEndLine(), 0)
+				assert.Positive(t, meta.Range().GetStartLine())
+				assert.Positive(t, meta.Range().GetEndLine())
 				meta = meta.Parent()
 			}
 		}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -71,7 +71,7 @@ func (Tool) Wire() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v1.58.2"
+	const version = "v1.59.1"
 	bin := filepath.Join(GOBIN, "golangci-lint")
 	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -17,7 +17,7 @@ func TestDownload(t *testing.T) {
 	// Set up a test server with a self-signed certificate
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("test content"))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -181,7 +181,7 @@ func TestArtifact_inspectOCIReferrerSBOM(t *testing.T) {
 		switch r.URL.Path {
 		case "/v2":
 			_, err := w.Write([]byte("ok"))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/v2/test/image/referrers/sha256:782143e39f1e7a04e3f6da2d88b1c057e5657363c4f90679f3e8a071b7619e02":
 			http.ServeFile(w, r, "testdata/index.json")
 		case "/v2/test/image/manifests/sha256:37c89af4907fa0af078aeba12d6f18dc0c63937c010030baaaa88e958f0719a5":

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -80,7 +80,7 @@ func Test_OptionWithDebugWriter(t *testing.T) {
 	_ = scanWithOptions(t, `
 resource "something" "else" {}
 `, scannerOpts...)
-	require.Greater(t, buffer.Len(), 0)
+	require.Positive(t, buffer.Len())
 }
 
 func Test_OptionWithPolicyDirs(t *testing.T) {
@@ -217,9 +217,13 @@ func Test_OptionWithPolicyNamespaces(t *testing.T) {
 			wantFailure:        true,
 		},
 		{
-			includedNamespaces: []string{"a", "users", "b"},
-			policyNamespace:    "users",
-			wantFailure:        true,
+			includedNamespaces: []string{
+				"a",
+				"users",
+				"b",
+			},
+			policyNamespace: "users",
+			wantFailure:     true,
 		},
 		{
 			includedNamespaces: []string{"user"},

--- a/pkg/plugin/index_test.go
+++ b/pkg/plugin/index_test.go
@@ -21,7 +21,7 @@ func TestManager_Update(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte(`this is index`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(ts.Close)
 

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -70,11 +70,11 @@ func TestManager_Install(t *testing.T) {
 		zr := zip.NewWriter(w)
 		switch r.URL.Path {
 		case "/test_plugin.zip":
-			require.NoError(t, zr.AddFS(os.DirFS("testdata/test_plugin/test_plugin")))
+			assert.NoError(t, zr.AddFS(os.DirFS("testdata/test_plugin/test_plugin")))
 		case "/test_nested.zip":
-			require.NoError(t, zr.AddFS(os.DirFS("testdata/test_plugin")))
+			assert.NoError(t, zr.AddFS(os.DirFS("testdata/test_plugin")))
 		}
-		require.NoError(t, zr.Close())
+		assert.NoError(t, zr.Close())
 	}))
 	t.Cleanup(ts.Close)
 

--- a/pkg/rekortest/server.go
+++ b/pkg/rekortest/server.go
@@ -11,7 +11,7 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/samber/lo"
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/aquasecurity/trivy/pkg/attestation"
 )
@@ -316,19 +316,19 @@ func NewServer(t *testing.T) *Server {
 		case "/api/v1/index/retrieve":
 			var params models.SearchIndex
 			err := json.NewDecoder(r.Body).Decode(&params)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			if res, ok := indexRes[params.Hash]; ok {
 				w.Header().Set("Content-Type", "application/json")
 				err = json.NewEncoder(w).Encode(res)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			} else {
 				http.Error(w, "something wrong", http.StatusNotFound)
 			}
 		case "/api/v1/log/entries/retrieve":
 			var params models.SearchLogQuery
 			err := json.NewDecoder(r.Body).Decode(&params)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			resEntries := models.LogEntry{}
 			for _, uuid := range params.EntryUUIDs {
@@ -341,7 +341,7 @@ func NewServer(t *testing.T) *Server {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			err = json.NewEncoder(w).Encode([]models.LogEntry{resEntries})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}
 		return
 	}))


### PR DESCRIPTION
## Description
Bump golangci-lint

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
