### PR TITLE
refactor(secret): add warning about large files

### DIFF
--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -166,7 +166,7 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 		return false
 	}
 
-	if size := fi.Size(); size > 209_715_200 { // 200MB
+	if size := fi.Size(); size > 10485760 { // 10MB
 		log.WithPrefix("secret").Warn("The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.", log.FilePath(filePath), log.Int64("size (MB)", size/1048576))
 	}
 	return true

--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/secret"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/utils"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 // To make sure SecretAnalyzer implements analyzer.Initializer
@@ -165,6 +166,9 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 		return false
 	}
 
+	if size := fi.Size(); size > 209_715_200 { // 200MB
+		log.WithPrefix("secret").Warn("The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.", log.FilePath(filePath), log.Int64("size (MB)", size/1048576))
+	}
 	return true
 }
 


### PR DESCRIPTION
## Description
Show warnings about large files so users can skip them.
See https://github.com/aquasecurity/trivy/discussions/7078 for more details.

example:
```bash
2024-07-03T12:46:19+06:00       WARN    [secret] The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.     file_path="fslibs-entry-point.sh" size (MB)=946
```

## Related discussions
- Close #7078

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
