### PR TITLE
fix(misconf): do not evaluate TF when a load error occurs

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -268,7 +268,10 @@ func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, cty.Value,
 	e, err := p.Load(ctx)
 	if errors.Is(err, ErrNoFiles) {
 		return nil, cty.NilVal, nil
+	} else if err != nil {
+		return nil, cty.NilVal, err
 	}
+
 	modules, fsMap := e.EvaluateAll(ctx)
 	p.debug.Log("Finished parsing module '%s'.", p.moduleName)
 	p.fsMap = fsMap


### PR DESCRIPTION
## Description
If an error occurs while loading the configuration files, we must skip the evaluation.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7084

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
