### PR TITLE
test: add missing advisory details for integration tests database

### DIFF
--- a/integration/testdata/conan.json.golden
+++ b/integration/testdata/conan.json.golden
@@ -171,7 +171,36 @@
           "FixedVersion": "8.45",
           "Status": "fixed",
           "Layer": {},
-          "Severity": "UNKNOWN"
+          "SeveritySource": "nvd",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2020-14155",
+          "Title": "pcre: Integer overflow when parsing callout numeric arguments",
+          "Description": "libpcre in PCRE before 8.44 allows an integer overflow via a large number after a (?C substring.",
+          "Severity": "MEDIUM",
+          "CweIDs": [
+            "CWE-190"
+          ],
+          "VendorSeverity": {
+            "alma": 1,
+            "nvd": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V2Score": 5,
+              "V3Score": 5.3
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 5.3
+            }
+          },
+          "References": [
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14155",
+            "https://nvd.nist.gov/vuln/detail/CVE-2020-14155"
+          ],
+          "PublishedDate": "2020-06-15T17:15:00Z",
+          "LastModifiedDate": "2022-04-28T15:06:00Z"
         }
       ]
     }

--- a/integration/testdata/fixtures/db/vulnerability.yaml
+++ b/integration/testdata/fixtures/db/vulnerability.yaml
@@ -1364,7 +1364,7 @@
           V3Vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
           V3Score: 8.1
       References:
-        - "https://github.com/advisories/GHSA-36p3-wjmg-h94x",
+        - "https://github.com/advisories/GHSA-36p3-wjmg-h94x"
       PublishedDate: "2022-04-01T23:15:00Z"
       LastModifiedDate: "2022-05-19T14:21:00Z"
   - key: CVE-2020-14155
@@ -1387,7 +1387,7 @@
           V3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
           V3Score: 5.3
       References:
-        - "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14155",
+        - "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14155"
         - "https://nvd.nist.gov/vuln/detail/CVE-2020-14155"
       PublishedDate: "2020-06-15T17:15:00Z"
       LastModifiedDate: "2022-04-28T15:06:00Z"

--- a/integration/testdata/spring4shell-jre11.json.golden
+++ b/integration/testdata/spring4shell-jre11.json.golden
@@ -245,7 +245,9 @@
           },
           "References": [
             "https://github.com/advisories/GHSA-36p3-wjmg-h94x"
-          ]
+          ],
+          "PublishedDate": "2022-04-01T23:15:00Z",
+          "LastModifiedDate": "2022-05-19T14:21:00Z"
         }
       ]
     },

--- a/integration/testdata/spring4shell-jre8.json.golden
+++ b/integration/testdata/spring4shell-jre8.json.golden
@@ -245,7 +245,9 @@
           },
           "References": [
             "https://github.com/advisories/GHSA-36p3-wjmg-h94x"
-          ]
+          ],
+          "PublishedDate": "2022-04-01T23:15:00Z",
+          "LastModifiedDate": "2022-05-19T14:21:00Z"
         }
       ]
     },


### PR DESCRIPTION
## Description
[vulnerability.yaml](https://github.com/aquasecurity/trivy/blob/main/integration/testdata/fixtures/db/vulnerability.yaml) file contains extra commas.
This is why advisory details for `CVE-2020-14155` (and new details added after this CVE) doesn't exist in test db.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
