### PR TITLE
refactor(secret): move warning about file size after `IsBinary` check

### DIFF
--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/aquasecurity/trivy/pkg/log"
 	"io"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/secret"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/utils"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 // To make sure SecretAnalyzer implements analyzer.Initializer

--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,7 +18,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/secret"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/utils"
-	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 // To make sure SecretAnalyzer implements analyzer.Initializer
@@ -100,6 +100,10 @@ func (a *SecretAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput
 		return nil, nil
 	}
 
+	if size := input.Info.Size(); size > 10485760 { // 10MB
+		log.WithPrefix("secret").Warn("The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.", log.FilePath(input.FilePath), log.Int64("size (MB)", size/1048576))
+	}
+
 	content, err := io.ReadAll(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("read error %s: %w", input.FilePath, err)
@@ -166,9 +170,6 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 		return false
 	}
 
-	if size := fi.Size(); size > 10485760 { // 10MB
-		log.WithPrefix("secret").Warn("The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.", log.FilePath(filePath), log.Int64("size (MB)", size/1048576))
-	}
 	return true
 }
 


### PR DESCRIPTION
## Description
Fix problem that we write warning every each binary  file larger than 10MB.

Before:
```bash
➜ ./trivy fs --scanners secret ./trivy 
2024-07-09T12:19:09+06:00       INFO    Secret scanning is enabled
2024-07-09T12:19:09+06:00       INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-09T12:19:09+06:00       INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret#recommendation for faster secret detection
2024-07-09T12:19:09+06:00       WARN    [secret] The size of the scanned file is too large. It is recommended to use `--skip-files` for this file to avoid high memory consumption.     file_path="trivy" size (MB)=240
```

After:
```bash
➜  ./trivy fs --scanners secret ./trivy
2024-07-09T12:21:13+06:00       INFO    Secret scanning is enabled
2024-07-09T12:21:13+06:00       INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-09T12:21:13+06:00       INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret#recommendation for faster secret detection

```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
