### PR TITLE
refactor(misconf): improve Terraform scanning logging

### DIFF
--- a/pkg/iac/debug/debug.go
+++ b/pkg/iac/debug/debug.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 )
-
-const timeFormat = "04:05.000000000"
 
 type Logger struct {
 	writer io.Writer
@@ -33,6 +30,6 @@ func (l *Logger) Log(format string, args ...any) {
 		return
 	}
 	message := fmt.Sprintf(format, args...)
-	line := fmt.Sprintf("%s %-32s %s\n", time.Now().Format(timeFormat), l.prefix, message)
+	line := fmt.Sprintf("%-32s %s\n", l.prefix, message)
 	_, _ = l.writer.Write([]byte(line))
 }

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -79,7 +79,7 @@ func (e *Executor) Execute(modules terraform.Modules) (scan.Results, error) {
 	results.Ignore(ignores, ignorers)
 
 	for _, ignored := range results.GetIgnored() {
-		e.debug.Log("Ignored '%s' at '%s'.", ignored.Rule().LongID(), ignored.Range())
+		e.debug.Log("Ignored %q at %q.", ignored.Rule().LongID(), ignored.Range())
 	}
 
 	results = e.filterResults(results)

--- a/pkg/iac/scanners/terraform/parser/load_module.go
+++ b/pkg/iac/scanners/terraform/parser/load_module.go
@@ -77,7 +77,7 @@ func (e *evaluator) loadModule(ctx context.Context, b *terraform.Block) (*Module
 	}
 
 	if def, err := e.loadModuleFromTerraformCache(ctx, b, source); err == nil {
-		e.debug.Log("found module '%s' in .terraform/modules", source)
+		e.debug.Log("Found module %q in .terraform/modules", source)
 		return def, nil
 	}
 
@@ -110,7 +110,7 @@ func (e *evaluator) loadModuleFromTerraformCache(ctx context.Context, b *terrafo
 		}
 	}
 
-	e.debug.Log("Module '%s' resolved to path '%s' in filesystem '%s' using modules.json", b.FullName(), modulePath, e.filesystem)
+	e.debug.Log("Module %q resolved to path %q using modules.json", b.FullName(), modulePath)
 	moduleParser := e.parentParser.newModuleParser(e.filesystem, source, modulePath, b.Label(), b)
 	if err := moduleParser.ParseFS(ctx, modulePath); err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func (e *evaluator) loadModuleFromTerraformCache(ctx context.Context, b *terrafo
 
 func (e *evaluator) loadExternalModule(ctx context.Context, b *terraform.Block, source string) (*ModuleDefinition, error) {
 
-	e.debug.Log("locating non-initialized module '%s'...", source)
+	e.debug.Log("Locating non-initialized module %q", source)
 
 	version := b.GetAttribute("version").AsStringValueOrDefault("", b).Value()
 	opt := resolvers.Options{
@@ -147,7 +147,7 @@ func (e *evaluator) loadExternalModule(ctx context.Context, b *terraform.Block, 
 		return nil, err
 	}
 	prefix = path.Join(e.parentParser.moduleSource, prefix)
-	e.debug.Log("Module '%s' resolved to path '%s' in filesystem '%s' with prefix '%s'", b.FullName(), downloadPath, filesystem, prefix)
+	e.debug.Log("Module %q resolved to path %q with prefix %q", b.FullName(), downloadPath, prefix)
 	moduleParser := e.parentParser.newModuleParser(filesystem, prefix, downloadPath, b.Label(), b)
 	if err := moduleParser.ParseFS(ctx, downloadPath); err != nil {
 		return nil, err

--- a/pkg/iac/scanners/terraform/parser/module_retrieval.go
+++ b/pkg/iac/scanners/terraform/parser/module_retrieval.go
@@ -20,7 +20,7 @@ var defaultResolvers = []ModuleResolver{
 }
 
 func resolveModule(ctx context.Context, current fs.FS, opt resolvers.Options) (filesystem fs.FS, sourcePrefix, downloadPath string, err error) {
-	opt.Debug("Resolving module '%s' with source: '%s'...", opt.Name, opt.Source)
+	opt.Debug("Resolving module %q with source: %q...", opt.Name, opt.Source)
 	for _, resolver := range defaultResolvers {
 		if filesystem, prefix, path, applies, err := resolver.Resolve(ctx, current, opt); err != nil {
 			return nil, "", "", err
@@ -29,5 +29,5 @@ func resolveModule(ctx context.Context, current fs.FS, opt resolvers.Options) (f
 			return filesystem, prefix, path, nil
 		}
 	}
-	return nil, "", "", fmt.Errorf("failed to resolve module '%s' with source: %s", opt.Name, opt.Source)
+	return nil, "", "", fmt.Errorf("failed to resolve module %q with source: %s", opt.Name, opt.Source)
 }

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -229,6 +229,16 @@ func (p *Parser) Load(ctx context.Context) (*evaluator, error) {
 			return nil, err
 		}
 		p.debug.Log("Added %d variables from tfvars.", len(inputVars))
+
+		for _, varBlock := range blocks.OfType("variable") {
+			if varBlock.GetAttribute("default") == nil {
+				if _, ok := inputVars[varBlock.TypeLabel()]; !ok {
+					p.debug.Log(
+						"Variable %q was not found in the environment or variable files. Evaluating may not work correctly.",
+						varBlock.TypeLabel())
+				}
+			}
+		}
 	}
 
 	modulesMetadata, metadataPath, err := loadModuleMetadata(p.moduleFS, p.projectRoot)

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -125,7 +125,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 		return nil
 	}
 
-	p.debug.Log("Parsing '%s'...", fullPath)
+	p.debug.Log("Parsing %q", fullPath)
 	f, err := p.moduleFS.Open(filepath.ToSlash(fullPath))
 	if err != nil {
 		return err
@@ -138,7 +138,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 	}
 
 	if dir := path.Dir(fullPath); p.projectRoot == "" {
-		p.debug.Log("Setting project/module root to '%s'", dir)
+		p.debug.Log("Setting project/module root to %q", dir)
 		p.projectRoot = dir
 		p.modulePath = dir
 	}
@@ -158,8 +158,6 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 		file: file,
 		path: fullPath,
 	})
-
-	p.debug.Log("Added file %s.", fullPath)
 	return nil
 }
 
@@ -169,13 +167,13 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 	dir = path.Clean(dir)
 
 	if p.projectRoot == "" {
-		p.debug.Log("Setting project/module root to '%s'", dir)
+		p.debug.Log("Setting project/module root to %q", dir)
 		p.projectRoot = dir
 		p.modulePath = dir
 	}
 
 	slashed := filepath.ToSlash(dir)
-	p.debug.Log("Parsing FS from '%s'", slashed)
+	p.debug.Log("Parsing FS from %q", slashed)
 	fileInfos, err := fs.ReadDir(p.moduleFS, slashed)
 	if err != nil {
 		return err
@@ -195,7 +193,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 			if p.stopOnHCLError {
 				return err
 			}
-			p.debug.Log("error parsing '%s': %s", path, err)
+			p.debug.Log("Error parsing file %q: %s", path, err.Error())
 			continue
 		}
 	}
@@ -206,18 +204,20 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 var ErrNoFiles = errors.New("no files found")
 
 func (p *Parser) Load(ctx context.Context) (*evaluator, error) {
-	p.debug.Log("Evaluating module...")
+	p.debug.Log("Loading module %q", p.moduleName)
 
 	if len(p.files) == 0 {
 		p.debug.Log("No files found, nothing to do.")
 		return nil, ErrNoFiles
 	}
 
+	p.debug.Log("Read %d file(s)", len(p.files))
+
 	blocks, ignores, err := p.readBlocks(p.files)
 	if err != nil {
 		return nil, err
 	}
-	p.debug.Log("Read %d block(s) and %d ignore(s) for module '%s' (%d file[s])...", len(blocks), len(ignores), p.moduleName, len(p.files))
+	p.debug.Log("Read %d block(s) and %d ignore(s)", len(blocks), len(ignores))
 
 	var inputVars map[string]cty.Value
 	if p.moduleBlock != nil {
@@ -270,7 +270,7 @@ func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, cty.Value,
 		return nil, cty.NilVal, nil
 	}
 	modules, fsMap := e.EvaluateAll(ctx)
-	p.debug.Log("Finished parsing module '%s'.", p.moduleName)
+	p.debug.Log("Finished parsing module %q.", p.moduleName)
 	p.fsMap = fsMap
 	return modules, e.exportOutputs(), nil
 }

--- a/pkg/iac/scanners/terraform/parser/resolvers/cache.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache.go
@@ -56,7 +56,7 @@ func (r *cacheResolver) Resolve(_ context.Context, _ fs.FS, opt Options) (filesy
 
 	opt.Debug("Trying to resolve: %s", key)
 	if info, err := fs.Stat(cacheFS, filepath.ToSlash(key)); err == nil && info.IsDir() {
-		opt.Debug("Module '%s' resolving via cache...", opt.Name)
+		opt.Debug("Module %q resolving via cache...", opt.Name)
 		cacheDir, err := locateCacheDir(opt.CacheDir)
 		if err != nil {
 			return nil, "", "", true, err

--- a/pkg/iac/scanners/terraform/parser/resolvers/local.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/local.go
@@ -17,11 +17,11 @@ func (r *localResolver) Resolve(_ context.Context, target fs.FS, opt Options) (f
 	}
 	joined := path.Clean(path.Join(opt.ModulePath, opt.Source))
 	if _, err := fs.Stat(target, filepath.ToSlash(joined)); err == nil {
-		opt.Debug("Module '%s' resolved locally to %s", opt.Name, joined)
+		opt.Debug("Module %q resolved locally to %s", opt.Name, joined)
 		return target, "", joined, true, nil
 	}
 
 	clean := path.Clean(opt.Source)
-	opt.Debug("Module '%s' resolved locally to %s", opt.Name, clean)
+	opt.Debug("Module %q resolved locally to %s", opt.Name, clean)
 	return target, "", clean, true, nil
 }

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry.go
@@ -69,7 +69,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 
 	if opt.Version != "" {
 		versionUrl := fmt.Sprintf("https://%s/v1/modules/%s/versions", hostname, moduleName)
-		opt.Debug("Requesting module versions from registry using '%s'...", versionUrl)
+		opt.Debug("Requesting module versions from registry using %q...", versionUrl)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionUrl, nil)
 		if err != nil {
 			return nil, "", "", true, err
@@ -94,7 +94,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 		if err != nil {
 			return nil, "", "", true, err
 		}
-		opt.Debug("Found version '%s' for constraint '%s'", opt.Version, inputVersion)
+		opt.Debug("Found version %q for constraint %q", opt.Version, inputVersion)
 	}
 
 	var url string
@@ -104,7 +104,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 		url = fmt.Sprintf("https://%s/v1/modules/%s/%s/download", hostname, moduleName, opt.Version)
 	}
 
-	opt.Debug("Requesting module source from registry using '%s'...", url)
+	opt.Debug("Requesting module source from registry using %q...", url)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 		return nil, "", "", true, fmt.Errorf("no source was found for the registry at %s", hostname)
 	}
 
-	opt.Debug("Module '%s' resolved via registry to new source: '%s'", opt.Name, opt.Source)
+	opt.Debug("Module %q resolved via registry to new source: %q", opt.Name, opt.Source)
 
 	filesystem, prefix, downloadPath, _, err = Remote.Resolve(ctx, target, opt)
 	if err != nil {
@@ -203,5 +203,5 @@ func resolveVersion(input string, versions moduleVersions) (string, error) {
 			return realVersion.String(), nil
 		}
 	}
-	return "", fmt.Errorf("no available versions for module constraint '%s'", input)
+	return "", fmt.Errorf("no available versions for module constraint %q", input)
 }

--- a/pkg/iac/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/remote.go
@@ -53,7 +53,7 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 
 	r.incrementCount(opt)
 	opt.Debug("Successfully downloaded %s from %s", opt.Name, opt.Source)
-	opt.Debug("Module '%s' resolved via remote download.", opt.Name)
+	opt.Debug("Module %q resolved via remote download.", opt.Name)
 	return os.DirFS(cacheDir), opt.Source, filepath.Join(".", opt.RelativePath), true, nil
 }
 

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -154,15 +154,12 @@ type terraformRootModule struct {
 }
 
 func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, dir string) (scan.Results, error) {
-
-	s.debug.Log("Scanning [%s] at '%s'...", target, dir)
-
 	// find directories which directly contain tf files
 	modulePaths := s.findModules(target, dir, dir)
 	sort.Strings(modulePaths)
 
 	if len(modulePaths) == 0 {
-		s.debug.Log("no modules found")
+		s.debug.Log("No modules found")
 		return nil, nil
 	}
 
@@ -178,6 +175,7 @@ func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, dir string) (scan.Re
 	var allResults scan.Results
 
 	p := parser.New(target, "", s.parserOpt...)
+	p.SetDebugWriter(io.Discard)
 	rootDirs, err := p.FindRootModules(ctx, modulePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find root modules: %w", err)
@@ -188,7 +186,7 @@ func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, dir string) (scan.Re
 	// parse all root module directories
 	for _, dir := range rootDirs {
 
-		s.debug.Log("Scanning root module '%s'...", dir)
+		s.debug.Log("Scanning root module %q", dir)
 
 		p := parser.New(target, "", s.parserOpt...)
 
@@ -298,7 +296,7 @@ func (s *Scanner) findModules(target fs.FS, scanDir string, dirs ...string) []st
 func (s *Scanner) isRootModule(target fs.FS, dir string) bool {
 	files, err := fs.ReadDir(target, filepath.ToSlash(dir))
 	if err != nil {
-		s.debug.Log("failed to read dir '%s' from filesystem [%s]: %s", dir, target, err)
+		s.debug.Log("failed to read dir %q from filesystem [%s]: %s", dir, target, err)
 		return false
 	}
 	for _, file := range files {

--- a/pkg/iac/terraform/module.go
+++ b/pkg/iac/terraform/module.go
@@ -136,13 +136,13 @@ func (c *Module) GetReferencedBlock(referringAttr *Attribute, parentBlock *Block
 			}
 		}
 	}
-	return nil, fmt.Errorf("no referenced block found in '%s'", referringAttr.Name())
+	return nil, fmt.Errorf("no referenced block found in %q", referringAttr.Name())
 }
 
 func (c *Module) GetBlockByID(id string) (*Block, error) {
 	found := c.blocks.WithID(id)
 	if found == nil {
-		return nil, fmt.Errorf("no block found with id '%s'", id)
+		return nil, fmt.Errorf("no block found with id %q", id)
 	}
 	return found, nil
 }


### PR DESCRIPTION
## Description

Removed noisy messages. Some messages have been added and changed:
```sh
2024-07-09T21:58:18+07:00       DEBUG   [misconf] terraform.parser.<root>.evaluator Failed to expand block "aws_subnet.public_subnet". Invalid "for-each" argument: cty.NilVal. Must be known and iterable.
```

Also removed duplicate time from the message.
Before:
```sh
2024-07-09T15:18:08Z    DEBUG   [misconf] 18:08.884431133 terraform.parser.<root>.evaluator Starting module evaluation...
```
After:
```sh
2024-07-09T21:58:18+07:00       DEBUG   [misconf] terraform.parser.<object>.evaluator Starting module "object" evaluation
```

### Related Issues:
- Close https://github.com/aquasecurity/trivy/issues/7099

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
