### PR TITLE
chore: add VEX for Trivy images

### DIFF
--- a/.vex/oci.openvex.json
+++ b/.vex/oci.openvex.json
@@ -13,25 +13,22 @@
         {
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         }
       ],
@@ -47,9 +44,8 @@
         {
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
@@ -63,9 +59,8 @@
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         }
       ],
@@ -81,25 +76,22 @@
         {
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         }
       ],
@@ -115,25 +107,22 @@
         {
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"}
           ]
         }
       ],

--- a/.vex/oci.openvex.json
+++ b/.vex/oci.openvex.json
@@ -1,0 +1,145 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8e30ed756ae8e4196af93bf43edf68360f396a98c0268787453a3443b26e7d6c",
+  "author": "Aqua Security",
+  "timestamp": "2024-07-10T12:17:44.60495+04:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42363"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "awk is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42364"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "awk is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42365"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "awk is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-42366"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {
+              "@id": "pkg:apk/alpine/busybox"
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "awk is not used"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Add OpenVEX file for OCI images

NOTE: In this case, I created it manually, but I feel like it's not a human task. I think we should generate VEX automatically from the image scan results and `.trivyignore.yaml`.

```
$ trivy image ghcr.io/aquasecurity/trivy:0.51.0 --vex .vex/oci.openvex.json --show-suppressed --pkg-types os


ghcr.io/aquasecurity/trivy:0.51.0 (alpine 3.19.1)
=================================================
Total: 17 (UNKNOWN: 0, LOW: 4, MEDIUM: 10, HIGH: 2, CRITICAL: 1)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
...
│            │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                   │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                │
│            ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘

Suppressed Vulnerabilities (Total: 8)
=====================================
┌───────────────┬────────────────┬──────────┬──────────────┬───────────────────────────────────────────────────┬─────────┐
│    Library    │ Vulnerability  │ Severity │    Status    │                     Statement                     │ Source  │
├───────────────┼────────────────┼──────────┼──────────────┼───────────────────────────────────────────────────┼─────────┤
│ busybox       │ CVE-2023-42363 │ MEDIUM   │ not_affected │ vulnerable_code_cannot_be_controlled_by_adversary │ OpenVEX │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42364 │          │              │                                                   │         │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42365 │          │              │                                                   │         │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42366 │          │              │                                                   │         │
├───────────────┼────────────────┤          │              │                                                   │         │
│ busybox-binsh │ CVE-2023-42363 │          │              │                                                   │         │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42364 │          │              │                                                   │         │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42365 │          │              │                                                   │         │
│               ├────────────────┤          │              │                                                   │         │
│               │ CVE-2023-42366 │          │              │                                                   │         │
└───────────────┴────────────────┴──────────┴──────────────┴───────────────────────────────────────────────────┴─────────┘
```

## Related PRs
- https://github.com/aquasecurity/trivy/pull/7128

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
