### PR TITLE
docs: Fix PR documentation to use GitHub Discussions, not Issues

### DIFF
--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -1,7 +1,7 @@
 Thank you for taking interest in contributing to Trivy!
 
-1. Every Pull Request should have an associated bug or feature issue unless you are fixing a trivial documentation issue.
-1. Please add the associated Issue link in the PR description.
+1. Every Pull Request should have an associated bug or feature [GitHub Discussion](./discussion.md) unless you are fixing a trivial documentation issue.
+1. Please add the associated Discussion link in the PR description.
 1. Your PR is more likely to be accepted if it focuses on just one change.
 1. There's no need to add or tag reviewers.
 1. If a reviewer commented on your code or asked for changes, please remember to respond with comment. Do not mark discussion as resolved. It's up to reviewer to mark it resolved (in case if suggested fix addresses problem properly). PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).

--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -1,7 +1,7 @@
 Thank you for taking interest in contributing to Trivy!
 
-1. Every Pull Request should have an associated bug or feature [GitHub Discussion](./discussion.md) unless you are fixing a trivial documentation issue.
-1. Please add the associated Discussion link in the PR description.
+1. Unless you are fixing a trivial documentation issue, every Pull Request should have either an associated bug or feature [issue](./issue.md), or a [discussion](./discussion.md). Users aren't expected to create issues directly but to start a discussion which will perhaps result in an issue.
+1. Please add the associated issue or discussion link in the PR description.
 1. Your PR is more likely to be accepted if it focuses on just one change.
 1. There's no need to add or tag reviewers.
 1. If a reviewer commented on your code or asked for changes, please remember to respond with comment. Do not mark discussion as resolved. It's up to reviewer to mark it resolved (in case if suggested fix addresses problem properly). PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).

--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -1,7 +1,6 @@
 Thank you for taking interest in contributing to Trivy!
 
-1. Unless you are fixing a trivial documentation issue, every Pull Request should have either an associated bug or feature [issue](./issue.md), or a [discussion](./discussion.md). Users aren't expected to create issues directly but to start a discussion which will perhaps result in an issue.
-1. Please add the associated issue or discussion link in the PR description.
+1. Every Pull Request should have an associated GitHub issue link in the PR description. Note that issues are created by Trivy maintainers based on feedback provided in a GitHub discussion. Please refer to the [issue](./issue.md) and [discussion](./discussion.md) pages for explanation about this process. If you think your change is trivial enough, you can skip the issue and instead add justification and explanation in the PR description.
 1. Your PR is more likely to be accepted if it focuses on just one change.
 1. There's no need to add or tag reviewers.
 1. If a reviewer commented on your code or asked for changes, please remember to respond with comment. Do not mark discussion as resolved. It's up to reviewer to mark it resolved (in case if suggested fix addresses problem properly). PRs with unresolved issues should not be merged (even if the comment is unclear or requires no action from your side).


### PR DESCRIPTION
## Description

Fix PR documentation page since non-maintainers cannot use GitHub issues in trivy project.

## Related issues
- None (basic documentation issue).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
