### PR TITLE
docs(misconf): add info about limitations for terraform plan json

### DIFF
--- a/docs/docs/coverage/iac/terraform.md
+++ b/docs/docs/coverage/iac/terraform.md
@@ -48,3 +48,32 @@ trivy conf --tf-exclude-downloaded-modules ./configs
 
 ## Secret
 The secret scan is performed on plain text files, with no special treatment for Terraform.
+
+## Limitations
+
+### Terraform Plan JSON
+
+#### For each and count objects in expression
+
+The plan created by Terraform does not provide complete information about references in expressions that use `each` or `count` objects. For this reason, in some situations it is not possible to establish references between resources that are needed for checks when detecting misconfigurations. An example of such a configuration is:
+
+```hcl
+locals {
+  buckets = toset(["test"])
+}
+
+resource "aws_s3_bucket" "this" {
+  for_each = local.buckets
+  bucket = each.key
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  for_each = local.buckets
+  bucket = aws_s3_bucket.this[each.key].id
+  acl    = "private"
+}
+```
+
+With this configuration, the plan will not contain information about which attribute of the `aws_s3_bucket` resource is referenced by the `aws_s3_bucket_acl` resource.
+
+See more [here](https://github.com/hashicorp/terraform/issues/30826).


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7098

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
