### PR TITLE
feat(misconf): port and protocol support for EC2 networks

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
@@ -51,15 +51,15 @@ Resources:
       SecurityGroupIngress:
         - IpProtocol: tcp
           Description: ingress
-          FromPort: 80
+          FromPort: "80"
           ToPort: 80
           CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
-        - IpProtocol: tcp
+        - IpProtocol: -1
           Description: egress
           FromPort: 80
-          ToPort: 80
-          CidrIp: 0.0.0.0/0
+          ToPort: "80"
+          CidrIp: "0.0.0.0/0"
   myNetworkAcl:
       Type: AWS::EC2::NetworkAcl
       Properties:
@@ -73,6 +73,9 @@ Resources:
        Protocol: 6
        RuleAction: allow
        CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: "23"
   myLaunchConfig: 
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -137,6 +140,9 @@ Resources:
 								CIDRs: []types.StringValue{
 									types.StringTest("0.0.0.0/0"),
 								},
+								FromPort: types.IntTest(80),
+								ToPort:   types.IntTest(80),
+								Protocol: types.StringTest("tcp"),
 							},
 						},
 						EgressRules: []ec2.SecurityGroupRule{
@@ -145,6 +151,9 @@ Resources:
 								CIDRs: []types.StringValue{
 									types.StringTest("0.0.0.0/0"),
 								},
+								FromPort: types.IntTest(80),
+								ToPort:   types.IntTest(80),
+								Protocol: types.StringTest("-1"),
 							},
 						},
 					},
@@ -159,6 +168,8 @@ Resources:
 								CIDRs: []types.StringValue{
 									types.StringTest("172.16.0.0/24"),
 								},
+								FromPort: types.IntTest(22),
+								ToPort:   types.IntTest(23),
 							},
 						},
 					},
@@ -309,6 +320,8 @@ Resources:
 								CIDRs: []types.StringValue{
 									types.StringTest("0.0.0.0/0"),
 								},
+								FromPort: types.IntTest(-1),
+								ToPort:   types.IntTest(-1),
 							},
 						},
 						EgressRules: []ec2.SecurityGroupRule{
@@ -317,6 +330,8 @@ Resources:
 								CIDRs: []types.StringValue{
 									types.StringTest("0.0.0.0/0"),
 								},
+								FromPort: types.IntTest(-1),
+								ToPort:   types.IntTest(-1),
 							},
 						},
 					},

--- a/pkg/iac/adapters/terraform/aws/ec2/subnet.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/subnet.go
@@ -9,13 +9,13 @@ func adaptSubnets(modules terraform.Modules) []ec2.Subnet {
 	var subnets []ec2.Subnet
 	for _, module := range modules {
 		for _, resource := range module.GetResourcesByType("aws_subnet") {
-			subnets = append(subnets, adaptSubnet(resource, module))
+			subnets = append(subnets, adaptSubnet(resource))
 		}
 	}
 	return subnets
 }
 
-func adaptSubnet(resource *terraform.Block, module *terraform.Module) ec2.Subnet {
+func adaptSubnet(resource *terraform.Block) ec2.Subnet {
 	mapPublicIpOnLaunchAttr := resource.GetAttribute("map_public_ip_on_launch")
 	mapPublicIpOnLaunchVal := mapPublicIpOnLaunchAttr.AsBoolValueOrDefault(false, resource)
 

--- a/pkg/iac/adapters/terraform/aws/ec2/subnet_test.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/subnet_test.go
@@ -61,7 +61,7 @@ func Test_adaptSubnet(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
-			adapted := adaptSubnet(modules.GetBlocks()[0], modules[0])
+			adapted := adaptSubnet(modules.GetBlocks()[0])
 			testutil.AssertDefsecEqual(t, test.expected, adapted)
 		})
 	}

--- a/pkg/iac/adapters/terraform/aws/ec2/vpc.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/vpc.go
@@ -72,9 +72,9 @@ func (a *sgAdapter) adaptSecurityGroups(modules terraform.Modules) []ec2.Securit
 		}
 		for _, sgRule := range orphanResources {
 			if sgRule.GetAttribute("type").Equals("ingress") {
-				orphanage.IngressRules = append(orphanage.IngressRules, adaptSGRule(sgRule, modules))
+				orphanage.IngressRules = append(orphanage.IngressRules, adaptSGRule(sgRule))
 			} else if sgRule.GetAttribute("type").Equals("egress") {
-				orphanage.EgressRules = append(orphanage.EgressRules, adaptSGRule(sgRule, modules))
+				orphanage.EgressRules = append(orphanage.EgressRules, adaptSGRule(sgRule))
 			}
 		}
 		securityGroups = append(securityGroups, orphanage)
@@ -116,21 +116,21 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 
 	ingressBlocks := resource.GetBlocks("ingress")
 	for _, ingressBlock := range ingressBlocks {
-		ingressRules = append(ingressRules, adaptSGRule(ingressBlock, module))
+		ingressRules = append(ingressRules, adaptSGRule(ingressBlock))
 	}
 
 	egressBlocks := resource.GetBlocks("egress")
 	for _, egressBlock := range egressBlocks {
-		egressRules = append(egressRules, adaptSGRule(egressBlock, module))
+		egressRules = append(egressRules, adaptSGRule(egressBlock))
 	}
 
 	rulesBlocks := module.GetReferencingResources(resource, "aws_security_group_rule", "security_group_id")
 	for _, ruleBlock := range rulesBlocks {
 		a.sgRuleIDs.Resolve(ruleBlock.ID())
 		if ruleBlock.GetAttribute("type").Equals("ingress") {
-			ingressRules = append(ingressRules, adaptSGRule(ruleBlock, module))
+			ingressRules = append(ingressRules, adaptSGRule(ruleBlock))
 		} else if ruleBlock.GetAttribute("type").Equals("egress") {
-			egressRules = append(egressRules, adaptSGRule(ruleBlock, module))
+			egressRules = append(egressRules, adaptSGRule(ruleBlock))
 		}
 	}
 
@@ -154,7 +154,7 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 	}
 }
 
-func adaptSGRule(resource *terraform.Block, modules terraform.Modules) ec2.SecurityGroupRule {
+func adaptSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
 	ruleDescAttr := resource.GetAttribute("description")
 	ruleDescVal := ruleDescAttr.AsStringValueOrDefault("", resource)
 
@@ -162,16 +162,6 @@ func adaptSGRule(resource *terraform.Block, modules terraform.Modules) ec2.Secur
 
 	cidrBlocks := resource.GetAttribute("cidr_blocks")
 	ipv6cidrBlocks := resource.GetAttribute("ipv6_cidr_blocks")
-	varBlocks := modules.GetBlocks().OfType("variable")
-
-	for _, vb := range varBlocks {
-		if cidrBlocks.IsNotNil() && cidrBlocks.ReferencesBlock(vb) {
-			cidrBlocks = vb.GetAttribute("default")
-		}
-		if ipv6cidrBlocks.IsNotNil() && ipv6cidrBlocks.ReferencesBlock(vb) {
-			ipv6cidrBlocks = vb.GetAttribute("default")
-		}
-	}
 
 	if cidrBlocks.IsNotNil() {
 		cidrs = cidrBlocks.AsStringValues()
@@ -185,6 +175,9 @@ func adaptSGRule(resource *terraform.Block, modules terraform.Modules) ec2.Secur
 		Metadata:    resource.GetMetadata(),
 		Description: ruleDescVal,
 		CIDRs:       cidrs,
+		FromPort:    resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
+		ToPort:      resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
+		Protocol:    resource.GetAttribute("protocol").AsStringValueOrDefault("", resource),
 	}
 }
 
@@ -203,6 +196,9 @@ func adaptSingleSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
 		Metadata:    resource.GetMetadata(),
 		Description: description,
 		CIDRs:       cidrs,
+		FromPort:    resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
+		ToPort:      resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
+		Protocol:    resource.GetAttribute("ip_protocol").AsStringValueOrDefault("", resource),
 	}
 }
 
@@ -236,7 +232,7 @@ func adaptNetworkACLRule(resource *terraform.Block) ec2.NetworkACLRule {
 	actionVal := actionAttr.AsStringValueOrDefault("", resource)
 
 	protocolAtrr := resource.GetAttribute("protocol")
-	protocolVal := protocolAtrr.AsStringValueOrDefault("-1", resource)
+	protocolVal := protocolAtrr.AsStringValueOrDefault("", resource)
 
 	cidrAttr := resource.GetAttribute("cidr_block")
 	if cidrAttr.IsNotNil() {
@@ -253,5 +249,7 @@ func adaptNetworkACLRule(resource *terraform.Block) ec2.NetworkACLRule {
 		Action:   actionVal,
 		Protocol: protocolVal,
 		CIDRs:    cidrs,
+		FromPort: resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
+		ToPort:   resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
@@ -102,6 +102,9 @@ func Test_AdaptVPC(t *testing.T) {
 								CIDRs: []iacTypes.StringValue{
 									iacTypes.String("4.5.6.7/32", iacTypes.NewTestMetadata()),
 								},
+								FromPort: iacTypes.IntTest(80),
+								ToPort:   iacTypes.IntTest(80),
+								Protocol: iacTypes.StringTest("tcp"),
 							},
 							{
 								Metadata: iacTypes.NewTestMetadata(),
@@ -111,6 +114,9 @@ func Test_AdaptVPC(t *testing.T) {
 									iacTypes.String("1.2.3.4/32", iacTypes.NewTestMetadata()),
 									iacTypes.String("4.5.6.7/32", iacTypes.NewTestMetadata()),
 								},
+								FromPort: iacTypes.IntTest(22),
+								ToPort:   iacTypes.IntTest(22),
+								Protocol: iacTypes.StringTest("tcp"),
 							},
 						},
 
@@ -121,6 +127,8 @@ func Test_AdaptVPC(t *testing.T) {
 								CIDRs: []iacTypes.StringValue{
 									iacTypes.String("1.2.3.4/32", iacTypes.NewTestMetadata()),
 								},
+								FromPort: iacTypes.IntTest(-1),
+								ToPort:   iacTypes.IntTest(-1),
 							},
 						},
 					},
@@ -137,6 +145,8 @@ func Test_AdaptVPC(t *testing.T) {
 								CIDRs: []iacTypes.StringValue{
 									iacTypes.String("10.0.0.0/16", iacTypes.NewTestMetadata()),
 								},
+								FromPort: iacTypes.IntTest(22),
+								ToPort:   iacTypes.IntTest(22),
 							},
 						},
 						IsDefaultRule: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
@@ -169,6 +179,8 @@ func Test_AdaptVPC(t *testing.T) {
 							{
 								Metadata:    iacTypes.NewTestMetadata(),
 								Description: iacTypes.String("", iacTypes.NewTestMetadata()),
+								FromPort:    iacTypes.IntTest(-1),
+								ToPort:      iacTypes.IntTest(-1),
 							},
 						},
 
@@ -176,6 +188,8 @@ func Test_AdaptVPC(t *testing.T) {
 							{
 								Metadata:    iacTypes.NewTestMetadata(),
 								Description: iacTypes.String("", iacTypes.NewTestMetadata()),
+								FromPort:    iacTypes.IntTest(-1),
+								ToPort:      iacTypes.IntTest(-1),
 							},
 						},
 					},
@@ -188,7 +202,9 @@ func Test_AdaptVPC(t *testing.T) {
 								Metadata: iacTypes.NewTestMetadata(),
 								Type:     iacTypes.String("ingress", iacTypes.NewTestMetadata()),
 								Action:   iacTypes.String("", iacTypes.NewTestMetadata()),
-								Protocol: iacTypes.String("-1", iacTypes.NewTestMetadata()),
+								Protocol: iacTypes.String("", iacTypes.NewTestMetadata()),
+								FromPort: iacTypes.IntTest(-1),
+								ToPort:   iacTypes.IntTest(-1),
 							},
 						},
 						IsDefaultRule: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
@@ -252,6 +268,9 @@ resource "aws_vpc_security_group_ingress_rule" "test" {
 								CIDRs: []iacTypes.StringValue{
 									iacTypes.StringTest("0.0.0.0/0"),
 								},
+								Protocol: iacTypes.StringTest("tcp"),
+								FromPort: iacTypes.IntTest(22),
+								ToPort:   iacTypes.IntTest(22),
 							},
 						},
 						EgressRules: []ec2.SecurityGroupRule{
@@ -259,6 +278,9 @@ resource "aws_vpc_security_group_ingress_rule" "test" {
 								CIDRs: []iacTypes.StringValue{
 									iacTypes.StringTest("0.0.0.0/0"),
 								},
+								Protocol: iacTypes.StringTest("-1"),
+								FromPort: iacTypes.IntTest(-1),
+								ToPort:   iacTypes.IntTest(-1),
 							},
 						},
 					},

--- a/pkg/iac/providers/aws/ec2/vpc.go
+++ b/pkg/iac/providers/aws/ec2/vpc.go
@@ -23,6 +23,9 @@ type SecurityGroupRule struct {
 	Metadata    iacTypes.Metadata
 	Description iacTypes.StringValue
 	CIDRs       []iacTypes.StringValue
+	Protocol    iacTypes.StringValue
+	FromPort    iacTypes.IntValue
+	ToPort      iacTypes.IntValue
 }
 
 type VPC struct {
@@ -49,4 +52,6 @@ type NetworkACLRule struct {
 	Action   iacTypes.StringValue
 	Protocol iacTypes.StringValue
 	CIDRs    []iacTypes.StringValue
+	FromPort iacTypes.IntValue
+	ToPort   iacTypes.IntValue
 }

--- a/pkg/iac/scanners/cloudformation/parser/property_conversion.go
+++ b/pkg/iac/scanners/cloudformation/parser/property_conversion.go
@@ -43,6 +43,8 @@ func (p *Property) isConvertableToBool() bool {
 
 	case cftypes.Int:
 		return p.EqualTo(1) || p.EqualTo(0)
+	case cftypes.Bool:
+		return true
 	}
 	return false
 }
@@ -53,13 +55,17 @@ func (p *Property) isConvertableToInt() bool {
 		if _, err := strconv.Atoi(p.AsString()); err == nil {
 			return true
 		}
-	case cftypes.Bool:
+	case cftypes.Bool, cftypes.Int:
 		return true
 	}
 	return false
 }
 
 func (p *Property) ConvertTo(conversionType cftypes.CfType) *Property {
+
+	if p.Type() == conversionType {
+		return p
+	}
 
 	if !p.IsConvertableTo(conversionType) {
 		_, _ = fmt.Fprintf(os.Stderr, "property of type %s cannot be converted to %s\n", p.Type(), conversionType)


### PR DESCRIPTION
## Description

- Added port support for Network ACLs
- Added port and protocol support for security group rules
- The default protocol for Network ACL was `-1`. This is not mentioned in the documentation and the protocol is required, so it is changed to blank.

Refs:
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkaclentry.html#cfn-ec2-networkaclentry-protocol
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule#protocol

## Related issues
- Fixes https://github.com/aquasecurity/trivy/issues/7137
## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
