### PR TITLE
fix: add missing platform and type to spec

### DIFF
--- a/pkg/iac/types/compliance.go
+++ b/pkg/iac/types/compliance.go
@@ -21,7 +21,9 @@ type Spec struct {
 	Title            string    `yaml:"title"`
 	Description      string    `yaml:"description"`
 	Version          string    `yaml:"version"`
-	RelatedResources []string  `yaml:"relatedResources"`
+	Platform         string    `yaml:"platform"`
+	Type             string    `yaml:"type"`
+	RelatedResources []string  `yaml:"relatedResources,omitempty"`
 	Controls         []Control `yaml:"controls"`
 }
 
@@ -30,8 +32,8 @@ type Control struct {
 	ID            string        `yaml:"id"`
 	Name          string        `yaml:"name"`
 	Description   string        `yaml:"description,omitempty"`
-	Checks        []SpecCheck   `yaml:"checks"`
-	Commands      []Command     `yaml:"commands"`
+	Checks        []SpecCheck   `yaml:"checks,omitempty"`
+	Commands      []Command     `yaml:"commands,omitempty"`
 	Severity      Severity      `yaml:"severity"`
 	DefaultStatus ControlStatus `yaml:"defaultStatus,omitempty"`
 }


### PR DESCRIPTION
## Description
The platform and type fields are present in the compliance specifications in trivy-checks, but missing in types.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
