### PR TITLE
fix: close file when failed to open gzip

### DIFF
--- a/pkg/fanal/image/docker.go
+++ b/pkg/fanal/image/docker.go
@@ -35,6 +35,7 @@ func fileOpener(fileName string) func() (io.ReadCloser, error) {
 		if utils.IsGzip(br) {
 			r, err = gzip.NewReader(br)
 			if err != nil {
+				_ = f.Close()
 				return nil, xerrors.Errorf("failed to open gzip: %w", err)
 			}
 		}


### PR DESCRIPTION
## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
