### PR TITLE
aws region name preset

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,11 +10,10 @@ In this section you will find an aggregation of the different ways to install Tr
     Add repository setting to `/etc/yum.repos.d`.
 
     ``` bash
-    RELEASE_VERSION=$(grep -Po '(?<=VERSION_ID=")[0-9]' /etc/os-release)
     cat << EOF | sudo tee -a /etc/yum.repos.d/trivy.repo
     [trivy]
     name=Trivy repository
-    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$RELEASE_VERSION/\$basearch/
+    baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/\$basearch/
     gpgcheck=1
     enabled=1
     gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key

--- a/pkg/iac/terraform/presets.go
+++ b/pkg/iac/terraform/presets.go
@@ -19,13 +19,16 @@ func createPresetValues(b *Block) map[string]cty.Value {
 		presets["arn"] = cty.StringVal(b.ID())
 	}
 
-	// workaround for weird iam feature
 	switch b.TypeLabel() {
+	// workaround for weird iam feature
 	case "aws_iam_policy_document":
 		presets["json"] = cty.StringVal(b.ID())
 	// If the user leaves the name blank, Terraform will automatically generate a unique name
 	case "aws_launch_template":
 		presets["name"] = cty.StringVal(uuid.New().String())
+	// allow referencing the current region name
+	case "aws_region":
+		presets["name"] = cty.StringVal("region-" + uuid.New().String())
 	}
 
 	return presets


### PR DESCRIPTION
- **fix: fileset escape FS (#1)**
- **feat: support TF 0.11 var types**
- **fix(terraform): add aws_region name to presets**
