### PR TITLE
docs: updates config file

### DIFF
--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -352,9 +352,9 @@ rego:
   # Default is false
   trace: false
 
-  # Same as '--skip-policy-update'
+  # Same as '--skip-check-update'
   # Default is false
-  skip-policy-update: false
+  skip-check-update: false
 
   # Same as '--config-policy'
   # Default is empty


### PR DESCRIPTION
## Description

The documentation for the config file states that the yaml field `rego.skip-policy-update` skips the retrieval of policy checks which is outdated or incorrect because the actual field is `rego.skip-check-update`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
