### PR TITLE
chore(vex): update subcomponents for CVE-2023-42363/42364/42365/42366

### DIFF
--- a/.vex/oci.openvex.json
+++ b/.vex/oci.openvex.json
@@ -14,21 +14,24 @@
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         }
       ],
@@ -45,22 +48,24 @@
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
-            {
-              "@id": "pkg:apk/alpine/busybox"
-            }
+            {"@id": "pkg:apk/alpine/busybox"},
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         }
       ],
@@ -77,21 +82,24 @@
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         }
       ],
@@ -108,21 +116,24 @@
           "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         },
         {
           "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
           "subcomponents": [
             {"@id": "pkg:apk/alpine/busybox"},
-            {"@id": "pkg:apk/alpine/busybox-binsh"}
+            {"@id": "pkg:apk/alpine/busybox-binsh"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
           ]
         }
       ],


### PR DESCRIPTION
## Description
CVE-2023-42364 and other awk vulnerabilities are detected on `ssl_client` as it is a binary package of busybox. It must not be affected.

```
$ trivy image ghcr.io/aquasecurity/trivy:0.52.0 --vex .vex/oci.openvex.json
...

ghcr.io/aquasecurity/trivy:0.52.0 (alpine 3.20.0)
=================================================
Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 0, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                     Title                      │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-4741  │ MEDIUM   │ fixed  │ 3.3.0-r2          │ 3.3.0-r3      │ openssl: Use After Free with SSL_free_buffers  │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741      │
│            ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────┤
│            │ CVE-2024-5535  │          │        │                   │ 3.3.1-r1      │ openssl: SSL_select_next_proto buffer overread │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535      │
├────────────┼────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────┤
│ libssl3    │ CVE-2024-4741  │          │        │                   │ 3.3.0-r3      │ openssl: Use After Free with SSL_free_buffers  │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741      │
│            ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────┤
│            │ CVE-2024-5535  │          │        │                   │ 3.3.1-r1      │ openssl: SSL_select_next_proto buffer overread │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535      │
├────────────┼────────────────┤          │        ├───────────────────┼───────────────┼────────────────────────────────────────────────┤
│ ssl_client │ CVE-2023-42364 │          │        │ 1.36.1-r28        │ 1.36.1-r29    │ busybox: use-after-free                        │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364     │
│            ├────────────────┤          │        │                   │               ├────────────────────────────────────────────────┤
│            │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                        │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365     │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────┘
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
