### PR TITLE
feat(misconf): support for ignore by nested attributes

### DIFF
--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -476,7 +476,7 @@ If you want to ignore multiple resources on different attributes, you can specif
 #trivy:ignore:aws-ec2-no-public-ingress-sgr[from_port=5432]
 ```
 
-You can also ignore a resource on multiple attributes:
+You can also ignore a resource on multiple attributes in the same rule:
 ```tf
 locals {
   rules = {
@@ -505,10 +505,7 @@ resource "aws_security_group_rule" "example" {
 }
 ```
 
-Checks can also be ignored by nested attributes, but certain restrictions apply:
-
-- You cannot access an individual block using indexes, for example when working with dynamic blocks.
-- Special variables like [each](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each#the-each-object) and [count](https://developer.hashicorp.com/terraform/language/meta-arguments/count#the-count-object) cannot be accessed.
+Checks can also be ignored by nested attributes:
 
 ```tf
 #trivy:ignore:*[logging_config.prefix=myprefix]

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -122,26 +122,23 @@ func ignoreByParams(params map[string]string, modules terraform.Modules, m *type
 	if block == nil {
 		return true
 	}
-	for key, val := range params {
-		attr, _ := block.GetNestedAttribute(key)
-		if attr.IsNil() || !attr.Value().IsKnown() {
-			return false
-		}
-		switch attr.Type() {
+	for key, param := range params {
+		val := block.GetValueByPath(key)
+		switch val.Type() {
 		case cty.String:
-			if !attr.Equals(val) {
+			if val.AsString() != param {
 				return false
 			}
 		case cty.Number:
-			bf := attr.Value().AsBigFloat()
+			bf := val.AsBigFloat()
 			f64, _ := bf.Float64()
 			comparableInt := fmt.Sprintf("%d", int(f64))
 			comparableFloat := fmt.Sprintf("%f", f64)
-			if val != comparableInt && val != comparableFloat {
+			if param != comparableInt && param != comparableFloat {
 				return false
 			}
 		case cty.Bool:
-			if fmt.Sprintf("%t", attr.IsTrue()) != val {
+			if fmt.Sprintf("%t", val.True()) != param {
 				return false
 			}
 		default:

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -446,6 +446,21 @@ resource "bad" "my-rule" {
 			assertLength: 0,
 		},
 		{
+			name: "ignore by indexed dynamic block value",
+			inputOptions: `
+// trivy:ignore:*[secure_settings.0.enabled=false]
+resource "bad" "my-rule" {
+  dynamic "secure_settings" {
+    for_each = ["false", "true"]
+    content {
+      enabled = secure_settings.value
+    }
+  }
+}
+`,
+			assertLength: 0,
+		},
+		{
 			name: "TrivyIgnoreLineStackedAboveTheBlock",
 			inputOptions: `
 // trivy:ignore:*

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -433,7 +433,7 @@ resource "bad" "my-rule" {
 		{
 			name: "ignore by dynamic block value",
 			inputOptions: `
-// trivy:ignore:*[secure_settings.enabled=false]
+// trivy:ignore:*[secure_settings.0.enabled=false]
 resource "bad" "my-rule" {
   dynamic "secure_settings" {
     for_each = ["false", "true"]
@@ -602,6 +602,154 @@ data "aws_iam_policy_document" "test_policy" {
       "cloudwatch:PutMetricData", # trivy:ignore:aws-iam-enforce-mfa
     ]
     resources = ["*"] # trivy:ignore:aws-iam-enforce-mfa
+  }
+}
+`,
+			assertLength: 0,
+		},
+		{
+			name: "ignore by each.value",
+			inputOptions: `
+// trivy:ignore:*[each.value=false]
+resource "bad" "my-rule" {
+  for_each = toset(["false", "true", "false"])
+  secure   = each.value
+}
+`,
+			assertLength: 0,
+		},
+		{
+			name: "ignore by nested each.value",
+			inputOptions: `
+locals {
+  vms = [
+    {
+      ip_address = "10.0.0.1"
+      name       = "vm-1"
+    },
+    {
+      ip_address = "10.0.0.2"
+      name       = "vm-2"
+    }
+  ]
+}
+// trivy:ignore:*[each.value.name=vm-2]
+resource "bad" "my-rule" {
+  secure = false
+  for_each   = { for vm in local.vms : vm.name => vm }
+  ip_address = each.value.ip_address
+}
+`,
+			assertLength: 1,
+		},
+		{
+			name: "ignore resource with `count` meta-argument",
+			inputOptions: `
+// trivy:ignore:*[count.index=1]
+resource "bad" "my-rule" {
+  count = 2
+  secure = false
+}
+`,
+			assertLength: 1,
+		},
+		{
+			name: "invalid index when accessing blocks",
+			inputOptions: `
+// trivy:ignore:*[ingress.99.port=9090]
+// trivy:ignore:*[ingress.-10.port=9090]
+resource "bad" "my-rule" {
+  secure = false
+  dynamic "ingress" {
+    for_each = [8080, 9090]
+    content {
+      port = ingress.value
+    }
+  }
+}
+`,
+			assertLength: 1,
+		},
+		{
+			name: "ignore by list value",
+			inputOptions: `
+#trivy:ignore:*[someattr.1.Environment=dev]
+resource "bad" "my-rule" {
+  secure = false
+  someattr = [
+	{
+		Environment = "prod"
+	},
+	{
+		Environment = "dev"
+	}
+  ]
+}
+`,
+			assertLength: 0,
+		},
+		{
+			name: "ignore by list value with invalid index",
+			inputOptions: `
+#trivy:ignore:*[someattr.-2.Environment=dev]
+resource "bad" "my-rule" {
+  secure = false
+  someattr = [
+	{
+		Environment = "prod"
+	},
+	{
+		Environment = "dev"
+	}
+  ]
+}
+`,
+			assertLength: 1,
+		},
+		{
+			name: "ignore by object value",
+			inputOptions: `
+#trivy:ignore:*[tags.Environment=dev]
+resource "bad" "my-rule" {
+  secure = false
+  tags = {
+    Environment = "dev"
+  }
+}
+`,
+			assertLength: 0,
+		},
+		{
+			name: "ignore by object value in block",
+			inputOptions: `
+#trivy:ignore:*[someblock.tags.Environment=dev]
+resource "bad" "my-rule" {
+  secure = false
+  someblock {
+	tags = {
+	  Environment = "dev"
+	}
+  }
+}
+`,
+			assertLength: 0,
+		},
+		{
+			name: "ignore by list value in map",
+			inputOptions: `
+variable "testvar" {
+  type = map(list(string))
+  default = {
+    server1 = ["web", "dev"]
+    server2 = ["prod"]
+  }
+}
+
+#trivy:ignore:*[someblock.someattr.server1.1=dev]
+resource "bad" "my-rule" {
+  secure = false
+  someblock {
+	someattr = var.testvar
   }
 }
 `,

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -433,7 +433,7 @@ resource "bad" "my-rule" {
 		{
 			name: "ignore by dynamic block value",
 			inputOptions: `
-// trivy:ignore:*[secure_settings.0.enabled=false]
+// trivy:ignore:*[secure_settings.enabled=false]
 resource "bad" "my-rule" {
   dynamic "secure_settings" {
     for_each = ["false", "true"]

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -353,7 +353,7 @@ func (b *Block) getAttributeByPath(path string) (*Attribute, []string) {
 	for currentBlock := b; currentBlock != nil && stepIndex < len(steps); {
 		blocks := currentBlock.GetBlocks(steps[stepIndex])
 		var nextBlock *Block
-		if !hasIndex(steps, stepIndex) && len(blocks) > 0 {
+		if !hasIndex(steps, stepIndex+1) && len(blocks) > 0 {
 			// if index is not provided then return the first block for backwards compatibility
 			nextBlock = blocks[0]
 		} else if len(blocks) > 1 && stepIndex < len(steps)-2 {

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -350,12 +350,11 @@ func (b *Block) getAttributeByPath(path string) (*Attribute, []string) {
 		stepIndex int
 	)
 
-	currentBlock := b
-	for currentBlock != nil && stepIndex <= len(steps)-1 {
+	for currentBlock := b; currentBlock != nil && stepIndex < len(steps); {
 		blocks := currentBlock.GetBlocks(steps[stepIndex])
-
 		var nextBlock *Block
-		if len(blocks) == 1 {
+		if !hasIndex(steps, stepIndex) && len(blocks) > 0 {
+			// if index is not provided then return the first block for backwards compatibility
 			nextBlock = blocks[0]
 		} else if len(blocks) > 1 && stepIndex < len(steps)-2 {
 			// handling the case when there are multiple blocks with the same name,
@@ -376,6 +375,14 @@ func (b *Block) getAttributeByPath(path string) (*Attribute, []string) {
 	}
 
 	return attribute, steps[stepIndex:]
+}
+
+func hasIndex(steps []string, idx int) bool {
+	if idx < 0 || idx >= len(steps) {
+		return false
+	}
+	_, err := strconv.Atoi(steps[idx])
+	return err == nil
 }
 
 func getValueByPath(val cty.Value, path []string) (cty.Value, error) {


### PR DESCRIPTION
## Description

Added ability to ignore by nested attributes and values.

## Related issues
- Part of https://github.com/aquasecurity/trivy/issues/7180

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
