### PR TITLE
feat(sbom): add vulnerability support for SPDX formats

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -410,15 +410,10 @@ func (o *Options) enableSBOM() {
 		o.Scanners.Enable(types.SBOMScanner)
 	}
 
-	if o.Format == types.FormatSPDX || o.Format == types.FormatSPDXJSON {
-		log.Info(`"--format spdx" and "--format spdx-json" disable security scanning`)
-		o.Scanners = types.Scanners{types.SBOMScanner}
-	}
-
-	if o.Format == types.FormatCycloneDX {
+	if o.Format == types.FormatCycloneDX || o.Format == types.FormatSPDX || o.Format == types.FormatSPDXJSON {
 		// Vulnerability scanning is disabled by default for CycloneDX.
 		if !viper.IsSet(ScannersFlag.ConfigName) {
-			log.Info(`"--format cyclonedx" disables security scanning. Specify "--scanners vuln" explicitly if you want to include vulnerabilities in the CycloneDX report.`)
+			log.Info(fmt.Sprintf(`"--format %s" disables security scanning. Specify "--scanners vuln" explicitly if you want to include vulnerabilities in the CycloneDX report.`, o.Format))
 			o.Scanners = nil
 		}
 		o.Scanners.Enable(types.SBOMScanner)

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -822,6 +822,112 @@ func TestMarshaler_Marshal(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path with vulnerability",
+			inputReport: types.Report{
+				SchemaVersion: report.SchemaVersion,
+				ArtifactName:  "log4j-core-2.17.0.jar",
+				ArtifactType:  artifact.TypeFilesystem,
+				Results: types.Results{
+					{
+						Target: "Java",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.Jar,
+						Packages: []ftypes.Package{
+							{
+								Name:    "org.apache.logging.log4j:log4j-core",
+								Version: "2.17.0",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeMaven,
+										Namespace: "org.apache.logging.log4j",
+										Name:      "log4j-core",
+										Version:   "2.17.0",
+									},
+								},
+							},
+						},
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2021-44832",
+								PkgName:          "org.apache.logging.log4j:log4j-core",
+								InstalledVersion: "2.17.0",
+								FixedVersion:     "2.3.2, 2.12.4, 2.17.1",
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2021-44832",
+							},
+						},
+					},
+				},
+			},
+			wantSBOM: &spdx.Document{
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				SPDXIdentifier:    "DOCUMENT",
+				DocumentName:      "log4j-core-2.17.0.jar",
+				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/log4j-core-2.17.0.jar-3ff14136-e09f-4df9-80ea-000000000003",
+				CreationInfo: &spdx.CreationInfo{
+					Creators: []common.Creator{
+						{
+							Creator:     "aquasecurity",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "trivy-0.38.1",
+							CreatorType: "Tool",
+						},
+					},
+					Created: "2021-08-25T12:20:30Z",
+				},
+				Packages: []*spdx.Package{
+					{
+						PackageSPDXIdentifier:   spdx.ElementID("Package-4ee6f197f4811213"),
+						PackageDownloadLocation: "NONE",
+						PackageName:             "org.apache.logging.log4j:log4j-core",
+						PackageVersion:          "2.17.0",
+						PackageLicenseConcluded: "NONE",
+						PackageLicenseDeclared:  "NONE",
+						PackageExternalReferences: []*spdx.PackageExternalReference{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.0",
+							},
+							{
+								Category: "SECURITY",
+								RefType:  "advisory",
+								Locator:  "https://avd.aquasec.com/nvd/cve-2021-44832",
+							},
+						},
+						PrimaryPackagePurpose: tspdx.PackagePurposeLibrary,
+						PackageSupplier:       &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
+						PackageAttributionTexts: []string{
+							"PkgType: jar",
+						},
+					},
+					{
+						PackageSPDXIdentifier:   spdx.ElementID("Filesystem-121e7e7a43f02ab"),
+						PackageDownloadLocation: "NONE",
+						PackageName:             "log4j-core-2.17.0.jar",
+						PackageAttributionTexts: []string{
+							"SchemaVersion: 2",
+						},
+						PrimaryPackagePurpose: tspdx.PackagePurposeSource,
+					},
+				},
+				Relationships: []*spdx.Relationship{
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
+						RefB:         spdx.DocElementID{ElementRefID: "Filesystem-121e7e7a43f02ab"},
+						Relationship: "DESCRIBES",
+					},
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "Filesystem-121e7e7a43f02ab"},
+						RefB:         spdx.DocElementID{ElementRefID: "Package-4ee6f197f4811213"},
+						Relationship: "CONTAINS",
+					},
+				},
+			},
+		},
+		{
 			name: "happy path aggregate results",
 			inputReport: types.Report{
 				SchemaVersion: report.SchemaVersion,


### PR DESCRIPTION
## Description
SPDX v2.3 uses `externalRefs` for advisories.
See #6308 for more details

example:
```bash
➜ trivy -d image -f spdx-json -o report.spdx.json ubuntu --scanners vuln
...
  {
      "name": "libssl3t64",
      "SPDXID": "SPDXRef-Package-ed46e6c8dd5adb2d",
      "versionInfo": "3.0.13-0ubuntu3.1",
      "supplier": "Organization: Ubuntu Developers \u003cubuntu-devel-discuss@lists.ubuntu.com\u003e",
      "downloadLocation": "NONE",
      "filesAnalyzed": false,
      "sourceInfo": "built package from: openssl 3.0.13-0ubuntu3.1",
      "licenseConcluded": "Apache-2.0 AND Artistic AND GPL-1.0-only",
      "licenseDeclared": "Apache-2.0 AND Artistic AND GPL-1.0-only",
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE-MANAGER",
          "referenceType": "purl",
          "referenceLocator": "pkg:deb/ubuntu/libssl3t64@3.0.13-0ubuntu3.1?arch=amd64\u0026distro=ubuntu-24.04"
        },
        {
          "referenceCategory": "SECURITY",
          "referenceType": "advisory",
          "referenceLocator": "https://avd.aquasec.com/nvd/cve-2024-2511"
        },
        {
          "referenceCategory": "SECURITY",
          "referenceType": "advisory",
          "referenceLocator": "https://avd.aquasec.com/nvd/cve-2024-4603"
        },
        {
          "referenceCategory": "SECURITY",
          "referenceType": "advisory",
          "referenceLocator": "https://avd.aquasec.com/nvd/cve-2024-4741"
        }
      ],
      "attributionTexts": [
        "LayerDiffID: sha256:a30a5965a4f7d9d5ff76a46eb8939f58e95be844de1ac4a4b452d5d31158fdea",
        "LayerDigest: sha256:9c704ecd0c694c4cbdd85e589ac8d1fc3fd8f890b7f3731769a5b169eb495809",
        "PkgID: libssl3t64@3.0.13-0ubuntu3.1",
        "PkgType: ubuntu"
      ],
      "primaryPackagePurpose": "LIBRARY"
    },
...

```

## Related issues
- Close #7211

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
