### PR TITLE
ci: use free runner for all tests except `build tests`

### DIFF
--- a/.github/workflows/bypass-test.yaml
+++ b/.github/workflows/bypass-test.yaml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest-m, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - run: 'echo "No test required"'
 
   integration:
     name: Integration Test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No test required"'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest-m, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4.1.6
 
@@ -31,7 +31,7 @@ jobs:
             echo "Run 'go mod tidy' and push it"
             exit 1
           fi
-        if: matrix.operating-system == 'ubuntu-latest-m'
+        if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Lint
         id: lint
@@ -39,7 +39,7 @@ jobs:
         with:
           version: v1.59
           args: --verbose --out-format=line-number
-        if: matrix.operating-system == 'ubuntu-latest-m'
+        if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed
         run: |
@@ -60,14 +60,14 @@ jobs:
             echo "Run 'mage docs:generate' and push it"
             exit 1
           fi
-        if: matrix.operating-system == 'ubuntu-latest-m'
+        if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Run unit tests
         run: mage test:unit
 
   integration:
     name: Integration Test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4.1.6
@@ -87,7 +87,7 @@ jobs:
 
   k8s-integration:
     name: K8s Integration Test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4.1.6
@@ -129,7 +129,7 @@ jobs:
 
   vm-test:
     name: VM Integration Test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.6


### PR DESCRIPTION
## Description
Use `ubuntu-latest-m` only for `build tests` and `release` action, to avoid running this runner a lot.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
