### PR TITLE
fix(secret): update length of `hugging-face-access-token`

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -165,7 +165,7 @@ var builtinRules = []Rule{
 		Category: CategoryHuggingFace,
 		Severity: "CRITICAL",
 		Title:    "Hugging Face Access Token",
-		Regex:    MustCompile(`hf_[A-Za-z0-9]{39}`),
+		Regex:    MustCompile(`hf_[A-Za-z0-9]{34,40}`),
 		Keywords: []string{"hf_"},
 	},
 	{


### PR DESCRIPTION
## Description
`hugging-face-access-token` can contain 34-40 characters.

## Related issues
- Close #6823

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
