### PR TITLE
fix(misconf): do not set default value for default_cache_behavior

### DIFF
--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
@@ -33,7 +33,7 @@ func adaptDistribution(resource *terraform.Block) cloudfront.Distribution {
 		},
 		DefaultCacheBehaviour: cloudfront.CacheBehaviour{
 			Metadata:             resource.GetMetadata(),
-			ViewerProtocolPolicy: types.String("allow-all", resource.GetMetadata()),
+			ViewerProtocolPolicy: types.StringDefault("", resource.GetMetadata()),
 		},
 		OrdererCacheBehaviours: nil,
 		ViewerCertificate: cloudfront.ViewerCertificate{
@@ -53,13 +53,13 @@ func adaptDistribution(resource *terraform.Block) cloudfront.Distribution {
 	if defaultCacheBlock := resource.GetBlock("default_cache_behavior"); defaultCacheBlock.IsNotNil() {
 		distribution.DefaultCacheBehaviour.Metadata = defaultCacheBlock.GetMetadata()
 		viewerProtocolPolicyAttr := defaultCacheBlock.GetAttribute("viewer_protocol_policy")
-		distribution.DefaultCacheBehaviour.ViewerProtocolPolicy = viewerProtocolPolicyAttr.AsStringValueOrDefault("allow-all", defaultCacheBlock)
+		distribution.DefaultCacheBehaviour.ViewerProtocolPolicy = viewerProtocolPolicyAttr.AsStringValueOrDefault("", defaultCacheBlock)
 	}
 
 	orderedCacheBlocks := resource.GetBlocks("ordered_cache_behavior")
 	for _, orderedCacheBlock := range orderedCacheBlocks {
 		viewerProtocolPolicyAttr := orderedCacheBlock.GetAttribute("viewer_protocol_policy")
-		viewerProtocolPolicyVal := viewerProtocolPolicyAttr.AsStringValueOrDefault("allow-all", orderedCacheBlock)
+		viewerProtocolPolicyVal := viewerProtocolPolicyAttr.AsStringValueOrDefault("", orderedCacheBlock)
 		distribution.OrdererCacheBehaviours = append(distribution.OrdererCacheBehaviours, cloudfront.CacheBehaviour{
 			Metadata:             orderedCacheBlock.GetMetadata(),
 			ViewerProtocolPolicy: viewerProtocolPolicyVal,

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
@@ -83,7 +83,7 @@ func Test_adaptDistribution(t *testing.T) {
 				},
 				DefaultCacheBehaviour: cloudfront.CacheBehaviour{
 					Metadata:             iacTypes.NewTestMetadata(),
-					ViewerProtocolPolicy: iacTypes.String("allow-all", iacTypes.NewTestMetadata()),
+					ViewerProtocolPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
 				},
 
 				ViewerCertificate: cloudfront.ViewerCertificate{


### PR DESCRIPTION
## Description

The documentation does not say that the `default_cache_behavior` argument has a default values.

Refs:
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_cache_behavior
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html


## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7233

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
