### PR TITLE
feat(vuln): add `--pkg-relationships`

### DIFF
--- a/docs/docs/scanner/vulnerability.md
+++ b/docs/docs/scanner/vulnerability.md
@@ -202,7 +202,8 @@ Currently, specifying a username and password is not supported.
 This section describes vulnerability-specific configuration.
 Other common options are documented [here](../configuration/index.md).
 
-### Enabling a subset of package types
+### Enabling a Subset of Package Types
+
 It's possible to only enable certain package types if you prefer.
 You can do so by passing the `--pkg-types` option.
 This flag takes a comma-separated list of package types.
@@ -267,6 +268,45 @@ Total: 7 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 3, CRITICAL: 2)
 ```
 
 </details>
+
+!!! info
+    This flag filters the packages themselves, so it also affects the `--list-all-pkgs` option and SBOM generation.
+
+### Filtering by Package Relationships
+
+
+Trivy supports filtering vulnerabilities based on the relationship of packages within a project.
+This is achieved through the `--pkg-relationships` flag.
+This feature allows you to focus on vulnerabilities in specific types of dependencies, such as only those in direct dependencies.
+
+In Trivy, there are four types of package relationships:
+
+1. `root`: The root package being scanned
+2. `direct`: Direct dependencies of the root package
+3. `indirect`: Transitive dependencies
+4. `unknown`: Packages whose relationship cannot be determined
+
+The available relationships may vary depending on the ecosystem.
+To see which relationships are supported for a particular project, you can use the JSON output format and check the `Relationship` field:
+
+```
+$ trivy repo -f json --list-all-pkgs /path/to/project
+```
+
+To scan only the root package and its direct dependencies, you can use the flag as follows:
+
+```
+$ trivy repo --pkg-relationships root,direct /path/to/project
+```
+
+By default, all relationships are included in the scan.
+
+!!! info
+    This flag filters the packages themselves, so it also affects the `--list-all-pkgs` option and SBOM generation.
+
+!!! warning
+    As it may not provide a complete package list, it can lead to incomplete dependency trees when using `--dependency-tree` or generate incomplete SBOMs.
+
 
 [^1]: https://github.com/GoogleContainerTools/distroless
 

--- a/docs/docs/scanner/vulnerability.md
+++ b/docs/docs/scanner/vulnerability.md
@@ -304,9 +304,6 @@ By default, all relationships are included in the scan.
 !!! info
     This flag filters the packages themselves, so it also affects the `--list-all-pkgs` option and SBOM generation.
 
-!!! warning
-    As it may not provide a complete package list, it can lead to incomplete dependency trees when using `--dependency-tree` or generate incomplete SBOMs.
-
 
 [^1]: https://github.com/GoogleContainerTools/distroless
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -239,9 +239,6 @@ func NewRootCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 }
 
 func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
-	scanFlagGroup := flag.NewScanFlagGroup()
-	scanFlagGroup.IncludeDevDeps = nil // disable '--include-dev-deps'
-
 	reportFlagGroup := flag.NewReportFlagGroup()
 	report := flag.ReportFormatFlag.Clone()
 	report.Default = "summary"                                   // override the default value as the summary is preferred for the compliance report
@@ -252,26 +249,27 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	compliance.Values = []string{types.ComplianceDockerCIS160}
 	reportFlagGroup.Compliance = compliance // override usage as the accepted values differ for each subcommand.
 
-	misconfFlagGroup := flag.NewMisconfFlagGroup()
-	misconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
-	misconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
-
 	imageFlags := &flag.Flags{
 		GlobalFlagGroup:        globalFlags,
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
 		DBFlagGroup:            flag.NewDBFlagGroup(),
 		ImageFlagGroup:         flag.NewImageFlagGroup(), // container image specific
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
-		MisconfFlagGroup:       misconfFlagGroup,
+		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
 		ModuleFlagGroup:        flag.NewModuleFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		RegistryFlagGroup:      flag.NewRegistryFlagGroup(),
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
 		ReportFlagGroup:        reportFlagGroup,
-		ScanFlagGroup:          scanFlagGroup,
+		ScanFlagGroup:          flag.NewScanFlagGroup(),
 		SecretFlagGroup:        flag.NewSecretFlagGroup(),
 		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
+
+	imageFlags.PackageFlagGroup.IncludeDevDeps = nil          // disable '--include-dev-deps'
+	imageFlags.MisconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
+	imageFlags.MisconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
 
 	cmd := &cobra.Command{
 		Use:     "image [flags] IMAGE_NAME",
@@ -338,6 +336,7 @@ func NewFilesystemCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
 		ModuleFlagGroup:        flag.NewModuleFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		RegistryFlagGroup:      flag.NewRegistryFlagGroup(),
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
@@ -396,6 +395,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
 		ModuleFlagGroup:        flag.NewModuleFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		RegistryFlagGroup:      flag.NewRegistryFlagGroup(),
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
@@ -407,7 +407,7 @@ func NewRootfsCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	rootfsFlags.ReportFlagGroup.ReportFormat = nil                             // TODO: support --report summary
 	rootfsFlags.ReportFlagGroup.Compliance = nil                               // disable '--compliance'
 	rootfsFlags.ReportFlagGroup.ReportFormat = nil                             // disable '--report'
-	rootfsFlags.ScanFlagGroup.IncludeDevDeps = nil                             // disable '--include-dev-deps'
+	rootfsFlags.PackageFlagGroup.IncludeDevDeps = nil                          // disable '--include-dev-deps'
 	rootfsFlags.CacheFlagGroup.CacheBackend.Default = string(cache.TypeMemory) // Use memory cache by default
 
 	cmd := &cobra.Command{
@@ -456,6 +456,7 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		LicenseFlagGroup:       flag.NewLicenseFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
 		ModuleFlagGroup:        flag.NewModuleFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RegistryFlagGroup:      flag.NewRegistryFlagGroup(),
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
@@ -512,7 +513,6 @@ func NewConvertCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		ScanFlagGroup:   &flag.ScanFlagGroup{},
 		ReportFlagGroup: flag.NewReportFlagGroup(),
 	}
-	convertFlags.ReportFlagGroup.PkgTypes = nil // disable '--pkg-types'
 
 	cmd := &cobra.Command{
 		Use:     "convert [flags] RESULT_JSON",
@@ -681,7 +681,6 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	configFlags.ReportFlagGroup.ListAllPkgs = nil                                                        // disable '--list-all-pkgs'
 	configFlags.ReportFlagGroup.ExitOnEOL = nil                                                          // disable '--exit-on-eol'
 	configFlags.ReportFlagGroup.ShowSuppressed = nil                                                     // disable '--show-suppressed'
-	configFlags.ReportFlagGroup.PkgTypes = nil                                                           // disable '--pkg-types'
 	configFlags.ReportFlagGroup.ReportFormat.Usage = "specify a compliance report format for the output" // @TODO: support --report summary for non compliance reports
 	configFlags.CacheFlagGroup.CacheBackend.Default = string(cache.TypeMemory)
 
@@ -956,7 +955,6 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	})
 	scanners.Default = scanners.Values
 	scanFlags.Scanners = scanners
-	scanFlags.IncludeDevDeps = nil // disable '--include-dev-deps'
 
 	// required only SourceFlag
 	imageFlags := &flag.ImageFlagGroup{ImageSources: flag.SourceFlag.Clone()}
@@ -993,6 +991,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		ImageFlagGroup:         imageFlags,
 		K8sFlagGroup:           flag.NewK8sFlagGroup(), // kubernetes-specific flags
 		MisconfFlagGroup:       misconfFlagGroup,
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RegoFlagGroup:          flag.NewRegoFlagGroup(),
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          scanFlags,
@@ -1000,6 +999,8 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		RegistryFlagGroup:      flag.NewRegistryFlagGroup(),
 		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),
 	}
+	k8sFlags.PackageFlagGroup.IncludeDevDeps = nil // disable '--include-dev-deps'
+
 	cmd := &cobra.Command{
 		Use:     "kubernetes [flags] [CONTEXT]",
 		Aliases: []string{"k8s"},
@@ -1051,6 +1052,7 @@ func NewVMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		DBFlagGroup:            flag.NewDBFlagGroup(),
 		MisconfFlagGroup:       flag.NewMisconfFlagGroup(),
 		ModuleFlagGroup:        flag.NewModuleFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		ReportFlagGroup:        flag.NewReportFlagGroup(),
 		ScanFlagGroup:          flag.NewScanFlagGroup(),
@@ -1065,7 +1067,7 @@ func NewVMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		},
 	}
 	vmFlags.ReportFlagGroup.ReportFormat = nil             // disable '--report'
-	vmFlags.ScanFlagGroup.IncludeDevDeps = nil             // disable '--include-dev-deps'
+	vmFlags.PackageFlagGroup.IncludeDevDeps = nil          // disable '--include-dev-deps'
 	vmFlags.MisconfFlagGroup.CloudformationParamVars = nil // disable '--cf-params'
 	vmFlags.MisconfFlagGroup.TerraformTFVars = nil         // disable '--tf-vars'
 
@@ -1124,9 +1126,8 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		types.VulnerabilityScanner,
 	})
 	scanFlagGroup := flag.NewScanFlagGroup()
-	scanFlagGroup.Scanners = scanners  // allow only 'vuln' and 'license' options for '--scanners'
-	scanFlagGroup.IncludeDevDeps = nil // disable '--include-dev-deps'
-	scanFlagGroup.Parallel = nil       // disable '--parallel'
+	scanFlagGroup.Scanners = scanners // allow only 'vuln' and 'license' options for '--scanners'
+	scanFlagGroup.Parallel = nil      // disable '--parallel'
 
 	licenseFlagGroup := flag.NewLicenseFlagGroup()
 	// License full-scan and confidence-level are for file content only
@@ -1137,6 +1138,7 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		GlobalFlagGroup:        globalFlags,
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
 		DBFlagGroup:            flag.NewDBFlagGroup(),
+		PackageFlagGroup:       flag.NewPackageFlagGroup(),
 		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          scanFlagGroup,
@@ -1146,6 +1148,7 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	}
 
 	sbomFlags.CacheFlagGroup.CacheBackend.Default = string(cache.TypeMemory) // Use memory cache by default
+	sbomFlags.PackageFlagGroup.IncludeDevDeps = nil                          // disable '--include-dev-deps'
 
 	cmd := &cobra.Command{
 		Use:     "sbom [flags] SBOM_PATH",

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -474,6 +474,7 @@ func (r *runner) initScannerConfig(opts flag.Options) (ScannerConfig, types.Scan
 
 	scanOptions := types.ScanOptions{
 		PkgTypes:            opts.PkgTypes,
+		PkgRelationships:    opts.PkgRelationships,
 		Scanners:            opts.Scanners,
 		ImageConfigScanners: opts.ImageConfigScanners, // this is valid only for 'image' subcommand
 		ScanRemovedPackages: opts.ScanRemovedPkgs,     // this is valid only for 'image' subcommand
@@ -483,18 +484,25 @@ func (r *runner) initScannerConfig(opts flag.Options) (ScannerConfig, types.Scan
 	}
 
 	if len(opts.ImageConfigScanners) != 0 {
-		log.Info("Container image config scanners", log.Any("scanners", opts.ImageConfigScanners))
+		log.WithPrefix(log.PrefixContainerImage).Info("Container image config scanners", log.Any("scanners", opts.ImageConfigScanners))
+	}
+
+	if opts.Scanners.Enabled(types.SBOMScanner) {
+		logger := log.WithPrefix(log.PrefixPackage)
+		logger.Debug("Package types", log.Any("types", scanOptions.PkgTypes))
+		logger.Debug("Package relationships", log.Any("relationships", scanOptions.PkgRelationships))
 	}
 
 	if opts.Scanners.Enabled(types.VulnerabilityScanner) {
-		log.Info("Vulnerability scanning is enabled")
-		log.Debug("Package types", log.Any("types", scanOptions.PkgTypes))
+		logger := log.WithPrefix(log.PrefixVulnerability)
+		logger.Info("Vulnerability scanning is enabled")
 	}
 
 	// ScannerOption is filled only when config scanning is enabled.
 	var configScannerOptions misconf.ScannerOption
 	if opts.Scanners.Enabled(types.MisconfigScanner) || opts.ImageConfigScanners.Enabled(types.MisconfigScanner) {
-		log.Info("Misconfiguration scanning is enabled")
+		logger := log.WithPrefix(log.PrefixMisconfiguration)
+		logger.Info("Misconfiguration scanning is enabled")
 
 		var downloadedPolicyPaths []string
 		var disableEmbedded bool
@@ -502,10 +510,10 @@ func (r *runner) initScannerConfig(opts flag.Options) (ScannerConfig, types.Scan
 		downloadedPolicyPaths, err := operation.InitBuiltinPolicies(context.Background(), opts.CacheDir, opts.Quiet, opts.SkipCheckUpdate, opts.MisconfOptions.ChecksBundleRepository, opts.RegistryOpts())
 		if err != nil {
 			if !opts.SkipCheckUpdate {
-				log.Error("Falling back to embedded checks", log.Err(err))
+				logger.Error("Falling back to embedded checks", log.Err(err))
 			}
 		} else {
-			log.Debug("Policies successfully loaded from disk")
+			logger.Debug("Policies successfully loaded from disk")
 			disableEmbedded = true
 		}
 		configScannerOptions = misconf.ScannerOption{
@@ -532,19 +540,21 @@ func (r *runner) initScannerConfig(opts flag.Options) (ScannerConfig, types.Scan
 
 	// Do not load config file for secret scanning
 	if opts.Scanners.Enabled(types.SecretScanner) {
-		log.Info("Secret scanning is enabled")
-		log.Info("If your scanning is slow, please try '--scanners vuln' to disable secret scanning")
+		logger := log.WithPrefix(log.PrefixSecret)
+		logger.Info("Secret scanning is enabled")
+		logger.Info("If your scanning is slow, please try '--scanners vuln' to disable secret scanning")
 		// e.g. https://aquasecurity.github.io/trivy/latest/docs/scanner/secret/#recommendation
-		log.Infof("Please see also %s for faster secret detection", doc.URL("/docs/scanner/secret/", "recommendation"))
+		logger.Info(fmt.Sprintf("Please see also %s for faster secret detection", doc.URL("/docs/scanner/secret/", "recommendation")))
 	} else {
 		opts.SecretConfigPath = ""
 	}
 
 	if opts.Scanners.Enabled(types.LicenseScanner) {
+		logger := log.WithPrefix(log.PrefixLicense)
 		if opts.LicenseFull {
-			log.Info("Full license scanning is enabled")
+			logger.Info("Full license scanning is enabled")
 		} else {
-			log.Info("License scanning is enabled")
+			logger.Info("License scanning is enabled")
 		}
 	}
 

--- a/pkg/fanal/types/package.go
+++ b/pkg/fanal/types/package.go
@@ -20,11 +20,29 @@ const (
 	RelationshipIndirect
 )
 
-var relationshipNames = [...]string{
-	"unknown",
-	"root",
-	"direct",
-	"indirect",
+var (
+	Relationships = []Relationship{
+		RelationshipUnknown,
+		RelationshipRoot,
+		RelationshipDirect,
+		RelationshipIndirect,
+	}
+
+	relationshipNames = [...]string{
+		"unknown",
+		"root",
+		"direct",
+		"indirect",
+	}
+)
+
+func NewRelationship(s string) (Relationship, error) {
+	for i, name := range relationshipNames {
+		if s == name {
+			return Relationship(i), nil
+		}
+	}
+	return RelationshipUnknown, xerrors.Errorf("invalid relationship (%s)", s)
 }
 
 func (r Relationship) String() string {

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -375,7 +375,7 @@ func (o *Options) Align(f *Flags) error {
 	if f.PackageFlagGroup != nil && f.PackageFlagGroup.PkgRelationships != nil &&
 		slices.Compare(o.PkgRelationships, ftypes.Relationships) != 0 &&
 		(o.DependencyTree || slices.Contains(types.SupportedSBOMFormats, o.Format) || o.VEXPath != "") {
-		log.Warn("Using '--pkg-relationships' may affect features that rely on package dependency information, such as SBOM relationships, dependency trees, and VEX filtering.")
+		return xerrors.Errorf("'--pkg-relationships' cannot be used with '--dependency-tree', '--vex' or SBOM formats")
 	}
 
 	if o.Compliance.Spec.ID != "" {

--- a/pkg/flag/package_flags.go
+++ b/pkg/flag/package_flags.go
@@ -1,0 +1,91 @@
+package flag
+
+import (
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+	xstrings "github.com/aquasecurity/trivy/pkg/x/strings"
+)
+
+var (
+	IncludeDevDepsFlag = Flag[bool]{
+		Name:       "include-dev-deps",
+		ConfigName: "pkg.include-dev-deps",
+		Usage:      "include development dependencies in the report (supported: npm, yarn)",
+	}
+	PkgTypesFlag = Flag[[]string]{
+		Name:       "pkg-types",
+		ConfigName: "pkg.types",
+		Default:    types.PkgTypes,
+		Values:     types.PkgTypes,
+		Usage:      "list of package types",
+		Aliases: []Alias{
+			{
+				Name:       "vuln-type",
+				ConfigName: "vulnerability.type",
+				Deprecated: true, // --vuln-type was renamed to --pkg-types
+			},
+		},
+	}
+	PkgRelationshipsFlag = Flag[[]string]{
+		Name:       "pkg-relationships",
+		ConfigName: "pkg.relationships",
+		Default:    xstrings.ToStringSlice(ftypes.Relationships),
+		Values:     xstrings.ToStringSlice(ftypes.Relationships),
+		Usage:      "list of package relationships",
+	}
+)
+
+// PackageFlagGroup composes common package flag structs.
+// These flags affect both SBOM and vulnerability scanning.
+type PackageFlagGroup struct {
+	IncludeDevDeps   *Flag[bool]
+	PkgTypes         *Flag[[]string]
+	PkgRelationships *Flag[[]string]
+}
+
+type PackageOptions struct {
+	IncludeDevDeps   bool
+	PkgTypes         []string
+	PkgRelationships []ftypes.Relationship
+}
+
+func NewPackageFlagGroup() *PackageFlagGroup {
+	return &PackageFlagGroup{
+		IncludeDevDeps:   IncludeDevDepsFlag.Clone(),
+		PkgTypes:         PkgTypesFlag.Clone(),
+		PkgRelationships: PkgRelationshipsFlag.Clone(),
+	}
+}
+
+func (f *PackageFlagGroup) Name() string {
+	return "Package"
+}
+
+func (f *PackageFlagGroup) Flags() []Flagger {
+	return []Flagger{
+		f.IncludeDevDeps,
+		f.PkgTypes,
+		f.PkgRelationships,
+	}
+}
+
+func (f *PackageFlagGroup) ToOptions() (PackageOptions, error) {
+	if err := parseFlags(f); err != nil {
+		return PackageOptions{}, err
+	}
+
+	var relationships []ftypes.Relationship
+	for _, r := range f.PkgRelationships.Value() {
+		relationship, err := ftypes.NewRelationship(r)
+		if err != nil {
+			return PackageOptions{}, err
+		}
+		relationships = append(relationships, relationship)
+	}
+
+	return PackageOptions{
+		IncludeDevDeps:   f.IncludeDevDeps.Value(),
+		PkgTypes:         f.PkgTypes.Value(),
+		PkgRelationships: relationships,
+	}, nil
+}

--- a/pkg/flag/package_flags_test.go
+++ b/pkg/flag/package_flags_test.go
@@ -1,0 +1,84 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/flag"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestPackageFlagGroup_ToOptions(t *testing.T) {
+	type fields struct {
+		pkgTypes         string
+		pkgRelationships string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		want     flag.PackageOptions
+		wantLogs []string
+	}{
+		{
+			name:   "happy default (without flags)",
+			fields: fields{},
+			want:   flag.PackageOptions{},
+		},
+		{
+			name: "happy path for OS packages",
+			fields: fields{
+				pkgTypes: "os",
+			},
+			want: flag.PackageOptions{
+				PkgTypes: []string{
+					types.PkgTypeOS,
+				},
+			},
+		},
+		{
+			name: "happy path for library packages",
+			fields: fields{
+				pkgTypes: "library",
+			},
+			want: flag.PackageOptions{
+				PkgTypes: []string{
+					types.PkgTypeLibrary,
+				},
+			},
+		},
+		{
+			name: "root and indirect relationships",
+			fields: fields{
+				pkgRelationships: "root,indirect",
+			},
+			want: flag.PackageOptions{
+				PkgRelationships: []ftypes.Relationship{
+					ftypes.RelationshipRoot,
+					ftypes.RelationshipIndirect,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			setValue(flag.PkgTypesFlag.ConfigName, tt.fields.pkgTypes)
+			setValue(flag.PkgRelationshipsFlag.ConfigName, tt.fields.pkgRelationships)
+
+			// Assert options
+			f := &flag.PackageFlagGroup{
+				PkgTypes:         flag.PkgTypesFlag.Clone(),
+				PkgRelationships: flag.PkgRelationshipsFlag.Clone(),
+			}
+
+			got, err := f.ToOptions()
+			require.NoError(t, err)
+			assert.EqualExportedValuesf(t, tt.want, got, "PackageFlagGroup")
+		})
+	}
+}

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -106,20 +106,6 @@ var (
 		ConfigName: "scan.show-suppressed",
 		Usage:      "[EXPERIMENTAL] show suppressed vulnerabilities",
 	}
-	PkgTypesFlag = Flag[[]string]{
-		Name:       "pkg-types",
-		ConfigName: "pkg-types",
-		Default:    types.PkgTypes,
-		Values:     types.PkgTypes,
-		Usage:      "comma-separated list of package types",
-		Aliases: []Alias{
-			{
-				Name:       "vuln-type",
-				ConfigName: "vulnerability.type",
-				Deprecated: true, // --vuln-type was renamed to --pkg-types
-			},
-		},
-	}
 )
 
 // ReportFlagGroup composes common printer flag structs
@@ -139,7 +125,6 @@ type ReportFlagGroup struct {
 	Severity        *Flag[[]string]
 	Compliance      *Flag[string]
 	ShowSuppressed  *Flag[bool]
-	PkgTypes        *Flag[[]string]
 }
 
 type ReportOptions struct {
@@ -157,7 +142,6 @@ type ReportOptions struct {
 	Severities       []dbTypes.Severity
 	Compliance       spec.ComplianceSpec
 	ShowSuppressed   bool
-	PkgTypes         []string
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
@@ -176,7 +160,6 @@ func NewReportFlagGroup() *ReportFlagGroup {
 		Severity:        SeverityFlag.Clone(),
 		Compliance:      ComplianceFlag.Clone(),
 		ShowSuppressed:  ShowSuppressedFlag.Clone(),
-		PkgTypes:        PkgTypesFlag.Clone(),
 	}
 }
 
@@ -200,7 +183,6 @@ func (f *ReportFlagGroup) Flags() []Flagger {
 		f.Severity,
 		f.Compliance,
 		f.ShowSuppressed,
-		f.PkgTypes,
 	}
 }
 
@@ -270,7 +252,6 @@ func (f *ReportFlagGroup) ToOptions() (ReportOptions, error) {
 		Severities:       toSeverity(f.Severity.Value()),
 		Compliance:       cs,
 		ShowSuppressed:   f.ShowSuppressed.Value(),
-		PkgTypes:         f.PkgTypes.Value(),
 	}, nil
 }
 

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -160,28 +160,6 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 				Severities: []dbTypes.Severity{dbTypes.SeverityLow},
 			},
 		},
-		{
-			name: "happy path for OS packages",
-			fields: fields{
-				pkgTypes: "os",
-			},
-			want: flag.ReportOptions{
-				PkgTypes: []string{
-					types.PkgTypeOS,
-				},
-			},
-		},
-		{
-			name: "happy path for library packages",
-			fields: fields{
-				pkgTypes: "library",
-			},
-			want: flag.ReportOptions{
-				PkgTypes: []string{
-					types.PkgTypeLibrary,
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -206,7 +184,6 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			setValue(flag.OutputPluginArgFlag.ConfigName, tt.fields.outputPluginArgs)
 			setValue(flag.SeverityFlag.ConfigName, tt.fields.severities)
 			setValue(flag.ComplianceFlag.ConfigName, tt.fields.compliance)
-			setValue(flag.PkgTypesFlag.ConfigName, tt.fields.pkgTypes)
 
 			// Assert options
 			f := &flag.ReportFlagGroup{
@@ -222,7 +199,6 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 				OutputPluginArg: flag.OutputPluginArgFlag.Clone(),
 				Severity:        flag.SeverityFlag.Clone(),
 				Compliance:      flag.ComplianceFlag.Clone(),
-				PkgTypes:        flag.PkgTypesFlag.Clone(),
 			}
 
 			got, err := f.ToOptions()

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -96,51 +96,43 @@ var (
 		Default:    "https://rekor.sigstore.dev",
 		Usage:      "[EXPERIMENTAL] address of rekor STL server",
 	}
-	IncludeDevDepsFlag = Flag[bool]{
-		Name:       "include-dev-deps",
-		ConfigName: "scan.include-dev-deps",
-		Usage:      "include development dependencies in the report (supported: npm, yarn)",
-	}
 )
 
 type ScanFlagGroup struct {
-	SkipDirs       *Flag[[]string]
-	SkipFiles      *Flag[[]string]
-	OfflineScan    *Flag[bool]
-	Scanners       *Flag[[]string]
-	FilePatterns   *Flag[[]string]
-	Slow           *Flag[bool] // deprecated
-	Parallel       *Flag[int]
-	SBOMSources    *Flag[[]string]
-	RekorURL       *Flag[string]
-	IncludeDevDeps *Flag[bool]
+	SkipDirs     *Flag[[]string]
+	SkipFiles    *Flag[[]string]
+	OfflineScan  *Flag[bool]
+	Scanners     *Flag[[]string]
+	FilePatterns *Flag[[]string]
+	Slow         *Flag[bool] // deprecated
+	Parallel     *Flag[int]
+	SBOMSources  *Flag[[]string]
+	RekorURL     *Flag[string]
 }
 
 type ScanOptions struct {
-	Target         string
-	SkipDirs       []string
-	SkipFiles      []string
-	OfflineScan    bool
-	Scanners       types.Scanners
-	FilePatterns   []string
-	Parallel       int
-	SBOMSources    []string
-	RekorURL       string
-	IncludeDevDeps bool
+	Target       string
+	SkipDirs     []string
+	SkipFiles    []string
+	OfflineScan  bool
+	Scanners     types.Scanners
+	FilePatterns []string
+	Parallel     int
+	SBOMSources  []string
+	RekorURL     string
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
-		SkipDirs:       SkipDirsFlag.Clone(),
-		SkipFiles:      SkipFilesFlag.Clone(),
-		OfflineScan:    OfflineScanFlag.Clone(),
-		Scanners:       ScannersFlag.Clone(),
-		FilePatterns:   FilePatternsFlag.Clone(),
-		Parallel:       ParallelFlag.Clone(),
-		SBOMSources:    SBOMSourcesFlag.Clone(),
-		RekorURL:       RekorURLFlag.Clone(),
-		IncludeDevDeps: IncludeDevDepsFlag.Clone(),
-		Slow:           SlowFlag.Clone(),
+		SkipDirs:     SkipDirsFlag.Clone(),
+		SkipFiles:    SkipFilesFlag.Clone(),
+		OfflineScan:  OfflineScanFlag.Clone(),
+		Scanners:     ScannersFlag.Clone(),
+		FilePatterns: FilePatternsFlag.Clone(),
+		Parallel:     ParallelFlag.Clone(),
+		SBOMSources:  SBOMSourcesFlag.Clone(),
+		RekorURL:     RekorURLFlag.Clone(),
+		Slow:         SlowFlag.Clone(),
 	}
 }
 
@@ -159,7 +151,6 @@ func (f *ScanFlagGroup) Flags() []Flagger {
 		f.Parallel,
 		f.SBOMSources,
 		f.RekorURL,
-		f.IncludeDevDeps,
 	}
 }
 
@@ -180,15 +171,14 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 	}
 
 	return ScanOptions{
-		Target:         target,
-		SkipDirs:       f.SkipDirs.Value(),
-		SkipFiles:      f.SkipFiles.Value(),
-		OfflineScan:    f.OfflineScan.Value(),
-		Scanners:       xstrings.ToTSlice[types.Scanner](f.Scanners.Value()),
-		FilePatterns:   f.FilePatterns.Value(),
-		Parallel:       parallel,
-		SBOMSources:    f.SBOMSources.Value(),
-		RekorURL:       f.RekorURL.Value(),
-		IncludeDevDeps: f.IncludeDevDeps.Value(),
+		Target:       target,
+		SkipDirs:     f.SkipDirs.Value(),
+		SkipFiles:    f.SkipFiles.Value(),
+		OfflineScan:  f.OfflineScan.Value(),
+		Scanners:     xstrings.ToTSlice[types.Scanner](f.Scanners.Value()),
+		FilePatterns: f.FilePatterns.Value(),
+		Parallel:     parallel,
+		SBOMSources:  f.SBOMSources.Value(),
+		RekorURL:     f.RekorURL.Value(),
 	}, nil
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -17,6 +17,13 @@ const (
 	LevelWarn  = slog.LevelWarn
 	LevelError = slog.LevelError
 	LevelFatal = slog.Level(12)
+
+	PrefixContainerImage   = "image"
+	PrefixPackage          = "pkg"
+	PrefixVulnerability    = "vuln"
+	PrefixMisconfiguration = "misconfig"
+	PrefixSecret           = "secret"
+	PrefixLicense          = "license"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/types/scan.go
+++ b/pkg/types/scan.go
@@ -23,6 +23,7 @@ type ScanTarget struct {
 // ScanOptions holds the attributes for scanning vulnerabilities
 type ScanOptions struct {
 	PkgTypes            []string
+	PkgRelationships    []types.Relationship
 	Scanners            Scanners
 	ImageConfigScanners Scanners // Scanners for container image configuration
 	ScanRemovedPackages bool

--- a/pkg/x/strings/strings.go
+++ b/pkg/x/strings/strings.go
@@ -1,17 +1,28 @@
 package strings
 
-import "github.com/samber/lo"
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+)
 
 type String interface {
 	~string
 }
 
-func ToStringSlice[T String](ss []T) []string {
-	if ss == nil {
+func ToStringSlice[T any](ss []T) []string {
+	if len(ss) == 0 {
 		return nil
 	}
 	return lo.Map(ss, func(s T, _ int) string {
-		return string(s)
+		switch v := any(s).(type) {
+		case string:
+			return v
+		case fmt.Stringer:
+			return v.String()
+		default:
+			return fmt.Sprint(v)
+		}
 	})
 }
 


### PR DESCRIPTION
## Description
Add `--pkg-relationships` to filter vulnerabilities by relationships. It cannot be used with `--dependency-tree`, `--vex` or `--format spdx|spdx-json|cyclonedx|github`.

### Usage

#### Withot `--pkg-relationships`

```
$ trivy repo ./go.mod
...

go.mod (gomod)
==============
Total: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-xr7q-jx4m-x55m │ LOW      │ fixed  │ 1.64.0            │ 1.64.1        │ Private tokens could appear in logs if context containing │
│                        │                     │          │        │                   │               │ gRPC metadata is...                                       │
│                        │                     │          │        │                   │               │ https://github.com/advisories/GHSA-xr7q-jx4m-x55m         │
└────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

#### With `--pkg-relationships`

```
$ trivy repo --scanners vuln --pkg-relationships direct ./go.mod
2024-07-26T11:19:11+04:00       INFO    [vuln] Vulnerability scanning is enabled
2024-07-26T11:19:13+04:00       INFO    Number of language-specific files       num=1
2024-07-26T11:19:13+04:00       INFO    [gomod] Detecting vulnerabilities...
```

#### With `--pkg-relationships` and `--format spdx`

```
$ trivy repo --pkg-relationships direct --format spdx ./go.mod
2024-07-26T11:20:33+04:00       INFO    "--format spdx" and "--format spdx-json" disable security scanning
2024-07-26T11:20:33+04:00       FATAL   Fatal error     flag error: align options error: '--pkg-relationships' cannot be used with '--dependency-tree', '--vex' or SBOM formats
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6889

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
