### PR TITLE
docs: show VEX cli pages + update config file page for VEX flags

### DIFF
--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -276,6 +276,16 @@ vulnerability:
   # Default is empty
   ignore-status: 
     - end_of_life
+
+  # Same as '--vex'
+  # Default is empty
+  vex:
+    - path/to/vex/file
+    - repo
+
+  # Same as '--skip-vex-repo-update'
+  # Default is false
+  skip-vex-repo-update: true
 ```
 
 ## License Options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,12 @@ nav:
                   - SBOM: docs/references/configuration/cli/trivy_sbom.md
                   - Server: docs/references/configuration/cli/trivy_server.md
                   - Version: docs/references/configuration/cli/trivy_version.md
+                  - VEX:
+                      - VEX: docs/references/configuration/cli/trivy_vex.md
+                      - VEX Download: docs/references/configuration/cli/trivy_vex_repo_download.md
+                      - VEX Init: docs/references/configuration/cli/trivy_vex_repo_init.md
+                      - VEX List: docs/references/configuration/cli/trivy_vex_repo_list.md
+                      - VEX Repo: docs/references/configuration/cli/trivy_vex_repo.md
                   - VM: docs/references/configuration/cli/trivy_vm.md
               - Config file: docs/references/configuration/config-file.md
           - Modes:


### PR DESCRIPTION
## Description
Show VEX cli pages (add them to docs config file) + update config file page for VEX flags.

## Related PRs
- [x] #7206

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
