### PR TITLE
fix(pom): avoid panic if deps from `pom` in `it` dir are not found

### DIFF
--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -32,7 +32,7 @@ func (a pomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*
 	}
 
 	// Mark integration test pom files for `maven-invoker-plugin` as Dev to skip them by default.
-	if isIntegrationTestDir(filePath) {
+	if isIntegrationTestDir(filePath) && res != nil {
 		for i := range res.Applications {
 			for j := range res.Applications[i].Packages {
 				res.Applications[i].Packages[j].Dev = true


### PR DESCRIPTION
## Description
Fix panic if deps from `pom` in `it` dir are not found.

## Related issues
- Close #7241

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
