### PR TITLE
chore: show VEX notice for OSS maintainers in CI environments

### DIFF
--- a/pkg/report/table/table_test.go
+++ b/pkg/report/table/table_test.go
@@ -73,6 +73,7 @@ Total: 1 (MEDIUM: 0, HIGH: 1)
 		},
 	}
 
+	t.Setenv("TRIVY_DISABLE_VEX_NOTICE", "1")
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tableWritten := bytes.Buffer{}

--- a/pkg/report/table/vulnerability.go
+++ b/pkg/report/table/vulnerability.go
@@ -3,12 +3,14 @@ package table
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/fatih/color"
 	"github.com/samber/lo"
 	"github.com/xlab/treeprint"
 
@@ -18,11 +20,29 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/version/doc"
 )
 
-var showSuppressedOnce = sync.OnceFunc(func() {
-	log.Info(`Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.`)
-})
+const (
+	vexNotice = `
+For OSS Maintainers: VEX Notice
+--------------------------------
+If you're an OSS maintainer and Trivy has detected vulnerabilities in your project that you believe are not actually exploitable, consider issuing a VEX (Vulnerability Exploitability eXchange) statement.
+VEX allows you to communicate the actual status of vulnerabilities in your project, improving security transparency and reducing false positives for your users.
+Learn more and start using VEX: %s
+
+To disable this notice, set the TRIVY_DISABLE_VEX_NOTICE environment variable.
+
+`
+	envDisableNotice = "TRIVY_DISABLE_VEX_NOTICE"
+)
+
+var (
+	showVEXNoticeOnce  = &sync.Once{}
+	showSuppressedOnce = sync.OnceFunc(func() {
+		log.Info(`Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.`)
+	})
+)
 
 type vulnerabilityRenderer struct {
 	w              *bytes.Buffer
@@ -73,6 +93,14 @@ func (r *vulnerabilityRenderer) Render() string {
 }
 
 func (r *vulnerabilityRenderer) renderDetectedVulnerabilities() {
+	// Show VEX notice only on CI
+	showVEXNoticeOnce.Do(func() {
+		if os.Getenv(envDisableNotice) != "" || os.Getenv("CI") == "" {
+			return
+		}
+		_, _ = color.New(color.FgCyan).Fprintf(r.w, vexNotice, doc.URL("docs/supply-chain/vex/repo", "publishing-vex-documents"))
+	})
+
 	tw := newTableWriter(r.w, r.isTerminal)
 	r.setHeaders(tw)
 	r.setVulnerabilityRows(tw, r.result.Vulnerabilities)


### PR DESCRIPTION
## Overview
This PR introduces a VEX (Vulnerability Exploitability eXchange) notice for OSS maintainers when Trivy is run in CI environments. The notice aims to encourage the use of VEX statements for more accurate vulnerability reporting.

## Key Changes
1. Implement a VEX notice that displays after vulnerability scanning results.
2. Add logic to show the notice only in CI environments.
3. Provide an option to disable the notice via an environment variable (`TRIVY_DISABLE_VEX_NOTICE`).

## Example Output

```
$ CI=true ./trivy image alpine:3.20
...

For OSS Maintainers: VEX Notice
--------------------------------
If you're an OSS maintainer and Trivy has detected vulnerabilities in your project that you believe are not actually exploitable, consider issuing a VEX (Vulnerability Exploitability eXchange) statement.
VEX allows you to communicate the actual status of vulnerabilities in your project, improving security transparency and reducing false positives for your users.
Learn more and start using VEX: https://aquasecurity.github.io/trivy/dev/docs/supply-chain/vex/repo#publishing-vex-documents

To disable this notice, set the TRIVY_DISABLE_VEX_NOTICE environment variable.


alpine:3.20 (alpine 3.20.2)
===========================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Rationale
- Encourages OSS maintainers to use VEX for more accurate vulnerability reporting.
- Targets CI environments to avoid disrupting local development workflows.
- Provides an easy opt-out mechanism for users who don't need the reminder.


## Related PRs
- https://github.com/aquasecurity/trivy/pull/7206

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
