### PR TITLE
refactor(flag): return error if both `--download-db-only` and `--download-java-db-only` are specified

### DIFF
--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -137,6 +137,9 @@ func (f *DBFlagGroup) ToOptions() (DBOptions, error) {
 	downloadDBOnly := f.DownloadDBOnly.Value()
 	downloadJavaDBOnly := f.DownloadJavaDBOnly.Value()
 
+	if downloadDBOnly && downloadJavaDBOnly {
+		return DBOptions{}, xerrors.New("--download-db-only and --download-java-db-only options can not be specified both")
+	}
 	if downloadDBOnly && skipDBUpdate {
 		return DBOptions{}, xerrors.New("--skip-db-update and --download-db-only options can not be specified both")
 	}


### PR DESCRIPTION
## Description
Trivy doesn't support simultaneous use of the `--download-db-only` and `--download-java-db-only` flags.
So in this case we need to return an error.

Example:
```bash
➜ trivy image --download-db-only --download-java-db-only
2024-07-30T12:19:15+06:00       FATAL   Fatal error     flag error: db flag error: --download-db-only and --download-java-db-only options can not be specified both
```


## Related discussions
- #7250

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
