### PR TITLE
fix(plugin): do not call GitHub content API for releases and tags

### DIFF
--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -154,7 +154,8 @@ func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func NewGitHubTransport(u *url.URL, insecure bool, token string) http.RoundTripper {
 	client := newGitHubClient(insecure, token)
 	ss := strings.SplitN(u.Path, "/", 4)
-	if len(ss) < 4 || strings.HasPrefix(ss[3], "archive/") {
+	if len(ss) < 4 || strings.HasPrefix(ss[3], "archive/") || strings.HasPrefix(ss[3], "releases/") ||
+		strings.HasPrefix(ss[3], "tags/") {
 		// Use the default transport from go-github for authentication
 		return client.Client().Transport
 	}


### PR DESCRIPTION
## Description

```
$ trivy plugin install referrer
...
2024-07-31T14:51:48+04:00       FATAL   Fatal error     plugin install error: failed to install the plugin: unable to download the execution file (https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.1/trivy_plugin_referrer_0.3.1_macOS-ARM64.tar.gz): failed to download https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.1/trivy_plugin_referrer_0.3.1_macOS-ARM64.tar.gz: Get "https://github.com/aquasecurity/trivy-plugin-referrer/releases/download/v0.3.1/trivy_plugin_referrer_0.3.1_macOS-ARM64.tar.gz": failed to round trip: failed to get the file content: GET https://api.github.com/repos/aquasecurity/trivy-plugin-referrer/contents/releases/download/v0.3.1: 404 Not Found []
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7273

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
