### PR TITLE
fix(java): Return error when trying to find a remote pom to avoid segfault

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -681,7 +681,7 @@ func (p *Parser) remoteRepoRequest(repo string, paths []string) (*http.Request, 
 	repoURL, err := url.Parse(repo)
 	if err != nil {
 		p.logger.Error("URL parse error", log.String("repo", repo))
-		return nil, nil
+		return nil, err
 	}
 
 	paths = append([]string{repoURL.Path}, paths...)
@@ -691,7 +691,7 @@ func (p *Parser) remoteRepoRequest(repo string, paths []string) (*http.Request, 
 	req, err := http.NewRequest("GET", repoURL.String(), http.NoBody)
 	if err != nil {
 		logger.Debug("HTTP request failed")
-		return nil, nil
+		return nil, err
 	}
 	if repoURL.User != nil {
 		password, _ := repoURL.User.Password()

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
 	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
@@ -680,18 +680,15 @@ func (p *Parser) fetchPOMFromRemoteRepositories(paths []string, snapshot bool) (
 func (p *Parser) remoteRepoRequest(repo string, paths []string) (*http.Request, error) {
 	repoURL, err := url.Parse(repo)
 	if err != nil {
-		p.logger.Error("URL parse error", log.String("repo", repo))
-		return nil, err
+		return nil, xerrors.Errorf("unable to parse URL: %w", err)
 	}
 
 	paths = append([]string{repoURL.Path}, paths...)
 	repoURL.Path = path.Join(paths...)
 
-	logger := p.logger.With(log.String("host", repoURL.Host), log.String("path", repoURL.Path))
 	req, err := http.NewRequest("GET", repoURL.String(), http.NoBody)
 	if err != nil {
-		logger.Debug("HTTP request failed")
-		return nil, err
+		return nil, xerrors.Errorf("unable to create HTTP request: %w", err)
 	}
 	if repoURL.User != nil {
 		password, _ := repoURL.User.Password()
@@ -709,7 +706,8 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(repo string, paths []string) 
 
 	req, err := p.remoteRepoRequest(repo, mavenMetadataPaths)
 	if err != nil {
-		return "", xerrors.Errorf("unable to create request for maven-metadata.xml file")
+		p.logger.Debug("Unable to create request", log.String("repo", repo), log.Err(err))
+		return "", nil
 	}
 
 	client := &http.Client{}
@@ -739,7 +737,8 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(repo string, paths []string) 
 func (p *Parser) fetchPOMFromRemoteRepository(repo string, paths []string) (*pom, error) {
 	req, err := p.remoteRepoRequest(repo, paths)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to create request for pom file")
+		p.logger.Debug("Unable to create request", log.String("repo", repo), log.Err(err))
+		return nil, nil
 	}
 
 	client := &http.Client{}


### PR DESCRIPTION
On updating from 0.52.x to 0.54.0, Trivy is segfaulting when scanning a maven filesystem due to the changes in https://github.com/aquasecurity/trivy/commit/1f8fca1fc77b989bb4e3ba820b297464dbdd825f

"Nil" is returned for the error in remoteRepoRequest, and so in fetchPOMFromRemoteRepository it proceeds to client.Do with a null "req".

The fix just returns the error in remoteRepoRequest and so it's handled properly by the calling functions.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x69868fb]

goroutine 41 [running]:
net/http.(*Client).do(0xc000c76580?, 0x0)
	/opt/hostedtoolcache/go/1.22.5/x64/src/net/http/client.go:599 +0xbb
net/http.(*Client).Do(...)
	/opt/hostedtoolcache/go/1.22.5/x64/src/net/http/client.go:590
github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom.(*Parser).fetchPOMFromRemoteRepository(0xc000c76580, {0xc002fc00e0?, 0xc002e7bd18?}, {0xc0010099e0?, 0xaff9300?, 0xc001e52070?})
	/home/runner/work/trivy/trivy/pkg/dependency/parser/java/pom/parse.go:746 +0x85
github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom.(*Parser).fetchPOMFromRemoteRepositories(0xc000c76580, {0xc0010098c0, 0x6, 0x2?}, 0x0)
	/home/runner/work/trivy/trivy/pkg/dependency/parser/java/pom/parse.go:669 +0x291
```