### PR TITLE
docs: update client/server docs for misconf and license scanning

### DIFF
--- a/docs/docs/references/modes/client-server.md
+++ b/docs/docs/references/modes/client-server.md
@@ -2,12 +2,22 @@
 
 Trivy has client/server mode. Trivy server has vulnerability database and Trivy client doesn't have to download vulnerability database. It is useful if you want to scan images or files at multiple locations and do not want to download the database at every location.
 
-|   Client/Server Mode  | Image | Rootfs | Filesystem | Repository | Config | K8s |
-|:---------------------:|:-----:|:------:|:----------:|:----------:|:------:|:---:|
-|       Supported       |   ✅  |   ✅     |     ✅     |     ✅     |  X    | X   |
+| Client/Server Mode | Image | Rootfs | Filesystem | Repository | Config | K8s |
+|:------------------:|:-----:|:------:|:----------:|:----------:|:------:|:---:|
+|     Supported      |   ✅   |   ✅    |     ✅      |     ✅      |   -    |  -  |
+
+Some scanners run on the client side, even in client/server mode.
+
+|     Scanner      | Run on Client or Server |
+|:----------------:|:-----------------------:|
+|  Vulnerability   |         Server          |
+| Misconfiguration |       Client[^1]        |
+|      Secret      |       Client[^2]        |
+|     License      |         Server          |
 
 !!! note
-    Scanning of misconfigurations and licenses is performed on the client side (as in standalone mode). Otherwise, the client would need to send files to the server that may contain sensitive information. The checks bundle is also downloaded on the client side.
+    Scanning of misconfigurations and licenses is performed on the client side (as in standalone mode).
+    Otherwise, the client would need to send files to the server that may contain sensitive information.
 
 ## Server
 At first, you need to launch Trivy server. It downloads vulnerability database automatically and continue to fetch the latest DB in the background.
@@ -341,3 +351,5 @@ Returns the `200 OK` status if the request was successful.
 
 ![architecture](../../../imgs/client-server.png)
 
+[^1]: The checks bundle is also downloaded on the client side.
+[^2]: The scan result with masked secrets is sent to the server

--- a/docs/docs/references/modes/client-server.md
+++ b/docs/docs/references/modes/client-server.md
@@ -2,9 +2,12 @@
 
 Trivy has client/server mode. Trivy server has vulnerability database and Trivy client doesn't have to download vulnerability database. It is useful if you want to scan images or files at multiple locations and do not want to download the database at every location.
 
-|   Client/Server Mode  | Image | Rootfs | Filesystem | Repository | Config | AWS | K8s |
-|:---------------------:|:-----:|:------:|:----------:|:----------:|:------:|:---:|:---:|
-|       Supported       |   ✅  |   ✅     |     ✅     |     ✅     |  ✅    | X   |  X  |
+|   Client/Server Mode  | Image | Rootfs | Filesystem | Repository | Config | K8s |
+|:---------------------:|:-----:|:------:|:----------:|:----------:|:------:|:---:|
+|       Supported       |   ✅  |   ✅     |     ✅     |     ✅     |  X    | X   |
+
+!!! note
+    Scanning of misconfigurations and licenses is performed on the client side (as in standalone mode). Otherwise, the client would need to send files to the server that may contain sensitive information. The checks bundle is also downloaded on the client side.
 
 ## Server
 At first, you need to launch Trivy server. It downloads vulnerability database automatically and continue to fetch the latest DB in the background.


### PR DESCRIPTION
## Description
Also added logging:
```bash
2024-07-31T18:16:37+07:00       WARN    Trivy runs in client/server mode, but misconfiguration and license scanning will be done on the client side, see https://aquasecurity.github.io/trivy/dev/docs/references/modes/client-server
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7177

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
