### PR TITLE
fix(flag): incorrect behavior for deprected flag `--clear-cache`

### DIFF
--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -80,6 +80,7 @@ type CacheOptions struct {
 // NewCacheFlagGroup returns a default CacheFlagGroup
 func NewCacheFlagGroup() *CacheFlagGroup {
 	return &CacheFlagGroup{
+		ClearCache:   ClearCacheFlag.Clone(),
 		CacheBackend: CacheBackendFlag.Clone(),
 		CacheTTL:     CacheTTLFlag.Clone(),
 		RedisTLS:     RedisTLSFlag.Clone(),


### PR DESCRIPTION
## Description
`ClearCache` should be initialized for correct message.

Before:
```sh
$ trivy image --clear-cache
Scan a container image
...
2024-07-31T18:13:26+06:00	FATAL	Fatal error	unknown flag: --clear-cache
```
After:
```sh
$ trivy image --clear-cache
2024-07-31T18:14:29+06:00	ERROR	"--clear-cache" was removed. Use "trivy clean --scan-cache" instead
2024-07-31T18:14:29+06:00	FATAL	Fatal error	flag error: cache flag error: unable to parse flag: removed flag ("--clear-cache")

```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
