### PR TITLE
refactor(misconf): remove file filtering from parsers

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -135,12 +135,17 @@ func init() {
 		}
 
 		sniff := struct {
-			ContentType string         `json:"contentType"`
-			Parameters  map[string]any `json:"parameters"`
-			Resources   []any          `json:"resources"`
+			Schema     string         `json:"$schema"`
+			Parameters map[string]any `json:"parameters"`
+			Resources  []any          `json:"resources"`
 		}{}
 		metadata := types.NewUnmanagedMetadata()
 		if err := armjson.UnmarshalFromReader(r, &sniff, &metadata); err != nil {
+			return false
+		}
+
+		// schema is required https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/syntax
+		if !strings.HasPrefix(sniff.Schema, "https://schema.management.azure.com/schemas") {
 			return false
 		}
 

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -355,6 +355,70 @@ rules:
 				FileTypeYAML,
 			},
 		},
+		{
+			name: "Azure ARM template with resources",
+			path: "test.json",
+			r: strings.NewReader(`
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2021-09-01",
+      "name": "{provide-unique-name}",
+      "location": "eastus",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "supportsHttpsTrafficOnly": true
+      }
+    }
+  ]
+}
+`),
+			expected: []FileType{
+				FileTypeJSON,
+				FileTypeAzureARM,
+			},
+		},
+		{
+			name: "Azure ARM template with parameters",
+			path: "test.json",
+			r: strings.NewReader(`
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageName": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 24
+    }
+  }
+}
+`),
+			expected: []FileType{
+				FileTypeJSON,
+				FileTypeAzureARM,
+			},
+		},
+		{
+			name: "empty Azure ARM template",
+			path: "test.json",
+			r: strings.NewReader(`
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": []
+}
+`),
+			expected: []FileType{
+				FileTypeJSON,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -138,10 +138,6 @@ func (s *Scanner) SetPolicyNamespaces(namespaces ...string) {
 	}
 }
 
-func (s *Scanner) SetSkipRequiredCheck(_ bool) {
-	// NOTE: Skip required option not applicable for rego.
-}
-
 func (s *Scanner) SetRegoErrorLimit(limit int) {
 	s.regoErrorLimit = limit
 }

--- a/pkg/iac/scanners/azure/arm/parser/parser_test.go
+++ b/pkg/iac/scanners/azure/arm/parser/parser_test.go
@@ -37,11 +37,6 @@ func TestParser_Parse(t *testing.T) {
 		wantDeployment bool
 	}{
 		{
-			name:           "invalid code",
-			input:          `blah`,
-			wantDeployment: false,
-		},
-		{
 			name: "basic param",
 			input: `{
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#", // another one

--- a/pkg/iac/scanners/dockerfile/parser/parser.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/aquasecurity/trivy/pkg/iac/debug"
-	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/dockerfile"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 )
@@ -20,16 +19,11 @@ import (
 var _ options.ConfigurableParser = (*Parser)(nil)
 
 type Parser struct {
-	debug        debug.Logger
-	skipRequired bool
+	debug debug.Logger
 }
 
 func (p *Parser) SetDebugWriter(writer io.Writer) {
 	p.debug = debug.New(writer, "dockerfile", "parser")
-}
-
-func (p *Parser) SetSkipRequiredCheck(b bool) {
-	p.skipRequired = b
 }
 
 // New creates a new Dockerfile parser
@@ -56,9 +50,7 @@ func (p *Parser) ParseFS(ctx context.Context, target fs.FS, path string) (map[st
 		if entry.IsDir() {
 			return nil
 		}
-		if !p.Required(path) {
-			return nil
-		}
+
 		df, err := p.ParseFile(ctx, target, path)
 		if err != nil {
 			// TODO add debug for parse errors
@@ -80,13 +72,6 @@ func (p *Parser) ParseFile(_ context.Context, fsys fs.FS, path string) (*dockerf
 	}
 	defer func() { _ = f.Close() }()
 	return p.parse(path, f)
-}
-
-func (p *Parser) Required(path string) bool {
-	if p.skipRequired {
-		return true
-	}
-	return detection.IsType(path, nil, detection.FileTypeDockerfile)
 }
 
 func (p *Parser) parse(path string, r io.Reader) (*dockerfile.Dockerfile, error) {

--- a/pkg/iac/scanners/helm/parser/parser.go
+++ b/pkg/iac/scanners/helm/parser/parser.go
@@ -34,7 +34,6 @@ type Parser struct {
 	ChartSource  string
 	filepaths    []string
 	debug        debug.Logger
-	skipRequired bool
 	workingFS    fs.FS
 	valuesFiles  []string
 	values       []string
@@ -51,10 +50,6 @@ type ChartFile struct {
 
 func (p *Parser) SetDebugWriter(writer io.Writer) {
 	p.debug = debug.New(writer, "helm", "parser")
-}
-
-func (p *Parser) SetSkipRequiredCheck(b bool) {
-	p.skipRequired = b
 }
 
 func (p *Parser) SetValuesFile(s ...string) {
@@ -126,10 +121,6 @@ func (p *Parser) ParseFS(ctx context.Context, target fs.FS, path string) error {
 			return err
 		}
 		if entry.IsDir() {
-			return nil
-		}
-
-		if !p.required(path, p.workingFS) {
 			return nil
 		}
 
@@ -309,16 +300,4 @@ func getManifestPath(manifest string) string {
 		return manifestFilePathParts[1]
 	}
 	return manifestFilePathParts[0]
-}
-
-func (p *Parser) required(path string, workingFS fs.FS) bool {
-	if p.skipRequired {
-		return true
-	}
-	content, err := fs.ReadFile(workingFS, path)
-	if err != nil {
-		return false
-	}
-
-	return detection.IsType(path, bytes.NewReader(content), detection.FileTypeHelm)
 }

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -36,7 +36,6 @@ type Scanner struct {
 	loadEmbeddedLibraries bool
 	loadEmbeddedPolicies  bool
 	policyFS              fs.FS
-	skipRequired          bool
 	frameworks            []framework.Framework
 	spec                  string
 	regoScanner           *rego.Scanner
@@ -88,12 +87,9 @@ func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
 	s.policyReaders = readers
 }
 
-func (s *Scanner) SetSkipRequiredCheck(skip bool) {
-	s.skipRequired = skip
-}
-
 func (s *Scanner) SetDebugWriter(writer io.Writer) {
 	s.debug = debug.New(writer, "helm", "scanner")
+	s.parserOptions = append(s.parserOptions, options.ParserWithDebug(writer))
 }
 
 func (s *Scanner) SetTraceWriter(_ io.Writer) {

--- a/pkg/iac/scanners/options/parser.go
+++ b/pkg/iac/scanners/options/parser.go
@@ -4,16 +4,9 @@ import "io"
 
 type ConfigurableParser interface {
 	SetDebugWriter(io.Writer)
-	SetSkipRequiredCheck(bool)
 }
 
 type ParserOption func(s ConfigurableParser)
-
-func ParserWithSkipRequiredCheck(skip bool) ParserOption {
-	return func(s ConfigurableParser) {
-		s.SetSkipRequiredCheck(skip)
-	}
-}
 
 // ParserWithDebug specifies an io.Writer for debug logs - if not set, they are discarded
 func ParserWithDebug(w io.Writer) ParserOption {

--- a/pkg/iac/scanners/options/scanner.go
+++ b/pkg/iac/scanners/options/scanner.go
@@ -14,7 +14,6 @@ type ConfigurableScanner interface {
 	SetPolicyDirs(...string)
 	SetDataDirs(...string)
 	SetPolicyNamespaces(...string)
-	SetSkipRequiredCheck(bool)
 	SetPolicyReaders([]io.Reader)
 	SetPolicyFilesystem(fs.FS)
 	SetDataFilesystem(fs.FS)
@@ -101,12 +100,6 @@ func ScannerWithDataDirs(paths ...string) ScannerOption {
 func ScannerWithPolicyNamespaces(namespaces ...string) ScannerOption {
 	return func(s ConfigurableScanner) {
 		s.SetPolicyNamespaces(namespaces...)
-	}
-}
-
-func ScannerWithSkipRequiredCheck(skip bool) ScannerOption {
-	return func(s ConfigurableScanner) {
-		s.SetSkipRequiredCheck(skip)
 	}
 }
 

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -48,7 +48,6 @@ type Parser struct {
 	allowDownloads    bool
 	skipCachedModules bool
 	fsMap             map[string]fs.FS
-	skipRequired      bool
 	configsFS         fs.FS
 }
 
@@ -74,10 +73,6 @@ func (p *Parser) SetAllowDownloads(b bool) {
 
 func (p *Parser) SetSkipCachedModules(b bool) {
 	p.skipCachedModules = b
-}
-
-func (p *Parser) SetSkipRequiredCheck(b bool) {
-	p.skipRequired = b
 }
 
 func (p *Parser) SetConfigsFS(fsys fs.FS) {

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -27,8 +27,8 @@ var _ scanners.FSScanner = (*Scanner)(nil)
 var _ options.ConfigurableScanner = (*Scanner)(nil)
 var _ ConfigurableTerraformScanner = (*Scanner)(nil)
 
-type Scanner struct { // nolint: gocritic
-	sync.Mutex
+type Scanner struct {
+	mu                    sync.Mutex
 	options               []options.ScannerOption
 	parserOpt             []options.ParserOption
 	executorOpt           []executor.Option
@@ -87,10 +87,6 @@ func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
 	s.policyReaders = readers
 }
 
-func (s *Scanner) SetSkipRequiredCheck(skip bool) {
-	s.parserOpt = append(s.parserOpt, options.ParserWithSkipRequiredCheck(skip))
-}
-
 func (s *Scanner) SetDebugWriter(writer io.Writer) {
 	s.parserOpt = append(s.parserOpt, options.ParserWithDebug(writer))
 	s.executorOpt = append(s.executorOpt, executor.OptionWithDebugWriter(writer))
@@ -131,8 +127,8 @@ func New(opts ...options.ScannerOption) *Scanner {
 }
 
 func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.regoScanner != nil {
 		return s.regoScanner, nil
 	}

--- a/pkg/iac/scanners/terraformplan/tfjson/scanner.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/scanner.go
@@ -23,8 +23,8 @@ var tfPlanExts = []string{
 }
 
 type Scanner struct {
-	parser    parser.Parser
-	parserOpt []options.ParserOption
+	parser    *parser.Parser
+	parserOpt []parser.Option
 	debug     debug.Logger
 
 	options                 []options.ScannerOption
@@ -68,12 +68,8 @@ func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
 	s.policyReaders = readers
 }
 
-func (s *Scanner) SetSkipRequiredCheck(skip bool) {
-	s.parserOpt = append(s.parserOpt, options.ParserWithSkipRequiredCheck(skip))
-}
-
 func (s *Scanner) SetDebugWriter(writer io.Writer) {
-	s.parserOpt = append(s.parserOpt, options.ParserWithDebug(writer))
+	s.parserOpt = append(s.parserOpt, parser.OptionWithDebugWriter(writer))
 	s.executorOpt = append(s.executorOpt, executor.OptionWithDebugWriter(writer))
 	s.debug = debug.New(writer, "tfplan", "scanner")
 }
@@ -128,12 +124,12 @@ func (s *Scanner) ScanFS(ctx context.Context, inputFS fs.FS, dir string) (scan.R
 
 func New(opts ...options.ScannerOption) *Scanner {
 	scanner := &Scanner{
-		parser:  *parser.New(),
 		options: opts,
 	}
 	for _, o := range opts {
 		o(scanner)
 	}
+	scanner.parser = parser.New(scanner.parserOpt...)
 	return scanner
 }
 

--- a/pkg/iac/scanners/toml/parser/parser.go
+++ b/pkg/iac/scanners/toml/parser/parser.go
@@ -9,23 +9,17 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/aquasecurity/trivy/pkg/iac/debug"
-	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 )
 
 var _ options.ConfigurableParser = (*Parser)(nil)
 
 type Parser struct {
-	debug        debug.Logger
-	skipRequired bool
+	debug debug.Logger
 }
 
 func (p *Parser) SetDebugWriter(writer io.Writer) {
 	p.debug = debug.New(writer, "toml", "parser")
-}
-
-func (p *Parser) SetSkipRequiredCheck(b bool) {
-	p.skipRequired = b
 }
 
 // New creates a new parser
@@ -52,9 +46,7 @@ func (p *Parser) ParseFS(ctx context.Context, target fs.FS, path string) (map[st
 		if entry.IsDir() {
 			return nil
 		}
-		if !p.Required(path) {
-			return nil
-		}
+
 		df, err := p.ParseFile(ctx, target, path)
 		if err != nil {
 			p.debug.Log("Parse error in '%s': %s", path, err)
@@ -80,11 +72,4 @@ func (p *Parser) ParseFile(_ context.Context, fsys fs.FS, path string) (any, err
 		return nil, err
 	}
 	return target, nil
-}
-
-func (p *Parser) Required(path string) bool {
-	if p.skipRequired {
-		return true
-	}
-	return detection.IsType(path, nil, detection.FileTypeTOML)
 }

--- a/pkg/iac/scanners/toml/scanner.go
+++ b/pkg/iac/scanners/toml/scanner.go
@@ -17,15 +17,15 @@ import (
 
 var _ options.ConfigurableScanner = (*Scanner)(nil)
 
-type Scanner struct { // nolint: gocritic
-	debug         debug.Logger
-	options       []options.ScannerOption
-	policyDirs    []string
-	policyReaders []io.Reader
-	parser        *parser.Parser
-	regoScanner   *rego.Scanner
-	skipRequired  bool
-	sync.Mutex
+type Scanner struct {
+	mu                    sync.Mutex
+	debug                 debug.Logger
+	options               []options.ScannerOption
+	parserOptions         []options.ParserOption
+	policyDirs            []string
+	policyReaders         []io.Reader
+	parser                *parser.Parser
+	regoScanner           *rego.Scanner
 	frameworks            []framework.Framework
 	spec                  string
 	loadEmbeddedPolicies  bool
@@ -60,12 +60,9 @@ func (s *Scanner) SetPolicyReaders(readers []io.Reader) {
 	s.policyReaders = readers
 }
 
-func (s *Scanner) SetSkipRequiredCheck(skip bool) {
-	s.skipRequired = skip
-}
-
 func (s *Scanner) SetDebugWriter(writer io.Writer) {
 	s.debug = debug.New(writer, "toml", "scanner")
+	s.parserOptions = append(s.parserOptions, options.ParserWithDebug(writer))
 }
 
 func (s *Scanner) SetTraceWriter(_ io.Writer)        {}
@@ -94,7 +91,7 @@ func NewScanner(opts ...options.ScannerOption) *Scanner {
 	for _, opt := range opts {
 		opt(s)
 	}
-	s.parser = parser.New(options.ParserWithSkipRequiredCheck(s.skipRequired))
+	s.parser = parser.New(s.parserOptions...)
 	return s
 }
 
@@ -138,8 +135,8 @@ func (s *Scanner) ScanFile(ctx context.Context, fsys fs.FS, path string) (scan.R
 }
 
 func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.regoScanner != nil {
 		return s.regoScanner, nil
 	}

--- a/pkg/iac/scanners/yaml/parser/parser.go
+++ b/pkg/iac/scanners/yaml/parser/parser.go
@@ -11,23 +11,17 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/iac/debug"
-	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 )
 
 var _ options.ConfigurableParser = (*Parser)(nil)
 
 type Parser struct {
-	debug        debug.Logger
-	skipRequired bool
+	debug debug.Logger
 }
 
 func (p *Parser) SetDebugWriter(writer io.Writer) {
 	p.debug = debug.New(writer, "yaml", "parser")
-}
-
-func (p *Parser) SetSkipRequiredCheck(b bool) {
-	p.skipRequired = b
 }
 
 // New creates a new parser
@@ -54,9 +48,7 @@ func (p *Parser) ParseFS(ctx context.Context, target fs.FS, path string) (map[st
 		if entry.IsDir() {
 			return nil
 		}
-		if !p.Required(path) {
-			return nil
-		}
+
 		df, err := p.ParseFile(ctx, target, path)
 		if err != nil {
 			p.debug.Log("Parse error in '%s': %s", path, err)
@@ -100,11 +92,4 @@ func (p *Parser) ParseFile(_ context.Context, fsys fs.FS, path string) ([]any, e
 	}
 
 	return results, nil
-}
-
-func (p *Parser) Required(path string) bool {
-	if p.skipRequired {
-		return true
-	}
-	return detection.IsType(path, nil, detection.FileTypeYAML)
 }

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -215,7 +215,6 @@ func (s *Scanner) filterFS(fsys fs.FS) (fs.FS, error) {
 
 func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerOption, error) {
 	opts := []options.ScannerOption{
-		options.ScannerWithSkipRequiredCheck(true),
 		options.ScannerWithEmbeddedPolicies(!opt.DisableEmbeddedPolicies),
 		options.ScannerWithEmbeddedLibraries(!opt.DisableEmbeddedLibraries),
 		options.ScannerWithIncludeDeprecatedChecks(opt.IncludeDeprecatedChecks),


### PR DESCRIPTION
## Description

This PR removes duplicate file filtering from the parsers, which was never done because a flag was always passed to disable it. Currently, the detection package is responsible for this, which filters files before scanning.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
