### PR TITLE
perf(misconf): do not convert contents of a YAML file to string

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -216,15 +216,15 @@ func init() {
 		}
 		data := buf.Bytes()
 
-		marker := "\n---\n"
-		altMarker := "\r\n---\r\n"
-		if bytes.Contains(data, []byte(altMarker)) {
+		marker := []byte("\n---\n")
+		altMarker := []byte("\r\n---\r\n")
+		if bytes.Contains(data, altMarker) {
 			marker = altMarker
 		}
 
-		for _, partial := range strings.Split(string(data), marker) {
+		for _, partial := range bytes.Split(data, marker) {
 			var result map[string]any
-			if err := yaml.Unmarshal([]byte(partial), &result); err != nil {
+			if err := yaml.Unmarshal(partial, &result); err != nil {
 				continue
 			}
 			match := true

--- a/pkg/iac/scanners/yaml/parser/parser.go
+++ b/pkg/iac/scanners/yaml/parser/parser.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -85,15 +84,15 @@ func (p *Parser) ParseFile(_ context.Context, fsys fs.FS, path string) ([]any, e
 
 	var results []any
 
-	marker := "\n---\n"
-	altMarker := "\r\n---\r\n"
+	marker := []byte("\n---\n")
+	altMarker := []byte("\r\n---\r\n")
 	if bytes.Contains(contents, []byte(altMarker)) {
 		marker = altMarker
 	}
 
-	for _, partial := range strings.Split(string(contents), marker) {
+	for _, partial := range bytes.Split(contents, marker) {
 		var target any
-		if err := yaml.Unmarshal([]byte(partial), &target); err != nil {
+		if err := yaml.Unmarshal(partial, &target); err != nil {
 			return nil, err
 		}
 		results = append(results, target)

--- a/pkg/iac/scanners/yaml/parser/parser.go
+++ b/pkg/iac/scanners/yaml/parser/parser.go
@@ -86,7 +86,7 @@ func (p *Parser) ParseFile(_ context.Context, fsys fs.FS, path string) ([]any, e
 
 	marker := []byte("\n---\n")
 	altMarker := []byte("\r\n---\r\n")
-	if bytes.Contains(contents, []byte(altMarker)) {
+	if bytes.Contains(contents, altMarker) {
 		marker = altMarker
 	}
 


### PR DESCRIPTION
## Description

To work with bytes, it is better to use the bytes package instead of converting bytes to a string.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
