### PR TITLE
perf(misconf): use json.Valid to check validity of JSON

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -45,8 +45,8 @@ func init() {
 			return true
 		}
 
-		var content any
-		return json.NewDecoder(r).Decode(&content) == nil
+		b, err := io.ReadAll(r)
+		return err == nil && json.Valid(b)
 	}
 
 	matchers[FileTypeYAML] = func(name string, r io.ReadSeeker) bool {


### PR DESCRIPTION
## Description

Validity checking with `json.Valid` is faster and produces fewer allocations than validity checking via unmarshalling.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
