### PR TITLE
feat(julia): Add license detection for Julia

### DIFF
--- a/docs/docs/coverage/language/julia.md
+++ b/docs/docs/coverage/language/julia.md
@@ -7,7 +7,7 @@ The following scanners are supported.
 
 | Package manager | SBOM | Vulnerability | License |
 |-----------------|:----:|:-------------:|:-------:|
-| Pkg.jl          |  ✓   |       -       |    -    |
+| Pkg.jl          |  ✓   |       -       |    ✓    |
 
 The following table provides an outline of the features Trivy offers.
 

--- a/pkg/dependency/parser/julia/manifest/parse.go
+++ b/pkg/dependency/parser/julia/manifest/parse.go
@@ -23,6 +23,7 @@ type primitiveDependency struct {
 	UUID         string         `toml:"uuid"`
 	Version      string         `toml:"version"` // not specified for stdlib packages, which are of the Julia version
 	DependsOn    []string       `toml:"-"`       // list of dependent UUID's.
+	Path         string         `toml:"path"`    // only set for dev'd packages
 }
 
 type Parser struct{}
@@ -87,6 +88,11 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 						EndLine:   pos.end,
 					},
 				}
+			}
+			if manifestDep.Path != "" {
+				// I am not thrilled about this but there is really nowhere else to put this information.
+				// This is needed later for determining licenses.
+				pkg.InstalledFiles = []string{manifestDep.Path}
 			}
 
 			pkgs = append(pkgs, pkg)

--- a/pkg/dependency/parser/julia/manifest/parse_testcase.go
+++ b/pkg/dependency/parser/julia/manifest/parse_testcase.go
@@ -76,11 +76,11 @@ var (
 	}
 
 	juliaV10FormatPkgs = []ftypes.Package{
-		{ID: "767738be-2f1f-45a9-b806-0234f3164144", Name: "Foo", Version: "unknown", Locations: []ftypes.Location{{StartLine: 1, EndLine: 5}}},
-		{ID: "6f418443-bd2e-4783-b551-cdbac608adf2", Name: "Foo", Version: "unknown", Locations: []ftypes.Location{{StartLine: 7, EndLine: 10}}},
-		{ID: "2a550a13-6bab-4a91-a4ee-dff34d6b99d0", Name: "Bar", Version: "unknown", Locations: []ftypes.Location{{StartLine: 12, EndLine: 14}}},
+		{ID: "767738be-2f1f-45a9-b806-0234f3164144", Name: "Foo", Version: "unknown", InstalledFiles: []string{"deps/Foo1"}, Locations: []ftypes.Location{{StartLine: 1, EndLine: 5}}},
+		{ID: "6f418443-bd2e-4783-b551-cdbac608adf2", Name: "Foo", Version: "unknown", InstalledFiles: []string{"deps/Foo2.jl"}, Locations: []ftypes.Location{{StartLine: 7, EndLine: 10}}},
+		{ID: "2a550a13-6bab-4a91-a4ee-dff34d6b99d0", Name: "Bar", Version: "unknown", InstalledFiles: []string{"deps/Bar"}, Locations: []ftypes.Location{{StartLine: 12, EndLine: 14}}},
 		{ID: "6801f525-dc68-44e8-a4e8-cabd286279e7", Name: "Baz", Version: "unknown", Locations: []ftypes.Location{{StartLine: 19, EndLine: 21}}},
-		{ID: "b5ec9b9c-e354-47fd-b367-a348bdc8f909", Name: "Qux", Version: "unknown", Locations: []ftypes.Location{{StartLine: 26, EndLine: 28}}},
+		{ID: "b5ec9b9c-e354-47fd-b367-a348bdc8f909", Name: "Qux", Version: "unknown", InstalledFiles: []string{"deps/Qux.jl"}, Locations: []ftypes.Location{{StartLine: 26, EndLine: 28}}},
 	}
 
 	juliaV10FormatDeps = []ftypes.Dependency{

--- a/pkg/fanal/analyzer/language/julia/pkg/wip.jl
+++ b/pkg/fanal/analyzer/language/julia/pkg/wip.jl
@@ -1,0 +1,49 @@
+
+# https://vscode.dev/github/Octogonapus/Pkg.jl/blob/manifest_check_errors/src/Operations.jl#L31
+function source_path(manifest_file::String, pkg::Union{PackageSpec, PackageEntry}, julia_version = VERSION)
+    pkg.tree_hash   !== nothing ? find_installed(pkg.name, pkg.uuid, pkg.tree_hash) :
+    pkg.path        !== nothing ? joinpath(dirname(manifest_file), pkg.path) :
+    is_or_was_stdlib(pkg.uuid, julia_version) ? Types.stdlib_path(pkg.name) :
+    nothing
+end
+
+function find_installed(name::String, uuid::UUID, sha1::SHA1)
+    slug_default = Base.version_slug(uuid, sha1)
+    # 4 used to be the default so look there first
+    for slug in (slug_default, Base.version_slug(uuid, sha1, 4))
+        for depot in depots()
+            path = abspath(depot, "packages", name, slug)
+            ispath(path) && return path
+        end
+    end
+    return abspath(depots1(), "packages", name, slug_default)
+end
+
+
+
+# https://vscode.dev/github/Octogonapus/Pkg.jl/blob/manifest_check_errorsiaup/julia-1.10.4%2B0.x64.linux.gnu/share/julia/base/loading.jl#L182
+## package path slugs: turning UUID + SHA1 into a pair of 4-byte "slugs" ##
+
+const slug_chars = String(['A':'Z'; 'a':'z'; '0':'9'])
+
+function slug(x::UInt32, p::Int)
+    y::UInt32 = x
+    sprint(sizehint=p) do io
+        n = length(slug_chars)
+        for i = 1:p
+            y, d = divrem(y, n)
+            write(io, slug_chars[1+d])
+        end
+    end
+end
+
+function package_slug(uuid::UUID, p::Int=5)
+    crc = _crc32c(uuid)
+    return slug(crc, p)
+end
+
+function version_slug(uuid::UUID, sha1::SHA1, p::Int=5)
+    crc = _crc32c(uuid)
+    crc = _crc32c(sha1.bytes, crc)
+    return slug(crc, p)
+end


### PR DESCRIPTION
## Description

Add license detection for Julia packages.

This is incomplete, I will add tests where needed and remove extraneous code before marking this PR as ready. First I am asking for some maintainer feedback:

Julia packages often don't specify their license in their Project.toml file (even though they should). I've included some rudimentary content-based license detection to help with that because I'm not sure if this project would accept adding a dependency for this. There are some dependencies (e.g. [licensecheck](https://pkg.go.dev/github.com/google/licensecheck) and [go-license-detector](https://github.com/go-enry/go-license-detector)) which do a better job. What do you think about adding a dependency for license detection?


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
