### PR TITLE
feat(misconf): Add optional start/end_line config values for ignorefile misconf

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -345,6 +345,8 @@ Available fields:
 | purls      |          | string array        | The list of PURLs to ignore packages. If `purls` is not set, the ignore finding is applied to all packages. This field is currently available only for vulnerabilities. |
 | expired_at |          | date (`yyyy-mm-dd`) | The expiration date of the ignore finding. If `expired_at` is not set, the ignore finding is always valid.                                                              |
 | statement  |          | string              | The reason for ignoring the finding. (This field is not used for filtering.)                                                                                            |
+| start_line |          | int                 | The starting line of where the ignore finding is applied.  This field is currently available only for misconfigurations.                                                |
+| end_line   |          | int                 | The ending line of where the ignore finding is applied. This field is currently available only for misconfigurations                                                    |
 
 ```bash
 $ cat .trivyignore.yaml
@@ -367,6 +369,11 @@ misconfigurations:
     paths:
       - "docs/Dockerfile"
     statement: The image needs root privileges
+  - id: AVD-DS-0003
+    paths:
+      - "docs/Dockerfile"
+    start_line: 20
+    end_line: 25
 
 secrets:
   - id: aws-access-key-id

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
@@ -32,6 +33,14 @@ type FilterOption struct {
 	PolicyFile         string
 	IgnoreLicenses     []string
 	VEXPath            string
+}
+
+type FindingsResults struct {
+	IDS        []string
+	TargetPath string
+	PackageURL *packageurl.PackageURL
+	StartLine  int
+	EndLine    int
 }
 
 // Filter filters out the report
@@ -151,8 +160,15 @@ func filterMisconfigurations(result *types.Result, severities []string, includeN
 			continue
 		}
 
+		findingsResults := &FindingsResults{
+			IDS:        []string{misconf.ID, misconf.AVDID},
+			TargetPath: result.Target,
+			StartLine:  misconf.CauseMetadata.StartLine,
+			EndLine:    misconf.CauseMetadata.EndLine,
+		}
+
 		// Filter by ignore file
-		if f := ignoreConfig.MatchMisconfiguration(misconf.ID, misconf.AVDID, result.Target); f != nil {
+		if f := ignoreConfig.MatchMisconfiguration(findingsResults); f != nil {
 			result.MisconfSummary.Exceptions++
 			result.ModifiedFindings = append(result.ModifiedFindings,
 				types.NewModifiedFinding(misconf, types.FindingStatusIgnored, f.Statement, ignoreConfig.FilePath))

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -147,6 +147,16 @@ func TestFilter(t *testing.T) {
 			Severity: dbTypes.SeverityLow.String(),
 			Status:   types.MisconfStatusFailure,
 		}
+		misconf4 = types.DetectedMisconfiguration{
+			Type:          "Kubernetes Security Check",
+			ID:            "ID300",
+			AVDID:         "AVD-ID300",
+			Title:         "Bad Job with defined ignore lines",
+			Message:       "something bad",
+			Severity:      dbTypes.SeverityLow.String(),
+			Status:        types.MisconfStatusException,
+			CauseMetadata: ftypes.CauseMetadata{StartLine: 10, EndLine: 11},
+		}
 		secret1 = types.DetectedSecret{
 			RuleID:    "generic-wanted-rule",
 			Severity:  dbTypes.SeverityHigh.String(),
@@ -458,6 +468,7 @@ func TestFilter(t *testing.T) {
 								misconf1, // ignored
 								misconf2, // ignored
 								misconf3,
+								misconf4, // ignored
 							},
 						},
 						{
@@ -523,7 +534,7 @@ func TestFilter(t *testing.T) {
 						MisconfSummary: &types.MisconfSummary{
 							Successes:  0,
 							Failures:   1,
-							Exceptions: 2,
+							Exceptions: 3,
 						},
 						Misconfigurations: []types.DetectedMisconfiguration{
 							misconf3,
@@ -540,6 +551,12 @@ func TestFilter(t *testing.T) {
 								Status:  types.FindingStatusIgnored,
 								Source:  "testdata/.trivyignore.yaml",
 								Finding: misconf2,
+							},
+							{
+								Type:    types.FindingTypeMisconfiguration,
+								Status:  types.FindingStatusIgnored,
+								Source:  "testdata/.trivyignore.yaml",
+								Finding: misconf4,
 							},
 						},
 					},

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -106,8 +106,11 @@ func (f *IgnoreFindings) Match(id string, results *FindingsResults) *IgnoreFindi
 			continue
 		}
 
-		log.Debug("Ignored", log.String("id", id), log.String("target", results.TargetPath),
-			log.String("startLine-endLine", fmt.Sprintf("%d-%d", results.StartLine, results.EndLine)))
+		log.Debug("Ignored", log.String("id", id), log.String("target", results.TargetPath))
+
+		if finding.StartLine > 0 || finding.EndLine > 0 {
+			log.Debug("Ignored lines", log.String("start_line:end_line", fmt.Sprintf("%d:%d", results.StartLine, results.EndLine)))
+		}
 
 		return &finding
 	}

--- a/pkg/result/testdata/.trivyignore.yaml
+++ b/pkg/result/testdata/.trivyignore.yaml
@@ -25,6 +25,11 @@ misconfigurations:
       - "app/Dockerfile"
   - id: ID300
     paths:
+      - "app/Dockerfile"
+    start_line: 10
+    end_line: 11
+  - id: ID300
+    paths:
       - "docs/Dockerfile"
 secrets:
   - id: generic-unwanted-rule


### PR DESCRIPTION
## Description

The proposal is to add the ability to define the start/end lines as optional config fields in the ignore file.

### Current:

```yaml
  - id: KSV048
    paths:
      - templates/test-template.yaml
 ```

### Proposed:

```yaml
  - id: KSV048
    start_line: 9
    end_line: 11
    paths:
      - templates/test-template.yaml
```

This is a relatively non-invasive small change, adding two fields to the IgnoreFinding struct, passing the values from the calling functions into the Match method, where a conditional then does the line comparsions. The value add here is to allow more granular control over the explicit rules being ignored, instead of ignoring the rule across the entire rendered output, but over specific lines in the output.

## Related issues
None - Discussion [7325](https://github.com/aquasecurity/trivy/discussions/7325)

## Related PRs
None

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
