### PR TITLE
fix(misconf): change default TLS values for the Azure storage account

### DIFF
--- a/pkg/iac/adapters/arm/storage/adapt.go
+++ b/pkg/iac/adapters/arm/storage/adapt.go
@@ -59,7 +59,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 				Metadata:      resource.Properties.GetMetadata(),
 				EnableLogging: types.BoolDefault(false, resource.Properties.GetMetadata()),
 			},
-			MinimumTLSVersion: resource.Properties.GetMapValue("minimumTlsVersion").AsStringValue("TLS1_0", resource.Properties.GetMetadata()),
+			MinimumTLSVersion: resource.Properties.GetMapValue("minimumTlsVersion").AsStringValue("", resource.Properties.GetMetadata()),
 			Queues:            queues,
 		}
 		accounts = append(accounts, account)

--- a/pkg/iac/adapters/arm/storage/adapt_test.go
+++ b/pkg/iac/adapters/arm/storage/adapt_test.go
@@ -26,7 +26,7 @@ func Test_AdaptStorageDefaults(t *testing.T) {
 	require.Len(t, output.Accounts, 1)
 
 	account := output.Accounts[0]
-	assert.Equal(t, "TLS1_0", account.MinimumTLSVersion.Value())
+	assert.Equal(t, "", account.MinimumTLSVersion.Value())
 	assert.False(t, account.EnforceHTTPS.Value())
 
 }

--- a/pkg/iac/adapters/terraform/azure/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/storage/adapt.go
@@ -6,6 +6,8 @@ import (
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
+const minimumTlsVersionOneTwo = "TLS1_2"
+
 func Adapt(modules terraform.Modules) storage.Storage {
 	accounts, containers, networkRules := adaptAccounts(modules)
 
@@ -106,7 +108,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 			Metadata:      resource.GetMetadata(),
 			EnableLogging: iacTypes.BoolDefault(false, resource.GetMetadata()),
 		},
-		MinimumTLSVersion: iacTypes.StringDefault("TLS1_2", resource.GetMetadata()),
+		MinimumTLSVersion: iacTypes.StringDefault(minimumTlsVersionOneTwo, resource.GetMetadata()),
 	}
 
 	networkRulesBlocks := resource.GetBlocks("network_rules")
@@ -127,7 +129,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 	}
 
 	minTLSVersionAttr := resource.GetAttribute("min_tls_version")
-	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValueOrDefault("TLS1_0", resource)
+	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValueOrDefault(minimumTlsVersionOneTwo, resource)
 	return account
 }
 


### PR DESCRIPTION
## Description

Now the default minimum TLS value for storage account in Terraform is `TLS1_2`. But Azure ARM sets the default value depending on the deployment method. If the account is created via ARM, the MinimumTlsVersion property is not set by default and does not return a value until you explicitly set it.

Refs:
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#min_tls_version
- https://learn.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version?tabs=azure-cli#configure-the-minimum-tls-version-for-a-storage-account

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
