### PR TITLE
fix: safely check if the directory exists

### DIFF
--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -1,7 +1,6 @@
 package fsutils
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -59,18 +58,13 @@ func CopyFile(src, dst string) (int64, error) {
 }
 
 func DirExists(path string) bool {
-	if f, err := os.Stat(path); os.IsNotExist(err) || !f.IsDir() {
-		return false
-	}
-	return true
+	f, err := os.Stat(path)
+	return err == nil && f.IsDir()
 }
 
 func FileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	if errors.Is(err, os.ErrNotExist) {
-		return false
-	}
-	return err == nil
+	f, err := os.Stat(filename)
+	return err == nil && !f.IsDir()
 }
 
 type WalkDirRequiredFunc func(path string, d fs.DirEntry) bool

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -2,28 +2,12 @@ package fsutils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func touch(t *testing.T, name string) {
-	f, err := os.Create(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func write(t *testing.T, name, content string) {
-	err := os.WriteFile(name, []byte(content), 0666)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
 
 func TestCopyFile(t *testing.T) {
 	type args struct {
@@ -71,4 +55,48 @@ func TestCopyFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDirExists(t *testing.T) {
+	t.Run("invalid path", func(t *testing.T) {
+		assert.False(t, DirExists("\000invalid:path"))
+	})
+
+	t.Run("valid path", func(t *testing.T) {
+		assert.True(t, DirExists(t.TempDir()))
+	})
+
+	t.Run("dir not exist", func(t *testing.T) {
+		assert.False(t, DirExists(filepath.Join(t.TempDir(), "tmp")))
+	})
+
+	t.Run("file path", func(t *testing.T) {
+		filePath := filepath.Join(t.TempDir(), "tmp")
+		f, err := os.Create(filePath)
+		require.NoError(t, f.Close())
+		require.NoError(t, err)
+		assert.False(t, DirExists(filePath))
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	t.Run("invalid path", func(t *testing.T) {
+		assert.False(t, FileExists("\000invalid:path"))
+	})
+
+	t.Run("valid path", func(t *testing.T) {
+		filePath := filepath.Join(t.TempDir(), "tmp")
+		f, err := os.Create(filePath)
+		require.NoError(t, f.Close())
+		require.NoError(t, err)
+		assert.True(t, FileExists(filePath))
+	})
+
+	t.Run("file not exist", func(t *testing.T) {
+		assert.False(t, FileExists(filepath.Join(t.TempDir(), "tmp")))
+	})
+
+	t.Run("dir path", func(t *testing.T) {
+		assert.False(t, FileExists(t.TempDir()))
+	})
 }


### PR DESCRIPTION
## Description
The `DirExists` function call caused a panic if an error not related to the existence of the file was received when retrieving the file information

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7352

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
