### PR TITLE
fix(misconf): wrap Azure PortRange in iac types

### DIFF
--- a/pkg/iac/adapters/arm/network/adapt.go
+++ b/pkg/iac/adapters/arm/network/adapt.go
@@ -27,11 +27,11 @@ func adaptSecurityGroups(deployment azure.Deployment) (sgs []network.SecurityGro
 func adaptSecurityGroup(resource azure.Resource, deployment azure.Deployment) network.SecurityGroup {
 	return network.SecurityGroup{
 		Metadata: resource.Metadata,
-		Rules:    adaptSecurityGroupRules(resource, deployment),
+		Rules:    adaptSecurityGroupRules(deployment),
 	}
 }
 
-func adaptSecurityGroupRules(resource azure.Resource, deployment azure.Deployment) (rules []network.SecurityGroupRule) {
+func adaptSecurityGroupRules(deployment azure.Deployment) (rules []network.SecurityGroupRule) {
 	for _, resource := range deployment.GetResourcesByType("Microsoft.Network/networkSecurityGroups/securityRules") {
 		rules = append(rules, adaptSecurityGroupRule(resource))
 	}
@@ -120,7 +120,7 @@ func expandRange(r string, m iacTypes.Metadata) network.PortRange {
 
 	return network.PortRange{
 		Metadata: m,
-		Start:    start,
-		End:      end,
+		Start:    iacTypes.Int(start, m),
+		End:      iacTypes.Int(end, m),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/network/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/network/adapt.go
@@ -136,8 +136,8 @@ func (a *adapter) adaptSource(ruleBlock *terraform.Block, rule *network.Security
 		f := sourcePortRangeAttr.AsNumber()
 		rule.SourcePorts = append(rule.SourcePorts, network.PortRange{
 			Metadata: sourcePortRangeAttr.GetMetadata(),
-			Start:    int(f),
-			End:      int(f),
+			Start:    iacTypes.Int(int(f), sourcePortRangeAttr.GetMetadata()),
+			End:      iacTypes.Int(int(f), sourcePortRangeAttr.GetMetadata()),
 		})
 	}
 }
@@ -160,8 +160,8 @@ func (a *adapter) adaptDestination(ruleBlock *terraform.Block, rule *network.Sec
 		f := destPortRangeAttr.AsNumber()
 		rule.DestinationPorts = append(rule.DestinationPorts, network.PortRange{
 			Metadata: destPortRangeAttr.GetMetadata(),
-			Start:    int(f),
-			End:      int(f),
+			Start:    iacTypes.Int(int(f), destPortRangeAttr.GetMetadata()),
+			End:      iacTypes.Int(int(f), destPortRangeAttr.GetMetadata()),
 		})
 	}
 }
@@ -189,8 +189,8 @@ func expandRange(r string, m iacTypes.Metadata) network.PortRange {
 
 	return network.PortRange{
 		Metadata: m,
-		Start:    start,
-		End:      end,
+		Start:    iacTypes.Int(start, m),
+		End:      iacTypes.Int(end, m),
 	}
 }
 

--- a/pkg/iac/adapters/terraform/azure/network/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/network/adapt_test.go
@@ -65,15 +65,15 @@ func Test_Adapt(t *testing.T) {
 								SourcePorts: []network.PortRange{
 									{
 										Metadata: iacTypes.NewTestMetadata(),
-										Start:    0,
-										End:      65535,
+										Start:    iacTypes.IntTest(0),
+										End:      iacTypes.IntTest(65535),
 									},
 								},
 								DestinationPorts: []network.PortRange{
 									{
 										Metadata: iacTypes.NewTestMetadata(),
-										Start:    3389,
-										End:      3389,
+										Start:    iacTypes.IntTest(3389),
+										End:      iacTypes.IntTest(3389),
 									},
 								},
 								Protocol: iacTypes.String("TCP", iacTypes.NewTestMetadata()),

--- a/pkg/iac/providers/azure/network/network.go
+++ b/pkg/iac/providers/azure/network/network.go
@@ -27,12 +27,12 @@ type SecurityGroupRule struct {
 
 type PortRange struct {
 	Metadata iacTypes.Metadata
-	Start    int
-	End      int
+	Start    iacTypes.IntValue
+	End      iacTypes.IntValue
 }
 
 func (r PortRange) Includes(port int) bool {
-	return port >= r.Start && port <= r.End
+	return port >= r.Start.Value() && port <= r.End.Value()
 }
 
 type NetworkWatcherFlowLog struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -5207,10 +5207,12 @@
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
         },
         "end": {
-          "type": "integer"
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         },
         "start": {
-          "type": "integer"
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         }
       }
     },


### PR DESCRIPTION
## Description
`PortRange` is not exported to json for Rego because it is not wrapped in IaC types.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
