### PR TITLE
fix(helm): explicitly define `kind` and `apiVersion` of `volumeClaimTemplate` element

### DIFF
--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
       spec:
         resources:


### PR DESCRIPTION
## Description

Hello, I made a quick fix to define explicitly all `volumeClaimTemplate` field.
This allows to use gitops tools (like argoCD) to sync raw k8s manifests (built via helm) with cluster resources. Without these fields defined, these will be added in the cluster resource resulting in an OutOfSync with the generated manifest.

Feel free to discuss this fix in the below linked discussion.

## Related issues

Like mentionned in [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/), I think this change is trivial. This is why I created this PR without any Issue linked.
Nevertheless, I oepened a discussion here: https://github.com/aquasecurity/trivy/discussions/7361


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
