### PR TITLE
fix(misconf): init frameworks before updating them

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -54,6 +54,9 @@ func NewStaticMetadata(pkgPath string, inputOpt InputOptions) *StaticMetadata {
 }
 
 func (sm *StaticMetadata) Update(meta map[string]any) error {
+	if sm.Frameworks == nil {
+		sm.Frameworks = make(map[framework.Framework][]string)
+	}
 
 	upd := func(field *string, key string) {
 		if raw, ok := meta[key]; ok {

--- a/pkg/iac/rego/metadata_test.go
+++ b/pkg/iac/rego/metadata_test.go
@@ -97,6 +97,7 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			References:     []string{"r", "r1_n", "r2_n"},
 			CloudFormation: &scan.EngineMetadata{},
 			Terraform:      &scan.EngineMetadata{},
+			Frameworks:     make(map[framework.Framework][]string),
 		}
 
 		assert.Equal(t, expected, sm)
@@ -114,6 +115,7 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			References:     []string{"r", "r1_n", "r2_n"},
 			CloudFormation: &scan.EngineMetadata{},
 			Terraform:      &scan.EngineMetadata{},
+			Frameworks:     make(map[framework.Framework][]string),
 		}
 
 		assert.Equal(t, expected, sm)
@@ -131,9 +133,18 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			Deprecated:     true,
 			CloudFormation: &scan.EngineMetadata{},
 			Terraform:      &scan.EngineMetadata{},
+			Frameworks:     make(map[framework.Framework][]string),
 		}
 
 		assert.Equal(t, expected, sm)
+	})
+
+	t.Run("frameworks is not initialized", func(t *testing.T) {
+		sm := StaticMetadata{}
+		err := sm.Update(map[string]any{
+			"frameworks": map[string]any{"all": []any{"a", "b", "c"}},
+		})
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## Description

Fixes:
```bash
2024-08-23T04:50:26Z    DEBUG   [misconf] 50:26.747428627 terraform.scanner.rego           Error occurred while parsing: root/.cache/trivy/policy/content/policies/cloud/policies/aws/ec2/no_public_ingress_sgr.rego, root/.cache/trivy/policy/content/policies/cloud/policies/aws/ec2/no_public_ingress_sgr.rego:44: rego_type_error: undefined function cidr.is_public. Trying to fallback to embedded check.
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/iac/rego.(*StaticMetadata).updateFrameworks(0xc004228500, 0xc0014cb5c0?)
        /Users/nikita/projects/trivy/pkg/iac/rego/metadata.go:138 +0x1f3
github.com/aquasecurity/trivy/pkg/iac/rego.(*StaticMetadata).Update(0xc004228500, 0xc0014cb5c0)
        /Users/nikita/projects/trivy/pkg/iac/rego/metadata.go:107 +0x8ff
github.com/aquasecurity/trivy/pkg/iac/rego.(*StaticMetadata).FromAnnotations(0xc004228500, 0xc0025a7260)
        /Users/nikita/projects/trivy/pkg/iac/rego/metadata.go:166 +0x1b9
github.com/aquasecurity/trivy/pkg/iac/rego.metadataFromRegoModule(0xc003192870)
        /Users/nikita/projects/trivy/pkg/iac/rego/metadata.go:428 +0x6f
github.com/aquasecurity/trivy/pkg/iac/rego.(*Scanner).findMatchedEmbeddedCheck(0xc003102000, 0xc003192870)
        /Users/nikita/projects/trivy/pkg/iac/rego/load.go:198 +0xff
github.com/aquasecurity/trivy/pkg/iac/rego.(*Scanner).fallbackChecks(0xc003102000, 0xc00308cc60)
        /Users/nikita/projects/trivy/pkg/iac/rego/load.go:173 +0x352
github.com/aquasecurity/trivy/pkg/iac/rego.(*Scanner).compilePolicies(0xc003102000, {0x533bc00, 0xc000212510}, {0xc002ff5970, 0x1, 0x1})
        /Users/nikita/projects/trivy/pkg/iac/rego/load.go:248 +0x151
github.com/aquasecurity/trivy/pkg/iac/rego.(*Scanner).LoadPolicies(0xc003102000, 0x0, 0x0, {0x533bc00?, 0xc002e6e2a0?}, {0xc002ff5970, 0x1, 0x1}, {0x0, 0x0, ...})
        /Users/nikita/projects/trivy/pkg/iac/rego/load.go:144 +0x8f6
github.com/aquasecurity/trivy/pkg/iac/scanners/terraform.(*Scanner).initRegoScanner(0xc0035b9900, {0x533bc00, 0xc002e6e2a0})
        /Users/nikita/projects/trivy/pkg/iac/scanners/terraform/scanner.go:138 +0x166
github.com/aquasecurity/trivy/pkg/iac/scanners/terraform.(*Scanner).ScanFS(0xc0035b9900, {0x53796a0, 0xc0010a1e30}, {0x533bc00, 0xc002e6e2a0}, {0x5320a88, 0x1})
        /Users/nikita/projects/trivy/pkg/iac/scanners/terraform/scanner.go:165 +0x190
github.com/aquasecurity/trivy/pkg/misconf.(*Scanner).Scan(0xc0017971d0, {0x53796a0, 0xc0010a1e30}, {0x533bc00?, 0xc002e6e288?})
        /Users/nikita/projects/trivy/pkg/misconf/scanner.go:158 +0x223
github.com/aquasecurity/trivy/pkg/fanal/analyzer/config.(*Analyzer).PostAnalyze(0xc002a2a7e0, {0x53796a0?, 0xc0010a1e30?}, {{0x533bc00?, 0xc002e6e288?}, {0x9?, 0x0?}})
        /Users/nikita/projects/trivy/pkg/fanal/analyzer/config/config.go:45 +0x46
github.com/aquasecurity/trivy/pkg/fanal/analyzer.AnalyzerGroup.PostAnalyze({0xc000d0e7e0, {0xc003690140, 0x3, 0x4}, {0xc0018c2280, 0x8, 0x8}, 0xc0012dee40, {0x0, 0x0}}, ...)
        /Users/nikita/projects/trivy/pkg/fanal/analyzer/analyzer.go:501 +0x2e2
github.com/aquasecurity/trivy/pkg/fanal/artifact/local.Artifact.Inspect({{0x7fffffffff74, 0x9}, {0x7ffeb86dc3b8, 0xc003690100}, {0x533bb40, 0x7abbb00}, {0xc000d0e7e0, {0xc003690140, 0x3, 0x4}, ...}, ...}, ...)
        /Users/nikita/projects/trivy/pkg/fanal/artifact/local/fs.go:120 +0x429
github.com/aquasecurity/trivy/pkg/scanner.Scanner.ScanArtifact({{_, _}, {_, _}}, {_, _}, {{0x0, 0x0, 0x0}, {0x0, ...}, ...})
        /Users/nikita/projects/trivy/pkg/scanner/scan.go:156 +0x103
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scan(_, {_, _}, {{{0x44a4d8a, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...}, ...)
        /Users/nikita/projects/trivy/pkg/commands/artifact/run.go:647 +0x2cb
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact(_, {_, _}, {{{0x44a4d8a, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...}, ...)
        /Users/nikita/projects/trivy/pkg/commands/artifact/run.go:258 +0xa5
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanFS(_, {_, _}, {{{0x44a4d8a, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...})
        /Users/nikita/projects/trivy/pkg/commands/artifact/run.go:203 +0xb4
github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).ScanFilesystem(_, {_, _}, {{{0x44a4d8a, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, ...}, ...})
        /Users/nikita/projects/trivy/pkg/commands/artifact/run.go:183 +0x205
github.com/aquasecurity/trivy/pkg/commands/artifact.Run({_, _}, {{{0x44a4d8a, 0xa}, 0x0, 0x0, 0x1, 0x0, 0x45d964b800, {0xc0027f1b60, ...}, ...}, ...}, ...)
        /Users/nikita/projects/trivy/pkg/commands/artifact/run.go:384 +0x87d
github.com/aquasecurity/trivy/pkg/commands.NewConfigCommand.func2(0xc000295508, {0xc00328f470, 0x1, 0x3})
        /Users/nikita/projects/trivy/pkg/commands/app.go:717 +0x2a5
github.com/spf13/cobra.(*Command).execute(0xc000295508, {0xc00328f410, 0x3, 0x3})
        /Users/nikita/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc0009ef508)
        /Users/nikita/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x44f9552?)
        /Users/nikita/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041 +0x13
main.run()
        /Users/nikita/projects/trivy/cmd/trivy/main.go:39 +0x113
main.main()
        /Users/nikita/projects/trivy/cmd/trivy/main.go:19 +0x1f
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
