### PR TITLE
fix(misconf): support deprecating for Go checks

### DIFF
--- a/pkg/iac/scanners/terraform/executor/option.go
+++ b/pkg/iac/scanners/terraform/executor/option.go
@@ -37,3 +37,9 @@ func OptionWithRegoOnly(regoOnly bool) Option {
 		e.regoOnly = regoOnly
 	}
 }
+
+func OptionWithIncludeDeprecatedChecks(b bool) Option {
+	return func(e *Executor) {
+		e.includeDeprecatedChecks = b
+	}
+}

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -46,7 +46,10 @@ type Scanner struct {
 	loadEmbeddedPolicies  bool
 }
 
-func (s *Scanner) SetIncludeDeprecatedChecks(b bool)  {}
+func (s *Scanner) SetIncludeDeprecatedChecks(b bool) {
+	s.executorOpt = append(s.executorOpt, executor.OptionWithIncludeDeprecatedChecks(b))
+}
+
 func (s *Scanner) SetCustomSchemas(map[string][]byte) {}
 
 func (s *Scanner) SetSpec(spec string) {


### PR DESCRIPTION
## Description

This PR adds deprecating support for Go checks for some scanners, which was not added [here](https://github.com/aquasecurity/trivy/pull/6664).

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
