### PR TITLE
feat(report): export modified findings in JSON

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -238,7 +238,7 @@ You can filter the results by
 To show the suppressed results, use the `--show-suppressed` flag.
 
 !!! note
-    This flag is currently available only in the table format.
+    It's exported as `ExperimentalModifiedFindings` in the JSON output.
 
 ```bash
 $ trivy image --vex debian11.csaf.vex --ignorefile .trivyignore.yaml --show-suppressed debian:11

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -14,8 +14,9 @@ import (
 
 // JSONWriter implements result Writer
 type JSONWriter struct {
-	Output      io.Writer
-	ListAllPkgs bool
+	Output         io.Writer
+	ListAllPkgs    bool
+	ShowSuppressed bool
 }
 
 // Write writes the results in JSON format
@@ -24,6 +25,12 @@ func (jw JSONWriter) Write(_ context.Context, report types.Report) error {
 		// Delete packages
 		for i := range report.Results {
 			report.Results[i].Packages = nil
+		}
+	}
+	if !jw.ShowSuppressed {
+		// Delete suppressed findings
+		for i := range report.Results {
+			report.Results[i].ModifiedFindings = nil
 		}
 	}
 	report.Results = lo.Filter(report.Results, func(r types.Result, _ int) bool {

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -56,8 +56,9 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 		}
 	case types.FormatJSON:
 		writer = &JSONWriter{
-			Output:      output,
-			ListAllPkgs: option.ListAllPkgs,
+			Output:         output,
+			ListAllPkgs:    option.ListAllPkgs,
+			ShowSuppressed: option.ShowSuppressed,
 		}
 	case types.FormatGitHub:
 		writer = &github.Writer{

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -120,8 +120,8 @@ type Result struct {
 
 	// ModifiedFindings holds a list of findings that have been modified from their original state.
 	// This can include vulnerabilities that have been marked as ignored, not affected, or have had
-	// their severity adjusted. It is currently available only in the table format.
-	ModifiedFindings []ModifiedFinding `json:"-"`
+	// their severity adjusted. It's still in an experimental stage and may change in the future.
+	ModifiedFindings []ModifiedFinding `json:"ExperimentalModifiedFindings,omitempty"`
 }
 
 func (r *Result) IsEmpty() bool {


### PR DESCRIPTION
## Description
`--show-suppressed` exports modified findings in JSON.

### Before

```
$ cat .trivyignore
CVE-2022-0563
$ trivy image -q -f json --show-suppressed debian:11 | jq ".Results[].ExperimentalModifiedFindings | length" 
0
```

### After

```
$ cat .trivyignore
CVE-2022-0563
$ trivy image -q -f json --show-suppressed debian:11 | jq ".Results[].ExperimentalModifiedFindings | length" 
7
```


## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7382

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
