### PR TITLE
fix(nodejs): check all `importers` to detect dev deps from pnpm-lock.yaml file

### DIFF
--- a/pkg/dependency/parser/nodejs/pnpm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_test.go
@@ -60,12 +60,6 @@ func TestParse(t *testing.T) {
 			wantDeps: pnpmV9Deps,
 		},
 		{
-			name:     "v9",
-			file:     "testdata/pnpm-lock_v9.yaml",
-			want:     pnpmV9,
-			wantDeps: pnpmV9Deps,
-		},
-		{
 			name:     "v9 with cyclic dependencies import",
 			file:     "testdata/pnpm-lock_v9_cyclic_import.yaml",
 			want:     pnpmV9CyclicImport,

--- a/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
@@ -753,6 +753,13 @@ var (
 			Relationship: ftypes.RelationshipIndirect,
 		},
 		{
+			ID:           "await-sleep@0.0.1",
+			Name:         "await-sleep",
+			Version:      "0.0.1",
+			Dev:          true,
+			Relationship: ftypes.RelationshipDirect,
+		},
+		{
 			ID:           "debug@4.3.4",
 			Name:         "debug",
 			Version:      "4.3.4",
@@ -841,6 +848,12 @@ var (
 			ID:           "promise@8.1.0",
 			Name:         "promise",
 			Version:      "8.1.0",
+			Relationship: ftypes.RelationshipDirect,
+		},
+		{
+			ID:           "sleep-utils@1.0.3",
+			Name:         "sleep-utils",
+			Version:      "1.0.3",
 			Relationship: ftypes.RelationshipDirect,
 		},
 		{

--- a/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9.yaml
+++ b/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9.yaml
@@ -40,6 +40,17 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
 
+  subdir:
+    dependencies:
+      sleep-utils:
+        specifier: 1.0.3
+        version: 1.0.3
+
+    devDependencies:
+      await-sleep:
+        specifier: ^0.0.1
+        version: 0.0.1
+
 packages:
 
   '@babel/helper-string-parser@7.24.1':
@@ -51,6 +62,9 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  await-sleep@0.0.1:
+    resolution: {integrity: sha512-H3X3eAxwGpeNIk/yvFOs8g7500Q1YvzrxjSC9TNgLGtjrMFxPwhDdcT34QNs2iGWpZ+5WKkMJdjDoYs+Sw+TaA==}
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -117,6 +131,9 @@ packages:
   promise@8.1.0:
     resolution: {integrity: sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==}
 
+  sleep-utils@1.0.3:
+    resolution: {integrity: sha512-uJW7WDHISE1zJIdvoIewcdmis3pBvJhM30rni2gH7fHhV1NkTWLKw3J6CPRFdg3h+rFChFHzAgbkCKUErd4s8Q==}
+
   statuses@1.4.0:
     resolution: {integrity: sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==}
     engines: {node: '>= 0.6'}
@@ -133,6 +150,8 @@ snapshots:
     optional: true
 
   asynckit@0.4.0: {}
+
+  await-sleep@0.0.1: {}
 
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
@@ -185,6 +204,8 @@ snapshots:
   promise@8.1.0:
     optionalDependencies:
       asap: 2.0.6
+
+  sleep-utils@1.0.3: {}
 
   statuses@1.4.0: {}
 


### PR DESCRIPTION
## Description
Check all `importers` to detect dev deps from pnpm-lock.yaml file.
More details in #7386

before:
```bash
➜ trivy -q fs ./pnpm-lock.yaml  --list-all-pkgs -f json --include-dev-deps
...
        {
          "ID": "sleep-utils@1.0.3",
          "Name": "sleep-utils",
          "Identifier": {
            "PURL": "pkg:npm/sleep-utils@1.0.3",
            "UID": "716b20f0563e731b"
          },
          "Version": "1.0.3",
          "Dev": true,
          "Indirect": true,
          "Relationship": "indirect",
          "Layer": {}
        }
      ]
    }
  ]
}
```

after:
```bash
➜ ./trivy -q fs ./pnpm-lock.yaml  --list-all-pkgs -f json --include-dev-deps
...
        {
          "ID": "sleep-utils@1.0.3",
          "Name": "sleep-utils",
          "Identifier": {
            "PURL": "pkg:npm/sleep-utils@1.0.3",
            "UID": "8981f07a21207ebb"
          },
          "Version": "1.0.3",
          "Relationship": "direct",
          "Layer": {}
        }
      ]
    }
  ]
}
```

## Related issues
- Close #7386

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
