### PR TITLE
docs(k8s): a note about k8s credentials

### DIFF
--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -28,7 +28,7 @@ Kubernetes resource definition is scanned for:
 
 
 !!! warning "Important Notice"
-     To successfully scan a Kubernetes cluster, the program must be executed under a role that has read permissions at the cluster scope.
+     To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has read permissions at the cluster scope.
 
      Trivy must be able to access information about all cluster resources, including pods, deployments etc.
 

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -28,9 +28,50 @@ Kubernetes resource definition is scanned for:
 
 
 !!! warning "Important Notice"
-     To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has read permissions at the cluster scope.
+     To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has some specific permissions.
 
-     Trivy must be able to access information about all cluster resources, including pods, deployments etc.
+     Without `node collecor` (with flag `--disable-node-collector`) the role must have `list` verb for all resources ("*") inside next API groups: core (""), "apps", "batch","networking.k8s.io", "rbac.authorization.k8s.io":
+     ```yaml
+     - apiGroups: [""]
+       resources: ["*"]
+       verbs: ["list"]
+     - apiGroups: ["apps", "batch", "networking.k8s.io", "rbac.authorization.k8s.io"]
+       resources: ["*"]
+       verbs: ["list"]
+     ```
+
+     If `node collector` is enabled (by default), the cluster role must have more permissions than:
+     ```yaml
+      - apiGroups: [""]
+        resources: ["*"]
+        verbs: ["list"]
+
+      - apiGroups: ["apps", "networking.k8s.io", "rbac.authorization.k8s.io"]
+        resources: ["*"]
+        verbs: ["list"]
+
+      - apiGroups: [""]
+        resources: ["nodes/proxy", "pods/log"]
+        verbs: ["get"]
+
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["watch"]  
+
+      - apiGroups: ["batch"]
+        resources: ["jobs", "cronjobs"]
+        verbs: ["list", "get"]
+
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["create","delete", "watch"]
+
+      - apiGroups: [""]
+        resources: ["namespaces"]
+        verbs: ["create"]
+     ```
+
+     Trivy must be able to access information about cluster resources, including pods, deployments etc.
 
      Flags `include/exclude` kinds and namespaces are used only for the result filter.
 

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -26,6 +26,14 @@ Kubernetes resource definition is scanned for:
 - Misconfigurations
 - Exposed secrets
 
+
+!!! warning "Important Notice"
+     To successfully scan a Kubernetes cluster, the program must be executed under a role that has read permissions at the cluster scope.
+
+     Trivy must be able to access information about all cluster resources, including pods, deployments etc.
+
+     Flags `include/exclude` kinds and namespaces are used only for the result filter.
+
 ## Kubernetes target configurations
 
 ```sh

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -29,7 +29,7 @@ Kubernetes resource definition is scanned for:
 ## Required roles
 To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has some specific permissions.
 
-Without `node collecor` (with flag `--disable-node-collector`) the role must have `list` verb for all resources ("*") inside next API groups: core (""), "apps", "batch","networking.k8s.io", "rbac.authorization.k8s.io":
+Without `node collector` (with flag `--disable-node-collector`) the role must have `list` verb for all resources ("*") inside next API groups: core (""), "apps", "batch","networking.k8s.io", "rbac.authorization.k8s.io":
 ```yaml
 - apiGroups: [""]
   resources: ["*"]

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -26,54 +26,53 @@ Kubernetes resource definition is scanned for:
 - Misconfigurations
 - Exposed secrets
 
+## Required roles
+To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has some specific permissions.
 
-!!! warning "Important Notice"
-     To successfully scan a Kubernetes cluster, `trivy kubernetes` subcommand must be executed under a role that has some specific permissions.
+Without `node collecor` (with flag `--disable-node-collector`) the role must have `list` verb for all resources ("*") inside next API groups: core (""), "apps", "batch","networking.k8s.io", "rbac.authorization.k8s.io":
+```yaml
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["list"]
+- apiGroups: ["apps", "batch", "networking.k8s.io", "rbac.authorization.k8s.io"]
+  resources: ["*"]
+  verbs: ["list"]
+```
 
-     Without `node collecor` (with flag `--disable-node-collector`) the role must have `list` verb for all resources ("*") inside next API groups: core (""), "apps", "batch","networking.k8s.io", "rbac.authorization.k8s.io":
-     ```yaml
-     - apiGroups: [""]
-       resources: ["*"]
-       verbs: ["list"]
-     - apiGroups: ["apps", "batch", "networking.k8s.io", "rbac.authorization.k8s.io"]
-       resources: ["*"]
-       verbs: ["list"]
-     ```
+If `node collector` is enabled (by default), the cluster role must have more permissions than:
+```yaml
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["list"]
 
-     If `node collector` is enabled (by default), the cluster role must have more permissions than:
-     ```yaml
-      - apiGroups: [""]
-        resources: ["*"]
-        verbs: ["list"]
+- apiGroups: ["apps", "networking.k8s.io", "rbac.authorization.k8s.io"]
+  resources: ["*"]
+  verbs: ["list"]
 
-      - apiGroups: ["apps", "networking.k8s.io", "rbac.authorization.k8s.io"]
-        resources: ["*"]
-        verbs: ["list"]
+- apiGroups: [""]
+  resources: ["nodes/proxy", "pods/log"]
+  verbs: ["get"]
 
-      - apiGroups: [""]
-        resources: ["nodes/proxy", "pods/log"]
-        verbs: ["get"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["watch"]
 
-      - apiGroups: [""]
-        resources: ["events"]
-        verbs: ["watch"]  
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["list", "get"]
 
-      - apiGroups: ["batch"]
-        resources: ["jobs", "cronjobs"]
-        verbs: ["list", "get"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create","delete", "watch"]
 
-      - apiGroups: ["batch"]
-        resources: ["jobs"]
-        verbs: ["create","delete", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["create"]
+```
 
-      - apiGroups: [""]
-        resources: ["namespaces"]
-        verbs: ["create"]
-     ```
+Trivy must be able to access information about cluster resources, including pods, deployments etc.
 
-     Trivy must be able to access information about cluster resources, including pods, deployments etc.
-
-     Flags `include/exclude` kinds and namespaces are used only for the result filter.
+Flags `include/exclude` kinds and namespaces are used only for the result filter.
 
 ## Kubernetes target configurations
 


### PR DESCRIPTION
## Description
This PR adds a block with permissions that `Trivy k8s` needs for scans: 

<img width="793" alt="изображение" src="https://github.com/user-attachments/assets/f877d3dd-bfff-410e-b481-3434c84bde39">

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
