### PR TITLE
fix: allow reading from cache folders for any users

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,6 +65,10 @@ linters-settings:
               - github.com/aquasecurity/go-version
             reason: "`aquasecurity/go-version` is designed for our use-cases"
   gosec:
+    config:
+      # Maximum allowed permissions mode for os.MkdirAll
+      # Default: 0750
+      G301: "0754"
     excludes:
       - G101
       - G114

--- a/pkg/cache/fs.go
+++ b/pkg/cache/fs.go
@@ -21,7 +21,7 @@ type FSCache struct {
 
 func NewFSCache(cacheDir string) (FSCache, error) {
 	dir := filepath.Join(cacheDir, scanCacheDirName)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0744); err != nil {
 		return FSCache{}, xerrors.Errorf("failed to create cache dir: %w", err)
 	}
 


### PR DESCRIPTION
## Description
A new cache folder is created without read access for another users. 
This PR grants read permissions.

Reproduction Steps:
```sh
$ trivy server -d --cache-dir ~/Library/Caches/trivy/subpath
```
Before:
```sh
$ ls -l ~/Library/Caches/trivy
total 0
drwxr-xr-x  4 user  staff  128 27 Aug 00:25 db
drwx------  3 user  staff   96 26 Aug 14:02 fanal
drwxr-xr-x@ 4 user  staff  128 16 Aug 12:45 java-db
drwxr-xr-x@ 4 user  staff  128 19 Aug 19:47 policy
drwx------  4 user  staff  128 27 Aug 01:15 subpath
```
After:
```sh
$ ls -l ~/Library/Caches/trivy                  
total 0
drwxr-xr-x  4 user  staff  128 27 Aug 00:25 db
drwx------  3 user  staff   96 26 Aug 14:02 fanal
drwxr-xr-x@ 4 user  staff  128 16 Aug 12:45 java-db
drwxr-xr-x@ 4 user  staff  128 19 Aug 19:47 policy
drwxr--r--@ 4 user  staff  128 27 Aug 01:29 subpath

```
## Related issues
- #7399 


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
