### PR TITLE
feat(sbom): set User-Agent header on requests to Rekor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,8 +47,8 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/fatih/color v1.17.0
 	github.com/go-git/go-git/v5 v5.12.0
-	github.com/go-openapi/runtime v0.28.0
-	github.com/go-openapi/strfmt v0.23.0
+	github.com/go-openapi/runtime v0.28.0 // indirect
+	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-containerregistry v0.20.2

--- a/pkg/rekor/client.go
+++ b/pkg/rekor/client.go
@@ -2,11 +2,10 @@ package rekor
 
 import (
 	"context"
-	"net/url"
+	"fmt"
 	"slices"
 
-	httptransport "github.com/go-openapi/runtime/client"
-	"github.com/go-openapi/strfmt"
+	pkgclient "github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	eclient "github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/client/index"
@@ -14,6 +13,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/version/app"
 )
 
 const (
@@ -64,15 +64,10 @@ type Client struct {
 }
 
 func NewClient(rekorURL string) (*Client, error) {
-	u, err := url.Parse(rekorURL)
+	c, err := pkgclient.GetRekorClient(rekorURL, pkgclient.WithUserAgent(fmt.Sprintf("trivy/%s", app.Version())))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse url: %w", err)
+		return nil, xerrors.Errorf("failed to create rekor client: %w", err)
 	}
-
-	c := client.New(
-		httptransport.New(u.Host, client.DefaultBasePath, []string{u.Scheme}),
-		strfmt.Default,
-	)
 	return &Client{Rekor: c}, nil
 }
 

--- a/pkg/rekor/client_test.go
+++ b/pkg/rekor/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,9 @@ func TestClient_Search(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.UserAgent(), "trivy/") {
+					t.Fatalf("User-Agent header was not specified")
+				}
 				http.ServeFile(w, r, tt.mockResponseFile)
 				return
 			}))
@@ -148,6 +152,9 @@ func TestClient_GetEntries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.UserAgent(), "trivy/") {
+					t.Fatalf("User-Agent header was not specified")
+				}
 				http.ServeFile(w, r, tt.mockResponseFile)
 				return
 			}))


### PR DESCRIPTION
## Description

* Added functionality to set the User-Agent header in Trivy when making requests to Sigstore's Rekor transparency log.
* Updated tests to cover the new functionality and ensure that the User-Agent header is properly set.

This enhancement is important for distinguishing requests to Rekor. It aids in tracking and managing Trivy requests more effectively.

Before the User-Agent header was just a plain `Go-http-client/2.0`. After the change, it becomes `trivy/version`.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
