### PR TITLE
fix(report): escape `Message` field in `asff.tpl` template

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -108,7 +108,7 @@
                     "Region": "{{ env "AWS_REGION" }}",
                     "Details": {
                         "Other": {
-                            "Message": "{{ .Message }}",
+                            "Message": "{{ escapeString .Message }}",
                             "Filename": "{{ $target }}",
                             "StartLine": "{{ .CauseMetadata.StartLine }}",
                             "EndLine": "{{ .CauseMetadata.EndLine }}"


### PR DESCRIPTION
## Description
Escape `Message` field in `asff.tpl`

## Related issues
- Close #7400

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
