### PR TITLE
fix(sbom): use `NOASSERTION` for licenses fields in SPDX formats

### DIFF
--- a/integration/testdata/julia-spdx.json.golden
+++ b/integration/testdata/julia-spdx.json.golden
@@ -31,8 +31,8 @@
       "downloadLocation": "NONE",
       "filesAnalyzed": false,
       "sourceInfo": "package found in: Manifest.toml",
-      "licenseConcluded": "NONE",
-      "licenseDeclared": "NONE",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
@@ -54,8 +54,8 @@
       "downloadLocation": "NONE",
       "filesAnalyzed": false,
       "sourceInfo": "package found in: Manifest.toml",
-      "licenseConcluded": "NONE",
-      "licenseDeclared": "NONE",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
@@ -77,8 +77,8 @@
       "downloadLocation": "NONE",
       "filesAnalyzed": false,
       "sourceInfo": "package found in: Manifest.toml",
-      "licenseConcluded": "NONE",
-      "licenseDeclared": "NONE",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -33,6 +33,7 @@ const (
 	CreatorOrganization    = "aquasecurity"
 	CreatorTool            = "trivy"
 	noneField              = "NONE"
+	noAssertionField       = "NOASSERTION"
 )
 
 const (
@@ -378,7 +379,7 @@ func (m *Marshaler) spdxAttributionTexts(c *core.Component) []string {
 
 func (m *Marshaler) spdxLicense(c *core.Component) string {
 	if len(c.Licenses) == 0 {
-		return noneField
+		return noAssertionField
 	}
 	return NormalizeLicense(c.Licenses)
 }

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -217,8 +217,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actioncontroller",
 						PackageVersion:          "7.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageAttributionTexts: []string{
 							"PkgType: bundler",
 						},
@@ -238,8 +238,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actionpack",
 						PackageVersion:          "7.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageAttributionTexts: []string{
 							"PkgType: bundler",
 						},
@@ -259,8 +259,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actionpack",
 						PackageVersion:          "7.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageAttributionTexts: []string{
 							"PkgType: bundler",
 						},
@@ -536,8 +536,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actionpack",
 						PackageVersion:          "7.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,
@@ -561,8 +561,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actionpack",
 						PackageVersion:          "7.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,
@@ -750,8 +750,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "actioncable",
 						PackageVersion:          "6.1.4.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,
@@ -771,8 +771,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "com.example:example",
 						PackageVersion:          "1.0.0",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,
@@ -889,8 +889,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "org.apache.logging.log4j:log4j-core",
 						PackageVersion:          "2.17.0",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,
@@ -1229,8 +1229,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageSPDXIdentifier:   spdx.ElementID("Package-b1c3b9e2363f5ff7"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "./private_repos/cnrm.googlesource.com/cnrm/",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PrimaryPackagePurpose:   tspdx.PackagePurposeLibrary,
 						PackageSupplier:         &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
 						PackageSourceInfo:       "package found in: /usr/local/bin/test",
@@ -1243,8 +1243,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageDownloadLocation: "NONE",
 						PackageName:             "golang.org/x/crypto",
 						PackageVersion:          "v0.0.1",
-						PackageLicenseConcluded: "NONE",
-						PackageLicenseDeclared:  "NONE",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
 						PackageExternalReferences: []*spdx.PackageExternalReference{
 							{
 								Category: tspdx.CategoryPackageManager,


### PR DESCRIPTION
## Description
See more in #7397

Before:
```bash
      "licenseConcluded": "NONE",
      "licenseDeclared": "NONE",
```

After:
```bash
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "NOASSERTION",
```

## Related issues
- Close #7402

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
