### PR TITLE
fix(misconf): use module to log when metadata retrieval fails

### DIFF
--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -54,11 +54,11 @@ func RegisterRegoRules(modules map[string]*ast.Module) {
 	for _, module := range modules {
 		metadata, err := retriever.RetrieveMetadata(ctx, module)
 		if err != nil {
-			log.Warn("Failed to retrieve metadata", log.String("avdid", metadata.AVDID), log.Err(err))
+			log.Warn("Failed to retrieve metadata", log.String("package", module.Package.String()), log.Err(err))
 			continue
 		}
 
-		if metadata.AVDID == "" {
+		if !metadata.Library && metadata.AVDID == "" {
 			log.Warn("Check ID is empty", log.FilePath(module.Package.Location.File))
 			continue
 		}


### PR DESCRIPTION
## Description
Access to metadata can cause panic in the event of an extraction failure.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
