### PR TITLE
fix(misconf): wrap AWS EnvVar to iac types

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
@@ -74,8 +74,8 @@ Resources:
 								Privileged: types.BoolTest(true),
 								Environment: []ecs.EnvVar{
 									{
-										Name:  "entryPoint",
-										Value: "sh, -c",
+										Name:  types.StringTest("entryPoint"),
+										Value: types.StringTest("sh, -c"),
 									},
 								},
 							},

--- a/pkg/iac/adapters/cloudformation/aws/ecs/task_definition.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/task_definition.go
@@ -36,8 +36,8 @@ func getContainerDefinitions(r *parser.Resource) ([]ecs.ContainerDefinition, err
 		if envVarsList.IsNotNil() && envVarsList.IsList() {
 			for _, envVar := range envVarsList.AsList() {
 				envVars = append(envVars, ecs.EnvVar{
-					Name:  envVar.GetStringProperty("Name").Value(),
-					Value: envVar.GetStringProperty("Value").Value(),
+					Name:  envVar.GetStringProperty("Name"),
+					Value: envVar.GetStringProperty("Value"),
 				})
 			}
 		}

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
@@ -131,8 +131,8 @@ func Test_adaptTaskDefinitionResource(t *testing.T) {
 						Privileged: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 						Environment: []ecs.EnvVar{
 							{
-								Name:  "ENVIRONMENT",
-								Value: "development",
+								Name:  iacTypes.StringTest("ENVIRONMENT"),
+								Value: iacTypes.StringTest("development"),
 							},
 						},
 					},

--- a/pkg/iac/providers/aws/ecs/ecs.go
+++ b/pkg/iac/providers/aws/ecs/ecs.go
@@ -69,10 +69,15 @@ func (j containerDefinitionJSON) convert(metadata iacTypes.Metadata) ContainerDe
 			HostPort:      iacTypes.Int(jMapping.HostPort, metadata),
 		})
 	}
+
 	var envVars []EnvVar
 	for _, env := range j.EnvVars {
-		envVars = append(envVars, EnvVar(env))
+		envVars = append(envVars, EnvVar{
+			Name:  iacTypes.String(env.Name, metadata),
+			Value: iacTypes.String(env.Value, metadata),
+		})
 	}
+
 	return ContainerDefinition{
 		Metadata:     metadata,
 		Name:         iacTypes.String(j.Name, metadata),
@@ -99,8 +104,8 @@ type ContainerDefinition struct {
 }
 
 type EnvVar struct {
-	Name  string
-	Value string
+	Name  iacTypes.StringValue
+	Value iacTypes.StringValue
 }
 
 type PortMapping struct {


### PR DESCRIPTION
## Description

EnvVar fields had primitive Go types that were not exported to Rego.

### Related PRs:
- https://github.com/aquasecurity/trivy-checks/pull/274

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
