### PR TITLE
fix(secret): use only line with secret for long secret lines

### DIFF
--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -504,8 +504,8 @@ func findLocation(start, end int, content []byte) (int, int, types.Code, string)
 	}
 
 	if lineEnd-lineStart > 100 {
-		lineStart = lo.Ternary(start-30 < 0, 0, start-30)
-		lineEnd = lo.Ternary(end+20 > len(content), len(content), end+20)
+		lineStart = lo.Ternary(start-lineStart-30 < 0, lineStart, start-30)
+		lineEnd = lo.Ternary(end+20 > lineEnd, lineEnd, end+20)
 	}
 	matchLine := string(content[lineStart:lineEnd])
 	endLineNum := startLineNum + bytes.Count(content[start:end], lineSep)

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -742,6 +742,42 @@ func TestSecretScanner(t *testing.T) {
 			},
 		},
 	}
+	wantFindingJWT := types.SecretFinding{
+		RuleID:    "jwt-token",
+		Category:  "JWT",
+		Title:     "JWT token",
+		Severity:  "MEDIUM",
+		StartLine: 3,
+		EndLine:   3,
+		Match:     "jwt: ***********************************************************************************************************************************************************",
+		Code: types.Code{
+			Lines: []types.Line{
+				{
+					Number:      1,
+					Content:     "asd",
+					Highlighted: "asd",
+				},
+				{
+					Number:      2,
+					Content:     "aaaa",
+					Highlighted: "aaaa",
+				},
+				{
+					Number:      3,
+					Content:     "jwt: ***********************************************************************************************************************************************************",
+					Highlighted: "jwt: ***********************************************************************************************************************************************************",
+					IsCause:     true,
+					FirstCause:  true,
+					LastCause:   true,
+				},
+				{
+					Number:      4,
+					Content:     "asda",
+					Highlighted: "asda",
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		name          string
@@ -820,6 +856,15 @@ func TestSecretScanner(t *testing.T) {
 			want: types.Secret{
 				FilePath: filepath.Join("testdata", "hugging-face-secret.txt"),
 				Findings: []types.SecretFinding{wantFindingHuggingFace},
+			},
+		},
+		{
+			name:          "find JWT token",
+			configPath:    filepath.Join("testdata", "config.yaml"),
+			inputFilePath: filepath.Join("testdata", "jwt-secret.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "jwt-secret.txt"),
+				Findings: []types.SecretFinding{wantFindingJWT},
 			},
 		},
 		{

--- a/pkg/fanal/secret/testdata/jwt-secret.txt
+++ b/pkg/fanal/secret/testdata/jwt-secret.txt
@@ -1,0 +1,4 @@
+asd
+aaaa
+jwt: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+asda


### PR DESCRIPTION
## Description
For long secret lines use only the line with the secret

before:
```bash
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 j.txt:3
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   asd
   2   aaaa
   3 [ asd
aaaa
jwt: ***********************************************************************************************************************************************************

asda
   4   
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


```

after:
```bash
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 j.txt:3
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   asd
   2   aaaa
   3 [ jwt: ***********************************************************************************************************************************************************
   4   
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


```

## Related issues
- Close #7411

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
