### PR TITLE
feat(java): add `test` scope support for `pom.xml` files

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -12,12 +12,12 @@ Each artifact supports the following scanners:
 
 The following table provides an outline of the features Trivy offers.
 
-| Artifact         |    Internet access    | Dev dependencies | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
-|------------------|:---------------------:|:----------------:|:------------------------------------:|:--------:|:----------------------------------------:|
-| JAR/WAR/PAR/EAR  |     Trivy Java DB     |     Include      |                  -                   |    -     |                Not needed                |
-| pom.xml          | Maven repository [^1] |     Exclude      |                  ✓                   |  ✓[^7]   |                    -                     |
-| *gradle.lockfile |           -           |     Exclude      |                  ✓                   |    ✓     |                Not needed                |
-| *.sbt.lock       |           -           |     Exclude      |                  -                   |    ✓     |                Not needed                |
+| Artifact         |    Internet access    |  Dev dependencies  | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
+|------------------|:---------------------:|:------------------:|:------------------------------------:|:--------:|:----------------------------------------:|
+| JAR/WAR/PAR/EAR  |     Trivy Java DB     |      Include       |                  -                   |    -     |                Not needed                |
+| pom.xml          | Maven repository [^1] | [Include](#scopes) |                  ✓                   |  ✓[^7]   |                    -                     |
+| *gradle.lockfile |           -           |      Exclude       |                  ✓                   |    ✓     |                Not needed                |
+| *.sbt.lock       |           -           |      Exclude       |                  -                   |    ✓     |                Not needed                |
 
 These may be enabled or disabled depending on the target.
 See [here](./index.md) for the detail.

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -15,7 +15,7 @@ The following table provides an outline of the features Trivy offers.
 | Artifact         |    Internet access    |  Dev dependencies  | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
 |------------------|:---------------------:|:------------------:|:------------------------------------:|:--------:|:----------------------------------------:|
 | JAR/WAR/PAR/EAR  |     Trivy Java DB     |      Include       |                  -                   |    -     |                Not needed                |
-| pom.xml          | Maven repository [^1] | [Include](#scopes) |                  ✓                   |  ✓[^7]   |                    -                     |
+| pom.xml          | Maven repository [^1] | [Exclude](#scopes) |                  ✓                   |  ✓[^7]   |                    -                     |
 | *gradle.lockfile |           -           |      Exclude       |                  ✓                   |    ✓     |                Not needed                |
 | *.sbt.lock       |           -           |      Exclude       |                  -                   |    ✓     |                Not needed                |
 
@@ -73,8 +73,7 @@ The vulnerability database will be downloaded anyway.
 Trivy supports `runtime`, `compile`, `test` and `import` (for `dependencyManagement`) [dependency scopes][dependency-scopes].
 Dependencies without scope are also detected.
 
-!!! Note
-    To detect dependencies with `test` scope, you need to use `--include-dev-deps` flag.
+By default, Trivy doesn't report dependencies with `test` scope. Use the `--include-dev-deps` flag to include them.
 
 ### maven-invoker-plugin
 Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin][maven-invoker-plugin] doesn't contain actual `pom.xml` files and should be skipped to avoid noise.

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -69,6 +69,12 @@ The vulnerability database will be downloaded anyway.
 !!! Warning
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
+### scopes
+Trivy supports `runtime`, `compile`, `test` and `import` (for `dependencyManagement`) [dependency scopes][dependency-scopes].
+Dependencies without scope are also detected.
+
+!!! Note
+    To detect dependencies with `test` scope, you need to use `--include-dev-deps` flag.
 
 ### maven-invoker-plugin
 Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin][maven-invoker-plugin] doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
@@ -120,3 +126,4 @@ Make sure that you have cache[^8] directory to find licenses from `*.pom` depend
 [maven-pom-repos]: https://maven.apache.org/settings.html#repositories
 [sbt-dependency-lock]: https://stringbean.github.io/sbt-dependency-lock
 [detection-priority]: ../../scanner/vulnerability.md#detection-priority
+[dependency-scopes]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope

--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -27,6 +27,7 @@ type artifact struct {
 
 	Module       bool
 	Relationship ftypes.Relationship
+	Test         bool
 
 	Locations ftypes.Locations
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -214,6 +214,7 @@ func (p *Parser) parseRoot(root artifact, uniqModules map[string]struct{}) ([]ft
 				Licenses:     result.artifact.Licenses,
 				Relationship: art.Relationship,
 				Locations:    art.Locations,
+				Test:         art.Test,
 			}
 
 			// save only dependency names
@@ -234,6 +235,7 @@ func (p *Parser) parseRoot(root artifact, uniqModules map[string]struct{}) ([]ft
 			Licenses:     art.Licenses,
 			Relationship: art.Relationship,
 			Locations:    art.Locations,
+			Dev:          art.Test,
 		}
 		pkgs = append(pkgs, pkg)
 
@@ -400,7 +402,7 @@ func (p *Parser) parseDependencies(deps []pomDependency, props map[string]string
 		// Resolve dependencies
 		d = d.Resolve(props, depManagement, rootDepManagement)
 
-		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime") || d.Optional {
+		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime" && d.Scope != "test") || d.Optional {
 			continue
 		}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -61,6 +61,19 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:           "org.example:example-test:2.0.0",
+					Name:         "org.example:example-test",
+					Version:      "2.0.0",
+					Relationship: ftypes.RelationshipDirect,
+					Dev:          true,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 49,
+							EndLine:   54,
+						},
+					},
+				},
 			},
 			wantDeps: []ftypes.Dependency{
 				{
@@ -68,6 +81,7 @@ func TestPom_Parse(t *testing.T) {
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
 						"org.example:example-runtime:1.0.0",
+						"org.example:example-test:2.0.0",
 					},
 				},
 			},
@@ -109,6 +123,19 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:           "org.example:example-test:2.0.0",
+					Name:         "org.example:example-test",
+					Version:      "2.0.0",
+					Relationship: ftypes.RelationshipDirect,
+					Dev:          true,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 49,
+							EndLine:   54,
+						},
+					},
+				},
 			},
 			wantDeps: []ftypes.Dependency{
 				{
@@ -116,6 +143,7 @@ func TestPom_Parse(t *testing.T) {
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
 						"org.example:example-runtime:1.0.0",
+						"org.example:example-test:2.0.0",
 					},
 				},
 			},

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -303,6 +303,7 @@ func (d pomDependency) ToArtifact(opts analysisOptions) artifact {
 		Exclusions:   exclusions,
 		Locations:    locations,
 		Relationship: ftypes.RelationshipIndirect, // default
+		Test:         d.Scope == "test",
 	}
 }
 

--- a/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
@@ -46,5 +46,11 @@
             <version>999</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-test</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description
Add `test` scope support and mark these dependencies as `Dev`.
To show these deps - use `--include-dev-deps` flag.

## Related issues
- Close #7384

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
