### PR TITLE
chore: fix allow rule of ignoring test files to make it case insensitive

### DIFF
--- a/pkg/fanal/secret/builtin-allow-rules.go
+++ b/pkg/fanal/secret/builtin-allow-rules.go
@@ -4,7 +4,7 @@ var builtinAllowRules = []AllowRule{
 	{
 		ID:          "tests",
 		Description: "Avoid test files and paths",
-		Path:        MustCompile(`(^test|\/test|-test|_test|\.test)`),
+		Path:        MustCompile(`(^(?i)test|\/test|-test|_test|\.test)`),
 	},
 	{
 		ID:          "examples",


### PR DESCRIPTION
## Description
Current functionality is not ignoring test files which are not in all lower case.
PS: Didn't add tests for this because we are disabling "tests" built in allow rule in code tests. Didn't want to disrupt the pattern for a small case.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
