### PR TITLE
fix(misconf): do not recreate filesystem map

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -175,7 +175,9 @@ func (e *evaluator) evaluateSubmodules(ctx context.Context, fsMap map[string]fs.
 	var modules terraform.Modules
 	for _, sm := range submodules {
 		modules = append(modules, sm.modules...)
-		fsMap = lo.Assign(fsMap, sm.fsMap)
+		for k, v := range sm.fsMap {
+			fsMap[k] = v
+		}
 	}
 
 	e.logger.Debug("Finished processing submodule(s).", log.Int("count", len(modules)))


### PR DESCRIPTION
## Description
Due to recreating the map with filesystems during submodule evaluation, the ability to retrieve file contents from other fs for results was lost.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
