### PR TITLE
fix(misconf): fix infer type for null value

### DIFF
--- a/pkg/iac/scanners/cloudformation/cftypes/types.go
+++ b/pkg/iac/scanners/cloudformation/cftypes/types.go
@@ -15,6 +15,9 @@ const (
 )
 
 func TypeFromGoValue(value any) CfType {
+	if value == nil {
+		return Unknown
+	}
 	switch reflect.TypeOf(value).Kind() {
 	case reflect.String:
 		return String

--- a/pkg/iac/scanners/cloudformation/parser/parser_test.go
+++ b/pkg/iac/scanners/cloudformation/parser/parser_test.go
@@ -419,3 +419,24 @@ func TestJsonWithNumbers(t *testing.T) {
 	assert.Equal(t, 1, res[0].GetProperty("SomeIntProp").AsIntValue().Value())
 	assert.Equal(t, 0, res[0].GetProperty("SomeFloatProp").AsIntValue().Value())
 }
+
+func TestParameterIsNull(t *testing.T) {
+	src := `---
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  Email:
+    Type: String
+
+Conditions:
+  SubscribeEmail: !Not [!Equals [ !Ref Email, ""]]
+`
+
+	fsys := testutil.CreateFS(t, map[string]string{
+		"main.yaml": src,
+	})
+
+	files, err := New().ParseFS(context.TODO(), fsys, ".")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+}


### PR DESCRIPTION
## Description
An example of a CloudFormation template for which parsing fails:

```yaml
AWSTemplateFormatVersion: 2010-09-09
Parameters:
  Email:
    Type: String
Conditions:
  SubscribeEmail: !Not [!Equals [ !Ref Email, ""]]
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
