### PR TITLE
feat(misconf): Register checks only when needed

### DIFF
--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/open-policy-agent/opa/ast"
 
@@ -14,8 +15,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-func init() {
-
+var LoadAndRegister = sync.OnceFunc(func() {
 	modules, err := LoadEmbeddedPolicies()
 	if err != nil {
 		// we should panic as the policies were not embedded properly
@@ -30,7 +30,7 @@ func init() {
 	}
 
 	RegisterRegoRules(modules)
-}
+})
 
 func RegisterRegoRules(modules map[string]*ast.Module) {
 	ctx := context.TODO()

--- a/pkg/iac/rego/embed_test.go
+++ b/pkg/iac/rego/embed_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_EmbeddedLoading(t *testing.T) {
+	LoadAndRegister()
 
 	frameworkRules := rules.GetRegistered()
 	var found bool

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -152,6 +152,8 @@ type DynamicMetadata struct {
 }
 
 func NewScanner(source types.Source, opts ...options.ScannerOption) *Scanner {
+	LoadAndRegister()
+
 	schema, ok := schemas.SchemaMap[source]
 	if !ok {
 		schema = schemas.Anything


### PR DESCRIPTION
## Description

Only register checks when needed, removing the `init` function to do so.  

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7434

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
