### PR TITLE
chore(helm): bump up Trivy Helm chart

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.7.0
-appVersion: 0.37.2
+version: 0.8.0
+appVersion: 0.55.0
 description: Trivy helm chart
 keywords:
   - scanner


### PR DESCRIPTION
## Description
This PR bumps up Trivy version in the helm chart.

**Note**: There is a breaking change since Trivy 0.51.0 for kubernetes scan - #6323. It can affect on UX.

The Helm chart runs Trivy in `server` mode, so this update shouldn't mark as a breaking change.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
