### PR TITLE
refactor(java): add error/statusCode for logs when we can't get pom.xml/maven-metadata.xml from remote repo

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -714,8 +714,11 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(repo string, paths []string) 
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()))
+	if err != nil {
+		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()), log.Err(err))
+		return "", nil
+	} else if resp.StatusCode != http.StatusOK {
+		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()), log.Int("statusCode", resp.StatusCode))
 		return "", nil
 	}
 	defer resp.Body.Close()
@@ -745,8 +748,11 @@ func (p *Parser) fetchPOMFromRemoteRepository(repo string, paths []string) (*pom
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()))
+	if err != nil {
+		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()), log.Err(err))
+		return nil, nil
+	} else if resp.StatusCode != http.StatusOK {
+		p.logger.Debug("Failed to fetch", log.String("url", req.URL.String()), log.Int("statusCode", resp.StatusCode))
 		return nil, nil
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
## Description
When we can't get `pom.xml` or `maven-metadata.xml` file from remote repository - we need to show more info.
See https://github.com/aquasecurity/trivy/discussions/7443#discussioncomment-10555485

Before:
```
2024-09-06T11:29:13+06:00       DEBUG   [pom] Failed to fetch   url="https://repo.maven.apache.org/maven2/abbot/abbot/1.4.0000/abbot-1.4.0000.pom"

```

After:
```
2024-09-06T11:23:02+06:00       DEBUG   [pom] Failed to fetch   url="https://repo.maven.apache.org/maven2/abbot/abbot/1.4.0/abbot-1.4.0.pom" err="Get \"https://repo.maven.apache.org/maven2/abbot/abbot/1.4.0/abbot-1.4.0.pom\": Bad Request"
```

```
2024-09-06T11:28:39+06:00       DEBUG   [pom] Failed to fetch   url="https://repo.maven.apache.org/maven2/abbot/abbot/1.4.0000/abbot-1.4.0000.pom" statusCode=404

```

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
