### PR TITLE
fix(oracle): Update EOL date for Oracle 7

### DIFF
--- a/pkg/detector/ospkg/oracle/oracle.go
+++ b/pkg/detector/ospkg/oracle/oracle.go
@@ -25,7 +25,7 @@ var (
 		"4": time.Date(2013, 12, 31, 23, 59, 59, 0, time.UTC),
 		"5": time.Date(2017, 12, 31, 23, 59, 59, 0, time.UTC),
 		"6": time.Date(2021, 3, 21, 23, 59, 59, 0, time.UTC),
-		"7": time.Date(2024, 7, 23, 23, 59, 59, 0, time.UTC),
+		"7": time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC),
 		"8": time.Date(2029, 7, 18, 23, 59, 59, 0, time.UTC),
 		"9": time.Date(2032, 7, 18, 23, 59, 59, 0, time.UTC),
 	}


### PR DESCRIPTION
## Description
There is only one change:

- Oracle 7 EOL date has been updated to 31-12-2024 as per official site (https://endoflife.date/oracle-linux)

## Related issues
- Close #7479 


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
