### PR TITLE
revert(java): stop supporting of `test` scope for `pom.xml` files

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -12,12 +12,12 @@ Each artifact supports the following scanners:
 
 The following table provides an outline of the features Trivy offers.
 
-| Artifact         |    Internet access    |  Dev dependencies  | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
-|------------------|:---------------------:|:------------------:|:------------------------------------:|:--------:|:----------------------------------------:|
-| JAR/WAR/PAR/EAR  |     Trivy Java DB     |      Include       |                  -                   |    -     |                Not needed                |
-| pom.xml          | Maven repository [^1] | [Exclude](#scopes) |                  ✓                   |  ✓[^7]   |                    -                     |
-| *gradle.lockfile |           -           |      Exclude       |                  ✓                   |    ✓     |                Not needed                |
-| *.sbt.lock       |           -           |      Exclude       |                  -                   |    ✓     |                Not needed                |
+| Artifact         |    Internet access    | Dev dependencies | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
+|------------------|:---------------------:|:----------------:|:------------------------------------:|:--------:|:----------------------------------------:|
+| JAR/WAR/PAR/EAR  |     Trivy Java DB     |     Include      |                  -                   |    -     |                Not needed                |
+| pom.xml          | Maven repository [^1] |     Exclude      |                  ✓                   |  ✓[^7]   |                    -                     |
+| *gradle.lockfile |           -           |     Exclude      |                  ✓                   |    ✓     |                Not needed                |
+| *.sbt.lock       |           -           |     Exclude      |                  -                   |    ✓     |                Not needed                |
 
 These may be enabled or disabled depending on the target.
 See [here](./index.md) for the detail.
@@ -69,11 +69,6 @@ The vulnerability database will be downloaded anyway.
 !!! Warning
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
-### scopes
-Trivy supports `runtime`, `compile`, `test` and `import` (for `dependencyManagement`) [dependency scopes][dependency-scopes].
-Dependencies without scope are also detected.
-
-By default, Trivy doesn't report dependencies with `test` scope. Use the `--include-dev-deps` flag to include them.
 
 ### maven-invoker-plugin
 Typically, the integration tests directory (`**/[src|target]/it/*/pom.xml`) of [maven-invoker-plugin][maven-invoker-plugin] doesn't contain actual `pom.xml` files and should be skipped to avoid noise.
@@ -125,4 +120,3 @@ Make sure that you have cache[^8] directory to find licenses from `*.pom` depend
 [maven-pom-repos]: https://maven.apache.org/settings.html#repositories
 [sbt-dependency-lock]: https://stringbean.github.io/sbt-dependency-lock
 [detection-priority]: ../../scanner/vulnerability.md#detection-priority
-[dependency-scopes]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope

--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -27,7 +27,6 @@ type artifact struct {
 
 	Module       bool
 	Relationship ftypes.Relationship
-	Test         bool
 
 	Locations ftypes.Locations
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -214,7 +214,6 @@ func (p *Parser) parseRoot(root artifact, uniqModules map[string]struct{}) ([]ft
 				Licenses:     result.artifact.Licenses,
 				Relationship: art.Relationship,
 				Locations:    art.Locations,
-				Test:         art.Test,
 			}
 
 			// save only dependency names
@@ -235,7 +234,6 @@ func (p *Parser) parseRoot(root artifact, uniqModules map[string]struct{}) ([]ft
 			Licenses:     art.Licenses,
 			Relationship: art.Relationship,
 			Locations:    art.Locations,
-			Dev:          art.Test,
 		}
 		pkgs = append(pkgs, pkg)
 
@@ -402,7 +400,7 @@ func (p *Parser) parseDependencies(deps []pomDependency, props map[string]string
 		// Resolve dependencies
 		d = d.Resolve(props, depManagement, rootDepManagement)
 
-		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime" && d.Scope != "test") || d.Optional {
+		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime") || d.Optional {
 			continue
 		}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -61,19 +61,6 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
-				{
-					ID:           "org.example:example-test:2.0.0",
-					Name:         "org.example:example-test",
-					Version:      "2.0.0",
-					Relationship: ftypes.RelationshipDirect,
-					Dev:          true,
-					Locations: ftypes.Locations{
-						{
-							StartLine: 49,
-							EndLine:   54,
-						},
-					},
-				},
 			},
 			wantDeps: []ftypes.Dependency{
 				{
@@ -81,7 +68,6 @@ func TestPom_Parse(t *testing.T) {
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
 						"org.example:example-runtime:1.0.0",
-						"org.example:example-test:2.0.0",
 					},
 				},
 			},
@@ -123,19 +109,6 @@ func TestPom_Parse(t *testing.T) {
 						},
 					},
 				},
-				{
-					ID:           "org.example:example-test:2.0.0",
-					Name:         "org.example:example-test",
-					Version:      "2.0.0",
-					Relationship: ftypes.RelationshipDirect,
-					Dev:          true,
-					Locations: ftypes.Locations{
-						{
-							StartLine: 49,
-							EndLine:   54,
-						},
-					},
-				},
 			},
 			wantDeps: []ftypes.Dependency{
 				{
@@ -143,7 +116,6 @@ func TestPom_Parse(t *testing.T) {
 					DependsOn: []string{
 						"org.example:example-api:1.7.30",
 						"org.example:example-runtime:1.0.0",
-						"org.example:example-test:2.0.0",
 					},
 				},
 			},

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -303,7 +303,6 @@ func (d pomDependency) ToArtifact(opts analysisOptions) artifact {
 		Exclusions:   exclusions,
 		Locations:    locations,
 		Relationship: ftypes.RelationshipIndirect, // default
-		Test:         d.Scope == "test",
 	}
 }
 

--- a/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/happy/pom.xml
@@ -46,11 +46,5 @@
             <version>999</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.example</groupId>
-            <artifactId>example-test</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description
We discovered a few problems with #7414:
1. Child dependencies of test dependency are not marked as `Dev` (see #7486).
2. Trivy scans test dependencies even  if `--include-dev-deps` flag doesn't present (this is due to our logic for excluding dev dependencies). Not being able to disable `test` dependency scanning slows down Trivy significantly. More details in #7476. 

Fixing these issues will take some time to be considered.
To avoid further issues with fast merging, we have decided to revert #7414.
The functionality of #7414 will be added in other PRs.

## Related issues
- #7476

## Related PRs
- [x] #7414
- [ ] #7484 
- [ ] #7486

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
