### PR TITLE
feat(misconf): Add support for `skip-dirs` and `skip-files` misconf scanning

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -470,6 +470,8 @@ func (o *Options) FilterOpts() result.FilterOptions {
 		IgnoreLicenses:     o.IgnoredLicenses,
 		CacheDir:           o.CacheDir,
 		VEXSources:         o.VEXSources,
+		SkipDirs:           o.SkipDirs,
+		SkipFiles:          o.SkipFiles,
 	}
 }
 

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -9,13 +9,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aquasecurity/trivy/pkg/fanal/walker"
-	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/fanal/walker"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/vex"
 )

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -137,8 +137,8 @@ func TestFilter(t *testing.T) {
 				EndLine:   456,
 				Occurrences: []ftypes.Occurrence{
 					{
-						Resource: "foo-resource-occurance-1",
-						Filename: "bar-filename-occurance-1",
+						Resource: "foo-resource-occurrence-1",
+						Filename: "bar-filename-occurrence-1",
 						Location: ftypes.Location{
 							StartLine: 666,
 							EndLine:   888,
@@ -172,8 +172,8 @@ func TestFilter(t *testing.T) {
 				EndLine:   456,
 				Occurrences: []ftypes.Occurrence{
 					{
-						Resource: "foo-resource-occurance-3",
-						Filename: "../modules/bar-filename-occurance-3",
+						Resource: "foo-resource-occurrence-3",
+						Filename: "../modules/bar-filename-occurrence-3",
 						Location: ftypes.Location{
 							StartLine: 666,
 							EndLine:   888,
@@ -1100,7 +1100,7 @@ func TestFilter(t *testing.T) {
 					dbTypes.SeverityLow,
 					dbTypes.SeverityHigh,
 				},
-				skipFiles: []string{"../**/bar-filename-occurance-3"},
+				skipFiles: []string{"../**/bar-filename-occurrence-3"},
 			},
 			want: types.Report{
 				Results: types.Results{
@@ -1117,7 +1117,7 @@ func TestFilter(t *testing.T) {
 							{
 								Type:      types.FindingTypeMisconfiguration,
 								Status:    types.FindingStatusIgnored,
-								Statement: "skipped due to glob match: [../**/bar-filename-occurance-3]",
+								Statement: "skipped due to glob match: [../**/bar-filename-occurrence-3]",
 								Source:    "trivy cli args",
 								Finding:   misconf3,
 							},


### PR DESCRIPTION
## Description

Add support for `skip-dirs` and `skip-files` in post misconf scanning reports.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7220


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
