### PR TITLE
fix(java): use `dependencyManagement` from root/child pom's for dependencies from parents

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -335,8 +335,20 @@ func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error)
 	p.releaseRemoteRepos = lo.Uniq(append(pomReleaseRemoteRepos, p.releaseRemoteRepos...))
 	p.snapshotRemoteRepos = lo.Uniq(append(pomSnapshotRemoteRepos, p.snapshotRemoteRepos...))
 
+	// We need to forward dependencyManagements from current and root pom to Parent,
+	// to use them for dependencies in parent.
+	// For better understanding see the following tests:
+	// - `dependency from parent uses version from child pom depManagement`
+	// - `dependency from parent uses version from root pom depManagement`
+	//
+	// depManagements from root pom has higher priority than depManagements from current pom.
+	depManagementForParent := lo.UniqBy(append(opts.depManagement, pom.content.DependencyManagement.Dependencies.Dependency...),
+		func(dep pomDependency) string {
+			return dep.Name()
+		})
+
 	// Parent
-	parent, err := p.parseParent(pom.filePath, pom.content.Parent)
+	parent, err := p.parseParent(pom.filePath, pom.content.Parent, depManagementForParent)
 	if err != nil {
 		return analysisResult{}, xerrors.Errorf("parent error: %w", err)
 	}
@@ -477,7 +489,7 @@ func excludeDep(exclusions map[string]struct{}, art artifact) bool {
 	return false
 }
 
-func (p *Parser) parseParent(currentPath string, parent pomParent) (analysisResult, error) {
+func (p *Parser) parseParent(currentPath string, parent pomParent, rootDepManagement []pomDependency) (analysisResult, error) {
 	// Pass nil properties so that variables in <parent> are not evaluated.
 	target := newArtifact(parent.GroupId, parent.ArtifactId, parent.Version, nil, nil)
 	// if version is property (e.g. ${revision}) - we still need to parse this pom
@@ -499,7 +511,9 @@ func (p *Parser) parseParent(currentPath string, parent pomParent) (analysisResu
 		logger.Debug("Parent POM not found", log.Err(err))
 	}
 
-	result, err := p.analyze(parentPOM, analysisOptions{})
+	result, err := p.analyze(parentPOM, analysisOptions{
+		depManagement: rootDepManagement,
+	})
 	if err != nil {
 		return analysisResult{}, xerrors.Errorf("analyze error: %w", err)
 	}

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1499,6 +1499,102 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
+		// [INFO] com.example:root-depManagement-in-parent:jar:1.0.0
+		// [INFO] \- org.example:example-dependency:jar:2.0.0:compile
+		// [INFO]    \- org.example:example-api:jar:1.0.1:compile
+		{
+			name:      "dependency from parent uses version from root pom depManagement",
+			inputFile: filepath.Join("testdata", "use-root-dep-management-in-parent", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:root-depManagement-in-parent:1.0.0",
+					Name:         "com.example:root-depManagement-in-parent",
+					Version:      "1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				{
+					ID:           "org.example:example-dependency:2.0.0",
+					Name:         "org.example:example-dependency",
+					Version:      "2.0.0",
+					Relationship: ftypes.RelationshipDirect,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 25,
+							EndLine:   29,
+						},
+					},
+				},
+				{
+					ID:           "org.example:example-api:1.0.1",
+					Name:         "org.example:example-api",
+					Version:      "1.0.1",
+					Relationship: ftypes.RelationshipIndirect,
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:root-depManagement-in-parent:1.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:1.0.1",
+					},
+				},
+			},
+		},
+		// [INFO] com.example:root-depManagement-in-parent:jar:1.0.0
+		// [INFO] \- org.example:example-dependency:jar:2.0.0:compile
+		// [INFO]    \- org.example:example-api:jar:2.0.1:compile
+		{
+			name:      "dependency from parent uses version from child pom depManagement",
+			inputFile: filepath.Join("testdata", "use-dep-management-from-child-in-parent", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:root-depManagement-in-parent:1.0.0",
+					Name:         "com.example:root-depManagement-in-parent",
+					Version:      "1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				{
+					ID:           "org.example:example-dependency:2.0.0",
+					Name:         "org.example:example-dependency",
+					Version:      "2.0.0",
+					Relationship: ftypes.RelationshipDirect,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 15,
+							EndLine:   19,
+						},
+					},
+				},
+				{
+					ID:           "org.example:example-api:2.0.1",
+					Name:         "org.example:example-api",
+					Version:      "2.0.1",
+					Relationship: ftypes.RelationshipIndirect,
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:root-depManagement-in-parent:1.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api:2.0.1",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-dependency/2.0.0/example-dependency-2.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-dependency/2.0.0/example-dependency-2.0.0.pom
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>3.0.0</version>
+    </parent>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-dependency</artifactId>
+    <version>2.0.0</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+              <groupId>org.example</groupId>
+              <artifactId>example-api</artifactId>
+              <version>2.0.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-parent/3.0.0/example-parent-3.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-parent/3.0.0/example-parent-3.0.0.pom
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>3.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <api.version>3.0.1</api.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+              <groupId>org.example</groupId>
+              <artifactId>example-api</artifactId>
+              <version>${api.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/use-dep-management-from-child-in-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-dep-management-from-child-in-parent/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>root-depManagement-in-parent</artifactId>
+    <version>1.0.0</version>
+
+
+    <properties>
+        <api.version>1.0.1</api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/use-root-dep-management-in-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-root-dep-management-in-parent/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>root-depManagement-in-parent</artifactId>
+    <version>1.0.0</version>
+
+
+    <properties>
+        <api.version>1.0.1</api.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api</artifactId>
+                <version>${api.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description
We need to overwrite versions from `dependencyManagement` of root/child pom.xml files for dependencies from parents.
See #7493 for more details.

## Related issues
- Close #7493

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
