### PR TITLE
chore(vex): suppress openssl vulnerabilities

### DIFF
--- a/.vex/oci.openvex.json
+++ b/.vex/oci.openvex.json
@@ -140,6 +140,105 @@
       "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "awk is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4741"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "openssl is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-5535"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"},
+            {"@id": "pkg:apk/alpine/ssl_client"}
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "openssl is not used"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-6119"
+      },
+      "products": [
+        {
+          "@id": "pkg:oci/trivy?repository_url=index.docker.io%2Faquasec%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=public.ecr.aws%2Faquasecurity%2Ftrivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"}
+          ]
+        },
+        {
+          "@id": "pkg:oci/trivy?repository_url=ghcr.io/aquasecurity/trivy",
+          "subcomponents": [
+            {"@id": "pkg:apk/alpine/libcrypto3"},
+            {"@id": "pkg:apk/alpine/libssl3"}
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "openssl is not used"
     }
   ]
 }


### PR DESCRIPTION
## Description
Suppress CVE-2024-4741, CVE-2024-5535 and CVE-2024-6119 since the Trivy images are not using OpenSSL in OS packages.

```
$ trivy image ghcr.io/aquasecurity/trivy:0.55.1 --vex .vex/oci.openvex.json --show-suppressed --pkg-types os
2024-09-13T14:16:45+04:00       INFO    [vuln] Vulnerability scanning is enabled

ghcr.io/aquasecurity/trivy:0.55.1 (alpine 3.20.0)
=================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


Suppressed Vulnerabilities (Total: 12)
======================================
┌───────────────┬────────────────┬──────────┬──────────────┬───────────────────────────────────────────────────┬───────────────────────┐
│    Library    │ Vulnerability  │ Severity │    Status    │                     Statement                     │        Source         │
├───────────────┼────────────────┼──────────┼──────────────┼───────────────────────────────────────────────────┼───────────────────────┤
│ busybox       │ CVE-2023-42364 │ MEDIUM   │ not_affected │ vulnerable_code_cannot_be_controlled_by_adversary │ .vex/oci.openvex.json │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2023-42365 │          │              │                                                   │                       │
├───────────────┼────────────────┤          │              │                                                   │                       │
│ busybox-binsh │ CVE-2023-42364 │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2023-42365 │          │              │                                                   │                       │
├───────────────┼────────────────┤          │              │                                                   │                       │
│ libcrypto3    │ CVE-2024-4741  │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2024-5535  │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2024-6119  │          │              │                                                   │                       │
├───────────────┼────────────────┤          │              │                                                   │                       │
│ libssl3       │ CVE-2024-4741  │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2024-5535  │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2024-6119  │          │              │                                                   │                       │
├───────────────┼────────────────┤          │              │                                                   │                       │
│ ssl_client    │ CVE-2023-42364 │          │              │                                                   │                       │
│               ├────────────────┤          │              │                                                   │                       │
│               │ CVE-2023-42365 │          │              │                                                   │                       │
└───────────────┴────────────────┴──────────┴──────────────┴───────────────────────────────────────────────────┴───────────────────────┘
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
