### PR TITLE
chore(deps): bump alpine from 3.20.0 to 3.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.0
+FROM alpine:3.20.3
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/


### PR DESCRIPTION
Fixes multiple vulnerabilities in the base image.

List is visible with scanning the image itself with Trivy:
```docker run --rm aquasec/trivy  fs .```

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.

