### PR TITLE
chore(vex): add `CVE-2024-34155`, `CVE-2024-34156` and `CVE-2024-34158` in `trivy.openvex.json`

### DIFF
--- a/.vex/trivy.openvex.json
+++ b/.vex/trivy.openvex.json
@@ -456,6 +456,35 @@
     },
     {
       "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2024-3105",
+        "name": "GO-2024-3105",
+        "description": "Stack exhaustion in all Parse functions in go/parser",
+        "aliases": [
+          "CVE-2024-34155"
+        ]
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aquasecurity/trivy",
+          "identifiers": {
+            "purl": "pkg:golang/github.com/aquasecurity/trivy"
+          },
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/stdlib",
+              "identifiers": {
+                "purl": "pkg:golang/stdlib"
+              }
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
+    },
+    {
+      "vulnerability": {
         "@id": "https://pkg.go.dev/vuln/GO-2024-3106",
         "name": "GO-2024-3106",
         "description": "Stack exhaustion in Decoder.Decode in encoding/gob",

--- a/.vex/trivy.openvex.json
+++ b/.vex/trivy.openvex.json
@@ -453,6 +453,35 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2024-3106",
+        "name": "GO-2024-3106",
+        "description": "Stack exhaustion in Decoder.Decode in encoding/gob",
+        "aliases": [
+          "CVE-2024-34156"
+        ]
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aquasecurity/trivy",
+          "identifiers": {
+            "purl": "pkg:golang/github.com/aquasecurity/trivy"
+          },
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/stdlib",
+              "identifiers": {
+                "purl": "pkg:golang/stdlib"
+              }
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Govulncheck incorrectly marks this vulnerability as affected. The vulnerable code isn't called. See https://github.com/golang/go/issues/69446"
     }
   ]
 }

--- a/.vex/trivy.openvex.json
+++ b/.vex/trivy.openvex.json
@@ -482,6 +482,35 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Govulncheck incorrectly marks this vulnerability as affected. The vulnerable code isn't called. See https://github.com/aquasecurity/trivy/issues/7478"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2024-3107",
+        "name": "GO-2024-3107",
+        "description": "Stack exhaustion in Parse in go/build/constraint",
+        "aliases": [
+          "CVE-2024-34158"
+        ]
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aquasecurity/trivy",
+          "identifiers": {
+            "purl": "pkg:golang/github.com/aquasecurity/trivy"
+          },
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/stdlib",
+              "identifiers": {
+                "purl": "pkg:golang/stdlib"
+              }
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
     }
   ]
 }

--- a/.vex/trivy.openvex.json
+++ b/.vex/trivy.openvex.json
@@ -481,7 +481,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Govulncheck incorrectly marks this vulnerability as affected. The vulnerable code isn't called. See https://github.com/golang/go/issues/69446"
+      "impact_statement": "Govulncheck incorrectly marks this vulnerability as affected. The vulnerable code isn't called. See https://github.com/aquasecurity/trivy/issues/7478"
     }
   ]
 }


### PR DESCRIPTION
## Description
Trivy doesn't use vulnerable packages for CVE-2024-34155, CVE-2024-34156 and CVE-2024-34158:
```bash
➜  govulncheck -format openvex ./... | jq '.statements[]'                                               
{
  "vulnerability": {
    "@id": "https://pkg.go.dev/vuln/GO-2024-3105",
    "name": "GO-2024-3105",
    "description": "Stack exhaustion in all Parse functions in go/parser",
    "aliases": [
      "CVE-2024-34155"
    ]
  },
  "products": [
    {
      "@id": "Unknown Product"
    }
  ],
  "status": "not_affected",
  "justification": "vulnerable_code_not_in_execute_path",
  "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
}
{
  "vulnerability": {
    "@id": "https://pkg.go.dev/vuln/GO-2024-3106",
    "name": "GO-2024-3106",
    "description": "Stack exhaustion in Decoder.Decode in encoding/gob",
    "aliases": [
      "CVE-2024-34156"
    ]
  },
  "products": [
    {
      "@id": "Unknown Product"
    }
  ],
  "status": "affected"
}
{
  "vulnerability": {
    "@id": "https://pkg.go.dev/vuln/GO-2024-3107",
    "name": "GO-2024-3107",
    "description": "Stack exhaustion in Parse in go/build/constraint",
    "aliases": [
      "CVE-2024-34158"
    ]
  },
  "products": [
    {
      "@id": "Unknown Product"
    }
  ],
  "status": "not_affected",
  "justification": "vulnerable_code_not_in_execute_path",
  "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
}

```

`govulncheck` marks `CVE-2024-34156` as `affected`, but this is mistake.
See https://github.com/aquasecurity/trivy/issues/7478 for more details.

example:
```bash
➜  trivy -q fs go.mod --detection-priority comprehensive --show-suppressed --vex .vex/trivy.openvex.json
...
Suppressed Vulnerabilities (Total: 3)

┌─────────┬────────────────┬──────────┬──────────────┬─────────────────────────────────────┬─────────────────────────┐
│ Library │ Vulnerability  │ Severity │    Status    │              Statement              │         Source          │
├─────────┼────────────────┼──────────┼──────────────┼─────────────────────────────────────┼─────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ not_affected │ vulnerable_code_not_in_execute_path │ .vex/trivy.openvex.json │
│         ├────────────────┼──────────┤              │                                     │                         │
│         │ CVE-2024-34155 │ MEDIUM   │              │                                     │                         │
│         ├────────────────┤          │              │                                     │                         │
│         │ CVE-2024-34158 │          │              │                                     │                         │
└─────────┴────────────────┴──────────┴──────────────┴─────────────────────────────────────┴─────────────────────────┘

➜  trivy -q rootfs ./trivy --show-suppressed --vex .vex/trivy.openvex.json                              
...
Suppressed Vulnerabilities (Total: 3)

┌─────────┬────────────────┬──────────┬──────────────┬─────────────────────────────────────┬─────────────────────────┐
│ Library │ Vulnerability  │ Severity │    Status    │              Statement              │         Source          │
├─────────┼────────────────┼──────────┼──────────────┼─────────────────────────────────────┼─────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ not_affected │ vulnerable_code_not_in_execute_path │ .vex/trivy.openvex.json │
│         ├────────────────┼──────────┤              │                                     │                         │
│         │ CVE-2024-34155 │ MEDIUM   │              │                                     │                         │
│         ├────────────────┤          │              │                                     │                         │
│         │ CVE-2024-34158 │          │              │                                     │                         │
└─────────┴────────────────┴──────────┴──────────────┴─────────────────────────────────────┴─────────────────────────┘

```

## Related issues
- Close #7478

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
