### PR TITLE
refactor(misconf): make Rego scanner independent of config type

### DIFF
--- a/pkg/iac/rego/build.go
+++ b/pkg/iac/rego/build.go
@@ -13,16 +13,15 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
-func BuildSchemaSetFromPolicies(policies map[string]*ast.Module, paths []string, fsys fs.FS, customSchemas map[string][]byte) (*ast.SchemaSet, bool, error) {
+func BuildSchemaSetFromPolicies(policies map[string]*ast.Module, paths []string, fsys fs.FS, customSchemas map[string][]byte) (*ast.SchemaSet, error) {
 	schemaSet := ast.NewSchemaSet()
 	schemaSet.Put(ast.MustParseRef("schema.input"), make(map[string]any)) // for backwards compat only
-	var customFound bool
 
 	for _, policy := range policies {
 		for _, annotation := range policy.Annotations {
 			for _, ss := range annotation.Schemas {
 				schemaName, err := ss.Schema.Ptr()
-				if err != nil || schemaName == "input" {
+				if err != nil || schemaName == "input" { // for backwards compat only
 					continue
 				}
 
@@ -38,11 +37,11 @@ func BuildSchemaSetFromPolicies(policies map[string]*ast.Module, paths []string,
 				} else {
 					b, err := findSchemaInFS(paths, fsys, schemaName)
 					if err != nil {
-						return schemaSet, true, err
+						return nil, err
 					}
 
 					if b == nil {
-						return nil, false, fmt.Errorf("could not find schema %q", schemaName)
+						return nil, fmt.Errorf("could not find schema %q", schemaName)
 					}
 
 					schema = b
@@ -50,15 +49,14 @@ func BuildSchemaSetFromPolicies(policies map[string]*ast.Module, paths []string,
 
 				var rawSchema any
 				if err := util.UnmarshalJSON(schema, &rawSchema); err != nil {
-					return schemaSet, false, fmt.Errorf("could not parse schema %q: %w", schemaName, err)
+					return schemaSet, fmt.Errorf("could not parse schema %q: %w", schemaName, err)
 				}
-				customFound = true
 				schemaSet.Put(ss.Schema, rawSchema)
 			}
 		}
 	}
 
-	return schemaSet, customFound, nil
+	return schemaSet, nil
 }
 
 // findSchemaInFS tries to find the schema anywhere in the specified FS

--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -36,7 +36,7 @@ var LoadAndRegister = sync.OnceFunc(func() {
 func RegisterRegoRules(modules map[string]*ast.Module) {
 	ctx := context.TODO()
 
-	schemaSet, _, _ := BuildSchemaSetFromPolicies(modules, nil, nil, make(map[string][]byte))
+	schemaSet, _ := BuildSchemaSetFromPolicies(modules, nil, nil, make(map[string][]byte))
 
 	compiler := ast.NewCompiler().
 		WithSchemas(schemaSet).

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -15,7 +15,6 @@ import (
 
 	checks "github.com/aquasecurity/trivy-checks"
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
-	"github.com/aquasecurity/trivy/pkg/iac/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
@@ -30,7 +29,6 @@ func Test_RegoScanning_WithSomeInvalidPolicies(t *testing.T) {
 		var debugBuf bytes.Buffer
 		slog.SetDefault(log.New(log.NewHandler(&debugBuf, nil)))
 		scanner := rego.NewScanner(
-			types.SourceDockerfile,
 			rego.WithRegoErrorLimits(0),
 			rego.WithPolicyDirs("."),
 		)
@@ -44,7 +42,6 @@ func Test_RegoScanning_WithSomeInvalidPolicies(t *testing.T) {
 		var debugBuf bytes.Buffer
 		slog.SetDefault(log.New(log.NewHandler(&debugBuf, nil)))
 		scanner := rego.NewScanner(
-			types.SourceDockerfile,
 			rego.WithRegoErrorLimits(1),
 			rego.WithPolicyDirs("."),
 		)
@@ -65,7 +62,6 @@ deny {
     input.evil == "foo bar"
 }`
 		scanner := rego.NewScanner(
-			types.SourceJSON,
 			rego.WithPolicyDirs("."),
 			rego.WithPolicyReader(strings.NewReader(check)),
 		)
@@ -84,7 +80,6 @@ deny {
     input.evil == "foo bar"
 }`
 		scanner := rego.NewScanner(
-			types.SourceJSON,
 			rego.WithPolicyDirs("."),
 			rego.WithPolicyReader(strings.NewReader(check)),
 		)
@@ -106,14 +101,12 @@ deny {
     input.evil == "foo bar"
 }`
 		scanner := rego.NewScanner(
-			types.SourceJSON,
 			rego.WithPolicyDirs("."),
 			rego.WithPolicyReader(strings.NewReader(check)),
 		)
 		err := scanner.LoadPolicies(fstest.MapFS{})
 		require.NoError(t, err)
 	})
-
 }
 
 func Test_FallbackToEmbedded(t *testing.T) {
@@ -195,7 +188,6 @@ deny {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner := rego.NewScanner(
-				types.SourceDockerfile,
 				rego.WithRegoErrorLimits(0),
 				rego.WithEmbeddedPolicies(false),
 				rego.WithPolicyDirs("."),
@@ -255,7 +247,6 @@ deny {
 	}
 
 	scanner := rego.NewScanner(
-		types.SourceDockerfile,
 		rego.WithEmbeddedPolicies(false),
 		rego.WithPolicyDirs("."),
 	)

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -44,12 +44,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -78,12 +77,11 @@ deny {
 	srcFS := os.DirFS(tmp)
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -111,12 +109,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": false,
@@ -147,12 +144,11 @@ deny_evil {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -178,12 +174,11 @@ deny[msg] {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -216,12 +211,11 @@ deny[res] {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -258,12 +252,11 @@ deny[res] {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -312,12 +305,11 @@ deny[res] {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -361,12 +353,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -395,12 +386,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -426,12 +416,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -461,13 +450,12 @@ deny {
 	traceBuffer := bytes.NewBuffer([]byte{})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithTrace(traceBuffer),
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -496,13 +484,12 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPerResultTracing(true),
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -535,12 +522,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "dynamic",
@@ -568,12 +554,11 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "test",
@@ -615,13 +600,12 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithPerResultTracing(true),
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "test",
@@ -654,7 +638,6 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceDockerfile,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
@@ -675,7 +658,6 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceDockerfile,
 		rego.WithPolicyDirs("policies"),
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
@@ -695,7 +677,6 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithRegoErrorLimits(0),
 		rego.WithPolicyDirs("policies"),
 	)
@@ -731,7 +712,6 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithDataFilesystem(dataFS),
 		rego.WithDataDirs("."),
 		rego.WithPolicyDirs("policies"),
@@ -739,7 +719,7 @@ deny {
 
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{})
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{})
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetFailed(), 1)
@@ -771,7 +751,6 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		types.SourceJSON,
 		rego.WithDataFilesystem(dataFS),
 		rego.WithDataDirs("X://"),
 		rego.WithPolicyDirs("policies"),
@@ -779,7 +758,7 @@ deny {
 
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{})
+	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{})
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetFailed(), 1)
@@ -807,11 +786,10 @@ deny {
 	}
 
 	scanner := rego.NewScanner(
-		types.SourceYAML,
 		rego.WithPolicyDirs("checks"),
 	)
 	require.NoError(t, scanner.LoadPolicies(fsys))
-	_, err := scanner.ScanInput(context.TODO(), rego.Input{})
+	_, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{})
 	require.NoError(t, err)
 }
 
@@ -872,10 +850,10 @@ deny {
 				"policies/test.rego": tc.policy,
 			})
 
-			scanner := rego.NewScanner(types.SourceJSON, rego.WithPolicyDirs("policies"))
+			scanner := rego.NewScanner(rego.WithPolicyDirs("policies"))
 			require.NoError(t, scanner.LoadPolicies(srcFS))
 
-			results, err := scanner.ScanInput(context.TODO(), rego.Input{
+			results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
 				Path: "/evil.lol",
 				Contents: map[string]any{
 					"text": "test",
@@ -937,7 +915,6 @@ deny {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			scanner := rego.NewScanner(
-				types.SourceYAML,
 				rego.WithCustomSchemas(map[string][]byte{
 					"test": []byte(schema),
 				}),
@@ -947,7 +924,7 @@ deny {
 
 			require.NoError(t, scanner.LoadPolicies(nil))
 
-			results, err := scanner.ScanInput(context.TODO(), rego.Input{
+			results, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{
 				Path:     "test.yaml",
 				Contents: map[string]any{"service": "test"},
 			})
@@ -1026,14 +1003,13 @@ deny {
 		t.Run(tt.name, func(t *testing.T) {
 
 			scanner := rego.NewScanner(
-				types.SourceYAML,
 				rego.WithPolicyReader(strings.NewReader(tt.inputCheck)),
 				rego.WithDisabledCheckIDs(tt.disabledChecks...),
 				rego.WithPolicyNamespaces("user"),
 			)
 
 			require.NoError(t, scanner.LoadPolicies(nil))
-			results, err := scanner.ScanInput(context.TODO(), rego.Input{})
+			results, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{})
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected, len(results.GetFailed()) > 0)

--- a/pkg/iac/rego/testdata/policies/invalid.rego
+++ b/pkg/iac/rego/testdata/policies/invalid.rego
@@ -1,6 +1,6 @@
 # METADATA
 # schemas:
-# - input: schema["input"]
+# - input: schema["dockerfile"]
 package defsec.test_invalid
 
 deny {

--- a/pkg/iac/rego/testdata/policies/valid.rego
+++ b/pkg/iac/rego/testdata/policies/valid.rego
@@ -1,6 +1,6 @@
 # METADATA
 # schemas:
-# - input: schema["input"]
+# - input: schema["dockerfile"]
 package defsec.test_valid
 
 deny {

--- a/pkg/iac/scanners/azure/arm/scanner.go
+++ b/pkg/iac/scanners/azure/arm/scanner.go
@@ -49,7 +49,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) error {
 	if s.regoScanner != nil {
 		return nil
 	}
-	regoScanner := rego.NewScanner(types.SourceCloud, s.scannerOptions...)
+	regoScanner := rego.NewScanner(s.scannerOptions...)
 	if err := regoScanner.LoadPolicies(srcFS); err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (s *Scanner) scanDeployments(ctx context.Context, deployments []azure.Deplo
 func (s *Scanner) scanDeployment(ctx context.Context, deployment azure.Deployment, fsys fs.FS) (scan.Results, error) {
 	deploymentState := s.adaptDeployment(ctx, deployment)
 
-	results, err := s.regoScanner.ScanInput(ctx, rego.Input{
+	results, err := s.regoScanner.ScanInput(ctx, types.SourceCloud, rego.Input{
 		Path:     deployment.Metadata.Range().GetFilename(),
 		FS:       fsys,
 		Contents: deploymentState.ToRego(),

--- a/pkg/iac/scanners/cloudformation/scanner.go
+++ b/pkg/iac/scanners/cloudformation/scanner.go
@@ -80,7 +80,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	if s.regoScanner != nil {
 		return s.regoScanner, nil
 	}
-	regoScanner := rego.NewScanner(types.SourceCloud, s.options...)
+	regoScanner := rego.NewScanner(s.options...)
 	if err := regoScanner.LoadPolicies(srcFS); err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (s *Scanner) scanFileContext(ctx context.Context, regoScanner *rego.Scanner
 		return nil, nil
 	}
 
-	results, err := regoScanner.ScanInput(ctx, rego.Input{
+	results, err := regoScanner.ScanInput(ctx, types.SourceCloud, rego.Input{
 		Path:     cfCtx.Metadata().Range().GetFilename(),
 		FS:       fsys,
 		Contents: state.ToRego(),

--- a/pkg/iac/scanners/generic/scanner.go
+++ b/pkg/iac/scanners/generic/scanner.go
@@ -119,7 +119,7 @@ func (s *GenericScanner) ScanFS(ctx context.Context, fsys fs.FS, dir string) (sc
 	}
 
 	s.logger.Debug("Scanning files...", log.Int("count", len(inputs)))
-	results, err := regoScanner.ScanInput(ctx, inputs...)
+	results, err := regoScanner.ScanInput(ctx, s.source, inputs...)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (s *GenericScanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	if s.regoScanner != nil {
 		return s.regoScanner, nil
 	}
-	regoScanner := rego.NewScanner(s.source, s.options...)
+	regoScanner := rego.NewScanner(s.options...)
 	if err := regoScanner.LoadPolicies(srcFS); err != nil {
 		return nil, err
 	}

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -132,7 +132,7 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 			return nil, fmt.Errorf("unmarshal yaml: %w", err)
 		}
 		for _, manifest := range manifests {
-			fileResults, err := s.regoScanner.ScanInput(ctx, rego.Input{
+			fileResults, err := s.regoScanner.ScanInput(ctx, types.SourceKubernetes, rego.Input{
 				Path:     file.TemplateFilePath,
 				Contents: manifest,
 				FS:       target,
@@ -168,7 +168,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) error {
 	if s.regoScanner != nil {
 		return nil
 	}
-	regoScanner := rego.NewScanner(types.SourceKubernetes, s.options...)
+	regoScanner := rego.NewScanner(s.options...)
 	if err := regoScanner.LoadPolicies(srcFS); err != nil {
 		return err
 	}

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -42,7 +42,7 @@ func (e *Executor) Execute(ctx context.Context, modules terraform.Modules, baseP
 	infra := adapter.Adapt(modules)
 	e.logger.Debug("Adapted module(s) into state data.", log.Int("count", len(modules)))
 
-	results, err := e.regoScanner.ScanInput(ctx, rego.Input{
+	results, err := e.regoScanner.ScanInput(ctx, types.SourceCloud, rego.Input{
 		Contents: infra.ToRego(),
 		Path:     basePath,
 	})

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/executor"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
-	"github.com/aquasecurity/trivy/pkg/iac/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/set"
 )
@@ -72,7 +71,7 @@ func (s *Scanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	if s.regoScanner != nil {
 		return s.regoScanner, nil
 	}
-	regoScanner := rego.NewScanner(types.SourceCloud, s.options...)
+	regoScanner := rego.NewScanner(s.options...)
 	if err := regoScanner.LoadPolicies(srcFS); err != nil {
 		return nil, err
 	}

--- a/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
@@ -73,7 +73,7 @@ func Test_TerraformScanner(t *testing.T) {
 # description: Bad buckets are bad because they are not good.
 # scope: package
 # schemas:
-#   - input: schema["input"]
+#   - input: schema["cloud"]
 # custom:
 #   avd_id: AVD-TEST-0123
 #   severity: CRITICAL


### PR DESCRIPTION
## Description

The source type (cloud, dockerfile, k8s, etc.) determines the default input schema when creating the scanner and filtering checks during scanning. However, this scheme is not applied if at least one check (custom or built in trivy) already uses the scheme. Since all checks from the `trivy-checks` repository use schemas, the default scheme is effectively never applied. This eliminates the dependency of the Rego scanner on the source type, which in turn makes it possible to compile the checks once and use a single instance for all IaC scanners.

Let's consider the options of specifying schemes in custom checks:
- Schema not specified - Schema does not apply. Since the default scheme has never been used, the behavior will not change.
- Schema specified - Trivy will load it from standard schemas (cloud, k8s, etc.), from the file system, or from a custom field with custom schemas.
- Specifies `input` schema - this is a deprecated way of specifying a default schema, which was previously selected based on the source type. Since the default scheme has never been used, the behavior will not change.

This PR removes the Rego scanner's dependency on source type, making it a single repository of all checks, regardless of their type.

Changes:
- The scanner constructor no longer accepts `SourceType`.
- The `ScanInput` method accepts a source type for filtering checks.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
