### PR TITLE
fix(sbom): parse type `framework` as `library` when unmarshalling `CycloneDX` files

### DIFF
--- a/pkg/sbom/cyclonedx/testdata/happy/third-party-bom.json
+++ b/pkg/sbom/cyclonedx/testdata/happy/third-party-bom.json
@@ -46,7 +46,7 @@
     },
     {
       "bom-ref": "pkg:composer/pear/pear_exception@v1.0.0",
-      "type": "library",
+      "type": "framework",
       "name": "pear/pear_exception",
       "version": "v1.0.0",
       "purl": "pkg:composer/pear/pear_exception@v1.0.0"

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -166,7 +166,10 @@ func (b *BOM) unmarshalType(t cdx.ComponentType) (core.ComponentType, error) {
 		ctype = core.TypeContainerImage
 	case cdx.ComponentTypeApplication:
 		ctype = core.TypeApplication
-	case cdx.ComponentTypeLibrary:
+	// There are not many differences between a `library` and a `framework` components, and sometimes it is difficult to choose the right type.
+	// That is why some users choose `framework` type.
+	// So we should parse and scan `framework` components as libraries.
+	case cdx.ComponentTypeLibrary, cdx.ComponentTypeFramework:
 		ctype = core.TypeLibrary
 	case cdx.ComponentTypeOS:
 		ctype = core.TypeOS


### PR DESCRIPTION
## Description
See #7432 for more details.

## Related issues
- Close #7432

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
