### PR TITLE
fix(misconf): disable DS016 check for image history analyzer

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -16,6 +16,10 @@ import (
 	"github.com/aquasecurity/trivy/pkg/misconf"
 )
 
+var disabledChecks = []string{
+	"DS016", // See https://github.com/aquasecurity/trivy/issues/7368
+}
+
 const analyzerVersion = 1
 
 func init() {
@@ -27,6 +31,7 @@ type historyAnalyzer struct {
 }
 
 func newHistoryAnalyzer(opts analyzer.ConfigAnalyzerOptions) (analyzer.ConfigAnalyzer, error) {
+	opts.MisconfScannerOption.DisabledCheckIDs = append(opts.MisconfScannerOption.DisabledCheckIDs, disabledChecks...)
 	s, err := misconf.NewScanner(detection.FileTypeDockerfile, opts.MisconfScannerOption)
 	if err != nil {
 		return nil, xerrors.Errorf("misconfiguration scanner error: %w", err)

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -284,6 +284,47 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 				Config: nil,
 			},
 		},
+		{
+			name: "DS016 check not detected",
+			input: analyzer.ConfigAnalysisInput{
+				Config: &v1.ConfigFile{
+					Config: v1.Config{
+						Healthcheck: &v1.HealthConfig{
+							Test:     []string{"CMD-SHELL", "curl --fail http://localhost:3000 || exit 1"},
+							Interval: time.Second * 10,
+							Timeout:  time.Second * 3,
+						},
+					},
+					History: []v1.History{
+						{
+							// duplicate command from another layer
+							CreatedBy:  `/bin/sh -c #(nop) CMD [\"/bin/bash\"]`,
+							EmptyLayer: true,
+						},
+						{
+							CreatedBy: "/bin/sh -c #(nop) ADD file:e4d600fc4c9c293efe360be7b30ee96579925d1b4634c94332e2ec73f7d8eca1 in /",
+						},
+						{
+							CreatedBy: `HEALTHCHECK &{["CMD-SHELL" "curl --fail http://localhost:3000 || exit 1"] "10s" "3s" "0s" '\x00'}`,
+						},
+						{
+							CreatedBy:  `USER user`,
+							EmptyLayer: true,
+						},
+						{
+							CreatedBy:  `/bin/sh -c #(nop)  CMD [\"/bin/sh\"]`,
+							EmptyLayer: true,
+						},
+					},
+				},
+			},
+			want: &analyzer.ConfigAnalysisResult{
+				Misconfiguration: &types.Misconfiguration{
+					FileType: types.Dockerfile,
+					FilePath: "Dockerfile",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -74,6 +74,8 @@ type ScannerOption struct {
 
 	FilePatterns      []string
 	ConfigFileSchemas []*ConfigFileSchema
+
+	DisabledCheckIDs []string
 }
 
 func (o *ScannerOption) Sort() {
@@ -212,6 +214,7 @@ func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerO
 		rego.WithEmbeddedPolicies(!opt.DisableEmbeddedPolicies),
 		rego.WithEmbeddedLibraries(!opt.DisableEmbeddedLibraries),
 		options.ScannerWithIncludeDeprecatedChecks(opt.IncludeDeprecatedChecks),
+		rego.WithDisabledCheckIDs(opt.DisabledCheckIDs...),
 	}
 
 	policyFS, policyPaths, err := CreatePolicyFS(opt.PolicyPaths)


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7368

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/7536

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
