### PR TITLE
fix(java): correctly inherit `version` and `scope` from upper/root `depManagement` and `dependencies` into parents

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -340,9 +340,15 @@ func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error)
 	// For better understanding see the following tests:
 	// - `dependency from parent uses version from child pom depManagement`
 	// - `dependency from parent uses version from root pom depManagement`
+	// - `dependency from parent uses version from scanned pom depManagement`
 	//
 	// depManagements from root pom has higher priority than depManagements from current pom.
-	depManagementForParent := lo.UniqBy(append(opts.depManagement, pom.content.DependencyManagement.Dependencies.Dependency...),
+
+	var resolvedPomDepManagent []pomDependency
+	for _, dep := range pom.content.DependencyManagement.Dependencies.Dependency {
+		resolvedPomDepManagent = append(resolvedPomDepManagent, dep.Resolve(pom.content.Properties, nil, nil))
+	}
+	depManagementForParent := lo.UniqBy(append(opts.depManagement, resolvedPomDepManagent...),
 		func(dep pomDependency) string {
 			return dep.Name()
 		})

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -96,7 +96,7 @@ func NewParser(filePath string, opts ...option) *Parser {
 }
 
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
-	content, err := parsePom(r)
+	content, err := parsePom(r, true)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to parse POM: %w", err)
 	}
@@ -107,7 +107,7 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 	}
 
 	// Analyze root POM
-	result, err := p.analyze(root, analysisOptions{lineNumber: true})
+	result, err := p.analyze(root, analysisOptions{})
 	if err != nil {
 		return nil, nil, xerrors.Errorf("analyze error (%s): %w", p.rootPath, err)
 	}
@@ -299,8 +299,8 @@ func (p *Parser) resolve(art artifact, rootDepManagement []pomDependency) (analy
 		p.logger.Debug("Repository error", log.Err(err))
 	}
 	result, err := p.analyze(pomContent, analysisOptions{
-		exclusions:        art.Exclusions,
-		rootDepManagement: rootDepManagement,
+		exclusions:    art.Exclusions,
+		depManagement: rootDepManagement,
 	})
 	if err != nil {
 		return analysisResult{}, xerrors.Errorf("analyze error: %w", err)
@@ -320,68 +320,29 @@ type analysisResult struct {
 }
 
 type analysisOptions struct {
-	exclusions             map[string]struct{}
-	depManagementForParent []pomDependency // from current and root POMs - used for parents
-	propsForParent         properties      // from current and root POMs - used for parents
-	rootDepManagement      []pomDependency // from the root POM
-	lineNumber             bool            // Save line numbers
+	exclusions    map[string]struct{}
+	depManagement []pomDependency // from the root POM
 }
 
 func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error) {
 	if pom == nil || pom.content == nil {
 		return analysisResult{}, nil
 	}
-
 	// Update remoteRepositories
 	pomReleaseRemoteRepos, pomSnapshotRemoteRepos := pom.repositories(p.servers)
 	p.releaseRemoteRepos = lo.Uniq(append(pomReleaseRemoteRepos, p.releaseRemoteRepos...))
 	p.snapshotRemoteRepos = lo.Uniq(append(pomSnapshotRemoteRepos, p.snapshotRemoteRepos...))
 
-	// Merge props from upper POM and current POM to use in parent
-	propsForParent := lo.Assign(opts.propsForParent, pom.content.Properties)
-
-	// We need to forward dependencyManagements from current and root pom to Parent,
-	// to use them for dependencies in parent.
-	// For better understanding see the following tests:
-	// - `dependency from parent uses version from child pom depManagement`
-	// - `dependency from parent uses version from root pom depManagement`
-	// - `dependency from parent uses version from scanned pom depManagement`
-	//
-	// Merge dependencyManagements from root, upper and current POM and remove duplicates
-	depManagementForParent := append(opts.rootDepManagement, opts.depManagementForParent...)
-	depManagementForParent = lo.UniqBy(append(depManagementForParent, pom.content.DependencyManagement.Dependencies.Dependency...),
-		func(dep pomDependency) string {
-			return dep.Name()
-		})
-
-	// Parent
-	parent, err := p.parseParent(pom.filePath, pom.content.Parent, depManagementForParent, propsForParent)
-	if err != nil {
-		return analysisResult{}, xerrors.Errorf("parent error: %w", err)
+	// Resolve parent POM
+	if err := p.resolveParent(pom); err != nil {
+		return analysisResult{}, xerrors.Errorf("pom resolve error: %w", err)
 	}
 
-	// Inherit values/properties from parent
-	pom.inherit(parent)
-
-	// Generate properties
+	// Resolve dependencies
 	props := pom.properties()
-
-	// To analyze parents:
-	// Take props from upper POM
-	props = lo.Assign(props, opts.propsForParent)
-
-	// dependencyManagements have the next priority:
-	// 1. Managed dependencies from upped POM (this case only works for parent analysis)
-	// 2. Managed dependencies from this POM
-	// 3. Managed dependencies from parent of this POM
-	depManagement := p.mergeDependencyManagements(opts.depManagementForParent,
-		pom.content.DependencyManagement.Dependencies.Dependency,
-		parent.dependencyManagement)
-
-	// Merge dependencies. Child dependencies must be preferred than parent dependencies.
-	// Parents don't have to resolve dependencies.
+	depManagement := pom.content.DependencyManagement.Dependencies.Dependency
 	deps := p.parseDependencies(pom.content.Dependencies.Dependency, props, depManagement, opts)
-	deps = p.mergeDependencies(parent.dependencies, deps, opts.exclusions)
+	deps = p.filterDependencies(deps, opts.exclusions)
 
 	return analysisResult{
 		filePath:             pom.filePath,
@@ -391,6 +352,39 @@ func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error)
 		properties:           props,
 		modules:              pom.content.Modules.Module,
 	}, nil
+}
+
+// resolveParent resolves its parent POMs and inherits properties, dependencies, and dependencyManagement.
+func (p *Parser) resolveParent(pom *pom) error {
+	if pom == nil || pom.content == nil {
+		return nil
+	}
+
+	// Parse parent POM
+	parent, err := p.parseParent(pom.filePath, pom.content.Parent)
+	if err != nil {
+		return xerrors.Errorf("parent error: %w", err)
+	}
+
+	// Inherit values/properties from parent
+	pom.inherit(parent)
+
+	// Merge properties
+	pom.content.Properties = p.mergeProperties(pom.content.Properties, parent.content.Properties)
+
+	// Merge dependencyManagement with the following priority:
+	// 1. Managed dependencies from this POM
+	// 2. Managed dependencies from parent of this POM
+	pom.content.DependencyManagement.Dependencies.Dependency = p.mergeDependencyManagements(
+		pom.content.DependencyManagement.Dependencies.Dependency,
+		parent.content.DependencyManagement.Dependencies.Dependency)
+
+	// Merge dependencies
+	pom.content.Dependencies.Dependency = p.mergeDependencies(
+		pom.content.Dependencies.Dependency,
+		parent.content.Dependencies.Dependency)
+
+	return nil
 }
 
 func (p *Parser) mergeDependencyManagements(depManagements ...[]pomDependency) []pomDependency {
@@ -419,7 +413,7 @@ func (p *Parser) parseDependencies(deps []pomDependency, props map[string]string
 	// Resolve dependencyManagement
 	depManagement = p.resolveDepManagement(props, depManagement)
 
-	rootDepManagement := opts.rootDepManagement
+	rootDepManagement := opts.depManagement
 	var dependencies []artifact
 	for _, d := range deps {
 		// Resolve dependencies
@@ -468,22 +462,20 @@ func (p *Parser) resolveDepManagement(props map[string]string, depManagement []p
 	return newDepManagement
 }
 
-func (p *Parser) mergeDependencies(parent, child []artifact, exclusions map[string]struct{}) []artifact {
-	var deps []artifact
-	unique := make(map[string]struct{})
+func (p *Parser) mergeProperties(child, parent properties) properties {
+	return lo.Assign(parent, child)
+}
 
-	for _, d := range append(child, parent...) {
-		if excludeDep(exclusions, d) {
-			continue
-		}
-		if _, ok := unique[d.Name()]; ok {
-			continue
-		}
-		unique[d.Name()] = struct{}{}
-		deps = append(deps, d)
-	}
+func (p *Parser) mergeDependencies(child, parent []pomDependency) []pomDependency {
+	return lo.UniqBy(append(child, parent...), func(d pomDependency) string {
+		return d.Name()
+	})
+}
 
-	return deps
+func (p *Parser) filterDependencies(artifacts []artifact, exclusions map[string]struct{}) []artifact {
+	return lo.Filter(artifacts, func(art artifact, _ int) bool {
+		return !excludeDep(exclusions, art)
+	})
 }
 
 func excludeDep(exclusions map[string]struct{}, art artifact) bool {
@@ -502,39 +494,29 @@ func excludeDep(exclusions map[string]struct{}, art artifact) bool {
 	return false
 }
 
-func (p *Parser) parseParent(currentPath string, parent pomParent, depManagementForParent []pomDependency, propsForParent properties) (analysisResult, error) {
+func (p *Parser) parseParent(currentPath string, parent pomParent) (*pom, error) {
 	// Pass nil properties so that variables in <parent> are not evaluated.
 	target := newArtifact(parent.GroupId, parent.ArtifactId, parent.Version, nil, nil)
 	// if version is property (e.g. ${revision}) - we still need to parse this pom
 	if target.IsEmpty() && !isProperty(parent.Version) {
-		return analysisResult{}, nil
+		return &pom{content: &pomXML{}}, nil
 	}
 
 	logger := p.logger.With("artifact", target.String())
 	logger.Debug("Start parent")
 	defer logger.Debug("Exit parent")
 
-	// If the artifact is found in cache, it is returned.
-	if result := p.cache.get(target); result != nil {
-		return *result, nil
-	}
-
 	parentPOM, err := p.retrieveParent(currentPath, parent.RelativePath, target)
 	if err != nil {
 		logger.Debug("Parent POM not found", log.Err(err))
+		return &pom{content: &pomXML{}}, nil
 	}
 
-	result, err := p.analyze(parentPOM, analysisOptions{
-		depManagementForParent: depManagementForParent,
-		propsForParent:         propsForParent,
-	})
-	if err != nil {
-		return analysisResult{}, xerrors.Errorf("analyze error: %w", err)
+	if err = p.resolveParent(parentPOM); err != nil {
+		return nil, xerrors.Errorf("parent pom resolve error: %w", err)
 	}
 
-	p.cache.put(target, result)
-
-	return result, nil
+	return parentPOM, nil
 }
 
 func (p *Parser) retrieveParent(currentPath, relativePath string, target artifact) (*pom, error) {
@@ -571,7 +553,7 @@ func (p *Parser) retrieveParent(currentPath, relativePath string, target artifac
 }
 
 func (p *Parser) tryRelativePath(parentArtifact artifact, currentPath, relativePath string) (*pom, error) {
-	pom, err := p.openRelativePom(currentPath, relativePath)
+	parsedPOM, err := p.openRelativePom(currentPath, relativePath)
 	if err != nil {
 		return nil, err
 	}
@@ -582,19 +564,18 @@ func (p *Parser) tryRelativePath(parentArtifact artifact, currentPath, relativeP
 	// But GroupID can be inherited from parent (`p.analyze` function is required to get the GroupID).
 	// Version can contain a property (`p.analyze` function is required to get the GroupID).
 	// So we can only match ArtifactID's.
-	if pom.artifact().ArtifactID != parentArtifact.ArtifactID {
+	if parsedPOM.artifact().ArtifactID != parentArtifact.ArtifactID {
 		return nil, xerrors.New("'parent.relativePath' points at wrong local POM")
 	}
-	result, err := p.analyze(pom, analysisOptions{})
-	if err != nil {
+	if err := p.resolveParent(parsedPOM); err != nil {
 		return nil, xerrors.Errorf("analyze error: %w", err)
 	}
 
-	if !parentArtifact.Equal(result.artifact) {
+	if !parentArtifact.Equal(parsedPOM.artifact()) {
 		return nil, xerrors.New("'parent.relativePath' points at wrong local POM")
 	}
 
-	return pom, nil
+	return parsedPOM, nil
 }
 
 func (p *Parser) openRelativePom(currentPath, relativePath string) (*pom, error) {
@@ -626,7 +607,7 @@ func (p *Parser) openPom(filePath string) (*pom, error) {
 	}
 	defer f.Close()
 
-	content, err := parsePom(f)
+	content, err := parsePom(f, false)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to parse the local POM: %w", err)
 	}
@@ -783,7 +764,7 @@ func (p *Parser) fetchPOMFromRemoteRepository(repo string, paths []string) (*pom
 	}
 	defer resp.Body.Close()
 
-	content, err := parsePom(resp.Body)
+	content, err := parsePom(resp.Body, false)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to parse the remote POM: %w", err)
 	}
@@ -794,12 +775,18 @@ func (p *Parser) fetchPOMFromRemoteRepository(repo string, paths []string) (*pom
 	}, nil
 }
 
-func parsePom(r io.Reader) (*pomXML, error) {
+func parsePom(r io.Reader, lineNumber bool) (*pomXML, error) {
 	parsed := &pomXML{}
 	decoder := xml.NewDecoder(r)
 	decoder.CharsetReader = charset.NewReaderLabel
 	if err := decoder.Decode(parsed); err != nil {
 		return nil, xerrors.Errorf("xml decode error: %w", err)
+	}
+	if !lineNumber {
+		for i := range parsed.Dependencies.Dependency {
+			parsed.Dependencies.Dependency[i].StartLine = 0
+			parsed.Dependencies.Dependency[i].EndLine = 0
+		}
 	}
 	return parsed, nil
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -346,13 +346,10 @@ func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error)
 	// - `dependency from parent uses version from child pom depManagement`
 	// - `dependency from parent uses version from root pom depManagement`
 	// - `dependency from parent uses version from scanned pom depManagement`
-	var resolvedPomDepManagement []pomDependency
-	for _, dep := range pom.content.DependencyManagement.Dependencies.Dependency {
-		resolvedPomDepManagement = append(resolvedPomDepManagement, dep.Resolve(propsForParent, nil, nil))
-	}
-	// depManagements from root pom has higher priority than depManagements from current POM.
+	//
+	// Merge dependencyManagements from root, upper and current POM and remove duplicates
 	depManagementForParent := append(opts.rootDepManagement, opts.depManagementForParent...)
-	depManagementForParent = lo.UniqBy(append(depManagementForParent, resolvedPomDepManagement...),
+	depManagementForParent = lo.UniqBy(append(depManagementForParent, pom.content.DependencyManagement.Dependencies.Dependency...),
 		func(dep pomDependency) string {
 			return dep.Name()
 		})

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -325,7 +325,7 @@ type analysisOptions struct {
 }
 
 func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error) {
-	if pom == nil || pom.content == nil {
+	if pom.nil() {
 		return analysisResult{}, nil
 	}
 	// Update remoteRepositories
@@ -356,7 +356,7 @@ func (p *Parser) analyze(pom *pom, opts analysisOptions) (analysisResult, error)
 
 // resolveParent resolves its parent POMs and inherits properties, dependencies, and dependencyManagement.
 func (p *Parser) resolveParent(pom *pom) error {
-	if pom == nil || pom.content == nil {
+	if pom.nil() {
 		return nil
 	}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1726,16 +1726,16 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
-		// [INFO] com.example:inherit-scopes-in-child-deps:jar:1.0.0
+		// [INFO] com.example:inherit-scopes-from-child-deps-and-their-parents:jar:0.0.1
 		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
-		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
-		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:test
+		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:runtime
+		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:runtime
 		// [INFO] +- org.example:example-nested-scope-compile:jar:1.0.0:compile
-		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:runtime
-		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:test
+		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:compile
+		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:compile
 		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:compile
-		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:runtime
-		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:test
+		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:compile
+		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:compile
 		//
 		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes
 		{
@@ -1806,7 +1806,7 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
-		// [INFO] com.example:inherit-scopes-in-children-from-root:jar:0.0.1
+		// [INFO] com.example:inherit-scopes-in-parents-from-root:jar:0.1.0
 		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
 		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
 		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:runtime

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1690,9 +1690,9 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		// [INFO] com.example:child-depManagement-in-parent:jar:1.0.0
-		// [INFO] +- org.example:example-api:jar:1.0.1:compile
 		// [INFO] +- org.example:example-api2:jar:1.0.2:runtime
-		// [INFO] \- org.example:example-api3:jar:4.0.3:compile
+		// [INFO] +- org.example:example-api3:jar:4.0.3:compile
+		// [INFO] \- org.example:example-api:jar:1.0.1:compile
 		{
 			name:      "dependency from parent uses version from child(scanned) pom depManagement",
 			inputFile: filepath.Join("testdata", "use-child-dep-management-in-parent", "pom.xml"),

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1707,13 +1707,13 @@ func TestPom_Parse(t *testing.T) {
 					ID:           "org.example:example-api:1.0.1",
 					Name:         "org.example:example-api",
 					Version:      "1.0.1",
-					Relationship: ftypes.RelationshipDirect, // TODO change this!!!
+					Relationship: ftypes.RelationshipDirect,
 				},
 				{
 					ID:           "org.example:example-api2:1.0.2",
 					Name:         "org.example:example-api2",
 					Version:      "1.0.2",
-					Relationship: ftypes.RelationshipDirect, // TODO change this!!!
+					Relationship: ftypes.RelationshipDirect,
 				},
 			},
 			wantDeps: []ftypes.Dependency{

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1595,6 +1595,43 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
+		// [INFO] com.example:child-depManagement-in-parent:jar:1.0.0
+		// [INFO] +- org.example:example-api:jar:1.0.1:compile
+		// [INFO] \- org.example:example-api2:jar:1.0.2:runtime
+		{
+			name:      "dependency from parent uses version from child(scanned) pom depManagement",
+			inputFile: filepath.Join("testdata", "use-child-dep-management-in-parent", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:child-depManagement-in-parent:1.0.0",
+					Name:         "com.example:child-depManagement-in-parent",
+					Version:      "1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				{
+					ID:           "org.example:example-api:1.0.1",
+					Name:         "org.example:example-api",
+					Version:      "1.0.1",
+					Relationship: ftypes.RelationshipDirect, // TODO change this!!!
+				},
+				{
+					ID:           "org.example:example-api2:1.0.2",
+					Name:         "org.example:example-api2",
+					Version:      "1.0.2",
+					Relationship: ftypes.RelationshipDirect, // TODO change this!!!
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:child-depManagement-in-parent:1.0.0",
+					DependsOn: []string{
+						"org.example:example-api2:1.0.2",
+						"org.example:example-api:1.0.1",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1873,7 +1873,6 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
-		// [INFO] --- dependency:3.7.0:tree (default-cli) @ inherit-scopes-in-parents-from-root ---
 		// [INFO] com.example:inherit-scopes-in-parents-from-root:jar:0.1.0
 		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
 		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
@@ -1881,8 +1880,8 @@ func TestPom_Parse(t *testing.T) {
 		// [INFO] +- org.example:example-nested-scope-compile:jar:1.0.0:compile
 		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:runtime
 		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:test
-		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:compile
-		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:runtime
+		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:test
+		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:test
 		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:test
 		//
 		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -14,6 +14,100 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
+var (
+	exampleNestedScopeCompile = func(start, end int) ftypes.Package {
+		var location ftypes.Locations
+		if start != 0 && end != 0 {
+			location = append(location, ftypes.Location{
+				StartLine: start,
+				EndLine:   end,
+			})
+		}
+		return ftypes.Package{
+			ID:           "org.example:example-nested-scope-compile:1.0.0",
+			Name:         "org.example:example-nested-scope-compile",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipDirect,
+			Locations:    location,
+		}
+	}
+
+	exampleNestedScopeEmpty = func(start, end int) ftypes.Package {
+		var location ftypes.Locations
+		if start != 0 && end != 0 {
+			location = append(location, ftypes.Location{
+				StartLine: start,
+				EndLine:   end,
+			})
+		}
+		return ftypes.Package{
+			ID:           "org.example:example-nested-scope-empty:1.0.0",
+			Name:         "org.example:example-nested-scope-empty",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipDirect,
+			Locations:    location,
+		}
+	}
+
+	exampleNestedScopeRuntime = func(start, end int) ftypes.Package {
+		var location ftypes.Locations
+		if start != 0 && end != 0 {
+			location = append(location, ftypes.Location{
+				StartLine: start,
+				EndLine:   end,
+			})
+		}
+		return ftypes.Package{
+			ID:           "org.example:example-nested-scope-runtime:1.0.0",
+			Name:         "org.example:example-nested-scope-runtime",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipDirect,
+			Locations:    location,
+		}
+	}
+
+	exampleScopeCompile = ftypes.Package{
+		ID:           "org.example:example-scope-compile:2.0.0",
+		Name:         "org.example:example-scope-compile",
+		Version:      "2.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+
+	exampleScopeEmpty = ftypes.Package{
+		ID:           "org.example:example-scope-empty:2.0.0",
+		Name:         "org.example:example-scope-empty",
+		Version:      "2.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+
+	exampleScopeRuntime = ftypes.Package{
+		ID:           "org.example:example-scope-runtime:2.0.0",
+		Name:         "org.example:example-scope-runtime",
+		Version:      "2.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+	exampleApiCompile = ftypes.Package{
+		ID:           "org.example:example-api-compile:3.0.0",
+		Name:         "org.example:example-api-compile",
+		Version:      "3.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+
+	exampleApiEmpty = ftypes.Package{
+		ID:           "org.example:example-api-empty:3.0.0",
+		Name:         "org.example:example-api-empty",
+		Version:      "3.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+
+	exampleApiRuntime = ftypes.Package{
+		ID:           "org.example:example-api-runtime:3.0.0",
+		Name:         "org.example:example-api-runtime",
+		Version:      "3.0.0",
+		Relationship: ftypes.RelationshipIndirect,
+	}
+)
+
 func TestPom_Parse(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1628,6 +1722,220 @@ func TestPom_Parse(t *testing.T) {
 					DependsOn: []string{
 						"org.example:example-api2:1.0.2",
 						"org.example:example-api:1.0.1",
+					},
+				},
+			},
+		},
+		// [INFO] com.example:inherit-scopes-in-child-deps:jar:1.0.0
+		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
+		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
+		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:test
+		// [INFO] +- org.example:example-nested-scope-compile:jar:1.0.0:compile
+		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:runtime
+		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:test
+		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:compile
+		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:runtime
+		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:test
+		//
+		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes
+		{
+			name:      "inherit scopes from child dependencies and their parents",
+			inputFile: filepath.Join("testdata", "inherit-scopes-from-child-deps-and-their-parents", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:inherit-scopes-from-child-deps-and-their-parents:0.0.1",
+					Name:         "com.example:inherit-scopes-from-child-deps-and-their-parents",
+					Version:      "0.0.1",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				exampleNestedScopeCompile(16, 21),
+				exampleNestedScopeEmpty(22, 26),
+				exampleNestedScopeRuntime(10, 15),
+				exampleApiCompile,
+				exampleApiEmpty,
+				exampleApiRuntime,
+				exampleScopeCompile,
+				exampleScopeEmpty,
+				exampleScopeRuntime,
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					DependsOn: []string{
+						"org.example:example-nested-scope-compile:1.0.0",
+						"org.example:example-nested-scope-empty:1.0.0",
+						"org.example:example-nested-scope-runtime:1.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-compile:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-compile:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-empty:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-empty:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-runtime:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-runtime:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-scope-compile:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api-compile:3.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-scope-empty:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api-empty:3.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-scope-runtime:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api-runtime:3.0.0",
+					},
+				},
+			},
+		},
+		// [INFO] com.example:inherit-scopes-in-children-from-root:jar:0.0.1
+		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
+		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
+		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:runtime
+		// [INFO] +- org.example:example-nested-scope-compile:jar:1.0.0:compile
+		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:runtime
+		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:test
+		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:compile
+		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:runtime
+		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:test
+		//
+		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes
+		// scopes from `dependencyManagement` of root pom are used
+		{
+			name:      "inherit scopes in children from root pom",
+			inputFile: filepath.Join("testdata", "inherit-scopes-in-children-from-root", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:inherit-scopes-in-children-from-root:0.0.1",
+					Name:         "com.example:inherit-scopes-in-children-from-root",
+					Version:      "0.0.1",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				exampleNestedScopeCompile(51, 56),
+				exampleNestedScopeEmpty(57, 61),
+				exampleNestedScopeRuntime(45, 50),
+				exampleApiRuntime,
+				exampleScopeCompile,
+				exampleScopeEmpty,
+				exampleScopeRuntime,
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					DependsOn: []string{
+						"org.example:example-nested-scope-compile:1.0.0",
+						"org.example:example-nested-scope-empty:1.0.0",
+						"org.example:example-nested-scope-runtime:1.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-compile:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-compile:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-empty:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-empty:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-runtime:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-runtime:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-scope-runtime:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api-runtime:3.0.0",
+					},
+				},
+			},
+		},
+		// [INFO] com.example:inherit-scopes-in-parents-of-children-from-root:jar:0.1.0
+		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
+		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
+		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:runtime
+		// [INFO] +- org.example:example-nested-scope-compile:jar:1.0.0:compile
+		// [INFO] |  \- org.example:example-scope-compile:jar:2.0.0:runtime
+		// [INFO] |     \- org.example:example-api-compile:jar:3.0.0:test
+		// [INFO] \- org.example:example-nested-scope-empty:jar:1.0.0:compile
+		// [INFO]    \- org.example:example-scope-empty:jar:2.0.0:runtime
+		// [INFO]       \- org.example:example-api-empty:jar:3.0.0:test
+		//
+		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes
+		// scopes from `dependencyManagement` of root pom are used in parent dependencies
+		{
+			name:      "inherit scopes in children from root pom",
+			inputFile: filepath.Join("testdata", "inherit-scopes-in-parents-of-children-from-root", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:inherit-scopes-in-parents-of-children-from-root:0.1.0",
+					Name:         "com.example:inherit-scopes-in-parents-of-children-from-root",
+					Version:      "0.1.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				exampleNestedScopeCompile(0, 0),
+				exampleNestedScopeEmpty(0, 0),
+				exampleNestedScopeRuntime(0, 0),
+				exampleApiRuntime,
+				exampleScopeCompile,
+				exampleScopeEmpty,
+				exampleScopeRuntime,
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					DependsOn: []string{
+						"org.example:example-nested-scope-compile:1.0.0",
+						"org.example:example-nested-scope-empty:1.0.0",
+						"org.example:example-nested-scope-runtime:1.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-compile:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-compile:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-empty:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-empty:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-nested-scope-runtime:1.0.0",
+					DependsOn: []string{
+						"org.example:example-scope-runtime:2.0.0",
+					},
+				},
+				{
+					ID: "org.example:example-scope-runtime:2.0.0",
+					DependsOn: []string{
+						"org.example:example-api-runtime:3.0.0",
 					},
 				},
 			},

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1761,7 +1761,7 @@ func TestPom_Parse(t *testing.T) {
 			},
 			wantDeps: []ftypes.Dependency{
 				{
-					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					ID: "com.example:inherit-scopes-from-child-deps-and-their-parents:0.0.1",
 					DependsOn: []string{
 						"org.example:example-nested-scope-compile:1.0.0",
 						"org.example:example-nested-scope-empty:1.0.0",
@@ -1840,7 +1840,7 @@ func TestPom_Parse(t *testing.T) {
 			},
 			wantDeps: []ftypes.Dependency{
 				{
-					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					ID: "com.example:inherit-scopes-in-children-from-root:0.0.1",
 					DependsOn: []string{
 						"org.example:example-nested-scope-compile:1.0.0",
 						"org.example:example-nested-scope-empty:1.0.0",
@@ -1908,7 +1908,7 @@ func TestPom_Parse(t *testing.T) {
 			},
 			wantDeps: []ftypes.Dependency{
 				{
-					ID: "com.example:inherit-scopes-for-child-deps-and-parents:0.0.1",
+					ID: "com.example:inherit-scopes-in-parents-from-root:0.1.0",
 					DependsOn: []string{
 						"org.example:example-nested-scope-compile:1.0.0",
 						"org.example:example-nested-scope-empty:1.0.0",

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1691,7 +1691,8 @@ func TestPom_Parse(t *testing.T) {
 		},
 		// [INFO] com.example:child-depManagement-in-parent:jar:1.0.0
 		// [INFO] +- org.example:example-api:jar:1.0.1:compile
-		// [INFO] \- org.example:example-api2:jar:1.0.2:runtime
+		// [INFO] +- org.example:example-api2:jar:1.0.2:runtime
+		// [INFO] \- org.example:example-api3:jar:4.0.3:compile
 		{
 			name:      "dependency from parent uses version from child(scanned) pom depManagement",
 			inputFile: filepath.Join("testdata", "use-child-dep-management-in-parent", "pom.xml"),
@@ -1715,12 +1716,19 @@ func TestPom_Parse(t *testing.T) {
 					Version:      "1.0.2",
 					Relationship: ftypes.RelationshipDirect,
 				},
+				{
+					ID:           "org.example:example-api3:4.0.3",
+					Name:         "org.example:example-api3",
+					Version:      "4.0.3",
+					Relationship: ftypes.RelationshipDirect,
+				},
 			},
 			wantDeps: []ftypes.Dependency{
 				{
 					ID: "com.example:child-depManagement-in-parent:1.0.0",
 					DependsOn: []string{
 						"org.example:example-api2:1.0.2",
+						"org.example:example-api3:4.0.3",
 						"org.example:example-api:1.0.1",
 					},
 				},
@@ -1898,11 +1906,9 @@ func TestPom_Parse(t *testing.T) {
 					Relationship: ftypes.RelationshipRoot,
 				},
 				exampleNestedScopeCompile(0, 0),
-				exampleNestedScopeEmpty(0, 0),
 				exampleNestedScopeRuntime(0, 0),
 				exampleApiRuntime,
 				exampleScopeCompile,
-				exampleScopeEmpty,
 				exampleScopeRuntime,
 			},
 			wantDeps: []ftypes.Dependency{
@@ -1910,7 +1916,6 @@ func TestPom_Parse(t *testing.T) {
 					ID: "com.example:inherit-scopes-in-parents-from-root:0.1.0",
 					DependsOn: []string{
 						"org.example:example-nested-scope-compile:1.0.0",
-						"org.example:example-nested-scope-empty:1.0.0",
 						"org.example:example-nested-scope-runtime:1.0.0",
 					},
 				},
@@ -1918,12 +1923,6 @@ func TestPom_Parse(t *testing.T) {
 					ID: "org.example:example-nested-scope-compile:1.0.0",
 					DependsOn: []string{
 						"org.example:example-scope-compile:2.0.0",
-					},
-				},
-				{
-					ID: "org.example:example-nested-scope-empty:1.0.0",
-					DependsOn: []string{
-						"org.example:example-scope-empty:2.0.0",
 					},
 				},
 				{

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1873,7 +1873,8 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
-		// [INFO] com.example:inherit-scopes-in-parents-of-children-from-root:jar:0.1.0
+		// [INFO] --- dependency:3.7.0:tree (default-cli) @ inherit-scopes-in-parents-from-root ---
+		// [INFO] com.example:inherit-scopes-in-parents-from-root:jar:0.1.0
 		// [INFO] +- org.example:example-nested-scope-runtime:jar:1.0.0:runtime
 		// [INFO] |  \- org.example:example-scope-runtime:jar:2.0.0:compile
 		// [INFO] |     \- org.example:example-api-runtime:jar:3.0.0:runtime
@@ -1887,13 +1888,13 @@ func TestPom_Parse(t *testing.T) {
 		// `example-nested-*" dependencies and their parents contain `dependencyManagement` with changed scopes
 		// scopes from `dependencyManagement` of root pom are used in parent dependencies
 		{
-			name:      "inherit scopes in children from root pom",
-			inputFile: filepath.Join("testdata", "inherit-scopes-in-parents-of-children-from-root", "pom.xml"),
+			name:      "inherit scopes in parent from root pom",
+			inputFile: filepath.Join("testdata", "inherit-scopes-in-parents-from-root", "pom.xml"),
 			local:     true,
 			want: []ftypes.Package{
 				{
-					ID:           "com.example:inherit-scopes-in-parents-of-children-from-root:0.1.0",
-					Name:         "com.example:inherit-scopes-in-parents-of-children-from-root",
+					ID:           "com.example:inherit-scopes-in-parents-from-root:0.1.0",
+					Name:         "com.example:inherit-scopes-in-parents-from-root",
 					Version:      "0.1.0",
 					Relationship: ftypes.RelationshipRoot,
 				},

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -239,10 +239,10 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 	// If this dependency is managed in the root POM,
 	// we need to overwrite fields according to the managed dependency.
 	if managed, found := findDep(d.Name(), rootDepManagement); found { // dependencyManagement from the root POM
-		if managed.Version != "" {
-			dep.Version = evaluateVariable(managed.Version, props, nil)
-		}
-		if managed.Scope != "" {
+		// We always need to use version from root POM
+		dep.Version = evaluateVariable(managed.Version, props, nil)
+
+		if managed.Scope == "" {
 			dep.Scope = evaluateVariable(managed.Scope, props, nil)
 		}
 		if managed.Optional {

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -239,12 +239,10 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 	// If this dependency is managed in the root POM,
 	// we need to overwrite fields according to the managed dependency.
 	if managed, found := findDep(d.Name(), rootDepManagement); found { // dependencyManagement from the root POM
-		// We always need to use version from root POM
+		// We always need to use version and scope from root POM
 		dep.Version = evaluateVariable(managed.Version, props, nil)
+		dep.Scope = evaluateVariable(managed.Scope, props, nil)
 
-		if managed.Scope == "" {
-			dep.Scope = evaluateVariable(managed.Scope, props, nil)
-		}
 		if managed.Optional {
 			dep.Optional = managed.Optional
 		}

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -23,11 +23,14 @@ type pom struct {
 	content  *pomXML
 }
 
-func (p *pom) inherit(result analysisResult) {
+func (p *pom) inherit(parent *pom) {
+	if parent == nil {
+		return
+	}
 	// Merge properties
-	p.content.Properties = utils.MergeMaps(result.properties, p.content.Properties)
+	p.content.Properties = utils.MergeMaps(parent.properties(), p.content.Properties)
 
-	art := p.artifact().Inherit(result.artifact)
+	art := p.artifact().Inherit(parent.artifact())
 
 	p.content.GroupId = art.GroupID
 	p.content.ArtifactId = art.ArtifactID
@@ -289,7 +292,7 @@ func (d pomDependency) ToArtifact(opts analysisOptions) artifact {
 	}
 
 	var locations ftypes.Locations
-	if opts.lineNumber {
+	if d.StartLine != 0 && d.EndLine != 0 {
 		locations = ftypes.Locations{
 			{
 				StartLine: d.StartLine,

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -239,9 +239,13 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 	// If this dependency is managed in the root POM,
 	// we need to overwrite fields according to the managed dependency.
 	if managed, found := findDep(d.Name(), rootDepManagement); found { // dependencyManagement from the root POM
-		// We always need to use version and scope from root POM
-		dep.Version = evaluateVariable(managed.Version, props, nil)
-		dep.Scope = evaluateVariable(managed.Scope, props, nil)
+		if managed.Version != "" {
+			dep.Version = evaluateVariable(managed.Version, props, nil)
+		}
+
+		if managed.Scope != "" {
+			dep.Scope = evaluateVariable(managed.Scope, props, nil)
+		}
 
 		if managed.Optional {
 			dep.Optional = managed.Optional

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -23,6 +23,10 @@ type pom struct {
 	content  *pomXML
 }
 
+func (p *pom) nil() bool {
+	return p == nil || p.content == nil
+}
+
 func (p *pom) inherit(parent *pom) {
 	if parent == nil {
 		return
@@ -43,12 +47,12 @@ func (p *pom) inherit(parent *pom) {
 	}
 }
 
-func (p pom) properties() properties {
+func (p *pom) properties() properties {
 	props := p.content.Properties
 	return utils.MergeMaps(props, p.projectProperties())
 }
 
-func (p pom) projectProperties() map[string]string {
+func (p *pom) projectProperties() map[string]string {
 	val := reflect.ValueOf(p.content).Elem()
 	props := p.listProperties(val)
 
@@ -76,7 +80,7 @@ func (p pom) projectProperties() map[string]string {
 	return projectProperties
 }
 
-func (p pom) listProperties(val reflect.Value) map[string]string {
+func (p *pom) listProperties(val reflect.Value) map[string]string {
 	props := make(map[string]string)
 	for i := 0; i < val.NumField(); i++ {
 		f := val.Type().Field(i)
@@ -109,17 +113,17 @@ func (p pom) listProperties(val reflect.Value) map[string]string {
 	return props
 }
 
-func (p pom) artifact() artifact {
+func (p *pom) artifact() artifact {
 	return newArtifact(p.content.GroupId, p.content.ArtifactId, p.content.Version, p.licenses(), p.content.Properties)
 }
 
-func (p pom) licenses() []string {
+func (p *pom) licenses() []string {
 	return slices.ZeroToNil(lo.FilterMap(p.content.Licenses.License, func(lic pomLicense, _ int) (string, bool) {
 		return lic.Name, lic.Name != ""
 	}))
 }
 
-func (p pom) repositories(servers []Server) ([]string, []string) {
+func (p *pom) repositories(servers []Server) ([]string, []string) {
 	logger := log.WithPrefix("pom")
 	var releaseRepos, snapshotRepos []string
 	for _, rep := range p.content.Repositories.Repository {

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-from-child-deps-and-their-parents/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-from-child-deps-and-their-parents/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>inherit-scopes-from-child-deps-and-their-parents</artifactId>
+    <version>0.0.1</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-runtime</artifactId>
+            <version>1.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-compile</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-empty</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-children-from-root/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-children-from-root/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>inherit-scopes-in-children-from-root</artifactId>
+    <version>0.0.1</version>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-runtime</artifactId>
+                <version>2.0.0</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-compile</artifactId>
+                <version>2.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-compile</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-empty</artifactId>
+                <version>2.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-empty</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-runtime</artifactId>
+            <version>1.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-compile</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-empty</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/parent/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
-    <artifactId>inherit-scopes-in-parents-of-children-from-root-parent</artifactId>
+    <artifactId>inherit-scopes-in-parents-from-root-parent</artifactId>
     <version>0.0.1</version>
     <packaging>pom</packaging>
 

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/parent/pom.xml
@@ -31,13 +31,25 @@
                 <groupId>org.example</groupId>
                 <artifactId>example-scope-empty</artifactId>
                 <version>2.0.0</version>
-                <scope>runtime</scope>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.example</groupId>
                 <artifactId>example-api-empty</artifactId>
                 <version>3.0.0</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested-scope-compile</artifactId>
+                <version>1.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested-scope-empty</artifactId>
+                <version>1.0.0</version>
+                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.example</groupId>
-    <artifactId>inherit-scopes-in-parents-of-children-from-root</artifactId>
+    <artifactId>inherit-scopes-in-parents-from-root</artifactId>
     <version>0.1.0</version>
 
     <parent>
         <groupId>com.example</groupId>
-        <artifactId>inherit-scopes-in-parents-of-children-from-root-parent</artifactId>
+        <artifactId>inherit-scopes-in-parents-from-root-parent</artifactId>
         <version>0.0.1</version>
         <relativePath>./parent</relativePath>
     </parent>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-from-root/pom.xml
@@ -13,4 +13,27 @@
         <relativePath>./parent</relativePath>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested-scope-runtime</artifactId>
+                <version>1.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested-scope-compile</artifactId>
+                <version>1.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-nested-scope-empty</artifactId>
+                <version>1.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-of-children-from-root/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-of-children-from-root/parent/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>inherit-scopes-in-parents-of-children-from-root-parent</artifactId>
+    <version>0.0.1</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-runtime</artifactId>
+                <version>2.0.0</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-compile</artifactId>
+                <version>2.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-compile</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-empty</artifactId>
+                <version>2.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-empty</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-runtime</artifactId>
+            <version>1.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-compile</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-nested-scope-empty</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-of-children-from-root/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/inherit-scopes-in-parents-of-children-from-root/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>inherit-scopes-in-parents-of-children-from-root</artifactId>
+    <version>0.1.0</version>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>inherit-scopes-in-parents-of-children-from-root-parent</artifactId>
+        <version>0.0.1</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-compile/1.0.0/example-nested-scope-compile-1.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-compile/1.0.0/example-nested-scope-compile-1.0.0.pom
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-nested-parent-scope-compile</artifactId>
+        <version>1.0.1</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-nested-scope-compile</artifactId>
+    <version>1.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-scope-compile 2.0.0</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-compile</artifactId>
+                <version>3.0.0</version>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-scope-compile</artifactId>
+            <version>2.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-compile/1.0.0/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-compile/1.0.0/parent/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example-nested-parent-scope-compile</artifactId>
+    <version>1.0.1</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-compile</artifactId>
+                <version>2.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-empty/1.0.0/example-nested-scope-empty-1.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-empty/1.0.0/example-nested-scope-empty-1.0.0.pom
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-nested-parent-scope-empty</artifactId>
+        <version>1.0.1</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-nested-scope-empty</artifactId>
+    <version>1.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-scope-empty 2.0.0</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-empty</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-scope-empty</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-empty/1.0.0/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-empty/1.0.0/parent/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example-nested-parent-scope-empty</artifactId>
+    <version>1.0.1</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-empty</artifactId>
+                <version>2.0.0</version>
+                <scope>compile</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-runtime/1.0.0/example-nested-scope-runtime-1.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-runtime/1.0.0/example-nested-scope-runtime-1.0.0.pom
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>example-nested-parent-scope-runtime</artifactId>
+        <version>1.0.1</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-nested-scope-runtime</artifactId>
+    <version>1.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-scope-runtime 2.0.0</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api-runtime</artifactId>
+                <version>3.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-scope-runtime</artifactId>
+            <version>2.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-runtime/1.0.0/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-nested-scope-runtime/1.0.0/parent/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example-nested-parent-scope-runtime</artifactId>
+    <version>1.0.1</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-scope-runtime</artifactId>
+                <version>2.0.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-compile/2.0.0/example-scope-compile-2.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-compile/2.0.0/example-scope-compile-2.0.0.pom
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-scope-compile</artifactId>
+    <version>2.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-api-compile 3.0.0</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api-compile</artifactId>
+            <version>3.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-empty/2.0.0/example-scope-empty-2.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-empty/2.0.0/example-scope-empty-2.0.0.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-scope-empty</artifactId>
+    <version>2.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-api-empty 3.0.0</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api-empty</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-runtime/2.0.0/example-scope-runtime-2.0.0.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-scope-runtime/2.0.0/example-scope-runtime-2.0.0.pom
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-scope-runtime</artifactId>
+    <version>2.0.0</version>
+
+    <packaging>jar</packaging>
+    <description>Example pom with example-api-runtime 3.0.0</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api-runtime</artifactId>
+            <version>3.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/transitive-parents/base/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/transitive-parents/base/pom.xml
@@ -13,7 +13,7 @@
         <groupId>com.example</groupId>
         <artifactId>parent</artifactId>
         <version>3.0.0</version>
-        <relativePath>../parent</relativePath>
+        <relativePath>../</relativePath>
     </parent>
 
     <licenses>

--- a/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/parent/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-parent</artifactId>
+    <version>4.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <api.version>4.0.1</api.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>${api.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api2</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/parent/pom.xml
@@ -24,5 +24,11 @@
             <groupId>org.example</groupId>
             <artifactId>example-api2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api3</artifactId>
+            <version>4.0.3</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.example</groupId>
+        <artifactId>example-parent</artifactId>
+        <version>4.0.0</version>
+        <relativePath>./parent/pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>child-depManagement-in-parent</artifactId>
+    <version>1.0.0</version>
+
+
+    <properties>
+        <api.version>1.0.1</api.version>
+        <api2.version>1.0.2</api2.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api</artifactId>
+                <version>${api.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api2</artifactId>
+                <version>${api2.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <api.version>1.0.1</api.version>
         <api2.version>1.0.2</api2.version>
+        <api3.version>1.0.3</api3.version>
     </properties>
 
     <dependencyManagement>
@@ -31,6 +32,12 @@
                 <groupId>org.example</groupId>
                 <artifactId>example-api2</artifactId>
                 <version>${api2.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api3</artifactId>
+                <version>${api3.version}</version>
                 <scope>runtime</scope>
             </dependency>
         </dependencies>

--- a/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/top-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/use-child-dep-management-in-parent/top-parent/pom.xml
@@ -4,22 +4,22 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.example</groupId>
-        <artifactId>example-top-parent</artifactId>
-        <version>5.0.0</version>
-        <relativePath>../top-parent/pom.xml</relativePath>
-    </parent>
-
     <groupId>org.example</groupId>
-    <artifactId>example-parent</artifactId>
-    <version>4.0.0</version>
+    <artifactId>example-top-parent</artifactId>
+    <version>5.0.0</version>
     <packaging>pom</packaging>
 
     <properties>
-        <api.version>4.0.1</api.version>
+        <api.version>5.0.1</api.version>
     </properties>
+
     <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>${api.version}</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.example</groupId>
             <artifactId>example-api2</artifactId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.example</groupId>
             <artifactId>example-api3</artifactId>
-            <version>4.0.3</version>
+            <version>5.0.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Description
Forward `dependencyManagement` and `Properties` field  from root/upper POM into parents.
`dependencyManagement` should be used as non-root dependencyManagement

See new test for more details.

## Related issues
- Close #7539

## Related PRs
- [x] #7521

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
