### PR TITLE
perf(misconf): use port ranges instead of enumeration

### DIFF
--- a/pkg/iac/adapters/terraform/google/compute/adapt_test.go
+++ b/pkg/iac/adapters/terraform/google/compute/adapt_test.go
@@ -184,8 +184,8 @@ func TestLines(t *testing.T) {
 	assert.Equal(t, 59, network.Firewall.IngressRules[0].Protocol.GetMetadata().Range().GetStartLine())
 	assert.Equal(t, 59, network.Firewall.IngressRules[0].Protocol.GetMetadata().Range().GetEndLine())
 
-	assert.Equal(t, 60, network.Firewall.IngressRules[0].Ports[0].GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 60, network.Firewall.IngressRules[0].Ports[0].GetMetadata().Range().GetEndLine())
+	assert.Equal(t, 60, network.Firewall.IngressRules[0].Ports[0].Metadata.Range().GetStartLine())
+	assert.Equal(t, 60, network.Firewall.IngressRules[0].Ports[0].Metadata.Range().GetEndLine())
 
 	assert.Equal(t, 64, network.Subnetworks[0].Metadata.Range().GetStartLine())
 	assert.Equal(t, 72, network.Subnetworks[0].Metadata.Range().GetEndLine())

--- a/pkg/iac/adapters/terraform/google/compute/networks_test.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks_test.go
@@ -39,7 +39,7 @@ func Test_adaptNetworks(t *testing.T) {
 				source_ranges = ["1.2.3.4/32"]
 				allow {
 				  protocol = "icmp"
-				  ports     = ["80", "8080"]
+				  ports     = ["80", "8080", "9090-9095"]
 				}
 			  }
 `,
@@ -57,9 +57,19 @@ func Test_adaptNetworks(t *testing.T) {
 									IsAllow:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 									Protocol: iacTypes.String("icmp", iacTypes.NewTestMetadata()),
 									Enforced: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-									Ports: []iacTypes.IntValue{
-										iacTypes.Int(80, iacTypes.NewTestMetadata()),
-										iacTypes.Int(8080, iacTypes.NewTestMetadata()),
+									Ports: []compute.PortRange{
+										{
+											Start: iacTypes.IntTest(80),
+											End:   iacTypes.IntTest(80),
+										},
+										{
+											Start: iacTypes.IntTest(8080),
+											End:   iacTypes.IntTest(8080),
+										},
+										{
+											Start: iacTypes.IntTest(9090),
+											End:   iacTypes.IntTest(9095),
+										},
 									},
 								},
 								SourceRanges: []iacTypes.StringValue{

--- a/pkg/iac/providers/google/compute/firewall.go
+++ b/pkg/iac/providers/google/compute/firewall.go
@@ -18,7 +18,13 @@ type FirewallRule struct {
 	Enforced iacTypes.BoolValue
 	IsAllow  iacTypes.BoolValue
 	Protocol iacTypes.StringValue
-	Ports    []iacTypes.IntValue
+	Ports    []PortRange
+}
+
+type PortRange struct {
+	Metadata iacTypes.Metadata
+	Start    iacTypes.IntValue
+	End      iacTypes.IntValue
 }
 
 type IngressRule struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -1615,9 +1615,17 @@
             "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
           }
         },
+        "fromport": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+        },
         "protocol": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "toport": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         },
         "type": {
           "type": "object",
@@ -1677,6 +1685,18 @@
         "description": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "fromport": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+        },
+        "protocol": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "toport": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         }
       }
     },
@@ -6086,7 +6106,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.PortRange"
           }
         },
         "protocol": {
@@ -6215,6 +6235,23 @@
         "subnetwork": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.SubNetwork"
+        }
+      }
+    },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.PortRange": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "end": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+        },
+        "start": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         }
       }
     },


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7548

Before
```bash
        5.52 real         8.00 user         0.36 sys
          2330689536  maximum resident set size
```

After
```bash
        2.81 real         0.78 user         0.09 sys
           171065344  maximum resident set size
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
