### PR TITLE
feat(sbom): keep internal uuid to identify components

### DIFF
--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+
+	"github.com/aquasecurity/trivy/pkg/uuid"
 )
 
 type OS struct {
@@ -13,6 +15,10 @@ type OS struct {
 
 	// This field is used for enhanced security maintenance programs such as Ubuntu ESM, Debian Extended LTS.
 	Extended bool `json:"extended,omitempty"`
+
+	// ComponentID is used for internal representation of the SBOM component.
+	// It is not exported to the JSON output.
+	ComponentID uuid.UUID `json:"-"`
 }
 
 func (o *OS) Detected() bool {
@@ -72,6 +78,10 @@ type Application struct {
 
 	// Packages is a list of lang-specific packages
 	Packages Packages
+
+	// ComponentID is used for internal representation of the SBOM component.
+	// It is not exported to the JSON output.
+	ComponentID uuid.UUID `json:"-"`
 }
 
 type File struct {

--- a/pkg/fanal/types/package.go
+++ b/pkg/fanal/types/package.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/digest"
+	"github.com/aquasecurity/trivy/pkg/uuid"
 )
 
 type Relationship int
@@ -213,6 +214,10 @@ type Package struct {
 
 	// Files installed by the package
 	InstalledFiles []string `json:",omitempty"`
+
+	// ComponentID is used for internal representation of the SBOM component.
+	// It is not exported to the JSON output.
+	ComponentID uuid.UUID `json:"-"`
 }
 
 func (pkg *Package) Empty() bool {

--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -290,6 +290,17 @@ func (b *BOM) Root() *Component {
 	return root
 }
 
+func (b *BOM) Component(id uuid.UUID) *Component {
+	c, ok := b.components[id]
+	if !ok {
+		return nil
+	}
+	if b.opts.GenerateBOMRef && c.PkgIdentifier.BOMRef == "" {
+		c.PkgIdentifier.BOMRef = b.bomRef(c)
+	}
+	return c
+}
+
 func (b *BOM) Components() map[uuid.UUID]*Component {
 	// Fill in BOMRefs for components
 	if b.opts.GenerateBOMRef {

--- a/pkg/sbom/io/decode.go
+++ b/pkg/sbom/io/decode.go
@@ -124,8 +124,9 @@ func (m *Decoder) decodeComponents(ctx context.Context, sbom *types.SBOM) error 
 			}
 			m.osID = id
 			sbom.Metadata.OS = &ftypes.OS{
-				Family: ftypes.OSType(c.Name),
-				Name:   c.Version,
+				Family:      ftypes.OSType(c.Name),
+				Name:        c.Version,
+				ComponentID: id,
 			}
 			continue
 		case core.TypeApplication:
@@ -169,7 +170,9 @@ func (m *Decoder) buildDependencyGraph() {
 }
 
 func (m *Decoder) decodeApplication(c *core.Component) *ftypes.Application {
-	var app ftypes.Application
+	app := ftypes.Application{
+		ComponentID: c.ID(),
+	}
 	for _, prop := range c.Properties {
 		if prop.Name == core.PropertyType {
 			app.Type = ftypes.LangType(prop.Value)
@@ -229,6 +232,7 @@ func (m *Decoder) decodePackage(ctx context.Context, c *core.Component) (*ftypes
 
 	pkg.Identifier.BOMRef = c.PkgIdentifier.BOMRef
 	pkg.Licenses = c.Licenses
+	pkg.ComponentID = c.ID()
 
 	for _, f := range c.Files {
 		if f.Path != "" && pkg.FilePath == "" {

--- a/pkg/scanner/langpkg/scan.go
+++ b/pkg/scanner/langpkg/scan.go
@@ -49,9 +49,10 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.
 
 		ctx = log.WithContextPrefix(ctx, string(app.Type))
 		result := types.Result{
-			Target: targetName(app.Type, app.FilePath),
-			Class:  types.ClassLangPkg,
-			Type:   app.Type,
+			Target:      targetName(app.Type, app.FilePath),
+			Class:       types.ClassLangPkg,
+			Type:        app.Type,
+			ComponentID: app.ComponentID,
 		}
 
 		sort.Sort(app.Packages)

--- a/pkg/scanner/ospkg/scan.go
+++ b/pkg/scanner/ospkg/scan.go
@@ -37,9 +37,10 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.
 	}
 
 	result := types.Result{
-		Target: fmt.Sprintf("%s (%s %s)", target.Name, target.OS.Family, target.OS.Name),
-		Class:  types.ClassOSPkg,
-		Type:   target.OS.Family,
+		Target:      fmt.Sprintf("%s (%s %s)", target.Name, target.OS.Family, target.OS.Name),
+		Class:       types.ClassOSPkg,
+		Type:        target.OS.Family,
+		ComponentID: target.OS.ComponentID,
 	}
 
 	sort.Sort(target.Packages)

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
+	"github.com/aquasecurity/trivy/pkg/uuid"
 )
 
 // Report represents a scan result
@@ -122,6 +123,10 @@ type Result struct {
 	// This can include vulnerabilities that have been marked as ignored, not affected, or have had
 	// their severity adjusted. It's still in an experimental stage and may change in the future.
 	ModifiedFindings []ModifiedFinding `json:"ExperimentalModifiedFindings,omitempty"`
+
+	// ComponentID is used for internal representation of the SBOM component.
+	// It is not exported to the JSON output.
+	ComponentID uuid.UUID `json:"-"`
 }
 
 func (r *Result) IsEmpty() bool {


### PR DESCRIPTION
## Description
There is no guarantee that [this approach](https://github.com/aquasecurity/trivy/pull/7340) will reliably identify identical components. In the current implementation, it is [possible](https://github.com/aquasecurity/trivy/discussions/7532
) for multiple components to have the same name and type.

To prevent this, I [used BOM-Ref](https://github.com/aquasecurity/trivy/pull/7340/commits/418100c2f525773e95193a6e1f8b32b4d12bfe7b) in CycloneDX using the BOM-Ref, but it does not work in SPDX, and furthermore, the BOM-Ref is [optional](https://github.com/aquasecurity/trivy/pull/7340#discussion_r1760553931) and may not exist.

Currently, [intermediate BOMs](https://github.com/aquasecurity/trivy/pull/6240) are used internally to abstract multiple SBOM implementations, and each component is assigned [a UUID](https://github.com/aquasecurity/trivy/blob/5dd94ebc1ffe3f1df511dee6381f92a5daefadf2/pkg/sbom/core/bom.go#L83-L85). This ensures that the same component can be reused.

## Related PRs
- #7340

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
