### PR TITLE
fix(misconf): escape all special sequences

### DIFF
--- a/pkg/iac/terraform/resource_block_test.go
+++ b/pkg/iac/terraform/resource_block_test.go
@@ -1,0 +1,62 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_EscapeSpecialSequences(t *testing.T) {
+	tests := []struct {
+		name     string
+		inp      string
+		expected string
+	}{
+		{
+			name:     "without special sequences",
+			inp:      `"hello world\\"`,
+			expected: `"hello world\\"`,
+		},
+		{
+			name:     "interpolation",
+			inp:      `"Hello, ${var.name}!"`,
+			expected: `"Hello, $${var.name}!"`,
+		},
+		{
+			name:     "directive",
+			inp:      `"Hello, %{ if true }foo%{ else }bar%{ endif }!"`,
+			expected: `"Hello, %%{ if true }foo%%{ else }bar%%{ endif }!"`,
+		},
+		{
+			name:     "interpolation already escaped",
+			inp:      `"Hello, $${var.name}!"`,
+			expected: `"Hello, $${var.name}!"`,
+		},
+		{
+			name:     "start with special character",
+			inp:      `${var.name}!"`,
+			expected: `$${var.name}!"`,
+		},
+		{
+			name:     "grok pattern",
+			inp:      "# Grok Pattern Template\ngrok_pattern = \"%{TIMESTAMP_ISO8601:time} \\\\[%{NUMBER:pid}\\\\] %{GREEDYDATA:message}\"",
+			expected: "# Grok Pattern Template\ngrok_pattern = \"%%{TIMESTAMP_ISO8601:time} \\\\[%%{NUMBER:pid}\\\\] %%{GREEDYDATA:message}\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeSpecialSequences(tt.inp)
+			assert.Equal(t, tt.expected, got)
+
+			// We make sure that the characters are properly escaped
+			_, diag := hclsyntax.ParseTemplate([]byte(got), "", hcl.InitialPos)
+			if diag.HasErrors() {
+				require.NoError(t, diag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7557

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
