### PR TITLE
fix(repo): `git clone` output to Stderr

### DIFF
--- a/pkg/fanal/artifact/repo/git.go
+++ b/pkg/fanal/artifact/repo/git.go
@@ -128,7 +128,7 @@ func cloneRepo(u *url.URL, artifactOpt artifact.Option) (string, error) {
 	cloneOptions := git.CloneOptions{
 		URL:             u.String(),
 		Auth:            gitAuth(),
-		Progress:        os.Stdout,
+		Progress:        os.Stderr,
 		InsecureSkipTLS: artifactOpt.Insecure,
 	}
 


### PR DESCRIPTION
## Description

This ensures that `git clone` output is directed to `os.Stderr` instead of `os.Stdout`.  Test added to demonstrate that stdout is empty after clone.

## Related issues
- Close #7547 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
