### PR TITLE
feat(misconf): ssl_mode support for GCP SQL DB instance

### DIFF
--- a/pkg/iac/adapters/terraform/google/sql/adapt.go
+++ b/pkg/iac/adapters/terraform/google/sql/adapt.go
@@ -52,6 +52,7 @@ func adaptInstance(resource *terraform.Block) sql.DatabaseInstance {
 			IPConfiguration: sql.IPConfiguration{
 				Metadata:           resource.GetMetadata(),
 				RequireTLS:         iacTypes.BoolDefault(false, resource.GetMetadata()),
+				SSLMode:            iacTypes.String("", resource.GetMetadata()),
 				EnableIPv4:         iacTypes.BoolDefault(true, resource.GetMetadata()),
 				AuthorizedNetworks: nil,
 			},
@@ -125,12 +126,6 @@ func adaptIPConfig(resource *terraform.Block) sql.IPConfiguration {
 		CIDR iacTypes.StringValue
 	}
 
-	tlsRequiredAttr := resource.GetAttribute("require_ssl")
-	tlsRequiredVal := tlsRequiredAttr.AsBoolValueOrDefault(false, resource)
-
-	ipv4enabledAttr := resource.GetAttribute("ipv4_enabled")
-	ipv4enabledVal := ipv4enabledAttr.AsBoolValueOrDefault(true, resource)
-
 	authNetworksBlocks := resource.GetBlocks("authorized_networks")
 	for _, authBlock := range authNetworksBlocks {
 		nameVal := authBlock.GetAttribute("name").AsStringValueOrDefault("", authBlock)
@@ -147,8 +142,9 @@ func adaptIPConfig(resource *terraform.Block) sql.IPConfiguration {
 
 	return sql.IPConfiguration{
 		Metadata:           resource.GetMetadata(),
-		RequireTLS:         tlsRequiredVal,
-		EnableIPv4:         ipv4enabledVal,
+		RequireTLS:         resource.GetAttribute("require_ssl").AsBoolValueOrDefault(false, resource),
+		SSLMode:            resource.GetAttribute("ssl_mode").AsStringValueOrDefault("", resource),
+		EnableIPv4:         resource.GetAttribute("ipv4_enabled").AsBoolValueOrDefault(true, resource),
 		AuthorizedNetworks: authorizedNetworks,
 	}
 }

--- a/pkg/iac/adapters/terraform/google/sql/adapt_test.go
+++ b/pkg/iac/adapters/terraform/google/sql/adapt_test.go
@@ -34,6 +34,7 @@ func Test_Adapt(t *testing.T) {
 							name            = "internal"
 						}
 						require_ssl = true
+						ssl_mode    = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
 					}
 				}
 			}
@@ -67,6 +68,7 @@ func Test_Adapt(t *testing.T) {
 								Metadata:   iacTypes.NewTestMetadata(),
 								RequireTLS: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 								EnableIPv4: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+								SSLMode:    iacTypes.StringTest("TRUSTED_CLIENT_CERTIFICATE_REQUIRED"),
 								AuthorizedNetworks: []struct {
 									Name iacTypes.StringValue
 									CIDR iacTypes.StringValue

--- a/pkg/iac/providers/google/sql/sql.go
+++ b/pkg/iac/providers/google/sql/sql.go
@@ -66,6 +66,7 @@ type Backups struct {
 type IPConfiguration struct {
 	Metadata           iacTypes.Metadata
 	RequireTLS         iacTypes.BoolValue
+	SSLMode            iacTypes.StringValue
 	EnableIPv4         iacTypes.BoolValue
 	AuthorizedNetworks []struct {
 		Name iacTypes.StringValue

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -6987,6 +6987,10 @@
         "requiretls": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "sslmode": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         }
       }
     },


### PR DESCRIPTION
## Description

This PR adds support for the ssl_mode attribute. The check will be fixed in trivy-checks.

## Related issues
- https://github.com/aquasecurity/trivy/issues/7565

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
