### PR TITLE
fix(misconf): change default ACL of digitalocean_spaces_bucket to private

### DIFF
--- a/pkg/iac/adapters/terraform/digitalocean/spaces/adapt.go
+++ b/pkg/iac/adapters/terraform/digitalocean/spaces/adapt.go
@@ -24,7 +24,7 @@ func adaptBuckets(modules terraform.Modules) []spaces.Bucket {
 				Metadata:     block.GetMetadata(),
 				Name:         block.GetAttribute("name").AsStringValueOrDefault("", block),
 				Objects:      nil,
-				ACL:          block.GetAttribute("acl").AsStringValueOrDefault("public-read", block),
+				ACL:          block.GetAttribute("acl").AsStringValueOrDefault("private", block),
 				ForceDestroy: block.GetAttribute("force_destroy").AsBoolValueOrDefault(false, block),
 				Versioning: spaces.Versioning{
 					Metadata: block.GetMetadata(),

--- a/pkg/iac/adapters/terraform/digitalocean/spaces/adapt_test.go
+++ b/pkg/iac/adapters/terraform/digitalocean/spaces/adapt_test.go
@@ -69,7 +69,7 @@ func Test_adaptBuckets(t *testing.T) {
 					Metadata:     iacTypes.NewTestMetadata(),
 					Name:         iacTypes.String("", iacTypes.NewTestMetadata()),
 					Objects:      nil,
-					ACL:          iacTypes.String("public-read", iacTypes.NewTestMetadata()),
+					ACL:          iacTypes.String("private", iacTypes.NewTestMetadata()),
 					ForceDestroy: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 					Versioning: spaces.Versioning{
 						Metadata: iacTypes.NewTestMetadata(),


### PR DESCRIPTION
## Description
The [acl](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket#acl) attribute of the `digitalocean_spaces_bucket` resource is [set](https://github.com/digitalocean/terraform-provider-digitalocean/blob/main/digitalocean/spaces/resource_spaces_bucket.go#L59) to `private` by default.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
