### PR TITLE
fix(misconf): check if property is not nil before conversion

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
@@ -338,6 +338,34 @@ Resources:
 				},
 			},
 		},
+		{
+			name: "empty",
+			source: `---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Godd example of excessive ports
+Resources: 
+  NetworkACL:
+    Type: AWS::EC2::NetworkAcl
+  Rule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId:
+        Ref: NetworkACL`,
+			expected: ec2.EC2{
+				NetworkACLs: []ec2.NetworkACL{
+					{
+						Rules: []ec2.NetworkACLRule{
+							{
+								Action:   types.StringTest("allow"),
+								Type:     types.StringTest("ingress"),
+								FromPort: types.IntTest(-1),
+								ToPort:   types.IntTest(-1),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/cloudformation/parser/property_conversion.go
+++ b/pkg/iac/scanners/cloudformation/parser/property_conversion.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (p *Property) IsConvertableTo(conversionType cftypes.CfType) bool {
+	if p.IsNil() {
+		return false
+	}
+
 	switch conversionType {
 	case cftypes.Int:
 		return p.isConvertableToInt()
@@ -62,6 +66,9 @@ func (p *Property) isConvertableToInt() bool {
 }
 
 func (p *Property) ConvertTo(conversionType cftypes.CfType) *Property {
+	if p.IsNil() {
+		return nil
+	}
 
 	if p.Type() == conversionType {
 		return p


### PR DESCRIPTION
## Description

This PR fixes the panic of trying to convert a property that is missing from the template.

Template:
```yaml
---
AWSTemplateFormatVersion: 2010-09-09
Description: Godd example of excessive ports
Resources: 
  NetworkACL:
    Type: AWS::EC2::NetworkAcl
  Rule:
    Type: AWS::EC2::NetworkAclEntry
    Properties:
      NetworkAclId:
        Ref: NetworkACL
```

Output:
```bash
trivy conf main.yaml
2024-09-23T23:28:45+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xe0 pc=0x10363f0c4]

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).Type(...)
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property.go:108
github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser.(*Property).ConvertTo(0x0, {0x1053ac0f7, 0x3})
        /home/runner/work/trivy/trivy/pkg/iac/scanners/cloudformation/parser/property_conversion.go:66 +0x24
github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation/aws/ec2.getRules({0x1400491f8e0, 0xa}, {{0x1400491f810, 0x9}, {0x140039bd080, 0xb, 0xb}, {0x1053addf7, 0x4}, {0x0, ...}, ...})
        /home/runner/work/trivy/trivy/pkg/iac/adapters/cloudformation/aws/ec2/nacl.go:68 +0x1638
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
