### PR TITLE
feat: add support for CoreOS RHEL flavor

### DIFF
--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
@@ -102,8 +102,10 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 					rhelVersion = "8.4"
 				} else if coreos4_7_0, _ := semver.Parse("4.7.0"); coreosVersion.GreaterThanOrEqual(coreos4_7_0) {
 					rhelVersion = "8.3"
-				} else {
+				} else if coreos4_6_0, _ := semver.Parse("4.6.0"); coreosVersion.GreaterThanOrEqual(coreos4_6_0) {
 					rhelVersion = "8.2"
+				} else {
+					return types.OS{}, xerrors.Errorf("coreos: invalid redhat-release")
 				}
 
 				return types.OS{

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase.go
@@ -77,7 +77,6 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 			}, nil
 		case "red hat enterprise linux coreos":
 			// https://access.redhat.com/articles/6907891
-			rhelVersion := "8.2"
 
 			var major, minor, rel int
 
@@ -92,6 +91,7 @@ func (a redhatOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 
 			coreosVersion, err := semver.Parse(fmt.Sprintf("%d.%d.%d", major, minor, rel))
 			if err == nil {
+				var rhelVersion string
 				if coreos4_16, _ := semver.Parse("4.16.0"); coreosVersion.GreaterThanOrEqual(coreos4_16) {
 					rhelVersion = "9.4"
 				} else if coreos4_13, _ := semver.Parse("4.13.0"); coreosVersion.GreaterThanOrEqual(coreos4_13) {

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
@@ -31,6 +31,18 @@ func Test_redhatOSAnalyzer_Analyze(t *testing.T) {
 			inputFile: "testdata/not_redhatbase/empty",
 			wantErr:   "redhatbase: unable to analyze OS information",
 		},
+		{
+			name:      "happy path coreos",
+			inputFile: "testdata/coreos/redhat-release",
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{Family: "redhat", Name: "9.4"},
+			},
+		},
+		{
+			name:      "sad path coreos",
+			inputFile: "testdata/coreos/invalid-redhat-release",
+			wantErr:   "coreos: invalid redhat-release",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/fanal/analyzer/os/redhatbase/testdata/coreos/invalid-redhat-release
+++ b/pkg/fanal/analyzer/os/redhatbase/testdata/coreos/invalid-redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux CoreOS release 2.3.0-12

--- a/pkg/fanal/analyzer/os/redhatbase/testdata/coreos/redhat-release
+++ b/pkg/fanal/analyzer/os/redhatbase/testdata/coreos/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux CoreOS release 4.16


### PR DESCRIPTION
## Description

CoreOS is based on RHEL but the parsing done for /etc/redhat-release reports the version of OpenShift instead of the version of RHEL, preventing vulnerability matching.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
