### PR TITLE
fix(db): check `DownloadedAt` for `trivy-java-db`

### DIFF
--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -93,7 +93,7 @@ func (u *Updater) isNewDB(meta db.Metadata) bool {
 	}
 
 	if now.Before(meta.DownloadedAt.Add(time.Hour * 24)) { // 1 day
-		log.Debug("Java DB update was skipped because the local Java DB was downloaded during the last hour")
+		log.Debug("Java DB update was skipped because the local Java DB was downloaded during the last day")
 		return true
 	}
 	return false

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -53,7 +53,7 @@ func (u *Updater) Update() error {
 		}
 	}
 
-	if (meta.Version != SchemaVersion || meta.NextUpdate.Before(time.Now().UTC())) && !u.skip {
+	if (meta.Version != SchemaVersion || !u.isNewDB(meta)) && !u.skip {
 		// Download DB
 		log.Info("Java DB Repository", log.Any("repository", u.repo))
 		log.Info("Downloading the Java DB...")
@@ -83,6 +83,20 @@ func (u *Updater) Update() error {
 	}
 
 	return nil
+}
+
+func (u *Updater) isNewDB(meta db.Metadata) bool {
+	now := time.Now().UTC()
+	if now.Before(meta.NextUpdate) {
+		log.Debug("Java DB update was skipped because the local Java DB is the latest")
+		return true
+	}
+
+	if now.Before(meta.DownloadedAt.Add(time.Hour * 24)) { // 1 day
+		log.Debug("Java DB update was skipped because the local Java DB was downloaded during the last hour")
+		return true
+	}
+	return false
 }
 
 func Init(cacheDir string, javaDBRepository name.Reference, skip, quiet bool, registryOption ftypes.RegistryOptions) {


### PR DESCRIPTION
## Description
in addition to checking `NextUpdate` - also check that `trivy-java-db` was downloaded more than one day ago (check `DownloadedAt` field).

## Related Discussions
- https://github.com/aquasecurity/trivy/discussions/7591#discussioncomment-10748187

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
