### PR TITLE
ci(test): cache test images for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,24 @@ jobs:
         with:
           aqua_version: v1.25.0
 
+      - name: Restore test images from cache
+        uses: actions/cache@v4
+        id: restore-test-images
+        with:
+          path: integration/testdata/fixtures/images
+          key: ${{ hashFiles('integration/testdata/fixtures/images/*') }}
+
+      - name: Download test images if cache is missing
+        if: steps.restore-test-images.outputs.cache-hit != 'true'
+        run: mage test:fixtureContainerImages
+
+      - name: Save test images into cache if cache is missing
+        if: steps.restore-test-images.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: integration/testdata/fixtures/images
+          key: ${{ hashFiles('integration/testdata/fixtures/images/*') }}
+
       - name: Run integration tests
         run: mage test:integration
 


### PR DESCRIPTION
## Description
We got a lot of `429` errors for the tests.
To avoid loading the test images on every run, we need to cache them.

## Related issues
- Close #7598

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
