### PR TITLE
feat(misconf): public network support for Azure Storage Account

### DIFF
--- a/pkg/iac/adapters/arm/storage/adapt.go
+++ b/pkg/iac/adapters/arm/storage/adapt.go
@@ -62,6 +62,12 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 			MinimumTLSVersion: resource.Properties.GetMapValue("minimumTlsVersion").AsStringValue("", resource.Properties.GetMetadata()),
 			Queues:            queues,
 		}
+
+		publicNetworkAccess := resource.Properties.GetMapValue("publicNetworkAccess")
+		account.PublicNetworkAccess = types.Bool(
+			publicNetworkAccess.AsStringValue("Enabled", publicNetworkAccess.Metadata).EqualTo("Enabled"),
+			publicNetworkAccess.Metadata,
+		)
 		accounts = append(accounts, account)
 	}
 	return accounts

--- a/pkg/iac/adapters/arm/storage/adapt_test.go
+++ b/pkg/iac/adapters/arm/storage/adapt_test.go
@@ -6,17 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	azure2 "github.com/aquasecurity/trivy/pkg/iac/scanners/azure"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/azure"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
 func Test_AdaptStorageDefaults(t *testing.T) {
 
-	input := azure2.Deployment{
-		Resources: []azure2.Resource{
+	input := azure.Deployment{
+		Resources: []azure.Resource{
 			{
-				Type:       azure2.NewValue("Microsoft.Storage/storageAccounts", types.NewTestMetadata()),
-				Properties: azure2.NewValue(make(map[string]azure2.Value), types.NewTestMetadata()),
+				Type:       azure.NewValue("Microsoft.Storage/storageAccounts", types.NewTestMetadata()),
+				Properties: azure.NewValue(make(map[string]azure.Value), types.NewTestMetadata()),
 			},
 		},
 	}
@@ -28,19 +28,21 @@ func Test_AdaptStorageDefaults(t *testing.T) {
 	account := output.Accounts[0]
 	assert.Equal(t, "", account.MinimumTLSVersion.Value())
 	assert.False(t, account.EnforceHTTPS.Value())
+	assert.True(t, account.PublicNetworkAccess.Value())
 
 }
 
 func Test_AdaptStorage(t *testing.T) {
 
-	input := azure2.Deployment{
-		Resources: []azure2.Resource{
+	input := azure.Deployment{
+		Resources: []azure.Resource{
 			{
-				Type: azure2.NewValue("Microsoft.Storage/storageAccounts", types.NewTestMetadata()),
-				Name: azure2.Value{},
-				Properties: azure2.NewValue(map[string]azure2.Value{
-					"minimumTlsVersion":        azure2.NewValue("TLS1_2", types.NewTestMetadata()),
-					"supportsHttpsTrafficOnly": azure2.NewValue(true, types.NewTestMetadata()),
+				Type: azure.NewValue("Microsoft.Storage/storageAccounts", types.NewTestMetadata()),
+				Name: azure.Value{},
+				Properties: azure.NewValue(map[string]azure.Value{
+					"minimumTlsVersion":        azure.NewValue("TLS1_2", types.NewTestMetadata()),
+					"supportsHttpsTrafficOnly": azure.NewValue(true, types.NewTestMetadata()),
+					"publicNetworkAccess":      azure.NewValue("Disabled", types.NewTestMetadata()),
 				}, types.NewTestMetadata()),
 			},
 		},
@@ -53,5 +55,6 @@ func Test_AdaptStorage(t *testing.T) {
 	account := output.Accounts[0]
 	assert.Equal(t, "TLS1_2", account.MinimumTLSVersion.Value())
 	assert.True(t, account.EnforceHTTPS.Value())
+	assert.False(t, account.PublicNetworkAccess.Value())
 
 }

--- a/pkg/iac/adapters/terraform/azure/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/storage/adapt.go
@@ -108,7 +108,8 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 			Metadata:      resource.GetMetadata(),
 			EnableLogging: iacTypes.BoolDefault(false, resource.GetMetadata()),
 		},
-		MinimumTLSVersion: iacTypes.StringDefault(minimumTlsVersionOneTwo, resource.GetMetadata()),
+		MinimumTLSVersion:   iacTypes.StringDefault(minimumTlsVersionOneTwo, resource.GetMetadata()),
+		PublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").AsBoolValueOrDefault(true, resource),
 	}
 
 	networkRulesBlocks := resource.GetBlocks("network_rules")

--- a/pkg/iac/adapters/terraform/azure/storage/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/storage/adapt_test.go
@@ -19,6 +19,20 @@ func Test_Adapt(t *testing.T) {
 		expected  storage.Storage
 	}{
 		{
+			name:      "default",
+			terraform: `resource "azurerm_storage_account" "example" {}`,
+			expected: storage.Storage{
+				Accounts: []storage.Account{
+					{
+						PublicNetworkAccess: iacTypes.BoolTest(true),
+						MinimumTLSVersion:   iacTypes.StringTest(minimumTlsVersionOneTwo),
+						EnforceHTTPS:        iacTypes.BoolTest(true),
+					},
+					{},
+				},
+			},
+		},
+		{
 			name: "defined",
 			terraform: `
 			resource "azurerm_resource_group" "example" {
@@ -45,6 +59,7 @@ func Test_Adapt(t *testing.T) {
 					}
 				  }
 				min_tls_version          = "TLS1_2"
+				public_network_access_enabled = false
 			  }
 
 			  resource "azurerm_storage_account_network_rules" "test" {
@@ -65,9 +80,10 @@ func Test_Adapt(t *testing.T) {
 				Accounts: []storage.Account{
 
 					{
-						Metadata:          iacTypes.NewTestMetadata(),
-						EnforceHTTPS:      iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-						MinimumTLSVersion: iacTypes.String("TLS1_2", iacTypes.NewTestMetadata()),
+						Metadata:            iacTypes.NewTestMetadata(),
+						EnforceHTTPS:        iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						MinimumTLSVersion:   iacTypes.String("TLS1_2", iacTypes.NewTestMetadata()),
+						PublicNetworkAccess: iacTypes.BoolTest(false),
 						NetworkRules: []storage.NetworkRule{
 							{
 								Metadata: iacTypes.NewTestMetadata(),

--- a/pkg/iac/providers/azure/storage/storage.go
+++ b/pkg/iac/providers/azure/storage/storage.go
@@ -9,13 +9,14 @@ type Storage struct {
 }
 
 type Account struct {
-	Metadata          iacTypes.Metadata
-	NetworkRules      []NetworkRule
-	EnforceHTTPS      iacTypes.BoolValue
-	Containers        []Container
-	QueueProperties   QueueProperties
-	MinimumTLSVersion iacTypes.StringValue
-	Queues            []Queue
+	Metadata            iacTypes.Metadata
+	NetworkRules        []NetworkRule
+	EnforceHTTPS        iacTypes.BoolValue
+	Containers          []Container
+	QueueProperties     QueueProperties
+	MinimumTLSVersion   iacTypes.StringValue
+	Queues              []Queue
+	PublicNetworkAccess iacTypes.BoolValue
 }
 
 type Queue struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -5396,6 +5396,10 @@
             "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.storage.NetworkRule"
           }
         },
+        "publicnetworkaccess": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
         "queueproperties": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.storage.QueueProperties"


### PR DESCRIPTION
## Description
The check will be fixed in trivy-checks

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/6459

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
