### PR TITLE
fix(misconf): fix for Azure Storage Account network acls adaptation

### DIFF
--- a/pkg/iac/adapters/arm/storage/adapt.go
+++ b/pkg/iac/adapters/arm/storage/adapt.go
@@ -18,20 +18,18 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 	var accounts []storage.Account
 	for _, resource := range deployment.GetResourcesByType("Microsoft.Storage/storageAccounts") {
 
-		var networkRules []storage.NetworkRule
-		for _, acl := range resource.Properties.GetMapValue("networkAcls").AsList() {
+		acl := resource.Properties.GetMapValue("networkAcls")
 
-			var bypasses []types.StringValue
-			bypassProp := acl.GetMapValue("bypass")
-			for _, bypass := range strings.Split(bypassProp.AsString(), ",") {
-				bypasses = append(bypasses, types.String(bypass, bypassProp.GetMetadata()))
-			}
+		var bypasses []types.StringValue
+		bypassProp := acl.GetMapValue("bypass")
+		for _, bypass := range strings.Split(bypassProp.AsString(), ",") {
+			bypasses = append(bypasses, types.String(strings.TrimSpace(bypass), bypassProp.GetMetadata()))
+		}
 
-			networkRules = append(networkRules, storage.NetworkRule{
-				Metadata:       acl.GetMetadata(),
-				Bypass:         bypasses,
-				AllowByDefault: types.Bool(acl.GetMapValue("defaultAction").EqualTo("Allow"), acl.GetMetadata()),
-			})
+		networkRule := storage.NetworkRule{
+			Metadata:       acl.GetMetadata(),
+			Bypass:         bypasses,
+			AllowByDefault: types.Bool(acl.GetMapValue("defaultAction").EqualTo("Allow"), acl.GetMetadata()),
 		}
 
 		var queues []storage.Queue
@@ -52,7 +50,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 
 		account := storage.Account{
 			Metadata:     resource.Metadata,
-			NetworkRules: networkRules,
+			NetworkRules: []storage.NetworkRule{networkRule},
 			EnforceHTTPS: resource.Properties.GetMapValue("supportsHttpsTrafficOnly").AsBoolValue(false, resource.Properties.GetMetadata()),
 			Containers:   containers,
 			QueueProperties: storage.QueueProperties{


### PR DESCRIPTION
## Description
1. `networkAcls` is an object, not a list.
2. `bypass` may contain multiple values separated by commas and may contain spaces. Spaces must be removed.

Doc: https://learn.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts?pivots=deployment-language-arm-template

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
