### PR TITLE
ci: split `save` and `restore` cache actions

### DIFF
--- a/.github/workflows/cache-test-images.yaml
+++ b/.github/workflows/cache-test-images.yaml
@@ -1,9 +1,9 @@
 name: Cache test images
 on:
+  schedule:
+    - cron: "0 0 * * *" # Run this workflow every day at 00:00 to avoid cache deletion.
   workflow_dispatch:
 
-env:
-  GO_VERSION: '1.22'
 jobs:
   test-images:
     name: Cache test images
@@ -15,32 +15,34 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.1
         with:
           aqua_version: v1.25.0
 
-      - name: Download test images
-        if: github.ref == 'refs/heads/main'
-        run: mage test:fixtureContainerImages
-
       - name: Generate image list digest
-        if: github.ref == 'refs/heads/main'
+        if: github.ref_name == 'main'
         id: image-digest
         run: |
           IMAGE_LIST=$(skopeo list-tags docker://ghcr.io/aquasecurity/trivy-test-images)
           DIGEST=$(echo "$IMAGE_LIST" | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
-      ## We need to save test image cache only for main branch
-      - name: Save test images into cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+      ## We need to work with test image cache only for main branch
+      - name: Restore and save test images cache
+        if: github.ref_name == 'main'
+        uses: actions/cache@v4
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
+          restore-keys:
+            cache-test-images-
+
+      - name: Download test images
+        if: github.ref_name == 'main'
+        run: mage test:fixtureContainerImages
 
   test-vm-images:
     name: Cache test VM images
@@ -52,29 +54,31 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install tools
         uses: aquaproj/aqua-installer@v3.0.1
         with:
           aqua_version: v1.25.0
 
-      - name: Download test VM images
-        if: github.ref == 'refs/heads/main'
-        run: mage test:fixtureVMImages
-
       - name: Generate image list digest
-        if: github.ref == 'refs/heads/main'
+        if: github.ref_name == 'main'
         id: image-digest
         run: |
           IMAGE_LIST=$(skopeo list-tags docker://ghcr.io/aquasecurity/trivy-test-vm-images)
           DIGEST=$(echo "$IMAGE_LIST" | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
-      ## We need to save test VM image cache only for main branch
-      - name: Save test VM images into cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+      ## We need to work with test VM image cache only for main branch
+      - name: Restore and save test VM images cache
+        if: github.ref_name == 'main'
+        uses: actions/cache@v4
         with:
           path: integration/testdata/fixtures/vm-images
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
+          restore-keys:
+            cache-test-vm-images-
+
+      - name: Download test VM images
+        if: github.ref_name == 'main'
+        run: mage test:fixtureVMImages

--- a/.github/workflows/cache-test-images.yaml
+++ b/.github/workflows/cache-test-images.yaml
@@ -1,0 +1,80 @@
+name: Cache test images
+on:
+  workflow_dispatch:
+
+env:
+  GO_VERSION: '1.22'
+jobs:
+  test-images:
+    name: Cache test images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4.1.6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install tools
+        uses: aquaproj/aqua-installer@v3.0.1
+        with:
+          aqua_version: v1.25.0
+
+      - name: Download test images
+        if: github.ref == 'refs/heads/main'
+        run: mage test:fixtureContainerImages
+
+      - name: Generate image list digest
+        if: github.ref == 'refs/heads/main'
+        id: image-digest
+        run: |
+          IMAGE_LIST=$(skopeo list-tags docker://ghcr.io/aquasecurity/trivy-test-images)
+          DIGEST=$(echo "$IMAGE_LIST" | sha256sum | cut -d' ' -f1)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      ## We need to save test image cache only for main branch
+      - name: Save test images into cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: integration/testdata/fixtures/images
+          key: cache-test-images-${{ steps.image-digest.outputs.digest }}
+
+  test-vm-images:
+    name: Cache test VM images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4.1.6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install tools
+        uses: aquaproj/aqua-installer@v3.0.1
+        with:
+          aqua_version: v1.25.0
+
+      - name: Download test VM images
+        if: github.ref == 'refs/heads/main'
+        run: mage test:fixtureVMImages
+
+      - name: Generate image list digest
+        if: github.ref == 'refs/heads/main'
+        id: image-digest
+        run: |
+          IMAGE_LIST=$(skopeo list-tags docker://ghcr.io/aquasecurity/trivy-test-vm-images)
+          DIGEST=$(echo "$IMAGE_LIST" | sha256sum | cut -d' ' -f1)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      ## We need to save test VM image cache only for main branch
+      - name: Save test VM images into cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: integration/testdata/fixtures/vm-images
+          key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,13 +92,20 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test images from cache
-        uses: actions/cache@v4
-        id: restore-test-images
+        uses: actions/cache/restore@v4
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
           restore-keys:
             cache-test-images-
+
+      ## We need to save test image cache only for main branch
+      - name: Save test images from cache
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@v4
+        with:
+          path: integration/testdata/fixtures/images
+          key: cache-test-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Run integration tests
         run: mage test:integration
@@ -148,13 +155,21 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test images from cache
-        uses: actions/cache@v4
-        id: restore-test-images
+        uses: actions/cache/restore@v4
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
           restore-keys:
             cache-test-images-
+
+
+      ## We need to save test image cache only for main branch
+      - name: Save test images from cache
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@v4
+        with:
+          path: integration/testdata/fixtures/images
+          key: cache-test-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Run module integration tests
         shell: bash
@@ -185,13 +200,20 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test VM images from cache
-        uses: actions/cache@v4
-        id: restore-test-vm-images
+        uses: actions/cache/restore@v4
         with:
           path: integration/testdata/fixtures/vm-images
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
           restore-keys:
             cache-test-vm-images-
+
+      ## We need to save test VM image cache only for main branch
+      - name: Save test VM images from cache
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@v4
+        with:
+          path: integration/testdata/fixtures/images
+          key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Run vm integration tests
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,14 +99,6 @@ jobs:
           restore-keys:
             cache-test-images-
 
-      ## We need to save test image cache only for main branch
-      - name: Save test images from cache
-        if: github.ref_name == 'main'
-        uses: actions/cache/save@v4
-        with:
-          path: integration/testdata/fixtures/images
-          key: cache-test-images-${{ steps.image-digest.outputs.digest }}
-
       - name: Run integration tests
         run: mage test:integration
 
@@ -162,15 +154,6 @@ jobs:
           restore-keys:
             cache-test-images-
 
-
-      ## We need to save test image cache only for main branch
-      - name: Save test images from cache
-        if: github.ref_name == 'main'
-        uses: actions/cache/save@v4
-        with:
-          path: integration/testdata/fixtures/images
-          key: cache-test-images-${{ steps.image-digest.outputs.digest }}
-
       - name: Run module integration tests
         shell: bash
         run: |
@@ -206,14 +189,6 @@ jobs:
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
           restore-keys:
             cache-test-vm-images-
-
-      ## We need to save test VM image cache only for main branch
-      - name: Save test VM images from cache
-        if: github.ref_name == 'main'
-        uses: actions/cache/save@v4
-        with:
-          path: integration/testdata/fixtures/images
-          key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Run vm integration tests
         run: |


### PR DESCRIPTION
## Description
Split `save` and `restore` cache actions:
- use `actions/cache/restore` in `tests`.
- use `actions/cache` in new `cache-test-images.yaml` workflow.

test runs:
- https://github.com/DmitriyLewen/trivy/actions/runs/11102892990/job/30843683889

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
