### PR TITLE
refactor: fix auth error handling

### DIFF
--- a/internal/dbtest/fake.go
+++ b/internal/dbtest/fake.go
@@ -62,10 +62,7 @@ func NewFakeDB(t *testing.T, dbPath string, opts FakeDBOptions) *oci.Artifact {
 	opt := ftypes.RegistryOptions{
 		Insecure: false,
 	}
-	art, err := oci.NewArtifact("dummy", true, opt, oci.WithImage(img))
-	require.NoError(t, err)
-
-	return art
+	return oci.NewArtifact("dummy", true, opt, oci.WithImage(img))
 }
 
 func ArchiveDir(t *testing.T, dir string) string {

--- a/pkg/fanal/artifact/image/remote_sbom.go
+++ b/pkg/fanal/artifact/image/remote_sbom.go
@@ -87,10 +87,6 @@ func (a Artifact) inspectOCIReferrerSBOM(ctx context.Context) (artifact.Referenc
 func (a Artifact) parseReferrer(ctx context.Context, repo string, desc v1.Descriptor) (artifact.Reference, error) {
 	const fileName string = "referrer.sbom"
 	repoName := fmt.Sprintf("%s@%s", repo, desc.Digest)
-	referrer, err := oci.NewArtifact(repoName, true, a.artifactOption.ImageOption.RegistryOptions)
-	if err != nil {
-		return artifact.Reference{}, xerrors.Errorf("OCI error: %w", err)
-	}
 
 	tmpDir, err := os.MkdirTemp("", "trivy-sbom-*")
 	if err != nil {
@@ -99,6 +95,7 @@ func (a Artifact) parseReferrer(ctx context.Context, repo string, desc v1.Descri
 	defer os.RemoveAll(tmpDir)
 
 	// Download SBOM to local filesystem
+	referrer := oci.NewArtifact(repoName, true, a.artifactOption.ImageOption.RegistryOptions)
 	if err = referrer.Download(ctx, tmpDir, oci.DownloadOption{
 		MediaType: desc.ArtifactType,
 		Filename:  fileName,

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -59,11 +59,8 @@ func (u *Updater) Update() error {
 		log.Info("Downloading the Java DB...")
 
 		// TODO: support remote options
-		var a *oci.Artifact
-		if a, err = oci.NewArtifact(u.repo.String(), u.quiet, u.registryOption); err != nil {
-			return xerrors.Errorf("oci error: %w", err)
-		}
-		if err = a.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: mediaType}); err != nil {
+		art := oci.NewArtifact(u.repo.String(), u.quiet, u.registryOption)
+		if err = art.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: mediaType}); err != nil {
 			return xerrors.Errorf("DB download error: %w", err)
 		}
 

--- a/pkg/module/command.go
+++ b/pkg/module/command.go
@@ -23,15 +23,11 @@ func Install(ctx context.Context, dir, repo string, quiet bool, opt types.Regist
 	}
 
 	log.Info("Installing the module from the repository...", log.String("repo", repo))
-	artifact, err := oci.NewArtifact(repo, quiet, opt)
-	if err != nil {
-		return xerrors.Errorf("module initialize error: %w", err)
-	}
+	art := oci.NewArtifact(repo, quiet, opt)
 
 	dst := filepath.Join(dir, ref.Context().Name())
 	log.Debug("Installing the module...", log.String("dst", dst))
-
-	if err = artifact.Download(ctx, dst, oci.DownloadOption{MediaType: mediaType}); err != nil {
+	if err = art.Download(ctx, dst, oci.DownloadOption{MediaType: mediaType}); err != nil {
 		return xerrors.Errorf("module download error: %w", err)
 	}
 

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -57,7 +57,7 @@ type Artifact struct {
 }
 
 // NewArtifact returns a new artifact
-func NewArtifact(repo string, quiet bool, registryOpt types.RegistryOptions, opts ...Option) (*Artifact, error) {
+func NewArtifact(repo string, quiet bool, registryOpt types.RegistryOptions, opts ...Option) *Artifact {
 	art := &Artifact{
 		repository:      repo,
 		quiet:           quiet,
@@ -67,7 +67,7 @@ func NewArtifact(repo string, quiet bool, registryOpt types.RegistryOptions, opt
 	for _, o := range opts {
 		o(art)
 	}
-	return art, nil
+	return art
 }
 
 func (a *Artifact) populate(ctx context.Context, opt types.RegistryOptions) error {

--- a/pkg/oci/artifact_test.go
+++ b/pkg/oci/artifact_test.go
@@ -116,9 +116,7 @@ func TestArtifact_Download(t *testing.T) {
 				},
 			}, nil)
 
-			artifact, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
-			require.NoError(t, err)
-
+			artifact := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			err = artifact.Download(context.Background(), tempDir, oci.DownloadOption{
 				MediaType: tt.mediaType,
 			})

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -89,23 +89,16 @@ func NewClient(cacheDir string, quiet bool, checkBundleRepo string, opts ...Opti
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact(registryOpts types.RegistryOptions) error {
+func (c *Client) populateOCIArtifact(registryOpts types.RegistryOptions) {
 	if c.artifact == nil {
 		log.Debug("Loading check bundle", log.String("repository", c.checkBundleRepo))
-		art, err := oci.NewArtifact(c.checkBundleRepo, c.quiet, registryOpts)
-		if err != nil {
-			return xerrors.Errorf("OCI artifact error: %w", err)
-		}
-		c.artifact = art
+		c.artifact = oci.NewArtifact(c.checkBundleRepo, c.quiet, registryOpts)
 	}
-	return nil
 }
 
 // DownloadBuiltinPolicies download default policies from GitHub Pages
 func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOpts types.RegistryOptions) error {
-	if err := c.populateOCIArtifact(registryOpts); err != nil {
-		return xerrors.Errorf("OPA bundle error: %w", err)
-	}
+	c.populateOCIArtifact(registryOpts)
 
 	dst := c.contentDir()
 	if err := c.artifact.Download(ctx, dst, oci.DownloadOption{MediaType: policyMediaType}); err != nil {
@@ -165,10 +158,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, registryOpts types.RegistryOpt
 		return false, nil
 	}
 
-	if err = c.populateOCIArtifact(registryOpts); err != nil {
-		return false, xerrors.Errorf("OPA bundle error: %w", err)
-	}
-
+	c.populateOCIArtifact(registryOpts)
 	digest, err := c.artifact.Digest(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("digest error: %w", err)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -116,9 +116,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 			}, nil)
 
 			// Mock OCI artifact
-			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
-			require.NoError(t, err)
-
+			art := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			c, err := policy.NewClient(tt.cacheDir, true, "", policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
@@ -257,9 +255,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
-			require.NoError(t, err)
-
+			art := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			c, err := policy.NewClient(tmpDir, true, "", policy.WithOCIArtifact(art), policy.WithClock(tt.clock))
 			require.NoError(t, err)
 
@@ -361,9 +357,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			}, nil)
 
 			// Mock OCI artifact
-			art, err := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
-			require.NoError(t, err)
-
+			art := oci.NewArtifact("repo", true, ftypes.RegistryOptions{}, oci.WithImage(img))
 			c, err := policy.NewClient(tempDir, true, "", policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Description
`oci.NewArtifact` doesn't return an error anymore.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
