### PR TITLE
test: use loaded image names

### DIFF
--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -1,19 +1,16 @@
 //go:build integration
-// +build integration
 
 package integration
 
 import (
 	"context"
-	"io"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/types"
 
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +20,6 @@ func TestDockerEngine(t *testing.T) {
 	}
 	tests := []struct {
 		name          string
-		imageTag      string
 		invalidImage  bool
 		ignoreUnfixed bool
 		ignoreStatus  []string
@@ -34,10 +30,9 @@ func TestDockerEngine(t *testing.T) {
 		wantErr       string
 	}{
 		{
-			name:     "alpine:3.9",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:alpine-39",
-			input:    "testdata/fixtures/images/alpine-39.tar.gz",
-			golden:   "testdata/alpine-39.json.golden",
+			name:   "alpine:3.9",
+			input:  "testdata/fixtures/images/alpine-39.tar.gz",
+			golden: "testdata/alpine-39.json.golden",
 		},
 		{
 			name: "alpine:3.9, with high and critical severity",
@@ -45,13 +40,11 @@ func TestDockerEngine(t *testing.T) {
 				"HIGH",
 				"CRITICAL",
 			},
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:alpine-39",
-			input:    "testdata/fixtures/images/alpine-39.tar.gz",
-			golden:   "testdata/alpine-39-high-critical.json.golden",
+			input:  "testdata/fixtures/images/alpine-39.tar.gz",
+			golden: "testdata/alpine-39-high-critical.json.golden",
 		},
 		{
-			name:     "alpine:3.9, with .trivyignore",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:alpine-39",
+			name: "alpine:3.9, with .trivyignore",
 			ignoreIDs: []string{
 				"CVE-2019-1549",
 				"CVE-2019-14697",
@@ -60,167 +53,141 @@ func TestDockerEngine(t *testing.T) {
 			golden: "testdata/alpine-39-ignore-cveids.json.golden",
 		},
 		{
-			name:     "alpine:3.10",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:alpine-310",
-			input:    "testdata/fixtures/images/alpine-310.tar.gz",
-			golden:   "testdata/alpine-310.json.golden",
+			name:   "alpine:3.10",
+			input:  "testdata/fixtures/images/alpine-310.tar.gz",
+			golden: "testdata/alpine-310.json.golden",
 		},
 		{
-			name:     "amazonlinux:1",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:amazon-1",
-			input:    "testdata/fixtures/images/amazon-1.tar.gz",
-			golden:   "testdata/amazon-1.json.golden",
+			name:   "amazonlinux:1",
+			input:  "testdata/fixtures/images/amazon-1.tar.gz",
+			golden: "testdata/amazon-1.json.golden",
 		},
 		{
-			name:     "amazonlinux:2",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:amazon-2",
-			input:    "testdata/fixtures/images/amazon-2.tar.gz",
-			golden:   "testdata/amazon-2.json.golden",
+			name:   "amazonlinux:2",
+			input:  "testdata/fixtures/images/amazon-2.tar.gz",
+			golden: "testdata/amazon-2.json.golden",
 		},
 		{
-			name:     "almalinux 8",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:almalinux-8",
-			input:    "testdata/fixtures/images/almalinux-8.tar.gz",
-			golden:   "testdata/almalinux-8.json.golden",
+			name:   "almalinux 8",
+			input:  "testdata/fixtures/images/almalinux-8.tar.gz",
+			golden: "testdata/almalinux-8.json.golden",
 		},
 		{
-			name:     "rocky linux 8",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:rockylinux-8",
-			input:    "testdata/fixtures/images/rockylinux-8.tar.gz",
-			golden:   "testdata/rockylinux-8.json.golden",
+			name:   "rocky linux 8",
+			input:  "testdata/fixtures/images/rockylinux-8.tar.gz",
+			golden: "testdata/rockylinux-8.json.golden",
 		},
 		{
-			name:     "centos 6",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:centos-6",
-			input:    "testdata/fixtures/images/centos-6.tar.gz",
-			golden:   "testdata/centos-6.json.golden",
+			name:   "centos 6",
+			input:  "testdata/fixtures/images/centos-6.tar.gz",
+			golden: "testdata/centos-6.json.golden",
 		},
 		{
-			name:     "centos 7",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:centos-7",
-			input:    "testdata/fixtures/images/centos-7.tar.gz",
-			golden:   "testdata/centos-7.json.golden",
+			name:   "centos 7",
+			input:  "testdata/fixtures/images/centos-7.tar.gz",
+			golden: "testdata/centos-7.json.golden",
 		},
 		{
 			name:          "centos 7, with --ignore-unfixed option",
-			imageTag:      "ghcr.io/aquasecurity/trivy-test-images:centos-7",
 			ignoreUnfixed: true,
 			input:         "testdata/fixtures/images/centos-7.tar.gz",
 			golden:        "testdata/centos-7-ignore-unfixed.json.golden",
 		},
 		{
 			name:         "centos 7, with --ignore-status option",
-			imageTag:     "ghcr.io/aquasecurity/trivy-test-images:centos-7",
 			ignoreStatus: []string{"will_not_fix"},
 			input:        "testdata/fixtures/images/centos-7.tar.gz",
 			golden:       "testdata/centos-7-ignore-unfixed.json.golden",
 		},
 		{
 			name:          "centos 7, with --ignore-unfixed option, with medium severity",
-			imageTag:      "ghcr.io/aquasecurity/trivy-test-images:centos-7",
 			ignoreUnfixed: true,
 			severity:      []string{"MEDIUM"},
 			input:         "testdata/fixtures/images/centos-7.tar.gz",
 			golden:        "testdata/centos-7-medium.json.golden",
 		},
 		{
-			name:     "registry.redhat.io/ubi7",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:ubi-7",
-			input:    "testdata/fixtures/images/ubi-7.tar.gz",
-			golden:   "testdata/ubi-7.json.golden",
+			name:   "registry.redhat.io/ubi7",
+			input:  "testdata/fixtures/images/ubi-7.tar.gz",
+			golden: "testdata/ubi-7.json.golden",
 		},
 		{
-			name:     "debian buster/10",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:debian-buster",
-			input:    "testdata/fixtures/images/debian-buster.tar.gz",
-			golden:   "testdata/debian-buster.json.golden",
+			name:   "debian buster/10",
+			input:  "testdata/fixtures/images/debian-buster.tar.gz",
+			golden: "testdata/debian-buster.json.golden",
 		},
 		{
 			name:          "debian buster/10, with --ignore-unfixed option",
 			ignoreUnfixed: true,
-			imageTag:      "ghcr.io/aquasecurity/trivy-test-images:debian-buster",
 			input:         "testdata/fixtures/images/debian-buster.tar.gz",
 			golden:        "testdata/debian-buster-ignore-unfixed.json.golden",
 		},
 		{
 			name:         "debian buster/10, with --ignore-status option",
 			ignoreStatus: []string{"affected"},
-			imageTag:     "ghcr.io/aquasecurity/trivy-test-images:debian-buster",
 			input:        "testdata/fixtures/images/debian-buster.tar.gz",
 			golden:       "testdata/debian-buster-ignore-unfixed.json.golden",
 		},
 		{
-			name:     "debian stretch/9",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:debian-stretch",
-			input:    "testdata/fixtures/images/debian-stretch.tar.gz",
-			golden:   "testdata/debian-stretch.json.golden",
+			name:   "debian stretch/9",
+			input:  "testdata/fixtures/images/debian-stretch.tar.gz",
+			golden: "testdata/debian-stretch.json.golden",
 		},
 		{
-			name:     "distroless base",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:distroless-base",
-			input:    "testdata/fixtures/images/distroless-base.tar.gz",
-			golden:   "testdata/distroless-base.json.golden",
+			name:   "distroless base",
+			input:  "testdata/fixtures/images/distroless-base.tar.gz",
+			golden: "testdata/distroless-base.json.golden",
 		},
 		{
-			name:     "distroless python2.7",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:distroless-python27",
-			input:    "testdata/fixtures/images/distroless-python27.tar.gz",
-			golden:   "testdata/distroless-python27.json.golden",
+			name:   "distroless python2.7",
+			input:  "testdata/fixtures/images/distroless-python27.tar.gz",
+			golden: "testdata/distroless-python27.json.golden",
 		},
 		{
-			name:     "oracle linux 8",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:oraclelinux-8",
-			input:    "testdata/fixtures/images/oraclelinux-8.tar.gz",
-			golden:   "testdata/oraclelinux-8.json.golden",
+			name:   "oracle linux 8",
+			input:  "testdata/fixtures/images/oraclelinux-8.tar.gz",
+			golden: "testdata/oraclelinux-8.json.golden",
 		},
 		{
-			name:     "ubuntu 18.04",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:ubuntu-1804",
-			input:    "testdata/fixtures/images/ubuntu-1804.tar.gz",
-			golden:   "testdata/ubuntu-1804.json.golden",
+			name:   "ubuntu 18.04",
+			input:  "testdata/fixtures/images/ubuntu-1804.tar.gz",
+			golden: "testdata/ubuntu-1804.json.golden",
 		},
 		{
 			name:          "ubuntu 18.04, with --ignore-unfixed option",
-			imageTag:      "ghcr.io/aquasecurity/trivy-test-images:ubuntu-1804",
 			ignoreUnfixed: true,
 			input:         "testdata/fixtures/images/ubuntu-1804.tar.gz",
 			golden:        "testdata/ubuntu-1804-ignore-unfixed.json.golden",
 		},
 		{
-			name:     "opensuse leap 15.1",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:opensuse-leap-151",
-			input:    "testdata/fixtures/images/opensuse-leap-151.tar.gz",
-			golden:   "testdata/opensuse-leap-151.json.golden",
+			name:   "opensuse leap 15.1",
+			input:  "testdata/fixtures/images/opensuse-leap-151.tar.gz",
+			golden: "testdata/opensuse-leap-151.json.golden",
 		},
 		{
-			name:     "opensuse tumbleweed",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:opensuse-tumbleweed",
-			input:    "testdata/fixtures/images/opensuse-tumbleweed.tar.gz",
-			golden:   "testdata/opensuse-tumbleweed.json.golden",
+			name:   "opensuse tumbleweed",
+			input:  "testdata/fixtures/images/opensuse-tumbleweed.tar.gz",
+			golden: "testdata/opensuse-tumbleweed.json.golden",
 		},
 		{
-			name:     "sle micro rancher 5.4",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:sle-micro-rancher-5.4_ndb",
-			input:    "testdata/fixtures/images/sle-micro-rancher-5.4_ndb.tar.gz",
-			golden:   "testdata/sl-micro-rancher5.4.json.golden",
+			name:   "sle micro rancher 5.4",
+			input:  "testdata/fixtures/images/sle-micro-rancher-5.4_ndb.tar.gz",
+			golden: "testdata/sl-micro-rancher5.4.json.golden",
 		},
 		{
-			name:     "photon 3.0",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:photon-30",
-			input:    "testdata/fixtures/images/photon-30.tar.gz",
-			golden:   "testdata/photon-30.json.golden",
+			name:   "photon 3.0",
+			input:  "testdata/fixtures/images/photon-30.tar.gz",
+			golden: "testdata/photon-30.json.golden",
 		},
 		{
-			name:     "CBL-Mariner 1.0",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:mariner-1.0",
-			input:    "testdata/fixtures/images/mariner-1.0.tar.gz",
-			golden:   "testdata/mariner-1.0.json.golden",
+			name:   "CBL-Mariner 1.0",
+			input:  "testdata/fixtures/images/mariner-1.0.tar.gz",
+			golden: "testdata/mariner-1.0.json.golden",
 		},
 		{
-			name:     "busybox with Cargo.lock",
-			imageTag: "ghcr.io/aquasecurity/trivy-test-images:busybox-with-lockfile",
-			input:    "testdata/fixtures/images/busybox-with-lockfile.tar.gz",
-			golden:   "testdata/busybox-with-lockfile.json.golden",
+			name:   "busybox with Cargo.lock",
+			input:  "testdata/fixtures/images/busybox-with-lockfile.tar.gz",
+			golden: "testdata/busybox-with-lockfile.json.golden",
 		},
 		{
 			name:         "sad path, invalid image",
@@ -239,44 +206,27 @@ func TestDockerEngine(t *testing.T) {
 	ctx := context.Background()
 	defer ctx.Done()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	require.NoError(t, err)
+	cli := testutil.NewDockerClient(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if !tt.invalidImage {
 				testfile, err := os.Open(tt.input)
 				require.NoError(t, err, tt.name)
+				defer testfile.Close()
 
-				// ensure image doesnt already exists
-				_, _ = cli.ImageRemove(ctx, tt.input, image.RemoveOptions{
-					Force:         true,
-					PruneChildren: true,
-				})
+				// Ensure image doesn't already exist
+				cli.ImageRemove(t, ctx, tt.input)
 
-				// load image into docker engine
-				res, err := cli.ImageLoad(ctx, testfile, true)
-				require.NoError(t, err, tt.name)
-				if _, err := io.Copy(io.Discard, res.Body); err != nil {
-					require.NoError(t, err, tt.name)
-				}
-				defer res.Body.Close()
+				// Load image into docker engine
+				loadedImage := cli.ImageLoad(t, ctx, tt.input)
 
-				// tag our image to something unique
-				err = cli.ImageTag(ctx, tt.imageTag, tt.input)
+				// Tag our image to something unique
+				err = cli.ImageTag(ctx, loadedImage, tt.input)
 				require.NoError(t, err, tt.name)
 
-				// cleanup
-				t.Cleanup(func() {
-					_, _ = cli.ImageRemove(ctx, tt.input, image.RemoveOptions{
-						Force:         true,
-						PruneChildren: true,
-					})
-					_, _ = cli.ImageRemove(ctx, tt.imageTag, image.RemoveOptions{
-						Force:         true,
-						PruneChildren: true,
-					})
-				})
+				// Cleanup
+				t.Cleanup(func() { cli.ImageRemove(t, ctx, tt.input) })
 			}
 
 			osArgs := []string{
@@ -309,7 +259,7 @@ func TestDockerEngine(t *testing.T) {
 			}
 			if len(tt.ignoreIDs) != 0 {
 				trivyIgnore := ".trivyignore"
-				err = os.WriteFile(trivyIgnore, []byte(strings.Join(tt.ignoreIDs, "\n")), 0444)
+				err := os.WriteFile(trivyIgnore, []byte(strings.Join(tt.ignoreIDs, "\n")), 0444)
 				require.NoError(t, err, "failed to write .trivyignore")
 				defer os.Remove(trivyIgnore)
 			}
@@ -320,7 +270,8 @@ func TestDockerEngine(t *testing.T) {
 				wantErr: tt.wantErr,
 				// Container field was removed in Docker Engine v26.0
 				// cf. https://github.com/docker/cli/blob/v26.1.3/docs/deprecated.md#container-and-containerconfig-fields-in-image-inspect
-				override: overrideFuncs(overrideUID, func(t *testing.T, want, _ *types.Report) {
+				override: overrideFuncs(overrideUID, func(t *testing.T, want, got *types.Report) {
+					got.Metadata.ImageConfig.Container = ""
 					want.Metadata.ImageConfig.Container = ""
 				}),
 			})

--- a/internal/testutil/docker.go
+++ b/internal/testutil/docker.go
@@ -1,0 +1,57 @@
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/require"
+)
+
+type DockerClient struct {
+	*client.Client
+}
+
+func NewDockerClient(t *testing.T) *DockerClient {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	return &DockerClient{Client: cli}
+}
+
+func (c *DockerClient) ImageLoad(t *testing.T, ctx context.Context, imageFile string) string {
+	t.Helper()
+	testfile, err := os.Open(imageFile)
+	require.NoError(t, err)
+	defer testfile.Close()
+
+	// Load image into docker engine
+	res, err := c.Client.ImageLoad(ctx, testfile, true)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	// Parse the response and extract the loaded image name
+	var data struct {
+		Stream string `json:"stream"`
+	}
+	err = json.NewDecoder(res.Body).Decode(&data)
+	require.NoError(t, err)
+	loadedImage := strings.TrimPrefix(data.Stream, "Loaded image: ")
+	loadedImage = strings.TrimSpace(loadedImage)
+	require.NotEmpty(t, loadedImage, data.Stream)
+
+	t.Cleanup(func() { c.ImageRemove(t, ctx, loadedImage) })
+
+	return loadedImage
+}
+
+func (c *DockerClient) ImageRemove(t *testing.T, ctx context.Context, imageID string) {
+	t.Helper()
+	_, _ = c.Client.ImageRemove(ctx, imageID, image.RemoveOptions{
+		Force:         true,
+		PruneChildren: true,
+	})
+}

--- a/pkg/fanal/test/integration/library_test.go
+++ b/pkg/fanal/test/integration/library_test.go
@@ -7,20 +7,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"sort"
-	"strings"
 	"testing"
 
-	dimage "github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
-
+	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/cache"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/all"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -29,6 +22,9 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -36,7 +32,7 @@ var update = flag.Bool("update", false, "update golden files")
 
 type testCase struct {
 	name                string
-	remoteImageName     string
+	imageTag            string
 	imageFile           string
 	wantOS              types.OS
 	wantPkgsFromCmds    string
@@ -45,63 +41,63 @@ type testCase struct {
 
 var tests = []testCase{
 	{
-		name:            "happy path, alpine:3.10",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:alpine-310",
-		imageFile:       "../../../../integration/testdata/fixtures/images/alpine-310.tar.gz",
+		name:      "happy path, alpine:3.10",
+		imageTag:  "alpine-310",
+		imageFile: "../../../../integration/testdata/fixtures/images/alpine-310.tar.gz",
 		wantOS: types.OS{
 			Name:   "3.10.2",
 			Family: "alpine",
 		},
 	},
 	{
-		name:            "happy path, amazonlinux:2",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:amazon-2",
-		imageFile:       "../../../../integration/testdata/fixtures/images/amazon-2.tar.gz",
+		name:      "happy path, amazonlinux:2",
+		imageTag:  "amazon-2",
+		imageFile: "../../../../integration/testdata/fixtures/images/amazon-2.tar.gz",
 		wantOS: types.OS{
 			Name:   "2 (Karoo)",
 			Family: "amazon",
 		},
 	},
 	{
-		name:            "happy path, debian:buster",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:debian-buster",
-		imageFile:       "../../../../integration/testdata/fixtures/images/debian-buster.tar.gz",
+		name:      "happy path, debian:buster",
+		imageTag:  "debian-buster",
+		imageFile: "../../../../integration/testdata/fixtures/images/debian-buster.tar.gz",
 		wantOS: types.OS{
 			Name:   "10.1",
 			Family: "debian",
 		},
 	},
 	{
-		name:            "happy path, photon:3.0",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:photon-30",
-		imageFile:       "../../../../integration/testdata/fixtures/images/photon-30.tar.gz",
+		name:      "happy path, photon:3.0",
+		imageTag:  "photon-30",
+		imageFile: "../../../../integration/testdata/fixtures/images/photon-30.tar.gz",
 		wantOS: types.OS{
 			Name:   "3.0",
 			Family: "photon",
 		},
 	},
 	{
-		name:            "happy path, registry.redhat.io/ubi7",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:ubi-7",
-		imageFile:       "../../../../integration/testdata/fixtures/images/ubi-7.tar.gz",
+		name:      "happy path, registry.redhat.io/ubi7",
+		imageTag:  "ubi-7",
+		imageFile: "../../../../integration/testdata/fixtures/images/ubi-7.tar.gz",
 		wantOS: types.OS{
 			Name:   "7.7",
 			Family: "redhat",
 		},
 	},
 	{
-		name:            "happy path, opensuse leap 15.1",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:opensuse-leap-151",
-		imageFile:       "../../../../integration/testdata/fixtures/images/opensuse-leap-151.tar.gz",
+		name:      "happy path, opensuse leap 15.1",
+		imageTag:  "opensuse-leap-151",
+		imageFile: "../../../../integration/testdata/fixtures/images/opensuse-leap-151.tar.gz",
 		wantOS: types.OS{
 			Name:   "15.1",
 			Family: "opensuse.leap",
 		},
 	},
 	{
-		name:            "happy path, opensuse tumbleweed",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:opensuse-tumbleweed",
-		imageFile:       "../../../../integration/testdata/fixtures/images/opensuse-tumbleweed.tar.gz",
+		name:      "happy path, opensuse tumbleweed",
+		imageTag:  "opensuse-tumbleweed",
+		imageFile: "../../../../integration/testdata/fixtures/images/opensuse-tumbleweed.tar.gz",
 		wantOS: types.OS{
 			Name:   "20240607",
 			Family: "opensuse.tumbleweed",
@@ -109,27 +105,27 @@ var tests = []testCase{
 	},
 	{
 		// from registry.suse.com/suse/sle15:15.3.17.8.16
-		name:            "happy path, suse 15.3 (NDB)",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:suse-15.3_ndb",
-		imageFile:       "../../../../integration/testdata/fixtures/images/suse-15.3_ndb.tar.gz",
+		name:      "happy path, suse 15.3 (NDB)",
+		imageTag:  "suse-15.3_ndb",
+		imageFile: "../../../../integration/testdata/fixtures/images/suse-15.3_ndb.tar.gz",
 		wantOS: types.OS{
 			Name:   "15.3",
 			Family: "suse linux enterprise server",
 		},
 	},
 	{
-		name:            "happy path, Fedora 35",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:fedora-35",
-		imageFile:       "../../../../integration/testdata/fixtures/images/fedora-35.tar.gz",
+		name:      "happy path, Fedora 35",
+		imageTag:  "fedora-35",
+		imageFile: "../../../../integration/testdata/fixtures/images/fedora-35.tar.gz",
 		wantOS: types.OS{
 			Name:   "35",
 			Family: "fedora",
 		},
 	},
 	{
-		name:            "happy path, vulnimage with lock files",
-		remoteImageName: "ghcr.io/aquasecurity/trivy-test-images:vulnimage",
-		imageFile:       "../../../../integration/testdata/fixtures/images/vulnimage.tar.gz",
+		name:      "happy path, vulnimage with lock files",
+		imageTag:  "vulnimage",
+		imageFile: "../../../../integration/testdata/fixtures/images/vulnimage.tar.gz",
 		wantOS: types.OS{
 			Name:   "3.7.1",
 			Family: "alpine",
@@ -145,6 +141,8 @@ func TestFanal_Library_DockerMode(t *testing.T) {
 	if *update {
 		t.Skipf("This test creates wrong golden file")
 	}
+
+	cli := testutil.NewDockerClient(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -153,20 +151,10 @@ func TestFanal_Library_DockerMode(t *testing.T) {
 			c, err := cache.NewFSCache(d)
 			require.NoError(t, err)
 
-			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-			require.NoError(t, err, tt.name)
-
-			testfile, err := os.Open(tt.imageFile)
-			require.NoError(t, err)
-
-			// load image into docker engine
-			resp, err := cli.ImageLoad(ctx, testfile, true)
-			require.NoError(t, err, tt.name)
-			_, err = io.Copy(io.Discard, resp.Body)
-			require.NoError(t, err, tt.name)
+			loadedImage := cli.ImageLoad(t, ctx, tt.imageFile)
 
 			// Enable only dockerd scanning
-			img, cleanup, err := image.NewContainerImage(ctx, tt.remoteImageName, types.ImageOptions{
+			img, cleanup, err := image.NewContainerImage(ctx, loadedImage, types.ImageOptions{
 				ImageSources: types.ImageSources{types.DockerImageSource},
 			})
 			require.NoError(t, err, tt.name)
@@ -190,11 +178,6 @@ func TestFanal_Library_DockerMode(t *testing.T) {
 
 			// clear Cache
 			require.NoError(t, c.Clear(), tt.name)
-
-			_, _ = cli.ImageRemove(ctx, tt.remoteImageName, dimage.RemoveOptions{
-				Force:         true,
-				PruneChildren: true,
-			})
 		})
 	}
 }
@@ -249,8 +232,7 @@ func checkOSPackages(t *testing.T, detail types.ArtifactDetail, tc testCase) {
 	// Sort OS packages for consistency
 	sort.Sort(detail.Packages)
 
-	splitted := strings.Split(tc.remoteImageName, ":")
-	goldenFile := fmt.Sprintf("testdata/goldens/packages/%s.json.golden", splitted[len(splitted)-1])
+	goldenFile := fmt.Sprintf("testdata/goldens/packages/%s.json.golden", tc.imageTag)
 
 	if *update {
 		b, err := json.MarshalIndent(detail.Packages, "", "  ")


### PR DESCRIPTION
## Description
Reduce dependencies of registry names in the code base as we might switch from GHCR to a different registry.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
