### PR TITLE
chore: add prefixes to log messages

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -618,8 +618,8 @@ func (r *runner) scan(ctx context.Context, opts flag.Options, initializeScanner 
 }
 
 func initMisconfScannerOption(ctx context.Context, opts flag.Options) (misconf.ScannerOption, error) {
-	logger := log.WithPrefix(log.PrefixMisconfiguration)
-	logger.Info("Misconfiguration scanning is enabled")
+	ctx = log.WithContextPrefix(ctx, log.PrefixMisconfiguration)
+	log.InfoContext(ctx, "Misconfiguration scanning is enabled")
 
 	var downloadedPolicyPaths []string
 	var disableEmbedded bool
@@ -627,10 +627,10 @@ func initMisconfScannerOption(ctx context.Context, opts flag.Options) (misconf.S
 	downloadedPolicyPaths, err := operation.InitBuiltinChecks(ctx, opts.CacheDir, opts.Quiet, opts.SkipCheckUpdate, opts.MisconfOptions.ChecksBundleRepository, opts.RegistryOpts())
 	if err != nil {
 		if !opts.SkipCheckUpdate {
-			logger.Error("Falling back to embedded checks", log.Err(err))
+			log.ErrorContext(ctx, "Falling back to embedded checks", log.Err(err))
 		}
 	} else {
-		logger.Debug("Checks successfully loaded from disk")
+		log.DebugContext(ctx, "Checks successfully loaded from disk")
 		disableEmbedded = true
 	}
 

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -82,7 +82,6 @@ func InitBuiltinChecks(ctx context.Context, cacheDir string, quiet, skipUpdate b
 	mu.Lock()
 	defer mu.Unlock()
 
-	ctx = log.WithContextPrefix(ctx, log.PrefixChecksBundle)
 	client, err := policy.NewClient(cacheDir, quiet, checkBundleRepository)
 	if err != nil {
 		return nil, xerrors.Errorf("check client error: %w", err)

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -26,7 +26,7 @@ func DownloadDB(ctx context.Context, appVersion, cacheDir string, dbRepositories
 	mu.Lock()
 	defer mu.Unlock()
 
-	ctx = log.WithContextPrefix(ctx, "db")
+	ctx = log.WithContextPrefix(ctx, log.PrefixVulnerabilityDB)
 	dbDir := db.Dir(cacheDir)
 	client := db.NewClient(dbDir, quiet, db.WithDBRepository(dbRepositories))
 	needsUpdate, err := client.NeedsUpdate(ctx, appVersion, skipUpdate)

--- a/pkg/commands/operation/operation.go
+++ b/pkg/commands/operation/operation.go
@@ -77,11 +77,12 @@ func DownloadVEXRepositories(ctx context.Context, opts flag.Options) error {
 
 }
 
-// InitBuiltinPolicies downloads the built-in policies and loads them
-func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate bool, checkBundleRepository string, registryOpts ftypes.RegistryOptions) ([]string, error) {
+// InitBuiltinChecks downloads the built-in policies and loads them
+func InitBuiltinChecks(ctx context.Context, cacheDir string, quiet, skipUpdate bool, checkBundleRepository string, registryOpts ftypes.RegistryOptions) ([]string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	ctx = log.WithContextPrefix(ctx, log.PrefixChecksBundle)
 	client, err := policy.NewClient(cacheDir, quiet, checkBundleRepository)
 	if err != nil {
 		return nil, xerrors.Errorf("check client error: %w", err)
@@ -96,14 +97,14 @@ func InitBuiltinPolicies(ctx context.Context, cacheDir string, quiet, skipUpdate
 	}
 
 	if needsUpdate {
-		log.Info("Need to update the built-in policies")
-		log.Info("Downloading the built-in policies...")
-		if err = client.DownloadBuiltinPolicies(ctx, registryOpts); err != nil {
+		log.InfoContext(ctx, "Need to update the built-in checks")
+		log.InfoContext(ctx, "Downloading the built-in checks...")
+		if err = client.DownloadBuiltinChecks(ctx, registryOpts); err != nil {
 			return nil, xerrors.Errorf("failed to download built-in policies: %w", err)
 		}
 	}
 
-	policyPaths, err := client.LoadBuiltinPolicies()
+	policyPaths, err := client.LoadBuiltinChecks()
 	if err != nil {
 		if skipUpdate {
 			msg := "No downloadable policies were loaded as --skip-check-update is enabled"

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -102,7 +102,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 	}
 
 	if db.SchemaVersion < meta.Version {
-		log.ErrorContext(ctx, "The Trivy version is old. Update to the latest version.", log.String("version", cliVersion))
+		log.ErrorContext(ctx, "Trivy version is old. Update to the latest version.", log.String("version", cliVersion))
 		return false, xerrors.Errorf("the version of DB schema doesn't match. Local DB: %d, Expected: %d",
 			meta.Version, db.SchemaVersion)
 	}

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -74,7 +74,7 @@ func (u *Updater) Update() error {
 		if err = metac.Update(meta); err != nil {
 			return xerrors.Errorf("Java DB metadata update error: %w", err)
 		}
-		log.InfoContext(ctx, "The Java DB is cached for 3 days. If you want to update the database more frequently, "+
+		log.InfoContext(ctx, "Java DB is cached for 3 days. If you want to update the database more frequently, "+
 			`"trivy clean --java-db" command clears the DB cache.`)
 	}
 

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -43,6 +43,7 @@ type Updater struct {
 }
 
 func (u *Updater) Update() error {
+	ctx := log.WithContextPrefix(context.Background(), log.PrefixJavaDB)
 	metac := db.NewMetadata(u.dbDir)
 
 	meta, err := metac.Get()
@@ -50,15 +51,15 @@ func (u *Updater) Update() error {
 		if !errors.Is(err, os.ErrNotExist) {
 			return xerrors.Errorf("Java DB metadata error: %w", err)
 		} else if u.skip {
-			log.Error("The first run cannot skip downloading Java DB")
+			log.ErrorContext(ctx, "The first run cannot skip downloading Java DB")
 			return xerrors.New("'--skip-java-db-update' cannot be specified on the first run")
 		}
 	}
 
-	if (meta.Version != SchemaVersion || !u.isNewDB(meta)) && !u.skip {
+	if (meta.Version != SchemaVersion || !u.isNewDB(ctx, meta)) && !u.skip {
 		// Download DB
 		// TODO: support remote options
-		if err := u.downloadDB(); err != nil {
+		if err := u.downloadDB(ctx); err != nil {
 			return xerrors.Errorf("OCI artifact error: %w", err)
 		}
 
@@ -73,33 +74,36 @@ func (u *Updater) Update() error {
 		if err = metac.Update(meta); err != nil {
 			return xerrors.Errorf("Java DB metadata update error: %w", err)
 		}
-		log.Info("The Java DB is cached for 3 days. If you want to update the database more frequently, " +
+		log.InfoContext(ctx, "The Java DB is cached for 3 days. If you want to update the database more frequently, "+
 			`"trivy clean --java-db" command clears the DB cache.`)
 	}
 
 	return nil
 }
 
-func (u *Updater) isNewDB(meta db.Metadata) bool {
+func (u *Updater) isNewDB(ctx context.Context, meta db.Metadata) bool {
 	now := time.Now().UTC()
 	if now.Before(meta.NextUpdate) {
-		log.Debug("Java DB update was skipped because the local Java DB is the latest")
+		log.DebugContext(ctx, "Java DB update was skipped because the local Java DB is the latest")
 		return true
 	}
 
 	if now.Before(meta.DownloadedAt.Add(time.Hour * 24)) { // 1 day
-		log.Debug("Java DB update was skipped because the local Java DB was downloaded during the last day")
+		log.DebugContext(ctx, "Java DB update was skipped because the local Java DB was downloaded during the last day")
 		return true
 	}
 	return false
 }
 
-func (u *Updater) downloadDB() error {
-	log.Info("Downloading Java DB...")
+func (u *Updater) downloadDB(ctx context.Context) error {
+	log.InfoContext(ctx, "Downloading Java DB...")
 
 	artifacts := oci.NewArtifacts(u.repos, u.registryOption)
-	downloadOpt := oci.DownloadOption{MediaType: mediaType, Quiet: u.quiet}
-	if err := artifacts.Download(context.Background(), u.dbDir, downloadOpt); err != nil {
+	downloadOpt := oci.DownloadOption{
+		MediaType: mediaType,
+		Quiet:     u.quiet,
+	}
+	if err := artifacts.Download(ctx, u.dbDir, downloadOpt); err != nil {
 		return xerrors.Errorf("failed to download vulnerability DB: %w", err)
 	}
 

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -37,7 +37,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 			trivyk8s.WithExcludeOwned(opts.ExcludeOwned),
 		}
 		if opts.Scanners.AnyEnabled(types.MisconfigScanner) && !opts.DisableNodeCollector {
-			artifacts, err = trivyk8s.New(cluster, k8sOpts...).ListArtifactAndNodeInfo(ctx, nodeCollectorOptions(opts)...)
+			artifacts, err = trivyk8s.New(cluster, k8sOpts...).ListArtifactAndNodeInfo(ctx, nodeCollectorOptions(ctx, opts)...)
 			if err != nil {
 				return xerrors.Errorf("get k8s artifacts with node info error: %w", err)
 			}
@@ -59,7 +59,7 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	return runner.run(ctx, artifacts)
 }
 
-func nodeCollectorOptions(opts flag.Options) []trivyk8s.NodeCollectorOption {
+func nodeCollectorOptions(ctx context.Context, opts flag.Options) []trivyk8s.NodeCollectorOption {
 	nodeCollectorOptions := []trivyk8s.NodeCollectorOption{
 		trivyk8s.WithScanJobNamespace(opts.NodeCollectorNamespace),
 		trivyk8s.WithIgnoreLabels(opts.ExcludeNodes),
@@ -67,13 +67,9 @@ func nodeCollectorOptions(opts flag.Options) []trivyk8s.NodeCollectorOption {
 		trivyk8s.WithTolerations(opts.Tolerations),
 	}
 
-	contentPath, err := operation.InitBuiltinChecks(context.Background(),
-		opts.CacheDir,
-		opts.Quiet,
-		opts.SkipCheckUpdate,
-		opts.MisconfOptions.ChecksBundleRepository,
-		opts.RegistryOpts())
-
+	ctx = log.WithContextPrefix(ctx, log.PrefixMisconfiguration)
+	contentPath, err := operation.InitBuiltinChecks(ctx, opts.CacheDir, opts.Quiet, opts.SkipCheckUpdate,
+		opts.MisconfOptions.ChecksBundleRepository, opts.RegistryOpts())
 	if err != nil {
 		log.Error("Falling back to embedded checks", log.Err(err))
 		nodeCollectorOptions = append(nodeCollectorOptions,

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -64,9 +64,10 @@ func nodeCollectorOptions(opts flag.Options) []trivyk8s.NodeCollectorOption {
 		trivyk8s.WithScanJobNamespace(opts.NodeCollectorNamespace),
 		trivyk8s.WithIgnoreLabels(opts.ExcludeNodes),
 		trivyk8s.WithScanJobImageRef(opts.NodeCollectorImageRef),
-		trivyk8s.WithTolerations(opts.Tolerations)}
+		trivyk8s.WithTolerations(opts.Tolerations),
+	}
 
-	contentPath, err := operation.InitBuiltinPolicies(context.Background(),
+	contentPath, err := operation.InitBuiltinChecks(context.Background(),
 		opts.CacheDir,
 		opts.Quiet,
 		opts.SkipCheckUpdate,

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -24,6 +24,7 @@ const (
 	PrefixSecret           = "secret"
 	PrefixLicense          = "license"
 	PrefixVulnerabilityDB  = "vuln-db"
+	PrefixJavaDB           = "java-db"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -23,8 +23,8 @@ const (
 	PrefixMisconfiguration = "misconfig"
 	PrefixSecret           = "secret"
 	PrefixLicense          = "license"
-	PrefixVulnerabilityDB  = "vuln-db"
-	PrefixJavaDB           = "java-db"
+	PrefixVulnerabilityDB  = "vulndb"
+	PrefixJavaDB           = "javadb"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -23,6 +23,7 @@ const (
 	PrefixMisconfiguration = "misconfig"
 	PrefixSecret           = "secret"
 	PrefixLicense          = "license"
+	PrefixVulnerabilityDB  = "vuln-db"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -25,6 +25,7 @@ const (
 	PrefixLicense          = "license"
 	PrefixVulnerabilityDB  = "vulndb"
 	PrefixJavaDB           = "javadb"
+	PrefixChecksBundle     = "checks"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -25,7 +25,6 @@ const (
 	PrefixLicense          = "license"
 	PrefixVulnerabilityDB  = "vulndb"
 	PrefixJavaDB           = "javadb"
-	PrefixChecksBundle     = "checks"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -225,19 +225,19 @@ func NewArtifacts(repos []name.Reference, opt types.RegistryOptions, opts ...Opt
 // Attempts to download next artifact if the first one fails due to a temporary error.
 func (a Artifacts) Download(ctx context.Context, dst string, opt DownloadOption) error {
 	for i, art := range a {
-		log.Info("Downloading  artifact...", log.String("repo", art.repository))
+		log.InfoContext(ctx, "Downloading artifact...", log.String("repo", art.repository))
 		err := art.Download(ctx, dst, opt)
 		if err == nil {
-			log.Info("Artifact successfully downloaded", log.String("repo", art.repository))
+			log.InfoContext(ctx, "Artifact successfully downloaded", log.String("repo", art.repository))
 			return nil
 		}
 
 		if !shouldTryOtherRepo(err) {
 			return xerrors.Errorf("failed to download artifact from %s: %w", art.repository, err)
 		}
-		log.Error("Failed to download artifact", log.String("repo", art.repository), log.Err(err))
+		log.ErrorContext(ctx, "Failed to download artifact", log.String("repo", art.repository), log.Err(err))
 		if i < len(a)-1 {
-			log.Info("Trying to download artifact from other repository...")
+			log.InfoContext(ctx, "Trying to download artifact from other repository...")
 		}
 	}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -152,7 +152,7 @@ func (c *Client) LoadBuiltinChecks() ([]string, error) {
 
 // NeedsUpdate returns if the default check should be updated
 func (c *Client) NeedsUpdate(ctx context.Context, registryOpts types.RegistryOptions) (bool, error) {
-	meta, err := c.GetMetadata()
+	meta, err := c.GetMetadata(ctx)
 	if err != nil {
 		return true, nil
 	}
@@ -213,17 +213,17 @@ func (c *Client) updateMetadata(digest string, now time.Time) error {
 	return nil
 }
 
-func (c *Client) GetMetadata() (*Metadata, error) {
+func (c *Client) GetMetadata(ctx context.Context) (*Metadata, error) {
 	f, err := os.Open(c.metadataPath())
 	if err != nil {
-		log.Debug("Failed to open the check metadata", log.Err(err))
+		log.DebugContext(ctx, "Failed to open the check metadata", log.Err(err))
 		return nil, err
 	}
 	defer f.Close()
 
 	var meta Metadata
 	if err = json.NewDecoder(f).Decode(&meta); err != nil {
-		log.Warn("Check metadata decode error", log.Err(err))
+		log.WarnContext(ctx, "Check metadata decode error", log.Err(err))
 		return nil, err
 	}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -89,20 +89,22 @@ func NewClient(cacheDir string, quiet bool, checkBundleRepo string, opts ...Opti
 	}, nil
 }
 
-func (c *Client) populateOCIArtifact(registryOpts types.RegistryOptions) {
+func (c *Client) populateOCIArtifact(ctx context.Context, registryOpts types.RegistryOptions) {
 	if c.artifact == nil {
-		log.Debug("Loading check bundle", log.String("repository", c.checkBundleRepo))
+		log.DebugContext(ctx, "Loading check bundle", log.String("repository", c.checkBundleRepo))
 		c.artifact = oci.NewArtifact(c.checkBundleRepo, registryOpts)
 	}
 }
 
-// DownloadBuiltinPolicies download default policies from GitHub Pages
-func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOpts types.RegistryOptions) error {
-	c.populateOCIArtifact(registryOpts)
+// DownloadBuiltinChecks download default policies from GitHub Pages
+func (c *Client) DownloadBuiltinChecks(ctx context.Context, registryOpts types.RegistryOptions) error {
+	c.populateOCIArtifact(ctx, registryOpts)
 
 	dst := c.contentDir()
-	if err := c.artifact.Download(ctx, dst,
-		oci.DownloadOption{MediaType: policyMediaType, Quiet: c.quiet},
+	if err := c.artifact.Download(ctx, dst, oci.DownloadOption{
+		MediaType: policyMediaType,
+		Quiet:     c.quiet,
+	},
 	); err != nil {
 		return xerrors.Errorf("download error: %w", err)
 	}
@@ -111,7 +113,7 @@ func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOpts types
 	if err != nil {
 		return xerrors.Errorf("digest error: %w", err)
 	}
-	log.Debug("Digest of the built-in policies", log.String("digest", digest))
+	log.DebugContext(ctx, "Digest of the built-in checks", log.String("digest", digest))
 
 	// Update metadata.json with the new digest and the current date
 	if err = c.updateMetadata(digest, c.clock.Now()); err != nil {
@@ -121,8 +123,8 @@ func (c *Client) DownloadBuiltinPolicies(ctx context.Context, registryOpts types
 	return nil
 }
 
-// LoadBuiltinPolicies loads default policies
-func (c *Client) LoadBuiltinPolicies() ([]string, error) {
+// LoadBuiltinChecks loads default policies
+func (c *Client) LoadBuiltinChecks() ([]string, error) {
 	f, err := os.Open(c.manifestPath())
 	if err != nil {
 		return nil, xerrors.Errorf("manifest file open error (%s): %w", c.manifestPath(), err)
@@ -160,7 +162,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, registryOpts types.RegistryOpt
 		return false, nil
 	}
 
-	c.populateOCIArtifact(registryOpts)
+	c.populateOCIArtifact(ctx, registryOpts)
 	digest, err := c.artifact.Digest(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("digest error: %w", err)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -120,7 +120,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 			c, err := policy.NewClient(tt.cacheDir, true, "", policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			got, err := c.LoadBuiltinPolicies()
+			got, err := c.LoadBuiltinChecks()
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -361,7 +361,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			c, err := policy.NewClient(tempDir, true, "", policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			err = c.DownloadBuiltinPolicies(context.Background(), ftypes.RegistryOptions{})
+			err = c.DownloadBuiltinChecks(context.Background(), ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -81,7 +81,7 @@ func NewVersionInfo(cacheDir string) VersionInfo {
 		log.Debug("Failed to instantiate policy client", log.Err(err))
 	}
 	if pc != nil && err == nil {
-		ctx := log.WithContextPrefix(context.TODO(), log.PrefixChecksBundle)
+		ctx := log.WithContextPrefix(context.TODO(), log.PrefixMisconfiguration)
 		pbMetaRaw, err := pc.GetMetadata(ctx)
 
 		if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -80,7 +81,8 @@ func NewVersionInfo(cacheDir string) VersionInfo {
 		log.Debug("Failed to instantiate policy client", log.Err(err))
 	}
 	if pc != nil && err == nil {
-		pbMetaRaw, err := pc.GetMetadata()
+		ctx := log.WithContextPrefix(context.TODO(), log.PrefixChecksBundle)
+		pbMetaRaw, err := pc.GetMetadata(ctx)
 
 		if err != nil {
 			log.Debug("Failed to get policy metadata", log.Err(err))


### PR DESCRIPTION
## Description
Adding prefixes for each artifact.

### Before

```
2024-10-01T15:43:48+04:00       INFO    [db] Need to update DB
2024-10-01T15:43:48+04:00       INFO    Downloading vulnerability DB...
2024-10-01T15:43:48+04:00       INFO    Downloading  artifact...        repo="ghcr.io/aquasecurity/trivy-db:2"
53.85 MiB / 53.85 MiB [---------------------------------------------------------------------------------------------------------------] 100.00% 23.26 MiB p/s 2.5s
2024-10-01T15:43:51+04:00       INFO    Artifact successfully downloaded        repo="ghcr.io/aquasecurity/trivy-db:2"
```

### After

```
2024-10-01T18:16:51+04:00       INFO    [vulndb] Need to update DB
2024-10-01T18:16:51+04:00       INFO    [vulndb] Downloading vulnerability DB...
2024-10-01T18:16:51+04:00       INFO    [vulndb] Downloading artifact...        repo="ghcr.io/aquasecurity/trivy-db:2"
53.87 MiB / 53.87 MiB [---------------------------------------------------------------------------------------------------------------] 100.00% 28.86 MiB p/s 2.1s
2024-10-01T18:16:55+04:00       INFO    [vulndb] Artifact successfully downloaded       repo="ghcr.io/aquasecurity/trivy-db:2"
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
