### PR TITLE
fix(misconf): not to warn about missing selectors of libraries

### DIFF
--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -302,14 +302,17 @@ func (s *Scanner) filterModules(retriever *MetadataRetriever) error {
 		}
 
 		if len(meta.InputOptions.Selectors) == 0 {
-			s.logger.Warn(
-				"Module has no input selectors - it will be loaded for all inputs!",
-				log.FilePath(module.Package.Location.File),
-				log.String("module", name),
-			)
+			if !meta.Library {
+				s.logger.Warn(
+					"Module has no input selectors - it will be loaded for all inputs!",
+					log.FilePath(module.Package.Location.File),
+					log.String("module", name),
+				)
+			}
 			filtered[name] = module
 			continue
 		}
+
 		for _, selector := range meta.InputOptions.Selectors {
 			if selector.Type == string(s.sourceType) {
 				filtered[name] = module


### PR DESCRIPTION
## Description

This PR gets rid of those noisy messages for Rego libraries:

```bash
2024-10-03T08:53:28+06:00       WARN    [rego] Module has no input selectors - it will be loaded for all inputs!        file_path="Users/nikita/Library/Caches/trivy/policy/content/policies/test/lib/test.rego" module="Users/nikita/Library/Caches/trivy/policy/content/policies/test/lib/test.rego"
2024-10-03T08:53:28+06:00       WARN    [rego] Module has no input selectors - it will be loaded for all inputs!        file_path="Users/nikita/Library/Caches/trivy/policy/content/policies/cloud/lib/metadata.rego" module="Users/nikita/Library/Caches/trivy/policy/content/policies/cloud/lib/metadata.rego"
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
