### PR TITLE
fix(redhat): include arch in PURL qualifiers

### DIFF
--- a/pkg/fanal/analyzer/pkg/rpm/archive.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive.go
@@ -136,13 +136,14 @@ func (a *rpmArchiveAnalyzer) generatePURL(pkg *types.Package) *packageurl.Packag
 	case strings.Contains(vendor, "suse"):
 		ns = "suse"
 	}
-	return packageurl.NewPackageURL(packageurl.TypeRPM, ns, pkg.Name, utils.FormatVersion(*pkg),
-		packageurl.Qualifiers{
-			{
-				Key:   "arch",
-				Value: pkg.Arch,
-			},
-		}, "")
+	var qualifiers packageurl.Qualifiers
+	if pkg.Arch != "" {
+		qualifiers = append(qualifiers, packageurl.Qualifier{
+			Key:   "arch",
+			Value: pkg.Arch,
+		})
+	}
+	return packageurl.NewPackageURL(packageurl.TypeRPM, ns, pkg.Name, utils.FormatVersion(*pkg), qualifiers, "")
 }
 
 func (a *rpmArchiveAnalyzer) unexpectedError(err error) error {

--- a/pkg/fanal/analyzer/pkg/rpm/archive.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive.go
@@ -136,7 +136,13 @@ func (a *rpmArchiveAnalyzer) generatePURL(pkg *types.Package) *packageurl.Packag
 	case strings.Contains(vendor, "suse"):
 		ns = "suse"
 	}
-	return packageurl.NewPackageURL(packageurl.TypeRPM, ns, pkg.Name, utils.FormatVersion(*pkg), nil, "")
+	return packageurl.NewPackageURL(packageurl.TypeRPM, ns, pkg.Name, utils.FormatVersion(*pkg),
+		packageurl.Qualifiers{
+			{
+				Key:   "arch",
+				Value: pkg.Arch,
+			},
+		}, "")
 }
 
 func (a *rpmArchiveAnalyzer) unexpectedError(err error) error {

--- a/pkg/fanal/analyzer/pkg/rpm/archive_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive_test.go
@@ -52,6 +52,12 @@ func Test_rpmArchiveAnalyzer_Analyze(t *testing.T) {
 										Namespace: "redhat",
 										Name:      "socat",
 										Version:   "1.7.3.2-2.el7",
+										Qualifiers: packageurl.Qualifiers{
+											{
+												Key:   "arch",
+												Value: "x86_64",
+											},
+										},
 									},
 								},
 							},


### PR DESCRIPTION
## Description
If arch is not included in the PURL, the CycloneDX BOM-Ref will conflict and the UUID will be used.

### Before

```
$ TRIVY_EXPERIMENTAL_RPM_ARCHIVE=true ./trivy fs -q /tmp/rhel7 -f cyclonedx | jq '.components[]."bom-ref"'
"1b4f1e8d-5ab2-4cc1-82ee-e6a3e1c01d0f"
"3d5fbe66-61ae-4e94-99a3-a0733bb02f23"
"40b75c7a-c905-4705-bb0e-1d10a928100b"
"6945ac93-e8ea-4206-86e2-d9ecc535a831"
"6a99e954-0bab-400b-b1cb-41aa05e0d98a"
"d20ed80e-2bb9-4b31-87cf-29effae1f56b"
"f11347f2-5bd0-44c7-9bdf-a675e34348a9"
"pkg:rpm/redhat/ant@1.9.4-2.el7"
"pkg:rpm/redhat/audispd-plugins@2.8.5-4.el7"
"pkg:rpm/redhat/audit@2.8.5-4.el7"
"pkg:rpm/redhat/bind-chroot@32%3A9.11.4-26.P2.el7"
"pkg:rpm/redhat/bind@32%3A9.11.4-26.P2.el7"
"pkg:rpm/redhat/binutils@2.27-44.base.el7"
"pkg:rpm/redhat/cpio@2.11-28.el7"
"pkg:rpm/redhat/crash@7.2.3-11.el7"
"pkg:rpm/redhat/criu@3.12-2.el7"
"pkg:rpm/redhat/cups@1%3A1.6.3-51.el7"
"pkg:rpm/redhat/curl@7.29.0-59.el7"
"pkg:rpm/redhat/dhcp@12%3A4.2.5-82.el7"
"pkg:rpm/redhat/dom4j@1.6.1-20.el7"
"pkg:rpm/redhat/expect@5.45-14.el7_1"
```

### After

```
$ TRIVY_EXPERIMENTAL_RPM_ARCHIVE=true ./trivy fs -q /tmp/rhel7 -f cyclonedx | jq '.components[]."bom-ref"'
"b4212da9-d0c1-4a65-9aea-af375e90b97d"
"pkg:rpm/redhat/ant@1.9.4-2.el7?arch=noarch"
"pkg:rpm/redhat/apr@1.4.8-7.el7?arch=i686"
"pkg:rpm/redhat/apr@1.4.8-7.el7?arch=x86_64"
"pkg:rpm/redhat/audispd-plugins@2.8.5-4.el7?arch=x86_64"
"pkg:rpm/redhat/audit@2.8.5-4.el7?arch=x86_64"
"pkg:rpm/redhat/bind-chroot@32%3A9.11.4-26.P2.el7?arch=x86_64"
"pkg:rpm/redhat/bind@32%3A9.11.4-26.P2.el7?arch=x86_64"
"pkg:rpm/redhat/binutils@2.27-44.base.el7?arch=x86_64"
"pkg:rpm/redhat/cpio@2.11-28.el7?arch=x86_64"
"pkg:rpm/redhat/crash@7.2.3-11.el7?arch=x86_64"
"pkg:rpm/redhat/criu@3.12-2.el7?arch=x86_64"
"pkg:rpm/redhat/cups@1%3A1.6.3-51.el7?arch=x86_64"
"pkg:rpm/redhat/curl@7.29.0-59.el7?arch=x86_64"
"pkg:rpm/redhat/dhcp@12%3A4.2.5-82.el7?arch=x86_64"
"pkg:rpm/redhat/dom4j@1.6.1-20.el7?arch=noarch"
"pkg:rpm/redhat/expat@2.1.0-12.el7?arch=i686"
"pkg:rpm/redhat/expat@2.1.0-12.el7?arch=x86_64"
"pkg:rpm/redhat/expect@5.45-14.el7_1?arch=x86_64"
"pkg:rpm/redhat/glibc@2.17-317.el7?arch=i686"
"pkg:rpm/redhat/glibc@2.17-317.el7?arch=x86_64"
```

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/7628

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
