### PR TITLE
fix(sbom): add options for DBs in private registries

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -47,12 +47,14 @@ trivy sbom [flags] SBOM_PATH
       --offline-scan                 do not issue API requests to identify dependencies
   -o, --output string                output file name
       --output-plugin-arg string     [EXPERIMENTAL] output plugin arguments
+      --password strings             password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --pkg-relationships strings    list of package relationships (unknown,root,direct,indirect) (default [unknown,root,direct,indirect])
       --pkg-types strings            list of package types (os,library) (default [os,library])
       --redis-ca string              redis ca file location, if using redis as cache backend
       --redis-cert string            redis certificate file location, if using redis as cache backend
       --redis-key string             redis key file location, if using redis as cache backend
       --redis-tls                    enable redis TLS with public certificates, if using redis as cache backend
+      --registry-token string        registry token
       --rekor-url string             [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sbom-sources strings         [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
       --scanners strings             comma-separated list of what security issues to detect (vuln,license) (default [vuln])
@@ -67,6 +69,7 @@ trivy sbom [flags] SBOM_PATH
   -t, --template string              output template
       --token string                 for authentication in client/server mode
       --token-header string          specify a header name for token in client/server mode (default "Trivy-Token")
+      --username strings             username. Comma-separated usernames allowed.
       --vex strings                  [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
 ```
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1143,7 +1143,8 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		CacheFlagGroup:         flag.NewCacheFlagGroup(),
 		DBFlagGroup:            flag.NewDBFlagGroup(),
 		PackageFlagGroup:       flag.NewPackageFlagGroup(),
-		RemoteFlagGroup:        flag.NewClientFlags(), // for client/server mode
+		RemoteFlagGroup:        flag.NewClientFlags(),       // for client/server mode
+		RegistryFlagGroup:      flag.NewRegistryFlagGroup(), // for DBs in private registries
 		ReportFlagGroup:        reportFlagGroup,
 		ScanFlagGroup:          scanFlagGroup,
 		VulnerabilityFlagGroup: flag.NewVulnerabilityFlagGroup(),


### PR DESCRIPTION
## Description
Enable registry option also in SBOM command to download DBs stored in private registry

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
