### PR TITLE
fix(terraform): set null value as fallback for missing variables

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -217,6 +217,7 @@ func (p *Parser) Load(ctx context.Context) (*evaluator, error) {
 				"Variable values was not found in the environment or variable files. Evaluating may not work correctly.",
 				log.String("variables", strings.Join(missingVars, ", ")),
 			)
+			setNullMissingVariableValues(inputVars, missingVars)
 		}
 	}
 
@@ -266,6 +267,14 @@ func missingVariableValues(blocks terraform.Blocks, inputVars map[string]cty.Val
 	}
 
 	return missing
+}
+
+// Set null values for missing variables, to allow expressions using them to be
+// still be possibly evaluated to a value different than null.
+func setNullMissingVariableValues(inputVars map[string]cty.Value, missingVars []string) {
+	for _, missingVar := range missingVars {
+		inputVars[missingVar] = cty.NullVal(cty.DynamicPseudoType)
+	}
 }
 
 func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, cty.Value, error) {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1671,6 +1671,36 @@ resource "test" "fileset-func" {
 	assert.Equal(t, []string{"a.py", "path/b.py"}, attr.GetRawValue())
 }
 
+func TestExprWithMissingVar(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+variable "v" {
+	type = string
+}
+
+resource "test" "values" {
+	s = "foo-${var.v}"
+    l1 = ["foo", var.v]
+    l2 = concat(["foo"], [var.v])
+    d1 = {foo = var.v}
+    d2 = merge({"foo": "bar"}, {"baz": var.v})
+}
+`,
+	}
+
+	resources := parse(t, files).GetResourcesByType("test")
+	require.Len(t, resources, 1)
+
+	s_attr := resources[0].GetAttribute("s")
+	require.NotNil(t, s_attr)
+	assert.Equal(t, "foo-", s_attr.GetRawValue())
+
+	for _, name := range []string{"l1", "l2", "d1", "d2"} {
+		attr := resources[0].GetAttribute(name)
+		require.NotNil(t, attr)
+	}
+}
+
 func TestVarTypeShortcut(t *testing.T) {
 	files := map[string]string{
 		"main.tf": `


### PR DESCRIPTION
## Description

This adds a default null value for variables that don't  get a value (either supplied or default).
It allows expressions using those variables to be evaluated, rather than just be set to null.
E.g

```terraform
variable "v" {
  type = string
}

locals {
  l = ["foo", var.v]
  d = {"foo": var.v}
}
```

would produce `l = ["foo" null]` and `d = {"foo": null}` rather than just being both `null`. 


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
