### PR TITLE
docs(report): fix reporting doc format

### DIFF
--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -259,11 +259,12 @@ $ trivy image --format sarif -o report.sarif  golang:1.12-alpine
 ```
 
 This SARIF file can be uploaded to several platforms, including:
-- [GitHub code scanning results][sarif-github], and there is a [Trivy GitHub Action][action] for automating this process;
-- [SonarQube][sarif-sonar].
+
+- [GitHub code scanning results][sarif-github], and there is a [Trivy GitHub Action][action] for automating this process
+- [SonarQube][sarif-sonar]
 
 ### GitHub dependency snapshot
-Trivy supports the following packages.
+Trivy supports the following packages:
 
 - [OS packages][os_packages]
 - [Language-specific packages][language_packages]


### PR DESCRIPTION
## Description

The list format is broken in https://aquasecurity.github.io/trivy/dev/docs/configuration/reporting/#sarif since an empty line is required before the list.

The markdown parser used for Trivy documentation is stricter than the one used by GitHub.

The list punctuation is also now more consistent in the document.

## Related PRs
- #7655

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
