### PR TITLE
docs: apt-transport-https is a transitional package

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,7 +34,7 @@ In this section you will find an aggregation of the different ways to install Tr
     Add repository setting to `/etc/apt/sources.list.d`.
 
     ``` bash
-    sudo apt-get install wget apt-transport-https gnupg
+    sudo apt-get install wget gnupg
     wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
     echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
     sudo apt-get update


### PR DESCRIPTION
This package contains nothing of value since at least Focal/20.04:

https://packages.ubuntu.com/focal/all/apt-transport-https/filelist:
```
/usr/share/doc/apt-transport-https/NEWS.Debian.gz
/usr/share/doc/apt-transport-https/changelog.gz
/usr/share/doc/apt-transport-https/copyright
```