### PR TITLE
refactor(k8s): scan config files as a folder

### DIFF
--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -42,9 +42,9 @@ func generateTempFileByArtifact(artifact *artifacts.Artifact, tempFolder string)
 	return filepath.Base(file.Name()), nil
 }
 
-// generateTempFolder creates a folder with yaml files generated from kubernetes artifacts
+// generateTempDir creates a folder with yaml files generated from kubernetes artifacts
 // returns a folder name, a map for mapping a temp target file to k8s artifact and error
-func generateTempFolder(arts []*artifacts.Artifact) (string, map[string]*artifacts.Artifact, error) {
+func generateTempDir(arts []*artifacts.Artifact) (string, map[string]*artifacts.Artifact, error) {
 	tempFolder, err := os.MkdirTemp("", "trivyk8s*")
 	if err != nil {
 		return "", nil, xerrors.Errorf("failed to create temp folder: %w", err)

--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -16,13 +16,13 @@ import (
 
 var r = regexp.MustCompile("[\\\\/:*?<>]")
 
-func generateTempFileByArtifact(artifact *artifacts.Artifact, tempFolder string) (string, error) {
+func generateTempFileByArtifact(artifact *artifacts.Artifact, tempDir string) (string, error) {
 	filename := fmt.Sprintf("%s-%s-%s-*.yaml", artifact.Namespace, artifact.Kind, artifact.Name)
 	if runtime.GOOS == "windows" {
 		// removes characters not permitted in file/directory names on Windows
 		filename = filenameWindowsFriendly(filename)
 	}
-	file, err := os.CreateTemp(tempFolder, filename)
+	file, err := os.CreateTemp(tempDir, filename)
 	if err != nil {
 		return "", xerrors.Errorf("failed to create temporary file: %w", err)
 	}
@@ -42,35 +42,35 @@ func generateTempFileByArtifact(artifact *artifacts.Artifact, tempFolder string)
 	return filepath.Base(file.Name()), nil
 }
 
-// generateTempDir creates a folder with yaml files generated from kubernetes artifacts
-// returns a folder name, a map for mapping a temp target file to k8s artifact and error
+// generateTempDir creates a directory with yaml files generated from kubernetes artifacts
+// returns a directory name, a map for mapping a temp target file to k8s artifact and error
 func generateTempDir(arts []*artifacts.Artifact) (string, map[string]*artifacts.Artifact, error) {
-	tempFolder, err := os.MkdirTemp("", "trivyk8s*")
+	tempDir, err := os.MkdirTemp("", "trivyk8s*")
 	if err != nil {
-		return "", nil, xerrors.Errorf("failed to create temp folder: %w", err)
+		return "", nil, xerrors.Errorf("failed to create temp directory: %w", err)
 	}
 
 	m := make(map[string]*artifacts.Artifact)
 	for _, artifact := range arts {
-		filename, err := generateTempFileByArtifact(artifact, tempFolder)
+		filename, err := generateTempFileByArtifact(artifact, tempDir)
 		if err != nil {
 			log.Error("Failed to create temp file", log.FilePath(filename), log.Err(err))
 			continue
 		}
 		m[filename] = artifact
 	}
-	return tempFolder, m, nil
+	return tempDir, m, nil
 }
 
-func removeFolder(foldername string) {
-	if err := os.RemoveAll(foldername); err != nil {
-		log.Error("Failed to remove temp folder", log.String("path", foldername), log.Err(err))
+func removeDir(dirname string) {
+	if err := os.RemoveAll(dirname); err != nil {
+		log.Error("Failed to remove temp directory", log.FilePath(dirname), log.Err(err))
 	}
 }
 
 func removeFile(filename string) {
 	if err := os.Remove(filename); err != nil {
-		log.Error("Failed to remove temp file", log.String("path", filename), log.Err(err))
+		log.Error("Failed to remove temp file", log.FilePath(filename), log.Err(err))
 	}
 }
 

--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -24,7 +24,7 @@ func generateTempFolder(arts []*artifacts.Artifact) (string, map[string]*artifac
 		return "", nil, xerrors.Errorf("failed to create temp folder: %w", err)
 	}
 
-	m := map[string]*artifacts.Artifact{}
+	m := make(map[string]*artifacts.Artifact)
 	for _, artifact := range arts {
 		filename := fmt.Sprintf("%s-%s-%s-*.yaml", artifact.Namespace, artifact.Kind, artifact.Name)
 		if runtime.GOOS == "windows" {

--- a/pkg/k8s/scanner/io.go
+++ b/pkg/k8s/scanner/io.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 )
 
-var r = regexp.MustCompile("\\\\|/|:|\\*|\\?|<|>")
+var r = regexp.MustCompile("[\\\\/:*?<>]")
 
 func generateTempFileByArtifact(artifact *artifacts.Artifact, tempFolder string) (string, error) {
 	filename := fmt.Sprintf("%s-%s-%s-*.yaml", artifact.Namespace, artifact.Kind, artifact.Name)

--- a/pkg/k8s/scanner/io_test.go
+++ b/pkg/k8s/scanner/io_test.go
@@ -23,6 +23,11 @@ func Test_FilenameWindowsFriendly(t *testing.T) {
 			fileName: `kube-system-Role-system-controller-bootstrap-signer-2934213283.yaml`,
 			want:     `kube-system-Role-system-controller-bootstrap-signer-2934213283.yaml`,
 		},
+		{
+			name:     "name with no invalid - slash",
+			fileName: "-ClusterRoleBinding-system\\basic-user-725844313.yaml",
+			want:     `-ClusterRoleBinding-system_basic-user-725844313.yaml`,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -167,7 +167,7 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 }
 
 func (s *Scanner) scanMisconfigs(ctx context.Context, k8sArtifacts []*artifacts.Artifact) ([]report.Resource, error) {
-	folder, artifactsByFilename, err := generateTempFolder(k8sArtifacts)
+	folder, artifactsByFilename, err := generateTempDir(k8sArtifacts)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to generate temp folder: %w", err)
 	}

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -166,8 +166,8 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 	return resources, nil
 }
 
-func (s *Scanner) scanMisconfigs(ctx context.Context, artifacts []*artifacts.Artifact) ([]report.Resource, error) {
-	folder, artifactsByFilename, err := generateTempFolder(artifacts)
+func (s *Scanner) scanMisconfigs(ctx context.Context, k8sArtifacts []*artifacts.Artifact) ([]report.Resource, error) {
+	folder, artifactsByFilename, err := generateTempFolder(k8sArtifacts)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to generate temp folder: %w", err)
 	}
@@ -181,7 +181,7 @@ func (s *Scanner) scanMisconfigs(ctx context.Context, artifacts []*artifacts.Art
 	if err != nil {
 		return nil, xerrors.Errorf("failed to scan filesystem: %w", err)
 	}
-	resources := make([]report.Resource, 0, len(artifacts))
+	resources := make([]report.Resource, 0, len(k8sArtifacts))
 
 	for _, res := range configReport.Results {
 		artifact := artifactsByFilename[res.Target]

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -167,16 +167,16 @@ func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, o
 }
 
 func (s *Scanner) scanMisconfigs(ctx context.Context, k8sArtifacts []*artifacts.Artifact) ([]report.Resource, error) {
-	folder, artifactsByFilename, err := generateTempDir(k8sArtifacts)
+	dir, artifactsByFilename, err := generateTempDir(k8sArtifacts)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to generate temp folder: %w", err)
+		return nil, xerrors.Errorf("failed to generate temp dir: %w", err)
 	}
 
-	s.opts.Target = folder
+	s.opts.Target = dir
 
 	configReport, err := s.runner.ScanFilesystem(ctx, s.opts)
 	// remove config files after scanning
-	removeFolder(folder)
+	removeDir(dir)
 
 	if err != nil {
 		return nil, xerrors.Errorf("failed to scan filesystem: %w", err)

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -184,11 +184,20 @@ func (s *Scanner) scanMisconfigs(ctx context.Context, artifacts []*artifacts.Art
 	resources := make([]report.Resource, 0, len(artifacts))
 
 	for _, res := range configReport.Results {
-
 		artifact := artifactsByFilename[res.Target]
-		resource, err := s.filter(ctx, configReport, artifact)
+
+		singleReport := types.Report{
+			SchemaVersion: configReport.SchemaVersion,
+			CreatedAt:     configReport.CreatedAt,
+			ArtifactName:  res.Target,
+			ArtifactType:  configReport.ArtifactType,
+			Metadata:      configReport.Metadata,
+			Results:       types.Results{res},
+		}
+
+		resource, err := s.filter(ctx, singleReport, artifact)
 		if err != nil {
-			resource = report.CreateResource(artifact, configReport, err)
+			resource = report.CreateResource(artifact, singleReport, err)
 		}
 		resources = append(resources, resource)
 	}


### PR DESCRIPTION
## Description

Trivy kubernetes scan tries to process the k8s configs in parallel.
but this leads to large overhead, due to initialize the scanner for each file separately (it needs to read rego policies).

This PR stores all k8s config in the same folder and scan this one at once.
it gives a boost about 9 times on my test minikube instance.

Before 
```sh
$ time trivy k8s --report all --skip-images -f json -o result.json
2024-10-10T10:12:01+06:00	INFO	Node scanning is enabled
2024-10-10T10:12:01+06:00	INFO	If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
235 / 235 [-----------------------------------------------------------------------------------------------------------------] 100.00% 3 p/s
trivy k8s --report all --skip-images -f json -o result.json  147,50s user 8,63s system 148% cpu 1:45,12 total
```
After
```sh
$ time ./tr k8s --report all --skip-images -f json -o result.json
2024-10-10T17:04:04+06:00	INFO	Node scanning is enabled
2024-10-10T17:04:04+06:00	INFO	If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
./tr k8s --report all --skip-images -f json -o result.json  16,83s user 1,12s system 85% cpu 21,002 total
```

## Related issues
- Close #7662
- Close #7684 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
