### PR TITLE
feat(db): Allow by default the mirror AWS registry as well as GHCR

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -31,7 +31,7 @@ var (
 
 	// AWS Container Registry
 	DefaultAWSRepository = fmt.Sprintf("%s:%d", "public.ecr.aws/aquasecurity/trivy-db", db.SchemaVersion)
-	defaultAWSRepository = lo.Must(name.NewTag(DefaultSecondGHCRRepository))
+	defaultAWSRepository = lo.Must(name.NewTag(DefaultAWSRepository))
 
 	Init  = db.Init
 	Close = db.Close

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -29,6 +29,10 @@ var (
 	DefaultGHCRRepository = fmt.Sprintf("%s:%d", "ghcr.io/aquasecurity/trivy-db", db.SchemaVersion)
 	defaultGHCRRepository = lo.Must(name.NewTag(DefaultGHCRRepository))
 
+	// AWS Container Registry
+	DefaultAWSRepository = fmt.Sprintf("%s:%d", "public.ecr.aws/aquasecurity/trivy-db", db.SchemaVersion)
+	defaultAWSRepository = lo.Must(name.NewTag(DefaultSecondGHCRRepository))
+
 	Init  = db.Init
 	Close = db.Close
 	Path  = db.Path

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -53,13 +53,13 @@ var (
 	DBRepositoryFlag = Flag[[]string]{
 		Name:       "db-repository",
 		ConfigName: "db.repository",
-		Default:    []string{db.DefaultGHCRRepository},
+		Default:    []string{db.DefaultGHCRRepository, db.DefaultAWSRepository},
 		Usage:      "OCI repository(ies) to retrieve trivy-db in order of priority",
 	}
 	JavaDBRepositoryFlag = Flag[[]string]{
 		Name:       "java-db-repository",
 		ConfigName: "db.java-repository",
-		Default:    []string{javadb.DefaultGHCRRepository},
+		Default:    []string{javadb.DefaultGHCRRepository, javadb.DefaultAWSRepository},
 		Usage:      "OCI repository(ies) to retrieve trivy-java-db in order of priority",
 	}
 	LightFlag = Flag[bool]{

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -29,6 +29,9 @@ const (
 var (
 	// GitHub Container Registry
 	DefaultGHCRRepository = fmt.Sprintf("%s:%d", "ghcr.io/aquasecurity/trivy-java-db", SchemaVersion)
+
+	// AWS Container Registry
+	DefaultAWSRepository = fmt.Sprintf("%s:%d", "public.ecr.aws/aquasecurity/trivy-java-db", SchemaVersion)
 )
 
 var updater *Updater


### PR DESCRIPTION
## Description

Given the last issues lately ( ref: https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2402471437), and that trivy now supports setting several DB repositories. It should be quite straightforward to allow by default the two official repositories. GHCR and the AWS mirror.

## Related issues



## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
