### PR TITLE
fix(cli): `clean --all` deletes only relevant dirs

### DIFF
--- a/pkg/commands/clean/run.go
+++ b/pkg/commands/clean/run.go
@@ -2,7 +2,6 @@ package clean
 
 import (
 	"context"
-	"os"
 
 	"golang.org/x/xerrors"
 
@@ -25,7 +24,11 @@ func Run(ctx context.Context, opts flag.Options) error {
 	}
 
 	if opts.CleanAll {
-		return cleanAll(ctx, opts)
+		opts.CleanScanCache = true
+		opts.CleanVulnerabilityDB = true
+		opts.CleanJavaDB = true
+		opts.CleanChecksBundle = true
+		opts.CleanVEXRepositories = true
 	}
 
 	if opts.CleanScanCache {
@@ -56,14 +59,6 @@ func Run(ctx context.Context, opts flag.Options) error {
 		if err := cleanVEXRepositories(opts); err != nil {
 			return xerrors.Errorf("VEX repositories clean error: %w", err)
 		}
-	}
-	return nil
-}
-
-func cleanAll(ctx context.Context, opts flag.Options) error {
-	log.InfoContext(ctx, "Removing all caches...")
-	if err := os.RemoveAll(opts.CacheDir); err != nil {
-		return xerrors.Errorf("failed to remove the directory (%s) : %w", opts.CacheDir, err)
 	}
 	return nil
 }

--- a/pkg/commands/clean/run_test.go
+++ b/pkg/commands/clean/run_test.go
@@ -28,7 +28,12 @@ func TestRun(t *testing.T) {
 			},
 			wantErr: false,
 			checkFunc: func(t *testing.T, dir string) {
-				assert.NoDirExists(t, dir)
+				assert.NoDirExists(t, filepath.Join(dir, "fanal"))
+				assert.NoDirExists(t, filepath.Join(dir, "db"))
+				assert.NoDirExists(t, filepath.Join(dir, "java-db"))
+				assert.NoDirExists(t, filepath.Join(dir, "policy"))
+				assert.NoDirExists(t, filepath.Join(dir, "vex"))
+				assert.DirExists(t, dir)
 			},
 		},
 		{
@@ -42,6 +47,7 @@ func TestRun(t *testing.T) {
 				assert.DirExists(t, filepath.Join(dir, "db"))
 				assert.DirExists(t, filepath.Join(dir, "java-db"))
 				assert.DirExists(t, filepath.Join(dir, "policy"))
+				assert.DirExists(t, filepath.Join(dir, "vex"))
 			},
 		},
 		{
@@ -55,6 +61,7 @@ func TestRun(t *testing.T) {
 				assert.DirExists(t, filepath.Join(dir, "fanal"))
 				assert.DirExists(t, filepath.Join(dir, "java-db"))
 				assert.DirExists(t, filepath.Join(dir, "policy"))
+				assert.DirExists(t, filepath.Join(dir, "vex"))
 			},
 		},
 		{
@@ -68,6 +75,7 @@ func TestRun(t *testing.T) {
 				assert.DirExists(t, filepath.Join(dir, "fanal"))
 				assert.DirExists(t, filepath.Join(dir, "db"))
 				assert.DirExists(t, filepath.Join(dir, "policy"))
+				assert.DirExists(t, filepath.Join(dir, "vex"))
 			},
 		},
 		{
@@ -81,6 +89,21 @@ func TestRun(t *testing.T) {
 				assert.DirExists(t, filepath.Join(dir, "fanal"))
 				assert.DirExists(t, filepath.Join(dir, "db"))
 				assert.DirExists(t, filepath.Join(dir, "java-db"))
+				assert.DirExists(t, filepath.Join(dir, "vex"))
+			},
+		},
+		{
+			name: "clean vex repositories",
+			cleanOpts: flag.CleanOptions{
+				CleanVEXRepositories: true,
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, dir string) {
+				assert.DirExists(t, filepath.Join(dir, "policy"))
+				assert.DirExists(t, filepath.Join(dir, "fanal"))
+				assert.DirExists(t, filepath.Join(dir, "db"))
+				assert.DirExists(t, filepath.Join(dir, "java-db"))
+				assert.NoDirExists(t, filepath.Join(dir, "vex"))
 			},
 		},
 		{
@@ -127,6 +150,7 @@ func createTestFiles(t *testing.T, dir string) {
 		"db",
 		"java-db",
 		"policy",
+		"vex",
 	}
 	for _, subdir := range subdirs {
 		err := os.MkdirAll(filepath.Join(dir, subdir), 0755)


### PR DESCRIPTION
## Description
See #7703 

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7703

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
