### PR TITLE
ci: improve release workflow for merge queue compatibility

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -83,33 +83,35 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.check-release-commit.outputs.is_release == 'true' }}
     steps:
-      - name: Tag release
-        if: ${{ needs.check-release-commit.outputs.version }}
-        uses: actions/github-script@v7
+      - name: Checkout specific commit
+        uses: actions/checkout@v4
         with:
-          github-token: ${{ secrets.ORG_REPO_TOKEN }} # To trigger another workflow
-          script: |
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/tags/v${{ needs.check-release-commit.outputs.version }}`,
-              sha: '${{ needs.check-release-commit.outputs.release_sha }}'
-            });
+          fetch-depth: 0
+          ref: ${{ needs.check-release-commit.outputs.release_sha }}
+          token: ${{ secrets.ORG_REPO_TOKEN }} # Must have `repo` and `workflow` scopes
 
-      # When v0.50.0 is released, a release branch "release/v0.50" is created.
-      - name: Create release branch for patch versions
-        if: ${{ endsWith(needs.check-release-commit.outputs.version, '.0') }} # Skip patch versions
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Should not trigger the workflow again
-          script: |
-            const releaseBranch = '${{ needs.check-release-commit.outputs.release_branch }}';
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/heads/${releaseBranch}`,
-              sha: '${{ needs.check-release-commit.outputs.release_sha }}'
-            });
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # `/repos/{owner}/{repo}/git/refs` API seems to work only with the head commit.
+      # cf. https://github.com/orgs/community/discussions/68932#discussioncomment-7176743
+      - name: Create and push tag
+        env:
+          VERSION: ${{ needs.check-release-commit.outputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push --tags
+
+      - name: Create release branch
+        if: ${{ endsWith(needs.check-release-commit.outputs.version, '.0') }}
+        env:
+          RELEASE_BRANCH: ${{ needs.check-release-commit.outputs.release_branch }}
+        run: |
+          git checkout -b "$RELEASE_BRANCH"
+          git push origin "$RELEASE_BRANCH"
+
 
       # Add release branch to rulesets to enable merge queue
       - name: Add release branch to rulesets

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,9 +13,49 @@ on:
         type: string
 
 jobs:
-  release-please:
+  # This job handles releases using Release Please, accommodating multiple commits
+  # pushed to the main branch simultaneously due to merge queues. It ensures that
+  # release tags are applied specifically to the release commit, not just the latest commit..
+  check-release-commit:
     runs-on: ubuntu-latest
-    if: ${{ !startsWith(github.event.head_commit.message, 'release:') && !github.event.inputs.version }}
+    outputs:
+      is_release: ${{ steps.check_release.outputs.is_release }}
+      release_sha: ${{ steps.check_release.outputs.release_sha }}
+      version: ${{ steps.check_release.outputs.version }}
+      pr_number: ${{ steps.check_release.outputs.pr_number }}
+      release_branch: ${{ steps.check_release.outputs.release_branch }}
+    steps:
+      - name: Check for release commit and extract information
+        id: check_release
+        env:
+          COMMITS: ${{ toJson(github.event.commits) }}
+        run: |
+          release_info=$(echo "$COMMITS" | jq -r '[.[] | select(.message | startswith("release:"))][0] | {message: .message, sha: .id}')
+          message=$(echo "$release_info" | jq -r '.message')
+          sha=$(echo "$release_info" | jq -r '.sha')
+
+          if [ -n "$message" ] && [ -n "$sha" ] && [ "$message" != "null" ] && [ "$sha" != "null" ]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            version=$(echo "$message" | grep -oP '^release: v\K[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+            pr_number=$(echo "$message" | grep -oP '#\K[0-9]+' || echo "")
+            if [ -n "$version" ]; then
+              release_branch="release/v$(echo "$version" | cut -d. -f1,2)"
+              echo "release_sha=$sha" >> $GITHUB_OUTPUT
+              echo "version=$version" >> $GITHUB_OUTPUT
+              echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+              echo "release_branch=$release_branch" >> $GITHUB_OUTPUT
+            else
+              echo "Error: Could not extract version from commit message"
+              exit 1
+            fi
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
+  release-please:
+    needs: check-release-commit
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-release-commit.outputs.is_release == 'false' && !github.event.inputs.version }}
     steps:
       - name: Release Please
         id: release
@@ -39,21 +79,12 @@ jobs:
             --target-branch=${{ github.ref_name }}
 
   release-tag:
+    needs: check-release-commit
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.head_commit.message, 'release:') }}
+    if: ${{ needs.check-release-commit.outputs.is_release == 'true' }}
     steps:
-      # Since skip-github-release is specified, the outputs of googleapis/release-please-action cannot be used.
-      # Therefore, we need to parse the version ourselves.
-      - name: Extract version and PR number from commit message
-        id: extract_info
-        shell: bash
-        run: |
-          echo "version=$( echo "${{ github.event.head_commit.message }}" | sed 's/^release: v\([0-9]\+\.[0-9]\+\.[0-9]\+\).*$/\1/' )" >> $GITHUB_OUTPUT
-          echo "pr_number=$( echo "${{ github.event.head_commit.message }}" | sed 's/.*(\#\([0-9]\+\)).*$/\1/' )" >> $GITHUB_OUTPUT
-          echo "release_branch=release/v$( echo "${{ github.event.head_commit.message }}" | sed 's/^release: v\([0-9]\+\.[0-9]\+\).*$/\1/' )" >> $GITHUB_OUTPUT
-
       - name: Tag release
-        if: ${{ steps.extract_info.outputs.version }}
+        if: ${{ needs.check-release-commit.outputs.version }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ORG_REPO_TOKEN }} # To trigger another workflow
@@ -61,46 +92,46 @@ jobs:
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `refs/tags/v${{ steps.extract_info.outputs.version }}`,
-              sha: context.sha
+              ref: `refs/tags/v${{ needs.check-release-commit.outputs.version }}`,
+              sha: '${{ needs.check-release-commit.outputs.release_sha }}'
             });
 
       # When v0.50.0 is released, a release branch "release/v0.50" is created.
       - name: Create release branch for patch versions
-        if: ${{ endsWith(steps.extract_info.outputs.version, '.0') }}
+        if: ${{ endsWith(needs.check-release-commit.outputs.version, '.0') }} # Skip patch versions
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Should not trigger the workflow again
           script: |
-            const releaseBranch = '${{ steps.extract_info.outputs.release_branch }}';
+            const releaseBranch = '${{ needs.check-release-commit.outputs.release_branch }}';
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `refs/heads/${releaseBranch}`,
-              sha: context.sha
+              sha: '${{ needs.check-release-commit.outputs.release_sha }}'
             });
-      
 
       # Add release branch to rulesets to enable merge queue
       - name: Add release branch to rulesets
-        if: ${{ endsWith(steps.extract_info.outputs.version, '.0') }}
+        if: ${{ endsWith(needs.check-release-commit.outputs.version, '.0') }}
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+          RELEASE_BRANCH: ${{ needs.check-release-commit.outputs.release_branch }}
         shell: bash
         run: |
           RULESET_ID=$(gh api /repos/${{ github.repository }}/rulesets --jq '.[] | select(.name=="release") | .id')
-          gh api /repos/${{ github.repository }}/rulesets/$RULESET_ID | jq '{conditions}' | jq '.conditions.ref_name.include += ["refs/heads/${{ steps.extract_info.outputs.release_branch }}"]' | gh api --method put --input - /repos/${{ github.repository }}/rulesets/$RULESET_ID
+          gh api /repos/${{ github.repository }}/rulesets/$RULESET_ID | jq '{conditions}' | jq ".conditions.ref_name.include += [\"refs/heads/$RELEASE_BRANCH\"]" | gh api --method put --input - /repos/${{ github.repository }}/rulesets/$RULESET_ID
 
       # Since skip-github-release is specified, googleapis/release-please-action doesn't delete the label from PR.
       # This label prevents the subsequent PRs from being created. Therefore, we need to delete it ourselves.
       # cf. https://github.com/googleapis/release-please?tab=readme-ov-file#release-please-bot-does-not-create-a-release-pr-why
       - name: Remove the label from PR
-        if: ${{ steps.extract_info.outputs.pr_number }}
+        if: ${{ needs.check-release-commit.outputs.pr_number }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = parseInt('${{ steps.extract_info.outputs.pr_number }}', 10);
+            const prNumber = parseInt('${{ needs.check-release-commit.outputs.pr_number }}', 10);
             github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Description
See https://github.com/aquasecurity/trivy/issues/7722

## Changes

1. Added a new job to iterate through multiple commits in the push event to check for release commits.
2. Modified subsequent jobs to use the outputs from this new job.
3. Replaced the `/repos/{owner}/{repo}/git/refs` API with Git commands due to API limitations.
4. Updated GitHub Actions configuration to address secret detection and workflow permission issues.

## Detailed Explanation
### API Replacement

We currently use the [/repos/{owner}/{repo}/git/refs API](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference) to check for release commits. However, after implementing support for multiple commits, I encountered 404 errors. Local testing revealed that the API only works reliably with the head commit of any branch. This issue has been [reported by other users as well](https://github.com/orgs/community/discussions/68932#discussioncomment-7176743).

To resolve this, I've switched to using Git commands instead of the API.

### Secret Detection and Fetch Depth

When using Git commands, I encountered another issue where setting `fetch-depth: 1` resulted in secret detection preventing pushes. 

<details><summary>Error</summary>
<p>

```
remote: error: GH013: Repository rule violations found for refs/tags/v0.57.0.        
remote: 
remote: - GITHUB PUSH PROTECTION        
remote:   —————————————————————————————————————————        
remote:     Resolve the following violations before pushing again        
remote: 
remote:     - Push cannot contain secrets        
remote: 
remote:             
remote:      (?) Learn how to resolve a blocked push        
remote:      https://docs.github.com/code-security/secret-scanning/working-with-secret-scanning-and-push-protection/working-with-push-protection-from-the-command-line#resolving-a-blocked-push        
remote:             
remote:      (?) This repository does not have Secret Scanning enabled, but is eligible. Enable Secret Scanning to view and manage detected secrets.        
remote:      Visit the repository settings page, https://github.com/knqyf263/trivy/settings/security_analysis        
remote:             
remote:             
remote:       —— GitHub SSH Private Key ————————————————————————————        
remote:        locations:        
remote:          - blob id: 68e459e1a8c71b2d57fe666486e67af03ecbabf7        
remote:             
remote:        (?) To push, remove secret from commit(s) or follow this URL to allow the secret.        
remote:        https://github.com/knqyf263/trivy/security/secret-scanning/unblock-secret/2nQ281VzLwsLLtEuKjux9VdVowG        
remote:             
remote:             
remote:     ——[ WARNING ]—————————————————————————————————————————        
remote:      Scan incomplete: This push was large and we didn't finish on time.        
remote:      It can still contain undetected secrets.        
remote:             
remote:      (?) Use the following command to find the path of the detected secret(s):        
remote:          git rev-list --objects --all | grep blobid        
remote:     ——————————————————————————————————————————————————————
```

</p>
</details> 

This doesn't occur with local pushes. To resolve this, I've set `fetch-depth: 0`. While we could allow the detected secret (which is a test secret and a false positive), I've opted for the `fetch-depth: 0` solution to prevent potential issues during future releases.

### GitHub Token Permissions

I discovered that using `secrets.GITHUB_TOKEN` causes errors when the commit includes workflow changes:

```
! [remote rejected]     v0.57.0 -> v0.57.0 (refusing to allow an OAuth App to create or update workflow `.github/workflows/release-please.yaml` without `workflow` scope)
```

Others are also facing [this issue](https://github.com/orgs/community/discussions/35410). To prevent hard-to-diagnose errors in case workflow changes are included with release PRs in the merge queue, I've switched to using `secrets.ORG_REPO_TOKEN` which has the `workflow` scope.

## Test Run

A successful test run of the updated workflow can be found here:
https://github.com/knqyf263/trivy/actions/runs/11322890634/job/31484563456

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7722

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
