### PR TITLE
docs: add note about disabled DS016 check

### DIFF
--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -154,6 +154,8 @@ See https://avd.aquasec.com/misconfig/ds026
 !!! tip
     You can see how each layer is created with `docker history`.
 
+The [AVD-DS-0016](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0016/) check is disabled for this scan type, see [issue](https://github.com/aquasecurity/trivy/issues/7368) for details.
+
 ### Secrets
 Trivy detects secrets on the configuration of container images.
 The image config is converted into JSON and Trivy scans the file for secrets.

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -16,8 +16,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/misconf"
 )
 
-var disabledChecks = []string{
-	"DS016", // See https://github.com/aquasecurity/trivy/issues/7368
+var disabledChecks = []misconf.DisabledCheck{
+	{
+		ID: "DS016", Scanner: string(analyzer.TypeHistoryDockerfile),
+		Reason: "See https://github.com/aquasecurity/trivy/issues/7368",
+	},
 }
 
 const analyzerVersion = 1
@@ -31,7 +34,7 @@ type historyAnalyzer struct {
 }
 
 func newHistoryAnalyzer(opts analyzer.ConfigAnalyzerOptions) (analyzer.ConfigAnalyzer, error) {
-	opts.MisconfScannerOption.DisabledCheckIDs = append(opts.MisconfScannerOption.DisabledCheckIDs, disabledChecks...)
+	opts.MisconfScannerOption.DisabledChecks = append(opts.MisconfScannerOption.DisabledChecks, disabledChecks...)
 	s, err := misconf.NewScanner(detection.FileTypeDockerfile, opts.MisconfScannerOption)
 	if err != nil {
 		return nil, xerrors.Errorf("misconfiguration scanner error: %w", err)

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -139,6 +139,7 @@ func NewScanner(t detection.FileType, opt ScannerOption) (*Scanner, error) {
 }
 
 func (s *Scanner) Scan(ctx context.Context, fsys fs.FS) ([]types.Misconfiguration, error) {
+	ctx = log.WithContextPrefix(ctx, log.PrefixMisconfiguration)
 	newfs, err := s.filterFS(fsys)
 	if err != nil {
 		return nil, xerrors.Errorf("fs filter error: %w", err)
@@ -147,12 +148,12 @@ func (s *Scanner) Scan(ctx context.Context, fsys fs.FS) ([]types.Misconfiguratio
 		return nil, nil
 	}
 
-	log.Debug("Scanning files for misconfigurations...", log.String("scanner", s.scanner.Name()))
+	log.DebugContext(ctx, "Scanning files for misconfigurations...", log.String("scanner", s.scanner.Name()))
 	results, err := s.scanner.ScanFS(ctx, newfs, ".")
 	if err != nil {
 		var invalidContentError *cfparser.InvalidContentError
 		if errors.As(err, &invalidContentError) {
-			log.Error("scan was broken with InvalidContentError", s.scanner.Name(), log.Err(err))
+			log.ErrorContext(ctx, "scan was broken with InvalidContentError", s.scanner.Name(), log.Err(err))
 			return nil, nil
 		}
 		return nil, xerrors.Errorf("scan config error: %w", err)
@@ -218,7 +219,7 @@ func (s *Scanner) filterFS(fsys fs.FS) (fs.FS, error) {
 
 func scannerOptions(t detection.FileType, opt ScannerOption) ([]options.ScannerOption, error) {
 	disabledCheckIDs := lo.Map(opt.DisabledChecks, func(check DisabledCheck, _ int) string {
-		log.Info("Check disabled", log.String("ID", check.ID),
+		log.Info("Check disabled", log.Prefix(log.PrefixMisconfiguration), log.String("ID", check.ID),
 			log.String("scanner", check.Scanner), log.String("reason", check.Reason))
 		return check.ID
 	})


### PR DESCRIPTION
## Description
```bash
./trivy image --scanners misconfig --image-config-scanners misconfig registry.access.redhat.com/ubi8/python-312:1-16.1721725207
2024-10-14T14:57:39+06:00       INFO    [image] Container image config scanners scanners=[misconfig]
2024-10-14T14:57:39+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2024-10-14T14:57:41+06:00       INFO    Check disabled  ID="DS016" scanner="history-dockerfile" reason="See https://github.com/aquasecurity/trivy/issues/7368"
...
```

Related PRs:
- https://github.com/aquasecurity/trivy/pull/7540

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
