### PR TITLE
feat(report): update gitlab template to populate operating_system value

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -29,6 +29,7 @@
   {{- range . }}
   {{- $target := .Target }}
     {{- $image := $target | regexFind "[^\\s]+" }}
+    {{- $os := regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}
@@ -65,7 +66,7 @@
           "version": "{{ .InstalledVersion }}"
         },
         {{- /* TODO: No mapping available - https://github.com/aquasecurity/trivy/issues/332 */}}
-        "operating_system": "Unknown",
+        "operating_system": "{{ $os }}",
         "image": "{{ $image }}"
       },
       "identifiers": [

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -29,7 +29,10 @@
   {{- range . }}
   {{- $target := .Target }}
     {{- $image := $target | regexFind "[^\\s]+" }}
-    {{- $os := regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
+    {{- $os := "Unknown" }}
+    {{- if contains "(" $target -}}
+      {{- $os = regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
+    {{- end }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}

--- a/integration/testdata/alpine-310.gitlab.golden
+++ b/integration/testdata/alpine-310.gitlab.golden
@@ -37,7 +37,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -104,7 +104,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -191,7 +191,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -258,7 +258,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [


### PR DESCRIPTION
## Description
Update the `gitlab.tpl` container scanning template to populate the `vulnerabilities[].location.operating_system` value from the `Target`. The current template [extracts the `image` from `Target`](https://github.com/aquasecurity/trivy/blob/31aa20ab90d52dd6cbc364fe0ff257b59cf02187/contrib/gitlab.tpl#L31), but the OS is not used and has the value hardcoded as [`"operating_system": "Unknown"`](https://github.com/aquasecurity/trivy/blob/31aa20ab90d52dd6cbc364fe0ff257b59cf02187/contrib/gitlab.tpl#L68). This update extracts the OS from `Target`, if specified (simply checking for `(` in the `Target`), to populate the `operating_system` value (for example `"operating_system": "alpine 3.10.2"`). If not specified, the default of `Unknown` is used.

## Related issues
- Partial fix for #332 (for the GitLab template)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
