### PR TITLE
feat(parser): ignore white space in pom.xml files

### DIFF
--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -163,7 +163,7 @@ func evaluateVariable(s string, props map[string]string, seenProps []string) str
 		}
 		s = strings.ReplaceAll(s, m[0], newValue)
 	}
-	return s
+	return strings.TrimSpace(s)
 }
 
 func printLoopedPropertiesStack(env string, usedProps []string) {

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1974,6 +1974,21 @@ func TestPom_Parse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "space at the start and/or end of the text nodes",
+			inputFile: filepath.Join("testdata", "with-spaces", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example : root-pom-with-spaces : 1.0.0",
+					Name:         "com.example : root-pom-with-spaces ",
+					Version:      " 1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+			},
+			// wantDeps: []ftypes.Dependency{
+			// },
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1996,8 +1996,8 @@ func TestPom_Parse(t *testing.T) {
 					Relationship: ftypes.RelationshipDirect,
 					Locations: ftypes.Locations{
 						{
-							StartLine: 20,
-							EndLine:   24,
+							StartLine: 24,
+							EndLine:   28,
 						},
 					},
 				},

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -333,7 +333,7 @@ func (props *properties) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error 
 			return xerrors.Errorf("XML decode error: %w", err)
 		}
 
-		(*props)[p.XMLName.Local] = strings.TrimSpace(p.Value)
+		(*props)[p.XMLName.Local] = p.Value
 	}
 	return nil
 }

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -333,7 +333,7 @@ func (props *properties) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error 
 			return xerrors.Errorf("XML decode error: %w", err)
 		}
 
-		(*props)[p.XMLName.Local] = p.Value
+		(*props)[p.XMLName.Local] = strings.TrimSpace(p.Value)
 	}
 	return nil
 }

--- a/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
@@ -16,6 +16,10 @@
         </dependencies>
     </dependencyManagement>
 
+    <properties>
+        <dependency.version > 1.2.4</dependency.version >
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId> org.example </groupId>

--- a/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
@@ -6,4 +6,22 @@
     <artifactId> root-pom-with-spaces </artifactId>
     <version> 1.0.0</version>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId> org.example</groupId>
+                <artifactId>example-dependency </artifactId>
+                <version>1.2.4 </version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId> org.example </groupId>
+            <artifactId>  example-nested   </artifactId>
+            <version>   3.3.3  </version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
@@ -6,19 +6,19 @@
     <artifactId> root-pom-with-spaces </artifactId>
     <version> 1.0.0</version>
 
+    <properties>
+        <dependency.version > 1.2.4</dependency.version >
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId> org.example</groupId>
                 <artifactId>example-dependency </artifactId>
-                <version>1.2.4 </version>
+                <version>${dependency.version} </version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <properties>
-        <dependency.version > 1.2.4</dependency.version >
-    </properties>
 
     <dependencies>
         <dependency>

--- a/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/with-spaces/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion> 4.0.0</modelVersion>
+
+    <groupId>com.example </groupId>
+    <artifactId> root-pom-with-spaces </artifactId>
+    <version> 1.0.0</version>
+
+</project>


### PR DESCRIPTION
## Description

This PR modifies the `pom.xml` parser so that the content of the fields are trimmed. It makes the parser behave in the same manner as maven.

## Related issues
- Close #7658

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
