### PR TITLE
test: use forked images

### DIFF
--- a/integration/testimages.ini
+++ b/integration/testimages.ini
@@ -1,3 +1,3 @@
 # Configuration file for both shell scripts and Go programs
-TEST_IMAGES=ghcr.io/aquasecurity/trivy-test-images
-TEST_VM_IMAGES=ghcr.io/aquasecurity/trivy-test-vm-images
+TEST_IMAGES=ghcr.io/knqyf263/trivy-test-images
+TEST_VM_IMAGES=ghcr.io/knqyf263/trivy-test-vm-images

--- a/pkg/attestation/attestation_test.go
+++ b/pkg/attestation/attestation_test.go
@@ -9,7 +9,6 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/attestation"
 )
 
@@ -28,7 +27,7 @@ func TestStatement_UnmarshalJSON(t *testing.T) {
 					PredicateType: "cosign.sigstore.dev/attestation/v1",
 					Subject: []in_toto.Subject{
 						{
-							Name: testutil.ImageName("", "", ""),
+							Name: "ghcr.io/aquasecurity/trivy-test-images", // Defined in the attestations.json file
 							Digest: slsa.DigestSet{
 								"sha256": "72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb",
 							},


### PR DESCRIPTION
## Description
The GHCR rate limits are applied to the entire `aquasecurity` organization, and currently the images for testing cannot be pulled, causing testing to fail. As a workaround, we are considering moving trivy-db to a separate organization or creating a separate organization for Trivy, but both of these measures need to be done after careful discussion with GitHub. So we will use the forked image as a temporary workaround until a solution is decided.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/7739

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
