### PR TITLE
fix(license): fix license normalization for Universal Permissive License

### DIFF
--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -626,7 +626,7 @@ func TrimLicenseText(text string) string {
 }
 
 // version number match
-var versionRegexpString = "([A-UW-Z)]{2,})( LICENSE)?\\s*[,(-]?\\s*(V|V\\.|VER|VER\\.|VERSION|VERSION-|-)?\\s*([1-9](\\.\\d)*)[)]?"
+var versionRegexpString = "([A-UW-Z)])( LICENSE)?\\s*[,(-]?\\s*(V|V\\.|VER|VER\\.|VERSION|VERSION-|-)?\\s*([1-9](\\.\\d)*)[)]?"
 
 // case insensitive version match anywhere in string
 var versionRegexp = regexp.MustCompile("(?i)" + versionRegexpString)

--- a/pkg/licensing/normalize_test.go
+++ b/pkg/licensing/normalize_test.go
@@ -209,6 +209,13 @@ func TestNormalize(t *testing.T) {
 			normalized:    " The unmapped license ",
 			normalizedKey: " The unmapped license ",
 		},
+		{
+			licenses: []string{
+				"Universal Permissive License, Version 1.0",
+			},
+			normalized:    "UPL-1.0",
+			normalizedKey: "UPL-1.0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.normalized, func(t *testing.T) {


### PR DESCRIPTION
## Description

"Universal Permissive License, Version 1.0" could not be normized because of the "v" in Permissive.

## Related issues
- None

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
