### PR TITLE
docs(k8s): add a note about multi-container pods

### DIFF
--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -38,7 +38,7 @@ for example:
 trivy k8s --report summary
 ```
 
-!!! note "Multi-container pods"
+!!! note "JSON result for multi-container pods"
     For multi-container pods, it may be challenging to associate results with specific images in the json summary report. Kubernetes treats a pod as a single object, so individual images within the pod aren’t distinguished. 
     For detailed information, please use the `--report all` option.
 

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -38,6 +38,10 @@ for example:
 trivy k8s --report summary
 ```
 
+!!! note "Multi-container pods"
+    For multi-container pods, it may be challenging to associate results with specific images in the summary report. Kubernetes treats a pod as a single object, so individual images within the pod aren’t distinguished. 
+    For detailed information, please use the `--report all` and `--format json` options.
+
 By default Trivy will look for a [`kubeconfig` configuration file in the default location](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), and use the default cluster that is specified.  
 You can also specify a `kubeconfig` using the `--kubeconfig` flag:
 

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -39,8 +39,8 @@ trivy k8s --report summary
 ```
 
 !!! note "Multi-container pods"
-    For multi-container pods, it may be challenging to associate results with specific images in the summary report. Kubernetes treats a pod as a single object, so individual images within the pod aren’t distinguished. 
-    For detailed information, please use the `--report all` and `--format json` options.
+    For multi-container pods, it may be challenging to associate results with specific images in the json summary report. Kubernetes treats a pod as a single object, so individual images within the pod aren’t distinguished. 
+    For detailed information, please use the `--report all` option.
 
 By default Trivy will look for a [`kubeconfig` configuration file in the default location](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/), and use the default cluster that is specified.  
 You can also specify a `kubeconfig` using the `--kubeconfig` flag:


### PR DESCRIPTION
## Description
Now #7444  is merged, we should clarify the position about association the result with the metadata for multi-container pdos. this PR adds a small note about it.
<img width="560" alt="" src="https://github.com/user-attachments/assets/2faab5b3-a80a-45e7-bded-b29fb8841cf0">
## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
