### PR TITLE
fix(cli): add config name to skip-policy-update alias

### DIFF
--- a/pkg/flag/rego_flags.go
+++ b/pkg/flag/rego_flags.go
@@ -19,6 +19,7 @@ var (
 		Aliases: []Alias{
 			{
 				Name:       "skip-policy-update",
+				ConfigName: "rego.skip-policy-update",
 				Deprecated: true,
 			},
 		},


### PR DESCRIPTION
## Description

An alias without a config name was added when the `skip-policy-update` flag was renamed, this caused the configuration tests ([TestConfiguration](https://github.com/aquasecurity/trivy/blob/main/integration/config_test.go#L76)) that used the old config to stop skipping the checks update.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
