### PR TITLE
docs(java): add info about supported scopes

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -70,7 +70,7 @@ The vulnerability database will be downloaded anyway.
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
 ### supported scopes
-Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes are not analyzed.
+Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes are not currently being analyzed.
 
 ### empty dependency version
 There are cases when Trivy cannot determine the version of dependencies:

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -70,7 +70,7 @@ The vulnerability database will be downloaded anyway.
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
 ### supported scopes
-Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes are not currently being analyzed.
+Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes and `Optional` dependencies are not currently being analyzed.
 
 ### empty dependency version
 There are cases when Trivy cannot determine the version of dependencies:

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -69,6 +69,9 @@ The vulnerability database will be downloaded anyway.
 !!! Warning
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
+### supported scopes
+Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes are not analyzed.
+
 ### empty dependency version
 There are cases when Trivy cannot determine the version of dependencies:
 
@@ -128,6 +131,7 @@ Make sure that you have cache[^8] directory to find licenses from `*.pom` depend
 [maven-invoker-plugin]: https://maven.apache.org/plugins/maven-invoker-plugin/usage.html
 [maven-central]: https://repo.maven.apache.org/maven2/
 [maven-pom-repos]: https://maven.apache.org/settings.html#repositories
+[maven-scopes]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope
 [sbt-dependency-lock]: https://stringbean.github.io/sbt-dependency-lock
 [detection-priority]: ../../scanner/vulnerability.md#detection-priority
 [version-requirement]: https://maven.apache.org/pom.html#dependency-version-requirement-specification


### PR DESCRIPTION
## Description
Trivy doesn't check all `scopes`:
https://github.com/aquasecurity/trivy/blob/57e24aa85382f749df7f673e241caaf3fcbb45cb/pkg/dependency/parser/java/pom/parse.go#L430

We need to write about this in the docs.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
