### PR TITLE
chore: lint `errors.Join`

### DIFF
--- a/misc/lint/rules.go
+++ b/misc/lint/rules.go
@@ -20,3 +20,13 @@ func initializeMaps(m dsl.Matcher) {
 		Suggest(`make(map[$key]$value)`).
 		Report(`replace '$$' with 'make(map[$key]$value)`)
 }
+
+// While errors.Join from standard library can combine multiple errors,
+// we use hashicorp/go-multierror for more user-friendly error outputs.
+func errorsJoin(m dsl.Matcher) {
+	m.Match(`errors.Join($x...)`).
+		Report("use github.com/hashicorp/go-multierror.Append instead of errors.Join.")
+
+	m.Match(`errors.Join($*args)`).
+		Report("use github.com/hashicorp/go-multierror.Append instead of errors.Join.")
+}

--- a/pkg/iac/scanners/cloudformation/parser/parser.go
+++ b/pkg/iac/scanners/cloudformation/parser/parser.go
@@ -3,13 +3,13 @@ package parser
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/liamg/jfather"
 	"gopkg.in/yaml.v3"
 
@@ -171,18 +171,17 @@ func (p *Parser) parseParams() error {
 
 	params := make(Parameters)
 
-	var errs []error
-
+	var errs error
 	for _, path := range p.parameterFiles {
 		if parameters, err := p.parseParametersFile(path); err != nil {
-			errs = append(errs, err)
+			errs = multierror.Append(errs, err)
 		} else {
 			params.Merge(parameters)
 		}
 	}
 
-	if len(errs) != 0 {
-		return errors.Join(errs...)
+	if errs != nil {
+		return errs
 	}
 
 	params.Merge(p.parameters)

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -2,10 +2,10 @@ package report
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	cr "github.com/aquasecurity/trivy/pkg/compliance/report"
@@ -32,7 +32,7 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 	}
 	defer func() {
 		if cerr := cleanup(); cerr != nil {
-			err = errors.Join(err, cerr)
+			err = multierror.Append(err, cerr)
 		}
 	}()
 

--- a/pkg/vex/repo/repo.go
+++ b/pkg/vex/repo/repo.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
@@ -256,7 +257,7 @@ func (r *Repository) download(ctx context.Context, ver Version, dst string, opts
 			etag = etags[loc.URL] // Keep the old ETag
 			// Update last updated time so that Trivy will not try to download the same URL soon
 		case err != nil:
-			errs = errors.Join(errs, err)
+			errs = multierror.Append(errs, err)
 			continue // Try the next location
 		default:
 			// Successfully downloaded


### PR DESCRIPTION
## Description
`hashicorp/go-multierror.Append` displays more user-friendly errors than `errors.Join`.
https://go.dev/play/p/AYls8a96t-j

```
[errors.Join]
err1
err2

[go-multierror.Append]
2 errors occurred:
	* err1
	* err2
```

This PR adds a new lint rule as the usage should be consistent in the project.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/7843

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
