### PR TITLE
feat(misconf): render causes for Terraform

### DIFF
--- a/pkg/fanal/types/misconf.go
+++ b/pkg/fanal/types/misconf.go
@@ -30,19 +30,25 @@ type MisconfResult struct {
 type MisconfResults []MisconfResult
 
 type CauseMetadata struct {
-	Resource    string       `json:",omitempty"`
-	Provider    string       `json:",omitempty"`
-	Service     string       `json:",omitempty"`
-	StartLine   int          `json:",omitempty"`
-	EndLine     int          `json:",omitempty"`
-	Code        Code         `json:",omitempty"`
-	Occurrences []Occurrence `json:",omitempty"`
+	Resource      string        `json:",omitempty"`
+	Provider      string        `json:",omitempty"`
+	Service       string        `json:",omitempty"`
+	StartLine     int           `json:",omitempty"`
+	EndLine       int           `json:",omitempty"`
+	Code          Code          `json:",omitempty"`
+	Occurrences   []Occurrence  `json:",omitempty"`
+	RenderedCause RenderedCause `json:",omitempty"`
 }
 
 type Occurrence struct {
 	Resource string `json:",omitempty"`
 	Filename string `json:",omitempty"`
 	Location Location
+}
+
+type RenderedCause struct {
+	Raw         string `json:",omitempty"`
+	Highlighted string `json:",omitempty"`
 }
 
 type Code struct {

--- a/pkg/iac/scan/code.go
+++ b/pkg/iac/scan/code.go
@@ -77,7 +77,7 @@ func (c *Code) IsCauseMultiline() bool {
 }
 
 const (
-	darkTheme  = "solarized-dark256"
+	DarkTheme  = "solarized-dark256"
 	lightTheme = "github"
 )
 
@@ -89,7 +89,7 @@ type codeSettings struct {
 }
 
 var defaultCodeSettings = codeSettings{
-	theme:              darkTheme,
+	theme:              DarkTheme,
 	allowTruncation:    true,
 	maxLines:           10,
 	includeHighlighted: true,
@@ -105,7 +105,7 @@ func OptionCodeWithTheme(theme string) CodeOption {
 
 func OptionCodeWithDarkTheme() CodeOption {
 	return func(s *codeSettings) {
-		s.theme = darkTheme
+		s.theme = DarkTheme
 	}
 }
 

--- a/pkg/iac/scan/flat.go
+++ b/pkg/iac/scan/flat.go
@@ -23,6 +23,7 @@ type FlatResult struct {
 	Resource        string             `json:"resource"`
 	Occurrences     []Occurrence       `json:"occurrences,omitempty"`
 	Location        FlatRange          `json:"location"`
+	RenderedCause   RenderedCause      `json:"rendered_cause"`
 }
 
 type FlatRange struct {
@@ -70,5 +71,6 @@ func (r *Result) Flatten() FlatResult {
 			StartLine: rng.GetStartLine(),
 			EndLine:   rng.GetEndLine(),
 		},
+		RenderedCause: r.renderedCause,
 	}
 }

--- a/pkg/iac/scan/highlighting.go
+++ b/pkg/iac/scan/highlighting.go
@@ -51,7 +51,7 @@ func highlight(fsKey, filename string, startLine, endLine int, input, theme stri
 	return lines
 }
 
-func Highlight(filename string, input, theme string) (string, bool) {
+func Highlight(filename, input, theme string) (string, bool) {
 	style := styles.Get(theme)
 	if style == nil {
 		style = styles.Fallback

--- a/pkg/iac/scan/highlighting.go
+++ b/pkg/iac/scan/highlighting.go
@@ -46,7 +46,7 @@ func highlight(fsKey, filename string, startLine, endLine int, input, theme stri
 		return nil
 	}
 
-	lines := strings.Split(string(highlighted), "\n")
+	lines := strings.Split(highlighted, "\n")
 	globalCache.Set(key, lines)
 	return lines
 }

--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -32,6 +32,7 @@ type Result struct {
 	warning          bool
 	traces           []string
 	fsPath           string
+	renderedCause    RenderedCause
 }
 
 func (r Result) RegoNamespace() string {
@@ -103,6 +104,15 @@ func (r Result) Range() iacTypes.Range {
 
 func (r Result) Traces() []string {
 	return r.traces
+}
+
+type RenderedCause struct {
+	Raw         string
+	Highlighted string
+}
+
+func (r *Result) WithRenderedCause(cause RenderedCause) {
+	r.renderedCause = cause
 }
 
 func (r *Result) AbsolutePath(fsRoot string, metadata iacTypes.Metadata) string {

--- a/pkg/iac/types/range.go
+++ b/pkg/iac/types/range.go
@@ -153,3 +153,11 @@ func (r Range) Validate() error {
 	}
 	return nil
 }
+
+func (r Range) Includes(other Range) bool {
+	return r.startLine < other.startLine && r.endLine > other.endLine
+}
+
+func (r Range) Covers(other Range) bool {
+	return r.startLine <= other.startLine && r.endLine >= other.endLine
+}

--- a/pkg/report/table/misconfig.go
+++ b/pkg/report/table/misconfig.go
@@ -107,6 +107,7 @@ func (r *misconfigRenderer) printSingleDivider() {
 func (r *misconfigRenderer) renderSingle(misconf types.DetectedMisconfiguration) {
 	r.renderSummary(misconf)
 	r.renderCode(misconf)
+	r.renderCause(misconf)
 	r.printf("\r\n\r\n")
 }
 
@@ -209,6 +210,23 @@ func (r *misconfigRenderer) renderCode(misconf types.DetectedMisconfiguration) {
 		}
 		r.printSingleDivider()
 	}
+}
+
+func (r *misconfigRenderer) renderCause(misconf types.DetectedMisconfiguration) {
+	cause := misconf.CauseMetadata.RenderedCause
+	if cause.Raw == "" {
+		return
+	}
+
+	content := cause.Raw
+	if cause.Highlighted != "" {
+		content = cause.Highlighted
+	}
+
+	r.printf("<dim>%s\r\n", "Rendered cause:")
+	r.printSingleDivider()
+	r.println(content)
+	r.printSingleDivider()
 }
 
 func (r *misconfigRenderer) outputTrace() {

--- a/pkg/report/table/table_test.go
+++ b/pkg/report/table/table_test.go
@@ -2,6 +2,7 @@ package table_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +87,7 @@ Total: 1 (MEDIUM: 0, HIGH: 1)
 					dbTypes.SeverityMedium,
 				},
 			}
-			err := writer.Write(nil, types.Report{Results: tc.results})
+			err := writer.Write(context.TODO(), types.Report{Results: tc.results})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, tableWritten.String(), tc.name)
 		})

--- a/pkg/scanner/local/scan.go
+++ b/pkg/scanner/local/scan.go
@@ -363,13 +363,14 @@ func toDetectedMisconfiguration(res ftypes.MisconfResult, defaultSeverity dbType
 		Layer:       layer,
 		Traces:      res.Traces,
 		CauseMetadata: ftypes.CauseMetadata{
-			Resource:    res.Resource,
-			Provider:    res.Provider,
-			Service:     res.Service,
-			StartLine:   res.StartLine,
-			EndLine:     res.EndLine,
-			Code:        res.Code,
-			Occurrences: res.Occurrences,
+			Resource:      res.Resource,
+			Provider:      res.Provider,
+			Service:       res.Service,
+			StartLine:     res.StartLine,
+			EndLine:       res.EndLine,
+			Code:          res.Code,
+			Occurrences:   res.Occurrences,
+			RenderedCause: res.RenderedCause,
 		},
 	}
 }


### PR DESCRIPTION
## Description

TODO:
- grpc
- tests
- show all attributes for the block scope?

```bash
./trivy conf main.tf
2024-11-01T17:19:19+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2024-11-01T17:19:19+06:00       INFO    [terraform scanner] Scanning root module        file_path="."
2024-11-01T17:19:19+06:00       INFO    Detected config files   num=2

main.tf (terraform)

Tests: 3 (SUCCESSES: 0, FAILURES: 3)
Failures: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 1)

AVD-AWS-0102 (CRITICAL): Network ACL rule allows access using ALL ports.
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Ensure access to specific required ports is allowed, and nothing else.


See https://avd.aquasec.com/misconfig/aws-vpc-no-excessive-port-access
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 main.tf:37
   via main.tf:31-41 (aws_network_acl_rule.public_inbound[0])
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  31   resource "aws_network_acl_rule" "public_inbound" {
  32     network_acl_id = aws_network_acl.this.id
  33     count          = 2
  34     egress         = false
  35     rule_number    = var.public_inbound_acl_rules[count.index]["rule_number"]
  36     rule_action    = var.public_inbound_acl_rules[count.index]["rule_action"]
  37 [   protocol       = var.public_inbound_acl_rules[count.index]["protocol"]
  38     cidr_block     = lookup(var.public_inbound_acl_rules[count.index], "cidr_block", null)
  39     from_port      = lookup(var.public_inbound_acl_rules[count.index], "from_port", null)
  ..   
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Rendered cause:
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
resource "aws_network_acl_rule" "public_inbound[0]" {
  protocol = "all"
}
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


AVD-AWS-0105 (MEDIUM): Network ACL rule allows ingress from public internet.
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
The Network Access Control List (NACL) function provide stateless filtering of ingress and
egress network traffic to AWS resources. It is recommended that no NACL allows
unrestricted ingress access to remote server administration ports, such as SSH to port 22
and RDP to port 3389.


See https://avd.aquasec.com/misconfig/aws-vpc-no-public-ingress-acl
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 main.tf:38
   via main.tf:31-41 (aws_network_acl_rule.public_inbound[1])
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  31   resource "aws_network_acl_rule" "public_inbound" {
  32     network_acl_id = aws_network_acl.this.id
  33     count          = 2
  34     egress         = false
  35     rule_number    = var.public_inbound_acl_rules[count.index]["rule_number"]
  36     rule_action    = var.public_inbound_acl_rules[count.index]["rule_action"]
  37     protocol       = var.public_inbound_acl_rules[count.index]["protocol"]
  38 [   cidr_block     = lookup(var.public_inbound_acl_rules[count.index], "cidr_block", null)
  39     from_port      = lookup(var.public_inbound_acl_rules[count.index], "from_port", null)
  ..   
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Rendered cause:
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
resource "aws_network_acl_rule" "public_inbound[0]" {
  cidr_block = "0.0.0.0/0"
}
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
