### PR TITLE
refactor:optimize performance by moving ToLower operation outside loop

### DIFF
--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -175,9 +175,9 @@ func (r *Rule) MatchKeywords(content []byte) bool {
 	if len(r.Keywords) == 0 {
 		return true
 	}
-
+	contentLower = bytes.ToLower(content)
 	for _, kw := range r.Keywords {
-		if bytes.Contains(bytes.ToLower(content), []byte(strings.ToLower(kw))) {
+		if bytes.Contains(contentLower, []byte(strings.ToLower(kw))) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description
This PR optimizes the performance of the keyword matching function by eliminating redundant ToLower operations inside the loop. Previously, content was being converted to lowercase in every loop iteration, which was inefficient. The change moves this operation outside the loop and stores the result in a variable for reuse.

Before:
```go
for _, kw := range r.Keywords {
    if bytes.Contains(bytes.ToLower(content), []byte(strings.ToLower(kw))) {
        return true
    }
}

After
contentLower = bytes.ToLower(content)
for _, kw := range r.Keywords {
    if bytes.Contains(contentLower, []byte(strings.ToLower(kw))) {
        return true
    }
}

## Checklist
- [x ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
