### PR TITLE
fix: Add additional mirror repositories as defaults

### DIFF
--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -4,14 +4,21 @@ Trivy needs to connect to the internet occasionally in order to download relevan
 
 ## Network requirements
 
-Trivy's databases are distributed as OCI images via GitHub Container registry (GHCR):
+Trivy's databases are distributed as OCI images via GitHub Container registry (GHCR), AWS Elastic Container Registry (ECR) or DockerHub:
 
-- <https://ghcr.io/aquasecurity/trivy-db>
-- <https://ghcr.io/aquasecurity/trivy-java-db>
-- <https://ghcr.io/aquasecurity/trivy-checks>
+- [AWS ECR](https://gallery.ecr.aws/aquasecurity): ``public.ecr.aws``
+- [DockerHub](https://hub.docker.com/u/aquasec): ``index.docker.io``
+- [GHCR](https://github.com/orgs/aquasecurity/packages): ``ghcr.io``
 
-The following hosts are required in order to fetch them:
+The following hosts are at least required in order to fetch them:
 
+AWS ECR:
+- `public.ecr.aws`
+
+DockerHub:
+- `index.docker.io`
+
+GHCR:
 - `ghcr.io`
 - `pkg-containers.githubusercontent.com`
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -25,6 +25,12 @@ const (
 )
 
 var (
+	// AWS Elastic Container Registry
+	DefaultECRRepository = fmt.Sprintf("%s:%d", "public.ecr.aws/aquasecurity/trivy-db", db.SchemaVersion)
+	defaultECRRepository = lo.Must(name.NewTag(DefaultECRRepository))
+	// DockerHub
+	DefaultDockerHubRepository = fmt.Sprintf("%s:%d", "aquasec/trivy-db", db.SchemaVersion)
+	defaultDockerHubRepository = lo.Must(name.NewTag(DefaultDockerHubRepository))
 	// GitHub Container Registry
 	DefaultGHCRRepository = fmt.Sprintf("%s:%d", "ghcr.io/aquasecurity/trivy-db", db.SchemaVersion)
 	defaultGHCRRepository = lo.Must(name.NewTag(DefaultGHCRRepository))
@@ -73,6 +79,8 @@ func Dir(cacheDir string) string {
 func NewClient(dbDir string, quiet bool, opts ...Option) *Client {
 	o := &options{
 		dbRepositories: []name.Reference{
+			defaultECRRepository,
+			defaultDockerHubRepository,
 			defaultGHCRRepository,
 		},
 	}

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -53,13 +53,13 @@ var (
 	DBRepositoryFlag = Flag[[]string]{
 		Name:       "db-repository",
 		ConfigName: "db.repository",
-		Default:    []string{db.DefaultGHCRRepository},
+		Default:    []string{db.DefaultECRRepository, db.DefaultDockerHubRepository, db.DefaultGHCRRepository},
 		Usage:      "OCI repository(ies) to retrieve trivy-db in order of priority",
 	}
 	JavaDBRepositoryFlag = Flag[[]string]{
 		Name:       "java-db-repository",
 		ConfigName: "db.java-repository",
-		Default:    []string{javadb.DefaultGHCRRepository},
+		Default:    []string{javadb.DefaultECRRepository, javadb.DefaultDockerHubRepository, javadb.DefaultGHCRRepository},
 		Usage:      "OCI repository(ies) to retrieve trivy-java-db in order of priority",
 	}
 	LightFlag = Flag[bool]{

--- a/pkg/javadb/client.go
+++ b/pkg/javadb/client.go
@@ -27,6 +27,10 @@ const (
 )
 
 var (
+	// AWS Elastic Container Registry
+	DefaultECRRepository = fmt.Sprintf("%s:%d", "public.ecr.aws/aquasecurity/trivy-java-db", SchemaVersion)
+	// DockerHub
+	DefaultDockerHubRepository = fmt.Sprintf("%s:%d", "aquasec/trivy-java-db", SchemaVersion)
 	// GitHub Container Registry
 	DefaultGHCRRepository = fmt.Sprintf("%s:%d", "ghcr.io/aquasecurity/trivy-java-db", SchemaVersion)
 )


### PR DESCRIPTION
## Description
### Overview
This is a simple fix that should get rid of the [constant ``TOOMANYREQUESTS`` problems](https://github.com/aquasecurity/trivy/discussions/7668).

It adds AWS ECR and DockerHub as additional mirrors.

### Details 

* Change primary mirror to AWS ECR as they have the "best" rate limiting policies: https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html
  > For unauthenticated customers, Amazon ECR Public supports up to 500GB of data per month
  > Rate of unauthenticated image pulls - Each supported Region: 1 per second
* Use DockerHub as secondary fallback:
  > Anonymous users - 100 pulls per 6 hours per IP address
* Use GHCR as final fallback as it is currently nearly constantly failing: (see issues below)

## Related issues
- https://github.com/aquasecurity/trivy/discussions/7668
- https://github.com/orgs/community/discussions/139074

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
  * Please note that I don't know all hosts that are required for pulling from DockerHub / AWS ECR as I don't work in an air-gapped environment.
