### PR TITLE
fix(fs): add missing defered Cleanup() call to post analyzer fs

### DIFF
--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -82,6 +82,7 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	if err != nil {
 		return artifact.Reference{}, xerrors.Errorf("failed to prepare filesystem for post analysis: %w", err)
 	}
+	defer composite.Cleanup()
 
 	err = a.walker.Walk(a.rootPath, a.artifactOption.WalkerOption, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
 		dir := a.rootPath


### PR DESCRIPTION
## Description

Trivy appears to be leaking `/tmp/analyzer-fs-*` directories when using FS artifacts.

This PR adds the call to `Cleanup()` that is already done in VM and Image artifacts.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
