### PR TITLE
fix(alpine): add `UID` for removed packages

### DIFF
--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aquasecurity/trivy/pkg/dependency"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
@@ -134,6 +135,7 @@ func (a alpineCmdAnalyzer) parseConfig(apkIndexArchive *apkIndex, config *v1.Con
 		pkgs = a.resolveDependencies(apkIndexArchive, pkgs)
 		results := a.guessVersion(apkIndexArchive, pkgs, history.Created.Time)
 		for _, result := range results {
+			result.Identifier.UID = dependency.UID("", result)
 			uniqPkgs[result.Name] = result
 		}
 	}

--- a/pkg/fanal/analyzer/imgconf/apk/apk_test.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk_test.go
@@ -570,454 +570,793 @@ var (
 		{
 			Name:    "acl",
 			Version: "2.2.52-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "784f131cd326111",
+			},
 		},
 		{
 			Name:    "apr",
 			Version: "1.6.5-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "1e7a6d0bda73a74f",
+			},
 		},
 		{
 			Name:    "apr-util",
 			Version: "1.6.1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "a2c929c03d9ad61a",
+			},
 		},
 		{
 			Name:    "argon2",
 			Version: "20171227-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "f1f015346e9d54db",
+			},
 		},
 		{
 			Name:    "argon2-dev",
 			Version: "20171227-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "dd027c90469eaea2",
+			},
 		},
 		{
 			Name:    "argon2-libs",
 			Version: "20171227-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "c18902624988b224",
+			},
 		},
 		{
 			Name:    "attr",
 			Version: "2.4.47-r7",
+			Identifier: types.PkgIdentifier{
+				UID: "88e3c95b0bd83fe",
+			},
 		},
 		{
 			Name:    "autoconf",
 			Version: "2.69-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "9282eebaa2edb18e",
+			},
 		},
 		{
 			Name:    "bash",
 			Version: "4.4.19-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "b9623518df2580d7",
+			},
 		},
 		{
 			Name:    "binutils",
 			Version: "2.31.1-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "6eb2b9ef787d20e5",
+			},
 		},
 		{
 			Name:    "busybox",
 			Version: "1.29.3-r10",
+			Identifier: types.PkgIdentifier{
+				UID: "6d4fece8eb9aed1b",
+			},
 		},
 		{
 			Name:    "bzip2",
 			Version: "1.0.6-r6",
+			Identifier: types.PkgIdentifier{
+				UID: "f10a7652e98de81",
+			},
 		},
 		{
 			Name:    "ca-certificates",
 			Version: "20190108-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "78b6dea410b11547",
+			},
 		},
 		{
 			Name:    "coreutils",
 			Version: "8.30-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "a65f04a5f1682ef3",
+			},
 		},
 		{
 			Name:    "curl",
 			Version: "7.64.0-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "653b9f8ab041d5ac",
+			},
 		},
 		{
 			Name:    "curl-dev",
 			Version: "7.64.0-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "cdaa10b4d0045df",
+			},
 		},
 		{
 			Name:    "cyrus-sasl",
 			Version: "2.1.27-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "11f463e17f11fc11",
+			},
 		},
 		{
 			Name:    "db",
 			Version: "5.3.28-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "3c96ed610406070f",
+			},
 		},
 		{
 			Name:    "dpkg",
 			Version: "1.19.2-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "291cdf92161b7a35",
+			},
 		},
 		{
 			Name:    "dpkg-dev",
 			Version: "1.19.2-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "c87dd7f90913b9c0",
+			},
 		},
 		{
 			Name:    "expat",
 			Version: "2.2.6-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "c17cef592b4cd1ac",
+			},
 		},
 		{
 			Name:    "file",
 			Version: "5.36-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "e9eac8d2344654b6",
+			},
 		},
 		{
 			Name:    "g++",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "b5a17a376ce78648",
+			},
 		},
 		{
 			Name:    "gcc",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "e0028b3f4edb10d0",
+			},
 		},
 		{
 			Name:    "gdbm",
 			Version: "1.13-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "ddf8257d2b4ffc7b",
+			},
 		},
 		{
 			Name:    "git",
 			Version: "2.20.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "7df769c499baac3e",
+			},
 		},
 		{
 			Name:    "gmp",
 			Version: "6.1.2-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "9543ab8b3ef71c6b",
+			},
 		},
 		{
 			Name:    "gnupg",
 			Version: "2.2.12-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "af5a8477a7bb8a39",
+			},
 		},
 		{
 			Name:    "gnutls",
 			Version: "3.6.7-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "7b8292fb2158b405",
+			},
 		},
 		{
 			Name:    "isl",
 			Version: "0.18-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "ff5808fa3be09223",
+			},
 		},
 		{
 			Name:    "libacl",
 			Version: "2.2.52-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "e1110bb9fa71e9b6",
+			},
 		},
 		{
 			Name:    "libassuan",
 			Version: "2.5.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "5c27356bfc0c8063",
+			},
 		},
 		{
 			Name:    "libatomic",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "9c448437636ec536",
+			},
 		},
 		{
 			Name:    "libattr",
 			Version: "2.4.47-r7",
+			Identifier: types.PkgIdentifier{
+				UID: "58d4cb13b94c427c",
+			},
 		},
 		{
 			Name:    "libbz2",
 			Version: "1.0.6-r6",
+			Identifier: types.PkgIdentifier{
+				UID: "b88167f64940af66",
+			},
 		},
 		{
 			Name:    "libc-dev",
 			Version: "0.7.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "804732077a4c662b",
+			},
 		},
 		{
 			Name:    "libcap",
 			Version: "2.26-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "9fe6eb7eda727396",
+			},
 		},
 		{
 			Name:    "libcrypto1.1",
 			Version: "1.1.1b-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "68da5e7990c8780c",
+			},
 		},
 		{
 			Name:    "libcurl",
 			Version: "7.64.0-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "49e0a68f77f67462",
+			},
 		},
 		{
 			Name:    "libedit",
 			Version: "20181209.3.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "cb42283699ac3423",
+			},
 		},
 		{
 			Name:    "libedit-dev",
 			Version: "20181209.3.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "e02c3a224e18a6b2",
+			},
 		},
 		{
 			Name:    "libffi",
 			Version: "3.2.1-r6",
+			Identifier: types.PkgIdentifier{
+				UID: "68833f89f34bd7ec",
+			},
 		},
 		{
 			Name:    "libgcc",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "27519ea7a3464bc0",
+			},
 		},
 		{
 			Name:    "libgcrypt",
 			Version: "1.8.4-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "f05eadedb8dc0151",
+			},
 		},
 		{
 			Name:    "libgomp",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "543d8918635c52d6",
+			},
 		},
 		{
 			Name:    "libgpg-error",
 			Version: "1.33-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "db991adc17654512",
+			},
 		},
 		{
 			Name:    "libksba",
 			Version: "1.3.5-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "2bdff3fcdb38fcc9",
+			},
 		},
 		{
 			Name:    "libldap",
 			Version: "2.4.47-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "7d1e18d46af8e64d",
+			},
 		},
 		{
 			Name:    "libmagic",
 			Version: "5.36-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "8de0dc2316c7f08c",
+			},
 		},
 		{
 			Name:    "libsasl",
 			Version: "2.1.27-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "32ade945216e13cb",
+			},
 		},
 		{
 			Name:    "libsodium",
 			Version: "1.0.16-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "7510915bba932b1b",
+			},
 		},
 		{
 			Name:    "libsodium-dev",
 			Version: "1.0.16-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "df3b47abf3f1411f",
+			},
 		},
 		{
 			Name:    "libssh2",
 			Version: "1.8.2-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "7cf64ca05155ca9c",
+			},
 		},
 		{
 			Name:    "libssh2-dev",
 			Version: "1.8.2-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "8afd5b832f1d474c",
+			},
 		},
 		{
 			Name:    "libssl1.1",
 			Version: "1.1.1b-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "b35faf606cddd965",
+			},
 		},
 		{
 			Name:    "libstdc++",
 			Version: "8.3.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "e56259710bdc7ded",
+			},
 		},
 		{
 			Name:    "libtasn1",
 			Version: "4.13-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "d78c8e47a85a4185",
+			},
 		},
 		{
 			Name:    "libunistring",
 			Version: "0.9.10-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "5f31755a4db496df",
+			},
 		},
 		{
 			Name:    "libuuid",
 			Version: "2.33-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "af33ae09a75e4ee2",
+			},
 		},
 		{
 			Name:    "libxml2",
 			Version: "2.9.9-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "f772ed5552f4248f",
+			},
 		},
 		{
 			Name:    "libxml2-dev",
 			Version: "2.9.9-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "3aa56b4d41995ecc",
+			},
 		},
 		{
 			Name:    "lz4",
 			Version: "1.8.3-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "16fe8f309f000a",
+			},
 		},
 		{
 			Name:    "lz4-libs",
 			Version: "1.8.3-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "f1cc72d3a4f0e3fa",
+			},
 		},
 		{
 			Name:    "m4",
 			Version: "1.4.18-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "279041efb6311a55",
+			},
 		},
 		{
 			Name:    "make",
 			Version: "4.2.1-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "aedc2f116a0a656",
+			},
 		},
 		{
 			Name:    "mercurial",
 			Version: "4.9.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "dd8db352af0fe45d",
+			},
 		},
 		{
 			Name:    "mpc1",
 			Version: "1.0.3-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "4ac00bb3c9d7b863",
+			},
 		},
 		{
 			Name:    "mpfr3",
 			Version: "3.1.5-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "7351997d7d25f69a",
+			},
 		},
 		{
 			Name:    "musl",
 			Version: "1.1.20-r4",
+			Identifier: types.PkgIdentifier{
+				UID: "8e5756f96b3b5f6",
+			},
 		},
 		{
 			Name:    "musl-dev",
 			Version: "1.1.20-r4",
+			Identifier: types.PkgIdentifier{
+				UID: "2232888b0c99c2d",
+			},
 		},
 		{
 			Name:    "ncurses",
 			Version: "6.1_p20190105-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "df982c6c8f287e6a",
+			},
 		},
 		{
 			Name:    "ncurses-dev",
 			Version: "6.1_p20190105-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "80932f0ecaf2d5f8",
+			},
 		},
 		{
 			Name:    "ncurses-libs",
 			Version: "6.1_p20190105-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "d8410f98ecc55ce4",
+			},
 		},
 		{
 			Name:    "ncurses-terminfo",
 			Version: "6.1_p20190105-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "c60fc6e5a37d8a95",
+			},
 		},
 		{
 			Name:    "ncurses-terminfo-base",
 			Version: "6.1_p20190105-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "c2beca25e6a5371f",
+			},
 		},
 		{
 			Name:    "nettle",
 			Version: "3.4.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "96dcec63030bedbb",
+			},
 		},
 		{
 			Name:    "nghttp2",
 			Version: "1.35.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "ba6c36de650ae267",
+			},
 		},
 		{
 			Name:    "nghttp2-dev",
 			Version: "1.35.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "db9600175e13927",
+			},
 		},
 		{
 			Name:    "nghttp2-libs",
 			Version: "1.35.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "66cd303081642354",
+			},
 		},
 		{
 			Name:    "npth",
 			Version: "1.6-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "4a8c2366f7da081d",
+			},
 		},
 		{
 			Name:    "openldap",
 			Version: "2.4.47-r2",
+			Identifier: types.PkgIdentifier{
+				UID: "4e116d327ed660e7",
+			},
 		},
 		{
 			Name:    "openssh",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "27574c5b357bd209",
+			},
 		},
 		{
 			Name:    "openssh-client",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "4d095f61f69debef",
+			},
 		},
 		{
 			Name:    "openssh-keygen",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "12cb2bcb1f6c2295",
+			},
 		},
 		{
 			Name:    "openssh-server",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "dee48c5c90bff0d6",
+			},
 		},
 		{
 			Name:    "openssh-server-common",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "ad06b8d442f8a162",
+			},
 		},
 		{
 			Name:    "openssh-sftp-server",
 			Version: "7.9_p1-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "e0bc3d8e794f06c8",
+			},
 		},
 		{
 			Name:    "openssl",
 			Version: "1.1.1b-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "1c8ae81a9b60513c",
+			},
 		},
 		{
 			Name:    "openssl-dev",
 			Version: "1.1.1b-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "c6549ade045edac",
+			},
 		},
 		{
 			Name:    "p11-kit",
 			Version: "0.23.14-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "4f77fc5f062368fc",
+			},
 		},
 		{
 			Name:    "patch",
 			Version: "2.7.6-r4",
+			Identifier: types.PkgIdentifier{
+				UID: "49b5c14cbee185b7",
+			},
 		},
 		{
 			Name:    "pcre2",
 			Version: "10.32-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "c3733a676cf271ba",
+			},
 		},
 		{
 			Name:    "perl",
 			Version: "5.26.3-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "10e2893a9ea288e",
+			},
 		},
 		{
 			Name:    "pinentry",
 			Version: "1.1.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "783866fca9a015bd",
+			},
 		},
 		{
 			Name:    "pkgconf",
 			Version: "1.6.0-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "33d19ebaf35432b0",
+			},
 		},
 		{
 			Name:    "python2",
 			Version: "2.7.16-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "a839b2c9a5f9ba73",
+			},
 		},
 		{
 			Name:    "re2c",
 			Version: "1.1.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "ec7d28a39ed7dfb6",
+			},
 		},
 		{
 			Name:    "readline",
 			Version: "7.0.003-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "7d4d5810d005452c",
+			},
 		},
 		{
 			Name:    "serf",
 			Version: "1.3.9-r5",
+			Identifier: types.PkgIdentifier{
+				UID: "7f23c377c19eff2f",
+			},
 		},
 		{
 			Name:    "sqlite",
 			Version: "3.26.0-r3",
+			Identifier: types.PkgIdentifier{
+				UID: "1eab4ef4d3ea8c3c",
+			},
 		},
 		{
 			Name:    "sqlite-dev",
 			Version: "3.26.0-r3",
+			Identifier: types.PkgIdentifier{
+				UID: "4dcddd5956410d59",
+			},
 		},
 		{
 			Name:    "sqlite-libs",
 			Version: "3.26.0-r3",
+			Identifier: types.PkgIdentifier{
+				UID: "9790a2922ebbad67",
+			},
 		},
 		{
 			Name:    "subversion",
 			Version: "1.11.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "9de851271909a16",
+			},
 		},
 		{
 			Name:    "subversion-libs",
 			Version: "1.11.1-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "f55079ee39f32296",
+			},
 		},
 		{
 			Name:    "tar",
 			Version: "1.32-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "ee612e956fb56928",
+			},
 		},
 		{
 			Name:    "unzip",
 			Version: "6.0-r4",
+			Identifier: types.PkgIdentifier{
+				UID: "a0da1ecf3082e04",
+			},
 		},
 		{
 			Name:    "util-linux",
 			Version: "2.33-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "1405b9526350c651",
+			},
 		},
 		{
 			Name:    "wget",
 			Version: "1.20.3-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "a5b83a24d7129300",
+			},
 		},
 		{
 			Name:    "xz",
 			Version: "5.2.4-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "253d1bd8b99d6062",
+			},
 		},
 		{
 			Name:    "xz-libs",
 			Version: "5.2.4-r0",
+			Identifier: types.PkgIdentifier{
+				UID: "a42777c05ddb55f3",
+			},
 		},
 		{
 			Name:    "zip",
 			Version: "3.0-r7",
+			Identifier: types.PkgIdentifier{
+				UID: "2039aba6424806a4",
+			},
 		},
 		{
 			Name:    "zlib",
 			Version: "1.2.11-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "b742ac29b1f34e",
+			},
 		},
 		{
 			Name:    "zlib-dev",
 			Version: "1.2.11-r1",
+			Identifier: types.PkgIdentifier{
+				UID: "e9a8669a86602c9d",
+			},
 		},
 	}
 )

--- a/pkg/fanal/test/integration/testdata/goldens/vuln-image1.2.3.expectedpkgsfromcmds.golden
+++ b/pkg/fanal/test/integration/testdata/goldens/vuln-image1.2.3.expectedpkgsfromcmds.golden
@@ -1,499 +1,665 @@
 [
   {
     "Name": "acl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "181b417cffad616f"
+    },
     "Version": "2.2.52-r3",
     "Layer": {}
   },
   {
     "Name": "apr",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "5083f2ffc2b7a814"
+    },
     "Version": "1.6.3-r0",
     "Layer": {}
   },
   {
     "Name": "apr-util",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "1e0af1c3510210ba"
+    },
     "Version": "1.6.1-r1",
     "Layer": {}
   },
   {
     "Name": "attr",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "a47bcc9298df6cb9"
+    },
     "Version": "2.4.47-r6",
     "Layer": {}
   },
   {
     "Name": "autoconf",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "3c70caeaed9a6ff9"
+    },
     "Version": "2.69-r0",
     "Layer": {}
   },
   {
     "Name": "bash",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "b9623518df2580d7"
+    },
     "Version": "4.4.19-r1",
     "Layer": {}
   },
   {
     "Name": "binutils",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "9c6d3cbf28294d8c"
+    },
     "Version": "2.30-r1",
     "Layer": {}
   },
   {
     "Name": "binutils-libs",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "bd787142d4ac226b"
+    },
     "Version": "2.30-r1",
     "Layer": {}
   },
   {
     "Name": "busybox",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7d2e7c1078ba7eb"
+    },
     "Version": "1.27.2-r11",
     "Layer": {}
   },
   {
     "Name": "bzip2",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "f10a7652e98de81"
+    },
     "Version": "1.0.6-r6",
     "Layer": {}
   },
   {
     "Name": "ca-certificates",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "15130b963760c251"
+    },
     "Version": "20171114-r0",
     "Layer": {}
   },
   {
     "Name": "coreutils",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "62b3a9f524fb42ae"
+    },
     "Version": "8.28-r0",
     "Layer": {}
   },
   {
     "Name": "cyrus-sasl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "3d54d810df71de08"
+    },
     "Version": "2.1.26-r11",
     "Layer": {}
   },
   {
     "Name": "db",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "c516bbf8a0460592"
+    },
     "Version": "5.3.28-r0",
     "Layer": {}
   },
   {
     "Name": "dpkg",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "48abb525a6e6484c"
+    },
     "Version": "1.18.24-r0",
     "Layer": {}
   },
   {
     "Name": "dpkg-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "751199098a59e38a"
+    },
     "Version": "1.18.24-r0",
     "Layer": {}
   },
   {
     "Name": "expat",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "39fb7474be7cbbd1"
+    },
     "Version": "2.2.5-r0",
     "Layer": {}
   },
   {
     "Name": "file",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "fce3c3b5b4ca8c61"
+    },
     "Version": "5.32-r0",
     "Layer": {}
   },
   {
     "Name": "g++",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "e38d4fbb4801e54"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "gcc",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7e7a1343cbee2437"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "gdbm",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "ddf8257d2b4ffc7b"
+    },
     "Version": "1.13-r1",
     "Layer": {}
   },
   {
     "Name": "gmp",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "9543ab8b3ef71c6b"
+    },
     "Version": "6.1.2-r1",
     "Layer": {}
   },
   {
     "Name": "gnupg",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "dc05954810cd6512"
+    },
     "Version": "2.2.3-r1",
     "Layer": {}
   },
   {
     "Name": "gnutls",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "3895e3c8d3c4eec5"
+    },
     "Version": "3.6.1-r0",
     "Layer": {}
   },
   {
     "Name": "isl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "ff5808fa3be09223"
+    },
     "Version": "0.18-r0",
     "Layer": {}
   },
   {
     "Name": "libacl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "8496f22e32d90dd9"
+    },
     "Version": "2.2.52-r3",
     "Layer": {}
   },
   {
     "Name": "libassuan",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7c44d43ad91014bb"
+    },
     "Version": "2.4.4-r0",
     "Layer": {}
   },
   {
     "Name": "libatomic",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "cc7cbb7bdeaceb7a"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "libattr",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "6ab5fd8ad7ea3579"
+    },
     "Version": "2.4.47-r6",
     "Layer": {}
   },
   {
     "Name": "libbz2",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "b88167f64940af66"
+    },
     "Version": "1.0.6-r6",
     "Layer": {}
   },
   {
     "Name": "libc-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "804732077a4c662b"
+    },
     "Version": "0.7.1-r0",
     "Layer": {}
   },
   {
     "Name": "libcap",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "d0374637d7ee148"
+    },
     "Version": "2.25-r1",
     "Layer": {}
   },
   {
     "Name": "libedit",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "a9e7bdfc780a5205"
+    },
     "Version": "20170329.3.1-r3",
     "Layer": {}
   },
   {
     "Name": "libedit-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "cc15a0075f19fb29"
+    },
     "Version": "20170329.3.1-r3",
     "Layer": {}
   },
   {
     "Name": "libffi",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2e7d2428b7208794"
+    },
     "Version": "3.2.1-r4",
     "Layer": {}
   },
   {
     "Name": "libgcc",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "337db1c98d7a2b24"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "libgcrypt",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "607b2546f0faa0dd"
+    },
     "Version": "1.8.3-r0",
     "Layer": {}
   },
   {
     "Name": "libgomp",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "6405f9ce160ce36"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "libgpg-error",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2e7c4543143270ba"
+    },
     "Version": "1.27-r1",
     "Layer": {}
   },
   {
     "Name": "libksba",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2bdff3fcdb38fcc9"
+    },
     "Version": "1.3.5-r0",
     "Layer": {}
   },
   {
     "Name": "libldap",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "9a1c31386d4c51d1"
+    },
     "Version": "2.4.45-r3",
     "Layer": {}
   },
   {
     "Name": "libmagic",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "ce8c19b21901c2ec"
+    },
     "Version": "5.32-r0",
     "Layer": {}
   },
   {
     "Name": "libressl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "e0990fc64593fc34"
+    },
     "Version": "2.6.5-r0",
     "Layer": {}
   },
   {
     "Name": "libressl-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2fc58a084fad510b"
+    },
     "Version": "2.6.5-r0",
     "Layer": {}
   },
   {
     "Name": "libressl2.6-libcrypto",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "b9b01ba0fd3c2f96"
+    },
     "Version": "2.6.5-r0",
     "Layer": {}
   },
   {
     "Name": "libressl2.6-libssl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7450166187e3c122"
+    },
     "Version": "2.6.5-r0",
     "Layer": {}
   },
   {
     "Name": "libressl2.6-libtls",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "31e6fafea5aee605"
+    },
     "Version": "2.6.5-r0",
     "Layer": {}
   },
   {
     "Name": "libsasl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "a5d9eed6b200ec9e"
+    },
     "Version": "2.1.26-r11",
     "Layer": {}
   },
   {
     "Name": "libsodium",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "d37655d3df6e7f60"
+    },
     "Version": "1.0.15-r0",
     "Layer": {}
   },
   {
     "Name": "libsodium-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "9ad59860b74f3bc9"
+    },
     "Version": "1.0.15-r0",
     "Layer": {}
   },
   {
     "Name": "libstdc++",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "3cb038e2e3f8f2d3"
+    },
     "Version": "6.4.0-r5",
     "Layer": {}
   },
   {
     "Name": "libtasn1",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "d64e086f11523544"
+    },
     "Version": "4.12-r3",
     "Layer": {}
   },
   {
     "Name": "libunistring",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "f011d575a1de2df6"
+    },
     "Version": "0.9.7-r0",
     "Layer": {}
   },
   {
     "Name": "m4",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "9a0327634e852d10"
+    },
     "Version": "1.4.18-r0",
     "Layer": {}
   },
   {
     "Name": "make",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "5563a4c45ccc0ca6"
+    },
     "Version": "4.2.1-r0",
     "Layer": {}
   },
   {
     "Name": "mercurial",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "5b844daeeb0ae32c"
+    },
     "Version": "4.5.2-r0",
     "Layer": {}
   },
   {
     "Name": "mpc1",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "4ac00bb3c9d7b863"
+    },
     "Version": "1.0.3-r1",
     "Layer": {}
   },
   {
     "Name": "mpfr3",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7351997d7d25f69a"
+    },
     "Version": "3.1.5-r1",
     "Layer": {}
   },
   {
     "Name": "musl",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "61c9bbf17ebf0ec5"
+    },
     "Version": "1.1.18-r3",
     "Layer": {}
   },
   {
     "Name": "musl-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "bddc3ce8e670295c"
+    },
     "Version": "1.1.18-r3",
     "Layer": {}
   },
   {
     "Name": "ncurses",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "268c30a59b31f30f"
+    },
     "Version": "6.0_p20171125-r1",
     "Layer": {}
   },
   {
     "Name": "ncurses-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "35e387a2169b6c35"
+    },
     "Version": "6.0_p20171125-r1",
     "Layer": {}
   },
   {
     "Name": "ncurses-libs",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "a698bd167c8edb63"
+    },
     "Version": "6.0_p20171125-r1",
     "Layer": {}
   },
   {
     "Name": "ncurses-terminfo",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "1d756cb96659dfe8"
+    },
     "Version": "6.0_p20171125-r1",
     "Layer": {}
   },
   {
     "Name": "ncurses-terminfo-base",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "70b90293a1ffd5c"
+    },
     "Version": "6.0_p20171125-r1",
     "Layer": {}
   },
   {
     "Name": "nettle",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2279fda8e0f37088"
+    },
     "Version": "3.3-r0",
     "Layer": {}
   },
   {
     "Name": "npth",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "5d5e661f25ccd3bb"
+    },
     "Version": "1.5-r1",
     "Layer": {}
   },
   {
     "Name": "openldap",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "f951698c7542567d"
+    },
     "Version": "2.4.45-r3",
     "Layer": {}
   },
   {
     "Name": "p11-kit",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "f9a3b6ef16728be3"
+    },
     "Version": "0.23.2-r2",
     "Layer": {}
   },
   {
     "Name": "patch",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "59097ece63a1532"
+    },
     "Version": "2.7.5-r2",
     "Layer": {}
   },
   {
     "Name": "pcre2",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "46c51355357283bd"
+    },
     "Version": "10.30-r0",
     "Layer": {}
   },
   {
     "Name": "pinentry",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "e0aa8991cc0d7ea9"
+    },
     "Version": "1.0.0-r0",
     "Layer": {}
   },
   {
     "Name": "pkgconf",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "558f6d8317744a54"
+    },
     "Version": "1.3.10-r0",
     "Layer": {}
   },
   {
     "Name": "python2",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "7e33eccd3ce9ae3f"
+    },
     "Version": "2.7.15-r2",
     "Layer": {}
   },
   {
     "Name": "re2c",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "6dbcd72a6ade1945"
+    },
     "Version": "1.0.2-r0",
     "Layer": {}
   },
   {
     "Name": "readline",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "c1cfb597544b76a5"
+    },
     "Version": "7.0.003-r0",
     "Layer": {}
   },
   {
     "Name": "serf",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "94872f984b4a0583"
+    },
     "Version": "1.3.9-r3",
     "Layer": {}
   },
   {
     "Name": "subversion",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "8fa2da2cba41429c"
+    },
     "Version": "1.9.7-r0",
     "Layer": {}
   },
   {
     "Name": "subversion-libs",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "2591b779b8cc1ec5"
+    },
     "Version": "1.9.7-r0",
     "Layer": {}
   },
   {
     "Name": "xz",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "74d9b4a853a25311"
+    },
     "Version": "5.2.3-r1",
     "Layer": {}
   },
   {
     "Name": "xz-libs",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "e6072b890db87763"
+    },
     "Version": "5.2.3-r1",
     "Layer": {}
   },
   {
     "Name": "zlib",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "b742ac29b1f34e"
+    },
     "Version": "1.2.11-r1",
     "Layer": {}
   },
   {
     "Name": "zlib-dev",
-    "Identifier": {},
+    "Identifier": {
+      "UID": "e9a8669a86602c9d"
+    },
     "Version": "1.2.11-r1",
     "Layer": {}
   }


### PR DESCRIPTION
## Description
Packages found from image config should also contain [UID](https://github.com/aquasecurity/trivy/blob/927c6e0c9d4d4a3f1be00f0f661c1d18325d9440/pkg/fanal/types/package.go#L75).

These changes also fix a dependency issue for the BOM core (see #7886)
e.g. for CycloneDX:

before:
```
➜ trivy -q image -f cyclonedx  node:22.11-alpine --removed-pkgs
...
      "ref": "8a1b0f78-6da7-4567-abd3-3d36951588bc",
      "dependsOn": [
        "678d2ae9-d409-4e33-bc1b-7304560ac75a",
        "678d2ae9-d409-4e33-bc1b-7304560ac75a",
        "678d2ae9-d409-4e33-bc1b-7304560ac75a",
...
```

after:
```
➜  ./trivy -q image -f cyclonedx  node:22.11-alpine --removed-pkgs

...
      "ref": "b6ada0a0-4305-40bd-a0f4-444bac8ec868",
      "dependsOn": [
        "037012ad-0b78-470d-80d0-efbc1b1a49f7",
        "05852c2e-b9f5-47d2-a54f-23801023974f",
        "076700ec-c73b-48a5-9b03-9ae03a9b2b00",
```


## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
