### PR TITLE
refactor(misconf): Remove unused options

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -222,7 +222,6 @@ func NewEngineMetadata(schema string, meta map[string]any) (*scan.EngineMetadata
 }
 
 type InputOptions struct {
-	Combined  bool
 	Selectors []Selector
 }
 
@@ -352,7 +351,6 @@ func (m *MetadataRetriever) RetrieveMetadata(ctx context.Context, module *ast.Mo
 func (m *MetadataRetriever) queryInputOptions(ctx context.Context, module *ast.Module) InputOptions {
 
 	options := InputOptions{
-		Combined:  false,
 		Selectors: nil,
 	}
 
@@ -393,12 +391,6 @@ func (m *MetadataRetriever) queryInputOptions(ctx context.Context, module *ast.M
 			return options
 		}
 		metadata = meta
-	}
-
-	if raw, ok := metadata["combine"]; ok {
-		if combine, ok := raw.(bool); ok {
-			options.Combined = combine
-		}
 	}
 
 	if raw, ok := metadata["selector"]; ok {

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -362,9 +362,7 @@ func (s *Scanner) applyRule(ctx context.Context, namespace, rule string, inputs 
 // severity is now set with metadata, so deny/warn/violation now behave the same way
 func isEnforcedRule(name string) bool {
 	switch {
-	case name == "deny", strings.HasPrefix(name, "deny_"),
-		name == "warn", strings.HasPrefix(name, "warn_"),
-		name == "violation", strings.HasPrefix(name, "violation_"):
+	case name == "deny", strings.HasPrefix(name, "deny_"):
 		return true
 	}
 	return false

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -359,24 +359,6 @@ func (s *Scanner) applyRule(ctx context.Context, namespace, rule string, inputs 
 	return results, nil
 }
 
-func (s *Scanner) applyRuleCombined(ctx context.Context, namespace, rule string, inputs []Input) (scan.Results, error) {
-	if len(inputs) == 0 {
-		return nil, nil
-	}
-
-	parsed, err := parseRawInput(inputs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse input: %w", err)
-	}
-
-	qualified := fmt.Sprintf("data.%s.%s", namespace, rule)
-	set, traces, err := s.runQuery(ctx, qualified, parsed, false)
-	if err != nil {
-		return nil, err
-	}
-	return s.convertResults(set, inputs[0], namespace, rule, traces), nil
-}
-
 // severity is now set with metadata, so deny/warn/violation now behave the same way
 func isEnforcedRule(name string) bool {
 	switch {

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -247,7 +247,7 @@ func (s *Scanner) ScanInput(ctx context.Context, inputs ...Input) (scan.Results,
 			}
 			usedRules[ruleName] = struct{}{}
 			if isEnforcedRule(ruleName) {
-				ruleResults, err := s.applyRule(ctx, namespace, ruleName, inputs, staticMeta.InputOptions.Combined)
+				ruleResults, err := s.applyRule(ctx, namespace, ruleName, inputs)
 				if err != nil {
 					s.logger.Error(
 						"Error occurred while applying rule from check",
@@ -328,14 +328,7 @@ func parseRawInput(input any) (ast.Value, error) {
 	return ast.InterfaceToValue(input)
 }
 
-func (s *Scanner) applyRule(ctx context.Context, namespace, rule string, inputs []Input, combined bool) (scan.Results, error) {
-
-	// handle combined evaluations if possible
-	if combined {
-		s.trace("INPUT", inputs)
-		return s.applyRuleCombined(ctx, namespace, rule, inputs)
-	}
-
+func (s *Scanner) applyRule(ctx context.Context, namespace, rule string, inputs []Input) (scan.Results, error) {
 	var results scan.Results
 	qualified := fmt.Sprintf("data.%s.%s", namespace, rule)
 	for _, input := range inputs {

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -99,37 +99,6 @@ deny {
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
 }
 
-func Test_RegoScanning_Warn(t *testing.T) {
-
-	srcFS := CreateFS(t, map[string]string{
-		"policies/test.rego": `
-package defsec.test
-
-warn {
-    input.evil
-}
-`,
-	})
-
-	scanner := rego.NewScanner(
-		types.SourceJSON,
-		rego.WithPolicyDirs("policies"),
-	)
-	require.NoError(t, scanner.LoadPolicies(srcFS))
-
-	results, err := scanner.ScanInput(context.TODO(), rego.Input{
-		Path: "/evil.lol",
-		Contents: map[string]any{
-			"evil": true,
-		},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, results.GetFailed(), 1)
-	require.Empty(t, results.GetPassed())
-	require.Empty(t, results.GetIgnored())
-}
-
 func Test_RegoScanning_Allow(t *testing.T) {
 	srcFS := CreateFS(t, map[string]string{
 		"policies/test.rego": `

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -63,7 +63,6 @@ deny {
 	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
-	assert.False(t, results.GetFailed()[0].IsWarning())
 }
 
 func Test_RegoScanning_AbsolutePolicyPath_Deny(t *testing.T) {
@@ -98,7 +97,6 @@ deny {
 	assert.Empty(t, results.GetIgnored())
 
 	assert.Equal(t, "/evil.lol", results.GetFailed()[0].Metadata().Range().GetFilename())
-	assert.False(t, results.GetFailed()[0].IsWarning())
 }
 
 func Test_RegoScanning_Warn(t *testing.T) {
@@ -130,8 +128,6 @@ warn {
 	require.Len(t, results.GetFailed(), 1)
 	require.Empty(t, results.GetPassed())
 	require.Empty(t, results.GetIgnored())
-
-	assert.True(t, results.GetFailed()[0].IsWarning())
 }
 
 func Test_RegoScanning_Allow(t *testing.T) {

--- a/pkg/iac/scan/flat.go
+++ b/pkg/iac/scan/flat.go
@@ -18,7 +18,6 @@ type FlatResult struct {
 	Description     string             `json:"description"`
 	RangeAnnotation string             `json:"-"`
 	Severity        severity.Severity  `json:"severity"`
-	Warning         bool               `json:"warning"`
 	Status          Status             `json:"status"`
 	Resource        string             `json:"resource"`
 	Occurrences     []Occurrence       `json:"occurrences,omitempty"`
@@ -64,7 +63,6 @@ func (r *Result) Flatten() FlatResult {
 		Status:          r.status,
 		Resource:        resMetadata.Reference(),
 		Occurrences:     r.Occurrences(),
-		Warning:         r.IsWarning(),
 		Location: FlatRange{
 			Filename:  rng.GetFilename(),
 			StartLine: rng.GetStartLine(),

--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -29,7 +29,6 @@ type Result struct {
 	severityOverride *severity.Severity
 	regoNamespace    string
 	regoRule         string
-	warning          bool
 	traces           []string
 	fsPath           string
 }
@@ -47,10 +46,6 @@ func (r Result) Severity() severity.Severity {
 		return *r.severityOverride
 	}
 	return r.Rule().Severity
-}
-
-func (r *Result) IsWarning() bool {
-	return r.warning
 }
 
 func (r *Result) OverrideSeverity(s severity.Severity) {
@@ -195,7 +190,6 @@ func (r *Results) AddRego(description, namespace, rule string, traces []string, 
 		description:   description,
 		regoNamespace: namespace,
 		regoRule:      rule,
-		warning:       rule == "warn" || strings.HasPrefix(rule, "warn_"),
 		traces:        traces,
 	}
 	result.metadata = getMetadataFromSource(source)

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -482,16 +482,13 @@ func ResultsToMisconf(configType types.ConfigType, scannerName string, results s
 			}
 		}
 
-		if flattened.Warning {
-			misconf.Warnings = append(misconf.Warnings, misconfResult)
-		} else {
-			switch flattened.Status {
-			case scan.StatusPassed:
-				misconf.Successes = append(misconf.Successes, misconfResult)
-			case scan.StatusFailed:
-				misconf.Failures = append(misconf.Failures, misconfResult)
-			}
+		switch flattened.Status {
+		case scan.StatusPassed:
+			misconf.Successes = append(misconf.Successes, misconfResult)
+		case scan.StatusFailed:
+			misconf.Failures = append(misconf.Failures, misconfResult)
 		}
+
 		misconfs[filePath] = misconf
 	}
 


### PR DESCRIPTION
## Description

These options aren't often used due to reasons described in the [disucussion](https://github.com/aquasecurity/trivy/discussions/7961) and can be deprecated.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7849

## Related discussion 
- https://github.com/aquasecurity/trivy/discussions/7961

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
