### PR TITLE
fix(report): handle `git@github.com` schema for misconfigs in `sarif` report

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -349,16 +349,35 @@ func ToPathUri(input string, resultClass types.ResultClass) string {
 // clearURI clears URI for misconfigs
 func clearURI(s string) string {
 	s = strings.ReplaceAll(s, "\\", "/")
-	if strings.HasPrefix(s, "git::https:/") {
-		s = strings.ReplaceAll(s, "git::https:/", "")
-		s = strings.ReplaceAll(s, ".git", "")
-	} else if strings.HasPrefix(s, "git@github.com:") {
+	// cf. https://developer.hashicorp.com/terraform/language/modules/sources
+	switch {
+	case strings.HasPrefix(s, "git@github.com:"):
 		// build GitHub url format
 		// e.g. `git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.2.0/main.tf` -> `github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf`
 		// cf. https://github.com/aquasecurity/trivy/issues/7897
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
 		s = strings.ReplaceAll(s, ".git", "")
 		s = strings.ReplaceAll(s, "?ref=", "/tree/")
+	case strings.HasPrefix(s, "git::ssh://"):
+		// `"`git::ssh://username@example.com/storage.git` -> `example.com/storage.git`
+		if _, u, ok := strings.Cut(s, "@"); ok {
+			s = u
+		}
+		s = strings.ReplaceAll(s, ".git", "")
+	case strings.HasPrefix(s, "git::"):
+		// `git::https://example.com/vpc.git` -> `https://example.com/vpc`
+		s = strings.TrimPrefix(s, "git::")
+		s = strings.ReplaceAll(s, ".git", "")
+	case strings.HasPrefix(s, "hg::"):
+		// `hg::http://example.com/vpc.hg` -> `http://example.com/vpc`
+		s = strings.TrimPrefix(s, "hg::")
+		s = strings.ReplaceAll(s, ".hg", "")
+	case strings.HasPrefix(s, "s3::"):
+		// `s3::https://s3-eu-west-1.amazonaws.com/examplecorp-terraform-modules/vpc.zip` -> `https://s3-eu-west-1.amazonaws.com/examplecorp-terraform-modules/vpc.zip`
+		s = strings.TrimPrefix(s, "s3::")
+	case strings.HasPrefix(s, "gcs::"):
+		// `gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zipp` -> `https://www.googleapis.com/storage/v1/modules/foomodule.zip`
+		s = strings.TrimPrefix(s, "gcs::")
 	}
 
 	return s

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -346,8 +346,18 @@ func ToPathUri(input string, resultClass types.ResultClass) string {
 	return clearURI(input)
 }
 
+// clearURI clears URI for misconfigs
 func clearURI(s string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(s, "\\", "/"), "git::https:/", "")
+	s = strings.ReplaceAll(s, "\\", "/")
+	if strings.HasPrefix(s, "git::https:/") {
+		s = strings.ReplaceAll(s, "git::https:/", "")
+	} else if strings.HasPrefix(s, "git@github.com:") {
+		// cf. https://developer.hashicorp.com/terraform/language/modules/sources#github
+		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
+		s = strings.ReplaceAll(s, ".git", "")
+	}
+
+	return s
 }
 
 func toUri(str string) *url.URL {

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -358,7 +358,7 @@ func clearURI(s string) string {
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
 		s = strings.ReplaceAll(s, ".git", "")
 		s = strings.ReplaceAll(s, "?ref=", "/tree/")
-	case strings.HasPrefix(s, "git::https:/"):
+	case strings.HasPrefix(s, "git::https:/") && !strings.HasPrefix(s, "git::https://"):
 		s = strings.TrimPrefix(s, "git::https:/")
 		s = strings.ReplaceAll(s, ".git", "")
 	case strings.HasPrefix(s, "git::ssh://"):

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -351,6 +351,7 @@ func clearURI(s string) string {
 	s = strings.ReplaceAll(s, "\\", "/")
 	if strings.HasPrefix(s, "git::https:/") {
 		s = strings.ReplaceAll(s, "git::https:/", "")
+		s = strings.ReplaceAll(s, ".git", "")
 	} else if strings.HasPrefix(s, "git@github.com:") {
 		// cf. https://developer.hashicorp.com/terraform/language/modules/sources#github
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -353,9 +353,12 @@ func clearURI(s string) string {
 		s = strings.ReplaceAll(s, "git::https:/", "")
 		s = strings.ReplaceAll(s, ".git", "")
 	} else if strings.HasPrefix(s, "git@github.com:") {
-		// cf. https://developer.hashicorp.com/terraform/language/modules/sources#github
+		// build GitHub url format
+		// e.g. `git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.2.0/main.tf` -> `github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf`
+		// cf. https://github.com/aquasecurity/trivy/issues/7897
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
 		s = strings.ReplaceAll(s, ".git", "")
+		s = strings.ReplaceAll(s, "?ref=", "/tree/")
 	}
 
 	return s

--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -358,6 +358,9 @@ func clearURI(s string) string {
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
 		s = strings.ReplaceAll(s, ".git", "")
 		s = strings.ReplaceAll(s, "?ref=", "/tree/")
+	case strings.HasPrefix(s, "git::https:/"):
+		s = strings.TrimPrefix(s, "git::https:/")
+		s = strings.ReplaceAll(s, ".git", "")
 	case strings.HasPrefix(s, "git::ssh://"):
 		// `"`git::ssh://username@example.com/storage.git` -> `example.com/storage.git`
 		if _, u, ok := strings.Cut(s, "@"); ok {

--- a/pkg/report/sarif_private_test.go
+++ b/pkg/report/sarif_private_test.go
@@ -1,0 +1,59 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_clearURI(t *testing.T) {
+	test := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "https",
+			uri:  "bitbucket.org/hashicorp/terraform-consul-aws",
+			want: "bitbucket.org/hashicorp/terraform-consul-aws",
+		},
+		{
+			name: "github",
+			uri:  "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.2.0/main.tf",
+			want: "github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf",
+		},
+		{
+			name: "git",
+			uri:  "git::https://example.com/storage.git?ref=51d462976d84fdea54b47d80dcabbf680badcdb8",
+			want: "https://example.com/storage?ref=51d462976d84fdea54b47d80dcabbf680badcdb8",
+		},
+		{
+			name: "git ssh",
+			uri:  "git::ssh://username@example.com/storage.git",
+			want: "example.com/storage",
+		},
+		{
+			name: "hg",
+			uri:  "hg::http://example.com/vpc.hg?ref=v1.2.0",
+			want: "http://example.com/vpc?ref=v1.2.0",
+		},
+		{
+			name: "s3",
+			uri:  "s3::https://s3-eu-west-1.amazonaws.com/examplecorp-terraform-modules/vpc.zip",
+			want: "https://s3-eu-west-1.amazonaws.com/examplecorp-terraform-modules/vpc.zip",
+		},
+		{
+			name: "gcs",
+			uri:  "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+			want: "https://www.googleapis.com/storage/v1/modules/foomodule.zip",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clearURI(tt.uri)
+			require.Equal(t, tt.want, got)
+			require.NotNil(t, toUri(got))
+		})
+	}
+}

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -589,7 +589,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 						},
 					},
 					{
-						Target: "git@github.com:rbs-path/terraform-modules.git/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf",
+						Target: "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.2.0/main.tf",
 						Class:  types.ClassConfig,
 						Type:   ftypes.Terraform,
 						Misconfigurations: []types.DetectedMisconfiguration{
@@ -615,7 +615,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 									Occurrences: []ftypes.Occurrence{
 										{
 											Resource: "google_project_iam_member.workload_identity_sa_bindings[\"roles/storage.admin\"]",
-											Filename: "git@github.com:rbs-path/terraform-modules.git/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf",
+											Filename: "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.2.0/main.tf",
 											Location: ftypes.Location{
 												StartLine: 87,
 												EndLine:   93,
@@ -697,13 +697,13 @@ func TestReportWriter_Sarif(t *testing.T) {
 								RuleID:    lo.ToPtr("AVD-GCP-0007"),
 								RuleIndex: lo.ToPtr(uint(0)),
 								Level:     lo.ToPtr("error"),
-								Message:   *sarif.NewTextMessage("Artifact: github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf\nType: terraform\nVulnerability AVD-GCP-0007\nSeverity: HIGH\nMessage: Service account is granted a privileged role.\nLink: [AVD-GCP-0007](https://avd.aquasec.com/misconfig/avd-gcp-0007)"),
+								Message:   *sarif.NewTextMessage("Artifact: github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf\nType: terraform\nVulnerability AVD-GCP-0007\nSeverity: HIGH\nMessage: Service account is granted a privileged role.\nLink: [AVD-GCP-0007](https://avd.aquasec.com/misconfig/avd-gcp-0007)"),
 								Locations: []*sarif.Location{
 									{
 										PhysicalLocation: sarif.NewPhysicalLocation().
 											WithArtifactLocation(
 												&sarif.ArtifactLocation{
-													URI:       lo.ToPtr("github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf"),
+													URI:       lo.ToPtr("github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf"),
 													URIBaseId: lo.ToPtr("ROOTPATH"),
 												},
 											).
@@ -715,7 +715,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 													EndColumn:   lo.ToPtr(1),
 												},
 											),
-										Message: sarif.NewTextMessage("github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf"),
+										Message: sarif.NewTextMessage("github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/v4.2.0/main.tf"),
 									},
 								},
 							},

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -588,6 +588,44 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 					},
+					{
+						Target: "git@github.com:rbs-path/terraform-modules.git/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf",
+						Class:  types.ClassConfig,
+						Type:   ftypes.Terraform,
+						Misconfigurations: []types.DetectedMisconfiguration{
+							{
+								Type:        "Terraform Security Check",
+								ID:          "AVD-GCP-0007",
+								AVDID:       "AVD-GCP-0007",
+								Title:       "Service accounts should not have roles assigned with excessive privileges",
+								Description: "Service accounts should have a minimal set of permissions assigned in order to do their job. They should never have excessive access as if compromised, an attacker can escalate privileges and take over the entire account.",
+								Message:     "Service account is granted a privileged role.",
+								Query:       "data..",
+								Resolution:  "Limit service account access to minimal required set",
+								Severity:    "HIGH",
+								PrimaryURL:  "https://avd.aquasec.com/misconfig/avd-gcp-0007",
+								References: []string{
+									"https://cloud.google.com/iam/docs/understanding-roles",
+									"https://avd.aquasec.com/misconfig/avd-gcp-0007",
+								},
+								Status: "Fail",
+								CauseMetadata: ftypes.CauseMetadata{
+									StartLine: 91,
+									EndLine:   91,
+									Occurrences: []ftypes.Occurrence{
+										{
+											Resource: "google_project_iam_member.workload_identity_sa_bindings[\"roles/storage.admin\"]",
+											Filename: "git@github.com:rbs-path/terraform-modules.git/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf",
+											Location: ftypes.Location{
+												StartLine: 87,
+												EndLine:   93,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			want: &sarif.Report{
@@ -652,6 +690,32 @@ func TestReportWriter_Sarif(t *testing.T) {
 												},
 											),
 										Message: sarif.NewTextMessage("github.com/terraform-google-modules/terraform-google-kubernetes-engine?ref=c4809044b52b91505bfba5ef9f25526aa0361788/modules/workload-identity/main.tf"),
+									},
+								},
+							},
+							{
+								RuleID:    lo.ToPtr("AVD-GCP-0007"),
+								RuleIndex: lo.ToPtr(uint(0)),
+								Level:     lo.ToPtr("error"),
+								Message:   *sarif.NewTextMessage("Artifact: github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf\nType: terraform\nVulnerability AVD-GCP-0007\nSeverity: HIGH\nMessage: Service account is granted a privileged role.\nLink: [AVD-GCP-0007](https://avd.aquasec.com/misconfig/avd-gcp-0007)"),
+								Locations: []*sarif.Location{
+									{
+										PhysicalLocation: sarif.NewPhysicalLocation().
+											WithArtifactLocation(
+												&sarif.ArtifactLocation{
+													URI:       lo.ToPtr("github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf"),
+													URIBaseId: lo.ToPtr("ROOTPATH"),
+												},
+											).
+											WithRegion(
+												&sarif.Region{
+													StartLine:   lo.ToPtr(91),
+													StartColumn: lo.ToPtr(1),
+													EndLine:     lo.ToPtr(91),
+													EndColumn:   lo.ToPtr(1),
+												},
+											),
+										Message: sarif.NewTextMessage("github.com/rbs-path/terraform-modules/modules/compute/aws-lambda?ref=v3.8.0/.terraform/modules/cleanup/modules/compute/aws-lambda/cloudwatch.tf"),
 									},
 								},
 							},


### PR DESCRIPTION
## Description
Overwrite `git@github.com` schema for misconfigs in `sarif` report.

## Related issues
- Close #7897

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
