### PR TITLE
fix(redhat): don't return error if `root/buildinfo/content_manifests/` contains files that are not `contentSets` files

### DIFF
--- a/pkg/fanal/analyzer/buildinfo/content_manifest.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest.go
@@ -31,6 +31,10 @@ func (a contentManifestAnalyzer) Analyze(_ context.Context, target analyzer.Anal
 		return nil, xerrors.Errorf("invalid content manifest: %w", err)
 	}
 
+	if len(manifest.ContentSets) == 0 {
+		return nil, nil
+	}
+
 	return &analyzer.AnalysisResult{
 		BuildInfo: &types.BuildInfo{
 			ContentSets: manifest.ContentSets,

--- a/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
@@ -32,6 +32,11 @@ func Test_contentManifestAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:  "happy path for non-contentSets file",
+			input: "testdata/content_manifests/sbom-purl.json",
+			want:  nil,
+		},
+		{
 			name:    "broken json",
 			input:   "testdata/content_manifests/broken.json",
 			wantErr: "invalid content manifest",

--- a/pkg/fanal/analyzer/buildinfo/testdata/content_manifests/sbom-purl.json
+++ b/pkg/fanal/analyzer/buildinfo/testdata/content_manifests/sbom-purl.json
@@ -1,0 +1,9 @@
+{
+  "image_contents": {
+    "dependencies": [
+      {
+        "purl": "pkg:rpm/redhat/zstd@1.5.1-2.el9?arch=src&checksum=sha256:f1ddea14d19746b867e69b48d128dd9c2d3e8cc021a5ea7b0674b48356ad3341&repository_id=rhel-9-base-source"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
We return empty `BuildInfo` if `root/buildinfo/content_manifests/*.json` doesn't contain contentSets.
But if `root/buildinfo/content_manifests/` doesn't have file with contentSets - we return error (because we don't use default contentSets)

That is why we need to return `nil` if contentSets are not found.

See #7911 to get example.

## Related issues
- Close #7911

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
