### PR TITLE
docs: add Headlamp to the Trivy Ecosystem page

### DIFF
--- a/docs/ecosystem/ide.md
+++ b/docs/ecosystem/ide.md
@@ -1,11 +1,13 @@
 # IDE and developer tools Integrations
 
 ## VSCode (Official)
+
 [Visual Studio Code](https://code.visualstudio.com/) is an open source versatile code editor and development environment.
 
 👉 Get it at: <https://github.com/aquasecurity/trivy-vscode-extension>
 
 ## JetBrains (Official)
+
 [JetBrains](https://jetbrains.com) makes IDEs such as Goland, Pycharm, IntelliJ, Webstorm, and more.
 
 The Trivy plugin for JetBrains IDEs lets you use Trivy right from your development environment.
@@ -13,6 +15,7 @@ The Trivy plugin for JetBrains IDEs lets you use Trivy right from your developme
 👉 Get it at: <https://plugins.jetbrains.com/plugin/18690-trivy-findings-explorer>
 
 ## Kubernetes Lens (Official)
+
 [Kubernetes Lens](https://k8slens.dev/) is a management application for Kubernetes clusters.
 
 Trivy has an extension for Kubernetes Lens that lets you scan Kubernetes workloads and view the results in the Lens UI.
@@ -20,6 +23,7 @@ Trivy has an extension for Kubernetes Lens that lets you scan Kubernetes workloa
 👉 Get it at: <https://github.com/aquasecurity/trivy-operator-lens-extension>
 
 ## Vim (Community)
+
 [Vim](https://www.vim.org/) is a terminal based text editor.
 
 Vim plugin for Trivy to install and run Trivy.
@@ -27,6 +31,7 @@ Vim plugin for Trivy to install and run Trivy.
 👉 Get it at: <https://github.com/aquasecurity/vim-trivy>
 
 ## Docker Desktop (Community)
+
 [Docker Desktop](https://www.docker.com/products/docker-desktop/) is an easy way to install [Docker]() container engine on your development machine, and manage it in a GUI .
 
 Trivy Docker Desktop extension for scanning container images for vulnerabilities and generating SBOMs
@@ -34,11 +39,13 @@ Trivy Docker Desktop extension for scanning container images for vulnerabilities
 👉 Get it at: <https://github.com/aquasecurity/trivy-docker-extension>
 
 ## Rancher Desktop (Community)
+
 [Rancher Desktop](https://rancherdesktop.io/) is an easy way to use containers and Kubernetes on your development machine, and manage it in a GUI.
 
 Trivy is natively integrated with Rancher, no installation is needed. More info in Rancher documentation: <https://docs.rancherdesktop.io/getting-started/features#scanning-images>
 
 ## LazyTrivy (Community)
+
 A terminal native UI for Trivy
 
 👉 Get it at: <https://github.com/owenrumney/lazytrivy>
@@ -64,3 +71,9 @@ A trivy pre-commit hook that runs a `trivy fs` in your git repo before commiting
 A CDK Construct Library to scan an image with trivy in CDK codes.
 
 👉 Get it at: <https://constructs.dev/packages/image-scanner-with-trivy>
+
+## Headlamp plugin (Community)
+
+[Headlamp](https://headlamp.dev/) is a user-friendly Kubernetes UI focused on extensibility. The Kubescape plugin extends Headlamp with views on Trivy reports.
+
+👉 Get it at: <https://github.com/kubebeam/trivy-headlamp-plugin>


### PR DESCRIPTION
## Description
Add Trivy Headlamp plugin to eco docs

## Checklist
- [x ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
