### PR TITLE
fix(misconf): load full Terraform module

### DIFF
--- a/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
@@ -4,8 +4,12 @@ package resolvers_test
 
 import (
 	"context"
+	"crypto/tls"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +36,18 @@ func testOptions(t *testing.T, source string) resolvers.Options {
 	}
 }
 
+func newRegistry(repoURL string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/modules/terraform-aws-modules/s3-bucket/aws/download", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Terraform-Get", repoURL)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	return httptest.NewTLSServer(mux)
+}
+
+func buildGitSource(repoURL string) string { return "git::" + repoURL }
+
 func TestResolveModuleFromCache(t *testing.T) {
 
 	repo := "terraform-aws-s3-bucket"
@@ -40,6 +56,11 @@ func TestResolveModuleFromCache(t *testing.T) {
 
 	repoURL := gs.URL + "/" + repo + ".git"
 
+	registry := newRegistry(buildGitSource(repoURL))
+	defer registry.Close()
+
+	registryAddress := strings.TrimPrefix(registry.URL, "https://")
+
 	tests := []struct {
 		name           string
 		opts           resolvers.Options
@@ -47,38 +68,48 @@ func TestResolveModuleFromCache(t *testing.T) {
 		expectedSubdir string
 		expectedString string
 	}{
-		// {
-		// 	name: "registry",
-		// 	opts: resolvers.Options{
-		// 		Name:    "bucket",
-		// 		Source:  "terraform-aws-modules/s3-bucket/aws",
-		// 		Version: "4.1.2",
-		// 	},
-		// 	firstResolver:  resolvers.Registry,
-		// 	expectedSubdir: ".",
-		// 	expectedString: "# AWS S3 bucket Terraform module",
-		// },
-		// {
-		// 	name: "registry with subdir",
-		// 	opts: resolvers.Options{
-		// 		Name:    "object",
-		// 		Source:  "terraform-aws-modules/s3-bucket/aws//modules/object",
-		// 		Version: "4.1.2",
-		// 	},
-		// 	firstResolver:  resolvers.Registry,
-		// 	expectedSubdir: "modules/object",
-		// 	expectedString: "# S3 bucket object",
-		// },
 		{
-			name:           "remote",
-			opts:           testOptions(t, "git::"+repoURL),
+			name: "registry",
+			opts: resolvers.Options{
+				Source: registryAddress + "/terraform-aws-modules/s3-bucket/aws",
+				Client: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				},
+			},
+			firstResolver:  resolvers.Registry,
+			expectedSubdir: ".",
+			expectedString: "# AWS S3 bucket Terraform module",
+		},
+		{
+			name: "registry with subdir",
+			opts: resolvers.Options{
+				Source: registryAddress + "/terraform-aws-modules/s3-bucket/aws//modules/object",
+				Client: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				},
+			},
+			firstResolver:  resolvers.Registry,
+			expectedSubdir: "modules/object",
+			expectedString: "# S3 bucket object",
+		},
+		{
+			name: "remote",
+			opts: resolvers.Options{
+				Source: buildGitSource(repoURL),
+			},
 			firstResolver:  resolvers.Remote,
 			expectedSubdir: ".",
 			expectedString: "# AWS S3 bucket Terraform module",
 		},
 		{
-			name:           "remote with subdir",
-			opts:           testOptions(t, "git::"+repoURL+"//modules/object"),
+			name: "remote with subdir",
+			opts: resolvers.Options{
+				Source: buildGitSource(repoURL) + "//modules/object",
+			},
 			firstResolver:  resolvers.Remote,
 			expectedSubdir: "modules/object",
 			expectedString: "# S3 bucket object",
@@ -87,6 +118,11 @@ func TestResolveModuleFromCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			tt.opts.OriginalSource = tt.opts.Source
+			tt.opts.AllowDownloads = true
+			tt.opts.CacheDir = t.TempDir()
+			tt.opts.Logger = log.WithPrefix("test")
 
 			fsys, _, dir, _, err := tt.firstResolver.Resolve(context.Background(), nil, tt.opts)
 			require.NoError(t, err)

--- a/pkg/iac/scanners/terraform/parser/resolvers/options.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/options.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -13,6 +14,7 @@ type Options struct {
 	SkipCache                                                                      bool
 	RelativePath                                                                   string
 	CacheDir                                                                       string
+	Client                                                                         *http.Client
 }
 
 func (o *Options) hasPrefix(prefixes ...string) bool {

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry.go
@@ -41,6 +41,11 @@ const registryHostname = "registry.terraform.io"
 // nolint
 func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Options) (filesystem fs.FS, prefix string, downloadPath string, applies bool, err error) {
 
+	client := r.client
+	if opt.Client != nil {
+		client = opt.Client
+	}
+
 	if !opt.AllowDownloads {
 		return
 	}
@@ -81,7 +86,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
-		resp, err := r.client.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, "", "", true, err
 		}
@@ -122,7 +127,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 		req.Header.Set("X-Terraform-Version", opt.Version)
 	}
 
-	resp, err := r.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", "", true, err
 	}

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry.go
@@ -46,7 +46,7 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 	}
 
 	inputVersion := opt.Version
-	source, _ := splitPackageSubdirRaw(opt.Source)
+	source, _ := splitPackageSubdirRaw(opt.OriginalSource)
 	parts := strings.Split(source, "/")
 	if len(parts) < 3 || len(parts) > 4 {
 		return

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser/resolvers"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 func TestResolveModuleFromOpenTofuRegistry(t *testing.T) {
@@ -17,12 +18,15 @@ func TestResolveModuleFromOpenTofuRegistry(t *testing.T) {
 	}
 
 	fsys, _, path, _, err := resolvers.Registry.Resolve(context.Background(), nil, resolvers.Options{
-		Source:         "registry.opentofu.org/terraform-aws-modules/s3-bucket/aws",
-		RelativePath:   "test",
-		Name:           "bucket",
-		Version:        "4.1.2",
-		AllowDownloads: true,
-		SkipCache:      true,
+		Source:          "registry.opentofu.org/terraform-aws-modules/s3-bucket/aws",
+		OriginalSource:  "registry.opentofu.org/terraform-aws-modules/s3-bucket/aws",
+		RelativePath:    "test",
+		Name:            "bucket",
+		Version:         "4.1.2",
+		OriginalVersion: "4.1.2",
+		AllowDownloads:  true,
+		SkipCache:       true,
+		Logger:          log.WithPrefix("test"),
 	})
 	require.NoError(t, err)
 

--- a/pkg/iac/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/remote.go
@@ -40,12 +40,9 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 		return nil, "", "", false, nil
 	}
 
-	src, subdir := splitPackageSubdirRaw(opt.Source)
-	key := cacheKey(src, opt.OriginalVersion)
+	origSrc, subdir := splitPackageSubdirRaw(opt.OriginalSource)
+	key := cacheKey(origSrc, opt.OriginalVersion)
 	opt.Logger.Debug("Caching module", log.String("key", key))
-
-	opt.OriginalSource = opt.Source
-	opt.Source = src
 
 	baseCacheDir, err := locateCacheDir(opt.CacheDir)
 	if err != nil {
@@ -53,6 +50,10 @@ func (r *remoteResolver) Resolve(ctx context.Context, _ fs.FS, opt Options) (fil
 	}
 
 	cacheDir := filepath.Join(baseCacheDir, key)
+
+	src, _ := splitPackageSubdirRaw(opt.Source)
+
+	opt.Source = src
 	if err := r.download(ctx, opt, cacheDir); err != nil {
 		return nil, "", "", true, err
 	}

--- a/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/README.md
+++ b/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/README.md
@@ -1,0 +1,1 @@
+# AWS S3 bucket Terraform module

--- a/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/modules/notification/README.md
+++ b/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/modules/notification/README.md
@@ -1,0 +1,1 @@
+# S3 bucket notification

--- a/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/modules/object/README.md
+++ b/pkg/iac/scanners/terraform/parser/resolvers/testdata/terraform-aws-s3-bucket/modules/object/README.md
@@ -1,0 +1,1 @@
+# S3 bucket object


### PR DESCRIPTION
## Description

Script for preparing repositories:
```bash
#!/usr/bin/env bash

readonly num_repos=100
readonly repos=$(
    gh repo list "cloudposse" -L $num_repos --json nameWithOwner,name | \
        jq '[ .[] | select(.name | startswith("terraform-aws")) ]'
)

mkdir -p aws

while read repo
do
  name=$(echo "$repo" | jq -r .name)
  nameWithOwner=$(echo "$repo" | jq -r .nameWithOwner)

  target=aws/$name
  if [ -d $target ]; then
    echo $name already exists
    continue
  fi
  mkdir -p $target
  git clone https://github.com/$nameWithOwner $target
done < <(echo "$repos" | jq -c '.[]')
```

First run to create the cache:
```bash
❯ rm -rf $TMPDIR/.aqua/cache
❯ ./trivy conf . -d --timeout 1h > log.txt 2>&1
❯ cat log.txt | grep "Module resolved from cache" | wc -l
    5595
❯ cat log.txt |grep "Downloading module" |wc -l
     328
```

Re-run using the cache:
```
❯ ./trivy conf . -d --timeout 1h > log2.txt 2>&1

❯ cat log2.txt | grep "Module resolved from cache" | wc -l
    5921

❯ cat log2.txt |grep "Downloading module"
2024-11-25T13:23:59+06:00       DEBUG   [module resolver] Downloading module    source="git::https://github.com/ACME/infrastructure.git?ref=0.1.0"
2024-11-25T13:24:02+06:00       DEBUG   [module resolver] Downloading module    source="git::https://github.com/ACME/infrastructure.git?ref=0.1.0"
```

The module could not be downloaded from `https://github.com/ACME/infrastructure.git` because the repository no longer exists.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7924

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
