### PR TITLE
fix(misconf): do not erase variable type for child modules

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -471,7 +471,7 @@ func (e *evaluator) evaluateVariable(b *terraform.Block) (cty.Value, error) {
 
 	var val cty.Value
 
-	if override, exists := e.inputVars[b.Label()]; exists {
+	if override, exists := e.inputVars[b.Label()]; exists && override.Type() != cty.NilType {
 		val = override
 	} else if def, exists := attributes["default"]; exists {
 		val = def.NullableValue()

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -2007,4 +2008,80 @@ variable "baz" {}
 
 	assert.Contains(t, buf.String(), "Variable values was not found in the environment or variable files.")
 	assert.Contains(t, buf.String(), "variables=\"foo\"")
+}
+
+func Test_PassingNullToChildModule_DoesNotEraseType(t *testing.T) {
+	tests := []struct {
+		name string
+		fsys fs.FS
+	}{
+		{
+			name: "typed variable",
+			fsys: fstest.MapFS{
+				"main.tf": &fstest.MapFile{Data: []byte(`module "test" {
+  source   = "./modules/test"
+  test_var = null
+}`)},
+				"modules/test/main.tf": &fstest.MapFile{Data: []byte(`variable "test_var" {
+  type    = number
+}
+
+resource "foo" "this" {
+  bar = var.test_var != null ? 1 : 2
+}`)},
+			},
+		},
+		{
+			name: "typed variable with default",
+			fsys: fstest.MapFS{
+				"main.tf": &fstest.MapFile{Data: []byte(`module "test" {
+  source   = "./modules/test"
+  test_var = null
+}`)},
+				"modules/test/main.tf": &fstest.MapFile{Data: []byte(`variable "test_var" {
+  type    = number
+  default = null
+}
+
+resource "foo" "this" {
+  bar = var.test_var != null ? 1 : 2
+}`)},
+			},
+		},
+		{
+			name: "empty variable",
+			fsys: fstest.MapFS{
+				"main.tf": &fstest.MapFile{Data: []byte(`module "test" {
+  source   = "./modules/test"
+  test_var = null
+}`)},
+				"modules/test/main.tf": &fstest.MapFile{Data: []byte(`variable "test_var" {}
+
+resource "foo" "this" {
+  bar = var.test_var != null ? 1 : 2
+}`)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := New(
+				tt.fsys, "",
+				OptionStopOnHCLError(true),
+			)
+			require.NoError(t, parser.ParseFS(context.TODO(), "."))
+
+			_, err := parser.Load(context.TODO())
+			require.NoError(t, err)
+
+			modules, _, err := parser.EvaluateAll(context.TODO())
+			require.NoError(t, err)
+
+			res := modules.GetResourcesByType("foo")[0]
+			attr := res.GetAttribute("bar")
+			val, _ := attr.Value().AsBigFloat().Int64()
+			assert.Equal(t, int64(2), val)
+		})
+	}
 }

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -585,7 +585,7 @@ func (b *Block) Values() cty.Value {
 		if attribute.Name() == "for_each" {
 			continue
 		}
-		values[attribute.Name()] = attribute.Value()
+		values[attribute.Name()] = attribute.NullableValue()
 	}
 	return cty.ObjectVal(postProcessValues(b, values))
 }
@@ -643,7 +643,7 @@ func (b *Block) expandDynamic() ([]*Block, error) {
 	)
 
 	forEachVal.ForEachElement(func(key, val cty.Value) (stop bool) {
-		if val.IsNull() {
+		if val.IsNull() || !val.IsKnown() {
 			return
 		}
 


### PR DESCRIPTION
## Description

Example config:
```hcl
module "aws-rds" {
  source         = "terraform-aws-modules/rds/aws"
  version        = "~> 6.10.0"
  identifier     = "mydb"
  engine         = "postgres"
  family         = "postgres13"
  instance_class = "db.t4g.medium"
}
```

Before:

```
trivy conf -d . > log1.txt 2>&1
cat log1.txt |grep "Failed to expand"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.restore_to_point_in_time" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.s3_import" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.restore_to_point_in_time" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.s3_import" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.restore_to_point_in_time" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.s3_import" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.restore_to_point_in_time" value="cty.NilVal"
2024-11-18T20:36:26+06:00       ERROR   [terraform evaluator] Failed to expand block. Invalid "for-each" argument. Must be known and iterable.  block="module.aws-rds.module.db_instance.dynamic.s3_import" value="cty.NilVal"
```

After:
```
cat log2.txt |grep "Failed to expand"
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/7936

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
