### PR TITLE
fix(k8s): check all results for vulnerabilities

### DIFF
--- a/pkg/k8s/report/report.go
+++ b/pkg/k8s/report/report.go
@@ -280,7 +280,12 @@ func shouldAddToReport(scanners types.Scanners) bool {
 }
 
 func vulnerabilitiesOrSecretResource(resource Resource) bool {
-	return len(resource.Results) > 0 && (len(resource.Results[0].Vulnerabilities) > 0 || len(resource.Results[0].Secrets) > 0)
+	for _, result := range resource.Results {
+		if len(result.Vulnerabilities) > 0 || len(resource.Results[0].Secrets) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func misconfigsResource(resource Resource) bool {


### PR DESCRIPTION
## Description

Previously, vulnerabilities were checked only for the first result of a resource. Now, all results are scanned.

Before
```sh
Workload Assessment
┌───────────┬──────────────────┬───────────────────┬───────────────────┬───────────────────┐
│ Namespace │     Resource     │  Vulnerabilities  │ Misconfigurations │      Secrets      │
│           │                  ├───┬───┬───┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│           │                  │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├───────────┼──────────────────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ test      │ Pod/postgres-pod │   │   │   │   │   │   │ 1 │ 4 │ 9 │   │   │   │   │   │   │
└───────────┴──────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```
After
```sh
Workload Assessment
┌───────────┬──────────────────┬─────────────────────┬───────────────────┬───────────────────┐
│ Namespace │     Resource     │   Vulnerabilities   │ Misconfigurations │      Secrets      │
│           │                  ├───┬────┬────┬───┬───┼───┬───┬───┬───┬───┼───┬───┬───┬───┬───┤
│           │                  │ C │ H  │ M  │ L │ U │ C │ H │ M │ L │ U │ C │ H │ M │ L │ U │
├───────────┼──────────────────┼───┼────┼────┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┼───┤
│ test      │ Pod/postgres-pod │ 3 │ 31 │ 20 │ 1 │   │   │ 1 │ 4 │ 9 │   │   │   │   │   │   │
└───────────┴──────────────────┴───┴────┴────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN

```

## Related issues
- Close #7937 

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
