### PR TITLE
fix(cli): Handle empty ignore files more gracefully

### DIFF
--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -213,7 +213,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 	t.Run("Error on non existing ignore file", func(t *testing.T) {
 		t.Cleanup(viper.Reset)
 
-		setValue(flag.IgnoreFileFlag.ConfigName, string("doesntexist"))
+		setValue(flag.IgnoreFileFlag.ConfigName, "doesntexist")
 		f := &flag.ReportFlagGroup{
 			IgnoreFile: flag.IgnoreFileFlag.Clone(),
 		}

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -183,8 +183,9 @@ func (c *IgnoreConfig) MatchLicense(licenseID, filePath string) *IgnoreFinding {
 
 func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {
 	var conf IgnoreConfig
-	if _, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) {
-		// .trivyignore doesn't necessarily exist
+	if fi, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) || fi.Size() == 0 {
+		// .trivyignore doesn't necessarily exist or maybe empty
+		log.Debug("Specified ignore file does not exist or is empty", log.String("file", ignoreFile), log.Int64("size", fi.Size()))
 		return IgnoreConfig{}, nil
 	} else if filepath.Ext(ignoreFile) == ".yml" || filepath.Ext(ignoreFile) == ".yaml" {
 		conf, err = parseIgnoreYAML(ignoreFile)

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -184,7 +184,7 @@ func (c *IgnoreConfig) MatchLicense(licenseID, filePath string) *IgnoreFinding {
 func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {
 	var conf IgnoreConfig
 	if _, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) {
-		// .trivyignore doesn't necessarily exist or maybe empty
+		// .trivyignore doesn't necessarily exist
 		log.Debug("Specified ignore file does not exist", log.String("file", ignoreFile))
 		return IgnoreConfig{}, nil
 	} else if filepath.Ext(ignoreFile) == ".yml" || filepath.Ext(ignoreFile) == ".yaml" {

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -226,6 +226,8 @@ func parseIgnoreYAML(ignoreFile string) (IgnoreConfig, error) {
 	log.Debug("Found an ignore yaml", log.FilePath(ignoreFile))
 
 	// Parse the YAML content
+	// We have to use Unmarshal() due to go-yaml returning an error with Decode()
+	// ref: https://github.com/go-yaml/yaml/issues/805
 	var ignoreConfig IgnoreConfig
 	if err = yaml.Unmarshal(b, &ignoreConfig); err != nil {
 		return IgnoreConfig{}, xerrors.Errorf("yaml decode error: %w", err)

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -183,9 +183,9 @@ func (c *IgnoreConfig) MatchLicense(licenseID, filePath string) *IgnoreFinding {
 
 func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {
 	var conf IgnoreConfig
-	if fi, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) || fi.Size() == 0 {
+	if _, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) {
 		// .trivyignore doesn't necessarily exist or maybe empty
-		log.Debug("Specified ignore file does not exist or is empty", log.String("file", ignoreFile), log.Int64("size", fi.Size()))
+		log.Debug("Specified ignore file does not exist", log.String("file", ignoreFile))
 		return IgnoreConfig{}, nil
 	} else if filepath.Ext(ignoreFile) == ".yml" || filepath.Ext(ignoreFile) == ".yaml" {
 		conf, err = parseIgnoreYAML(ignoreFile)
@@ -219,16 +219,15 @@ func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, erro
 
 func parseIgnoreYAML(ignoreFile string) (IgnoreConfig, error) {
 	// Read .trivyignore.yaml
-	f, err := os.Open(ignoreFile)
+	b, err := os.ReadFile(ignoreFile)
 	if err != nil {
 		return IgnoreConfig{}, xerrors.Errorf("file open error: %w", err)
 	}
-	defer f.Close()
 	log.Debug("Found an ignore yaml", log.FilePath(ignoreFile))
 
 	// Parse the YAML content
 	var ignoreConfig IgnoreConfig
-	if err = yaml.NewDecoder(f).Decode(&ignoreConfig); err != nil {
+	if err = yaml.Unmarshal(b, &ignoreConfig); err != nil {
 		return IgnoreConfig{}, xerrors.Errorf("yaml decode error: %w", err)
 	}
 	return ignoreConfig, nil

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -38,9 +38,8 @@ func TestParseIgnoreFile(t *testing.T) {
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
 
-		got, err := ParseIgnoreFile(context.TODO(), f.Name())
+		_, err = ParseIgnoreFile(context.TODO(), f.Name())
 		require.NoError(t, err)
-		assert.Empty(t, got)
 	})
 
 	t.Run("invalid YAML file passed", func(t *testing.T) {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -53,19 +53,15 @@ func TestParseIgnoreFile(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
-	// TODO(simar7): This test currently fails as we don't validate
-	// the correctness of ignore file when not in YAML format
-	/*
-		t.Run("invalid file passed", func(t *testing.T) {
-			f, err := os.CreateTemp("", "TestParseIgnoreFile-*")
-			require.NoError(t, err)
-			defer os.Remove(f.Name())
-			_, _ = f.WriteString("this file is not a valid trivyignore file")
+	t.Run("invalid file passed", func(t *testing.T) {
+		f, err := os.CreateTemp("", "TestParseIgnoreFile-*")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+		_, _ = f.WriteString("this file is not a valid trivyignore file")
 
-			_, err = ParseIgnoreFile(context.TODO(), f.Name())
-			require.Error(t, err)
-		})
-	*/
+		_, err = ParseIgnoreFile(context.TODO(), f.Name())
+		require.NoError(t, err) // TODO(simar7): We don't verify correctness, should we?
+	})
 
 	t.Run("non existing file passed", func(t *testing.T) {
 		got, err := ParseIgnoreFile(context.TODO(), "does-not-exist.yaml")

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -1,0 +1,77 @@
+package result
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIgnoreFile(t *testing.T) {
+	t.Run("happy path valid config file", func(t *testing.T) {
+		got, err := ParseIgnoreFile(context.TODO(), "testdata/.trivyignore")
+		require.NoError(t, err)
+		assert.Equal(t, "testdata/.trivyignore", got.FilePath)
+
+		// IDs in .trivyignore are treated as IDs for all scanners
+		// as it is unclear which type of security issue they are
+		assert.Len(t, got.Vulnerabilities, 6)
+		assert.Len(t, got.Misconfigurations, 6)
+		assert.Len(t, got.Secrets, 6)
+		assert.Len(t, got.Licenses, 6)
+	})
+
+	t.Run("happy path valid YAML config file", func(t *testing.T) {
+		got, err := ParseIgnoreFile(context.TODO(), "testdata/.trivyignore.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, "testdata/.trivyignore.yaml", got.FilePath)
+		assert.Len(t, got.Vulnerabilities, 5)
+		assert.Len(t, got.Misconfigurations, 3)
+		assert.Len(t, got.Secrets, 3)
+		assert.Len(t, got.Licenses, 1)
+	})
+
+	t.Run("empty YAML file passed", func(t *testing.T) {
+		f, err := os.CreateTemp("", "TestParseIgnoreFile-*.yaml")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		got, err := ParseIgnoreFile(context.TODO(), f.Name())
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("invalid YAML file passed", func(t *testing.T) {
+		f, err := os.CreateTemp("", "TestParseIgnoreFile-*.yaml")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+		_, _ = f.WriteString("this file is not a yaml file")
+
+		got, err := ParseIgnoreFile(context.TODO(), f.Name())
+		assert.Contains(t, err.Error(), "yaml decode error")
+		assert.Empty(t, got)
+	})
+
+	// TODO(simar7): This test currently fails as we don't validate
+	// the correctness of ignore file when not in YAML format
+	/*
+		t.Run("invalid file passed", func(t *testing.T) {
+			f, err := os.CreateTemp("", "TestParseIgnoreFile-*")
+			require.NoError(t, err)
+			defer os.Remove(f.Name())
+			_, _ = f.WriteString("this file is not a valid trivyignore file")
+
+			_, err = ParseIgnoreFile(context.TODO(), f.Name())
+			require.Error(t, err)
+		})
+	*/
+
+	t.Run("non existing file passed", func(t *testing.T) {
+		got, err := ParseIgnoreFile(context.TODO(), "does-not-exist.yaml")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+}


### PR DESCRIPTION
## Description

Also adds a log message to the debug stream when such a case occurs.

```shell
trivy --debug config --ignorefile ./invalid-file.yaml  /tmp
<snip>
2024-11-19T23:55:01-07:00       DEBUG   Specified ignore file does not exist        file="./invalid-file.yaml"
</snip>
```

## Related issues
- Fixes: https://github.com/aquasecurity/trivy/issues/7934

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
