### PR TITLE
chore: downgrade the failed block expand message to debug

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -266,7 +266,7 @@ func (e *evaluator) expandBlocks(blocks terraform.Blocks) terraform.Blocks {
 func (e *evaluator) expandDynamicBlocks(blocks ...*terraform.Block) terraform.Blocks {
 	for _, b := range blocks {
 		if err := b.ExpandBlock(); err != nil {
-			e.logger.Error(`Failed to expand dynamic block.`,
+			e.logger.Debug(`Failed to expand dynamic block.`,
 				log.String("block", b.FullName()), log.Err(err))
 		}
 	}
@@ -297,7 +297,7 @@ func (e *evaluator) expandBlockForEaches(blocks terraform.Blocks) terraform.Bloc
 		forEachVal := forEachAttr.Value()
 
 		if forEachVal.IsNull() || !forEachVal.IsKnown() || !forEachAttr.IsIterable() {
-			e.logger.Error(`Failed to expand block. Invalid "for-each" argument. Must be known and iterable.`,
+			e.logger.Debug(`Failed to expand block. Invalid "for-each" argument. Must be known and iterable.`,
 				log.String("block", block.FullName()),
 				log.String("value", forEachVal.GoString()),
 			)
@@ -314,7 +314,7 @@ func (e *evaluator) expandBlockForEaches(blocks terraform.Blocks) terraform.Bloc
 			// instances are identified by a map key (or set member) from the value provided to for_each
 			idx, err := convert.Convert(key, cty.String)
 			if err != nil {
-				e.logger.Error(
+				e.logger.Debug(
 					`Failed to expand block. Invalid "for-each" argument: map key (or set value) is not a string`,
 					log.String("block", block.FullName()),
 					log.String("key", key.GoString()),
@@ -331,7 +331,7 @@ func (e *evaluator) expandBlockForEaches(blocks terraform.Blocks) terraform.Bloc
 				!forEachVal.Type().IsMapType() {
 				stringVal, err := convert.Convert(val, cty.String)
 				if err != nil {
-					e.logger.Error(
+					e.logger.Debug(
 						"Failed to expand block. Invalid 'for-each' argument: value is not a string",
 						log.String("block", block.FullName()),
 						log.String("key", idx.AsString()),


### PR DESCRIPTION
## Description
This PR lowers the message level when a block expand error occurs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
