### PR TITLE
docs: add `overview` page for `others`

### DIFF
--- a/docs/docs/coverage/language/index.md
+++ b/docs/docs/coverage/language/index.md
@@ -44,7 +44,7 @@ On the other hand, when the target is a post-build artifact, like a container im
 | [Rust](rust.md)      | Cargo.lock                                                                                 |     ✅     |     ✅      |       ✅        |       ✅        |
 |                      | Binaries built with [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable) |     ✅     |     ✅      |       -        |       -        |
 | [C/C++](c.md)        | conan.lock                                                                                 |     -     |     -      |       ✅        |       ✅        |
-| [Elixir](elixir.md)  | mix.lock[^9]                                                                              |     -     |     -      |       ✅        |       ✅        |
+| [Elixir](elixir.md)  | mix.lock[^9]                                                                               |     -     |     -      |       ✅        |       ✅        |
 | [Dart](dart.md)      | pubspec.lock                                                                               |     -     |     -      |       ✅        |       ✅        |
 | [Swift](swift.md)    | Podfile.lock                                                                               |     -     |     -      |       ✅        |       ✅        |
 |                      | Package.resolved                                                                           |     -     |     -      |       ✅        |       ✅        |

--- a/docs/docs/coverage/language/index.md
+++ b/docs/docs/coverage/language/index.md
@@ -16,7 +16,7 @@ This is because Trivy primarily categorizes targets into two groups:
 If the target is a pre-build project, like a code repository, Trivy will analyze files used for building, such as lock files.
 On the other hand, when the target is a post-build artifact, like a container image, Trivy will analyze installed package metadata like `.gemspec`, binary files, and so on.
 
-| Language             | File                                                                                       | Image[^5] | Rootfs[^6] | Filesystem[^7] | Repository[^8] |
+| Language             | File                                                                                       | Image[^4] | Rootfs[^5] | Filesystem[^6] | Repository[^7] |
 |----------------------|--------------------------------------------------------------------------------------------|:---------:|:----------:|:--------------:|:--------------:|
 | [Ruby](ruby.md)      | Gemfile.lock                                                                               |     -     |     -      |       ✅        |       ✅        |
 |                      | gemspec                                                                                    |     ✅     |     ✅      |       -        |       -        |
@@ -25,7 +25,6 @@ On the other hand, when the target is a post-build artifact, like a container im
 |                      | requirements.txt                                                                           |     -     |     -      |       ✅        |       ✅        |
 |                      | egg package[^1]                                                                            |     ✅     |     ✅      |       -        |       -        |
 |                      | wheel package[^2]                                                                          |     ✅     |     ✅      |       -        |       -        |
-|                      | conda package[^3]                                                                          |     ✅     |     ✅      |       -        |       -        |
 | [PHP](php.md)        | composer.lock                                                                              |     -     |     -      |       ✅        |       ✅        |
 |                      | installed.json                                                                             |     ✅     |     ✅      |       -        |       -        |
 | [Node.js](nodejs.md) | package-lock.json                                                                          |     -     |     -      |       ✅        |       ✅        |
@@ -35,8 +34,8 @@ On the other hand, when the target is a post-build artifact, like a container im
 | [.NET](dotnet.md)    | packages.lock.json                                                                         |     ✅     |     ✅      |       ✅        |       ✅        |
 |                      | packages.config                                                                            |     ✅     |     ✅      |       ✅        |       ✅        |
 |                      | .deps.json                                                                                 |     ✅     |     ✅      |       ✅        |       ✅        |
-|                      | *Packages.props[^11]                                                                       |     ✅     |     ✅      |       ✅        |       ✅        |
-| [Java](java.md)      | JAR/WAR/PAR/EAR[^4]                                                                        |     ✅     |     ✅      |       -        |       -        |
+|                      | *Packages.props[^10]                                                                       |     ✅     |     ✅      |       ✅        |       ✅        |
+| [Java](java.md)      | JAR/WAR/PAR/EAR[^3]                                                                        |     ✅     |     ✅      |       -        |       -        |
 |                      | pom.xml                                                                                    |     -     |     -      |       ✅        |       ✅        |
 |                      | *gradle.lockfile                                                                           |     -     |     -      |       ✅        |       ✅        |
 |                      | *.sbt.lock                                                                                 |     -     |     -      |       ✅        |       ✅        |
@@ -45,7 +44,7 @@ On the other hand, when the target is a post-build artifact, like a container im
 | [Rust](rust.md)      | Cargo.lock                                                                                 |     ✅     |     ✅      |       ✅        |       ✅        |
 |                      | Binaries built with [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable) |     ✅     |     ✅      |       -        |       -        |
 | [C/C++](c.md)        | conan.lock                                                                                 |     -     |     -      |       ✅        |       ✅        |
-| [Elixir](elixir.md)  | mix.lock[^10]                                                                              |     -     |     -      |       ✅        |       ✅        |
+| [Elixir](elixir.md)  | mix.lock[^9]                                                                              |     -     |     -      |       ✅        |       ✅        |
 | [Dart](dart.md)      | pubspec.lock                                                                               |     -     |     -      |       ✅        |       ✅        |
 | [Swift](swift.md)    | Podfile.lock                                                                               |     -     |     -      |       ✅        |       ✅        |
 |                      | Package.resolved                                                                           |     -     |     -      |       ✅        |       ✅        |
@@ -61,12 +60,11 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 
 [^1]: `*.egg-info`, `*.egg-info/PKG-INFO`, `*.egg` and `EGG-INFO/PKG-INFO`
 [^2]: `.dist-info/META-DATA`
-[^3]: `envs/*/conda-meta/*.json`
-[^4]: `*.jar`, `*.war`, `*.par` and `*.ear`
-[^5]: ✅ means "enabled" and `-` means "disabled" in the image scanning
-[^6]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
-[^7]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
-[^8]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning
-[^9]: ✅ means that Trivy detects line numbers where each dependency is declared in the scanned file. Only supported in [json](../../configuration/reporting.md#json) and [sarif](../../configuration/reporting.md#sarif) formats. SARIF uses `startline == 1 and endline == 1` for unsupported file types
-[^10]: To scan a filename other than the default filename use [file-patterns](../../configuration/skipping.md#file-patterns)
-[^11]: `Directory.Packages.props` and  legacy `Packages.props` file names are supported
+[^3]: `*.jar`, `*.war`, `*.par` and `*.ear`
+[^4]: ✅ means "enabled" and `-` means "disabled" in the image scanning
+[^5]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
+[^6]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
+[^7]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning
+[^8]: ✅ means that Trivy detects line numbers where each dependency is declared in the scanned file. Only supported in [json](../../configuration/reporting.md#json) and [sarif](../../configuration/reporting.md#sarif) formats. SARIF uses `startline == 1 and endline == 1` for unsupported file types
+[^9]: To scan a filename other than the default filename use [file-patterns](../../configuration/skipping.md#file-patterns)
+[^10]: `Directory.Packages.props` and  legacy `Packages.props` file names are supported

--- a/docs/docs/coverage/others/index.md
+++ b/docs/docs/coverage/others/index.md
@@ -1,0 +1,28 @@
+# Programming Language
+
+In this section we have placed images, package managers and files that we can't assign to existing sections.
+
+Trivy supports them for
+
+- [SBOM][sbom]
+- [Vulnerabilities][vuln]
+- [Licenses][license]
+
+## Supported elements
+
+| Element                        | File                                                | Image[^1] | Rootfs[^2] | Filesystem[^3] | Repository[^4] |
+|--------------------------------|-----------------------------------------------------|:---------:|:----------:|:--------------:|:--------------:|
+| [Bitnami packages](bitnami.md) | `/opt/bitnami/<component>/.spdx-<component>.spdx`   |     ✅     |     ✅      |       -        |       -        |
+| [Conda](conda.md)              | `<conda-root>/envs/<env>/conda-meta/<package>.json` |     ✅     |     ✅      |       -        |       -        |
+|                                | `environment.yml`                                   |     -     |     -      |       ✅        |       ✅        |
+| [RPM Archives](rpm.md)         | `*.rpm`                                             |   ✅[^5]   |   ✅[^5]    |     ✅[^5]      |     ✅[^5]      |
+
+[sbom]: ../../supply-chain/sbom.md
+[vuln]: ../../scanner/vulnerability.md
+[license]: ../../scanner/license.md
+
+[^1]: ✅ means "enabled" and `-` means "disabled" in the image scanning
+[^2]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
+[^3]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
+[^4]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning
+[^5]: Only if the `TRIVY_EXPERIMENTAL_RPM_ARCHIVE` env is set.

--- a/docs/docs/coverage/others/index.md
+++ b/docs/docs/coverage/others/index.md
@@ -1,4 +1,4 @@
-# Programming Language
+# Others
 
 In this section we have placed images, package managers and files that we can't assign to existing sections.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
               - Kubernetes: docs/coverage/iac/kubernetes.md
               - Terraform: docs/coverage/iac/terraform.md
           - Others:
+              - Overview: docs/coverage/others/index.md
               - Bitnami Images: docs/coverage/others/bitnami.md
               - Conda: docs/coverage/others/conda.md
               - RPM Archives: docs/coverage/others/rpm.md


### PR DESCRIPTION
## Description
Add overview page for `others`
![изображение](https://github.com/user-attachments/assets/10e3f796-7fd9-4a41-834f-0d5ddc2d1891)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
