### PR TITLE
fix: skip people apache org repositories pom

### DIFF
--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -140,6 +140,14 @@ func (p *pom) repositories(servers []Server) ([]string, []string) {
 			continue
 		}
 
+		// remove all people.apache.org repositories
+		// this domain is used to fetch pom files in some cases, but it just nearly always times out and makes everything extremely slow
+		// so we just skip it
+		if strings.Contains(repoURL.Host, "people.apache.org") {
+			logger.Debug("Skipping people.apache.org repository", log.String("url", rep.URL))
+			continue
+		}
+
 		// Get the credentials from settings.xml based on matching server id
 		// with the repository id from pom.xml and use it for accessing the repository url
 		for _, server := range servers {


### PR DESCRIPTION
## Description
When Trivy tries to fetch pom files from people.apache.org, the domain throttles/blocks you, which results in constant timeouts and extremely slow scans.
These people.apache.org are always just 404 or not relevant.

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/8000

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
