### PR TITLE
fix(misconf): use log instead of fmt for logging

### DIFF
--- a/pkg/iac/scanners/cloudformation/parser/property_conversion.go
+++ b/pkg/iac/scanners/cloudformation/parser/property_conversion.go
@@ -2,11 +2,11 @@ package parser
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/cftypes"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 func (p *Property) IsConvertableTo(conversionType cftypes.CfType) bool {
@@ -75,7 +75,11 @@ func (p *Property) ConvertTo(conversionType cftypes.CfType) *Property {
 	}
 
 	if !p.IsConvertableTo(conversionType) {
-		_, _ = fmt.Fprintf(os.Stderr, "property of type %s cannot be converted to %s\n", p.Type(), conversionType)
+		log.Debug("Failed to convert property",
+			log.String("from", string(p.Type())),
+			log.String("to", string(conversionType)),
+			log.Any("range", p.Range().String()),
+		)
 		return p
 	}
 	switch conversionType {


### PR DESCRIPTION
## Description

This PR fixes logging when a property conversion fails, which could not be suppressed with the `quiet` flag.

Before:
```bash
property of type map cannot be converted to int
```

After:
```bash
2024-12-03T16:25:00+06:00       DEBUG   Failed to convert property      from="map" to="int" range="template.yaml:7-8"
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
