### PR TITLE
fix: update all documentation links

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/bugs.yml
@@ -10,7 +10,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description
@@ -117,7 +117,7 @@ body:
       description: Have you tried the following?
       options:
         - label: Run `trivy clean --all`
-        - label: Read [the troubleshooting](https://aquasecurity.github.io/trivy/latest/docs/references/troubleshooting/)
+        - label: Read [the troubleshooting](https://trivy.dev/latest/docs/references/troubleshooting/)
   - type: markdown
     attributes:
       value: |

--- a/.github/DISCUSSION_TEMPLATE/documentation.yml
+++ b/.github/DISCUSSION_TEMPLATE/documentation.yml
@@ -7,7 +7,7 @@ body:
         Feel free to create a docs report if something doesn't work as expected or is unclear in the documentation.
         Please ensure that you're not creating a duplicate report by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         
-        Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description

--- a/.github/DISCUSSION_TEMPLATE/false-detection.yml
+++ b/.github/DISCUSSION_TEMPLATE/false-detection.yml
@@ -8,7 +8,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
   - type: input
     attributes:
       label: IDs
@@ -86,7 +86,7 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: Read [the documentation regarding wrong detection](https://aquasecurity.github.io/trivy/dev/community/contribute/discussion/#false-detection)
+        - label: Read [the documentation regarding wrong detection](https://trivy.dev/dev/community/contribute/discussion/#false-detection)
         - label: Ran Trivy with `-f json` that shows data sources and confirmed that the security advisory in data sources was correct
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -9,7 +9,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -9,7 +9,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Question

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,8 @@
 Remove this section if you don't have related PRs.
 
 ## Checklist
-- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
-- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
+- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
+- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
 - [ ] I've added tests that prove my fix is effective or that my feature works.
 - [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
 - [ ] I've added usage information (if the PR introduces new options)

--- a/.github/workflows/auto-close-issue.yaml
+++ b/.github/workflows/auto-close-issue.yaml
@@ -26,7 +26,7 @@ jobs:
             
             // If the user does not have write or admin permissions, leave a comment and close the issue
             if (permission !== 'write' && permission !== 'admin') {
-              const commentBody = "Please see https://aquasecurity.github.io/trivy/latest/community/contribute/issue/";
+              const commentBody = "Please see https://trivy.dev/latest/community/contribute/issue/";
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See [Issues](https://aquasecurity.github.io/trivy/latest/community/contribute/issue/) and [Pull Requests](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/)
+See [Issues](https://trivy.dev/latest/community/contribute/issue/) and [Pull Requests](https://trivy.dev/latest/community/contribute/pr/)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [license]: https://github.com/aquasecurity/trivy/blob/main/LICENSE
 [license-img]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [homepage]: https://trivy.dev
-[docs]: https://aquasecurity.github.io/trivy
+[docs]: https://trivy.dev/trivy
 [pronunciation]: #how-to-pronounce-the-name-trivy
 [slack]: https://slack.aquasec.com
 [code-of-conduct]: https://github.com/aquasecurity/community/blob/main/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [slack]: https://slack.aquasec.com
 [code-of-conduct]: https://github.com/aquasecurity/community/blob/main/CODE_OF_CONDUCT.md
 
-[Installation]:https://aquasecurity.github.io/trivy/latest/getting-started/installation/
-[Ecosystem]: https://aquasecurity.github.io/trivy/latest/ecosystem/
-[Scanning Coverage]: https://aquasecurity.github.io/trivy/latest/docs/coverage/
+[Installation]:https://trivy.dev/latest/getting-started/installation/
+[Ecosystem]: https://trivy.dev/latest/ecosystem/
+[Scanning Coverage]: https://trivy.dev/latest/docs/coverage/
 
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego

--- a/docs/commercial/compare.md
+++ b/docs/commercial/compare.md
@@ -66,7 +66,7 @@ If you'd like to learn more or request a demo, [click here to contact us](./cont
 
 | Feature | Trivy OSS | Aqua |
 | --- | --- | --- |
-| Infrastructure as Code (IaC) | Many popular languages as detailed [here](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/policy/builtin/) | In addition, Build Pipeline configuration scanning |
+| Infrastructure as Code (IaC) | Many popular languages as detailed [here](https://trivy.dev/latest/docs/scanner/misconfiguration/policy/builtin/) | In addition, Build Pipeline configuration scanning |
 | Checks customization | Create custom checks with Rego | Create custom checks in no-code interface <br> Customize existing checks with organizational preferences |
 | Cloud scanning | AWS (subset of services) | AWS, Azure, GCP, Alibaba Cloud, Oracle Cloud |
 | Compliance frameworks | CIS, NSA, vendor guides | More than 25 compliance programs |

--- a/docs/community/contribute/discussion.md
+++ b/docs/community/contribute/discussion.md
@@ -24,7 +24,7 @@ There are 4 categories:
     If you find any false positives or false negatives, please make sure to report them under the "False Detection" category, not "Bugs".
 
 ## False detection
-Trivy depends on [multiple data sources](https://aquasecurity.github.io/trivy/latest/docs/scanner/vulnerability/#data-sources).
+Trivy depends on [multiple data sources](https://trivy.dev/latest/docs/scanner/vulnerability/#data-sources).
 Sometime these databases contain mistakes.
 
 If Trivy can't detect any CVE-IDs or shows false positive result, at first please follow the next steps:

--- a/docs/docs/advanced/air-gap.md
+++ b/docs/docs/advanced/air-gap.md
@@ -10,7 +10,7 @@ External Resource | Feature | Details
 Vulnerability Database | Vulnerability scanning | [Trivy DB](../scanner/vulnerability.md)
 Java Vulnerability Database | Java vulnerability scanning | [Trivy Java DB](../coverage/language/java.md)
 Checks Bundle | Misconfigurations scanning | [Trivy Checks](../scanner/misconfiguration/check/builtin.md)
-VEX Hub | VEX Hub | [VEX Hub](../supply-chain/vex/repo/#vex-hub)
+VEX Hub | VEX Hub | [VEX Hub](../supply-chain/vex/repo.md)
 Maven Central / Remote Repositories | Java vulnerability scanning | [Java Scanner/Remote Repositories](../coverage/language/java.md#remote-repositories)
 
 !!! note

--- a/docs/docs/advanced/self-hosting.md
+++ b/docs/docs/advanced/self-hosting.md
@@ -123,10 +123,10 @@ To make a copy of VEX Hub in a location that is accessible to Trivy.
 
 To configure Trivy to use the local VEX Repository:
 
-1. Locate your [Trivy VEX configuration file](../supply-chain/vex/repo/#configuration-file) by running `trivy vex repo init`. Make the following changes to the file.
+1. Locate your [Trivy VEX configuration file](../supply-chain/vex/repo.md#configuration-file) by running `trivy vex repo init`. Make the following changes to the file.
 1. Disable the default VEX Hub repo (`enabled: false`)
-1. Add your internal VEX Hub repository as a [custom repository](../supply-chain/vex/repo/#custom-repositories) with the URL pointing to your local server (e.g `url: https://server.local`).
+1. Add your internal VEX Hub repository as a [custom repository](../supply-chain/vex/repo.md#custom-repositories) with the URL pointing to your local server (e.g `url: https://server.local`).
 
 ### Authentication
 
-If your server requires authentication, you can configure it as described in the [VEX Repository Authentication document](../supply-chain/vex/repo/#authentication).
+If your server requires authentication, you can configure it as described in the [VEX Repository Authentication document](../supply-chain/vex/repo.md#authentication).

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -35,7 +35,6 @@ For the list of built-in compliance reports, please see the relevant section:
 
 - [Docker compliance](../target/container_image.md#compliance)
 - [Kubernetes compliance](../target/kubernetes.md#compliance)
-- [AWS compliance](../target/aws.md#compliance)
 
 ## Contribute a Built-in Compliance Report
 

--- a/docs/docs/configuration/cache.md
+++ b/docs/docs/configuration/cache.md
@@ -100,7 +100,7 @@ $ trivy server --cache-backend redis://localhost:6379 \
 [trivy-java-db]: ./db.md#java-index-database
 [misconf-checks]: ../scanner/misconfiguration/check/builtin.md
 [boltdb]: https://github.com/etcd-io/bbolt
-[parallel-run]: https://aquasecurity.github.io/trivy/v0.52/docs/references/troubleshooting/#running-in-parallel-takes-same-time-as-series-run
+[parallel-run]: https://trivy.dev/v0.52/docs/references/troubleshooting/#running-in-parallel-takes-same-time-as-series-run
 
 [^1]: Downloaded when scanning for vulnerabilities
 [^2]: Downloaded when scanning `jar/war/par/ear` files

--- a/docs/docs/configuration/cache.md
+++ b/docs/docs/configuration/cache.md
@@ -100,7 +100,7 @@ $ trivy server --cache-backend redis://localhost:6379 \
 [trivy-java-db]: ./db.md
 [misconf-checks]: ../scanner/misconfiguration/check/builtin.md
 [boltdb]: https://github.com/etcd-io/bbolt
-[parallel-run]: https://trivy.dev/v0.52/docs/references/troubleshooting/#running-in-parallel-takes-same-time-as-series-run
+[parallel-run]: https://trivy.dev/{{ git.tag}}/docs/references/troubleshooting/#running-in-parallel-takes-same-time-as-series-run
 
 [^1]: Downloaded when scanning for vulnerabilities
 [^2]: Downloaded when scanning `jar/war/par/ear` files

--- a/docs/docs/configuration/cache.md
+++ b/docs/docs/configuration/cache.md
@@ -96,8 +96,8 @@ $ trivy server --cache-backend redis://localhost:6379 \
   --redis-key /path/to/key.pem
 ```
 
-[trivy-db]: ./db.md#vulnerability-database
-[trivy-java-db]: ./db.md#java-index-database
+[trivy-db]: ./db.md
+[trivy-java-db]: ./db.md
 [misconf-checks]: ../scanner/misconfiguration/check/builtin.md
 [boltdb]: https://github.com/etcd-io/bbolt
 [parallel-run]: https://trivy.dev/v0.52/docs/references/troubleshooting/#running-in-parallel-takes-same-time-as-series-run

--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -394,7 +394,7 @@ $ trivy image --ignorefile ./.trivyignore.yaml python:3.9.16-alpine3.16
 2023-08-31T11:10:27.155+0600	INFO	Vulnerability scanning is enabled
 2023-08-31T11:10:27.155+0600	INFO	Secret scanning is enabled
 2023-08-31T11:10:27.155+0600	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
-2023-08-31T11:10:27.155+0600	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/scanner/secret/#recommendation for faster secret detection
+2023-08-31T11:10:27.155+0600	INFO	Please see also https://trivy.dev/dev/docs/scanner/secret/#recommendation for faster secret detection
 2023-08-31T11:10:29.164+0600	INFO	Detected OS: alpine
 2023-08-31T11:10:29.164+0600	INFO	Detecting Alpine vulnerabilities...
 2023-08-31T11:10:29.169+0600	INFO	Number of language-specific files: 1

--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -125,22 +125,6 @@ $ trivy image -f json -o results.json alpine:latest
 ```
 
 <details>
-<summary>Result</summary>
-
-```
-2024-12-26T22:01:18+05:30	INFO	[vuln] Vulnerability scanning is enabled
-2024-12-26T22:01:18+05:30	INFO	[secret] Secret scanning is enabled
-2024-12-26T22:01:18+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
-2024-12-26T22:01:18+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.58/docs/scanner/secret#recommendation for faster secret detection
-2024-12-26T22:01:18+05:30	INFO	Detected OS	family="alpine" version="3.20.3"
-2024-12-26T22:01:18+05:30	INFO	[alpine] Detecting vulnerabilities...	os_version="3.20" repository="3.20" pkg_num=14
-2024-12-26T22:01:18+05:30	INFO	Number of language-specific files	num=0
-2024-12-26T22:01:18+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.58/docs/scanner/vulnerability#severity-selection for details.
-```
-
-</details>
-
-<details>
 <summary>JSON</summary>
 
 ```

--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -277,5 +277,5 @@ $ trivy clean --all
 ```
 
 [air-gapped]: ../advanced/air-gap.md
-[network]: ../advanced/air-gap.md#network-requirements
+[network]: ../advanced/air-gap.md#connectivity-requirements
 [redis-cache]: ../configuration/cache.md#redis

--- a/docs/docs/supply-chain/attestation/rekor.md
+++ b/docs/docs/supply-chain/attestation/rekor.md
@@ -22,7 +22,7 @@ $ trivy image --sbom-sources rekor otms61/alpine:3.7.3                          
 2022-09-16T17:37:13.258+0900	INFO	Vulnerability scanning is enabled
 2022-09-16T17:37:13.258+0900	INFO	Secret scanning is enabled
 2022-09-16T17:37:13.258+0900	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
-2022-09-16T17:37:13.258+0900	INFO	Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
+2022-09-16T17:37:13.258+0900	INFO	Please see also https://trivy.dev/dev/docs/secret/scanning/#recommendation for faster secret detection
 2022-09-16T17:37:14.827+0900	INFO	Detected SBOM format: cyclonedx-json
 2022-09-16T17:37:14.901+0900	INFO	Found SBOM (cyclonedx) attestation in Rekor
 2022-09-16T17:37:14.903+0900	INFO	Detected OS: alpine

--- a/docs/docs/supply-chain/sbom.md
+++ b/docs/docs/supply-chain/sbom.md
@@ -453,7 +453,7 @@ SPDXVersion: SPDX-2.2
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: alpine:3.15
-DocumentNamespace: https://aquasecurity.github.io/trivy/container_image/alpine:3.15-bebf6b19-a94c-4e2c-af44-065f63923f48
+DocumentNamespace: https://trivy.dev/container_image/alpine:3.15-bebf6b19-a94c-4e2c-af44-065f63923f48
 Creator: Organization: aquasecurity
 Creator: Tool: trivy-0.38.1
 Created: 2022-04-28T07:32:57.142806Z
@@ -608,7 +608,7 @@ $ cat result.spdx.json | jq .
 		]
 	},
 	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://aquasecurity.github.io/trivy/container_image/alpine:3.15-d9549e3a-a4c5-4ee3-8bde-8c78d451fbe7",
+	"documentNamespace": "http://trivy.dev/container_image/alpine:3.15-d9549e3a-a4c5-4ee3-8bde-8c78d451fbe7",
 	"name": "alpine:3.15",
 	"packages": [
 		{

--- a/docs/docs/supply-chain/sbom.md
+++ b/docs/docs/supply-chain/sbom.md
@@ -438,7 +438,7 @@ $ trivy image --scanners vuln --format cyclonedx --output result.json alpine:3.1
 #### SPDX
 Trivy can generate SBOM in the [SPDX][spdx] format.
 
-You can use the regular subcommands (like `image`, `fs` and `rootfs`) and specify `spdx` with the `--format` option.
+You can use the regular subcommands (like `image`, `fs` and `rootfs`) and specify `spdx` or `spdx-json` with the `--format` option.
 
 ```
 $ trivy image --format spdx --output result.spdx alpine:3.15
@@ -447,7 +447,7 @@ $ trivy image --format spdx --output result.spdx alpine:3.15
 <details>
 <summary>Result</summary>
 
-```
+```bash
 $ cat result.spdx
 SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
@@ -726,6 +726,1008 @@ Relationship: SPDXRef-Package-d9ad92ed9413c93b DEPENDS_ON SPDXRef-Package-ee9b51
 Relationship: SPDXRef-Package-f00669065070476c DEPENDS_ON SPDXRef-Package-ba5f079c5c32fc8
 Relationship: SPDXRef-Package-f00669065070476c DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
 Relationship: SPDXRef-Package-fcb106f21773cad3 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+```
+
+</details>
+
+```
+$ trivy image --format spdx-json --output result.spdx alpine:3.15
+```
+
+<details>
+<summary>Result</summary>
+
+```json
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "alpine:3.15",
+  "documentNamespace": "http://trivy.dev/container_image/alpine:3.15-bbe0096f-0ed0-47b4-bbea-82121a9201f1",
+  "creationInfo": {
+    "creators": [
+      "Organization: aquasecurity",
+      "Tool: trivy-0.58.0"
+    ],
+    "created": "2025-02-13T12:22:22Z"
+  },
+  "packages": [
+    {
+      "name": "alpine:3.15",
+      "SPDXID": "SPDXRef-ContainerImage-d8b2a386253047e7",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:oci/alpine@sha256%3A19b4bcc4f60e99dd5ebdca0cbce22c503bbcff197549d7e19dab4f22254dc864?arch=amd64\u0026repository_url=index.docker.io%2Flibrary%2Falpine"
+        }
+      ],
+      "primaryPackagePurpose": "CONTAINER",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "DiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "ImageID: sha256:32b91e3161c8fc2e3baf2732a594305ca5093c82ff4e0c9f6ebbd2a879468e1d"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "RepoDigest: alpine@sha256:19b4bcc4f60e99dd5ebdca0cbce22c503bbcff197549d7e19dab4f22254dc864"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "RepoTag: alpine:3.15"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "SchemaVersion: 2"
+        }
+      ]
+    },
+    {
+      "name": "alpine-baselayout",
+      "SPDXID": "SPDXRef-Package-64b7e662458dcd5f",
+      "versionInfo": "3.2.0-r18",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "132992eab020986b3b5d886a77212889680467a0"
+        }
+      ],
+      "sourceInfo": "built package from: alpine-baselayout 3.2.0-r18",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-baselayout@3.2.0-r18?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: alpine-baselayout@3.2.0-r18"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "alpine-keys",
+      "SPDXID": "SPDXRef-Package-be18726b6be779d1",
+      "versionInfo": "2.4-r1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "903176b2d2a8ddefd1ba6940f19ad17c2c1d4aff"
+        }
+      ],
+      "sourceInfo": "built package from: alpine-keys 2.4-r1",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: alpine-keys@2.4-r1"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "apk-tools",
+      "SPDXID": "SPDXRef-Package-aa2e51a695e95cb9",
+      "versionInfo": "2.12.7-r3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ddf3ddf8545768bc323649559feaae1560f29273"
+        }
+      ],
+      "sourceInfo": "built package from: apk-tools 2.12.7-r3",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/apk-tools@2.12.7-r3?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: apk-tools@2.12.7-r3"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "busybox",
+      "SPDXID": "SPDXRef-Package-6c7c9dac75e301b7",
+      "versionInfo": "1.34.1-r7",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "21f9265e7a34c795fba4e99c8ae37b57f31cd1a2"
+        }
+      ],
+      "sourceInfo": "built package from: busybox 1.34.1-r7",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/busybox@1.34.1-r7?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: busybox@1.34.1-r7"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "ca-certificates-bundle",
+      "SPDXID": "SPDXRef-Package-702c9bf0cfddb42e",
+      "versionInfo": "20230506-r0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "99894c0b834a3f5955e6e5d5f0d804943f05ff52"
+        }
+      ],
+      "sourceInfo": "built package from: ca-certificates 20230506-r0",
+      "licenseConcluded": "MPL-2.0 AND MIT",
+      "licenseDeclared": "MPL-2.0 AND MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ca-certificates-bundle@20230506-r0?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: ca-certificates-bundle@20230506-r0"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "libc-utils",
+      "SPDXID": "SPDXRef-Package-43343abe5c1a0439",
+      "versionInfo": "0.7.2-r3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "798de3ebb57f3e28f408080746935f213a099722"
+        }
+      ],
+      "sourceInfo": "built package from: libc-dev 0.7.2-r3",
+      "licenseConcluded": "BSD-2-Clause AND BSD-3-Clause",
+      "licenseDeclared": "BSD-2-Clause AND BSD-3-Clause",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: libc-utils@0.7.2-r3"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "libcrypto1.1",
+      "SPDXID": "SPDXRef-Package-ba5f079c5c32fc8",
+      "versionInfo": "1.1.1w-r1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "e378634f5c8af32ca75ac56f41ecf4e8d49584a0"
+        }
+      ],
+      "sourceInfo": "built package from: openssl 1.1.1w-r1",
+      "licenseConcluded": "OpenSSL",
+      "licenseDeclared": "OpenSSL",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libcrypto1.1@1.1.1w-r1?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: libcrypto1.1@1.1.1w-r1"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "libretls",
+      "SPDXID": "SPDXRef-Package-343391d704e00fbd",
+      "versionInfo": "3.3.4-r3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "67dfefe5456c45192b60d76ade98c501b0ae814f"
+        }
+      ],
+      "sourceInfo": "built package from: libretls 3.3.4-r3",
+      "licenseConcluded": "ISC AND BSD-3-Clause AND MIT",
+      "licenseDeclared": "ISC AND BSD-3-Clause AND MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libretls@3.3.4-r3?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: libretls@3.3.4-r3"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "libssl1.1",
+      "SPDXID": "SPDXRef-Package-f00669065070476c",
+      "versionInfo": "1.1.1w-r1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9306ed15b3bdfc7553d5c14c472d87a41fef8541"
+        }
+      ],
+      "sourceInfo": "built package from: openssl 1.1.1w-r1",
+      "licenseConcluded": "OpenSSL",
+      "licenseDeclared": "OpenSSL",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/libssl1.1@1.1.1w-r1?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: libssl1.1@1.1.1w-r1"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "musl",
+      "SPDXID": "SPDXRef-Package-ee9b5186331e7a76",
+      "versionInfo": "1.2.2-r9",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "7ebdef6cf7f9b58c0e213b333db946d22b00b777"
+        }
+      ],
+      "sourceInfo": "built package from: musl 1.2.2-r9",
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl@1.2.2-r9?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: musl@1.2.2-r9"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "musl-utils",
+      "SPDXID": "SPDXRef-Package-92eb9ab29b057905",
+      "versionInfo": "1.2.2-r9",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "f69aa6d6a57c90358005ce61ccb4ad96cdc303f4"
+        }
+      ],
+      "sourceInfo": "built package from: musl 1.2.2-r9",
+      "licenseConcluded": "MIT AND BSD-3-Clause AND GPL-2.0-or-later",
+      "licenseDeclared": "MIT AND BSD-3-Clause AND GPL-2.0-or-later",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/musl-utils@1.2.2-r9?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: musl-utils@1.2.2-r9"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "scanelf",
+      "SPDXID": "SPDXRef-Package-988bca2f70cf58f6",
+      "versionInfo": "1.3.3-r0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "d7f7590e450870a4f79671c2369b31b5bb07349a"
+        }
+      ],
+      "sourceInfo": "built package from: pax-utils 1.3.3-r0",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/scanelf@1.3.3-r0?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: scanelf@1.3.3-r0"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "ssl_client",
+      "SPDXID": "SPDXRef-Package-d9ad92ed9413c93b",
+      "versionInfo": "1.34.1-r7",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "dddfa62dd51bd8807ee1d8660e860574a9dd78ed"
+        }
+      ],
+      "sourceInfo": "built package from: busybox 1.34.1-r7",
+      "licenseConcluded": "GPL-2.0-only",
+      "licenseDeclared": "GPL-2.0-only",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/ssl_client@1.34.1-r7?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: ssl_client@1.34.1-r7"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "zlib",
+      "SPDXID": "SPDXRef-Package-fcb106f21773cad3",
+      "versionInfo": "1.2.12-r3",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ab98d0416bf1dcd245c7b0800f99cbceacfa48b3"
+        }
+      ],
+      "sourceInfo": "built package from: zlib 1.2.12-r3",
+      "licenseConcluded": "Zlib",
+      "licenseDeclared": "Zlib",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64\u0026distro=3.15.11"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDiffID: sha256:2879a4821959ab702528e28a1c59cd26c4956112497f6d1dbfd86c8d88003983"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "LayerDigest: sha256:d078792c4f9122259f14b539315bd92cbd9490ed73e08255a08689122b143108"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgID: zlib@1.2.12-r3"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "PkgType: alpine"
+        }
+      ]
+    },
+    {
+      "name": "alpine",
+      "SPDXID": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "versionInfo": "3.15.11",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "OPERATING-SYSTEM",
+      "annotations": [
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "Class: os-pkgs"
+        },
+        {
+          "annotator": "Tool: trivy-0.58.0",
+          "annotationDate": "2025-02-13T12:22:22Z",
+          "annotationType": "OTHER",
+          "comment": "Type: alpine"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-ContainerImage-d8b2a386253047e7",
+      "relatedSpdxElement": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-ContainerImage-d8b2a386253047e7",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-343391d704e00fbd",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-43343abe5c1a0439",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-64b7e662458dcd5f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-6c7c9dac75e301b7",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-702c9bf0cfddb42e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-92eb9ab29b057905",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-988bca2f70cf58f6",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-ba5f079c5c32fc8",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-be18726b6be779d1",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-d9ad92ed9413c93b",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-f00669065070476c",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-c24750c3b737d897",
+      "relatedSpdxElement": "SPDXRef-Package-fcb106f21773cad3",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-343391d704e00fbd",
+      "relatedSpdxElement": "SPDXRef-Package-702c9bf0cfddb42e",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-343391d704e00fbd",
+      "relatedSpdxElement": "SPDXRef-Package-ba5f079c5c32fc8",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-343391d704e00fbd",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-343391d704e00fbd",
+      "relatedSpdxElement": "SPDXRef-Package-f00669065070476c",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-43343abe5c1a0439",
+      "relatedSpdxElement": "SPDXRef-Package-92eb9ab29b057905",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-64b7e662458dcd5f",
+      "relatedSpdxElement": "SPDXRef-Package-6c7c9dac75e301b7",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-64b7e662458dcd5f",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-6c7c9dac75e301b7",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-92eb9ab29b057905",
+      "relatedSpdxElement": "SPDXRef-Package-988bca2f70cf58f6",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-92eb9ab29b057905",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-988bca2f70cf58f6",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relatedSpdxElement": "SPDXRef-Package-702c9bf0cfddb42e",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relatedSpdxElement": "SPDXRef-Package-ba5f079c5c32fc8",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relatedSpdxElement": "SPDXRef-Package-f00669065070476c",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-aa2e51a695e95cb9",
+      "relatedSpdxElement": "SPDXRef-Package-fcb106f21773cad3",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ba5f079c5c32fc8",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-d9ad92ed9413c93b",
+      "relatedSpdxElement": "SPDXRef-Package-343391d704e00fbd",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-d9ad92ed9413c93b",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-f00669065070476c",
+      "relatedSpdxElement": "SPDXRef-Package-ba5f079c5c32fc8",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-f00669065070476c",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fcb106f21773cad3",
+      "relatedSpdxElement": "SPDXRef-Package-ee9b5186331e7a76",
+      "relationshipType": "DEPENDS_ON"
+    }
+  ]
+}
 ```
 
 </details>

--- a/docs/docs/supply-chain/sbom.md
+++ b/docs/docs/supply-chain/sbom.md
@@ -447,8 +447,7 @@ $ trivy image --format spdx --output result.spdx alpine:3.15
 <details>
 <summary>Result</summary>
 
-```bash
-$ cat result.spdx
+```spdx
 SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT

--- a/docs/docs/supply-chain/sbom.md
+++ b/docs/docs/supply-chain/sbom.md
@@ -449,283 +449,283 @@ $ trivy image --format spdx --output result.spdx alpine:3.15
 
 ```
 $ cat result.spdx
-SPDXVersion: SPDX-2.2
+SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: alpine:3.15
-DocumentNamespace: https://trivy.dev/container_image/alpine:3.15-bebf6b19-a94c-4e2c-af44-065f63923f48
+DocumentNamespace: http://trivy.dev/container_image/alpine:3.15-12db86e1-4aa4-40ec-900b-5aaa5d82461b
 Creator: Organization: aquasecurity
-Creator: Tool: trivy-0.38.1
-Created: 2022-04-28T07:32:57.142806Z
+Creator: Tool: trivy-0.58.0
+Created: 2025-02-11T07:43:38Z
 
-##### Package: zlib
+##### Package: alpine:3.15
 
-PackageName: zlib
-SPDXID: SPDXRef-12bc938ac028a5e1
-PackageVersion: 1.2.12-r0
+PackageName: alpine:3.15
+SPDXID: SPDXRef-ContainerImage-d8b2a386253047e7
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: CONTAINER
 FilesAnalyzed: false
-PackageLicenseConcluded: Zlib
-PackageLicenseDeclared: Zlib
+ExternalRef: PACKAGE-MANAGER purl pkg:oci/alpine@sha256%3A19b4bcc4f60e99dd5ebdca0cbce22c503bbcff197549d7e19dab4f22254dc864?arch=amd64&repository_url=index.docker.io%2Flibrary%2Falpine
 
-##### Package: apk-tools
+##### Package: alpine
 
-PackageName: apk-tools
-SPDXID: SPDXRef-26c274652190d87f
-PackageVersion: 2.12.7-r3
+PackageName: alpine
+SPDXID: SPDXRef-OperatingSystem-c24750c3b737d897
+PackageVersion: 3.15.11
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: OPERATING-SYSTEM
 FilesAnalyzed: false
-PackageLicenseConcluded: GPL-2.0-only
-PackageLicenseDeclared: GPL-2.0-only
 
 ##### Package: libretls
 
 PackageName: libretls
-SPDXID: SPDXRef-2b021966d19a8211
+SPDXID: SPDXRef-Package-343391d704e00fbd
 PackageVersion: 3.3.4-r3
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
 FilesAnalyzed: false
-PackageLicenseConcluded: ISC AND (BSD-3-Clause OR MIT)
-PackageLicenseDeclared: ISC AND (BSD-3-Clause OR MIT)
-
-##### Package: busybox
-
-PackageName: busybox
-SPDXID: SPDXRef-317ce3476703f20d
-PackageVersion: 1.34.1-r5
-FilesAnalyzed: false
-PackageLicenseConcluded: GPL-2.0-only
-PackageLicenseDeclared: GPL-2.0-only
-
-##### Package: libcrypto1.1
-
-PackageName: libcrypto1.1
-SPDXID: SPDXRef-34f407fb4dbd67f4
-PackageVersion: 1.1.1n-r0
-FilesAnalyzed: false
-PackageLicenseConcluded: OpenSSL
-PackageLicenseDeclared: OpenSSL
+PackageChecksum: SHA1: 67dfefe5456c45192b60d76ade98c501b0ae814f
+PackageSourceInfo: built package from: libretls 3.3.4-r3
+PackageLicenseConcluded: ISC AND BSD-3-Clause AND MIT
+PackageLicenseDeclared: ISC AND BSD-3-Clause AND MIT
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/libretls@3.3.4-r3?arch=x86_64&distro=3.15.11
 
 ##### Package: libc-utils
 
 PackageName: libc-utils
-SPDXID: SPDXRef-4bbc1cb449d54083
+SPDXID: SPDXRef-Package-43343abe5c1a0439
 PackageVersion: 0.7.2-r3
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
 FilesAnalyzed: false
+PackageChecksum: SHA1: 798de3ebb57f3e28f408080746935f213a099722
+PackageSourceInfo: built package from: libc-dev 0.7.2-r3
 PackageLicenseConcluded: BSD-2-Clause AND BSD-3-Clause
 PackageLicenseDeclared: BSD-2-Clause AND BSD-3-Clause
-
-##### Package: alpine-keys
-
-PackageName: alpine-keys
-SPDXID: SPDXRef-a3bdd174be1456b6
-PackageVersion: 2.4-r1
-FilesAnalyzed: false
-PackageLicenseConcluded: MIT
-PackageLicenseDeclared: MIT
-
-##### Package: ca-certificates-bundle
-
-PackageName: ca-certificates-bundle
-SPDXID: SPDXRef-ac6472ba26fb991c
-PackageVersion: 20211220-r0
-FilesAnalyzed: false
-PackageLicenseConcluded: MPL-2.0 AND MIT
-PackageLicenseDeclared: MPL-2.0 AND MIT
-
-##### Package: libssl1.1
-
-PackageName: libssl1.1
-SPDXID: SPDXRef-b2d1b1d70fe90f7d
-PackageVersion: 1.1.1n-r0
-FilesAnalyzed: false
-PackageLicenseConcluded: OpenSSL
-PackageLicenseDeclared: OpenSSL
-
-##### Package: scanelf
-
-PackageName: scanelf
-SPDXID: SPDXRef-c617077ba6649520
-PackageVersion: 1.3.3-r0
-FilesAnalyzed: false
-PackageLicenseConcluded: GPL-2.0-only
-PackageLicenseDeclared: GPL-2.0-only
-
-##### Package: musl
-
-PackageName: musl
-SPDXID: SPDXRef-ca80b810029cde0e
-PackageVersion: 1.2.2-r7
-FilesAnalyzed: false
-PackageLicenseConcluded: MIT
-PackageLicenseDeclared: MIT
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&distro=3.15.11
 
 ##### Package: alpine-baselayout
 
 PackageName: alpine-baselayout
-SPDXID: SPDXRef-d782e64751ba9faa
+SPDXID: SPDXRef-Package-64b7e662458dcd5f
 PackageVersion: 3.2.0-r18
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
 FilesAnalyzed: false
+PackageChecksum: SHA1: 132992eab020986b3b5d886a77212889680467a0
+PackageSourceInfo: built package from: alpine-baselayout 3.2.0-r18
 PackageLicenseConcluded: GPL-2.0-only
 PackageLicenseDeclared: GPL-2.0-only
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/alpine-baselayout@3.2.0-r18?arch=x86_64&distro=3.15.11
+
+##### Package: busybox
+
+PackageName: busybox
+SPDXID: SPDXRef-Package-6c7c9dac75e301b7
+PackageVersion: 1.34.1-r7
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: 21f9265e7a34c795fba4e99c8ae37b57f31cd1a2
+PackageSourceInfo: built package from: busybox 1.34.1-r7
+PackageLicenseConcluded: GPL-2.0-only
+PackageLicenseDeclared: GPL-2.0-only
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/busybox@1.34.1-r7?arch=x86_64&distro=3.15.11
+
+##### Package: ca-certificates-bundle
+
+PackageName: ca-certificates-bundle
+SPDXID: SPDXRef-Package-702c9bf0cfddb42e
+PackageVersion: 20230506-r0
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: 99894c0b834a3f5955e6e5d5f0d804943f05ff52
+PackageSourceInfo: built package from: ca-certificates 20230506-r0
+PackageLicenseConcluded: MPL-2.0 AND MIT
+PackageLicenseDeclared: MPL-2.0 AND MIT
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/ca-certificates-bundle@20230506-r0?arch=x86_64&distro=3.15.11
 
 ##### Package: musl-utils
 
 PackageName: musl-utils
-SPDXID: SPDXRef-e5e8a237f6162e22
-PackageVersion: 1.2.2-r7
+SPDXID: SPDXRef-Package-92eb9ab29b057905
+PackageVersion: 1.2.2-r9
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
 FilesAnalyzed: false
-PackageLicenseConcluded: MIT BSD GPL2+
-PackageLicenseDeclared: MIT BSD GPL2+
+PackageChecksum: SHA1: f69aa6d6a57c90358005ce61ccb4ad96cdc303f4
+PackageSourceInfo: built package from: musl 1.2.2-r9
+PackageLicenseConcluded: MIT AND BSD-3-Clause AND GPL-2.0-or-later
+PackageLicenseDeclared: MIT AND BSD-3-Clause AND GPL-2.0-or-later
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/musl-utils@1.2.2-r9?arch=x86_64&distro=3.15.11
+
+##### Package: scanelf
+
+PackageName: scanelf
+SPDXID: SPDXRef-Package-988bca2f70cf58f6
+PackageVersion: 1.3.3-r0
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: d7f7590e450870a4f79671c2369b31b5bb07349a
+PackageSourceInfo: built package from: pax-utils 1.3.3-r0
+PackageLicenseConcluded: GPL-2.0-only
+PackageLicenseDeclared: GPL-2.0-only
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/scanelf@1.3.3-r0?arch=x86_64&distro=3.15.11
+
+##### Package: apk-tools
+
+PackageName: apk-tools
+SPDXID: SPDXRef-Package-aa2e51a695e95cb9
+PackageVersion: 2.12.7-r3
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: ddf3ddf8545768bc323649559feaae1560f29273
+PackageSourceInfo: built package from: apk-tools 2.12.7-r3
+PackageLicenseConcluded: GPL-2.0-only
+PackageLicenseDeclared: GPL-2.0-only
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/apk-tools@2.12.7-r3?arch=x86_64&distro=3.15.11
+
+##### Package: libcrypto1.1
+
+PackageName: libcrypto1.1
+SPDXID: SPDXRef-Package-ba5f079c5c32fc8
+PackageVersion: 1.1.1w-r1
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: e378634f5c8af32ca75ac56f41ecf4e8d49584a0
+PackageSourceInfo: built package from: openssl 1.1.1w-r1
+PackageLicenseConcluded: OpenSSL
+PackageLicenseDeclared: OpenSSL
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/libcrypto1.1@1.1.1w-r1?arch=x86_64&distro=3.15.11
+
+##### Package: alpine-keys
+
+PackageName: alpine-keys
+SPDXID: SPDXRef-Package-be18726b6be779d1
+PackageVersion: 2.4-r1
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: 903176b2d2a8ddefd1ba6940f19ad17c2c1d4aff
+PackageSourceInfo: built package from: alpine-keys 2.4-r1
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&distro=3.15.11
 
 ##### Package: ssl_client
 
 PackageName: ssl_client
-SPDXID: SPDXRef-fdf0ce84f6337be4
-PackageVersion: 1.34.1-r5
+SPDXID: SPDXRef-Package-d9ad92ed9413c93b
+PackageVersion: 1.34.1-r7
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
 FilesAnalyzed: false
+PackageChecksum: SHA1: dddfa62dd51bd8807ee1d8660e860574a9dd78ed
+PackageSourceInfo: built package from: busybox 1.34.1-r7
 PackageLicenseConcluded: GPL-2.0-only
 PackageLicenseDeclared: GPL-2.0-only
-```
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/ssl_client@1.34.1-r7?arch=x86_64&distro=3.15.11
 
-</details>
+##### Package: musl
 
-SPDX-JSON format is also supported by using `spdx-json` with the `--format` option.
+PackageName: musl
+SPDXID: SPDXRef-Package-ee9b5186331e7a76
+PackageVersion: 1.2.2-r9
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: 7ebdef6cf7f9b58c0e213b333db946d22b00b777
+PackageSourceInfo: built package from: musl 1.2.2-r9
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/musl@1.2.2-r9?arch=x86_64&distro=3.15.11
 
-```
-$ trivy image --format spdx-json --output result.spdx.json alpine:3.15
-```
+##### Package: libssl1.1
 
-<details>
-<summary>Result</summary>
+PackageName: libssl1.1
+SPDXID: SPDXRef-Package-f00669065070476c
+PackageVersion: 1.1.1w-r1
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: 9306ed15b3bdfc7553d5c14c472d87a41fef8541
+PackageSourceInfo: built package from: openssl 1.1.1w-r1
+PackageLicenseConcluded: OpenSSL
+PackageLicenseDeclared: OpenSSL
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/libssl1.1@1.1.1w-r1?arch=x86_64&distro=3.15.11
 
-```
-$ cat result.spdx.json | jq .
-{
-	"SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {
-		"created": "2022-04-28T08:16:55.328255Z",
-		"creators": [
-			"Tool: trivy-0.38.1",
-			"Organization: aquasecurity"
-		]
-	},
-	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://trivy.dev/container_image/alpine:3.15-d9549e3a-a4c5-4ee3-8bde-8c78d451fbe7",
-	"name": "alpine:3.15",
-	"packages": [
-		{
-			"SPDXID": "SPDXRef-12bc938ac028a5e1",
-			"filesAnalyzed": false,
-			"licenseConcluded": "Zlib",
-			"licenseDeclared": "Zlib",
-			"name": "zlib",
-			"versionInfo": "1.2.12-r0"
-		},
-		{
-			"SPDXID": "SPDXRef-26c274652190d87f",
-			"filesAnalyzed": false,
-			"licenseConcluded": "GPL-2.0-only",
-			"licenseDeclared": "GPL-2.0-only",
-			"name": "apk-tools",
-			"versionInfo": "2.12.7-r3"
-		},
-		{
-			"SPDXID": "SPDXRef-2b021966d19a8211",
-			"filesAnalyzed": false,
-			"licenseConcluded": "ISC AND (BSD-3-Clause OR MIT)",
-			"licenseDeclared": "ISC AND (BSD-3-Clause OR MIT)",
-			"name": "libretls",
-			"versionInfo": "3.3.4-r3"
-		},
-		{
-			"SPDXID": "SPDXRef-317ce3476703f20d",
-			"filesAnalyzed": false,
-			"licenseConcluded": "GPL-2.0-only",
-			"licenseDeclared": "GPL-2.0-only",
-			"name": "busybox",
-			"versionInfo": "1.34.1-r5"
-		},
-		{
-			"SPDXID": "SPDXRef-34f407fb4dbd67f4",
-			"filesAnalyzed": false,
-			"licenseConcluded": "OpenSSL",
-			"licenseDeclared": "OpenSSL",
-			"name": "libcrypto1.1",
-			"versionInfo": "1.1.1n-r0"
-		},
-		{
-			"SPDXID": "SPDXRef-4bbc1cb449d54083",
-			"filesAnalyzed": false,
-			"licenseConcluded": "BSD-2-Clause AND BSD-3-Clause",
-			"licenseDeclared": "BSD-2-Clause AND BSD-3-Clause",
-			"name": "libc-utils",
-			"versionInfo": "0.7.2-r3"
-		},
-		{
-			"SPDXID": "SPDXRef-a3bdd174be1456b6",
-			"filesAnalyzed": false,
-			"licenseConcluded": "MIT",
-			"licenseDeclared": "MIT",
-			"name": "alpine-keys",
-			"versionInfo": "2.4-r1"
-		},
-		{
-			"SPDXID": "SPDXRef-ac6472ba26fb991c",
-			"filesAnalyzed": false,
-			"licenseConcluded": "MPL-2.0 AND MIT",
-			"licenseDeclared": "MPL-2.0 AND MIT",
-			"name": "ca-certificates-bundle",
-			"versionInfo": "20211220-r0"
-		},
-		{
-			"SPDXID": "SPDXRef-b2d1b1d70fe90f7d",
-			"filesAnalyzed": false,
-			"licenseConcluded": "OpenSSL",
-			"licenseDeclared": "OpenSSL",
-			"name": "libssl1.1",
-			"versionInfo": "1.1.1n-r0"
-		},
-		{
-			"SPDXID": "SPDXRef-c617077ba6649520",
-			"filesAnalyzed": false,
-			"licenseConcluded": "GPL-2.0-only",
-			"licenseDeclared": "GPL-2.0-only",
-			"name": "scanelf",
-			"versionInfo": "1.3.3-r0"
-		},
-		{
-			"SPDXID": "SPDXRef-ca80b810029cde0e",
-			"filesAnalyzed": false,
-			"licenseConcluded": "MIT",
-			"licenseDeclared": "MIT",
-			"name": "musl",
-			"versionInfo": "1.2.2-r7"
-		},
-		{
-			"SPDXID": "SPDXRef-d782e64751ba9faa",
-			"filesAnalyzed": false,
-			"licenseConcluded": "GPL-2.0-only",
-			"licenseDeclared": "GPL-2.0-only",
-			"name": "alpine-baselayout",
-			"versionInfo": "3.2.0-r18"
-		},
-		{
-			"SPDXID": "SPDXRef-e5e8a237f6162e22",
-			"filesAnalyzed": false,
-			"licenseConcluded": "MIT BSD GPL2+",
-			"licenseDeclared": "MIT BSD GPL2+",
-			"name": "musl-utils",
-			"versionInfo": "1.2.2-r7"
-		},
-		{
-			"SPDXID": "SPDXRef-fdf0ce84f6337be4",
-			"filesAnalyzed": false,
-			"licenseConcluded": "GPL-2.0-only",
-			"licenseDeclared": "GPL-2.0-only",
-			"name": "ssl_client",
-			"versionInfo": "1.34.1-r5"
-		}
-	],
-	"spdxVersion": "SPDX-2.2"
-}
+##### Package: zlib
+
+PackageName: zlib
+SPDXID: SPDXRef-Package-fcb106f21773cad3
+PackageVersion: 1.2.12-r3
+PackageSupplier: NOASSERTION
+PackageDownloadLocation: NONE
+PrimaryPackagePurpose: LIBRARY
+FilesAnalyzed: false
+PackageChecksum: SHA1: ab98d0416bf1dcd245c7b0800f99cbceacfa48b3
+PackageSourceInfo: built package from: zlib 1.2.12-r3
+PackageLicenseConcluded: Zlib
+PackageLicenseDeclared: Zlib
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64&distro=3.15.11
+
+##### Relationships
+
+Relationship: SPDXRef-ContainerImage-d8b2a386253047e7 CONTAINS SPDXRef-OperatingSystem-c24750c3b737d897
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-ContainerImage-d8b2a386253047e7
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-343391d704e00fbd
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-43343abe5c1a0439
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-64b7e662458dcd5f
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-6c7c9dac75e301b7
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-702c9bf0cfddb42e
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-92eb9ab29b057905
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-988bca2f70cf58f6
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-aa2e51a695e95cb9
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-ba5f079c5c32fc8
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-be18726b6be779d1
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-d9ad92ed9413c93b
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-f00669065070476c
+Relationship: SPDXRef-OperatingSystem-c24750c3b737d897 CONTAINS SPDXRef-Package-fcb106f21773cad3
+Relationship: SPDXRef-Package-343391d704e00fbd DEPENDS_ON SPDXRef-Package-702c9bf0cfddb42e
+Relationship: SPDXRef-Package-343391d704e00fbd DEPENDS_ON SPDXRef-Package-ba5f079c5c32fc8
+Relationship: SPDXRef-Package-343391d704e00fbd DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-343391d704e00fbd DEPENDS_ON SPDXRef-Package-f00669065070476c
+Relationship: SPDXRef-Package-43343abe5c1a0439 DEPENDS_ON SPDXRef-Package-92eb9ab29b057905
+Relationship: SPDXRef-Package-64b7e662458dcd5f DEPENDS_ON SPDXRef-Package-6c7c9dac75e301b7
+Relationship: SPDXRef-Package-64b7e662458dcd5f DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-6c7c9dac75e301b7 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-92eb9ab29b057905 DEPENDS_ON SPDXRef-Package-988bca2f70cf58f6
+Relationship: SPDXRef-Package-92eb9ab29b057905 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-988bca2f70cf58f6 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-aa2e51a695e95cb9 DEPENDS_ON SPDXRef-Package-702c9bf0cfddb42e
+Relationship: SPDXRef-Package-aa2e51a695e95cb9 DEPENDS_ON SPDXRef-Package-ba5f079c5c32fc8
+Relationship: SPDXRef-Package-aa2e51a695e95cb9 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-aa2e51a695e95cb9 DEPENDS_ON SPDXRef-Package-f00669065070476c
+Relationship: SPDXRef-Package-aa2e51a695e95cb9 DEPENDS_ON SPDXRef-Package-fcb106f21773cad3
+Relationship: SPDXRef-Package-ba5f079c5c32fc8 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-d9ad92ed9413c93b DEPENDS_ON SPDXRef-Package-343391d704e00fbd
+Relationship: SPDXRef-Package-d9ad92ed9413c93b DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-f00669065070476c DEPENDS_ON SPDXRef-Package-ba5f079c5c32fc8
+Relationship: SPDXRef-Package-f00669065070476c DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
+Relationship: SPDXRef-Package-fcb106f21773cad3 DEPENDS_ON SPDXRef-Package-ee9b5186331e7a76
 ```
 
 </details>

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -491,7 +491,7 @@ $ trivy image --platform=linux/arm alpine:3.16.1
 2022-10-25T21:00:50.972+0300    INFO    Vulnerability scanning is enabled
 2022-10-25T21:00:50.972+0300    INFO    Secret scanning is enabled
 2022-10-25T21:00:50.972+0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
-2022-10-25T21:00:50.972+0300    INFO    Please see also https://aquasecurity.github.io/trivy/dev/docs/secret/scanning/#recommendation for faster secret detection
+2022-10-25T21:00:50.972+0300    INFO    Please see also https://trivy.dev/dev/docs/secret/scanning/#recommendation for faster secret detection
 2022-10-25T21:00:56.190+0300    INFO    Detected OS: alpine
 2022-10-25T21:00:56.190+0300    INFO    Detecting Alpine vulnerabilities...
 2022-10-25T21:00:56.191+0300    INFO    Number of language-specific files: 0

--- a/docs/tutorials/misconfiguration/custom-checks.md
+++ b/docs/tutorials/misconfiguration/custom-checks.md
@@ -1,6 +1,6 @@
 # Custom Checks with Rego
 
-Trivy can scan configuration files for common security issues (a.k.a IaC misconfiguration scanning). In addition to a comprehensive built in database of checks, you can add your own custom checks. Checks are written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) language and the full documentation for checks and customizing them is available [here](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/). 
+Trivy can scan configuration files for common security issues (a.k.a IaC misconfiguration scanning). In addition to a comprehensive built in database of checks, you can add your own custom checks. Checks are written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) language and the full documentation for checks and customizing them is available [here](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/). 
 
 This tutorial will walk you through writing a custom check in Rego that checks for an issue in a Dockerfile.
 
@@ -38,7 +38,7 @@ Next, we need to specify metadata about the check. This is information that help
 
 Important: The `METADATA` has to be defined on top of the file.
 
-More information on the different fields in the metadata can be found in the [Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/)
+More information on the different fields in the metadata can be found in the [Trivy documentation.](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/)
 
 ## Package and imports
 

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -9,7 +9,7 @@ We have been consolidating all of our scanning-related efforts in one place, and
 
 ## Trivy Config Command 
 
-Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/) 
+Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://trivy.dev/latest/docs/scanner/misconfiguration/) 
 
 Command structure: 
 ``` 
@@ -23,7 +23,7 @@ The `trivy config` command can scan Terraform configuration, CloudFormation, Doc
 - If the configuration that has been defined does not follow best practices, the check will fail.  
 
 ### Prerequisites 
-Install Trivy on your local machines. The documentation provides several [different installation options.](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) 
+Install Trivy on your local machines. The documentation provides several [different installation options.](https://trivy.dev/latest/getting-started/installation/) 
 This tutorial will use this example [Terraform tutorial](https://github.com/Cloud-Native-Security/trivy-demo/tree/main/bad_iac/terraform) for terraform misconfiguration scanning with Trivy. 
 
 Git clone the tutorial and cd into the directory: 
@@ -83,14 +83,14 @@ trivy config --severity CRITICAL, MEDIUM terraform-infra
 
 ### Passing tf.tfvars files into `trivy config` scans 
 
-You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://aquasecurity.github.io/trivy/latest/docs/coverage/iac/terraform/#value-overrides) 
+You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://trivy.dev/latest/docs/coverage/iac/terraform/#value-overrides) 
 
 ``` 
 trivy config --tf-vars terraform.tfvars ./
 ``` 
 ### Custom Checks 
 
-We have lots of examples in the [documentation](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/custom/) on how you can write and pass custom Rego checks into terraform misconfiguration scans. 
+We have lots of examples in the [documentation](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/) on how you can write and pass custom Rego checks into terraform misconfiguration scans. 
 
 ## Secret and vulnerability scans
 
@@ -100,15 +100,15 @@ The `trivy config` command does not perform secrete and vulnerability checks out
 trivy fs --scanners secret,misconfig ./
 ```
 
-The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/) 
+The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://trivy.dev/latest/docs/target/filesystem/) 
 
 ## Scanning Terraform Plan files
 
-Instead of scanning your different Terraform resources individually, you could also scan your Terraform Plan file before it is deployed for misconfiguration. This will give you insights into any misconfiguration of your resources as they would become deployed. [Here](https://aquasecurity.github.io/trivy/latest/docs/coverage/iac/terraform/#terraform) is the link to the documentation.
+Instead of scanning your different Terraform resources individually, you could also scan your Terraform Plan file before it is deployed for misconfiguration. This will give you insights into any misconfiguration of your resources as they would become deployed. [Here](https://trivy.dev/latest/docs/coverage/iac/terraform/#terraform) is the link to the documentation.
 
 Note that you need to be able to create a terraform init and plan without any errors. 
 
 ## Using Trivy in your CI/CD pipeline 
-Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://aquasecurity.github.io/trivy/latest/tutorials/integrations/](https://aquasecurity.github.io/trivy/latest/tutorials/integrations/) 
+Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://trivy.dev/latest/tutorials/integrations/](https://trivy.dev/latest/tutorials/integrations/) 
 
  

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -165,7 +165,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/amd64"
     extra_files:
     - contrib/
@@ -190,7 +190,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/arm64"
     extra_files:
     - contrib/
@@ -215,7 +215,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/s390x"
     extra_files:
     - contrib/
@@ -240,7 +240,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/trivy/v{{ .Version }}/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
       - "--platform=linux/ppc64le"
     extra_files:
     - contrib/

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -77,7 +77,7 @@ trivy:
   gitHubToken: ""
 
   # Docker registry credentials
-  # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
+  # See also: https://trivy.dev/dev/advanced/private-registries/docker-hub/
   #
   # Either
   # Directly in this file

--- a/integration/testdata/conda-spdx.json.golden
+++ b/integration/testdata/conda-spdx.json.golden
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "testdata/fixtures/repo/conda",
-  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/testdata/fixtures/repo/conda-3ff14136-e09f-4df9-80ea-000000000004",
+  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/conda-3ff14136-e09f-4df9-80ea-000000000004",
   "creationInfo": {
     "creators": [
       "Organization: aquasecurity",

--- a/integration/testdata/fixtures/sbom/centos-7-spdx.json
+++ b/integration/testdata/fixtures/sbom/centos-7-spdx.json
@@ -8,7 +8,7 @@
 		]
 	},
 	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://aquasecurity.github.io/trivy/container_image/integration/testdata/fixtures/images/centos-7.tar.gz-2906855d-5098-4a22-9a72-4f7099ea3d66",
+	"documentNamespace": "http://trivy.dev/container_image/integration/testdata/fixtures/images/centos-7.tar.gz-2906855d-5098-4a22-9a72-4f7099ea3d66",
 	"name": "integration/testdata/fixtures/images/centos-7.tar.gz",
 	"packages": [
 		{

--- a/integration/testdata/fixtures/sbom/centos-7-spdx.txt
+++ b/integration/testdata/fixtures/sbom/centos-7-spdx.txt
@@ -2,7 +2,7 @@ SPDXVersion: SPDX-2.2
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: integration/testdata/fixtures/images/centos-7.tar.gz
-DocumentNamespace: http://aquasecurity.github.io/trivy/container_image/integration/testdata/fixtures/images/centos-7.tar.gz-6a2c050f-bc12-46dc-b2df-1f4e3e0b5e1d
+DocumentNamespace: http://trivy.dev/container_image/integration/testdata/fixtures/images/centos-7.tar.gz-6a2c050f-bc12-46dc-b2df-1f4e3e0b5e1d
 Creator: Organization: aquasecurity
 Creator: Tool: trivy-dev
 Created: 2022-09-13T13:24:58.796907Z

--- a/integration/testdata/julia-spdx.json.golden
+++ b/integration/testdata/julia-spdx.json.golden
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "testdata/fixtures/repo/julia",
-  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/testdata/fixtures/repo/julia-3ff14136-e09f-4df9-80ea-000000000006",
+  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/julia-3ff14136-e09f-4df9-80ea-000000000006",
   "creationInfo": {
     "creators": [
       "Organization: aquasecurity",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Trivy
-site_url: https://aquasecurity.github.io/trivy/
+site_url: https://trivy.dev/
 site_description: Trivy - All-in-one open source security scanner
 docs_dir: docs/
 repo_name: GitHub

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -340,7 +340,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 
 	defer func() {
 		if errors.Is(err, context.DeadlineExceeded) {
-			// e.g. https://aquasecurity.github.io/trivy/latest/docs/configuration/
+			// e.g. https://trivy.dev/latest/docs/configuration/
 			log.WarnContext(ctx, fmt.Sprintf("Provide a higher timeout value, see %s", doc.URL("/docs/configuration/", "")))
 		}
 	}()
@@ -529,7 +529,7 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 		logger := log.WithPrefix(log.PrefixSecret)
 		logger.Info("Secret scanning is enabled")
 		logger.Info("If your scanning is slow, please try '--scanners vuln' to disable secret scanning")
-		// e.g. https://aquasecurity.github.io/trivy/latest/docs/scanner/secret/#recommendation
+		// e.g. https://trivy.dev/latest/docs/scanner/secret/#recommendation
 		logger.Info(fmt.Sprintf("Please see also %s for faster secret detection", doc.URL("/docs/scanner/secret/", "recommendation")))
 	} else {
 		opts.SecretConfigPath = ""

--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -20,7 +20,7 @@ var (
 	varRegexp        = regexp.MustCompile(`\${(\S+?)}`)
 	emptyVersionWarn = sync.OnceFunc(func() {
 		log.WithPrefix("pom").Warn("Dependency version cannot be determined. Child dependencies will not be found.",
-			// e.g. https://aquasecurity.github.io/trivy/latest/docs/coverage/language/java/#empty-dependency-version
+			// e.g. https://trivy.dev/latest/docs/coverage/language/java/#empty-dependency-version
 			log.String("details", doc.URL("/docs/coverage/language/java/", "empty-dependency-version")))
 	})
 )

--- a/pkg/fanal/analyzer/language/conda/environment/environment.go
+++ b/pkg/fanal/analyzer/language/conda/environment/environment.go
@@ -43,7 +43,7 @@ func (*parser) Parse(r xio.ReadSeekerAt) ([]types.Package, []types.Dependency, e
 			if err != nil {
 				// Show log once per file
 				once.Do(func() {
-					// e.g. https://aquasecurity.github.io/trivy/latest/docs/coverage/os/conda/#license_1
+					// e.g. https://trivy.dev/latest/docs/coverage/os/conda/#license_1
 					log.WithPrefix("conda").Debug(fmt.Sprintf("License not found. See %s for details.", doc.URL("docs/coverage/os/conda/", "license_1")),
 						log.String("pkg", pkg.Name), log.Err(err))
 				})

--- a/pkg/fanal/analyzer/sbom/testdata/ca-certificates.spdx.json
+++ b/pkg/fanal/analyzer/sbom/testdata/ca-certificates.spdx.json
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "host",
-  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/host-1022538e-83fe-4aa7-8718-a78839114c83",
+  "documentNamespace": "http://trivy.dev/filesystem/host-1022538e-83fe-4aa7-8718-a78839114c83",
   "creationInfo": {
     "creators": [
       "Organization: aquasecurity",

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, args []string, opts flag.Options) error {
 	defer func() {
 		cancel()
 		if errors.Is(err, context.DeadlineExceeded) {
-			// e.g. https://aquasecurity.github.io/trivy/latest/docs/configuration
+			// e.g. https://trivy.dev/latest/docs/configuration
 			log.WarnContext(ctx, fmt.Sprintf("Provide a higher timeout value, see %s", doc.URL("/docs/configuration/", "")))
 		}
 	}()

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -256,7 +256,7 @@ func shouldTryOtherRepo(err error) bool {
 	for _, diagnostic := range terr.Errors {
 		// For better user experience
 		if diagnostic.Code == transport.DeniedErrorCode || diagnostic.Code == transport.UnauthorizedErrorCode {
-			// e.g. https://aquasecurity.github.io/trivy/latest/docs/references/troubleshooting/#db
+			// e.g. https://trivy.dev/latest/docs/references/troubleshooting/#db
 			log.Warnf("See %s", doc.URL("/docs/references/troubleshooting/", "db"))
 			break
 		}

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	DocumentSPDXIdentifier = "DOCUMENT"
-	DocumentNamespace      = "http://aquasecurity.github.io/trivy"
+	DocumentNamespace      = "http://trivy.dev"
 	CreatorOrganization    = "aquasecurity"
 	CreatorTool            = "trivy"
 	noneField              = "NONE"

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -884,7 +884,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "pom.xml",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/pom.xml-3ff14136-e09f-4df9-80ea-000000000004",
+				DocumentNamespace: "http://trivy.dev/filesystem/pom.xml-3ff14136-e09f-4df9-80ea-000000000004",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -170,7 +170,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "rails:latest",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000009",
+				DocumentNamespace: "http://trivy.dev/container_image/rails:latest-3ff14136-e09f-4df9-80ea-000000000009",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -492,7 +492,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "centos:latest",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000006",
+				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000006",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -725,7 +725,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "masahiro331/CVE-2021-41098",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000006",
+				DocumentNamespace: "http://trivy.dev/filesystem/masahiro331/CVE-2021-41098-3ff14136-e09f-4df9-80ea-000000000006",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -1026,7 +1026,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "log4j-core-2.17.0.jar",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/log4j-core-2.17.0.jar-3ff14136-e09f-4df9-80ea-000000000003",
+				DocumentNamespace: "http://trivy.dev/filesystem/log4j-core-2.17.0.jar-3ff14136-e09f-4df9-80ea-000000000003",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -1128,7 +1128,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "http://test-aggregate",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000003",
+				DocumentNamespace: "http://trivy.dev/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000003",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -1222,7 +1222,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "empty/path",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000002",
+				DocumentNamespace: "http://trivy.dev/filesystem/empty/path-3ff14136-e09f-4df9-80ea-000000000002",
 
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
@@ -1285,7 +1285,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "secret",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/secret-3ff14136-e09f-4df9-80ea-000000000002",
+				DocumentNamespace: "http://trivy.dev/filesystem/secret-3ff14136-e09f-4df9-80ea-000000000002",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -1357,7 +1357,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "go-artifact",
-				DocumentNamespace: "http://aquasecurity.github.io/trivy/filesystem/go-artifact-3ff14136-e09f-4df9-80ea-000000000005",
+				DocumentNamespace: "http://trivy.dev/filesystem/go-artifact-3ff14136-e09f-4df9-80ea-000000000005",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{

--- a/pkg/sbom/spdx/testdata/happy/bom.json
+++ b/pkg/sbom/spdx/testdata/happy/bom.json
@@ -8,7 +8,7 @@
 		]
 	},
 	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://aquasecurity.github.io/trivy/container/meven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
+	"documentNamespace": "http://trivy.dev/container/meven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
 	"name": "maven-test-projecct",
 	"packages": [
 		{

--- a/pkg/sbom/spdx/testdata/happy/empty-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/empty-bom.json
@@ -11,7 +11,7 @@
 	"documentDescribes": [
 		"SPDXRef-ContainerImage-7f428bd075b13fe8"
 	],
-	"documentNamespace": "http://aquasecurity.github.io/trivy/container/maven-test-project-3e87878b-eac3-4baa-af11-bdf2c5eab8ea",
+	"documentNamespace": "http://trivy.dev/container/maven-test-project-3e87878b-eac3-4baa-af11-bdf2c5eab8ea",
 	"name": "maven-test-project",
 	"packages": [
 		{

--- a/pkg/sbom/spdx/testdata/happy/os-only-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/os-only-bom.json
@@ -8,7 +8,7 @@
 		]
 	},
 	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://aquasecurity.github.io/trivy/container/maven-test-project-1a255568-e896-498f-93de-7975a5cb0212",
+	"documentNamespace": "http://trivy.dev/container/maven-test-project-1a255568-e896-498f-93de-7975a5cb0212",
 	"name": "maven-test-project",
 	"packages": [
 		{

--- a/pkg/sbom/spdx/testdata/happy/unrelated-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/unrelated-bom.json
@@ -8,7 +8,7 @@
 		]
 	},
 	"dataLicense": "CC0-1.0",
-	"documentNamespace": "http://aquasecurity.github.io/trivy/application/maven-test-project-8aa3b6db-bae7-4755-b43e-00b4bcf46410",
+	"documentNamespace": "http://trivy.dev/application/maven-test-project-8aa3b6db-bae7-4755-b43e-00b4bcf46410",
 	"name": "maven-test-project",
 	"packages": [
 		{

--- a/pkg/sbom/spdx/testdata/happy/with-files-in-relationships-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/with-files-in-relationships-bom.json
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "app",
-  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/app-8e571278-2221-4dcd-bc56-0b256210fa91",
+  "documentNamespace": "http://trivy.dev/filesystem/app-8e571278-2221-4dcd-bc56-0b256210fa91",
   "creationInfo": {
     "licenseListVersion": "",
     "creators": [

--- a/pkg/sbom/spdx/testdata/happy/with-hasfiles-bom.json
+++ b/pkg/sbom/spdx/testdata/happy/with-hasfiles-bom.json
@@ -11,7 +11,7 @@
   "documentDescribes": [
     "SPDXRef-Filesystem-13b142ca391a006e"
   ],
-  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/app-ab9e166e-7229-4d03-947e-8ffc9c60cf6f",
+  "documentNamespace": "http://trivy.dev/filesystem/app-ab9e166e-7229-4d03-947e-8ffc9c60cf6f",
   "files": [
     {
       "SPDXID": "SPDXRef-File-51bb5f929ef68877",

--- a/pkg/sbom/spdx/testdata/sad/invalid-purl.json
+++ b/pkg/sbom/spdx/testdata/sad/invalid-purl.json
@@ -8,7 +8,7 @@
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://aquasecurity.github.io/trivy/container/meven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
+  "documentNamespace": "http://trivy.dev/container/meven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
   "name": "maven-test-projecct",
   "packages": [
     {

--- a/pkg/version/doc/doc.go
+++ b/pkg/version/doc/doc.go
@@ -18,7 +18,7 @@ func BaseURL(ver string) *url.URL {
 	return &url.URL{
 		Scheme: "https",
 		Host:   "trivy.dev",
-		Path:   (ver),
+		Path:   ver,
 	}
 }
 

--- a/pkg/version/doc/doc.go
+++ b/pkg/version/doc/doc.go
@@ -17,8 +17,8 @@ func BaseURL(ver string) *url.URL {
 	ver = canonicalVersion(ver)
 	return &url.URL{
 		Scheme: "https",
-		Host:   "aquasecurity.github.io",
-		Path:   path.Join("trivy", ver),
+		Host:   "trivy.dev",
+		Path:   (ver),
 	}
 }
 

--- a/pkg/version/doc/doc_test.go
+++ b/pkg/version/doc/doc_test.go
@@ -17,32 +17,32 @@ func TestBaseURL(t *testing.T) {
 		{
 			name: "dev",
 			ver:  "dev",
-			want: "https://aquasecurity.github.io/trivy/dev",
+			want: "https://trivy.dev/dev",
 		},
 		{
 			name: "semver",
 			ver:  "0.52.0",
-			want: "https://aquasecurity.github.io/trivy/v0.52",
+			want: "https://trivy.dev/v0.52",
 		},
 		{
 			name: "with v prefix",
 			ver:  "v0.52.0",
-			want: "https://aquasecurity.github.io/trivy/v0.52",
+			want: "https://trivy.dev/v0.52",
 		},
 		{
 			name: "pre-release",
 			ver:  "0.52.0-beta1",
-			want: "https://aquasecurity.github.io/trivy/dev",
+			want: "https://trivy.dev/dev",
 		},
 		{
 			name: "non-semver",
 			ver:  "1",
-			want: "https://aquasecurity.github.io/trivy/dev",
+			want: "https://trivy.dev/dev",
 		},
 		{
 			name: "empty",
 			ver:  "",
-			want: "https://aquasecurity.github.io/trivy/dev",
+			want: "https://trivy.dev/dev",
 		},
 	}
 	for _, tt := range tests {
@@ -63,28 +63,28 @@ func TestURL(t *testing.T) {
 		{
 			name:    "path without slash",
 			rawPath: "foo",
-			want:    "https://aquasecurity.github.io/trivy/dev/foo",
+			want:    "https://trivy.dev/dev/foo",
 		},
 		{
 			name:    "path with leading slash",
 			rawPath: "/foo",
-			want:    "https://aquasecurity.github.io/trivy/dev/foo",
+			want:    "https://trivy.dev/dev/foo",
 		},
 		{
 			name:    "path with slash",
 			rawPath: "foo/bar",
-			want:    "https://aquasecurity.github.io/trivy/dev/foo/bar",
+			want:    "https://trivy.dev/dev/foo/bar",
 		},
 		{
 			name:     "path with fragment",
 			rawPath:  "foo",
 			fragment: "bar",
-			want:     "https://aquasecurity.github.io/trivy/dev/foo#bar",
+			want:     "https://trivy.dev/dev/foo#bar",
 		},
 		{
 			name:    "empty",
 			rawPath: "",
-			want:    "https://aquasecurity.github.io/trivy/dev",
+			want:    "https://trivy.dev/dev",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -52,7 +52,7 @@ var SuperSet = wire.NewSet(
 // Show warning if we use severity from another vendor
 // cf. https://github.com/aquasecurity/trivy/issues/6714
 var onceWarn = sync.OnceFunc(func() {
-	// e.g. https://aquasecurity.github.io/trivy/latest/docs/scanner/vulnerability/#severity-selection
+	// e.g. https://trivy.dev/latest/docs/scanner/vulnerability/#severity-selection
 	log.Warnf("Using severities from other vendors for some vulnerabilities. Read %s for details.", doc.URL("/docs/scanner/vulnerability/", "severity-selection"))
 })
 


### PR DESCRIPTION
## Description
update all links from `aquasecurity.github.io/trivy` to `trivy.dev`
links are found in:
- documentation 
- code comments
- SPDX SBOM