### PR TITLE
fix(flag): skip hidden flags for `--generate-default-config` command

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -358,9 +358,9 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 		log.Info("Writing the default config to trivy-default.yaml...")
 
 		hiddenFlags := flag.HiddenFlags()
-		allFlags := make(map[string]any)
 		// Viper does not have the ability to remove flags.
 		// So we only save the necessary flags and set these flags after viper.Reset
+		v := viper.New()
 		for _, k := range viper.AllKeys() {
 			// Skip the `GenerateDefaultConfigFlag` flags to avoid errors with default config file.
 			// Users often use "normal" formats instead of compliance. So we'll skip ComplianceFlag
@@ -368,15 +368,10 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 			if k == flag.GenerateDefaultConfigFlag.ConfigName || k == flag.ComplianceFlag.ConfigName || slices.Contains(hiddenFlags, k) {
 				continue
 			}
-			allFlags[k] = viper.Get(k)
+			v.Set(k, viper.Get(k))
 		}
 
-		viper.Reset()
-		for k, v := range allFlags {
-			viper.Set(k, v)
-		}
-
-		return viper.SafeWriteConfigAs("trivy-default.yaml")
+		return v.SafeWriteConfigAs("trivy-default.yaml")
 	}
 
 	r, err := NewRunner(ctx, opts)

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -362,7 +362,8 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 		// Viper does not have the ability to remove flags.
 		// So we only save the necessary flags and set these flags after viper.Reset
 		for _, k := range viper.AllKeys() {
-			// Skip the `GenerateDefaultConfigFlag` and `ComplianceFlag` flags to avoid errors with default config file.
+			// Skip the `GenerateDefaultConfigFlag` flags to avoid errors with default config file.
+			// Users often use "normal" formats instead of compliance. So we'll skip ComplianceFlag
 			// Also don't keep removed or deprecated flags to avoid confusing users.
 			if k == flag.GenerateDefaultConfigFlag.ConfigName || k == flag.ComplianceFlag.ConfigName || slices.Contains(hiddenFlags, k) {
 				continue

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -358,7 +358,7 @@ func Run(ctx context.Context, opts flag.Options, targetKind TargetKind) (err err
 		log.Info("Writing the default config to trivy-default.yaml...")
 
 		hiddenFlags := flag.HiddenFlags()
-		allFlags := map[string]any{}
+		allFlags := make(map[string]any)
 		// Viper does not have the ability to remove flags.
 		// So we only save the necessary flags and set these flags after viper.Reset
 		for _, k := range viper.AllKeys() {

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -855,4 +856,38 @@ func (a flagAliases) NormalizeFunc() func(*pflag.FlagSet, string) pflag.Normaliz
 		}
 		return pflag.NormalizedName(name)
 	}
+}
+
+func HiddenFlags() []string {
+	var allFlagGroups = []FlagGroup{
+		NewGlobalFlagGroup(),
+		NewCacheFlagGroup(),
+		NewCleanFlagGroup(),
+		NewClientFlags(),
+		NewDBFlagGroup(),
+		NewImageFlagGroup(),
+		NewK8sFlagGroup(),
+		NewLicenseFlagGroup(),
+		NewMisconfFlagGroup(),
+		NewModuleFlagGroup(),
+		NewPackageFlagGroup(),
+		NewRegistryFlagGroup(),
+		NewRegoFlagGroup(),
+		NewReportFlagGroup(),
+		NewRepoFlagGroup(),
+		NewScanFlagGroup(),
+		NewSecretFlagGroup(),
+		NewServerFlags(),
+		NewVulnerabilityFlagGroup(),
+	}
+
+	var hiddenFlags []string
+	for _, flagGroup := range allFlagGroups {
+		for _, flag := range flagGroup.Flags() {
+			if !reflect.ValueOf(flag).IsNil() && flag.Hidden() {
+				hiddenFlags = append(hiddenFlags, flag.GetConfigName())
+			}
+		}
+	}
+	return hiddenFlags
 }


### PR DESCRIPTION
## Description
Currently we include all flags in the default config.
But Trivy returns an error for removed flags.

Unfortunately `viper` has no options to remove flags, so we need to reset viper and add the required flags to `--generate-default-config`

Before:
```
➜  trivy image --generate-default-config && cat trivy-default.yaml | grep reset
2024-12-04T17:35:49+06:00       INFO    Writing the default config to trivy-default.yaml...
    reset-checks-bundle: false
reset: false
```

After:
```                                                             
➜  ./trivy image --generate-default-config && cat trivy-default.yaml | grep reset
2024-12-04T17:36:18+06:00       INFO    Writing the default config to trivy-default.yaml...

```

## Related issues
- Close #8043

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
