### PR TITLE
fix(java): correctly overwrite version from depManagement if dependency uses `project.*` props

### DIFF
--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1471,6 +1471,52 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "overwrite artifact version from dependencyManagement in the root POM when dependency uses `project.*` props",
+			inputFile: filepath.Join("testdata", "root-pom-dep-management-for-deps-with-project-props", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:root-pom-dep-management-for-deps-with-project-props:1.0.0",
+					Name:         "com.example:root-pom-dep-management-for-deps-with-project-props",
+					Version:      "1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+				{
+					ID:           "org.example:example-dependency:1.7.30",
+					Name:         "org.example:example-dependency",
+					Version:      "1.7.30",
+					Relationship: ftypes.RelationshipDirect,
+					Locations: ftypes.Locations{
+						{
+							StartLine: 21,
+							EndLine:   25,
+						},
+					},
+				},
+				{
+					ID:           "org.example:example-api:2.0.0",
+					Name:         "org.example:example-api",
+					Version:      "2.0.0",
+					Licenses:     []string{"The Apache Software License, Version 2.0"},
+					Relationship: ftypes.RelationshipIndirect,
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID: "com.example:root-pom-dep-management-for-deps-with-project-props:1.0.0",
+					DependsOn: []string{
+						"org.example:example-dependency:1.7.30",
+					},
+				},
+				{
+					ID: "org.example:example-dependency:1.7.30",
+					DependsOn: []string{
+						"org.example:example-api:2.0.0",
+					},
+				},
+			},
+		},
+		{
 			name:      "transitive dependencyManagement should not be inherited",
 			inputFile: filepath.Join("testdata", "transitive-dependency-management", "pom.xml"),
 			local:     true,

--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -245,7 +245,7 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 
 	// If this dependency is managed in the root POM,
 	// we need to overwrite fields according to the managed dependency.
-	if managed, found := findDep(d.Name(), rootDepManagement); found { // dependencyManagement from the root POM
+	if managed, found := findDep(dep.Name(), rootDepManagement); found { // dependencyManagement from the root POM
 		if managed.Version != "" {
 			dep.Version = evaluateVariable(managed.Version, props, nil)
 		}
@@ -264,7 +264,7 @@ func (d pomDependency) Resolve(props map[string]string, depManagement, rootDepMa
 	}
 
 	// Inherit version, scope and optional from dependencyManagement if empty
-	if managed, found := findDep(d.Name(), depManagement); found { // dependencyManagement from parent
+	if managed, found := findDep(dep.Name(), depManagement); found { // dependencyManagement from parent
 		if dep.Version == "" {
 			dep.Version = evaluateVariable(managed.Version, props, nil)
 		}

--- a/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-dependency/1.7.30/example-dependency-1.7.30.pom
+++ b/pkg/dependency/parser/java/pom/testdata/repository/org/example/example-dependency/1.7.30/example-dependency-1.7.30.pom
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>example-dependency</artifactId>
+    <version>1.7.30</version>
+
+    <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>example-api</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/root-pom-dep-management-for-deps-with-project-props/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/root-pom-dep-management-for-deps-with-project-props/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>root-pom-dep-management-for-deps-with-project-props</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>example-api</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
## Description
We should use resolved dependencies (with replaceable properties) to find dependencies in depManagements.

example:
pom file:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>com.bbb.aaa</groupId>
    <artifactId>aaa</artifactId>
    <version>1.0.0</version>
    <packaging>pom</packaging>
    <name>aaa</name>
    <description>desc</description>

    <parent>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-parent</artifactId>
        <version>3.2.11</version>
        <relativePath />
    </parent>

    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>io.netty</groupId>
                <artifactId>netty-common</artifactId>
                <version>4.1.115.Final</version>
            </dependency>
        </dependencies>
    </dependencyManagement>

    <dependencies>
        <dependency>
            <groupId>io.projectreactor.netty</groupId>
            <artifactId>reactor-netty-core</artifactId>
            <version>1.1.23</version>
            <scope>runtime</scope>
        </dependency>
    </dependencies>
</project>
```
changes:
```
➜ diff <(trivy -q fs . --list-all-pkgs -f json | grep '"ID": "io.netty:netty-') <(./trivy -q fs . --list-all-pkgs -f json | grep '"ID": "io.netty:netty-')
6c6
<           "ID": "io.netty:netty-common:4.1.114.Final",
---
>           "ID": "io.netty:netty-common:4.1.115.Final",
```

## Related issues
- Close #8049

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
