### PR TITLE
fix(sbom): fix wrong overwriting of applications obtained from different sbom files but having same app type

### DIFF
--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -49,6 +50,14 @@ func (a sbomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput)
 	// ref: https://github.com/bitnami/vulndb#how-to-consume-this-cve-feed
 	if strings.HasPrefix(input.FilePath, "opt/bitnami/") {
 		handleBitnamiImages(path.Dir(input.FilePath), bom)
+	}
+
+	// FilePath for apps with aggregatingTypes is empty.
+	// Set the SBOM file path as Application.FilePath to correctly overwrite applications when merging layers.
+	for i, app := range bom.Applications {
+		if slices.Contains(ftypes.AggregatingTypes, app.Type) && app.FilePath == "" {
+			bom.Applications[i].FilePath = input.FilePath
+		}
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/sbom/sbom_test.go
+++ b/pkg/fanal/analyzer/sbom/sbom_test.go
@@ -28,7 +28,34 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 			want: &analyzer.AnalysisResult{
 				Applications: []types.Application{
 					{
-						Type: types.Jar,
+						Type:     types.Bitnami,
+						FilePath: "opt/bitnami/elasticsearch",
+						Packages: types.Packages{
+							{
+								ID:       "elasticsearch@8.9.1",
+								Name:     "elasticsearch",
+								Version:  "8.9.1",
+								Arch:     "arm64",
+								Licenses: []string{"Elastic-2.0"},
+								Identifier: types.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypeBitnami,
+										Name:    "elasticsearch",
+										Version: "8.9.1",
+										Qualifiers: packageurl.Qualifiers{
+											{
+												Key:   "arch",
+												Value: "arm64",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type:     types.Jar,
+						FilePath: "opt/bitnami/elasticsearch/.spdx-elasticsearch.spdx",
 						Packages: types.Packages{
 							{
 								ID:       "co.elastic.apm:apm-agent:1.36.0",
@@ -88,32 +115,6 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 							},
 						},
 					},
-					{
-						Type:     types.Bitnami,
-						FilePath: "opt/bitnami/elasticsearch",
-						Packages: types.Packages{
-							{
-								ID:       "elasticsearch@8.9.1",
-								Name:     "elasticsearch",
-								Version:  "8.9.1",
-								Arch:     "arm64",
-								Licenses: []string{"Elastic-2.0"},
-								Identifier: types.PkgIdentifier{
-									PURL: &packageurl.PackageURL{
-										Type:    packageurl.TypeBitnami,
-										Name:    "elasticsearch",
-										Version: "8.9.1",
-										Qualifiers: packageurl.Qualifiers{
-											{
-												Key:   "arch",
-												Value: "arm64",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 			wantErr: require.NoError,
@@ -125,7 +126,8 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 			want: &analyzer.AnalysisResult{
 				Applications: []types.Application{
 					{
-						Type: types.Jar,
+						Type:     types.Jar,
+						FilePath: "opt/bitnami/elasticsearch/.spdx-elasticsearch.cdx",
 						Packages: types.Packages{
 							{
 								FilePath: "opt/bitnami/elasticsearch/modules/apm/elastic-apm-agent-1.36.0.jar",


### PR DESCRIPTION
## Description
We don't save `FilePath` for app with aggregatedTypes.
That is why we overwrite apps with same types.
See more in #7851

This PR adds filepath (path to the SBOM file) for Apps got from SBOM analyzer.
This helps with overwriting when merging layers.


Example:
```Dockerfile
FROM alpine

COPY ./api/report-api.spdx.json /api/report-api.spdx.json

COPY ./core/report-core.spdx.json /core/report-core.spdx.json
```
before:
```bash
➜ trivy -q image test:7846 -f json --list-all-pkgs --pkg-types library --cache-backend memory | grep -E '"ID"|"FilePath"'
          "ID": "org.apache.logging.log4j:log4j-core:2.24.1",
          "FilePath": "log4j-core-2.24.1.jar"

```
after:
```bash
➜ ./trivy -q image test:7846 -f json --list-all-pkgs --pkg-types library --cache-backend memory | grep -E '"ID"|"FilePath"'
          "ID": "org.apache.logging.log4j:log4j-api:2.24.1",
          "FilePath": "log4j-api-2.24.1.jar"
          "ID": "org.apache.logging.log4j:log4j-core:2.24.1",
          "FilePath": "log4j-core-2.24.1.jar"
```

## Related issues
- Close #7851

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
