### PR TITLE
fix: handle `BLOW_UNKNOWN` error to download DBs

### DIFF
--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -262,6 +262,19 @@ func shouldTryOtherRepo(err error) bool {
 		}
 	}
 
-	// try the following artifact only if a temporary error occurs
-	return terr.Temporary()
+	// try the following artifact if a temporary error occurs
+	if terr.Temporary() {
+		return true
+	}
+
+	// `GCR` periodically returns `BLOB_UNKNOWN` error.
+	// cf. https://github.com/aquasecurity/trivy/discussions/8020
+	// In this case we need to check other repositories.
+	for _, e := range terr.Errors {
+		if e.Code == transport.BlobUnknownErrorCode {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Description
We found that `GCR` periodically returns `BLOW_UNKNOWN` error - #8020
We assume that this is related to their cache.

But in any case, we need to handle this error and check other repositories if loading a repository returns `BLOW_UNKNOWN` error.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
