### PR TITLE
feat: add a examples field to check metadata

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -39,6 +39,7 @@ type StaticMetadata struct {
 	Library            bool
 	CloudFormation     *scan.EngineMetadata
 	Terraform          *scan.EngineMetadata
+	Examples           string
 }
 
 func NewStaticMetadata(pkgPath string, inputOpt InputOptions) *StaticMetadata {
@@ -75,6 +76,7 @@ func (sm *StaticMetadata) update(meta map[string]any) error {
 	upd(&sm.Provider, "provider")
 	upd(&sm.RecommendedActions, "recommended_actions")
 	upd(&sm.RecommendedActions, "recommended_action")
+	upd(&sm.Examples, "examples")
 
 	if raw, ok := meta["deprecated"]; ok {
 		if dep, ok := raw.(bool); ok {
@@ -269,6 +271,7 @@ func (m StaticMetadata) ToRule() scan.Rule {
 		Frameworks:     m.Frameworks,
 		CloudFormation: m.CloudFormation,
 		Terraform:      m.Terraform,
+		Examples:       m.Examples,
 	}
 }
 

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -50,6 +50,7 @@ type Rule struct {
 	Severity       severity.Severity                `json:"severity"`
 	Terraform      *EngineMetadata                  `json:"terraform,omitempty"`
 	CloudFormation *EngineMetadata                  `json:"cloud_formation,omitempty"`
+	Examples       string                           `json:"-"`
 	CustomChecks   CustomChecks                     `json:"-"`
 	RegoPackage    string                           `json:"-"`
 	Frameworks     map[framework.Framework][]string `json:"frameworks"`


### PR DESCRIPTION
## Description

Previously, examples for checks were stored in separate files for each provider. For example, the examples for Terraform `<name>` checks were in the `<name>.tf.go` file, and the examples for CloudFormation were in` <name>.cf.go`. With the discontinuation of support for Go checks, there is no longer a need to store examples in Go files as it makes them harder to retrieve. Therefore, the examples for each check have been moved from Go to YAML with a new schema:

```yaml
cloudformation:
  good:
    - |-
       ...
  bad:
    - |-
       ...
terraform:
  good:
    - |-
       ...
  bad:
    - |-
       ...
```

Currently, the check metadata includes fields for each provider with the same structure:
```
#   terraform:
#     good_examples: checks/cloud/aws/s3/enable_bucket_logging.yaml
#     links:
#       - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
#   cloud_formation:
#     good_examples: checks/cloud/aws/s3/enable_bucket_logging.yaml
```

I have an idea to convert [test data](https://github.com/aquasecurity/trivy-checks/tree/main/test/testdata) for Dockerfile and Kubernetes into examples for integration testing and display on a website. ([draft PR](https://github.com/aquasecurity/trivy-checks/pull/300)). However, the current approach when adding a new provider requires the following steps:
1. Add support for the new provider to the metadata in the Trivy repository.
2. Add a new provider to the metadata of each check.


This process is awkward and inflexible. To simplify it, I propose to introduce a new `examples` field, which will contain the path to the file with examples to check, replacing the current fields with providers:
```
#   examples: checks/cloud/aws/s3/enable_bucket_logging.yaml
```

Along with this, the structure of the example file can be updated to make it more flexible:
```yaml
providers:
  cloudformation:
    examples:
      good:
        - code: |-
            ...
      bad:
        - code: |-
            ...
  terraform:
    links:
      - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
    examples:
      good:
        - code: |-
            ...
```


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
