### PR TITLE
feat: allow restricting filesystem walk to specific folders

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -36,6 +36,7 @@ trivy config [flags] DIR
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan-json,terraformplan-snapshot])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -65,6 +65,7 @@ trivy filesystem [flags] PATH
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -83,6 +83,7 @@ trivy image [flags] IMAGE_NAME
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -80,6 +80,7 @@ trivy kubernetes [flags] [CONTEXT]
       --node-collector-imageref string    indicate the image reference for the node-collector scan job (default "ghcr.io/aquasecurity/node-collector:0.3.1")
       --node-collector-namespace string   specify the namespace in which the node-collector job should be deployed (default "trivy-temp")
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -64,6 +64,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -67,6 +67,7 @@ trivy rootfs [flags] ROOTDIR
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -46,6 +46,7 @@ trivy sbom [flags] SBOM_PATH
       --list-all-pkgs                output all packages in the JSON report regardless of vulnerability
       --no-progress                  suppress progress bar
       --offline-scan                 do not issue API requests to identify dependencies
+      --only-dirs strings            specify the directories where the traversal is allowed
   -o, --output string                output file name
       --output-plugin-arg string     [EXPERIMENTAL] output plugin arguments
       --password strings             password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -59,6 +59,7 @@ trivy vm [flags] VM_IMAGE
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar
       --offline-scan                      do not issue API requests to identify dependencies
+      --only-dirs strings                 specify the directories where the traversal is allowed
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)

--- a/pkg/cache/key.go
+++ b/pkg/cache/key.go
@@ -30,6 +30,7 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 		HookVersions      map[string]int
 		SkipFiles         []string
 		SkipDirs          []string
+		OnlyDirs          []string
 		FilePatterns      []string                `json:",omitempty"`
 		DetectionPriority types.DetectionPriority `json:",omitempty"`
 	}{
@@ -38,6 +39,7 @@ func CalcKey(id string, analyzerVersions analyzer.Versions, hookVersions map[str
 		hookVersions,
 		artifactOpt.WalkerOption.SkipFiles,
 		artifactOpt.WalkerOption.SkipDirs,
+		artifactOpt.WalkerOption.OnlyDirs,
 		artifactOpt.FilePatterns,
 		artifactOpt.DetectionPriority,
 	}

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -668,6 +668,7 @@ func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 		SkipDirs:     flag.SkipDirsFlag.Clone(),
 		SkipFiles:    flag.SkipFilesFlag.Clone(),
 		FilePatterns: flag.FilePatternsFlag.Clone(),
+		OnlyDirs:     flag.OnlyDirsFlag.Clone(),
 	}
 
 	configFlags := &flag.Flags{

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -607,6 +607,7 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 			WalkerOption: walker.Option{
 				SkipFiles: opts.SkipFiles,
 				SkipDirs:  opts.SkipDirs,
+				OnlyDirs:  opts.OnlyDirs,
 			},
 		},
 	}, scanOptions, nil

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -73,6 +73,7 @@ func (o *Option) Sort() {
 	})
 	sort.Strings(o.WalkerOption.SkipFiles)
 	sort.Strings(o.WalkerOption.SkipDirs)
+	sort.Strings(o.WalkerOption.OnlyDirs)
 	sort.Strings(o.FilePatterns)
 }
 

--- a/pkg/fanal/utils/utils.go
+++ b/pkg/fanal/utils/utils.go
@@ -125,6 +125,32 @@ func SkipPath(path string, skipPaths []string) bool {
 	return false
 }
 
+func OnlyPath(path string, onlyPaths []string) bool {
+	if len(onlyPaths) == 0 {
+		return false
+	}
+
+	if path == "" || path == "." {
+		return false
+	}
+
+	path = strings.TrimLeft(path, "/")
+
+	for _, pattern := range onlyPaths {
+		if strings.HasPrefix(pattern, path+"/") {
+			return false
+		}
+		match, err := doublestar.Match(pattern, path)
+		if err != nil {
+			return false // return early if bad pattern
+		} else if match {
+			return false
+		}
+	}
+	log.Debug("Skipping path", log.String("path", path))
+	return true
+}
+
 func ExtractPrintableBytes(content xio.ReadSeekerAt) ([]byte, error) {
 	const minLength = 4 // Minimum length of strings to extract
 	var result []byte

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -26,6 +26,7 @@ func (w *FS) Walk(root string, opt Option, fn WalkFunc) error {
 	opt.SkipFiles = w.BuildSkipPaths(root, opt.SkipFiles)
 	opt.SkipDirs = w.BuildSkipPaths(root, opt.SkipDirs)
 	opt.SkipDirs = append(opt.SkipDirs, defaultSkipDirs...)
+	opt.OnlyDirs = w.BuildSkipPaths(root, opt.OnlyDirs)
 
 	walkDirFunc := w.WalkDirFunc(root, fn, opt)
 	walkDirFunc = w.onError(walkDirFunc)
@@ -57,10 +58,15 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 			if utils.SkipPath(relPath, opt.SkipDirs) {
 				return filepath.SkipDir
 			}
+			if utils.OnlyPath(relPath, opt.OnlyDirs) {
+				return filepath.SkipDir
+			}
 			return nil
 		case !d.Type().IsRegular():
 			return nil
 		case utils.SkipPath(relPath, opt.SkipFiles):
+			return nil
+		case utils.OnlyPath(relPath, opt.OnlyDirs):
 			return nil
 		}
 

--- a/pkg/fanal/walker/tar.go
+++ b/pkg/fanal/walker/tar.go
@@ -23,12 +23,14 @@ var parentDir = ".." + utils.PathSeparator
 type LayerTar struct {
 	skipFiles []string
 	skipDirs  []string
+	onlyDirs  []string
 }
 
 func NewLayerTar(opt Option) LayerTar {
 	return LayerTar{
 		skipFiles: utils.CleanSkipPaths(opt.SkipFiles),
 		skipDirs:  utils.CleanSkipPaths(opt.SkipDirs),
+		onlyDirs:  utils.CleanSkipPaths(opt.OnlyDirs),
 	}
 }
 

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -18,6 +18,8 @@ var defaultSkipDirs = []string{
 type Option struct {
 	SkipFiles []string
 	SkipDirs  []string
+	OnlyDirs  []string
 }
 
 type WalkFunc func(filePath string, info os.FileInfo, opener analyzer.Opener) error
+

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -31,6 +31,12 @@ var (
 		ConfigName: "scan.offline",
 		Usage:      "do not issue API requests to identify dependencies",
 	}
+	OnlyDirsFlag = Flag[[]string]{
+		Name:       "only-dirs",
+		ConfigName: "scan.only-dirs",
+		Default:    []string{},
+		Usage:      "specify the directories where the traversal is allowed",
+	}
 	ScannersFlag = Flag[[]string]{
 		Name:       "scanners",
 		ConfigName: "scan.scanners",
@@ -123,6 +129,7 @@ var (
 type ScanFlagGroup struct {
 	SkipDirs          *Flag[[]string]
 	SkipFiles         *Flag[[]string]
+	OnlyDirs          *Flag[[]string]
 	OfflineScan       *Flag[bool]
 	Scanners          *Flag[[]string]
 	FilePatterns      *Flag[[]string]
@@ -138,6 +145,7 @@ type ScanOptions struct {
 	Target            string
 	SkipDirs          []string
 	SkipFiles         []string
+	OnlyDirs          []string
 	OfflineScan       bool
 	Scanners          types.Scanners
 	FilePatterns      []string
@@ -152,6 +160,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
 		SkipDirs:          SkipDirsFlag.Clone(),
 		SkipFiles:         SkipFilesFlag.Clone(),
+		OnlyDirs:          OnlyDirsFlag.Clone(),
 		OfflineScan:       OfflineScanFlag.Clone(),
 		Scanners:          ScannersFlag.Clone(),
 		FilePatterns:      FilePatternsFlag.Clone(),
@@ -172,6 +181,7 @@ func (f *ScanFlagGroup) Flags() []Flagger {
 	return []Flagger{
 		f.SkipDirs,
 		f.SkipFiles,
+		f.OnlyDirs,
 		f.OfflineScan,
 		f.Scanners,
 		f.FilePatterns,
@@ -216,6 +226,7 @@ func (f *ScanFlagGroup) ToOptions(args []string) (ScanOptions, error) {
 		Target:            target,
 		SkipDirs:          f.SkipDirs.Value(),
 		SkipFiles:         f.SkipFiles.Value(),
+		OnlyDirs:          f.OnlyDirs.Value(),
 		OfflineScan:       f.OfflineScan.Value(),
 		Scanners:          xstrings.ToTSlice[types.Scanner](f.Scanners.Value()),
 		FilePatterns:      f.FilePatterns.Value(),

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -16,6 +16,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 	type fields struct {
 		skipDirs    []string
 		skipFiles   []string
+		onlyDirs    []string
 		offlineScan bool
 		scanners    string
 		distro      string
@@ -134,6 +135,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			t.Cleanup(viper.Reset)
 			setSliceValue(flag.SkipDirsFlag.ConfigName, tt.fields.skipDirs)
 			setSliceValue(flag.SkipFilesFlag.ConfigName, tt.fields.skipFiles)
+			setSliceValue(flag.OnlyDirsFlag.ConfigName, tt.fields.onlyDirs)
 			setValue(flag.OfflineScanFlag.ConfigName, tt.fields.offlineScan)
 			setValue(flag.ScannersFlag.ConfigName, tt.fields.scanners)
 			setValue(flag.DistroFlag.ConfigName, tt.fields.distro)
@@ -142,6 +144,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			f := &flag.ScanFlagGroup{
 				SkipDirs:    flag.SkipDirsFlag.Clone(),
 				SkipFiles:   flag.SkipFilesFlag.Clone(),
+				OnlyDirs:    flag.OnlyDirsFlag.Clone(),
 				OfflineScan: flag.OfflineScanFlag.Clone(),
 				Scanners:    flag.ScannersFlag.Clone(),
 				DistroFlag:  flag.DistroFlag.Clone(),


### PR DESCRIPTION
## Description

This change adds a new `OnlyDirs` parameter to the walker to only analyze the files located in a specified set of folders.

This can greatly improve the performance when a specific set of analyzers is used and the required paths for these analyzers are known.

This new parameter is analogous to the existing `SkipDirs` and `SkipFiles` parameters, but works the opposite way.
The paths follow the same syntax rules as the existing `SkipDirs` and `SkipFiles` parameters.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
