### PR TITLE
fix(license): always trim leading and trailing spaces for licenses

### DIFF
--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -641,7 +641,6 @@ var plusSuffixes = [3]string{"+", "-OR-LATER", " OR LATER"}
 func standardizeKeyAndSuffix(name string) expr.SimpleExpr {
 	// Standardize space, including newline
 	name = strings.Join(strings.Fields(name), " ")
-	name = strings.TrimSpace(name)
 	name = strings.ToUpper(name)
 	// Do not perform any further normalization for URLs
 	if strings.HasPrefix(name, "HTTP") {
@@ -679,6 +678,8 @@ func Normalize(name string) string {
 }
 
 func NormalizeLicense(name string) expr.SimpleExpr {
+	// Always trim leading and trailing spaces, even if we don't find this license in `mapping`.
+	name = strings.TrimSpace(name)
 	normalized := standardizeKeyAndSuffix(name)
 	if found, ok := mapping[normalized.License]; ok {
 		return expr.SimpleExpr{License: found.License, HasPlus: found.HasPlus || normalized.HasPlus}

--- a/pkg/licensing/normalize_test.go
+++ b/pkg/licensing/normalize_test.go
@@ -206,8 +206,8 @@ func TestNormalize(t *testing.T) {
 			licenses: []string{
 				" The unmapped license ",
 			},
-			normalized:    " The unmapped license ",
-			normalizedKey: " The unmapped license ",
+			normalized:    "The unmapped license",
+			normalizedKey: "The unmapped license",
 		},
 		{
 			licenses: []string{


### PR DESCRIPTION
## Description
See #8094

example:
test pom.xml file:
```xml
    <licenses>
        <license>
            <name>
                Dual license consisting of the CDDL v1.1 and GPL v2
            </name>
            <url>https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html</url>
            <distribution>repo</distribution>
        </license>
    </licenses>
```
Before:
```bash
➜ trivy -q fs --scanners license /Users/dmitriy/work/tmp/8086/pom.xml -f json | grep '"Name"'
          "Name": "\n                Dual license consisting of the CDDL v1.1 and GPL v2\n            ",
          "Name": "CDDL-1.0",
```
After:
```bash
➜ ./trivy -q fs --scanners license /Users/dmitriy/work/tmp/8086/pom.xml -f json | grep '"Name"'
          "Name": "Dual license consisting of the CDDL v1.1 and GPL v2",
          "Name": "CDDL-1.0",
```

## Related issues
- Close #8094

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
