### PR TITLE
fix: wasm module test

### DIFF
--- a/pkg/module/wasm/sdk.go
+++ b/pkg/module/wasm/sdk.go
@@ -140,8 +140,8 @@ func marshal(v any) uint64 {
 }
 
 func unmarshal(ptr, size uint32, v any) error {
-	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), size)
-	if err := json.Unmarshal(b, v); err != nil {
+	s := ptrToString(ptr, size)
+	if err := json.Unmarshal([]byte(s), v); err != nil {
 		return fmt.Errorf("unmarshal error: %s", err)
 	}
 	return nil

--- a/pkg/module/wasm/sdk.go
+++ b/pkg/module/wasm/sdk.go
@@ -8,7 +8,6 @@ package wasm
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"github.com/aquasecurity/trivy/pkg/module/api"
@@ -141,28 +140,17 @@ func marshal(v any) uint64 {
 }
 
 func unmarshal(ptr, size uint32, v any) error {
-	var b []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	s.Len = uintptr(size)
-	s.Cap = uintptr(size)
-	s.Data = uintptr(ptr)
-
+	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), size)
 	if err := json.Unmarshal(b, v); err != nil {
 		return fmt.Errorf("unmarshal error: %s", err)
 	}
-
 	return nil
 }
 
 // ptrToString returns a string from WebAssembly compatible numeric types representing its pointer and length.
 func ptrToString(ptr uint32, size uint32) string {
-	// Get a slice view of the underlying bytes in the stream. We use SliceHeader, not StringHeader
-	// as it allows us to fix the capacity to what was allocated.
-	return *(*string)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(ptr),
-		Len:  uintptr(size), // Tinygo requires these as uintptrs even if they are int fields.
-		Cap:  uintptr(size), // ^^ See https://github.com/tinygo-org/tinygo/issues/1284
-	}))
+	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), size)
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 // stringToPtr returns a pointer and size pair for the given string in a way compatible with WebAssembly numeric types.


### PR DESCRIPTION
## Description

I saw that the [build in another PR failed](https://github.com/aquasecurity/trivy/actions/runs/12158773997/job/33907438365?pr=8045), and wanted to investigate. I could reproduce it on my laptop also when pulling latest `main`. However no other workflow fails which I'm not sure why.

Error: 

```
~/dev/trivy ❯ mage test:generatemodules
 # github.com/aquasecurity/trivy/pkg/module/wasm
../../wasm/sdk.go:146:10: cannot use uintptr(size) (value of type uintptr) as int value in assignment 
../../wasm/sdk.go:147:10: cannot use uintptr(size) (value of type uintptr) as int value in assignment 
../../wasm/sdk.go:163:9: cannot use uintptr(size) (value of type uintptr) as int value in struct literal
 ../../wasm/sdk.go:164:9: cannot use uintptr(size) (value of type uintptr) as int value in struct literal 
pkg/module/testdata/analyzer/analyzer.go:1: running "tinygo": exit status 1 
Error: running "go generate pkg/module/testdata/analyzer/analyzer.go" failed with exit code 1
```

I'm not an expert in this :) , let me know if I got it right:
Offending code is trying to convert ptr/size pair from wasm world into a Go string.
[tinygo docs says](https://tinygo.org/docs/guides/compatibility/) that Go's `SliceHeader`'s  `Len` and `Cap` are `int` and in tinygo they are `uintptr` (this is by design).
But the error tells us that when it tried to assign `size`, it got it as `uintptr` but it expected `int` (as if it is building with Go). Not sure how this happens becuase this code has a build constraint of `tinygo.wasm`.

Anyway, the same doc says we should no longer use `SliceHeader` (it's deprecated) and instead use `unsafe.Slice`. I noticed there is also now an `unsafe.String` which sounds even more fitting for this use case.
So I changed the offending code to use it and it now compiles (and also unit tests succeed).

As a side, this error occurs twice, but it seems like with a small refactor we can reuse the code, so I added a second commit that does that.

I'm still unsure of:
1. why only this PR fails and other don't
2. why my main is failing while others not (maybe tinygo version? I'm on `tinygo version 0.34.0 darwin/arm64 (using go version go1.23.1 and LLVM version 18.1.2)`)
3. why this code fails for a behavior that looks like was trying to compile using Go and not tinygo.