### PR TITLE
test: set dummy value for NUGET_PACKAGES

### DIFF
--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -16,6 +16,7 @@ import (
 
 // TestRepository tests `trivy repo` with the local code repositories
 func TestRepository(t *testing.T) {
+	t.Setenv("NUGET_PACKAGES", "/tmp/fake_nuget_packages")
 	type args struct {
 		scanner        types.Scanner
 		ignoreIDs      []string

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestRepository tests `trivy repo` with the local code repositories
 func TestRepository(t *testing.T) {
-	t.Setenv("NUGET_PACKAGES", "/tmp/fake_nuget_packages")
+	t.Setenv("NUGET_PACKAGES", t.TempDir())
 	type args struct {
 		scanner        types.Scanner
 		ignoreIDs      []string


### PR DESCRIPTION
## Description

Tests for `nuget` may fail if the packages used in the tests are located on the developer's machine in the ~/.nuget/packages or `NUGET_PACKAGES` directory, since the analyser uses this directory to search for licenses:

```bash
--- FAIL: TestRepository (8.14s)
    --- FAIL: TestRepository/nuget (0.01s)
        /Users/nikita/projects/trivy/integration/integration_test.go:304: 
...
            	            	-     Licenses: ([]string) <nil>,
            	            	+     Licenses: ([]string) (len=1) {
            	            	+      (string) (len=3) "MIT"
            	            	+     },
...
```

This PR sets a dummy value for the `NUGET_PACKAGES` environment variable.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
