### PR TITLE
fix(misconf): allow null values only for tf variables

### DIFF
--- a/pkg/iac/scanners/terraform/parser/load_module.go
+++ b/pkg/iac/scanners/terraform/parser/load_module.go
@@ -25,7 +25,7 @@ type ModuleDefinition struct {
 }
 
 func (d *ModuleDefinition) inputVars() map[string]cty.Value {
-	inputs := d.Definition.Values().AsValueMap()
+	inputs := d.Definition.NullableValues().AsValueMap()
 	if inputs == nil {
 		return make(map[string]cty.Value)
 	}

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -569,13 +569,25 @@ func (b *Block) Attributes() map[string]*Attribute {
 	return attributes
 }
 
+func (b *Block) NullableValues() cty.Value {
+	return b.values(true)
+}
+
 func (b *Block) Values() cty.Value {
+	return b.values(false)
+}
+
+func (b *Block) values(allowNull bool) cty.Value {
 	values := createPresetValues(b)
 	for _, attribute := range b.GetAttributes() {
 		if attribute.Name() == "for_each" {
 			continue
 		}
-		values[attribute.Name()] = attribute.NullableValue()
+		if allowNull {
+			values[attribute.Name()] = attribute.NullableValue()
+		} else {
+			values[attribute.Name()] = attribute.Value()
+		}
 	}
 	return cty.ObjectVal(postProcessValues(b, values))
 }


### PR DESCRIPTION
## Description
We should only use null values for variables to preserve the type when passing them to modules. 

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8093

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
