### PR TITLE
feat(misconf): support for ignoring by inline comments for Dockerfile

### DIFF
--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -449,9 +449,9 @@ From the Terraform [docs](https://developer.hashicorp.com/terraform/cli/config/c
 If multiple variables evaluate to the same hostname, Trivy will choose the environment variable name where the dashes have not been encoded as double underscores.
 
 
-### Skipping resources by inline comments
+### Skipping detected misconfigurations by inline comments
 
-Trivy supports ignoring misconfigured resources by inline comments for Terraform, CloudFormation and Helm configuration files only.
+Trivy supports ignoring detected misconfigurations by inline comments for Terraform, CloudFormation (YAML), Helm and Dockerfile configuration files only.
 
 In cases where Trivy can detect comments of a specific format immediately adjacent to resource definitions, it is possible to ignore findings from a single source of resource definition (in contrast to `.trivyignore`, which has a directory-wide scope on all of the files scanned). The format for these comments is `trivy:ignore:<rule>` immediately following the format-specific line-comment [token](https://developer.hashicorp.com/terraform/language/syntax/configuration#comments).
 
@@ -517,6 +517,13 @@ Example for Helm:
             runAsGroup: 3000
           image: "your-repository/your-image:your-tag"
           imagePullPolicy: "Always"
+```
+
+Example for Dockerfile:
+```Dockerfile
+FROM scratch
+# trivy:ignore:AVD-DS-0022
+MAINTAINER moby@example.com
 ```
 
 #### Expiration Date

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -3,7 +3,9 @@ package dockerfile_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -629,4 +631,74 @@ COPY --from=dep /binary /`
 		})
 	}
 
+}
+
+func Test_IgnoreByInlineComments(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected bool
+	}{
+		{
+			name: "without ignore rule",
+			src: `FROM scratch
+MAINTAINER moby@example.com`,
+			expected: true,
+		},
+		{
+			name: "with ignore rule",
+			src: `FROM scratch
+# trivy:ignore:USER-TEST-0001
+MAINTAINER moby@example.com`,
+			expected: false,
+		},
+	}
+
+	check := `# METADATA
+# title: test
+# schemas:
+# - input: schema["dockerfile"]
+# custom:
+#   avd_id: USER-TEST-0001
+#   short_code: maintainer-deprecated
+#   input:
+#     selector:
+#     - type: dockerfile
+package user.test0001
+
+import rego.v1
+
+get_maintainer contains cmd if {
+	cmd := input.Stages[_].Commands[_]
+	cmd.Cmd == "maintainer"
+}
+
+deny contains res if {
+	cmd := get_maintainer[_]
+	msg := sprintf("MAINTAINER should not be used: 'MAINTAINER %s'", [cmd.Value[0]])
+	res := result.new(msg, cmd)
+}
+`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsys := fstest.MapFS{
+				"Dockerfile": &fstest.MapFile{Data: []byte(tt.src)},
+			}
+
+			scanner := dockerfile.NewScanner(
+				rego.WithPolicyReader(strings.NewReader(check)),
+				rego.WithPolicyNamespaces("user"),
+				rego.WithEmbeddedLibraries(true),
+				rego.WithRegoErrorLimits(0),
+			)
+			results, err := scanner.ScanFS(context.TODO(), fsys, ".")
+			require.NoError(t, err)
+			if tt.expected {
+				testutil.AssertRuleFound(t, "dockerfile-general-maintainer-deprecated", results, "")
+			} else {
+				testutil.AssertRuleNotFailed(t, "dockerfile-general-maintainer-deprecated", results, "")
+			}
+		})
+	}
 }

--- a/pkg/iac/scanners/generic/scanner.go
+++ b/pkg/iac/scanners/generic/scanner.go
@@ -12,8 +12,10 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/toml"
+	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
 
+	"github.com/aquasecurity/trivy/pkg/iac/ignore"
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
@@ -122,7 +124,16 @@ func (s *GenericScanner) ScanFS(ctx context.Context, fsys fs.FS, dir string) (sc
 		return nil, err
 	}
 	results.SetSourceAndFilesystem("", fsys, false)
+
+	if err := s.applyIgnoreRules(fsys, results); err != nil {
+		return nil, err
+	}
+
 	return results, nil
+}
+
+func (s *GenericScanner) supportsIgnoreRules() bool {
+	return s.source == types.SourceDockerfile
 }
 
 func (s *GenericScanner) parseFS(ctx context.Context, fsys fs.FS, path string) (map[string]any, error) {
@@ -171,6 +182,27 @@ func (s *GenericScanner) initRegoScanner(srcFS fs.FS) (*rego.Scanner, error) {
 	}
 	s.regoScanner = regoScanner
 	return regoScanner, nil
+}
+
+func (s *GenericScanner) applyIgnoreRules(fsys fs.FS, results scan.Results) error {
+	if !s.supportsIgnoreRules() {
+		return nil
+	}
+
+	uniqueFiles := lo.Uniq(lo.Map(results.GetFailed(), func(res scan.Result, _ int) string {
+		return res.Metadata().Range().GetFilename()
+	}))
+
+	for _, filename := range uniqueFiles {
+		content, err := fs.ReadFile(fsys, filename)
+		if err != nil {
+			return err
+		}
+
+		ignoreRules := ignore.Parse(string(content), filename, "")
+		results.Ignore(ignoreRules, nil)
+	}
+	return nil
 }
 
 func parseJson(ctx context.Context, r io.Reader, _ string) (any, error) {


### PR DESCRIPTION
## Description

Example config:
```Dockerfile
FROM scratch

# trivy:ignore:AVD-DS-0022
MAINTAINER moby@example.com
```

Before:
```bash
❯ trivy conf Dockerfile.dev |grep "AVD-DS-0022"
2024-12-17T18:12:25+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2024-12-17T18:12:26+06:00       INFO    Detected config files   num=1
AVD-DS-0022 (HIGH): MAINTAINER should not be used: 'MAINTAINER moby@example.com'
```

After:
```bash
❯ ./trivy conf Dockerfile.dev |grep "AVD-DS-0022"
2024-12-17T18:12:14+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2024-12-17T18:12:15+06:00       INFO    Detected config files   num=1
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8113

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
