### PR TITLE
feat(misconf): support for ignoring by inline comments for Helm

### DIFF
--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -451,7 +451,7 @@ If multiple variables evaluate to the same hostname, Trivy will choose the envir
 
 ### Skipping resources by inline comments
 
-Trivy supports ignoring misconfigured resources by inline comments for Terraform and CloudFormation configuration files only.
+Trivy supports ignoring misconfigured resources by inline comments for Terraform, CloudFormation and Helm configuration files only.
 
 In cases where Trivy can detect comments of a specific format immediately adjacent to resource definitions, it is possible to ignore findings from a single source of resource definition (in contrast to `.trivyignore`, which has a directory-wide scope on all of the files scanned). The format for these comments is `trivy:ignore:<rule>` immediately following the format-specific line-comment [token](https://developer.hashicorp.com/terraform/language/syntax/configuration#comments).
 

--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -503,6 +503,22 @@ Resources:
       BucketName: test-bucket
 ```
 
+!!!note
+    Ignore rules for Helm files should be placed before the YAML object, since only it contains the location data needed for ignoring.
+    
+Example for Helm:
+```yaml
+      serviceAccountName: "testchart.serviceAccountName"
+      containers:
+        # trivy:ignore:KSV018
+        - name: "testchart"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+          image: "your-repository/your-image:your-tag"
+          imagePullPolicy: "Always"
+```
+
 #### Expiration Date
 
 You can specify the expiration date of the ignore rule in `yyyy-mm-dd` format. This is a useful feature when you want to make sure that an ignored issue is not forgotten and worth revisiting in the future. For example:

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/liamg/memoryfs"
 
 	"github.com/aquasecurity/trivy/pkg/iac/detection"
+	"github.com/aquasecurity/trivy/pkg/iac/ignore"
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners"
@@ -125,6 +126,7 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 		file := file
 		s.logger.Debug("Processing rendered chart file", log.FilePath(file.TemplateFilePath))
 
+		ignoreRules := ignore.Parse(file.ManifestContent, file.TemplateFilePath, "")
 		manifests, err := kparser.Parse(ctx, strings.NewReader(file.ManifestContent), file.TemplateFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal yaml: %w", err)
@@ -150,6 +152,7 @@ func (s *Scanner) getScanResults(path string, ctx context.Context, target fs.FS)
 					return nil, err
 				}
 				fileResults.SetSourceAndFilesystem(helmParser.ChartSource, renderedFS, detection.IsArchive(helmParser.ChartSource))
+				fileResults.Ignore(ignoreRules, nil)
 			}
 
 			results = append(results, fileResults...)

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -136,28 +137,28 @@ func Test_helm_scanner_with_dir(t *testing.T) {
 		require.NotNil(t, results)
 
 		failed := results.GetFailed()
-		assert.Len(t, failed, 14)
+		assert.Len(t, failed, 13)
 
 		visited := make(map[string]bool)
-		var errorCodes []string
 		for _, result := range failed {
-			id := result.Flatten().RuleID
-			if _, exists := visited[id]; !exists {
-				visited[id] = true
-				errorCodes = append(errorCodes, id)
-			}
+			visited[result.Rule().AVDID] = true
 		}
+		errorCodes := lo.Keys(visited)
 
-		sort.Strings(errorCodes)
-
-		assert.Equal(t, []string{
+		assert.ElementsMatch(t, []string{
 			"AVD-KSV-0001", "AVD-KSV-0003",
 			"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
-			"AVD-KSV-0015", "AVD-KSV-0016", "AVD-KSV-0018",
+			"AVD-KSV-0015", "AVD-KSV-0016",
 			"AVD-KSV-0020", "AVD-KSV-0021", "AVD-KSV-0030",
 			"AVD-KSV-0104", "AVD-KSV-0106",
 			"AVD-KSV-0117",
 		}, errorCodes)
+
+		ignored := results.GetIgnored()
+		assert.Len(t, ignored, 1)
+
+		assert.Equal(t, "AVD-KSV-0018", ignored[0].Rule().AVDID)
+		assert.Equal(t, "templates/deployment.yaml", ignored[0].Metadata().Range().GetFilename())
 	}
 }
 
@@ -231,19 +232,12 @@ deny[res] {
 			assert.Len(t, failed, 15)
 
 			visited := make(map[string]bool)
-			var errorCodes []string
 			for _, result := range failed {
-				id := result.Flatten().RuleID
-				if _, exists := visited[id]; !exists {
-					visited[id] = true
-					errorCodes = append(errorCodes, id)
-				}
+				visited[result.Rule().AVDID] = true
 			}
-			assert.Len(t, errorCodes, 14)
+			errorCodes := lo.Keys(visited)
 
-			sort.Strings(errorCodes)
-
-			assert.Equal(t, []string{
+			assert.ElementsMatch(t, []string{
 				"AVD-KSV-0001", "AVD-KSV-0003",
 				"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
 				"AVD-KSV-0015", "AVD-KSV-0016", "AVD-KSV-0018",

--- a/pkg/iac/scanners/helm/test/testdata/expected/options/testchart/templates/deployment.yaml
+++ b/pkg/iac/scanners/helm/test/testdata/expected/options/testchart/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       securityContext:
         {}
       containers:
+          # trivy:ignore:KSV018
         - name: testchart
           securityContext:
             runAsUser: 0

--- a/pkg/iac/scanners/helm/test/testdata/expected/testchart/templates/deployment.yaml
+++ b/pkg/iac/scanners/helm/test/testdata/expected/testchart/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       securityContext:
         {}
       containers:
+          # trivy:ignore:KSV018
         - name: testchart
           securityContext:
             {}

--- a/pkg/iac/scanners/helm/test/testdata/testchart/templates/deployment.yaml
+++ b/pkg/iac/scanners/helm/test/testdata/testchart/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+          # trivy:ignore:KSV018
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}


### PR DESCRIPTION
## Description

This PR adds support for ignoring misconfigurations in Helm configurations.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8198

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
