### PR TITLE
refactor(python): use once + debug for `License acquired from METADATA...` logs

### DIFF
--- a/pkg/dependency/parser/python/packaging/parse.go
+++ b/pkg/dependency/parser/python/packaging/parse.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/textproto"
 	"strings"
+	"sync"
 
 	"golang.org/x/xerrors"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
+
+var licenseMetadataInfoOnce sync.Once
 
 type Parser struct {
 	logger *log.Logger
@@ -70,7 +73,10 @@ func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependenc
 
 		if l := h.Get("License"); l != "" {
 			if len(licenses) != 0 {
-				p.logger.Info("License acquired from METADATA classifiers may be subject to additional terms",
+				licenseMetadataInfoOnce.Do(func() {
+					p.logger.Info("Licenses acquired from one or more METADATA files may be subject to additional terms. Use `--debug` flag to see all affected packages.")
+				})
+				p.logger.Debug("License acquired from METADATA classifiers may be subject to additional terms",
 					log.String("name", name), log.String("version", version))
 			} else {
 				license = l


### PR DESCRIPTION
## Description
See #8160

Before:
```bash
2024-12-25T12:00:53+06:00       INFO    [python] License acquired from METADATA classifiers may be subject to additional terms  name="pip" version="24.2"
2024-12-25T12:00:53+06:00       INFO    [python] License acquired from METADATA classifiers may be subject to additional terms  name="autocommand" version="2.2.2"
2024-12-25T12:00:53+06:00       INFO    [python] License acquired from METADATA classifiers may be subject to additional terms  name="typeguard" version="4.3.0"
2024-12-25T12:00:53+06:00       INFO    [python] License acquired from METADATA classifiers may be subject to additional terms  name="mercurial" version="6.3.2"
```

After:
```bash
2024-12-25T12:01:29+06:00       INFO    [python] Licenses acquired from one or more METADATA files may be subject to additional terms. Use `--debug` flag to see all affected packages.
2024-12-25T12:01:29+06:00       DEBUG   [python] License acquired from METADATA classifiers may be subject to additional terms  name="pip" version="24.2"
2024-12-25T12:01:29+06:00       DEBUG   [python] License acquired from METADATA classifiers may be subject to additional terms  name="autocommand" version="2.2.2"
2024-12-25T12:01:29+06:00       DEBUG   [python] License acquired from METADATA classifiers may be subject to additional terms  name="typeguard" version="4.3.0"
2024-12-25T12:01:29+06:00       DEBUG   [python] License acquired from METADATA classifiers may be subject to additional terms  name="mercurial" version="6.3.2"

```

## Related issues
- Close #8160

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
