### PR TITLE
feat(image): prevent scanning oversized container images

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 
 	"golang.org/x/xerrors"
@@ -25,8 +24,7 @@ func main() {
 
 		var userErr *types.UserError
 		if errors.As(err, &userErr) {
-			fmt.Println("Error: " + userErr.Error())
-			os.Exit(1)
+			log.Fatal("Error", log.Err(userErr))
 		}
 
 		log.Fatal("Fatal error", log.Err(err))

--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/xerrors"
@@ -21,6 +22,13 @@ func main() {
 		if errors.As(err, &exitError) {
 			os.Exit(exitError.Code)
 		}
+
+		var userErr *types.UserError
+		if errors.As(err, &userErr) {
+			fmt.Println("Error: " + userErr.Error())
+			os.Exit(1)
+		}
+
 		log.Fatal("Fatal error", log.Err(err))
 	}
 }

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -79,6 +79,7 @@ trivy image [flags] IMAGE_NAME
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     output all packages in the JSON report regardless of vulnerability
+      --max-image-size string             maximum image size to process, specified in a human-readable format (e.g., '44kB', '17MB'); an error will be returned if the image exceeds this size
       --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan-json,terraformplan-snapshot])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -79,7 +79,7 @@ trivy image [flags] IMAGE_NAME
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)
       --license-full                      eagerly look for licenses in source code headers and license files
       --list-all-pkgs                     output all packages in the JSON report regardless of vulnerability
-      --max-image-size string             maximum image size to process, specified in a human-readable format (e.g., '44kB', '17MB'); an error will be returned if the image exceeds this size
+      --max-image-size string             [EXPERIMENTAL] maximum image size to process, specified in a human-readable format (e.g., '44kB', '17MB'); an error will be returned if the image exceeds this size
       --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan-json,terraformplan-snapshot])
       --module-dir string                 specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
       --no-progress                       suppress progress bar

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -137,6 +137,9 @@ image:
   # Same as '--input'
   input: ""
 
+  # Same as '--max-image-size'
+  max-size: ""
+
   # Same as '--platform'
   platform: ""
 

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -518,3 +518,21 @@ You can configure Podman daemon socket with `--podman-host`.
 ```shell
 $ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE
 ```
+
+### Prevent scanning oversized container images
+Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format (e.g., `100MB`, `10GB`). If the compressed image size exceeds the specified threshold, an error is returned immediately. Otherwise, all layers are pulled, stored in a temporary folder, and their uncompressed size is verified before scanning. Temporary layers are always cleaned up, even after a successful scan.
+
+!!! warning "EXPERIMENTAL"
+    This feature might change without preserving backwards compatibility.
+
+
+Example Usage:
+```bash
+# Limit uncompressed image size to 10GB
+$ trivy image --max-image-size=10GB myapp:latest
+```
+
+Error Output:
+```bash
+Error: uncompressed image size (15GB) exceeds maximum allowed size (10GB)
+```

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/docker/cli v27.4.1+incompatible
 	github.com/docker/docker v27.4.1+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-openapi/runtime v0.28.0 // indirect
@@ -217,7 +218,6 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -205,8 +205,8 @@ func TestDockerEngine(t *testing.T) {
 		{
 			name:         "sad path, image size is larger than the maximum",
 			input:        "testdata/fixtures/images/alpine-39.tar.gz",
-			maxImageSize: "1mb",
-			wantErr:      "uncompressed image size 5.8MB exceeds maximum allowed size 1MB",
+			maxImageSize: "3mb",
+			wantErr:      "uncompressed image size 5.8MB exceeds maximum allowed size 3MB",
 		},
 	}
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -587,6 +587,7 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 					Host: opts.PodmanHost,
 				},
 				ImageSources: opts.ImageSources,
+				MaxImageSize: opts.MaxImageSize,
 			},
 
 			// For misconfiguration scanning

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -68,7 +68,7 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, opt artifact.Option) (a
 
 	cacheDir, err := os.MkdirTemp("", "layers")
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create a temp dir: %w", err)
+		return nil, xerrors.Errorf("failed to create a cache layers temp dir: %w", err)
 	}
 
 	return Artifact{

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -235,7 +235,7 @@ func (a Artifact) checkImageSize(ctx context.Context, diffIDs []string) error {
 
 	compressedSize, err := a.compressedImageSize(diffIDs)
 	if err != nil {
-		return nil
+		return xerrors.Errorf("failed to get compressed image size: %w", err)
 	}
 
 	if compressedSize > maxSize {

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/parallel"
 	"github.com/aquasecurity/trivy/pkg/semaphore"
+	trivyTypes "github.com/aquasecurity/trivy/pkg/types"
 )
 
 type Artifact struct {
@@ -225,10 +227,13 @@ func (a Artifact) checkImageSize(ctx context.Context, diffIDs []string) error {
 	}
 
 	if imageSize > maxSize {
-		return xerrors.Errorf(
-			"uncompressed image size %s exceeds maximum allowed size %s",
-			units.HumanSizeWithPrecision(float64(imageSize), 3), units.HumanSize(float64(maxSize)),
-		)
+		return &trivyTypes.UserError{
+			Message: fmt.Sprintf(
+				"uncompressed image size %s exceeds maximum allowed size %s",
+				units.HumanSizeWithPrecision(float64(imageSize), 3),
+				units.HumanSize(float64(maxSize)),
+			),
+		}
 	}
 	return nil
 }

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -302,6 +302,7 @@ func (a Artifact) imageSize(ctx context.Context, diffIDs []string) (int64, error
 }
 
 func (a Artifact) saveLayer(diffID string) (int64, error) {
+	a.logger.Debug("Pulling the layer to the local cache", log.String("diff_id", diffID))
 	_, rc, err := a.uncompressedLayer(diffID)
 	if err != nil {
 		return -1, xerrors.Errorf("unable to get uncompressed layer %s: %w", diffID, err)
@@ -482,6 +483,7 @@ func (a Artifact) uncompressedLayer(diffID string) (string, io.ReadCloser, error
 
 	f, err := os.Open(filepath.Join(a.layerCacheDir, diffID))
 	if err == nil {
+		a.logger.Debug("Loaded the layer from the local cache", log.String("diff_id", diffID))
 		return digest, f, nil
 	}
 

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2272,6 +2272,8 @@ func TestArtifact_Inspect(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			}
+			defer a.Clean(got)
+
 			require.NoError(t, err, tt.name)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/go-units"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -348,6 +349,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			imagePath: "../../test/testdata/alpine-311.tar.gz",
 			artifactOpt: artifact.Option{
 				LicenseScannerOption: analyzer.LicenseScannerOption{Full: true},
+				ImageOption:          types.ImageOptions{MaxImageSize: units.GB},
 			},
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
@@ -2242,6 +2244,14 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 			},
 			wantErr: "put artifact failed",
+		},
+		{
+			name:      "sad path, image size is larger than the maximum",
+			imagePath: "../../test/testdata/alpine-311.tar.gz",
+			artifactOpt: artifact.Option{
+				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
+			},
+			wantErr: "uncompressed image size 5.86MB exceeds maximum allowed size 1MB",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2246,12 +2246,20 @@ func TestArtifact_Inspect(t *testing.T) {
 			wantErr: "put artifact failed",
 		},
 		{
-			name:      "sad path, image size is larger than the maximum",
+			name:      "sad path, compressed image size is larger than the maximum",
 			imagePath: "../../test/testdata/alpine-311.tar.gz",
 			artifactOpt: artifact.Option{
 				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
 			},
-			wantErr: "uncompressed image size 5.86MB exceeds maximum allowed size 1MB",
+			wantErr: "compressed image size 3.03MB exceeds maximum allowed size 1MB",
+		},
+		{
+			name:      "sad path, image size is larger than the maximum",
+			imagePath: "../../test/testdata/alpine-311.tar.gz",
+			artifactOpt: artifact.Option{
+				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 4},
+			},
+			wantErr: "uncompressed image size 5.86MB exceeds maximum allowed size 4MB",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -170,6 +170,8 @@ func TestArtifact_InspectRekorAttestation(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
+			defer a.Clean(got)
+
 			require.NoError(t, err, tt.name)
 			got.BOM = nil
 			assert.Equal(t, tt.want, got)
@@ -312,6 +314,7 @@ func TestArtifact_inspectOCIReferrerSBOM(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
+			defer a.Clean(got)
 
 			require.NoError(t, err, tt.name)
 			got.BOM = nil

--- a/pkg/fanal/test/integration/registry_test.go
+++ b/pkg/fanal/test/integration/registry_test.go
@@ -256,6 +256,7 @@ func analyze(ctx context.Context, imageRef string, opt types.ImageOptions) (*typ
 	if err != nil {
 		return nil, err
 	}
+	defer ar.Clean(imageInfo)
 
 	imageDetail, err := ap.ApplyLayers(imageInfo.ID, imageInfo.BlobIDs)
 	if err != nil {

--- a/pkg/fanal/types/image.go
+++ b/pkg/fanal/types/image.go
@@ -53,6 +53,7 @@ type ImageOptions struct {
 	PodmanOptions     PodmanOptions
 	ContainerdOptions ContainerdOptions
 	ImageSources      ImageSources
+	MaxImageSize      int64
 }
 
 type DockerOptions struct {

--- a/pkg/flag/image_flags.go
+++ b/pkg/flag/image_flags.go
@@ -63,7 +63,7 @@ var (
 		Name:       "max-image-size",
 		ConfigName: "image.max-size",
 		Default:    "",
-		Usage:      "maximum image size to process, specified in a human-readable format (e.g., '44kB', '17MB'); an error will be returned if the image exceeds this size",
+		Usage:      "[EXPERIMENTAL] maximum image size to process, specified in a human-readable format (e.g., '44kB', '17MB'); an error will be returned if the image exceeds this size",
 	}
 )
 

--- a/pkg/flag/image_flags_test.go
+++ b/pkg/flag/image_flags_test.go
@@ -1,0 +1,91 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/docker/go-units"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/flag"
+)
+
+func TestImageFlagGroup_ToOptions(t *testing.T) {
+	type fields struct {
+		maxImgSize string
+		platform   string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    flag.ImageOptions
+		wantErr string
+	}{
+		{
+			name:   "happy default (without flags)",
+			fields: fields{},
+			want:   flag.ImageOptions{},
+		},
+		{
+			name: "happy path with max image size",
+			fields: fields{
+				maxImgSize: "10mb",
+			},
+			want: flag.ImageOptions{
+				MaxImageSize: units.MB * 10,
+			},
+		},
+		{
+			name: "invalid max image size",
+			fields: fields{
+				maxImgSize: "10foo",
+			},
+			wantErr: "invalid max image size",
+		},
+		{
+			name: "happy path with platform",
+			fields: fields{
+				platform: "linux/amd64",
+			},
+			want: flag.ImageOptions{
+				Platform: types.Platform{
+					Platform: &v1.Platform{
+						OS:           "linux",
+						Architecture: "amd64",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid platform",
+			fields: fields{
+				platform: "unknown/unknown/unknown/unknown",
+			},
+			wantErr: "unable to parse platform",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			setValue(flag.MaxImageSize.ConfigName, tt.fields.maxImgSize)
+			setValue(flag.PlatformFlag.ConfigName, tt.fields.platform)
+
+			f := &flag.ImageFlagGroup{
+				MaxImageSize: flag.MaxImageSize.Clone(),
+				Platform:     flag.PlatformFlag.Clone(),
+			}
+
+			got, err := f.ToOptions()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.EqualExportedValues(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/types/error.go
+++ b/pkg/types/error.go
@@ -11,3 +11,12 @@ type ExitError struct {
 func (e *ExitError) Error() string {
 	return fmt.Sprintf("exit status %d", e.Code)
 }
+
+// UserError represents an error with a user-friendly message.
+type UserError struct {
+	Message string
+}
+
+func (e *UserError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
## Description

This PR adds the `--max-image-size` flag. If the flag is specified and the uncompressed image size exceeds the maximum size, Trivy exits with an error. If the flag is not specified, the behaviour does not change.

For more implementation details, see https://github.com/aquasecurity/trivy/issues/8176

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8176

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
