### PR TITLE
docs: Updated JSON schema version 2 in the trivy documentation

### DIFF
--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -121,15 +121,21 @@ Then, you can try to update **axios@0.21.4** and **cra-append-sw@2.7.0** to reso
 |     License      |     ✓     |
 
 ```
-$ trivy image -f json -o results.json golang:1.12-alpine
+$ trivy image -f json -o results.json alpine:latest
 ```
 
 <details>
 <summary>Result</summary>
 
 ```
-2019-05-16T01:46:31.777+0900    INFO    Updating vulnerability database...
-2019-05-16T01:47:03.007+0900    INFO    Detecting Alpine vulnerabilities...
+2024-12-26T22:01:18+05:30	INFO	[vuln] Vulnerability scanning is enabled
+2024-12-26T22:01:18+05:30	INFO	[secret] Secret scanning is enabled
+2024-12-26T22:01:18+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
+2024-12-26T22:01:18+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.58/docs/scanner/secret#recommendation for faster secret detection
+2024-12-26T22:01:18+05:30	INFO	Detected OS	family="alpine" version="3.20.3"
+2024-12-26T22:01:18+05:30	INFO	[alpine] Detecting vulnerabilities...	os_version="3.20" repository="3.20" pkg_num=14
+2024-12-26T22:01:18+05:30	INFO	Number of language-specific files	num=0
+2024-12-26T22:01:18+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.58/docs/scanner/vulnerability#severity-selection for details.
 ```
 
 </details>
@@ -138,107 +144,176 @@ $ trivy image -f json -o results.json golang:1.12-alpine
 <summary>JSON</summary>
 
 ```
-[
-  {
-    "Target": "php-app/composer.lock",
-    "Vulnerabilities": null
-  },
-  {
-    "Target": "node-app/package-lock.json",
-    "Vulnerabilities": [
-      {
-        "VulnerabilityID": "CVE-2018-16487",
-        "PkgName": "lodash",
-        "InstalledVersion": "4.17.4",
-        "FixedVersion": "\u003e=4.17.11",
-        "Title": "lodash: Prototype pollution in utilities function",
-        "Description": "A prototype pollution vulnerability was found in lodash \u003c4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.",
-        "Severity": "HIGH",
-        "References": [
-          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487",
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2024-12-26T21:58:15.943876+05:30",
+  "ArtifactName": "alpine:latest",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "alpine",
+      "Name": "3.20.3"
+    },
+    "ImageID": "sha256:511a44083d3a23416fadc62847c45d14c25cbace86e7a72b2b350436978a0450",
+    "DiffIDs": [
+      "sha256:651d9022c23486dfbd396c13db293af6845731cbd098a5f5606db4bc9f5573e8"
+    ],
+    "RepoTags": [
+      "alpine:latest"
+    ],
+    "RepoDigests": [
+      "alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a"
+    ],
+    "ImageConfig": {
+      "architecture": "arm64",
+      "created": "2024-09-06T12:05:36Z",
+      "history": [
+        {
+          "created": "2024-09-06T12:05:36Z",
+          "created_by": "ADD alpine-minirootfs-3.20.3-aarch64.tar.gz / # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2024-09-06T12:05:36Z",
+          "created_by": "CMD [\"/bin/sh\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:651d9022c23486dfbd396c13db293af6845731cbd098a5f5606db4bc9f5573e8"
         ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/sh"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "WorkingDir": "/",
+        "ArgsEscaped": true
       }
-    ]
+    }
   },
-  {
-    "Target": "trivy-ci-test (alpine 3.7.1)",
-    "Vulnerabilities": [
-      {
-        "VulnerabilityID": "CVE-2018-16840",
-        "PkgName": "curl",
-        "InstalledVersion": "7.61.0-r0",
-        "FixedVersion": "7.61.1-r1",
-        "Title": "curl: Use-after-free when closing \"easy\" handle in Curl_close()",
-        "Description": "A heap use-after-free flaw was found in curl versions from 7.59.0 through 7.61.1 in the code related to closing an easy handle. ",
-        "Severity": "HIGH",
-        "References": [
-          "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840",
-        ]
-      },
-      {
-        "VulnerabilityID": "CVE-2019-3822",
-        "PkgName": "curl",
-        "InstalledVersion": "7.61.0-r0",
-        "FixedVersion": "7.61.1-r2",
-        "Title": "curl: NTLMv2 type-3 header stack buffer overflow",
-        "Description": "libcurl versions from 7.36.0 to before 7.64.0 are vulnerable to a stack-based buffer overflow. ",
-        "Severity": "HIGH",
-        "References": [
-          "https://curl.haxx.se/docs/CVE-2019-3822.html",
-          "https://lists.apache.org/thread.html/8338a0f605bdbb3a6098bb76f666a95fc2b2f53f37fa1ecc89f1146f@%3Cdevnull.infra.apache.org%3E"
-        ]
-      },
-      {
-        "VulnerabilityID": "CVE-2018-16839",
-        "PkgName": "curl",
-        "InstalledVersion": "7.61.0-r0",
-        "FixedVersion": "7.61.1-r1",
-        "Title": "curl: Integer overflow leading to heap-based buffer overflow in Curl_sasl_create_plain_message()",
-        "Description": "Curl versions 7.33.0 through 7.61.1 are vulnerable to a buffer overrun in the SASL authentication code that may lead to denial of service.",
-        "Severity": "HIGH",
-        "References": [
-          "https://github.com/curl/curl/commit/f3a24d7916b9173c69a3e0ee790102993833d6c5",
-        ]
-      },
-      {
-        "VulnerabilityID": "CVE-2018-19486",
-        "PkgName": "git",
-        "InstalledVersion": "2.15.2-r0",
-        "FixedVersion": "2.15.3-r0",
-        "Title": "git: Improper handling of PATH allows for commands to be executed from the current directory",
-        "Description": "Git before 2.19.2 on Linux and UNIX executes commands from the current working directory (as if '.' were at the end of $PATH) in certain cases involving the run_command() API and run-command.c, because there was a dangerous change from execvp to execv during 2017.",
-        "Severity": "HIGH",
-        "References": [
-          "https://usn.ubuntu.com/3829-1/",
-        ]
-      },
-      {
-        "VulnerabilityID": "CVE-2018-17456",
-        "PkgName": "git",
-        "InstalledVersion": "2.15.2-r0",
-        "FixedVersion": "2.15.3-r0",
-        "Title": "git: arbitrary code execution via .gitmodules",
-        "Description": "Git before 2.14.5, 2.15.x before 2.15.3, 2.16.x before 2.16.5, 2.17.x before 2.17.2, 2.18.x before 2.18.1, and 2.19.x before 2.19.1 allows remote code execution during processing of a recursive \"git clone\" of a superproject if a .gitmodules file has a URL field beginning with a '-' character.",
-        "Severity": "HIGH",
-        "References": [
-          "http://www.securitytracker.com/id/1041811",
-        ]
-      }
-    ]
-  },
-  {
-    "Target": "python-app/Pipfile.lock",
-    "Vulnerabilities": null
-  },
-  {
-    "Target": "ruby-app/Gemfile.lock",
-    "Vulnerabilities": null
-  },
-  {
-    "Target": "rust-app/Cargo.lock",
-    "Vulnerabilities": null
-  }
-]
+  "Results": [
+    {
+      "Target": "alpine:latest (alpine 3.20.3)",
+      "Class": "os-pkgs",
+      "Type": "alpine",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2024-9143",
+          "PkgID": "libcrypto3@3.3.2-r0",
+          "PkgName": "libcrypto3",
+          "PkgIdentifier": {
+            "PURL": "pkg:apk/alpine/libcrypto3@3.3.2-r0?arch=aarch64\u0026distro=3.20.3",
+            "UID": "f705555b49cd2259"
+          },
+          "InstalledVersion": "3.3.2-r0",
+          "FixedVersion": "3.3.2-r1",
+          "Status": "fixed",
+          "Layer": {
+            "DiffID": "sha256:651d9022c23486dfbd396c13db293af6845731cbd098a5f5606db4bc9f5573e8"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-9143",
+          "DataSource": {
+            "ID": "alpine",
+            "Name": "Alpine Secdb",
+            "URL": "https://secdb.alpinelinux.org/"
+          },
+          "Title": "openssl: Low-level invalid GF(2^m) parameters lead to OOB memory access",
+          "Description": "Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted\nexplicit values for the field polynomial can lead to out-of-bounds memory reads\nor writes.\n\nImpact summary: Out of bound memory writes can lead to an application crash or\neven a possibility of a remote code execution, however, in all the protocols\ninvolving Elliptic Curve Cryptography that we're aware of, either only \"named\ncurves\" are supported, or, if explicit curve parameters are supported, they\nspecify an X9.62 encoding of binary (GF(2^m)) curves that can't represent\nproblematic input values. Thus the likelihood of existence of a vulnerable\napplication is low.\n\nIn particular, the X9.62 encoding is used for ECC keys in X.509 certificates,\nso problematic inputs cannot occur in the context of processing X.509\ncertificates.  Any problematic use-cases would have to be using an \"exotic\"\ncurve encoding.\n\nThe affected APIs include: EC_GROUP_new_curve_GF2m(), EC_GROUP_new_from_params(),\nand various supporting BN_GF2m_*() functions.\n\nApplications working with \"exotic\" explicit binary (GF(2^m)) curve parameters,\nthat make it possible to represent invalid field polynomials with a zero\nconstant term, via the above or similar APIs, may terminate abruptly as a\nresult of reading or writing outside of array bounds.  Remote code execution\ncannot easily be ruled out.\n\nThe FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-787"
+          ],
+          "VendorSeverity": {
+            "amazon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.7
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2024-9143",
+            "https://github.com/openssl/openssl/commit/72ae83ad214d2eef262461365a1975707f862712",
+            "https://github.com/openssl/openssl/commit/bc7e04d7c8d509fb78fc0e285aa948fb0da04700",
+            "https://github.com/openssl/openssl/commit/c0d3e4d32d2805f49bec30547f225bc4d092e1f4",
+            "https://github.com/openssl/openssl/commit/fdf6723362ca51bd883295efe206cb5b1cfa5154",
+            "https://github.openssl.org/openssl/extended-releases/commit/8efc0cbaa8ebba8e116f7b81a876a4123594d86a",
+            "https://github.openssl.org/openssl/extended-releases/commit/9d576994cec2b7aa37a91740ea7e680810957e41",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-9143",
+            "https://openssl-library.org/news/secadv/20241016.txt",
+            "https://www.cve.org/CVERecord?id=CVE-2024-9143"
+          ],
+          "PublishedDate": "2024-10-16T17:15:18.13Z",
+          "LastModifiedDate": "2024-11-08T16:35:21.58Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2024-9143",
+          "PkgID": "libssl3@3.3.2-r0",
+          "PkgName": "libssl3",
+          "PkgIdentifier": {
+            "PURL": "pkg:apk/alpine/libssl3@3.3.2-r0?arch=aarch64\u0026distro=3.20.3",
+            "UID": "c4a39ef718e71832"
+          },
+          "InstalledVersion": "3.3.2-r0",
+          "FixedVersion": "3.3.2-r1",
+          "Status": "fixed",
+          "Layer": {
+            "DiffID": "sha256:651d9022c23486dfbd396c13db293af6845731cbd098a5f5606db4bc9f5573e8"
+          },
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2024-9143",
+          "DataSource": {
+            "ID": "alpine",
+            "Name": "Alpine Secdb",
+            "URL": "https://secdb.alpinelinux.org/"
+          },
+          "Title": "openssl: Low-level invalid GF(2^m) parameters lead to OOB memory access",
+          "Description": "Issue summary: Use of the low-level GF(2^m) elliptic curve APIs with untrusted\nexplicit values for the field polynomial can lead to out-of-bounds memory reads\nor writes.\n\nImpact summary: Out of bound memory writes can lead to an application crash or\neven a possibility of a remote code execution, however, in all the protocols\ninvolving Elliptic Curve Cryptography that we're aware of, either only \"named\ncurves\" are supported, or, if explicit curve parameters are supported, they\nspecify an X9.62 encoding of binary (GF(2^m)) curves that can't represent\nproblematic input values. Thus the likelihood of existence of a vulnerable\napplication is low.\n\nIn particular, the X9.62 encoding is used for ECC keys in X.509 certificates,\nso problematic inputs cannot occur in the context of processing X.509\ncertificates.  Any problematic use-cases would have to be using an \"exotic\"\ncurve encoding.\n\nThe affected APIs include: EC_GROUP_new_curve_GF2m(), EC_GROUP_new_from_params(),\nand various supporting BN_GF2m_*() functions.\n\nApplications working with \"exotic\" explicit binary (GF(2^m)) curve parameters,\nthat make it possible to represent invalid field polynomials with a zero\nconstant term, via the above or similar APIs, may terminate abruptly as a\nresult of reading or writing outside of array bounds.  Remote code execution\ncannot easily be ruled out.\n\nThe FIPS modules in 3.3, 3.2, 3.1 and 3.0 are not affected by this issue.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-787"
+          ],
+          "VendorSeverity": {
+            "amazon": 3,
+            "redhat": 1,
+            "ubuntu": 1
+          },
+          "CVSS": {
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+              "V3Score": 3.7
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2024-9143",
+            "https://github.com/openssl/openssl/commit/72ae83ad214d2eef262461365a1975707f862712",
+            "https://github.com/openssl/openssl/commit/bc7e04d7c8d509fb78fc0e285aa948fb0da04700",
+            "https://github.com/openssl/openssl/commit/c0d3e4d32d2805f49bec30547f225bc4d092e1f4",
+            "https://github.com/openssl/openssl/commit/fdf6723362ca51bd883295efe206cb5b1cfa5154",
+            "https://github.openssl.org/openssl/extended-releases/commit/8efc0cbaa8ebba8e116f7b81a876a4123594d86a",
+            "https://github.openssl.org/openssl/extended-releases/commit/9d576994cec2b7aa37a91740ea7e680810957e41",
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-9143",
+            "https://openssl-library.org/news/secadv/20241016.txt",
+            "https://www.cve.org/CVERecord?id=CVE-2024-9143"
+          ],
+          "PublishedDate": "2024-10-16T17:15:18.13Z",
+          "LastModifiedDate": "2024-11-08T16:35:21.58Z"
+        }
+      ]
+    }
+  ]
+}
+
 ```
 
 </details>


### PR DESCRIPTION
## Description
Since, Trivy Open Source is currently using schema version 2 as discueed [here](https://github.com/aquasecurity/trivy/discussions/1050). But even after migrating to new change, the documentation still contains an [example](https://trivy.dev/v0.55/docs/configuration/reporting/#json) which shows result in older schema version 1. 
This PR addresses the JSON schema version change to 2 in Trivy documentaion. With the changes made in this PR, the trivy documentation page is showing example in updated schema version.

## Related issues
- [Close #7553](https://github.com/aquasecurity/trivy/issues/7553)


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
