### PR TITLE
chore(alpine): add EOL date for Alpine 3.21

### DIFF
--- a/docs/docs/coverage/os/index.md
+++ b/docs/docs/coverage/os/index.md
@@ -11,7 +11,7 @@ Trivy supports operating systems for
 
 | OS                                    | Supported Versions                  | Package Managers |
 |---------------------------------------|-------------------------------------|------------------|
-| [Alpine Linux](alpine.md)             | 2.2 - 2.7, 3.0 - 3.20, edge         | apk              |
+| [Alpine Linux](alpine.md)             | 2.2 - 2.7, 3.0 - 3.21, edge         | apk              |
 | [Wolfi Linux](wolfi.md)               | (n/a)                               | apk              |
 | [Chainguard](chainguard.md)           | (n/a)                               | apk              |
 | [Red Hat Enterprise Linux](rhel.md)   | 6, 7, 8                             | dnf/yum/rpm      |

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -48,6 +48,7 @@ var (
 		"3.18": time.Date(2025, 5, 9, 23, 59, 59, 0, time.UTC),
 		"3.19": time.Date(2025, 11, 1, 23, 59, 59, 0, time.UTC),
 		"3.20": time.Date(2026, 04, 1, 23, 59, 59, 0, time.UTC),
+		"3.21": time.Date(2026, 12, 5, 23, 59, 59, 0, time.UTC),
 		"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 )


### PR DESCRIPTION
## Description

[Alpine Linux 3.21](https://alpinelinux.org/releases/) was released on 2024-12-05 and is expected to receive support for 2 years, making its EOL date approximately 2026-12-05.

The Trivy DB already contains vulnerabilities affecting Alpine 3.21:

```
$ ./trivy i docker.io/library/alpine:3.21 2>&1 | grep Detecting
2025-01-08T17:59:45Z    INFO    [alpine] Detecting vulnerabilities...   os_version="3.21" repository="3.21" pkg_num=15
```

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
