### PR TITLE
fix(redhat): check `usr/share/buildinfo/` dir to detect content sets

### DIFF
--- a/pkg/fanal/analyzer/buildinfo/content_manifest.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest.go
@@ -10,11 +10,17 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/set"
 )
 
 func init() {
 	analyzer.RegisterAnalyzer(&contentManifestAnalyzer{})
 }
+
+var contentSetsDirs = set.New[string](
+	"root/buildinfo/content_manifests/",
+	"usr/share/buildinfo/", // for RHCOS
+)
 
 const contentManifestAnalyzerVersion = 1
 
@@ -44,7 +50,7 @@ func (a contentManifestAnalyzer) Analyze(_ context.Context, target analyzer.Anal
 
 func (a contentManifestAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	dir, file := filepath.Split(filepath.ToSlash(filePath))
-	if dir != "root/buildinfo/content_manifests/" {
+	if !contentSetsDirs.Contains(dir) {
 		return false
 	}
 	return filepath.Ext(file) == ".json"

--- a/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
@@ -73,12 +73,22 @@ func Test_contentManifestAnalyzer_Required(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "happy path",
+			name:     "happy path root dir",
 			filePath: "root/buildinfo/content_manifests/nodejs-12-container-1-66.json",
 			want:     true,
 		},
 		{
-			name:     "sad path",
+			name:     "happy path usr dir",
+			filePath: "usr/share/buildinfo/nodejs-12-container-1-66.json",
+			want:     true,
+		},
+		{
+			name:     "sad path wrong dir",
+			filePath: "foo/bar/nodejs-12-container-1-66.json",
+			want:     false,
+		},
+		{
+			name:     "sad path wrong extension",
 			filePath: "root/buildinfo/content_manifests/nodejs-12-container-1-66.xml",
 			want:     false,
 		},


### PR DESCRIPTION
## Description
In RHCOS you don't have permissions to the `/root` directory. 
That's why in `RHCOS` the content set files are in `/usr/share/buildinfo/*.json`

## Related issues
- Close #8213

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
