### PR TITLE
refactor: use trivy-checks/pkg/specs package

### DIFF
--- a/pkg/compliance/spec/compliance.go
+++ b/pkg/compliance/spec/compliance.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 
-	sp "github.com/aquasecurity/trivy-checks/pkg/spec"
+	"github.com/aquasecurity/trivy-checks/pkg/specs"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/set"
@@ -97,7 +97,7 @@ func GetComplianceSpec(specNameOrPath, cacheDir string) (ComplianceSpec, error) 
 	} else {
 		_, err := os.Stat(filepath.Join(checksDir(cacheDir), "metadata.json"))
 		if err != nil { // cache corrupt or bundle does not exist, load embedded version
-			b = []byte(sp.NewSpecLoader().GetSpecByName(specNameOrPath))
+			b = []byte(specs.GetSpec(specNameOrPath))
 			log.Debug("Compliance spec loaded from embedded library", log.String("spec", specNameOrPath))
 		} else {
 			// load from bundle on disk


### PR DESCRIPTION
## Description

The `spec` package simply uses functions from the `specs` package, so we can use `specs` directly.

## Related PRs
- [x] https://github.com/aquasecurity/trivy-checks/pull/308

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
