### PR TITLE
fix(ci): fix path to main dir for canary builds

### DIFF
--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -3,7 +3,7 @@ version: 2
 project_name: trivy_canary_build
 builds:
   -
-    main: cmd/trivy/main.go
+    main: ./cmd/trivy/
     binary: trivy
     ldflags:
       - -s -w


### PR DESCRIPTION
## Description
Canary binaries don't have info about main module.

before:
```
➜ go version -m trivy
trivy: go1.23.4
	path	command-line-arguments
	dep	cloud.google.com/go	v0.116.0	h1:B3fRrSDkLRt5qSHWe40ERJvhvnQwdZiHu0bJOpldweE=
```

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
