### PR TITLE
ci: add workflow to restrict direct PRs to release branches

### DIFF
--- a/.github/workflows/release-pr-check.yaml
+++ b/.github/workflows/release-pr-check.yaml
@@ -1,0 +1,19 @@
+name: Backport PR Check
+
+on:
+  pull_request:
+    branches:
+      - 'release/v*'
+
+jobs:
+  check-pr-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR author
+        id: check_author
+        run: |
+          if [ "${{ github.actor }}" != "aqua-bot" ]; then
+            echo "::error::This branch is intended for automated backporting by bot. Please refer to the documentation:"
+            echo "::error::https://trivy.dev/latest/community/maintainer/backporting/"
+            exit 1
+          fi


### PR DESCRIPTION
## Description
Added workflow to prevent direct PRs to release branches (release/v*)
- Fails if PR is created by non-aqua-bot user
- Includes documentation link about the backporting process in error message

## Tests
I confirmed this workflow correctly failed PRs from other than aqua-bot, but I didn't have a token of aqua-bot. I didn't have an idea to test it.
https://github.com/knqyf263/trivy/pull/68

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a before and after example to the description (if the PR is a user interface change).