### PR TITLE
feat: add support for registry mirrors

### DIFF
--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -137,3 +137,25 @@ registry:
     index.docker.io:
      - mirror.gcr.io
 ```
+
+### Registry check procedure
+Trivy uses the following registry order to get the image:
+
+- mirrors in the same order as they are specified in the configuration file
+- source registry
+
+In cases where we can't get the image from the mirror registry (e.g. when authentication fails, image doesn't exist, etc.) - Trivy will check other mirrors (or the source registry if all mirrors have already been checked).
+
+Example:
+```yaml
+registry:
+  mirrors:
+    index.docker.io:
+     - mirror.with.bad.auth // We don't have credentials for this registry
+     - mirror.without.image // Registry doesn't have this image
+```
+
+When we want to get the image `alpine` with the settings above. The logic will be as follows:
+1. Try to get the image from `mirror.with.bad.auth/library/alpine`, but we get an error because there are no credentials for this registry.
+2. Try to get the image from `mirror.without.image/library/alpine`, but we get an error because this registry doesn't have this image (but most likely it will be an error about authorization).
+3. Get the image from `index.docker.io` (the original registry).

--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -117,3 +117,23 @@ The following example will fail when a critical vulnerability is found or the OS
 ```
 $ trivy image --exit-code 1 --exit-on-eol 1 --severity CRITICAL alpine:3.16.3
 ```
+
+## Mirrors support
+
+!!! warning "EXPERIMENTAL"
+    This feature might change without preserving backwards compatibility.
+
+Trivy supports mirrors for [remote container images](../target/container_image.md#container-registry) and [databases](./db.md).
+
+To configure them, add a list of mirrors along with the host to the [trivy config file](../references/configuration/config-file.md#registry-options).
+
+!!! note
+    Use the `index.docker.io` host for images from `Docker Hub`, even if you don't use that prefix.
+
+Example for `index.docker.io`:
+```yaml
+registry:
+  mirrors:
+    index.docker.io:
+     - mirror.gcr.io
+```

--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -156,6 +156,7 @@ registry:
 ```
 
 When we want to get the image `alpine` with the settings above. The logic will be as follows:
+
 1. Try to get the image from `mirror.with.bad.auth/library/alpine`, but we get an error because there are no credentials for this registry.
 2. Try to get the image from `mirror.without.image/library/alpine`, but we get an error because this registry doesn't have this image (but most likely it will be an error about authorization).
 3. Get the image from `index.docker.io` (the original registry).

--- a/docs/docs/configuration/others.md
+++ b/docs/docs/configuration/others.md
@@ -118,7 +118,7 @@ The following example will fail when a critical vulnerability is found or the OS
 $ trivy image --exit-code 1 --exit-on-eol 1 --severity CRITICAL alpine:3.16.3
 ```
 
-## Mirrors support
+## Mirror Registries
 
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -462,7 +462,7 @@ pkg:
 ```yaml
 registry:
   mirrors:
-    docker.io:
+    index.docker.io:
      - harbor.example.com/docker.io
      - mirror.gcr.io
 

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -461,6 +461,11 @@ pkg:
 
 ```yaml
 registry:
+  mirrors:
+    docker.io:
+     - harbor.example.com/docker.io
+     - mirror.gcr.io
+
   # Same as '--password'
   password: []
 

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -462,9 +462,6 @@ pkg:
 ```yaml
 registry:
   mirrors:
-    index.docker.io:
-     - harbor.example.com/docker.io
-     - mirror.gcr.io
 
   # Same as '--password'
   password: []

--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -127,7 +127,7 @@ func writeFlags(group flag.FlagGroup, w *os.File) {
 			}
 			w.WriteString(ind + parts[i] + ":")
 			if isLastPart {
-				writeFlagValue(flg.GetDefaultValue(), ind, w)
+				writeFlagValue(value(flg), ind, w)
 			}
 			w.WriteString("\n")
 		}
@@ -147,9 +147,31 @@ func writeFlagValue(val any, ind string, w *os.File) {
 		} else {
 			w.WriteString(" []\n")
 		}
+	case map[string][]string:
+		w.WriteString("\n")
+		for k, vv := range v {
+			fmt.Fprintf(w, "%s  %s:\n", ind, k)
+			for _, vvv := range vv {
+				fmt.Fprintf(w, "  %s - %s\n", ind, vvv)
+			}
+		}
 	case string:
 		fmt.Fprintf(w, " %q\n", v)
 	default:
 		fmt.Fprintf(w, " %v\n", v)
 	}
+}
+
+var registryMirrorsExample = map[string][]string{
+	"docker.io": {
+		"harbor.example.com/docker.io",
+		"mirror.gcr.io",
+	},
+}
+
+func value(flg flag.Flagger) any {
+	if flg.GetConfigName() == flag.RegistryMirrorsFlag.ConfigName {
+		return registryMirrorsExample
+	}
+	return flg.GetDefaultValue()
 }

--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -163,7 +163,7 @@ func writeFlagValue(val any, ind string, w *os.File) {
 }
 
 var registryMirrorsExample = map[string][]string{
-	"docker.io": {
+	"index.docker.io": {
 		"harbor.example.com/docker.io",
 		"mirror.gcr.io",
 	},

--- a/magefiles/docs.go
+++ b/magefiles/docs.go
@@ -127,7 +127,7 @@ func writeFlags(group flag.FlagGroup, w *os.File) {
 			}
 			w.WriteString(ind + parts[i] + ":")
 			if isLastPart {
-				writeFlagValue(value(flg), ind, w)
+				writeFlagValue(flg.GetDefaultValue(), ind, w)
 			}
 			w.WriteString("\n")
 		}
@@ -160,18 +160,4 @@ func writeFlagValue(val any, ind string, w *os.File) {
 	default:
 		fmt.Fprintf(w, " %v\n", v)
 	}
-}
-
-var registryMirrorsExample = map[string][]string{
-	"index.docker.io": {
-		"harbor.example.com/docker.io",
-		"mirror.gcr.io",
-	},
-}
-
-func value(flg flag.Flagger) any {
-	if flg.GetConfigName() == flag.RegistryMirrorsFlag.ConfigName {
-		return registryMirrorsExample
-	}
-	return flg.GetDefaultValue()
 }

--- a/pkg/fanal/types/image.go
+++ b/pkg/fanal/types/image.go
@@ -81,6 +81,9 @@ type RegistryOptions struct {
 	// RegistryToken is a bearer token to be sent to a registry
 	RegistryToken string
 
+	// RegistryMirrors is a map of hosts with mirrors for them
+	RegistryMirrors map[string][]string
+
 	// SSL/TLS
 	Insecure bool
 

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -30,7 +30,7 @@ import (
 )
 
 type FlagType interface {
-	int | string | []string | bool | time.Duration | float64
+	int | string | []string | bool | time.Duration | float64 | map[string][]string
 }
 
 type Flag[T FlagType] struct {
@@ -161,6 +161,8 @@ func (f *Flag[T]) cast(val any) any {
 		return cast.ToFloat64(val)
 	case time.Duration:
 		return cast.ToDuration(val)
+	case map[string][]string:
+		return cast.ToStringMapStringSlice(val)
 	case []string:
 		if s, ok := val.(string); ok && strings.Contains(s, ",") {
 			// Split environmental variables by comma as it is not done by viper.

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -469,11 +469,12 @@ func (o *Options) ScanOpts() types.ScanOptions {
 // RegistryOpts returns options for OCI registries
 func (o *Options) RegistryOpts() ftypes.RegistryOptions {
 	return ftypes.RegistryOptions{
-		Credentials:   o.Credentials,
-		RegistryToken: o.RegistryToken,
-		Insecure:      o.Insecure,
-		Platform:      o.Platform,
-		AWSRegion:     o.AWSOptions.Region,
+		Credentials:     o.Credentials,
+		RegistryToken:   o.RegistryToken,
+		Insecure:        o.Insecure,
+		Platform:        o.Platform,
+		AWSRegion:       o.AWSOptions.Region,
+		RegistryMirrors: o.RegistryMirrors,
 	}
 }
 

--- a/pkg/flag/registry_flags.go
+++ b/pkg/flag/registry_flags.go
@@ -31,26 +31,33 @@ var (
 		ConfigName: "registry.token",
 		Usage:      "registry token",
 	}
+	RegistryMirrorsFlag = Flag[map[string][]string]{
+		ConfigName: "registry.mirrors",
+		Usage:      "map of hosts and registries for them.",
+	}
 )
 
 type RegistryFlagGroup struct {
-	Username      *Flag[[]string]
-	Password      *Flag[[]string]
-	PasswordStdin *Flag[bool]
-	RegistryToken *Flag[string]
+	Username        *Flag[[]string]
+	Password        *Flag[[]string]
+	PasswordStdin   *Flag[bool]
+	RegistryToken   *Flag[string]
+	RegistryMirrors *Flag[map[string][]string]
 }
 
 type RegistryOptions struct {
-	Credentials   []types.Credential
-	RegistryToken string
+	Credentials     []types.Credential
+	RegistryToken   string
+	RegistryMirrors map[string][]string
 }
 
 func NewRegistryFlagGroup() *RegistryFlagGroup {
 	return &RegistryFlagGroup{
-		Username:      UsernameFlag.Clone(),
-		Password:      PasswordFlag.Clone(),
-		PasswordStdin: PasswordStdinFlag.Clone(),
-		RegistryToken: RegistryTokenFlag.Clone(),
+		Username:        UsernameFlag.Clone(),
+		Password:        PasswordFlag.Clone(),
+		PasswordStdin:   PasswordStdinFlag.Clone(),
+		RegistryToken:   RegistryTokenFlag.Clone(),
+		RegistryMirrors: RegistryMirrorsFlag.Clone(),
 	}
 }
 
@@ -64,6 +71,7 @@ func (f *RegistryFlagGroup) Flags() []Flagger {
 		f.Password,
 		f.PasswordStdin,
 		f.RegistryToken,
+		f.RegistryMirrors,
 	}
 }
 
@@ -97,7 +105,8 @@ func (f *RegistryFlagGroup) ToOptions() (RegistryOptions, error) {
 	}
 
 	return RegistryOptions{
-		Credentials:   credentials,
-		RegistryToken: f.RegistryToken.Value(),
+		Credentials:     credentials,
+		RegistryToken:   f.RegistryToken.Value(),
+		RegistryMirrors: f.RegistryMirrors.Value(),
 	}, nil
 }

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -57,6 +57,11 @@ func Get(ctx context.Context, ref name.Reference, option types.RegistryOptions) 
 			// Other errors
 			return nil, err
 		}
+
+		if ref.Context().RegistryStr() != r.Context().RegistryStr() {
+			log.WithPrefix("remote").Info("Mirror was used to get remote image",
+				log.String("image", ref.String()), log.String("mirror", r.Context().RegistryStr()))
+		}
 		return desc, nil
 	}
 
@@ -64,6 +69,7 @@ func Get(ctx context.Context, ref name.Reference, option types.RegistryOptions) 
 	return nil, errs
 }
 
+// tryGet checks all auth options and tries to get Descriptor.
 func tryGet(ctx context.Context, tr http.RoundTripper, ref name.Reference, option types.RegistryOptions) (*Descriptor, error) {
 	var errs error
 	for _, authOpt := range authOptions(ctx, ref, option) {
@@ -94,9 +100,6 @@ func tryGet(ctx context.Context, tr http.RoundTripper, ref name.Reference, optio
 				return nil, err
 			}
 		}
-		if ref.Context().RegistryStr() != ref.Context().RegistryStr() {
-			log.WithPrefix("remote").Info("Mirror was used to get remote image", log.String("image", ref.String()), log.String("mirror", ref.Context().RegistryStr()))
-		}
 		return desc, nil
 	}
 	return nil, errs
@@ -126,6 +129,10 @@ func Image(ctx context.Context, ref name.Reference, option types.RegistryOptions
 			continue
 
 		}
+		if ref.Context().RegistryStr() != r.Context().RegistryStr() {
+			log.WithPrefix("remote").Info("Mirror was used to get remote image",
+				log.String("image", ref.String()), log.String("mirror", r.Context().RegistryStr()))
+		}
 		return image, nil
 	}
 
@@ -148,10 +155,6 @@ func tryImage(ctx context.Context, tr http.RoundTripper, ref name.Reference, opt
 			continue
 		}
 
-		if ref.Context().RegistryStr() != ref.Context().RegistryStr() {
-			log.WithPrefix("remote").Info("Mirror was used to get remote image",
-				log.String("image", ref.String()), log.String("mirror", ref.Context().RegistryStr()))
-		}
 		return index, nil
 	}
 	return nil, errs

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -184,6 +184,10 @@ func Referrers(ctx context.Context, d name.Digest, option types.RegistryOptions)
 	return nil, errs
 }
 
+// registryMirrors returns a list of mirrors for ref, obtained from options.RegistryMirrors
+// `go-containerregistry` doesn't support mirrors, so we need to handle them ourselves.
+// TODO: use `WithMirror` when `go-containerregistry` will support mirrors.
+// cf. https://github.com/google/go-containerregistry/pull/2010
 func registryMirrors(hostRef name.Reference, option types.RegistryOptions) ([]name.Reference, error) {
 	var mirrors []name.Reference
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -144,8 +144,7 @@ func Referrers(ctx context.Context, d name.Digest, option types.RegistryOptions)
 func registryMirrors(hostRef name.Reference, option types.RegistryOptions) []name.Reference {
 	var mirrors []name.Reference
 
-	ctx := hostRef.Context()
-	reg := ctx.RegistryStr()
+	reg := hostRef.Context().RegistryStr()
 	if ms, ok := option.RegistryMirrors[reg]; ok {
 		for _, m := range ms {
 			var nameOpts []name.Option

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -122,7 +122,7 @@ func Image(ctx context.Context, ref name.Reference, option types.RegistryOptions
 		var image v1.Image
 		image, err = tryImage(ctx, tr, r, option)
 		if err != nil {
-			err = multierror.Append(errs, err)
+			errs = multierror.Append(errs, err)
 			continue
 
 		}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -24,8 +25,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/version/app"
 )
-
-var logger = log.WithPrefix("remote")
 
 type Descriptor = remote.Descriptor
 
@@ -147,14 +146,13 @@ func registryMirrors(hostRef name.Reference, option types.RegistryOptions) []nam
 
 	ctx := hostRef.Context()
 	reg := ctx.RegistryStr()
-	repo := ctx.RepositoryStr()
 	if ms, ok := option.RegistryMirrors[reg]; ok {
 		for _, m := range ms {
 			var nameOpts []name.Option
 			if option.Insecure {
 				nameOpts = append(nameOpts, name.Insecure)
 			}
-			mirrorImageName := fmt.Sprintf("%s/%s", m, repo)
+			mirrorImageName := strings.Replace(hostRef.Name(), reg, m, 1)
 			ref, err := name.ParseReference(mirrorImageName, nameOpts...)
 			if err != nil {
 				log.WithPrefix("remote").Warn("Unable to parse mirror of image", log.String("mirror", mirrorImageName))

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -114,6 +114,26 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
+			name: "mirror for dockerhub",
+			args: args{
+				imageName: "alpine:3.10",
+				option: types.RegistryOptions{
+					Credentials: []types.Credential{
+						{
+							Username: "test",
+							Password: "testpass",
+						},
+					},
+					RegistryMirrors: map[string][]string{
+						"index.docker.io": {
+							serverAddr,
+						},
+					},
+					Insecure: true,
+				},
+			},
+		},
+		{
 			name: "incorrect mirror - use image from host",
 			args: args{
 				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -258,6 +258,28 @@ func TestGet(t *testing.T) {
 			wantErr: "invalid username/password",
 		},
 		{
+			name: "bad credential for multiple mirrors",
+			args: args{
+				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
+				option: types.RegistryOptions{
+					Credentials: []types.Credential{
+						{
+							Username: "foo",
+							Password: "bar",
+						},
+					},
+					Insecure: true,
+					RegistryMirrors: map[string][]string{
+						serverAddr: {
+							serverAddr,
+							serverAddr,
+						},
+					},
+				},
+			},
+			wantErr: "6 errors occurred:", // 2 errors for each repository (for 2 mirrors and the original repository)
+		},
+		{
 			name: "bad keychain",
 			args: args{
 				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -94,6 +94,46 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
+			name: "mirror",
+			args: args{
+				imageName: "foo.bar.io/library/alpine:3.10",
+				option: types.RegistryOptions{
+					Credentials: []types.Credential{
+						{
+							Username: "test",
+							Password: "testpass",
+						},
+					},
+					RegistryMirrors: map[string][]string{
+						"foo.bar.io": {
+							serverAddr,
+						},
+					},
+					Insecure: true,
+				},
+			},
+		},
+		{
+			name: "incorrect mirror - use image from host",
+			args: args{
+				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
+				option: types.RegistryOptions{
+					Credentials: []types.Credential{
+						{
+							Username: "test",
+							Password: "testpass",
+						},
+					},
+					RegistryMirrors: map[string][]string{
+						"foo.bar.io": {
+							"wrong.repository",
+						},
+					},
+					Insecure: true,
+				},
+			},
+		},
+		{
 			name: "multiple credential",
 			args: args{
 				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -134,7 +134,7 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			name: "incorrect mirror - use image from host",
+			name: "non-existent mirror image - use image from host",
 			args: args{
 				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
 				option: types.RegistryOptions{
@@ -152,6 +152,21 @@ func TestGet(t *testing.T) {
 					Insecure: true,
 				},
 			},
+		},
+		{
+			name: "wrong mirror",
+			args: args{
+				imageName: fmt.Sprintf("%s/library/alpine:3.10", serverAddr),
+				option: types.RegistryOptions{
+					RegistryMirrors: map[string][]string{
+						serverAddr: {
+							"wrong.repository:tag@digest",
+						},
+					},
+					Insecure: true,
+				},
+			},
+			wantErr: "could not parse reference: wrong.repository:tag@digest/library/alpine:3.10",
 		},
 		{
 			name: "multiple credential",

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -125,7 +125,7 @@ func TestGet(t *testing.T) {
 						},
 					},
 					RegistryMirrors: map[string][]string{
-						"foo.bar.io": {
+						serverAddr: {
 							"wrong.repository",
 						},
 					},


### PR DESCRIPTION
## Description
- added `registry.mirrors` flag (only for config file)
  e.g. :
  ```
  registry:
    mirrors:
      index.docker.io:
        - harbor.example.com/docker.io
        - mirror.gcr.io
  ```
- add logic to check mirrors. If can't get image from mirrors - check host registry.

## Related issues
- Close #7966

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
