### PR TITLE
build: Ensure constant format strings in fmt and printf calls

### DIFF
--- a/pkg/iac/scanners/terraform/parser/funcs/collection.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/collection.go
@@ -509,7 +509,8 @@ var SumFunc = function.New(&function.Spec{
 		ty := args[0].Type()
 
 		if !ty.IsListType() && !ty.IsSetType() && !ty.IsTupleType() {
-			return cty.NilVal, function.NewArgErrorf(0, fmt.Sprintf("argument must be list, set, or tuple. Received %s", ty.FriendlyName()))
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple. Received %s", ty.FriendlyName())
+
 		}
 
 		if !args[0].IsWhollyKnown() {

--- a/pkg/iac/scanners/terraform/parser/funcs/crypto.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/crypto.go
@@ -175,7 +175,7 @@ var RsaDecryptFunc = function.New(&function.Spec{
 			default:
 				errStr = fmt.Sprintf("invalid private key: %s", e)
 			}
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, errStr)
+			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%s", errStr)
 		}
 		privateKey, ok := rawKey.(*rsa.PrivateKey)
 		if !ok {


### PR DESCRIPTION
Go 1.24 introduces stricter checks for format string validation. This commit fixes instances where non-constant format strings were used in calls to functions like `fmt.Errorf`, `fmt.Printf`, and similar.

~~~
$ go version
go version go1.24rc2 linux/amd64

$ go vet -printf ./...
(...)
pkg/iac/scanners/terraform/parser/funcs/collection.go:512:48: non-constant format string in call to github.com/zclconf/go-cty/cty/function.NewArgErrorf
pkg/iac/scanners/terraform/parser/funcs/crypto.go:178:64: non-constant format string in call to github.com/zclconf/go-cty/cty/function.NewArgErrorf
~~~

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
