### PR TITLE
fix(misconf): correctly handle all YAML tags in K8S templates

### DIFF
--- a/pkg/iac/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_node.go
@@ -39,7 +39,7 @@ func (r *ManifestNode) ToRego() any {
 		return nil
 	}
 	switch r.Type {
-	case TagBool, TagInt, TagString, TagStr, TagBinary:
+	case TagBool, TagInt, TagFloat, TagString, TagStr, TagBinary:
 		return r.Value
 	case TagTimestamp:
 		t, ok := r.Value.(time.Time)

--- a/pkg/iac/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_node.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"time"
@@ -21,6 +22,7 @@ const (
 	TagSlice     TagType = "!!seq"
 	TagMap       TagType = "!!map"
 	TagTimestamp TagType = "!!timestamp"
+	TagBinary    TagType = "!!binary"
 )
 
 type ManifestNode struct {
@@ -37,7 +39,7 @@ func (r *ManifestNode) ToRego() any {
 		return nil
 	}
 	switch r.Type {
-	case TagBool, TagInt, TagString, TagStr:
+	case TagBool, TagInt, TagString, TagStr, TagBinary:
 		return r.Value
 	case TagTimestamp:
 		t, ok := r.Value.(time.Time)
@@ -97,6 +99,12 @@ func (r *ManifestNode) UnmarshalYAML(node *yaml.Node) error {
 		var val time.Time
 		if err := node.Decode(&val); err != nil {
 			return fmt.Errorf("failed to decode timestamp: %w", err)
+		}
+		r.Value = val
+	case TagBinary:
+		val, err := base64.StdEncoding.DecodeString(node.Value)
+		if err != nil {
+			return fmt.Errorf("failed to decode binary data: %w", err)
 		}
 		r.Value = val
 	case TagMap:

--- a/pkg/iac/scanners/kubernetes/parser/manifest_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_test.go
@@ -18,7 +18,7 @@ func TestManifestToRego(t *testing.T) {
 	}{
 		{
 			name: "timestamp tag",
-			src:  `global: !!timestamp 2024-04-01`,
+			src:  `field: !!timestamp 2024-04-01`,
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
 					"filepath":  "",
@@ -26,12 +26,12 @@ func TestManifestToRego(t *testing.T) {
 					"startline": 1,
 					"endline":   1,
 				},
-				"global": "2024-04-01T00:00:00Z",
+				"field": "2024-04-01T00:00:00Z",
 			},
 		},
 		{
 			name: "binary tag",
-			src:  `binaryField: !!binary dGVzdA==`,
+			src:  `field: !!binary dGVzdA==`,
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
 					"filepath":  "",
@@ -39,7 +39,20 @@ func TestManifestToRego(t *testing.T) {
 					"startline": 1,
 					"endline":   1,
 				},
-				"binaryField": []uint8{0x74, 0x65, 0x73, 0x74},
+				"field": []uint8{0x74, 0x65, 0x73, 0x74},
+			},
+		},
+		{
+			name: "float tag",
+			src:  `field: 1.1`,
+			expected: map[string]any{
+				"__defsec_metadata": map[string]any{
+					"filepath":  "",
+					"offset":    0,
+					"startline": 1,
+					"endline":   1,
+				},
+				"field": 1.1,
 			},
 		},
 	}

--- a/pkg/iac/scanners/kubernetes/parser/manifest_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_test.go
@@ -17,7 +17,7 @@ func TestManifestToRego(t *testing.T) {
 		expected any
 	}{
 		{
-			name: "use timestamp tag",
+			name: "timestamp tag",
 			src:  `global: !!timestamp 2024-04-01`,
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
@@ -27,6 +27,19 @@ func TestManifestToRego(t *testing.T) {
 					"endline":   1,
 				},
 				"global": "2024-04-01T00:00:00Z",
+			},
+		},
+		{
+			name: "binary tag",
+			src:  `binaryField: !!binary dGVzdA==`,
+			expected: map[string]any{
+				"__defsec_metadata": map[string]any{
+					"filepath":  "",
+					"offset":    0,
+					"startline": 1,
+					"endline":   1,
+				},
+				"binaryField": []uint8{0x74, 0x65, 0x73, 0x74},
 			},
 		},
 	}

--- a/pkg/iac/scanners/kubernetes/parser/manifest_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_test.go
@@ -1,0 +1,43 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/kubernetes/parser"
+)
+
+func TestManifestToRego(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected any
+	}{
+		{
+			name: "use timestamp tag",
+			src:  `global: !!timestamp 2024-04-01`,
+			expected: map[string]any{
+				"__defsec_metadata": map[string]any{
+					"filepath":  "",
+					"offset":    0,
+					"startline": 1,
+					"endline":   1,
+				},
+				"global": "2024-04-01T00:00:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifest parser.Manifest
+			err := yaml.Unmarshal([]byte(tt.src), &manifest)
+			require.NoError(t, err)
+			data := manifest.ToRego()
+			assert.Equal(t, tt.expected, data)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR includes the following changes:

- Added support for binary and timestamp tags.
- Added export of float node to Rego.
- Log unsupported tags instead of returning an error.



## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8252

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
