### PR TITLE
fix(misconf): handle heredocs in dockerfile instructions

### DIFF
--- a/pkg/iac/scanners/dockerfile/parser/parser.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser.go
@@ -107,7 +107,7 @@ func originalFromHeredoc(node *parser.Node) string {
 // heredoc processing taken from here
 // https://github.com/moby/buildkit/blob/9a39e2c112b7c98353c27e64602bc08f31fe356e/frontend/dockerfile/dockerfile2llb/convert.go#L1200
 func processHeredoc(node *parser.Node) string {
-	if parser.MustParseHeredoc(node.Next.Value) == nil {
+	if parser.MustParseHeredoc(node.Next.Value) == nil || strings.HasPrefix(node.Heredocs[0].Content, "#!") {
 		// more complex heredoc is passed to the shell as is
 		var sb strings.Builder
 		sb.WriteString(node.Next.Value)
@@ -117,11 +117,6 @@ func processHeredoc(node *parser.Node) string {
 			sb.WriteString(heredoc.Name)
 		}
 		return sb.String()
-	}
-
-	// if heredoc contains shebang, docker creates a file with the contents and runs it
-	if strings.HasPrefix(node.Heredocs[0].Content, "#!") {
-		return "/dev/pipes/" + node.Heredocs[0].Name
 	}
 
 	// simple heredoc and the content is run in a shell

--- a/pkg/iac/scanners/dockerfile/parser/parser.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser.go
@@ -30,7 +30,7 @@ func Parse(_ context.Context, r io.Reader, path string) (any, error) {
 
 		instr, err := instructions.ParseInstruction(child)
 		if err != nil {
-			return nil, fmt.Errorf("process dockerfile instructions: %w", err)
+			return nil, fmt.Errorf("parse dockerfile instruction: %w", err)
 		}
 
 		if _, ok := instr.(*instructions.Stage); ok {
@@ -56,14 +56,27 @@ func Parse(_ context.Context, r io.Reader, path string) (any, error) {
 			EndLine:   child.EndLine,
 		}
 
+		// processing statement with sub-statement
+		// example: ONBUILD RUN foo bar
+		// https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#onbuild
 		if child.Next != nil && len(child.Next.Children) > 0 {
 			cmd.SubCmd = child.Next.Children[0].Value
 			child = child.Next.Children[0]
 		}
 
+		// mark if the instruction is in exec form
+		// https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#exec-form
 		cmd.JSON = child.Attributes["json"]
-		for n := child.Next; n != nil; n = n.Next {
-			cmd.Value = append(cmd.Value, n.Value)
+
+		// heredoc may contain a script that will be executed in the shell, so we need to process it
+		// https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#here-documents
+		if len(child.Heredocs) > 0 && child.Next != nil {
+			cmd.Original = originalFromHeredoc(child)
+			cmd.Value = []string{processHeredoc(child)}
+		} else {
+			for n := child.Next; n != nil; n = n.Next {
+				cmd.Value = append(cmd.Value, n.Value)
+			}
 		}
 
 		stage.Commands = append(stage.Commands, cmd)
@@ -74,4 +87,50 @@ func Parse(_ context.Context, r io.Reader, path string) (any, error) {
 	}
 
 	return &parsedFile, nil
+}
+
+func originalFromHeredoc(node *parser.Node) string {
+	var sb strings.Builder
+	sb.WriteString(node.Original)
+	sb.WriteRune('\n')
+	for i, heredoc := range node.Heredocs {
+		sb.WriteString(heredoc.Content)
+		sb.WriteString(heredoc.Name)
+		if i != len(node.Heredocs)-1 {
+			sb.WriteRune('\n')
+		}
+	}
+
+	return sb.String()
+}
+
+// heredoc processing taken from here
+// https://github.com/moby/buildkit/blob/9a39e2c112b7c98353c27e64602bc08f31fe356e/frontend/dockerfile/dockerfile2llb/convert.go#L1200
+func processHeredoc(node *parser.Node) string {
+	if parser.MustParseHeredoc(node.Next.Value) == nil {
+		// more complex heredoc is passed to the shell as is
+		var sb strings.Builder
+		sb.WriteString(node.Next.Value)
+		for _, heredoc := range node.Heredocs {
+			sb.WriteRune('\n')
+			sb.WriteString(heredoc.Content)
+			sb.WriteString(heredoc.Name)
+		}
+		return sb.String()
+	}
+
+	// if heredoc contains shebang, docker creates a file with the contents and runs it
+	if strings.HasPrefix(node.Heredocs[0].Content, "#!") {
+		return "/dev/pipes/" + node.Heredocs[0].Name
+	}
+
+	// simple heredoc and the content is run in a shell
+	content := node.Heredocs[0].Content
+	if node.Heredocs[0].Chomp {
+		content = parser.ChompHeredocContent(content)
+	}
+
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	cmds := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	return strings.Join(cmds, " ; ")
 }

--- a/pkg/iac/scanners/dockerfile/parser/parser_test.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser_test.go
@@ -97,7 +97,7 @@ EOF`,
 #!/usr/bin/env python
 print("hello world")
 EOF`,
-			expected: "/dev/pipes/EOF",
+			expected: "<<EOF\n#!/usr/bin/env python\nprint(\"hello world\")\nEOF",
 		},
 	}
 

--- a/pkg/iac/scanners/dockerfile/parser/parser_test.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser_test.go
@@ -59,3 +59,60 @@ CMD python /app/app.py
 	assert.Equal(t, 4, commands[3].StartLine)
 	assert.Equal(t, 4, commands[3].EndLine)
 }
+
+func Test_ParseHeredocs(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected string
+	}{
+		{
+			name: "multi-line script",
+			src: `RUN <<EOF
+apk add curl
+apk add git
+EOF`,
+			expected: "apk add curl ; apk add git",
+		},
+		{
+			name: "file redirection and chained command",
+			src: `RUN cat <<EOF > /tmp/output && echo 'done'
+hello
+mr
+potato
+EOF`,
+			expected: "cat <<EOF > /tmp/output && echo 'done'\nhello\nmr\npotato\nEOF",
+		},
+		{
+			name: "redirect to file",
+			src: `RUN <<EOF > /etc/config.yaml
+key1: value1
+key2: value2
+EOF`,
+			expected: "<<EOF > /etc/config.yaml\nkey1: value1\nkey2: value2\nEOF",
+		},
+		{
+			name: "with a shebang",
+			src: `RUN <<EOF
+#!/usr/bin/env python
+print("hello world")
+EOF`,
+			expected: "/dev/pipes/EOF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := parser.Parse(context.TODO(), strings.NewReader(tt.src), "Dockerfile")
+			require.NoError(t, err)
+
+			df, ok := res.(*dockerfile.Dockerfile)
+			require.True(t, ok)
+
+			cmd := df.Stages[0].Commands[0]
+
+			assert.Equal(t, tt.src, cmd.Original)
+			assert.Equal(t, []string{tt.expected}, cmd.Value)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Heredocs allow redirection of subsequent Dockerfile lines to the input of RUN or COPY commands. Right now, Trivy does not handle heredocs in instructions and only exports the first line as an instruction value:
```bash
TRACE | | | Unify {"Cmd": "run", "EndLine": 4, "Flags": [], "JSON": false, "Original": "RUN <<EOF", "Path": "Dockerfile", "Stage": 0, "StartLine": 2, "SubCmd": "", "Value": ["<<EOF"]} = instruction
```

The following scenarios are taken into account:
1. If the first line in the heredoc is a shebang, the value of the command is the file containing the contents of the heredoc for execution.
2. In the case of a simple heredoc, its contents are converted into commands.
3. In other cases, the heredoc is exported as is.

Example Dockerfile:
```Dockerfile
FROM alpine:3.21
RUN <<EOF
apk add curl
EOF
```

Output:
```bash
./trivy conf --cache-dir cache --checks-bundle-repository localhost:5111/trivy-checks:latest Dockerfile --trace
2025-01-23T18:24:42+06:00       INFO    [misconfig] Misconfiguration scanning is enabled
2025-01-23T18:24:43+06:00       INFO    Detected config files   num=1
...
AVD-DS-0025 (HIGH): '--no-cache' is missed: apk add curl
═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
You should use 'apk add' with '--no-cache' to clean package cached data and reduce image size.

See https://avd.aquasec.com/misconfig/ds025
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Dockerfile:2-4
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   2 ┌ RUN <<EOF
   3 │ apk add curl
   4 └ EOF
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Trace:
```bash
TRACE | | | Unify {"Cmd": "run", "EndLine": 4, "Flags": [], "JSON": false, "Original": "RUN <<EOF\napk add curl\nEOF", "Path": "Dockerfile", "Stage": 0, "StartLine": 2, "SubCmd": "", "Value": ["apk add curl"]} = instruction
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8283

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
