### PR TITLE
chore: use require.ErrorContains when possible

### DIFF
--- a/pkg/cache/fs_test.go
+++ b/pkg/cache/fs_test.go
@@ -286,8 +286,7 @@ func TestFSCache_PutBlob(t *testing.T) {
 
 			err = fs.PutBlob(tt.args.diffID, tt.args.layerInfo)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -366,8 +365,7 @@ func TestFSCache_PutArtifact(t *testing.T) {
 
 			err = fs.PutArtifact(tt.args.imageID, tt.args.imageConfig)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -314,8 +314,7 @@ func TestMemoryCache_DeleteBlobs(t *testing.T) {
 			// Check that the blobs are no longer in the cache
 			for _, blobID := range tt.blobIDs {
 				_, err := c.GetBlob(blobID)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "not found in memory cache")
+				require.ErrorContains(t, err, "not found in memory cache")
 			}
 		})
 	}
@@ -348,12 +347,10 @@ func TestMemoryCache_Clear(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = c.GetArtifact(tt.artifactID)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "not found in memory cache")
+			require.ErrorContains(t, err, "not found in memory cache")
 
 			_, err = c.GetBlob(tt.blobID)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "not found in memory cache")
+			require.ErrorContains(t, err, "not found in memory cache")
 		})
 	}
 }
@@ -385,12 +382,10 @@ func TestMemoryCache_Close(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = c.GetArtifact(tt.artifactID)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "not found in memory cache")
+			require.ErrorContains(t, err, "not found in memory cache")
 
 			_, err = c.GetBlob(tt.blobID)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "not found in memory cache")
+			require.ErrorContains(t, err, "not found in memory cache")
 		})
 	}
 }

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -537,8 +537,7 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 
 			err = c.DeleteBlobs(tt.args.blobIDs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/cache/remote_test.go
+++ b/pkg/cache/remote_test.go
@@ -152,8 +152,7 @@ func TestRemoteCache_PutArtifact(t *testing.T) {
 			})
 			err := c.PutArtifact(tt.args.imageID, tt.args.imageInfo)
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -217,8 +216,7 @@ func TestRemoteCache_PutBlob(t *testing.T) {
 			})
 			err := c.PutBlob(tt.args.diffID, tt.args.layerInfo)
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -299,8 +297,7 @@ func TestRemoteCache_MissingBlobs(t *testing.T) {
 			})
 			gotMissingImage, gotMissingLayerIDs, err := c.MissingBlobs(tt.args.imageID, tt.args.layerIDs)
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -353,8 +350,7 @@ func TestRemoteCache_PutArtifactInsecure(t *testing.T) {
 			})
 			err := c.PutArtifact(tt.args.imageID, tt.args.imageInfo)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err, tt.name)

--- a/pkg/compliance/spec/compliance_test.go
+++ b/pkg/compliance/spec/compliance_test.go
@@ -271,7 +271,7 @@ func TestComplianceSpec_LoadFromDiskBundle(t *testing.T) {
 
 	t.Run("load user specified spec from disk fails", func(t *testing.T) {
 		_, err := spec.GetComplianceSpec("@doesnotexist", "does-not-matter")
-		assert.Contains(t, err.Error(), "error retrieving compliance spec from path")
+		require.ErrorContains(t, err, "error retrieving compliance spec from path")
 	})
 
 	t.Run("bundle does not exist", func(t *testing.T) {
@@ -288,6 +288,6 @@ func TestComplianceSpec_LoadFromDiskBundle(t *testing.T) {
 
 	t.Run("load spec yaml unmarshal failure", func(t *testing.T) {
 		_, err := spec.GetComplianceSpec("invalid", filepath.Join("testdata", "testcache"))
-		assert.Contains(t, err.Error(), "spec yaml decode error")
+		require.ErrorContains(t, err, "spec yaml decode error")
 	})
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -127,8 +127,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 
 			switch {
 			case tt.wantErr != "":
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 			default:
 				require.NoError(t, err, tt.name)
 			}

--- a/pkg/dependency/parser/dotnet/core_deps/parse_test.go
+++ b/pkg/dependency/parser/dotnet/core_deps/parse_test.go
@@ -93,8 +93,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
 

--- a/pkg/dependency/parser/frameworks/wordpress/parse_test.go
+++ b/pkg/dependency/parser/frameworks/wordpress/parse_test.go
@@ -37,8 +37,7 @@ func TestParseWordPress(t *testing.T) {
 
 			got, err := Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -2160,8 +2160,7 @@ func TestPom_Parse(t *testing.T) {
 
 			gotPkgs, gotDeps, err := p.Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/dependency/parser/nuget/config/parse_test.go
+++ b/pkg/dependency/parser/nuget/config/parse_test.go
@@ -46,8 +46,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := config.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/dependency/parser/nuget/packagesprops/parse_test.go
+++ b/pkg/dependency/parser/nuget/packagesprops/parse_test.go
@@ -70,8 +70,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := config.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/dependency/parser/ruby/gemspec/parse_test.go
+++ b/pkg/dependency/parser/ruby/gemspec/parse_test.go
@@ -83,8 +83,7 @@ func TestParse(t *testing.T) {
 
 			got, _, err := gemspec.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			assert.Equal(t, tt.want, got)

--- a/pkg/dependency/parser/rust/binary/parse_test.go
+++ b/pkg/dependency/parser/rust/binary/parse_test.go
@@ -77,8 +77,7 @@ func TestParse(t *testing.T) {
 
 			got, gotDeps, err := binary.NewParser().Parse(f)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -220,8 +220,7 @@ func TestDriver_Detect(t *testing.T) {
 
 			got, err := driver.DetectVulnerabilities("", tt.args.pkgName, tt.args.pkgVer)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -165,8 +165,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := alma.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/alpine/alpine_test.go
+++ b/pkg/detector/ospkg/alpine/alpine_test.go
@@ -254,8 +254,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := alpine.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, tt.args.repo, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -180,8 +180,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := amazon.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/azure/azure_test.go
+++ b/pkg/detector/ospkg/azure/azure_test.go
@@ -187,8 +187,7 @@ func TestScanner_Detect(t *testing.T) {
 			}
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/chainguard/chainguard_test.go
+++ b/pkg/detector/ospkg/chainguard/chainguard_test.go
@@ -196,8 +196,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := chainguard.NewScanner()
 			got, err := s.Detect(nil, "", tt.args.repo, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -118,8 +118,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := debian.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -343,8 +343,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -97,8 +97,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := photon.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -125,8 +125,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := rocky.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/suse/suse_test.go
+++ b/pkg/detector/ospkg/suse/suse_test.go
@@ -220,8 +220,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := suse.NewScanner(tt.distribution)
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -182,8 +182,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := ubuntu.NewScanner()
 			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			sort.Slice(got, func(i, j int) bool {

--- a/pkg/detector/ospkg/wolfi/wolfi_test.go
+++ b/pkg/detector/ospkg/wolfi/wolfi_test.go
@@ -196,8 +196,7 @@ func TestScanner_Detect(t *testing.T) {
 			s := wolfi.NewScanner()
 			got, err := s.Detect(nil, "", tt.args.repo, tt.args.pkgs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -522,8 +522,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 				DisabledAnalyzers: tt.args.disabledAnalyzers,
 			})
 			if err != nil && tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
@@ -549,8 +548,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 
 			wg.Wait()
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
@@ -55,8 +55,7 @@ func Test_contentManifestAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/language/analyze_test.go
+++ b/pkg/fanal/analyzer/language/analyze_test.go
@@ -97,8 +97,7 @@ func TestAnalyze(t *testing.T) {
 
 			got, err := language.Analyze(tt.args.fileType, tt.args.filePath, tt.args.content, mp)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
@@ -64,8 +64,7 @@ func Test_depsLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -191,8 +191,7 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 				},
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
@@ -89,8 +89,7 @@ func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 

--- a/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
@@ -141,8 +141,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
+++ b/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
@@ -92,8 +92,7 @@ func Test_gemspecLibraryAnalyzer_Analyze(t *testing.T) {
 			})
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -95,8 +95,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, tt.input)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/debian/debian_test.go
+++ b/pkg/fanal/analyzer/os/debian/debian_test.go
@@ -59,8 +59,7 @@ func Test_debianOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/alma_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/alma_test.go
@@ -46,8 +46,7 @@ func Test_almaOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/centos_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos_test.go
@@ -45,8 +45,7 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
@@ -45,8 +45,7 @@ func Test_fedoraOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
@@ -45,8 +45,7 @@ func Test_oracleOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
@@ -45,8 +45,7 @@ func Test_redhatOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/redhatbase/rocky_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/rocky_test.go
@@ -45,8 +45,7 @@ func Test_rockyOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
+++ b/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
@@ -45,8 +45,7 @@ func Test_ubuntuOSAnalyzer_Analyze(t *testing.T) {
 				Content:  f,
 			})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/applier/applier_test.go
+++ b/pkg/fanal/applier/applier_test.go
@@ -1057,8 +1057,7 @@ func TestApplier_ApplyLayers(t *testing.T) {
 
 			got, err := a.ApplyLayers(tt.args.imageID, tt.args.layerIDs)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 			} else {
 				require.NoError(t, err, tt.name)
 			}

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -265,8 +265,7 @@ func TestArtifact_Inspect(t *testing.T) {
 
 			got, err := a.Inspect(context.Background())
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -261,8 +261,7 @@ func Test_newURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newURL(tt.args.rawurl)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			} else {
 				require.NoError(t, err)

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -397,8 +397,7 @@ func TestNewDockerImageWithPrivateRegistry(t *testing.T) {
 			defer cleanup()
 
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, err)
+				require.ErrorContains(t, err, tt.wantErr, err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -488,8 +487,7 @@ func TestNewArchiveImage(t *testing.T) {
 			img, err := NewArchiveImage(tt.args.fileName)
 			switch {
 			case tt.wantErr != "":
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			default:
 				require.NoError(t, err, tt.name)

--- a/pkg/fanal/image/oci_test.go
+++ b/pkg/fanal/image/oci_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,8 +61,7 @@ func TestTryOCI(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := tryOCI(test.ociImagePath)
 			if test.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.wantErr, err)
+				require.ErrorContains(t, err, test.wantErr, err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/fanal/walker/tar_test.go
+++ b/pkg/fanal/walker/tar_test.go
@@ -80,8 +80,7 @@ func TestLayerTar_Walk(t *testing.T) {
 			w := walker.NewLayerTar(tt.option)
 			gotOpqDirs, gotWhFiles, err := w.Walk(f, tt.analyzeFn)
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -122,8 +122,7 @@ func TestClient_LoadBuiltinPolicies(t *testing.T) {
 
 			got, err := c.LoadBuiltinChecks()
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
@@ -363,8 +362,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 
 			err = c.DownloadBuiltinChecks(context.Background(), ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -446,8 +446,7 @@ func TestNewPackageURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			packageURL, err := purl.New(tc.typ, tc.metadata, tc.pkg)
 			if tc.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -49,7 +49,7 @@ func TestParseIgnoreFile(t *testing.T) {
 		_, _ = f.WriteString("this file is not a yaml file")
 
 		got, err := ParseIgnoreFile(context.TODO(), f.Name())
-		assert.Contains(t, err.Error(), "yaml decode error")
+		require.ErrorContains(t, err, "yaml decode error")
 		assert.Empty(t, got)
 	})
 

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -101,8 +101,7 @@ func Test_dbWorker_update(t *testing.T) {
 			err = w.update(ctx, "1.2.3", dbDir,
 				tt.skipUpdate, &dbUpdateWg, &requestWg, ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			}
 			require.NoError(t, err, tt.name)

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -174,8 +174,7 @@ func TestScanServer_Scan(t *testing.T) {
 			s := NewScanServer(mockDriver)
 			got, err := s.Scan(context.Background(), tt.args.in)
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			}
 			require.NoError(t, err, tt.name)
@@ -273,8 +272,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 			got, err := s.PutArtifact(context.Background(), tt.args.in)
 
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -508,8 +506,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 			got, err := s.PutBlob(context.Background(), tt.args.in)
 
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)
@@ -573,8 +570,7 @@ func TestCacheServer_MissingBlobs(t *testing.T) {
 			s := NewCacheServer(mockCache)
 			got, err := s.MissingBlobs(tt.args.ctx, tt.args.in)
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.name)
-				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
 			} else {
 				require.NoError(t, err, tt.name)


### PR DESCRIPTION
## Description

use [`require.ErrorContains`](https://pkg.go.dev/github.com/stretchr/testify/require#ErrorContains) instead of `require.Error` with `assert.Contains`  when possible
