### PR TITLE
feat(image): return error early if total size of layers exceeds limit

### DIFF
--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -520,7 +520,14 @@ $ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE
 ```
 
 ### Prevent scanning oversized container images
-Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format (e.g., `100MB`, `10GB`). If the compressed image size exceeds the specified threshold, an error is returned immediately. Otherwise, all layers are pulled, stored in a temporary folder, and their uncompressed size is verified before scanning. Temporary layers are always cleaned up, even after a successful scan.
+Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format (e.g., `100MB`, `10GB`).
+
+An error is returned in the following cases:
+- if the compressed image size exceeds the limit,
+- if the total size of the layers exceeds the specified limit during their pulling,
+- if the uncompressed image size exceeds the limit after the layers are pulled.
+
+The layers are pulled into a temporary folder during their pulling and are always cleaned up, even after a successful scan.
 
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -523,9 +523,9 @@ $ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE
 Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format (e.g., `100MB`, `10GB`).
 
 An error is returned in the following cases:
+
 - if the compressed image size exceeds the limit,
-- if the total size of the layers exceeds the specified limit during their pulling,
-- if the uncompressed image size exceeds the limit after the layers are pulled.
+- if the accumulated size of the uncompressed layers exceeds the limit during their pulling.
 
 The layers are pulled into a temporary folder during their pulling and are always cleaned up, even after a successful scan.
 

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -520,7 +520,7 @@ $ trivy image --podman-host /run/user/1000/podman/podman.sock YOUR_IMAGE
 ```
 
 ### Prevent scanning oversized container images
-Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format (e.g., `100MB`, `10GB`).
+Use the `--max-image-size` flag to avoid scanning images that exceed a specified size. The size is specified in a human-readable format[^1] (e.g., `100MB`, `10GB`).
 
 An error is returned in the following cases:
 
@@ -544,5 +544,4 @@ Error Output:
 Error: uncompressed image size (15GB) exceeds maximum allowed size (10GB)
 ```
 
-!!! note
-    Trivy displays size using decimal (SI) prefixes (based on 1000).
+[^1]: Trivy uses decimal (SI) prefixes (based on 1000) for size.

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -543,3 +543,6 @@ Error Output:
 ```bash
 Error: uncompressed image size (15GB) exceeds maximum allowed size (10GB)
 ```
+
+!!! note
+    Trivy displays size using decimal (SI) prefixes (based on 1000).

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -206,7 +206,7 @@ func TestDockerEngine(t *testing.T) {
 			name:         "sad path, image size is larger than the maximum",
 			input:        "testdata/fixtures/images/alpine-39.tar.gz",
 			maxImageSize: "3mb",
-			wantErr:      "uncompressed image size 5.8MB exceeds maximum allowed size 3MB",
+			wantErr:      "uncompressed layers size 5.8MB exceeds maximum allowed size 3MB",
 		},
 	}
 

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -297,7 +297,8 @@ func (a Artifact) imageSize(ctx context.Context, diffIDs []string) (int64, error
 			totalSize += layerSize
 			completedLayers += 1
 			// If the layer size exceeds the limit during loading, return an error immediately.
-			// Otherwise, if the image is fully loaded, check the size later.
+			// Otherwise, if the image is fully loaded, check the size later
+			// to possibly work with the image
 			if totalSize > a.artifactOption.ImageOption.MaxImageSize &&
 				completedLayers != len(diffIDs) {
 				return a.imageSizeError("uncompressed layers", totalSize)

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2255,11 +2255,19 @@ func TestArtifact_Inspect(t *testing.T) {
 		},
 		{
 			name:      "sad path, image size is larger than the maximum",
-			imagePath: "../../test/testdata/alpine-311.tar.gz",
+			imagePath: "../../test/testdata/image2.tar",
 			artifactOpt: artifact.Option{
-				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 4},
+				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 4.1},
 			},
-			wantErr: "uncompressed image size 5.86MB exceeds maximum allowed size 4MB",
+			wantErr: "uncompressed image size 4.2MB exceeds maximum allowed size 4.1MB",
+		},
+		{
+			name:      "sad path, the first layer is larger than the threshold",
+			imagePath: "../../test/testdata/image2.tar",
+			artifactOpt: artifact.Option{
+				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
+			},
+			wantErr: "the accumulated size of uncompressed layers 2.1MB exceeds maximum allowed size 1MB",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -3,11 +3,13 @@ package image_test
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/docker/go-units"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
@@ -2245,30 +2247,6 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			wantErr: "put artifact failed",
 		},
-		{
-			name:      "sad path, compressed image size is larger than the maximum",
-			imagePath: "../../test/testdata/alpine-311.tar.gz",
-			artifactOpt: artifact.Option{
-				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
-			},
-			wantErr: "compressed image size 3.03MB exceeds maximum allowed size 1MB",
-		},
-		{
-			name:      "sad path, image size is larger than the maximum",
-			imagePath: "../../test/testdata/image2.tar",
-			artifactOpt: artifact.Option{
-				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 4.1},
-			},
-			wantErr: "uncompressed image size 4.2MB exceeds maximum allowed size 4.1MB",
-		},
-		{
-			name:      "sad path, the first layer is larger than the threshold",
-			imagePath: "../../test/testdata/image2.tar",
-			artifactOpt: artifact.Option{
-				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
-			},
-			wantErr: "uncompressed layers size 2.1MB exceeds maximum allowed size 1MB",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2292,6 +2270,45 @@ func TestArtifact_Inspect(t *testing.T) {
 
 			require.NoError(t, err, tt.name)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestArtifact_InspectWithMaxImageSize(t *testing.T) {
+	randomImage, err := random.Image(1000, 2, random.WithSource(rand.NewSource(0)))
+	require.NoError(t, err)
+
+	img := &fakeImage{Image: randomImage}
+	mockCache := new(cache.MockArtifactCache)
+
+	tests := []struct {
+		name        string
+		artifactOpt artifact.Option
+		wantErr     string
+	}{
+		{
+			name: "compressed image size is larger than the maximum",
+			artifactOpt: artifact.Option{
+				ImageOption: types.ImageOptions{MaxImageSize: units.KB * 1},
+			},
+			wantErr: "compressed image size 2.44kB exceeds maximum allowed size 1kB",
+		},
+		{
+			name: "uncompressed image size is larger than the maximum",
+			artifactOpt: artifact.Option{
+				ImageOption: types.ImageOptions{MaxImageSize: units.KB * 3},
+			},
+			wantErr: "uncompressed image size 5.12kB exceeds maximum allowed size 3kB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artifact, err := image2.NewArtifact(img, mockCache, tt.artifactOpt)
+			require.NoError(t, err)
+
+			_, err = artifact.Inspect(context.Background())
+			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2294,11 +2294,11 @@ func TestArtifact_InspectWithMaxImageSize(t *testing.T) {
 			wantErr: "compressed image size 2.44kB exceeds maximum allowed size 1kB",
 		},
 		{
-			name: "uncompressed image size is larger than the maximum",
+			name: "uncompressed layers size is larger than the maximum",
 			artifactOpt: artifact.Option{
 				ImageOption: types.ImageOptions{MaxImageSize: units.KB * 3},
 			},
-			wantErr: "uncompressed image size 5.12kB exceeds maximum allowed size 3kB",
+			wantErr: "uncompressed layers size 5.12kB exceeds maximum allowed size 3kB",
 		},
 	}
 

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2267,7 +2267,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			artifactOpt: artifact.Option{
 				ImageOption: types.ImageOptions{MaxImageSize: units.MB * 1},
 			},
-			wantErr: "the accumulated size of uncompressed layers 2.1MB exceeds maximum allowed size 1MB",
+			wantErr: "uncompressed layers size 2.1MB exceeds maximum allowed size 1MB",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 type fakeImage struct {
 	name        string
 	repoDigests []string
-	*fakei.FakeImage
+	v1.Image
 	types.ImageExtension
 }
 
@@ -160,7 +160,7 @@ func TestArtifact_InspectRekorAttestation(t *testing.T) {
 			img := &fakeImage{
 				name:        tt.fields.imageName,
 				repoDigests: tt.fields.repoDigests,
-				FakeImage:   fi,
+				Image:       fi,
 			}
 			a, err := image2.NewArtifact(img, mockCache, tt.artifactOpt)
 			require.NoError(t, err)
@@ -304,7 +304,7 @@ func TestArtifact_inspectOCIReferrerSBOM(t *testing.T) {
 			img := &fakeImage{
 				name:        tt.fields.imageName,
 				repoDigests: tt.fields.repoDigests,
-				FakeImage:   fi,
+				Image:       fi,
 			}
 			a, err := image2.NewArtifact(img, mockCache, tt.artifactOpt)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR optimizes the image size check by returning an error if the total size of the layers exceeds the limit, without the need to load the entire image.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/8178

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
