### PR TITLE
docs: replace short codes with Unicode emojis

### DIFF
--- a/docs/docs/scanner/misconfiguration/custom/index.md
+++ b/docs/docs/scanner/misconfiguration/custom/index.md
@@ -121,17 +121,17 @@ Trivy supports extra fields in the `custom` section as described below.
 If you are creating checks for your Trivy misconfiguration scans, some fields are optional as referenced in the table below. The `schemas` field should be used to enable policy validation using a built-in schema. It is recommended to use this to ensure your checks are 
 correct and do not reference incorrect properties/values.
 
-| Field name                 | Allowed values                                                    |        Default value         |     In table     |     In JSON      |
-|----------------------------|-------------------------------------------------------------------|:----------------------------:|:----------------:|:----------------:|
-| title                      | Any characters                                                    |             N/A              | :material-check: | :material-check: |
-| description                | Any characters                                                    |                              | :material-close: | :material-check: |
-| schemas.input              | `schema["kubernetes"]`, `schema["dockerfile"]`, `schema["cloud"]` | (applied to all input types) | :material-close: | :material-close: |
-| custom.id                  | Any characters                                                    |             N/A              | :material-check: | :material-check: |
-| custom.severity            | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`                               |           UNKNOWN            | :material-check: | :material-check: |
-| custom.recommended_actions | Any characters                                                    |                              | :material-close: | :material-check: |
-| custom.deprecated          | `true`, `false`                                                   |           `false`            | :material-close: | :material-check: | 
-| custom.input.selector.type | Any item(s) in [this list][source-types]                          |                              | :material-close: | :material-check: |
-| url                        | Any characters                                                    |                              | :material-close: | :material-check: |
+| Field name                 | Allowed values                                                    |        Default value         | In table | In JSON |
+|----------------------------|-------------------------------------------------------------------|:----------------------------:|:--------:|:-------:|
+| title                      | Any characters                                                    |             N/A              |    ✅     |    ✅    |
+| description                | Any characters                                                    |                              |    -     |    ✅    |
+| schemas.input              | `schema["kubernetes"]`, `schema["dockerfile"]`, `schema["cloud"]` | (applied to all input types) |    -     |    -    |
+| custom.id                  | Any characters                                                    |             N/A              |    ✅     |    ✅    |
+| custom.severity            | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`                               |           UNKNOWN            |    ✅     |    ✅    |
+| custom.recommended_actions | Any characters                                                    |                              |    -     |    ✅    |
+| custom.deprecated          | `true`, `false`                                                   |           `false`            |    -     |    ✅    |
+| custom.input.selector.type | Any item(s) in [this list][source-types]                          |                              |    -     |    ✅    |
+| url                        | Any characters                                                    |                              |    -     |    ✅    |
 
 #### custom.avd_id and custom.id
 


### PR DESCRIPTION
## Description
[This](https://github.com/aquasecurity/trivy/pull/7884) PR removed the emoji extension, which broke the emoji display. This PR replaces short codes with unicode emoji, which are used throughout the documentation.

### Before
<img width="704" alt="image" src="https://github.com/user-attachments/assets/b31011d8-2318-4961-b605-f29775d84bba" />


### After
<img width="706" alt="image" src="https://github.com/user-attachments/assets/4cd6bc4b-f68f-4562-83a3-9ae2cf5c3304" />


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
