### PR TITLE
chore(terraform): add accessors to underlying raw hcl values

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -90,6 +90,10 @@ func (p *Parser) newModuleParser(moduleFS fs.FS, moduleSource, modulePath, modul
 	return mp
 }
 
+func (p *Parser) Files() map[string]*hcl.File {
+	return p.underlying.Files()
+}
+
 func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 
 	isJSON := strings.HasSuffix(fullPath, ".tf.json")

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -61,7 +61,7 @@ func NewAttribute(attr *hcl.Attribute, ctx *context.Context, module string, pare
 	}
 }
 
-func (a *Attribute) AsNative() *hcl.Attribute {
+func (a *Attribute) HCLAttribute() *hcl.Attribute {
 	return a.hclAttribute
 }
 

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -61,6 +61,10 @@ func NewAttribute(attr *hcl.Attribute, ctx *context.Context, module string, pare
 	}
 }
 
+func (a *Attribute) AsNative() *hcl.Attribute {
+	return a.hclAttribute
+}
+
 func (a *Attribute) GetMetadata() iacTypes.Metadata {
 	return a.metadata
 }

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -123,6 +123,10 @@ func NewBlock(hclBlock *hcl.Block, ctx *context.Context, moduleBlock *Block, par
 	return &b
 }
 
+func (b *Block) AsNative() *hcl.Block {
+	return b.hclBlock
+}
+
 func (b *Block) ID() string {
 	return b.id
 }

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -123,7 +123,7 @@ func NewBlock(hclBlock *hcl.Block, ctx *context.Context, moduleBlock *Block, par
 	return &b
 }
 
-func (b *Block) AsNative() *hcl.Block {
+func (b *Block) HCLBlock() *hcl.Block {
 	return b.hclBlock
 }
 


### PR DESCRIPTION
## Description

The abstraction layer serves as a convient layer for handling 'Value()' outputs. If the return value is unknown, the underlying raw HCL is useful for additional diagnostics.

Similarly, to print out diagnostics, the underlying parser files are required for the raw source code.


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
