### PR TITLE
fix: improve conversion of image config to Dockerfile

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -99,6 +99,12 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 		case strings.HasPrefix(h.CreatedBy, "HEALTHCHECK"):
 			// HEALTHCHECK instruction
 			createdBy = buildHealthcheckInstruction(cfg.Config.Healthcheck)
+		default:
+			for _, prefix := range []string{"ARG", "ENV", "ENTRYPOINT"} {
+				strings.HasPrefix(h.CreatedBy, prefix)
+				createdBy = h.CreatedBy
+				break
+			}
 		}
 		dockerfile.WriteString(strings.TrimSpace(createdBy) + "\n")
 	}

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -411,6 +411,26 @@ func Test_ImageConfigToDockerfile(t *testing.T) {
 			},
 			expected: "ARG TAG=latest\n",
 		},
+		{
+			name: "buildkit metadata instructions",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "ARG TAG=latest",
+					},
+					{
+						CreatedBy: "ENV TAG=latest",
+					},
+					{
+						CreatedBy: "ENTRYPOINT [\"/bin/sh\" \"-c\" \"echo test\"]",
+					},
+				},
+			},
+			expected: `ARG TAG=latest
+ENV TAG=latest
+ENTRYPOINT ["/bin/sh" "-c" "echo test"]
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -1,11 +1,13 @@
 package dockerfile
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -340,6 +342,84 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_ImageConfigToDockerfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *v1.ConfigFile
+		expected string
+	}{
+		{
+			name: "run instruction with build args",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "RUN |1 pkg=curl /bin/sh -c apk add $pkg # buildkit",
+					},
+				},
+			},
+			expected: "RUN apk add $pkg\n",
+		},
+		{
+			name: "healthcheck instruction with system's default shell",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "HEALTHCHECK &{[\"CMD-SHELL\" \"curl -f http://localhost/ || exit 1\"] \"5m0s\" \"3s\" \"1s\" \"5s\" '\\x03'}",
+					},
+				},
+				Config: v1.Config{
+					Healthcheck: &v1.HealthConfig{
+						Test:        []string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"},
+						Interval:    time.Minute * 5,
+						Timeout:     time.Second * 3,
+						StartPeriod: time.Second * 1,
+						Retries:     3,
+					},
+				},
+			},
+			expected: "HEALTHCHECK --interval=5m0s --timeout=3s --startPeriod=1s --retries=3 CMD curl -f http://localhost/ || exit 1\n",
+		},
+		{
+			name: "healthcheck instruction exec arguments directly",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "HEALTHCHECK &{[\"CMD\" \"curl\" \"-f\" \"http://localhost/\" \"||\" \"exit 1\"] \"0s\" \"0s\" \"0s\" \"0s\" '\x03'}",
+					},
+				},
+				Config: v1.Config{
+					Healthcheck: &v1.HealthConfig{
+						Test:    []string{"CMD", "curl", "-f", "http://localhost/", "||", "exit 1"},
+						Retries: 3,
+					},
+				},
+			},
+			expected: "HEALTHCHECK --retries=3 CMD curl -f http://localhost/ || exit 1\n",
+		},
+		{
+			name: "nop, no run instruction",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "/bin/sh -c #(nop)  ARG TAG=latest",
+					},
+				},
+			},
+			expected: "ARG TAG=latest\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := imageConfigToDockerfile(tt.input)
+			_, err := parser.Parse(bytes.NewReader(got))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, string(got))
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR includes the following changes:
- extracts config conversion to dockerfile into a separate function to facilitate testing
- adds support for buildkit metadata instructions, e.g. `env`, `arg`. Such commands show up in the history without the `# buildkit` suffix, so Trivy ignored them.
```bash
ENTRYPOINT ["/bin/sh" "-c" "echo test"]
RUN /bin/sh -c apk add $pkg # buildkit
```
- fixes the handling of `run` with build arguments

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8277


## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
