### PR TITLE
fix(misconf)!: Add AWS ECS Enhanced Container Insights

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
@@ -27,8 +27,8 @@ func getClusters(ctx parser.FileContext) (clusters []ecs.Cluster) {
 func getClusterSettings(r *parser.Resource) ecs.ClusterSettings {
 
 	clusterSettings := ecs.ClusterSettings{
-		Metadata:                 r.Metadata(),
-		ContainerInsightsEnabled: types.BoolDefault(false, r.Metadata()),
+		Metadata:              r.Metadata(),
+		ContainerInsightsMode: types.StringDefault("disabled", r.Metadata()),
 	}
 
 	clusterSettingMap := r.GetProperty("ClusterSettings")
@@ -50,8 +50,8 @@ func checkProperty(setting *parser.Property, clusterSettings *ecs.ClusterSetting
 	name := settingMap["Name"]
 	if name.IsNotNil() && name.EqualTo("containerInsights") {
 		value := settingMap["Value"]
-		if value.IsNotNil() && value.EqualTo("enabled") {
-			clusterSettings.ContainerInsightsEnabled = types.Bool(true, value.Metadata())
+		if value.IsNotNil() {
+			clusterSettings.ContainerInsightsMode = types.String(value.AsString(), value.Metadata())
 		}
 	}
 }

--- a/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
@@ -25,11 +25,11 @@ Resources:
       ClusterSettings:
         - Name: containerInsights
           Value: enabled
-  taskdefinition: 
+  taskdefinition:
     Type: AWS::ECS::TaskDefinition
-    Properties: 
-      ContainerDefinitions: 
-        - 
+    Properties:
+      ContainerDefinitions:
+        -
           Name: "busybox"
           Image: "busybox"
           Cpu: "256"
@@ -39,9 +39,9 @@ Resources:
           Environment:
             - Name: entryPoint
               Value: 'sh, -c'
-      Volumes: 
-        - 
-          Host: 
+      Volumes:
+        -
+          Host:
             SourcePath: "/var/lib/docker/vfs/dir/"
           Name: "my-vol"
           EFSVolumeConfiguration:
@@ -51,7 +51,7 @@ Resources:
 				Clusters: []ecs.Cluster{
 					{
 						Settings: ecs.ClusterSettings{
-							ContainerInsightsEnabled: types.BoolTest(true),
+							ContainerInsightsMode: types.StringTest("enabled"),
 						},
 					},
 				},
@@ -90,7 +90,7 @@ Resources:
 Resources:
   ECSCluster:
     Type: 'AWS::ECS::Cluster'
-  taskdefinition: 
+  taskdefinition:
     Type: AWS::ECS::TaskDefinition
   `,
 			expected: ecs.ECS{

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt.go
@@ -32,17 +32,17 @@ func adaptClusterResource(resourceBlock *terraform.Block) ecs.Cluster {
 
 func adaptClusterSettings(resourceBlock *terraform.Block) ecs.ClusterSettings {
 	settings := ecs.ClusterSettings{
-		Metadata:                 resourceBlock.GetMetadata(),
-		ContainerInsightsEnabled: types.BoolDefault(false, resourceBlock.GetMetadata()),
+		Metadata:              resourceBlock.GetMetadata(),
+		ContainerInsightsMode: types.StringDefault("disabled", resourceBlock.GetMetadata()),
 	}
 
 	if settingBlock := resourceBlock.GetBlock("setting"); settingBlock.IsNotNil() {
 		settings.Metadata = settingBlock.GetMetadata()
 		if settingBlock.GetAttribute("name").Equals("containerInsights") {
 			insightsAttr := settingBlock.GetAttribute("value")
-			settings.ContainerInsightsEnabled = types.Bool(insightsAttr.Equals("enabled"), settingBlock.GetMetadata())
+			settings.ContainerInsightsMode = insightsAttr.AsStringValueOrDefault("enabled", settingBlock)
 			if insightsAttr.IsNotNil() {
-				settings.ContainerInsightsEnabled = types.Bool(insightsAttr.Equals("enabled"), insightsAttr.GetMetadata())
+				settings.ContainerInsightsMode = insightsAttr.AsStringValueOrDefault("enabled", settingBlock)
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
@@ -23,7 +23,7 @@ func Test_adaptClusterSettings(t *testing.T) {
 			terraform: `
 			resource "aws_ecs_cluster" "example" {
 				name = "services-cluster"
-			  
+
 				setting {
 				  name  = "containerInsights"
 				  value = "enabled"
@@ -31,8 +31,25 @@ func Test_adaptClusterSettings(t *testing.T) {
 			}
 `,
 			expected: ecs.ClusterSettings{
-				Metadata:                 iacTypes.NewTestMetadata(),
-				ContainerInsightsEnabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+				Metadata:              iacTypes.NewTestMetadata(),
+				ContainerInsightsMode: iacTypes.String("enabled", iacTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "container insights enhanced",
+			terraform: `
+			resource "aws_ecs_cluster" "example" {
+				name = "services-cluster"
+
+				setting {
+				  name  = "containerInsights"
+				  value = "enhanced"
+				}
+			}
+`,
+			expected: ecs.ClusterSettings{
+				Metadata:              iacTypes.NewTestMetadata(),
+				ContainerInsightsMode: iacTypes.String("enhanced", iacTypes.NewTestMetadata()),
 			},
 		},
 		{
@@ -40,7 +57,7 @@ func Test_adaptClusterSettings(t *testing.T) {
 			terraform: `
 			resource "aws_ecs_cluster" "example" {
 				name = "services-cluster"
-			  
+
 				setting {
 				  name  = "invalidName"
 				  value = "enabled"
@@ -48,19 +65,19 @@ func Test_adaptClusterSettings(t *testing.T) {
 			}
 `,
 			expected: ecs.ClusterSettings{
-				Metadata:                 iacTypes.NewTestMetadata(),
-				ContainerInsightsEnabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+				Metadata:              iacTypes.NewTestMetadata(),
+				ContainerInsightsMode: iacTypes.String("disabled", iacTypes.NewTestMetadata()),
 			},
 		},
 		{
 			name: "defaults",
 			terraform: `
-			resource "aws_ecs_cluster" "example" {			
+			resource "aws_ecs_cluster" "example" {
 			}
 `,
 			expected: ecs.ClusterSettings{
-				Metadata:                 iacTypes.NewTestMetadata(),
-				ContainerInsightsEnabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+				Metadata:              iacTypes.NewTestMetadata(),
+				ContainerInsightsMode: iacTypes.String("disabled", iacTypes.NewTestMetadata()),
 			},
 		},
 	}
@@ -99,10 +116,10 @@ func Test_adaptTaskDefinitionResource(t *testing.T) {
 	}
 ]
 				EOF
-			  
+
 				volume {
 				  name = "service-storage"
-			  
+
 				  efs_volume_configuration {
 					transit_encryption      = "ENABLED"
 				  }
@@ -145,7 +162,7 @@ func Test_adaptTaskDefinitionResource(t *testing.T) {
 			resource "aws_ecs_task_definition" "example" {
 				volume {
 					name = "service-storage"
-				
+
 					efs_volume_configuration {
 					}
 				  }
@@ -181,7 +198,7 @@ func TestLines(t *testing.T) {
 	src := `
 	resource "aws_ecs_cluster" "example" {
 		name = "services-cluster"
-	  
+
 		setting {
 		  name  = "containerInsights"
 		  value = "enabled"
@@ -202,10 +219,10 @@ func TestLines(t *testing.T) {
 		}
 	]
 		EOF
-	  
+
 		volume {
 		  name = "service-storage"
-	  
+
 		  efs_volume_configuration {
 			transit_encryption      = "ENABLED"
 		  }
@@ -227,8 +244,8 @@ func TestLines(t *testing.T) {
 	assert.Equal(t, 5, cluster.Settings.Metadata.Range().GetStartLine())
 	assert.Equal(t, 8, cluster.Settings.Metadata.Range().GetEndLine())
 
-	assert.Equal(t, 7, cluster.Settings.ContainerInsightsEnabled.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 7, cluster.Settings.ContainerInsightsEnabled.GetMetadata().Range().GetEndLine())
+	assert.Equal(t, 7, cluster.Settings.ContainerInsightsMode.GetMetadata().Range().GetStartLine())
+	assert.Equal(t, 7, cluster.Settings.ContainerInsightsMode.GetMetadata().Range().GetEndLine())
 
 	assert.Equal(t, 11, taskDefinition.Metadata.Range().GetStartLine())
 	assert.Equal(t, 33, taskDefinition.Metadata.Range().GetEndLine())

--- a/pkg/iac/providers/aws/ecs/ecs.go
+++ b/pkg/iac/providers/aws/ecs/ecs.go
@@ -17,8 +17,8 @@ type Cluster struct {
 }
 
 type ClusterSettings struct {
-	Metadata                 iacTypes.Metadata
-	ContainerInsightsEnabled iacTypes.BoolValue
+	Metadata              iacTypes.Metadata
+	ContainerInsightsMode iacTypes.StringValue
 }
 
 type TaskDefinition struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -1844,9 +1844,9 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
         },
-        "containerinsightsenabled": {
+        "containerinsightsmode": {
           "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         }
       }
     },


### PR DESCRIPTION
## Description
Replaces the current ContainerInsightsEnabled boolean attribute on the ECS cluster settings with ContainerInsightsMode. Container Insights now supports three possible values, enabled, disabled and enhanced (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ClusterSetting.html) 

The enhanced mode is what is recommended by AWS now to get further metrics and details but has been separted from enable/disable due to its cost. 

## Related issues
- Haven't raised an issue but did check to see if one existed

## Related PRs
- [ ] https://github.com/aquasecurity/trivy-checks/pull/332

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
