### PR TITLE
fix(sbom): preserve OS packages from multiple SBOMs

### DIFF
--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -52,6 +52,8 @@ func (a sbomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput)
 		handleBitnamiImages(path.Dir(input.FilePath), bom)
 	}
 
+	// Add the filePath to avoid overwriting OS packages when merging packages from multiple SBOM files.
+	// cf. https://github.com/aquasecurity/trivy/issues/8324
 	for i, pkgInfo := range bom.Packages {
 		bom.Packages[i].FilePath = path.Join(input.FilePath, pkgInfo.FilePath)
 	}

--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -52,6 +52,10 @@ func (a sbomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput)
 		handleBitnamiImages(path.Dir(input.FilePath), bom)
 	}
 
+	for i, pkgInfo := range bom.Packages {
+		bom.Packages[i].FilePath = path.Join(input.FilePath, pkgInfo.FilePath)
+	}
+
 	// FilePath for apps with aggregatingTypes is empty.
 	// Set the SBOM file path as Application.FilePath to correctly overwrite applications when merging layers.
 	for i, app := range bom.Applications {

--- a/pkg/fanal/analyzer/sbom/sbom_test.go
+++ b/pkg/fanal/analyzer/sbom/sbom_test.go
@@ -239,6 +239,42 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name:     "valid ca-certificates spdx file",
+			file:     "testdata/ca-certificates.spdx.json",
+			filePath: "opt/bitnami/ca-certificates/.spdx-ca-certificates.spdx",
+			want: &analyzer.AnalysisResult{
+				PackageInfos: []types.PackageInfo{
+					{
+						FilePath: "opt/bitnami/ca-certificates/.spdx-ca-certificates.spdx",
+						Packages: types.Packages{
+							{
+								ID:         "ca-certificates@20230311",
+								Name:       "ca-certificates",
+								Version:    "20230311",
+								Arch:       "all",
+								SrcName:    "ca-certificates",
+								SrcVersion: "20230311",
+								Licenses:   []string{"GPL-2.0-or-later AND GPL-2.0-only AND MPL-2.0"},
+								Identifier: types.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeDebian,
+										Namespace: "debian",
+										Name:      "ca-certificates",
+										Version:   "20230311",
+										Qualifiers: packageurl.Qualifiers{
+											{Key: "arch", Value: "all"},
+											{Key: "distro", Value: "debian-12.9"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name:     "invalid spdx file",
 			file:     "testdata/invalid_spdx.json",
 			filePath: "opt/bitnami/elasticsearch/.spdx-elasticsearch.spdx",

--- a/pkg/fanal/analyzer/sbom/testdata/ca-certificates.spdx.json
+++ b/pkg/fanal/analyzer/sbom/testdata/ca-certificates.spdx.json
@@ -1,0 +1,55 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "host",
+  "documentNamespace": "http://aquasecurity.github.io/trivy/filesystem/host-1022538e-83fe-4aa7-8718-a78839114c83",
+  "creationInfo": {
+    "creators": [
+      "Organization: aquasecurity",
+      "Tool: trivy-0.58.1"
+    ],
+    "created": "2025-01-30T11:30:05Z"
+  },
+  "packages": [
+    {
+      "name": "ca-certificates",
+      "SPDXID": "SPDXRef-Package-c1d4029824045f75",
+      "versionInfo": "20230311",
+      "supplier": "Organization: Julien Cristau <jcristau@debian.org>",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "sourceInfo": "built package from: ca-certificates 20230311",
+      "licenseConcluded": "GPL-2.0-or-later AND GPL-2.0-only AND MPL-2.0",
+      "licenseDeclared": "GPL-2.0-or-later AND GPL-2.0-only AND MPL-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:deb/debian/ca-certificates@20230311?arch=all&distro=debian-12.9"
+        }
+      ],
+      "primaryPackagePurpose": "LIBRARY"
+    },
+    {
+      "name": "debian",
+      "SPDXID": "SPDXRef-OperatingSystem-23c1e7dfb45d904f",
+      "versionInfo": "12.9",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "OPERATING-SYSTEM"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-OperatingSystem-23c1e7dfb45d904f",
+      "relatedSpdxElement": "SPDXRef-Package-c1d4029824045f75",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-OperatingSystem-23c1e7dfb45d904f",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
This PR fixes a bug in the SBOM analyzer where OS packages from multiple SBOM files were being overwritten during the merge process.

### Usage
No changes in usage. This is a bug fix in how Trivy handles OS packages from multiple SBOM files.

## Description
When scanning container images with multiple SBOM files containing OS packages, only the packages from the last processed SBOM remained in the final result. This was because OS packages didn't have a file path set, causing them to be overwritten during the merge process.

This PR fixes the issue by:

1. Setting the SBOM file path as the package file path for OS packages
2. This ensures packages from different SBOMs are preserved as distinct entries

For example, when scanning an image with these SBOM files:
- `/opt/bitnami/debian/.spdx-ca-certificates.spdx`
- `/opt/bitnami/debian/.spdx-tzdata.spdx`
- `/opt/bitnami/debian/.spdx-netbase.spdx`

All OS packages will now be correctly preserved in the final result.

## Related Issues
- https://github.com/aquasecurity/trivy/issues/8324

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).