### PR TITLE
fix(misconf): ecs include enhanced for container insights

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
@@ -50,7 +50,7 @@ func checkProperty(setting *parser.Property, clusterSettings *ecs.ClusterSetting
 	name := settingMap["Name"]
 	if name.IsNotNil() && name.EqualTo("containerInsights") {
 		value := settingMap["Value"]
-		if value.IsNotNil() && (value.EqualTo("enabled") || value.EqualTo("enhanced")) {
+		if value.IsNotNil() && !value.EqualTo("disabled") {
 			clusterSettings.ContainerInsightsEnabled = types.Bool(true, value.Metadata())
 		}
 	}

--- a/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/cluster.go
@@ -50,7 +50,7 @@ func checkProperty(setting *parser.Property, clusterSettings *ecs.ClusterSetting
 	name := settingMap["Name"]
 	if name.IsNotNil() && name.EqualTo("containerInsights") {
 		value := settingMap["Value"]
-		if value.IsNotNil() && value.EqualTo("enabled") {
+		if value.IsNotNil() && (value.EqualTo("enabled") || value.EqualTo("enhanced")) {
 			clusterSettings.ContainerInsightsEnabled = types.Bool(true, value.Metadata())
 		}
 	}

--- a/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ecs/ecs_test.go
@@ -25,11 +25,11 @@ Resources:
       ClusterSettings:
         - Name: containerInsights
           Value: enabled
-  taskdefinition: 
+  taskdefinition:
     Type: AWS::ECS::TaskDefinition
-    Properties: 
-      ContainerDefinitions: 
-        - 
+    Properties:
+      ContainerDefinitions:
+        -
           Name: "busybox"
           Image: "busybox"
           Cpu: "256"
@@ -39,9 +39,9 @@ Resources:
           Environment:
             - Name: entryPoint
               Value: 'sh, -c'
-      Volumes: 
-        - 
-          Host: 
+      Volumes:
+        -
+          Host:
             SourcePath: "/var/lib/docker/vfs/dir/"
           Name: "my-vol"
           EFSVolumeConfiguration:
@@ -85,12 +85,34 @@ Resources:
 			},
 		},
 		{
+			name: "ecs Cluster Enhanced Container Insights",
+			source: `AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ECSCluster:
+    Type: 'AWS::ECS::Cluster'
+    Properties:
+      ClusterName: MyFargateCluster
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enhanced
+`,
+			expected: ecs.ECS{
+				Clusters: []ecs.Cluster{
+					{
+						Settings: ecs.ClusterSettings{
+							ContainerInsightsEnabled: types.BoolTest(true),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "empty",
 			source: `AWSTemplateFormatVersion: 2010-09-09
 Resources:
   ECSCluster:
     Type: 'AWS::ECS::Cluster'
-  taskdefinition: 
+  taskdefinition:
     Type: AWS::ECS::TaskDefinition
   `,
 			expected: ecs.ECS{

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt.go
@@ -40,9 +40,9 @@ func adaptClusterSettings(resourceBlock *terraform.Block) ecs.ClusterSettings {
 		settings.Metadata = settingBlock.GetMetadata()
 		if settingBlock.GetAttribute("name").Equals("containerInsights") {
 			insightsAttr := settingBlock.GetAttribute("value")
-			settings.ContainerInsightsEnabled = types.Bool(insightsAttr.Equals("enabled"), settingBlock.GetMetadata())
+			settings.ContainerInsightsEnabled = types.Bool(insightsAttr.IsAny("enabled", "enhanced"), settingBlock.GetMetadata())
 			if insightsAttr.IsNotNil() {
-				settings.ContainerInsightsEnabled = types.Bool(insightsAttr.Equals("enabled"), insightsAttr.GetMetadata())
+				settings.ContainerInsightsEnabled = types.Bool(insightsAttr.IsAny("enabled", "enhanced"), insightsAttr.GetMetadata())
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt.go
@@ -40,7 +40,7 @@ func adaptClusterSettings(resourceBlock *terraform.Block) ecs.ClusterSettings {
 		settings.Metadata = settingBlock.GetMetadata()
 		if settingBlock.GetAttribute("name").Equals("containerInsights") {
 			insightsAttr := settingBlock.GetAttribute("value")
-			settings.ContainerInsightsEnabled = types.Bool(insightsAttr.IsAny("enabled", "enhanced"), settingBlock.GetMetadata())
+			settings.ContainerInsightsEnabled = types.Bool(!insightsAttr.Equals("disabled"), settingBlock.GetMetadata())
 			if insightsAttr.IsNotNil() {
 				settings.ContainerInsightsEnabled = types.Bool(insightsAttr.IsAny("enabled", "enhanced"), insightsAttr.GetMetadata())
 			}

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt.go
@@ -42,7 +42,7 @@ func adaptClusterSettings(resourceBlock *terraform.Block) ecs.ClusterSettings {
 			insightsAttr := settingBlock.GetAttribute("value")
 			settings.ContainerInsightsEnabled = types.Bool(!insightsAttr.Equals("disabled"), settingBlock.GetMetadata())
 			if insightsAttr.IsNotNil() {
-				settings.ContainerInsightsEnabled = types.Bool(insightsAttr.IsAny("enabled", "enhanced"), insightsAttr.GetMetadata())
+				settings.ContainerInsightsEnabled = types.Bool(!insightsAttr.Equals("disabled"), insightsAttr.GetMetadata())
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/ecs/adapt_test.go
@@ -23,10 +23,27 @@ func Test_adaptClusterSettings(t *testing.T) {
 			terraform: `
 			resource "aws_ecs_cluster" "example" {
 				name = "services-cluster"
-			  
+
 				setting {
 				  name  = "containerInsights"
 				  value = "enabled"
+				}
+			}
+`,
+			expected: ecs.ClusterSettings{
+				Metadata:                 iacTypes.NewTestMetadata(),
+				ContainerInsightsEnabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "container insights enhanced",
+			terraform: `
+			resource "aws_ecs_cluster" "example" {
+				name = "services-cluster"
+
+				setting {
+				  name  = "containerInsights"
+				  value = "enhanced"
 				}
 			}
 `,
@@ -40,7 +57,7 @@ func Test_adaptClusterSettings(t *testing.T) {
 			terraform: `
 			resource "aws_ecs_cluster" "example" {
 				name = "services-cluster"
-			  
+
 				setting {
 				  name  = "invalidName"
 				  value = "enabled"
@@ -55,7 +72,7 @@ func Test_adaptClusterSettings(t *testing.T) {
 		{
 			name: "defaults",
 			terraform: `
-			resource "aws_ecs_cluster" "example" {			
+			resource "aws_ecs_cluster" "example" {
 			}
 `,
 			expected: ecs.ClusterSettings{
@@ -99,10 +116,10 @@ func Test_adaptTaskDefinitionResource(t *testing.T) {
 	}
 ]
 				EOF
-			  
+
 				volume {
 				  name = "service-storage"
-			  
+
 				  efs_volume_configuration {
 					transit_encryption      = "ENABLED"
 				  }
@@ -145,7 +162,7 @@ func Test_adaptTaskDefinitionResource(t *testing.T) {
 			resource "aws_ecs_task_definition" "example" {
 				volume {
 					name = "service-storage"
-				
+
 					efs_volume_configuration {
 					}
 				  }
@@ -181,7 +198,7 @@ func TestLines(t *testing.T) {
 	src := `
 	resource "aws_ecs_cluster" "example" {
 		name = "services-cluster"
-	  
+
 		setting {
 		  name  = "containerInsights"
 		  value = "enabled"
@@ -202,10 +219,10 @@ func TestLines(t *testing.T) {
 		}
 	]
 		EOF
-	  
+
 		volume {
 		  name = "service-storage"
-	  
+
 		  efs_volume_configuration {
 			transit_encryption      = "ENABLED"
 		  }


### PR DESCRIPTION
## Description

ECS released support for enhanced container insights in [December 2024](https://aws.amazon.com/blogs/aws/container-insights-with-enhanced-observability-now-available-in-amazon-ecs/) 

This adds a new value to the [containerInsights cluster setting](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ClusterSetting.html) `enhanced`. This PR includes the enhanced settings when considering if Container Insights is enabled. 

## Related issues
- Didn't have an issue as it was a minor issue

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
