### PR TITLE
fix(report): remove html escaping for `shortDescription` and `fullDescription` fields for sarif reports

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -3,7 +3,6 @@ package report
 import (
 	"context"
 	"fmt"
-	"html"
 	"io"
 	"net/url"
 	"path/filepath"
@@ -171,8 +170,8 @@ func (sw *SarifWriter) Write(ctx context.Context, report types.Report) error {
 				locationMessage:  fmt.Sprintf("%v: %v@%v", path, vuln.PkgName, vuln.InstalledVersion),
 				locations:        sw.getLocations(vuln.PkgName, vuln.InstalledVersion, path, res.Packages),
 				resultIndex:      getRuleIndex(vuln.VulnerabilityID, ruleIndexes),
-				shortDescription: html.EscapeString(vuln.Title),
-				fullDescription:  html.EscapeString(fullDescription),
+				shortDescription: vuln.Title,
+				fullDescription:  fullDescription,
 				helpText: fmt.Sprintf("Vulnerability %v\nSeverity: %v\nPackage: %v\nFixed Version: %v\nLink: [%v](%v)\n%v",
 					vuln.VulnerabilityID, vuln.Severity, vuln.PkgName, vuln.FixedVersion, vuln.VulnerabilityID, vuln.PrimaryURL, vuln.Description),
 				helpMarkdown: fmt.Sprintf("**Vulnerability %v**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|%v|%v|%v|[%v](%v)|\n\n%v",
@@ -199,8 +198,8 @@ func (sw *SarifWriter) Write(ctx context.Context, report types.Report) error {
 					},
 				},
 				resultIndex:      getRuleIndex(misconf.ID, ruleIndexes),
-				shortDescription: html.EscapeString(misconf.Title),
-				fullDescription:  html.EscapeString(misconf.Description),
+				shortDescription: misconf.Title,
+				fullDescription:  misconf.Description,
 				helpText: fmt.Sprintf("Misconfiguration %v\nType: %s\nSeverity: %v\nCheck: %v\nMessage: %v\nLink: [%v](%v)\n%s",
 					misconf.ID, misconf.Type, misconf.Severity, misconf.Title, misconf.Message, misconf.ID, misconf.PrimaryURL, misconf.Description),
 				helpMarkdown: fmt.Sprintf("**Misconfiguration %v**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|%v|%v|%v|%s|[%v](%v)|\n\n%v",
@@ -226,8 +225,8 @@ func (sw *SarifWriter) Write(ctx context.Context, report types.Report) error {
 					},
 				},
 				resultIndex:      getRuleIndex(secret.RuleID, ruleIndexes),
-				shortDescription: html.EscapeString(secret.Title),
-				fullDescription:  html.EscapeString(secret.Match),
+				shortDescription: secret.Title,
+				fullDescription:  secret.Match,
 				helpText: fmt.Sprintf("Secret %v\nSeverity: %v\nMatch: %s",
 					secret.Title, secret.Severity, secret.Match),
 				helpMarkdown: fmt.Sprintf("**Secret %v**\n| Severity | Match |\n| --- | --- |\n|%v|%v|",

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -232,7 +232,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 									{
 										ID:               "KSV001",
 										Name:             lo.ToPtr("Misconfiguration"),
-										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("Image tag &#39;:latest&#39; used")},
+										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("Image tag ':latest' used")},
 										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("")},
 										DefaultConfiguration: &sarif.ReportingConfiguration{
 											Level: "error",
@@ -373,7 +373,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 										ID:               "aws-secret-access-key",
 										Name:             lo.ToPtr("Secret"),
 										ShortDescription: &sarif.MultiformatMessageString{Text: lo.ToPtr("AWS Secret Access Key")},
-										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("\u0026#39;AWS_secret_KEY\u0026#39;=\u0026#34;****************************************\u0026#34;")},
+										FullDescription:  &sarif.MultiformatMessageString{Text: lo.ToPtr("'AWS_secret_KEY'=\"****************************************\"")},
 										DefaultConfiguration: &sarif.ReportingConfiguration{
 											Level: "error",
 										},


### PR DESCRIPTION
## Description
See #8342

## Related issues
- Close #8342

## Related PRs
- [x] #5897

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
