### PR TITLE
fix(sbom): add SBOM file's filePath as Application FilePath if we can't detect its path

### DIFF
--- a/pkg/fanal/analyzer/sbom/sbom_test.go
+++ b/pkg/fanal/analyzer/sbom/sbom_test.go
@@ -166,6 +166,57 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name:     "valid sbom spdx file without application component",
+			file:     "testdata/sbom-without-app-component.spdx.json",
+			filePath: "layers/sbom/launch/buildpacksio_lifecycle/launcher/sbom.spdx.json",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "layers/sbom/launch/buildpacksio_lifecycle/launcher/sbom.spdx.json",
+						Packages: types.Packages{
+							{
+								ID:      "github.com/buildpacks/lifecycle@v0.20.2",
+								Name:    "github.com/buildpacks/lifecycle",
+								Version: "v0.20.2",
+								Identifier: types.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeGolang,
+										Namespace: "github.com/buildpacks",
+										Name:      "lifecycle",
+										Version:   "v0.20.2",
+									},
+								},
+								Licenses: []string{
+									"NOASSERTION",
+								},
+							},
+						},
+					},
+					{
+						Type:     types.Jar,
+						FilePath: "layers/sbom/launch/buildpacksio_lifecycle/launcher/sbom.spdx.json",
+						Packages: types.Packages{
+							{
+								ID:      "co.elastic.apm:apm-agent:1.36.0",
+								Name:    "co.elastic.apm:apm-agent",
+								Version: "1.36.0",
+								Identifier: types.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeMaven,
+										Namespace: "co.elastic.apm",
+										Name:      "apm-agent",
+										Version:   "1.36.0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: require.NoError,
+		},
+		{
 			name:     "valid postgresql spdx file",
 			file:     "testdata/postgresql.spdx.json",
 			filePath: "opt/bitnami/postgresql/.spdx-postgresql.spdx",

--- a/pkg/fanal/analyzer/sbom/testdata/sbom-without-app-component.spdx.json
+++ b/pkg/fanal/analyzer/sbom/testdata/sbom-without-app-component.spdx.json
@@ -1,0 +1,111 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "launcher",
+  "documentNamespace": "https://anchore.com/syft/file/launcher-268e7779-ba66-4422-a5b0-d4d83f7b5d8c",
+  "creationInfo": {
+    "licenseListVersion": "3.25",
+    "creators": [
+      "Organization: Anchore, Inc",
+      "Tool: syft-1.13.0"
+    ],
+    "created": "2024-09-25T21:11:50Z"
+  },
+  "packages": [
+    {
+      "name": "co.elastic.apm:apm-agent",
+      "SPDXID": "SPDXRef-Package-f0db45781e6813a1",
+      "versionInfo": "1.36.0",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NONE",
+      "licenseConcluded": "NONE",
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:maven/co.elastic.apm/apm-agent@1.36.0"
+        }
+      ],
+      "filesAnalyzed": false
+    },
+    {
+      "name": "github.com/buildpacks/lifecycle",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
+      "versionInfo": "v0.20.2",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "sourceInfo": "acquired package info from go module information: /launcher",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:buildpacks:lifecycle:v0.20.2:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/buildpacks/lifecycle@v0.20.2"
+        }
+      ]
+    },
+    {
+      "name": "launcher",
+      "SPDXID": "SPDXRef-DocumentRoot-File-launcher",
+      "versionInfo": "sha256:716665ae98fb4b4675d5184f80884547597d47be1395d1049dc9e16035f32cc1",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "716665ae98fb4b4675d5184f80884547597d47be1395d1049dc9e16035f32cc1"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "primaryPackagePurpose": "FILE"
+    }
+  ],
+  "files": [
+    {
+      "fileName": "/launcher",
+      "SPDXID": "SPDXRef-File-launcher-361242815a383bec",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "0000000000000000000000000000000000000000"
+        }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": [
+        "NOASSERTION"
+      ],
+      "copyrightText": ""
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
+      "relatedSpdxElement": "SPDXRef-File-launcher-361242815a383bec",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-launcher",
+      "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-File-launcher",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
There are cases when we can't determine the FilePath of the application from the SBOM file (see https://github.com/aquasecurity/trivy/discussions/7556#discussioncomment-12016209).

So we need to add the FilePath of the SBOM file as the Application FilePath to avoid an empty Target (and an empty `name` field for the SBOM component, which makes the SBOM file invalid))

example:
```bash
➜ cat sbom-without-app-component.spdx.json 
{
  "spdxVersion": "SPDX-2.3",
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "launcher",
  "documentNamespace": "https://anchore.com/syft/file/launcher-268e7779-ba66-4422-a5b0-d4d83f7b5d8c",
  "creationInfo": {
    "licenseListVersion": "3.25",
    "creators": [
      "Organization: Anchore, Inc",
      "Tool: syft-1.13.0"
    ],
    "created": "2024-09-25T21:11:50Z"
  },
  "packages": [
    {
      "name": "co.elastic.apm:apm-agent",
      "SPDXID": "SPDXRef-Package-f0db45781e6813a1",
      "versionInfo": "1.36.0",
      "supplier": "NOASSERTION",
      "downloadLocation": "NONE",
      "licenseConcluded": "NONE",
      "licenseDeclared": "NONE",
      "copyrightText": "NOASSERTION",
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceType": "purl",
          "referenceLocator": "pkg:maven/co.elastic.apm/apm-agent@1.36.0"
        }
      ],
      "filesAnalyzed": false
    },
    {
      "name": "github.com/buildpacks/lifecycle",
      "SPDXID": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
      "versionInfo": "v0.20.2",
      "supplier": "NOASSERTION",
      "downloadLocation": "NOASSERTION",
      "filesAnalyzed": false,
      "sourceInfo": "acquired package info from go module information: /launcher",
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "NOASSERTION",
      "copyrightText": "NOASSERTION",
      "externalRefs": [
        {
          "referenceCategory": "SECURITY",
          "referenceType": "cpe23Type",
          "referenceLocator": "cpe:2.3:a:buildpacks:lifecycle:v0.20.2:*:*:*:*:*:*:*"
        },
        {
          "referenceCategory": "PACKAGE-MANAGER",
          "referenceType": "purl",
          "referenceLocator": "pkg:golang/github.com/buildpacks/lifecycle@v0.20.2"
        }
      ]
    },
    {
      "name": "launcher",
      "SPDXID": "SPDXRef-DocumentRoot-File-launcher",
      "versionInfo": "sha256:716665ae98fb4b4675d5184f80884547597d47be1395d1049dc9e16035f32cc1",
      "supplier": "NOASSERTION",
      "downloadLocation": "NOASSERTION",
      "filesAnalyzed": false,
      "checksums": [
        {
          "algorithm": "SHA256",
          "checksumValue": "716665ae98fb4b4675d5184f80884547597d47be1395d1049dc9e16035f32cc1"
        }
      ],
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "NOASSERTION",
      "primaryPackagePurpose": "FILE"
    }
  ],
  "files": [
    {
      "fileName": "/launcher",
      "SPDXID": "SPDXRef-File-launcher-361242815a383bec",
      "checksums": [
        {
          "algorithm": "SHA1",
          "checksumValue": "0000000000000000000000000000000000000000"
        }
      ],
      "licenseConcluded": "NOASSERTION",
      "licenseInfoInFiles": [
        "NOASSERTION"
      ],
      "copyrightText": ""
    }
  ],
  "relationships": [
    {
      "spdxElementId": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
      "relatedSpdxElement": "SPDXRef-File-launcher-361242815a383bec",
      "relationshipType": "OTHER",
      "comment": "evident-by: indicates the package's existence is evident by the given file"
    },
    {
      "spdxElementId": "SPDXRef-DocumentRoot-File-launcher",
      "relatedSpdxElement": "SPDXRef-Package-go-module-github.com-buildpacks-lifecycle-89c3bd8d4c2e75b7",
      "relationshipType": "CONTAINS"
    },
    {
      "spdxElementId": "SPDXRef-DOCUMENT",
      "relatedSpdxElement": "SPDXRef-DocumentRoot-File-launcher",
      "relationshipType": "DESCRIBES"
    }
  ]
```
before:
```bash
➜ trivy -q image 7556 -f cyclonedx --pkg-types library | grep '"type": "application",' -A 1
          "type": "application",
          "group": "aquasecurity",
--
      "type": "application",
      "name": "",
```

after:
```bash
➜  ./trivy -q image 7556 -f cyclonedx --pkg-types library | grep '"type": "application",' -A 1
          "type": "application",
          "group": "aquasecurity",
--
      "type": "application",
      "name": "foo/bar/sbom-without-app-component.spdx.json",

```

## Related issues
- Close #8189

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
