### PR TITLE
ci(spdx): add `aqua-installer` step to fix `mage` error

### DIFF
--- a/.github/workflows/spdx-cron.yaml
+++ b/.github/workflows/spdx-cron.yaml
@@ -12,6 +12,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4.1.6
 
+      - name: Install tools
+        uses: aquaproj/aqua-installer@v3.1.1
+        with:
+          aqua_version: v1.25.0
+          aqua_opts: ""
+
       - name: Check if SPDX exceptions are up-to-date
         run: |
           mage spdx:updateLicenseExceptions


### PR DESCRIPTION
## Description
We added cron workflow to check SPDX License exceptions (#8077).
But i forgot to install `aqua-installer`.

This PR added this step.
Test run - https://github.com/DmitriyLewen/trivy/actions/runs/13150768822/job/36697700228

## Related PRs
- [x] #8077

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
