### PR TITLE
docs: Fix typos in documentation

### DIFF
--- a/docs/community/contribute/checks/overview.md
+++ b/docs/community/contribute/checks/overview.md
@@ -80,7 +80,7 @@ The package name should be in the format `builtin.PROVIDER.SERVICE.ID`, e.g. `bu
 
 ## Generating an ID
 
-Every check has a custom ID that is referenced throughout the metadata of the check to uniquely identify the check. If you plan to contribue your check back into the [trivy-checks](https://github.com/aquasecurity/trivy-checks) repository, it will require a valid ID. 
+Every check has a custom ID that is referenced throughout the metadata of the check to uniquely identify the check. If you plan to contribute your check back into the [trivy-checks](https://github.com/aquasecurity/trivy-checks) repository, it will require a valid ID. 
 
 Running `make id` in the root of the trivy-checks repository will provide you with the next available _ID_ for your rule. 
 

--- a/docs/community/contribute/checks/service-support.md
+++ b/docs/community/contribute/checks/service-support.md
@@ -57,7 +57,7 @@ type AWS struct {
 
 ### Update Adapters
 
-Now you'll need to update all of the [adapters](https://github.com/aquasecurity/trivy/tree/main/pkg/iac/adapters) which populate the struct of the provider that you have been using. Following the example above, if you want to add support for CodeBuild in Terraform, you'll need to update the Terraform AWS adatper as shown here: [`trivy/pkg/iac/adapters/terraform/aws/codebuild/adapt.go`](https://github.com/aquasecurity/trivy/blob/main/pkg/iac/adapters/terraform/aws/codebuild/adapt.go).
+Now you'll need to update all of the [adapters](https://github.com/aquasecurity/trivy/tree/main/pkg/iac/adapters) which populate the struct of the provider that you have been using. Following the example above, if you want to add support for CodeBuild in Terraform, you'll need to update the Terraform AWS adapter as shown here: [`trivy/pkg/iac/adapters/terraform/aws/codebuild/adapt.go`](https://github.com/aquasecurity/trivy/blob/main/pkg/iac/adapters/terraform/aws/codebuild/adapt.go).
 
 Another example for updating the adapters is provided in the [following PR.](https://github.com/aquasecurity/defsec/pull/1000/files) Additionally, please refer to the respective Terraform documentation on the provider to which you are adding the service. For instance, the Terraform documentation for AWS CodeBuild is provided [here.](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project)
 

--- a/docs/docs/compliance/compliance.md
+++ b/docs/docs/compliance/compliance.md
@@ -166,7 +166,7 @@ Example of how to define command data under [commands folder](https://github.com
   title: kubelet.conf file permissions
   nodeType: worker
   audit: stat -c %a $kubelet.kubeconfig
-  platfroms:
+  platforms:
     - k8s
     - aks
 ```
@@ -181,7 +181,7 @@ make command-id
 
 #### Command Key
 
-- Re-use an existing key or specifiy a new one (make sure key name has no spaces)
+- Re-use an existing key or specify a new one (make sure key name has no spaces)
 
 Note: The key value should match the key name evaluated by the Rego check.
 
@@ -198,7 +198,7 @@ Specify the node type on which the command is supposed to run.
 
 ### Command Audit
 
-Specify here the shell command to be used please make sure to add error supression (2>/dev/null)
+Specify here the shell command to be used please make sure to add error suppression (2>/dev/null)
 
 ### Command Platforms
 

--- a/docs/docs/compliance/contrib-compliance.md
+++ b/docs/docs/compliance/contrib-compliance.md
@@ -56,7 +56,7 @@ Thus, we can use the information already present:
 ```
 
 - The `ID`, `name`, and `description` is taken directly from the AWS EKS CIS Benchmarks
-- The `check` and `severity` are taken from the existing complaince check in the `k8s-cis-1.23.yaml`
+- The `check` and `severity` are taken from the existing compliance check in the `k8s-cis-1.23.yaml`
 
 
 #### 2. Referencing a check manually that is not part of the Trivy default checks

--- a/docs/docs/coverage/language/golang.md
+++ b/docs/docs/coverage/language/golang.md
@@ -100,7 +100,7 @@ $ trivy rootfs ./your_binary
     It doesn't work with UPX-compressed binaries.
 
 ### Main Module
-Go binaries installed using the `go install` command contains correct (semver) version for the main module and therefor are detected by Trivy.
+Go binaries installed using the `go install` command contains correct (semver) version for the main module and therefore are detected by Trivy.
 In other cases, Go uses the `(devel)` version[^2].
 In this case, Trivy will attempt to parse any `-ldflags` as it's a common practice to pass versions this way.
 If unsuccessful, the version will be empty[^3].

--- a/docs/docs/scanner/license.md
+++ b/docs/docs/scanner/license.md
@@ -23,7 +23,7 @@ To enable extended license scanning, you can use `--license-full`.
 In addition to package licenses, Trivy scans source code files, Markdown documents, text files and `LICENSE` documents to identify license usage within the image or filesystem.
 
 By default, Trivy only classifies licenses that are matched with a confidence level of 0.9 or more by the classifier.
-To configure the confidence level, you can use `--license-confidence-level`. This enables us to classify licenses that might be matched with a lower confidence level by the classifer. 
+To configure the confidence level, you can use `--license-confidence-level`. This enables us to classify licenses that might be matched with a lower confidence level by the classifier. 
 
 !!! note
     The full license scanning is expensive. It takes a while.

--- a/docs/docs/scanner/misconfiguration/custom/index.md
+++ b/docs/docs/scanner/misconfiguration/custom/index.md
@@ -149,7 +149,7 @@ Services are defined within a provider. For instance, RDS is a service and AWS i
 
 #### custom.input
 
-The `input` tells Trivy what inputs this check should be applied to. Cloud provider checks should always use the `selector` input, and should always use the `type` selector with `cloud`. Check targeting Kubernetes yaml can use `kubenetes`, RBAC can use `rbac`, and so on.
+The `input` tells Trivy what inputs this check should be applied to. Cloud provider checks should always use the `selector` input, and should always use the `type` selector with `cloud`. Check targeting Kubernetes yaml can use `kubernetes`, RBAC can use `rbac`, and so on.
 
 #### Subtypes in the custom data
 

--- a/docs/docs/scanner/misconfiguration/index.md
+++ b/docs/docs/scanner/misconfiguration/index.md
@@ -407,7 +407,7 @@ If the schema is specified in the check metadata and is in the directory specifi
     If a user specifies the `--config-file-schemas` flag, all input IaC config files are ensured that they pass type-checking. It is not required to pass an input schema in case type checking is not required. This is helpful for scenarios where you simply want to write a Rego check and pass in IaC input for it. Such a use case could include scanning for a new service which Trivy might not support just yet.
 
 !!! tip
-    It is also possible to specify multiple input schemas with `--config-file-schema` flag as it can accept a comma seperated list of file paths or a directory as input. In the case of multiple schemas being specified, all of them will be evaluated against all the input files.
+    It is also possible to specify multiple input schemas with `--config-file-schema` flag as it can accept a comma separated list of file paths or a directory as input. In the case of multiple schemas being specified, all of them will be evaluated against all the input files.
 
 
 ### Passing custom data

--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -144,7 +144,7 @@ See https://avd.aquasec.com/misconfig/ds005
 
 LOW: Add HEALTHCHECK instruction in your Dockerfile
 ════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
-You shoud add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.
+You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.
 
 See https://avd.aquasec.com/misconfig/ds026
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/docs/docs/target/kubernetes.md
+++ b/docs/docs/target/kubernetes.md
@@ -180,7 +180,7 @@ trivy k8s --report summary --disable-node-collector
 
 The node-collector scan-job will run on every node. In case the node has been tainted, it is possible to add toleration to the scan job for it to be scheduled on the tainted node. for more details [see k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 
-- `--tolerations  key1=value1:NoExecute,key2=value2:NoSchedule` this flag wil enable node-collector to be schedule on tainted Node
+- `--tolerations  key1=value1:NoExecute,key2=value2:NoSchedule` this flag will enable node-collector to be schedule on tainted Node
 
 Example:
 

--- a/docs/ecosystem/ide.md
+++ b/docs/ecosystem/ide.md
@@ -58,7 +58,7 @@ Web application that allows to load a Trivy report in json format and displays t
 
 ## Trivy pre-commit (Community)
 
-A trivy pre-commit hook that runs a `trivy fs` in your git repo before commiting, preventing you from commiting secrets in the first place.
+A trivy pre-commit hook that runs a `trivy fs` in your git repo before committing, preventing you from committing secrets in the first place.
 
 👉 Get it at: <https://github.com/mxab/pre-commit-trivy>
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -167,7 +167,7 @@ See their respective documentation for more information of how to install them a
 - [asdf](https://asdf-vm.com/guide/getting-started.html)
 - [mise](https://mise.jdx.dev/getting-started.html)
 
-The plugin used by both tools is developped [here](https://github.com/zufardhiyaulhaq/asdf-trivy)
+The plugin used by both tools is developed [here](https://github.com/zufardhiyaulhaq/asdf-trivy)
 
 
 === "asdf"

--- a/docs/tutorials/misconfiguration/custom-checks.md
+++ b/docs/tutorials/misconfiguration/custom-checks.md
@@ -86,7 +86,7 @@ Let's look at the check line by line:
 Note that Rego
 
 * uses `AND` automatically to combine conditions in this check
-* automatically iterates through the array of commands in the Dockefile and allowed images 
+* automatically iterates through the array of commands in the Dockerfile and allowed images 
 
 ## Run the check in a Trivy misconfiguration scan
 

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -31,7 +31,7 @@ Git clone the tutorial and cd into the directory:
 git clone git@github.com:Cloud-Native-Security/trivy-demo.git
 cd bad_iac/terraform
 ``` 
-In this case, the folder only containes Terraform configuration files. However, you could scan a directory that contains several different configurations e.g. Kubernetes YAML manifests, Dockerfile, and Terraform. Trivy will then detect the different configuration files and apply the right rules automatically. 
+In this case, the folder only contains Terraform configuration files. However, you could scan a directory that contains several different configurations e.g. Kubernetes YAML manifests, Dockerfile, and Terraform. Trivy will then detect the different configuration files and apply the right rules automatically. 
 
 ## Different types of `trivy config` scans 
 


### PR DESCRIPTION
## Description

Fixes typos in a number of doc files

- "contribue" -> "contribute" in docs/contribute/checks/overview.md
- "adatper" -> "adapter" in docs/contribute/checks/service-support.md
- "platfroms" -> "platforms" in docs/compliance/compliance.md
- "specifiy" -> "specify" in docs/compliance/compliance.md
- "supression" -> "suppression" in docs/compliance/compliance.md
- "complaince" -> "compliance" in docs/compliance/contrib-compliance.md
- "therefor" -> "therefore" in docs/coverage/language/golang.md
- "classifer" -> "classifier" in docs/scanner/license.md
- "kubenetes" -> "kubernetes" in docs/scanner/misconfiguration/custom/index.md
- "seperated" -> "separated" in docs/scanner/misconfiguration/index.md
- "shoud" -> "should" in docs/target/container_image.md
- "wil" -> "will" in docs/target/kubernetes.md
- "commiting" -> "committing" in docs/ecosystem/ide.md
- "developped" -> "developed" in docs/getting-started/installation.md
- "Dockefile" -> "Dockerfile" in docs/tutorials/misconfiguration/custom-checks.md
- "containes" -> "contains" in docs/tutorials/misconfiguration/terraform.md

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
