### PR TITLE
fix(image): disable AVD-DS-0007 for history scanning

### DIFF
--- a/docs/docs/target/container_image.md
+++ b/docs/docs/target/container_image.md
@@ -154,7 +154,15 @@ See https://avd.aquasec.com/misconfig/ds026
 !!! tip
     You can see how each layer is created with `docker history`.
 
-The [AVD-DS-0016](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0016/) check is disabled for this scan type, see [issue](https://github.com/aquasecurity/trivy/issues/7368) for details.
+#### Disabled checks
+
+The following checks are disabled for this scan type due to known issues. See the linked issues for more details.
+
+| Check ID | Reason | Issue |
+|----------|------------|--------|
+| [AVD-DS-0007](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0007/) | This check detects multiple `ENTRYPOINT` instructions in a stage, but since image history analysis does not identify stages, this check is not relevant for this scan type. | [#8364](https://github.com/aquasecurity/trivy/issues/8364) |
+| [AVD-DS-0016](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0016/) | This check detects multiple `CMD` instructions in a stage, but since image history analysis does not identify stages, this check is not relevant for this scan type. | [#7368](https://github.com/aquasecurity/trivy/issues/7368) |
+
 
 ### Secrets
 Trivy detects secrets on the configuration of container images.

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -15,12 +15,17 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"github.com/aquasecurity/trivy/pkg/misconf"
+	"github.com/aquasecurity/trivy/pkg/version/doc"
 )
 
 var disabledChecks = []misconf.DisabledCheck{
 	{
+		ID: "DS007", Scanner: string(analyzer.TypeHistoryDockerfile),
+		Reason: "See " + doc.URL("docs/target/container_image", "disabled-checks"),
+	},
+	{
 		ID: "DS016", Scanner: string(analyzer.TypeHistoryDockerfile),
-		Reason: "See https://github.com/aquasecurity/trivy/issues/7368",
+		Reason: "See " + doc.URL("docs/target/container_image", "disabled-checks"),
 	},
 }
 
@@ -101,9 +106,10 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 			createdBy = buildHealthcheckInstruction(cfg.Config.Healthcheck)
 		default:
 			for _, prefix := range []string{"ARG", "ENV", "ENTRYPOINT"} {
-				strings.HasPrefix(h.CreatedBy, prefix)
-				createdBy = h.CreatedBy
-				break
+				if strings.HasPrefix(h.CreatedBy, prefix) {
+					createdBy = h.CreatedBy
+					break
+				}
 			}
 		}
 		dockerfile.WriteString(strings.TrimSpace(createdBy) + "\n")


### PR DESCRIPTION
## Description

The `AVD-DS-0007` check should only be applied to the final layer. This PR removes the recently added export of the `etrypoint` instruction to the Dockerfile and fixes a bug with exporting metadata instructions.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8364

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
