### PR TITLE
fix(go): merge nested flags into string for ldflags for Go binaries

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse_private_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_private_test.go
@@ -1,0 +1,67 @@
+package binary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitLDFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:  "flag with single nested flag",
+			input: "-extldflags '-static'",
+			want: []string{
+				"-extldflags",
+				"'-static'",
+			},
+		},
+		{
+			name:  "flag with multiple nested flag",
+			input: "-extldflags '-static -lm -ldl -lz -lpthread'",
+			want: []string{
+				"-extldflags",
+				"'-static -lm -ldl -lz -lpthread'",
+			},
+		},
+		{
+			name:  "multiple flags with nested flag",
+			input: "-extldflags '-static -lm -ldl -lz -lpthread' -s -w -extldflags '-static'",
+			want: []string{
+				"-extldflags",
+				"'-static -lm -ldl -lz -lpthread'",
+				"-s",
+				"-w",
+				"-extldflags",
+				"'-static'",
+			},
+		},
+		{
+			name:  "without nested flags",
+			input: "-s -w -X='github.com/aquasecurity/trivy/cmd/Any.Ver=0.50.0'",
+			want: []string{
+				"-s",
+				"-w",
+				"-X='github.com/aquasecurity/trivy/cmd/Any.Ver=0.50.0'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitLDFlags(tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -391,6 +391,21 @@ func TestParser_ParseLDFlags(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "flag with nested flags",
+			args: args{
+				name: "github.com/k3s-io/k3s",
+				flags: []string{
+					"-X",
+					"github.com/k3s-io/k3s/version.Version=v1.28.6+k3s2",
+					"-w",
+					"-s",
+					"-extldflags",
+					"'-static -lm -ldl -lz -lpthread'",
+				},
+			},
+			want: "v1.28.6+k3s2",
+		},
+		{
 			name: "with no flags",
 			args: args{
 				name:  "github.com/aquasecurity/test",


### PR DESCRIPTION
## Description
See #8365

## Related issues
- Close #8365

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
