### PR TITLE
chore(terraform): export module path on terraform modules

### DIFF
--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -484,6 +484,10 @@ func (b *Block) FullName() string {
 	return b.LocalName()
 }
 
+func (b *Block) ModuleBlock() *Block {
+	return b.moduleBlock
+}
+
 func (b *Block) ModuleKey() string {
 	name := b.Reference().NameLabel()
 	if b.moduleBlock == nil {

--- a/pkg/iac/terraform/module.go
+++ b/pkg/iac/terraform/module.go
@@ -43,6 +43,10 @@ func (c *Module) RootPath() string {
 	return c.rootPath
 }
 
+func (c *Module) ModulePath() string {
+	return c.modulePath
+}
+
 func (c *Module) Ignores() ignore.Rules {
 	return c.ignores
 }


### PR DESCRIPTION
## Description

Module path is required to distinguish between 2 modules loaded from the same root. Without the accessor, is difficult to know which `module` is which when iterating through the type `Modules`. There is value in exporting this.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
