### PR TITLE
fix(terraform): apply parser options to submodule parsing

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -83,6 +83,7 @@ func (p *Parser) newModuleParser(moduleFS fs.FS, moduleSource, modulePath, modul
 	mp.logger = log.WithPrefix("terraform parser").With("module", moduleName)
 	mp.projectRoot = p.projectRoot
 	mp.skipPaths = p.skipPaths
+	mp.options = p.options
 	p.children = append(p.children, mp)
 	for _, option := range p.options {
 		option(mp)

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1648,9 +1648,10 @@ func TestNestedDynamicBlock(t *testing.T) {
 	assert.Len(t, nested, 4)
 }
 
-func parse(t *testing.T, files map[string]string) terraform.Modules {
+func parse(t *testing.T, files map[string]string, opts ...Option) terraform.Modules {
 	fs := testutil.CreateFS(t, files)
-	parser := New(fs, "", OptionStopOnHCLError(true))
+	opts = append(opts, OptionStopOnHCLError(true))
+	parser := New(fs, "", opts...)
 	require.NoError(t, parser.ParseFS(context.TODO(), "."))
 
 	modules, _, err := parser.EvaluateAll(context.TODO())
@@ -1700,6 +1701,74 @@ resource "test_resource" "this" {
 	require.NotNil(t, attr)
 
 	assert.Equal(t, "test_value", attr.GetRawValue())
+}
+
+// TestNestedModulesOptions ensures parser options are carried to the nested
+// submodule evaluators.
+// The test will include an invalid module that will fail to download
+// if it is attempted.
+func TestNestedModulesOptions(t *testing.T) {
+	// reset the previous default logger
+	prevLog := slog.Default()
+	defer slog.SetDefault(prevLog)
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(log.NewHandler(&buf, nil)))
+
+	files := map[string]string{
+		"main.tf": `
+module "city" {
+	source = "./modules/city"
+}
+
+resource "city" "neighborhoods" {
+	names = module.city.neighborhoods
+}
+`,
+		"modules/city/main.tf": `
+module "brooklyn" {
+	source = "./brooklyn"
+}
+
+module "queens" {
+	source = "./queens"
+}
+
+output "neighborhoods" {
+	value = [module.brooklyn.name, module.queens.name]
+}
+`,
+		"modules/city/brooklyn/main.tf": `
+output "name" {
+	value = "Brooklyn"
+}
+`,
+		"modules/city/queens/main.tf": `
+output "name" {
+	value = "Queens"
+}
+
+module "invalid" {
+	source         = "https://example.invaliddomain"
+}
+`,
+	}
+
+	// Using the OptionWithDownloads(false) option will prevent the invalid
+	// module from being downloaded. If the log exists "failed to download"
+	// then the submodule evaluator attempted to download, which was disallowed.
+	modules := parse(t, files, OptionWithDownloads(false))
+	require.Len(t, modules, 4)
+
+	resources := modules.GetResourcesByType("city")
+	require.Len(t, resources, 1)
+
+	for _, res := range resources {
+		attr, _ := res.GetNestedAttribute("names")
+		require.NotNil(t, attr, res.FullName())
+		assert.Equal(t, []string{"Brooklyn", "Queens"}, attr.GetRawValue())
+	}
+
+	require.NotContains(t, buf.String(), "failed to download")
 }
 
 func TestCyclicModules(t *testing.T) {


### PR DESCRIPTION
## Description

Submodule parsers should keep the same parser options as the root. Carrying forward options like "AllowDownload". Without this, submodules could download remote modules, even though the root explicitly disabled that behavior.

I believe this is safe, as options do pass to a depth of 1 before this change. This change ensures they pass to a depth of >1.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
