### PR TITLE
fix(spdx): init `pkgFilePaths` map for all formats

### DIFF
--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -53,9 +53,6 @@ func (s *SPDX) UnmarshalJSON(b []byte) error {
 	if s.BOM == nil {
 		s.BOM = core.NewBOM(core.Options{})
 	}
-	if s.pkgFilePaths == nil {
-		s.pkgFilePaths = make(map[common.ElementID]string)
-	}
 
 	spdxDocument, err := json.Read(bytes.NewReader(b))
 	if err != nil {
@@ -70,6 +67,10 @@ func (s *SPDX) UnmarshalJSON(b []byte) error {
 
 func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 	s.trivySBOM = s.isTrivySBOM(spdxDocument)
+
+	if s.pkgFilePaths == nil {
+		s.pkgFilePaths = make(map[common.ElementID]string)
+	}
 
 	// Parse files and find file paths for packages
 	s.parseFiles(spdxDocument)


### PR DESCRIPTION
## Description
See #8379

Before:
```
➜  8367 trivy -q sbom alpine3212.spdx
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/sbom/spdx.(*SPDX).parseFiles(0x14001432780, 0x14000a90b40)
	github.com/aquasecurity/trivy/pkg/sbom/spdx/unmarshal.go:127 +0x164
github.com/aquasecurity/trivy/pkg/sbom/spdx.(*SPDX).unmarshal(0x14001432780, 0x14000a90b40)
	github.com/aquasecurity/trivy/pkg/sbom/spdx/unmarshal.go:75 +0x48
github.com/aquasecurity/trivy/pkg/sbom/spdx.(*TVDecoder).Decode(0x0?, {0x107750180, 0x14001432780})
	github.com/aquasecurity/trivy/pkg/sbom/spdx/unmarshal.go:45 +0xb8
github.com/aquasecurity/trivy/pkg/sbom.Decode({_, _}, {_, _}, {_, _})
	github.com/aquasecurity/trivy/pkg/sbom/sbom.go:226 +0x5dc
...
```

after:
```bash
➜  ./trivy  sbom /Users/dmitriy/work/tmp/8367/alpine3212.spdx           
2025-02-10T12:56:49+06:00       INFO    Loaded  file_path="trivy.yaml"
2025-02-10T12:56:49+06:00       INFO    [vuln] Vulnerability scanning is enabled
2025-02-10T12:56:49+06:00       INFO    Detected SBOM format    format="spdx-tv"
2025-02-10T12:56:49+06:00       WARN    [sbom] Ignore the OS package as no OS is detected.      file_path="/Users/dmitriy/work/tmp/8367/alpine3212.spdx"
2025-02-10T12:56:49+06:00       INFO    Number of language-specific files       num=0

```

## Related issues
- Close #8379

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
