### PR TITLE
chore(deps): update Go to 1.24 and switch to go-version-file

### DIFF
--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -5,8 +5,6 @@ on:
       - 'misc/triage/labels.yaml'
     branches:
       - main
-env:
-  GO_VERSION: '1.23'
 jobs:
   deploy:
     name: Auto-update labels
@@ -18,8 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          # cf. https://github.com/aquasecurity/trivy/pull/6711
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: Install aqua tools

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -14,7 +14,6 @@ on:
 
 env:
   GH_USER: "aqua-bot"
-  GO_VERSION: '1.23'
 
 jobs:
   release:
@@ -68,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
 
       - name: Generate SBOM

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-env:
-  GO_VERSION: '1.23'
 jobs:
   test:
     name: Test
@@ -26,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: go mod tidy
@@ -80,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: Install tools
@@ -117,7 +115,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: Install tools
@@ -138,7 +136,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: Install tools
@@ -177,7 +175,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
 
       - name: Install tools
@@ -220,7 +218,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
         cache: false
 
     - name: Determine GoReleaser ID

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
         id: lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.61
+          version: v1.64
           args: --verbose --out-format=line-number
         if: matrix.operating-system == 'ubuntu-latest'
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -122,7 +122,7 @@ linters:
     - usestdlibvars
 
 run:
-  go: '1.23'
+  go: '1.24'
   timeout: 30m
 
 issues:

--- a/Dockerfile.protoc
+++ b/Dockerfile.protoc
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.23
+FROM --platform=linux/amd64 golang:1.24
 
 # Set environment variable for protoc
 ENV PROTOC_ZIP=protoc-3.19.4-linux-x86_64.zip

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -5,6 +5,6 @@ registries:
 - type: standard
   ref: v3.157.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: tinygo-org/tinygo@v0.33.0
+- name: tinygo-org/tinygo@v0.36.0
 - name: WebAssembly/binaryen@version_112
 - name: magefile/mage@v1.14.0

--- a/examples/module/spring4shell/spring4shell.go
+++ b/examples/module/spring4shell/spring4shell.go
@@ -1,4 +1,4 @@
-//go:generate tinygo build -o spring4shell.wasm -scheduler=none -target=wasi --no-debug spring4shell.go
+//go:generate tinygo build -o spring4shell.wasm -target=wasip1 --buildmode=c-shared spring4shell.go
 //go:build tinygo.wasm
 
 package main
@@ -29,8 +29,7 @@ var (
 	tomcatVersionRegex = regexp.MustCompile(`Apache Tomcat Version ([\d.]+)`)
 )
 
-// main is required for TinyGo to compile to Wasm.
-func main() {
+func init() {
 	wasm.RegisterModule(Spring4Shell{})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/localstack v0.35.0
-	github.com/tetratelabs/wazero v1.8.2
+	github.com/tetratelabs/wazero v1.9.0
 	github.com/twitchtv/twirp v8.1.3+incompatible
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/xlab/treeprint v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy
 
-go 1.23.5
+go 1.24
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1887,8 +1887,8 @@ github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X
 github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.35.0 h1:0EbOXcy8XQkyDUs1Y9YPUHOUByNnlGsLi5B3ln8F/RU=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.35.0/go.mod h1:MlHuaWQimz+15dmQ6R2S1vpYxhGFEpmRZQsL2NVWNng=
-github.com/tetratelabs/wazero v1.8.2 h1:yIgLR/b2bN31bjxwXHD8a3d+BogigR952csSDdLYEv4=
-github.com/tetratelabs/wazero v1.8.2/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
+github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
+github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -95,7 +95,7 @@ func (Tool) PipTools() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v1.61.0"
+	const version = "v1.64.2"
 	bin := filepath.Join(GOBIN, "golangci-lint")
 	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil

--- a/pkg/iac/scanners/terraform/parser/funcs/collection.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/collection.go
@@ -509,7 +509,7 @@ var SumFunc = function.New(&function.Spec{
 		ty := args[0].Type()
 
 		if !ty.IsListType() && !ty.IsSetType() && !ty.IsTupleType() {
-			return cty.NilVal, function.NewArgErrorf(0, fmt.Sprintf("argument must be list, set, or tuple. Received %s", ty.FriendlyName()))
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple. Received %s", ty.FriendlyName())
 		}
 
 		if !args[0].IsWhollyKnown() {

--- a/pkg/iac/scanners/terraform/parser/funcs/crypto.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/crypto.go
@@ -175,7 +175,7 @@ var RsaDecryptFunc = function.New(&function.Spec{
 			default:
 				errStr = fmt.Sprintf("invalid private key: %s", e)
 			}
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, errStr)
+			return cty.UnknownVal(cty.String), function.NewArgError(1, errors.New(errStr))
 		}
 		privateKey, ok := rawKey.(*rsa.PrivateKey)
 		if !ok {

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -280,7 +280,7 @@ type wasmModule struct {
 
 func newWASMPlugin(ctx context.Context, ccache wazero.CompilationCache, code []byte) (*wasmModule, error) {
 	mf := &memFS{}
-	config := wazero.NewModuleConfig().WithStdout(os.Stdout).WithFS(mf)
+	config := wazero.NewModuleConfig().WithStdout(os.Stdout).WithFS(mf).WithStartFunctions("_initialize")
 
 	// Create an empty namespace so that multiple modules will not conflict
 	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(ccache))

--- a/pkg/module/testdata/analyzer/analyzer.go
+++ b/pkg/module/testdata/analyzer/analyzer.go
@@ -1,4 +1,4 @@
-//go:generate tinygo build -o analyzer.wasm -scheduler=none -target=wasi --no-debug analyzer.go
+//go:generate tinygo build -o analyzer.wasm -target=wasip1 --buildmode=c-shared analyzer.go
 //go:build tinygo.wasm
 
 package main
@@ -13,7 +13,7 @@ const (
 	moduleName    = "analyzer"
 )
 
-func main() {
+func init() {
 	wasm.RegisterModule(AnalyzerModule{})
 }
 

--- a/pkg/module/testdata/happy/happy.go
+++ b/pkg/module/testdata/happy/happy.go
@@ -1,4 +1,4 @@
-//go:generate tinygo build -o happy.wasm -scheduler=none -target=wasi --no-debug happy.go
+//go:generate tinygo build -o happy.wasm -target=wasip1 --buildmode=c-shared happy.go
 //go:build tinygo.wasm
 
 package main
@@ -14,7 +14,7 @@ const (
 	moduleName    = "happy"
 )
 
-func main() {
+func init() {
 	wasm.RegisterModule(HappyModule{})
 }
 

--- a/pkg/module/testdata/scanner/scanner.go
+++ b/pkg/module/testdata/scanner/scanner.go
@@ -1,4 +1,4 @@
-//go:generate tinygo build -o scanner.wasm -scheduler=none -target=wasi --no-debug scanner.go
+//go:generate tinygo build -o scanner.wasm -target=wasip1 --buildmode=c-shared scanner.go
 //go:build tinygo.wasm
 
 package main
@@ -14,7 +14,7 @@ const (
 	moduleName    = "scanner"
 )
 
-func main() {
+func init() {
 	wasm.RegisterModule(PostScannerModule{})
 }
 

--- a/pkg/module/wasm/sdk.go
+++ b/pkg/module/wasm/sdk.go
@@ -56,24 +56,24 @@ func RegisterModule(p api.Module) {
 	module = p
 }
 
-//export name
+//go:wasmexport name
 func _name() uint64 {
 	name := module.Name()
 	ptr, size := stringToPtr(name)
 	return (uint64(ptr) << uint64(32)) | uint64(size)
 }
 
-//export api_version
+//go:wasmexport api_version
 func _apiVersion() uint32 {
 	return api.Version
 }
 
-//export version
+//go:wasmexport version
 func _version() uint32 {
 	return uint32(module.Version())
 }
 
-//export is_analyzer
+//go:wasmexport is_analyzer
 func _isAnalyzer() uint64 {
 	if _, ok := module.(api.Analyzer); !ok {
 		return 0
@@ -81,14 +81,14 @@ func _isAnalyzer() uint64 {
 	return 1
 }
 
-//export required
+//go:wasmexport required
 func _required() uint64 {
 	files := module.(api.Analyzer).RequiredFiles()
 	ss := serialize.StringSlice(files)
 	return marshal(ss)
 }
 
-//export analyze
+//go:wasmexport analyze
 func _analyze(ptr, size uint32) uint64 {
 	filePath := ptrToString(ptr, size)
 	custom, err := module.(api.Analyzer).Analyze(filePath)
@@ -99,7 +99,7 @@ func _analyze(ptr, size uint32) uint64 {
 	return marshal(custom)
 }
 
-//export is_post_scanner
+//go:wasmexport is_post_scanner
 func _isPostScanner() uint64 {
 	if _, ok := module.(api.PostScanner); !ok {
 		return 0
@@ -107,12 +107,12 @@ func _isPostScanner() uint64 {
 	return 1
 }
 
-//export post_scan_spec
+//go:wasmexport post_scan_spec
 func _post_scan_spec() uint64 {
 	return marshal(module.(api.PostScanner).PostScanSpec())
 }
 
-//export post_scan
+//go:wasmexport post_scan
 func _post_scan(ptr, size uint32) uint64 {
 	var results serialize.Results
 	if err := unmarshal(ptr, size, &results); err != nil {


### PR DESCRIPTION
## Overview
This PR updates Go to version 1.24 and changes how we manage Go versions in GitHub Actions from `go-version` to `go-version-file`.

## Description
This PR includes the following changes:

1. Update Go version to 1.24 in go.mod
2. Bump golangci-lint to v1.64.2 that supports Go 1.24
3. Switch from `go-version` to `go-version-file` in GitHub Actions workflows

The switch to `go-version-file` was made to improve version management clarity and reduce confusion. Previously, we had a discussion in #6711 about using `go-version` to automatically use the latest patch version. However, this approach led to confusion as the version specified in the workflow could differ from the one in go.mod.

For example, in #8341, we unnecessarily updated the Go version even though the latest patch version would have been used during the release anyway. To avoid such confusion, it looks better to manage Go versions explicitly through go.mod and use `go-version-file` in workflows. This approach:

- Makes version management more transparent and explicit
- Reduces the number of places where Go versions need to be managed
- Ensures consistency between go.mod and CI/CD environments

## Related PRs
- #6711
- #8341

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
