### PR TITLE
fix: don't use `scope` for `trivy registry login` command

### DIFF
--- a/pkg/commands/auth/run.go
+++ b/pkg/commands/auth/run.go
@@ -34,7 +34,7 @@ func Login(ctx context.Context, registry string, opts flag.Options) error {
 	_, err = transport.NewWithContext(ctx, reg, &authn.Basic{
 		Username: opts.Credentials[0].Username,
 		Password: opts.Credentials[0].Password,
-	}, httpTransport(opts), []string{reg.Scope(transport.PullScope)})
+	}, httpTransport(opts), nil)
 	if err != nil {
 		return xerrors.Errorf("failed to authenticate: %w", err)
 	}


### PR DESCRIPTION
## Description
DockerHub returns error when we use `scope` (see #8386 ).
So we need to use empty scope to fix this error.

We can confirm that it works for DockerHub, GHCR (https://github.com/aquasecurity/trivy/issues/8386#issuecomment-2653143840). 

## Related issues
- Close #8386

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
