### PR TITLE
feat(analyzer): Add analyzer support for the Mageia distribution

### DIFF
--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -128,6 +128,7 @@ os:
 - amazon
 - suse
 - photon
+- mageia
 - distroless
 
 language:

--- a/docs/docs/coverage/os/index.md
+++ b/docs/docs/coverage/os/index.md
@@ -25,6 +25,7 @@ Trivy supports operating systems for
 | [openSUSE Tumbleweed](suse.md)        | (n/a)                               | zypper/rpm       |
 | [SUSE Linux Enterprise](suse.md)      | 11, 12, 15                          | zypper/rpm       |
 | [SUSE Linux Enterprise Micro](suse.md)| 5, 6                                | zypper/rpm       |
+| [Mageia Linux](mageia.md)             | 2, 3, 4, 5, 6, 7, 8, 9              | dnf/urpmi/rpm    |
 | [Photon OS](photon.md)                | 1.0, 2.0, 3.0, 4.0                  | tndf/yum/rpm     |
 | [Debian GNU/Linux](debian.md)         | 7, 8, 9, 10, 11, 12                 | apt/dpkg         |
 | [Ubuntu](ubuntu.md)                   | All versions supported by Canonical | apt/dpkg         |

--- a/docs/docs/coverage/os/mageia.md
+++ b/docs/docs/coverage/os/mageia.md
@@ -1,0 +1,34 @@
+# Mageia
+
+Trivy supports these scanners for OS packages.
+
+|    Scanner    | Supported |
+| :-----------: | :-------: |
+|     SBOM      |     ✓     |
+| Vulnerability |     -     |
+|    License    |     ✓     |
+
+The table below outlines the features offered by Trivy.
+
+|               Feature                | Supported |
+|:------------------------------------:|:---------:|
+|       Unfixed vulnerabilities        |     -     |
+| [Dependency graph][dependency-graph] |     ✓     |
+
+## SBOM
+Trivy detects packages that have been installed through package managers such as `dnf` and `urpmi`.
+
+## Vulnerability
+Mageia offers its [own security advisories][mgasa], and these are utilized when scanning Mageia for vulnerabilities.
+
+### Data Source
+See [here](../../scanner/vulnerability.md#data-sources).
+
+## License
+Trivy identifies licenses by examining the metadata of RPM packages.
+
+
+[dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
+[mgasa]: https://advisories.mageia.org/
+
+[vulnerability statuses]: ../../configuration/filtering.md#by-status

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -21,6 +21,7 @@ const (
 	TypeRocky      Type = "rocky"
 	TypeAlma       Type = "alma"
 	TypeFedora     Type = "fedora"
+	TypeMageia     Type = "mageia"
 	TypeOracle     Type = "oracle"
 	TypeRedHatBase Type = "redhat"
 	TypeSUSE       Type = "suse"
@@ -160,6 +161,7 @@ var (
 		TypeRocky,
 		TypeAlma,
 		TypeFedora,
+		TypeMageia,
 		TypeOracle,
 		TypeRedHatBase,
 		TypeSUSE,

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -70,6 +70,8 @@ func (a osReleaseAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInp
 			family = types.Azure
 		case "mariner":
 			family = types.CBLMariner
+		case "mageia":
+			family = types.Mageia
 		}
 
 		if family != "" && versionID != "" {

--- a/pkg/fanal/analyzer/os/release/release_test.go
+++ b/pkg/fanal/analyzer/os/release/release_test.go
@@ -31,6 +31,16 @@ func Test_osReleaseAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:      "mageia",
+			inputFile: "testdata/mageia",
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.Mageia,
+					Name:   "9",
+				},
+			},
+		},
+		{
 			name:      "openSUSE-leap 15.2.1",
 			inputFile: "testdata/opensuseleap-15.2.1",
 			want: &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/os/release/testdata/mageia
+++ b/pkg/fanal/analyzer/os/release/testdata/mageia
@@ -1,0 +1,11 @@
+NAME="Mageia"
+VERSION="9"
+ID=mageia
+VERSION_ID=9
+ID_LIKE="mandriva fedora"
+PRETTY_NAME="Mageia 9"
+ANSI_COLOR="1;36"
+HOME_URL="https://www.mageia.org/"
+SUPPORT_URL="https://www.mageia.org/support/"
+BUG_REPORT_URL="https://bugs.mageia.org/"
+PRIVACY_POLICY_URL="https://wiki.mageia.org/en/Privacy_policy"

--- a/pkg/fanal/analyzer/pkg/rpm/archive.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive.go
@@ -131,6 +131,8 @@ func (a *rpmArchiveAnalyzer) generatePURL(pkg *types.Package) *packageurl.Packag
 		ns = "redhat"
 	case strings.Contains(vendor, "fedora"):
 		ns = "fedora"
+	case strings.Contains(vendor, "mageia"):
+		ns = "mageia"
 	case strings.Contains(vendor, "opensuse"):
 		ns = "opensuse"
 	case strings.Contains(vendor, "suse"):

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -49,6 +49,7 @@ var osVendors = []string{
 	"Amazon.com",            // Amazon Linux 2
 	"CentOS",                // CentOS
 	"Fedora Project",        // Fedora
+	"Mageia.Org",            // Mageia
 	"Oracle America",        // Oracle Linux
 	"Red Hat",               // Red Hat
 	"AlmaLinux",             // AlmaLinux

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -30,6 +30,7 @@ const (
 	Chainguard         OSType = "chainguard"
 	Debian             OSType = "debian"
 	Fedora             OSType = "fedora"
+	Mageia             OSType = "mageia"
 	OpenSUSE           OSType = "opensuse"
 	OpenSUSELeap       OSType = "opensuse-leap"
 	OpenSUSETumbleweed OSType = "opensuse-tumbleweed"
@@ -108,6 +109,7 @@ var (
 		Chainguard,
 		Debian,
 		Fedora,
+		Mageia,
 		OpenSUSE,
 		OpenSUSELeap,
 		OpenSUSETumbleweed,

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -480,7 +480,7 @@ func purlType(t ftypes.TargetType) string {
 	case ftypes.RedHat, ftypes.CentOS, ftypes.Rocky, ftypes.Alma,
 		ftypes.Amazon, ftypes.Fedora, ftypes.Oracle, ftypes.OpenSUSE,
 		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.SLEMicro, ftypes.Photon,
-		ftypes.Azure, ftypes.CBLMariner:
+		ftypes.Azure, ftypes.Mageia, ftypes.CBLMariner:
 		return packageurl.TypeRPM
 	case TypeOCI:
 		return packageurl.TypeOCI


### PR DESCRIPTION
## Description
Adds support for the Mageia distribution to the scanner.

Note that I encountered some dependency mismatches and haven't been able to run some of the tests locally. It seems to work when scanning a Mageia filesystem.

## Related issues
#8407 

## Checklist
- [X] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
