### PR TITLE
fix empty licenses for dpkg if package dir is symlink (filesystem sca…

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -143,6 +143,7 @@ type AnalysisInput struct {
 
 type PostAnalysisInput struct {
 	FS      fs.FS
+	LocalFS *fs.FS
 	Options AnalysisOptions
 }
 
@@ -472,7 +473,7 @@ func (ag AnalyzerGroup) RequiredPostAnalyzers(filePath string, info os.FileInfo)
 // and passes it to the respective post-analyzer.
 // The obtained results are merged into the "result".
 // This function may be called concurrently and must be thread-safe.
-func (ag AnalyzerGroup) PostAnalyze(ctx context.Context, compositeFS *CompositeFS, result *AnalysisResult, opts AnalysisOptions) error {
+func (ag AnalyzerGroup) PostAnalyze(ctx context.Context, localFS *fs.FS, compositeFS *CompositeFS, result *AnalysisResult, opts AnalysisOptions) error {
 	for _, a := range ag.postAnalyzers {
 		fsys, ok := compositeFS.Get(a.Type())
 		if !ok {
@@ -504,6 +505,7 @@ func (ag AnalyzerGroup) PostAnalyze(ctx context.Context, compositeFS *CompositeF
 
 		res, err := a.PostAnalyze(ctx, PostAnalysisInput{
 			FS:      filteredFS,
+			LocalFS: localFS,
 			Options: opts,
 		})
 		if err != nil {

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -627,7 +627,7 @@ func TestAnalyzerGroup_PostAnalyze(t *testing.T) {
 
 			ctx := context.Background()
 			got := new(analyzer.AnalysisResult)
-			err = a.PostAnalyze(ctx, composite, got, analyzer.AnalysisOptions{})
+			err = a.PostAnalyze(ctx, nil, composite, got, analyzer.AnalysisOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -412,7 +412,7 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 	wg.Wait()
 
 	// Post-analysis
-	if err = a.analyzer.PostAnalyze(ctx, composite, result, opts); err != nil {
+	if err = a.analyzer.PostAnalyze(ctx, nil, composite, result, opts); err != nil {
 		return types.BlobInfo{}, xerrors.Errorf("post analysis error: %w", err)
 	}
 

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -200,8 +200,9 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	// Wait for all the goroutine to finish.
 	wg.Wait()
 
+	localFS := os.DirFS(a.rootPath)
 	// Post-analysis
-	if err = a.analyzer.PostAnalyze(ctx, composite, result, opts); err != nil {
+	if err = a.analyzer.PostAnalyze(ctx, &localFS, composite, result, opts); err != nil {
 		return artifact.Reference{}, xerrors.Errorf("post analysis error: %w", err)
 	}
 

--- a/pkg/fanal/artifact/vm/vm.go
+++ b/pkg/fanal/artifact/vm/vm.go
@@ -142,7 +142,7 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 	}
 
 	// Post-analysis
-	if err = a.analyzer.PostAnalyze(ctx, composite, result, opts); err != nil {
+	if err = a.analyzer.PostAnalyze(ctx, nil, composite, result, opts); err != nil {
 		return types.BlobInfo{}, xerrors.Errorf("post analysis error: %w", err)
 	}
 


### PR DESCRIPTION
Currently trivy don't support symlinks as they can create loops and that is why  filepath.WalkDir skips them.

When we skip symlink directories in /usr/share/doc - packages with the same directory name don't have licenses.

It is hard to sync symlinks if they located on different layers, but for local filesystem we have only one layer. So we don't need to sync anything. In case we know exact path of license path (and for dpkg packages we know) and we have access to filesystem we can resolve this symlinks by just reading file. As we read it by full path, and there are no iterations by directories it is safe.

So in this fix we produce dpkg analyzer with access to local filesystem to read files from there. The same action with file read can be done with other analyzers.

After this change if we scan trivy with filesystem scan all dkpg packages which has symlink directory will be resolved.

Image scan will work as before, as it is impossible for now to fix it:
- symlink can be on layer1, and real dir can be on layer0. So layer1 has no access to data on layer0.
- if original file in symlink directory will be changes, this also must be synced with symlink content.

This all requires a lot of changes in cache.
