### PR TITLE
fix(flag): resolve env's from config file for `string` and `[]string` flags

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -154,7 +154,9 @@ func (f *Flag[T]) cast(val any) any {
 	case bool:
 		return cast.ToBool(val)
 	case string:
-		return cast.ToString(val)
+		// Viper doesn't resolve ENVs from config file.
+		// cf. https://github.com/spf13/viper/issues/315
+		return os.ExpandEnv(cast.ToString(val))
 	case int:
 		return cast.ToInt(val)
 	case float64, float32:
@@ -171,7 +173,13 @@ func (f *Flag[T]) cast(val any) any {
 			// https://github.com/spf13/cast/blob/48ddde5701366ade1d3aba346e09bb58430d37c6/caste.go#L1296-L1297
 			val = strings.Split(s, ",")
 		}
-		return cast.ToStringSlice(val)
+		ss := cast.ToStringSlice(val)
+		for i := range ss {
+			// Viper doesn't resolve ENVs from config file.
+			// cf. https://github.com/spf13/viper/issues/315
+			ss[i] = os.ExpandEnv(ss[i])
+		}
+		return ss
 	}
 	return val
 }


### PR DESCRIPTION
## Description
See #8436

Example:
```yaml
cache:
  dir: "$HOME/.cache/trivy"
```

Before:
```bash
2025-02-24T11:48:13+06:00       DEBUG   Cache dir       dir="$HOME/.cache/trivy"
```

After:
```bash
2025-02-24T11:47:23+06:00       DEBUG   Cache dir       dir="/Users/dmitriy/.cache/trivy"
```


## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
