### PR TITLE
fix(k8s): add missed option `PkgRelationships`

### DIFF
--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -232,8 +232,9 @@ func (s *Scanner) scanK8sVulns(ctx context.Context, artifactsData []*artifacts.A
 
 	k8sScanner := k8s.NewKubernetesScanner()
 	scanOptions := types.ScanOptions{
-		Scanners: s.opts.Scanners,
-		PkgTypes: s.opts.PkgTypes,
+		Scanners:         s.opts.Scanners,
+		PkgTypes:         s.opts.PkgTypes,
+		PkgRelationships: s.opts.PackageOptions.PkgRelationships,
 	}
 	for _, artifact := range artifactsData {
 		switch artifact.Kind {


### PR DESCRIPTION
## Description
This PR adds a skipped option `PkgRelationships`.  

### Reproduction steps
```sh
$ kind create cluster --image "kindest/node:v1.25.0"
$ trivy  k8s --scanners vuln --skip-images --report all
```
before
```sh
2025-02-24T16:05:17+06:00       INFO    Node scanning is enabled
2025-02-24T16:05:17+06:00       INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-02-24T16:05:17+06:00       INFO    Scanning K8s... K8s="kind-kind"
```
after
```sh
2025-02-24T16:05:22+06:00       INFO    Node scanning is enabled
2025-02-24T16:05:22+06:00       INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-02-24T16:05:22+06:00       INFO    Scanning K8s... K8s="kind-kind"

namespace: , node: kind-control-plane (kubernetes)

Total: 4 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 3, CRITICAL: 0)

┌────────────────┬───────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│    Library     │ Vulnerability │ Severity │ Status │ Installed Version │              Fixed Version               │                            Title                             │
├────────────────┼───────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ k8s.io/kubelet │ CVE-2023-3676 │ HIGH     │ fixed  │ v1.25.0           │ 1.28.1, 1.27.5, 1.26.8, 1.25.13, 1.24.17 │ kubernetes: Insufficient input sanitization on Windows nodes │
│                │               │          │        │                   │                                          │ leads to privilege escalation                                │
│                │               │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2023-3676                    │
│                ├───────────────┤          │        │                   │                                          ├──────────────────────────────────────────────────────────────┤
│                │ CVE-2023-3955 │          │        │                   │                                          │ kubernetes: Insufficient input sanitization on Windows nodes │
│                │               │          │        │                   │                                          │ leads to privilege escalation                                │
│                │               │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2023-3955                    │
│                ├───────────────┤          │        │                   ├──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                │ CVE-2023-5528 │          │        │                   │ 1.28.4, 1.27.8, 1.26.11, 1.25.16         │ kubernetes: Insufficient input sanitization in in-tree       │
│                │               │          │        │                   │                                          │ storage plugin leads to privilege escalation...              │
│                │               │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2023-5528                    │
│                ├───────────────┼──────────┤        │                   ├──────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                │ CVE-2023-2431 │ LOW      │        │                   │ 1.24.14, 1.25.10, 1.26.5, 1.27.2         │ kubernetes: Bypass of seccomp profile enforcement            │
│                │               │          │        │                   │                                          │ https://avd.aquasec.com/nvd/cve-2023-2431                    │
└────────────────┴───────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘

namespace: , node: kind-control-plane (gobinary)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 0, CRITICAL: 0)

┌──────────────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│             Library              │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├──────────────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ github.com/containerd/containerd │ CVE-2022-23471      │ MEDIUM   │ fixed  │ v1.6.7            │ 1.5.16, 1.6.12 │ containerd is an open source container runtime. A bug was │
│                                  │                     │          │        │                   │                │ found in...                                               │
│                                  │                     │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2022-23471                │
│                                  ├─────────────────────┤          │        │                   ├────────────────┼───────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25153      │          │        │                   │ 1.5.18, 1.6.18 │ containerd: OCI image importer memory exhaustion          │
│                                  │                     │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-25153                │
│                                  ├─────────────────────┤          │        │                   │                ├───────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25173      │          │        │                   │                │ containerd: Supplementary groups are not set up properly  │
│                                  │                     │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-25173                │
│                                  ├─────────────────────┤          │        │                   ├────────────────┼───────────────────────────────────────────────────────────┤
│                                  │ GHSA-7ww5-4wqc-m92c │          │        │                   │ 1.6.26, 1.7.11 │ containerd allows RAPL to be accessible to a container    │
│                                  │                     │          │        │                   │                │ https://github.com/advisories/GHSA-7ww5-4wqc-m92c         │
└──────────────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘
```

## Related issues
- Close #8441 

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
