### PR TITLE
chore(terraform): assign *terraform.Module 'parent' field

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1729,7 +1729,7 @@ func TestNestedModulesOptions(t *testing.T) {
 	//
 	// Modules referenced
 	// main -> city ├─> brooklyn
-	//	            └─> queens
+	//              └─> queens
 	files := map[string]string{
 		"main.tf": `
 module "city" {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1729,7 +1729,7 @@ func TestNestedModulesOptions(t *testing.T) {
 	//
 	// Modules referenced
 	// main -> city ├─> brooklyn
-	//				└─> queens
+	//	            └─> queens
 	files := map[string]string{
 		"main.tf": `
 module "city" {

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/main.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/main.tf
@@ -1,0 +1,9 @@
+module "north-america" {
+  source = "./north-america"
+}
+
+output "all" {
+  value = [
+    module.north-america,
+  ]
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/canada/canada.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/canada/canada.tf
@@ -1,0 +1,17 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}canada"
+}
+
+module "ontario-springfield" {
+  source = "./springfield"
+  prefix = "ontario-"
+}
+
+output "ontario-springfield" {
+  value = module.ontario-springfield.name
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/canada/springfield/springfield.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/canada/springfield/springfield.tf
@@ -1,0 +1,8 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}springfield"
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/north-america.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/north-america.tf
@@ -1,0 +1,22 @@
+variable "prefix" {
+    type = string
+    default = ""
+}
+
+output "name" {
+  value = "${var.prefix}north-america"
+}
+
+module "canada" {
+  source = "./canada"
+  prefix = ""
+}
+
+module "united-states" {
+  source = "./united-states"
+  prefix = ""
+}
+
+output "united-states" {
+  value = module.united-states.name
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/new-york/new-york-city/new-york-city.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/new-york/new-york-city/new-york-city.tf
@@ -1,0 +1,8 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}new-york-city"
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/new-york/new-york.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/new-york/new-york.tf
@@ -1,0 +1,17 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}new-york"
+}
+
+module "new-york-city" {
+  source = "./new-york-city"
+  prefix = ""
+}
+
+output "new-york-city" {
+  value = module.new-york-city.name
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/springfield/springfield.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/springfield/springfield.tf
@@ -1,0 +1,8 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}springfield"
+}

--- a/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/united-states.tf
+++ b/pkg/iac/scanners/terraform/parser/testdata/nested/north-america/united-states/united-states.tf
@@ -1,0 +1,38 @@
+variable "prefix" {
+  type = string
+  default = ""
+}
+
+output "name" {
+  value = "${var.prefix}united-states"
+}
+
+// Same module twice, with different variables
+module "illinois-springfield" {
+  source = "./springfield"
+  prefix = "illinois-"
+}
+
+output "illinois-springfield" {
+  value = module.illinois-springfield.name
+}
+
+module "idaho-springfield" {
+  source = "./springfield"
+  prefix = "idaho-"
+}
+
+output "idaho-springfield" {
+  value = module.idaho-springfield.name
+}
+
+module "new-york" {
+  source = "./new-york"
+  prefix = ""
+}
+
+output "new-york" {
+  value = module.new-york.name
+}
+
+

--- a/pkg/iac/terraform/module.go
+++ b/pkg/iac/terraform/module.go
@@ -47,6 +47,10 @@ func (c *Module) ModulePath() string {
 	return c.modulePath
 }
 
+func (c *Module) Parent() *Module {
+	return c.parent
+}
+
 func (c *Module) Ignores() ignore.Rules {
 	return c.ignores
 }


### PR DESCRIPTION
## Description

Setting 'parent' field was omitted for submodules.
This commit corrects that. Submodules can now traverse up their
parents until they hit the root module.

I made a unit test to really put it through the paces.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
