### PR TITLE
ci: update GitHub Actions cache to v4

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore Trivy binaries from cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: dist/
           key: ${{ runner.os }}-bins-${{github.workflow}}-${{github.sha}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore Trivy binaries from cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: dist/
           key: ${{ runner.os }}-bins-${{github.workflow}}-${{github.sha}}

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -120,7 +120,7 @@ jobs:
             public.ecr.aws/aquasecurity/trivy:canary
 
       - name: Cache Trivy binaries
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: dist/
           # use 'github.sha' to create a unique cache folder for each run.


### PR DESCRIPTION
## Description
Update cache action version from v4.0.2 to v4 in multiple workflow files

>Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

https://github.com/aquasecurity/trivy/actions/runs/13629588758/job/38097043500



## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
