### PR TITLE
perf(misconf): parse input for Rego once

### DIFF
--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/util"
+	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/iac/framework"
 	"github.com/aquasecurity/trivy/pkg/iac/providers"
@@ -145,6 +146,9 @@ type Input struct {
 	Path     string `json:"path"`
 	FS       fs.FS  `json:"-"`
 	Contents any    `json:"contents"`
+
+	// parsed is the parsed input value for the rego query
+	parsed ast.Value
 }
 
 func GetInputsContents(inputs []Input) []any {
@@ -158,6 +162,21 @@ func GetInputsContents(inputs []Input) []any {
 func (s *Scanner) ScanInput(ctx context.Context, sourceType types.Source, inputs ...Input) (scan.Results, error) {
 
 	s.logger.Debug("Scanning inputs", "count", len(inputs))
+
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	inputs = lo.FilterMap(inputs, func(input Input, _ int) (Input, bool) {
+		s.trace("INPUT", input)
+		parsed, err := parseRawInput(input.Contents)
+		if err != nil {
+			s.logger.Error("Failed to parse input", log.FilePath(input.Path), log.Err(err))
+			return input, false
+		}
+		input.parsed = parsed
+		return input, true
+	})
 
 	var results scan.Results
 
@@ -191,10 +210,6 @@ func (s *Scanner) ScanInput(ctx context.Context, sourceType types.Source, inputs
 
 		// skip if check isn't relevant to what is being scanned
 		if !isPolicyApplicable(sourceType, staticMeta, inputs...) {
-			continue
-		}
-
-		if len(inputs) == 0 {
 			continue
 		}
 
@@ -302,14 +317,8 @@ func (s *Scanner) applyRule(ctx context.Context, namespace, rule string, inputs 
 	var results scan.Results
 	qualified := fmt.Sprintf("data.%s.%s", namespace, rule)
 	for _, input := range inputs {
-		s.trace("INPUT", input)
-		parsedInput, err := parseRawInput(input.Contents)
-		if err != nil {
-			s.logger.Error("Error occurred while parsing input", log.Err(err))
-			continue
-		}
 
-		resultSet, traces, err := s.runQuery(ctx, qualified, parsedInput, false)
+		resultSet, traces, err := s.runQuery(ctx, qualified, input.parsed, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

While writing integration tests in trivy-checks, I noticed that it takes a lot of time to scan test data. Trivy parses the input data before Rego query for each scan, i.e. Trivy parses the input data n times, where n is the number of checks. This leads to large memory allocation and takes a lot of CPU time. 

This PR moves the parsing of the input data before running all checks.

### Before
```bash
/usr/bin/time -l trivy conf output -f json -o report1.json -q
       23.12 real        30.69 user         1.17 sys
           635666432  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               39678  page reclaims
                5694  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                3019  signals received
                3912  voluntary context switches
              210086  involuntary context switches
        274946052226  instructions retired
         88964216095  cycles elapsed
           567790336  peak memory footprint
```

### After
```bash
❯ /usr/bin/time -l ./trivy conf output -f json -o report2.json -q
       14.32 real        19.67 user         0.76 sys
           687472640  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               40874  page reclaims
                1358  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                1695  signals received
                1113  voluntary context switches
              154940  involuntary context switches
        179149408054  instructions retired
         57700642912  cycles elapsed
           618695552  peak memory footprint
```


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
