### PR TITLE
fix(sbom): improve logic for binding direct dependency to parent component

### DIFF
--- a/pkg/sbom/io/encode.go
+++ b/pkg/sbom/io/encode.go
@@ -200,9 +200,16 @@ func (e *Encoder) encodePackages(parent *core.Component, result types.Result) {
 	components := make(map[string]*core.Component, len(result.Packages))
 	// PkgID => Package Component
 	dependencies := make(map[string]*core.Component, len(result.Packages))
+	var hasRoot bool
 	for i, pkg := range result.Packages {
 		pkgID := lo.Ternary(pkg.ID == "", fmt.Sprintf("%s@%s", pkg.Name, pkg.Version), pkg.ID)
 		result.Packages[i].ID = pkgID
+
+		// Check if the project has a root dependency
+		// TODO: Ideally, all projects should have a root dependency.
+		if pkg.Relationship == ftypes.RelationshipRoot {
+			hasRoot = true
+		}
 
 		// Convert packages to components
 		c := e.component(result, pkg)
@@ -226,7 +233,7 @@ func (e *Encoder) encodePackages(parent *core.Component, result types.Result) {
 		c := components[pkg.Identifier.UID]
 
 		// Add a relationship between the parent and the package if needed
-		if e.belongToParent(pkg, parents) {
+		if e.belongToParent(pkg, parents, hasRoot) {
 			e.bom.AddRelationship(parent, c, core.RelationshipContains)
 		}
 
@@ -403,16 +410,15 @@ func (*Encoder) vulnerability(vuln types.DetectedVulnerability) core.Vulnerabili
 }
 
 // belongToParent determines if a package should be directly included in the parent based on its relationship and dependencies.
-func (*Encoder) belongToParent(pkg ftypes.Package, parents map[string]ftypes.Packages) bool {
+func (*Encoder) belongToParent(pkg ftypes.Package, parents map[string]ftypes.Packages, hasRoot bool) bool {
 	// Case 1: Relationship: known , DependsOn: known
 	//         Packages with no parent are included in the parent
 	//         - Relationship:
 	//           - Root: true (it doesn't have a parent)
 	//           - Workspace: false (it always has a parent)
 	//           - Direct:
-	//             - Under Root or Workspace: false (it always has a parent)
-	//             - No parents: true (e.g., package-lock.json)
-	//             - There are parents, but they are not Root or Workspace: true (when indirect dependency was installed manually. cf. https://github.com/aquasecurity/trivy/issues/8488)
+	//             - No root dependency in the project: true (e.g., poetry.lock)
+	//             - Otherwise: false (Direct dependencies should belong to the root/workspace)
 	//           - Indirect: false (it always has a parent)
 	// Case 2: Relationship: unknown, DependsOn: unknown (e.g., conan lockfile v2)
 	//         All packages are included in the parent
@@ -421,16 +427,11 @@ func (*Encoder) belongToParent(pkg ftypes.Package, parents map[string]ftypes.Pac
 	// Case 4: Relationship: unknown, DependsOn: known (e.g., GoBinaries, OS packages)
 	//         - Packages with parents: false. These packages are included in the packages from `parents` (e.g. GoBinaries deps and root package).
 	//         - Packages without parents: true. These packages are included in the parent (e.g. OS packages without parents).
-	pkgParents := parents[pkg.ID]
-	if pkg.Relationship != ftypes.RelationshipDirect {
-		return len(pkgParents) == 0
+	if pkg.Relationship == ftypes.RelationshipDirect {
+		return !hasRoot
 	}
 
-	_, found := lo.Find(pkgParents, func(pkg ftypes.Package) bool {
-		return pkg.Relationship == ftypes.RelationshipRoot || pkg.Relationship == ftypes.RelationshipWorkspace
-	})
-
-	return !found
+	return len(parents[pkg.ID]) == 0
 }
 
 func filterProperties(props []core.Property) []core.Property {

--- a/pkg/sbom/io/encode_test.go
+++ b/pkg/sbom/io/encode_test.go
@@ -839,6 +839,163 @@ func TestEncoder_Encode(t *testing.T) {
 			wantVulns: make(map[uuid.UUID][]core.Vulnerability),
 		},
 		{
+			name: "direct package is also dependency",
+			report: types.Report{
+				SchemaVersion: 2,
+				ArtifactName:  "test",
+				ArtifactType:  artifact.TypeFilesystem,
+				Results: []types.Result{
+					{
+						Target: "poetry.lock",
+						Type:   ftypes.Poetry,
+						Class:  types.ClassLangPkg,
+						Packages: []ftypes.Package{
+							{
+								ID:      "django@5.1.6",
+								Name:    "django",
+								Version: "5.1.6",
+								Identifier: ftypes.PkgIdentifier{
+									UID: "69691e87e187021d",
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypePyPi,
+										Name:    "django",
+										Version: "5.1.6",
+									},
+								},
+								Relationship: ftypes.RelationshipDirect,
+							},
+							{
+								ID:      "sentry-sdk@2.22.0",
+								Name:    "sentry-sdk",
+								Version: "2.22.0",
+								Identifier: ftypes.PkgIdentifier{
+									UID: "7e53a15e8bec68ad",
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypePyPi,
+										Name:    "sentry-sdk",
+										Version: "2.22.0",
+									},
+								},
+								Relationship: ftypes.RelationshipDirect,
+								DependsOn: []string{
+									"django@5.1.6",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantComponents: map[uuid.UUID]*core.Component{
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000001"): {
+					Type: core.TypeFilesystem,
+					Name: "test",
+					Root: true,
+					Properties: []core.Property{
+						{
+							Name:  core.PropertySchemaVersion,
+							Value: "2",
+						},
+					},
+					PkgIdentifier: ftypes.PkgIdentifier{
+						BOMRef: "3ff14136-e09f-4df9-80ea-000000000001",
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000002"): {
+					Type: core.TypeApplication,
+					Name: "poetry.lock",
+					Properties: []core.Property{
+						{
+							Name:  core.PropertyClass,
+							Value: "lang-pkgs",
+						},
+						{
+							Name:  core.PropertyType,
+							Value: "poetry",
+						},
+					},
+					PkgIdentifier: ftypes.PkgIdentifier{
+						BOMRef: "3ff14136-e09f-4df9-80ea-000000000002",
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000003"): {
+					Type:    core.TypeLibrary,
+					Name:    "django",
+					Version: "5.1.6",
+					SrcFile: "poetry.lock",
+					Properties: []core.Property{
+						{
+							Name:  core.PropertyPkgID,
+							Value: "django@5.1.6",
+						},
+						{
+							Name:  core.PropertyPkgType,
+							Value: "poetry",
+						},
+					},
+					PkgIdentifier: ftypes.PkgIdentifier{
+						UID: "69691e87e187021d",
+						PURL: &packageurl.PackageURL{
+							Type:    packageurl.TypePyPi,
+							Name:    "django",
+							Version: "5.1.6",
+						},
+						BOMRef: "pkg:pypi/django@5.1.6",
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000004"): {
+					Type:    core.TypeLibrary,
+					Name:    "sentry-sdk",
+					Version: "2.22.0",
+					SrcFile: "poetry.lock",
+					Properties: []core.Property{
+						{
+							Name:  core.PropertyPkgID,
+							Value: "sentry-sdk@2.22.0",
+						},
+						{
+							Name:  core.PropertyPkgType,
+							Value: "poetry",
+						},
+					},
+					PkgIdentifier: ftypes.PkgIdentifier{
+						UID: "7e53a15e8bec68ad",
+						PURL: &packageurl.PackageURL{
+							Type:    packageurl.TypePyPi,
+							Name:    "sentry-sdk",
+							Version: "2.22.0",
+						},
+						BOMRef: "pkg:pypi/sentry-sdk@2.22.0",
+					},
+				},
+			},
+			wantRels: map[uuid.UUID][]core.Relationship{
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000001"): {
+					{
+						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000002"),
+						Type:       core.RelationshipContains,
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000002"): {
+					{
+						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000003"),
+						Type:       core.RelationshipContains,
+					},
+					{
+						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000004"),
+						Type:       core.RelationshipContains,
+					},
+				},
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000003"): nil,
+				uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000004"): {
+					{
+						Dependency: uuid.MustParse("3ff14136-e09f-4df9-80ea-000000000003"),
+						Type:       core.RelationshipDependsOn,
+					},
+				},
+			},
+			wantVulns: make(map[uuid.UUID][]core.Vulnerability),
+		},
+		{
 			name: "SBOM file",
 			report: types.Report{
 				SchemaVersion: 2,


### PR DESCRIPTION
## Description
This PR improves `belongToParent` logic for Direct dependencies:
- If parents contains `Root` or `Workspace` - doesn't bind dependency to the parent component (current logic)
- for other cases (if there are parents) we need to bind dependency to parent component (see #8488 for more details)

Example:
```json
{
  "ID": "django@5.1.6",
  "Name": "django",
  "Identifier": {
    "PURL": "pkg:pypi/django@5.1.6",
    "UID": "69691e87e187021d"
  },
  "Version": "5.1.6",
  "Relationship": "direct",
  "DependsOn": [
    "asgiref@3.8.1",
    "sqlparse@0.5.3",
    "tzdata@2025.1"
  ],
  "Layer": {}
},
{
  "ID": "sentry-sdk@2.22.0",
  "Name": "sentry-sdk",
  "Identifier": {
    "PURL": "pkg:pypi/sentry-sdk@2.22.0",
    "UID": "7e53a15e8bec68ad"
  },
  "Version": "2.22.0",
  "Relationship": "direct",
  "DependsOn": [
    "certifi@2025.1.31",
    "django@5.1.6",
    "urllib3@2.3.0"
  ],
  "Layer": {}
},
```

before:
```json
{
  "ref": "59c637a8-4c7b-4c61-b68e-a8731ff3bb09", // Application component
  "dependsOn": [
    "pkg:pypi/sentry-sdk@2.22.0"
  ]
},
{
  "ref": "pkg:pypi/sentry-sdk@2.22.0",
  "dependsOn": [
    "pkg:pypi/certifi@2025.1.31",
    "pkg:pypi/django@5.1.6",
    "pkg:pypi/urllib3@2.3.0"
  ]
},
```
after:
```json
{
  "ref": "285569c7-9e19-44e1-8bf0-906f4ef8d2a2",  // Application component
  "dependsOn": [
    "pkg:pypi/django@5.1.6",
    "pkg:pypi/sentry-sdk@2.22.0"
  ]
},
{
  "ref": "pkg:pypi/sentry-sdk@2.22.0",
  "dependsOn": [
    "pkg:pypi/certifi@2025.1.31",
    "pkg:pypi/django@5.1.6",
    "pkg:pypi/urllib3@2.3.0"
  ]
},
```

## Related issues
- Close #8488

## Related PRs
- [x] #8104


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
