### PR TITLE
fix(spdx): save text licenses into `otherLicenses` without normalize

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -415,8 +415,7 @@ func (m *Marshaler) spdxLicense(c *core.Component) (string, []*spdx.OtherLicense
 func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherLicense) {
 	var otherLicenses = make(map[string]*spdx.OtherLicense) // licenseID -> OtherLicense
 
-	var licenseNames []string
-	for _, license := range licenses {
+	license := strings.Join(lo.Map(licenses, func(license string, index int) string {
 		// We need to save text licenses before normalization,
 		// because it is impossible to handle all cases possible in the text.
 		// as an example, parse a license with 2 consecutive tokens (see https://github.com/aquasecurity/trivy/issues/8465)
@@ -426,10 +425,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			otherLicenses[otherLicense.LicenseIdentifier] = otherLicense
 			license = otherLicense.LicenseIdentifier
 		}
-		licenseNames = append(licenseNames, license)
-	}
 
-	license := strings.Join(lo.Map(licenseNames, func(license string, index int) string {
 		// e.g. GPL-3.0-with-autoconf-exception
 		license = strings.ReplaceAll(license, "-with-", " WITH ")
 		license = strings.ReplaceAll(license, "-WITH-", " WITH ")

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -423,7 +423,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			license = strings.TrimPrefix(license, licensing.LicenseTextPrefix)
 			otherLicense := m.newOtherLicense(license, true)
 			otherLicenses[otherLicense.LicenseIdentifier] = otherLicense
-			license = otherLicense.LicenseIdentifier
+			return otherLicense.LicenseIdentifier
 		}
 
 		// e.g. GPL-3.0-with-autoconf-exception

--- a/pkg/sbom/spdx/marshal_private_test.go
+++ b/pkg/sbom/spdx/marshal_private_test.go
@@ -100,11 +100,11 @@ func TestMarshaler_normalizeLicenses(t *testing.T) {
 		{
 			name: "happy path with text of license",
 			input: []string{
-				"text://unknown-license",
+				"text://Redistribution and use in source and binary forms, with or without",
 				"AFL 2.0",
 				"unknown-license",
 			},
-			wantLicenseName: "LicenseRef-ffca10435cadded4 AND AFL-2.0 AND LicenseRef-a0bb0951a6dfbdbe",
+			wantLicenseName: "LicenseRef-b5b4cc09bc5f0e16 AND AFL-2.0 AND LicenseRef-a0bb0951a6dfbdbe",
 			wantOtherLicenses: []*spdx.OtherLicense{
 				{
 					LicenseIdentifier: "LicenseRef-a0bb0951a6dfbdbe",
@@ -112,9 +112,9 @@ func TestMarshaler_normalizeLicenses(t *testing.T) {
 					ExtractedText:     `This component is licensed under "unknown-license"`,
 				},
 				{
-					LicenseIdentifier: "LicenseRef-ffca10435cadded4",
+					LicenseIdentifier: "LicenseRef-b5b4cc09bc5f0e16",
 					LicenseName:       "NOASSERTION",
-					ExtractedText:     "unknown-license",
+					ExtractedText:     "Redistribution and use in source and binary forms, with or without",
 					LicenseComment:    "The license text represents text found in package metadata and may not represent the full text of the license",
 				},
 			},


### PR DESCRIPTION
## Description
Save text licenses in `otherLicenses` without normalization.
This is necessary to avoid errors when parsing the license text.
Also, we did not include these "incorrect" licenses in the report.

See #8465 for more details.

Before (report doesn't contain this license):
```
➜  trivy image 8449 -f spdx-json | grep Redistribution 
...
2025-03-06T13:33:03+06:00       WARN    [spdx] Unable to marshal SPDX licenses  license="(GPL-2.0-only) AND (text://Redistribution and use in source and binary forms, with or without) AND (text://By obtaining, using, and/or copying this software and/or its) AND (text://Permission to use, copy, modify, and distribute this software and) AND (text://This software is provided 'as-is', without any express or implied) AND (text://Permission  is  hereby granted,  free  of charge,  to  any person) AND (text://Permission is hereby granted, free of charge, to any person obtaining) AND (text://Permission to use, copy, modify, and distribute this software and its) AND (text://This software is provided as-is, without express or implied) AND (text://Permission to use, copy, modify, and distribute this software for any) AND (text://* Permission to use this software in any way is granted without)"
```

After:
```
➜ ./trivy image 8449 -f spdx-json | grep Redistribution
...
      "extractedText": "Redistribution and use in source and binary forms, with or without",
```

## Related issues
- Close #8465

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
