### PR TITLE
chore: replace deprecated tenv linter with usetesting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -114,7 +114,7 @@ linters:
     - misspell
     - perfsprint
     - revive
-    - tenv
+    - usetesting
     - testifylint
     - typecheck
     - unconvert

--- a/pkg/attestation/sbom/rekor_test.go
+++ b/pkg/attestation/sbom/rekor_test.go
@@ -1,7 +1,6 @@
 package sbom_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,7 @@ func TestRekor_RetrieveSBOM(t *testing.T) {
 			rc, err := sbom.NewRekor(ts.URL())
 			require.NoError(t, err)
 
-			got, err := rc.RetrieveSBOM(context.Background(), tt.digest)
+			got, err := rc.RetrieveSBOM(t.Context(), tt.digest)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/commands/auth/run_test.go
+++ b/pkg/commands/auth/run_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,7 +102,7 @@ func TestLogin(t *testing.T) {
 			t.Setenv("DOCKER_CONFIG", filepath.Join(t.TempDir(), "config.json"))
 
 			reg := lo.Ternary(tt.args.registry == "", strings.TrimPrefix(tr.URL, "http://"), tt.args.registry)
-			err := auth.Login(context.Background(), reg, tt.args.opts)
+			err := auth.Login(t.Context(), reg, tt.args.opts)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -124,19 +123,19 @@ func TestLogout(t *testing.T) {
 		err := os.WriteFile(configFile, []byte(`{"auths": {"auth.test": {"auth": "dXNlcjpwYXNz"}}}`), 0600)
 		require.NoError(t, err)
 
-		err = auth.Logout(context.Background(), "auth.test")
+		err = auth.Logout(t.Context(), "auth.test")
 		require.NoError(t, err)
 		b, err := os.ReadFile(configFile)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"auths": {}}`, string(b))
 	})
 	t.Run("not found", func(t *testing.T) {
-		err := auth.Logout(context.Background(), "notfound.test")
+		err := auth.Logout(t.Context(), "notfound.test")
 		require.NoError(t, err) // Return an error if "credsStore" is "osxkeychain".
 	})
 
 	t.Run("invalid registry", func(t *testing.T) {
-		err := auth.Logout(context.Background(), "aaa://invalid.test")
+		err := auth.Logout(t.Context(), "aaa://invalid.test")
 		require.ErrorContains(t, err, "registries must be valid RFC 3986 URI authorities")
 	})
 }

--- a/pkg/commands/clean/run_test.go
+++ b/pkg/commands/clean/run_test.go
@@ -1,7 +1,6 @@
 package clean_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -130,7 +129,7 @@ func TestRun(t *testing.T) {
 				CleanOptions: tt.cleanOpts,
 			}
 
-			err := clean.Run(context.Background(), opts)
+			err := clean.Run(t.Context(), opts)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/pkg/compliance/report/table_test.go
+++ b/pkg/compliance/report/table_test.go
@@ -2,7 +2,6 @@ package report_test
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,7 +72,7 @@ func TestTableWriter_Write(t *testing.T) {
 				Report: tt.reportType,
 				Output: buf,
 			}
-			err := tr.Write(context.Background(), tt.input)
+			err := tr.Write(t.Context(), tt.input)
 			require.NoError(t, err)
 
 			want, err := os.ReadFile(tt.want)

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -147,7 +146,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			}
 
 			// Set a fake time
-			ctx := clock.With(context.Background(), time.Date(2019, 10, 1, 0, 0, 0, 0, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2019, 10, 1, 0, 0, 0, 0, time.UTC))
 
 			client := db.NewClient(dbDir, true)
 			needsUpdate, err := client.NeedsUpdate(ctx, "test", tt.skip)
@@ -191,7 +190,7 @@ func TestClient_Download(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set a fake time
-			ctx := clock.With(context.Background(), time.Date(2019, 10, 1, 0, 0, 0, 0, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2019, 10, 1, 0, 0, 0, 0, time.UTC))
 
 			// Fake DB
 			art := dbtest.NewFakeDB(t, tt.input, dbtest.FakeDBOptions{})

--- a/pkg/detector/ospkg/alma/alma_test.go
+++ b/pkg/detector/ospkg/alma/alma_test.go
@@ -1,7 +1,6 @@
 package alma_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -215,7 +214,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := alma.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/alpine/alpine_test.go
+++ b/pkg/detector/ospkg/alpine/alpine_test.go
@@ -1,7 +1,6 @@
 package alpine_test
 
 import (
-	"context"
 	"sort"
 	"testing"
 	"time"
@@ -326,7 +325,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := alpine.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -1,7 +1,6 @@
 package amazon_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -248,7 +247,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := amazon.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -1,7 +1,6 @@
 package debian_test
 
 import (
-	"context"
 	"sort"
 	"testing"
 	"time"
@@ -172,7 +171,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := debian.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/oracle/oracle_test.go
+++ b/pkg/detector/ospkg/oracle/oracle_test.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -83,7 +82,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	for testName, tt := range tests {
 		s := NewScanner()
 		t.Run(testName, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			actual := s.IsSupportedVersion(ctx, tt.osFamily, tt.osVersion)
 			if actual != tt.expected {
 				t.Errorf("[%s] got %v, want %v", testName, actual, tt.expected)

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -1,7 +1,6 @@
 package photon_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -147,7 +146,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := photon.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -1,7 +1,6 @@
 package redhat_test
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -494,7 +493,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := redhat.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -1,7 +1,6 @@
 package rocky_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -175,7 +174,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := rocky.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/suse/suse_test.go
+++ b/pkg/detector/ospkg/suse/suse_test.go
@@ -1,7 +1,6 @@
 package suse_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -283,7 +282,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := suse.NewScanner(tt.distribution)
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -1,7 +1,6 @@
 package ubuntu_test
 
 import (
-	"context"
 	"sort"
 	"testing"
 	"time"
@@ -253,7 +252,7 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 			s := ubuntu.NewScanner()
 			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
 			assert.Equal(t, tt.want, got)

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -1,7 +1,6 @@
 package downloader_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,7 +43,7 @@ func TestDownload(t *testing.T) {
 			dst := t.TempDir()
 
 			// Execute the download
-			_, err := downloader.Download(context.Background(), server.URL, dst, "", downloader.Options{
+			_, err := downloader.Download(t.Context(), server.URL, dst, "", downloader.Options{
 				Insecure: tt.insecure,
 			})
 

--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -1,7 +1,6 @@
 package analyzer_test
 
 import (
-	"context"
 	"os"
 	"sync"
 	"testing"
@@ -529,7 +528,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 			info, err := os.Stat(tt.args.testFilePath)
 			require.NoError(t, err)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			err = a.AnalyzeFile(ctx, &wg, limit, got, "", tt.args.filePath, info,
 				func() (xio.ReadSeekCloserAt, error) {
 					if tt.args.testFilePath == "testdata/error" {
@@ -625,7 +624,7 @@ func TestAnalyzerGroup_PostAnalyze(t *testing.T) {
 				javadb.Init("./language/java/jar/testdata", []name.Reference{repo}, true, false, types.RegistryOptions{Insecure: false})
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got := new(analyzer.AnalysisResult)
 			err = a.PostAnalyze(ctx, composite, got, analyzer.AnalysisOptions{})
 			require.NoError(t, err)

--- a/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
+++ b/pkg/fanal/analyzer/buildinfo/content_manifest_test.go
@@ -1,7 +1,6 @@
 package buildinfo
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -49,7 +48,7 @@ func Test_contentManifestAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := contentManifestAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.input,
 				Content:  f,
 			})

--- a/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
+++ b/pkg/fanal/analyzer/buildinfo/dockerfile_test.go
@@ -1,7 +1,6 @@
 package buildinfo
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -52,7 +51,7 @@ func Test_dockerfileAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := dockerfileAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/pkg/fanal/analyzer/config/config_test.go
+++ b/pkg/fanal/analyzer/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -94,7 +93,7 @@ func TestAnalyzer_PostAnalyze(t *testing.T) {
 			a, err := config.NewAnalyzer(tt.fields.typ, 0, tt.fields.fileType, tt.fields.opts)
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 			if tt.wantErr != "" {

--- a/pkg/fanal/analyzer/config_analyzer_test.go
+++ b/pkg/fanal/analyzer/config_analyzer_test.go
@@ -116,7 +116,7 @@ func TestAnalyzeConfig(t *testing.T) {
 				DisabledAnalyzers: tt.args.disabledAnalyzers,
 			})
 			require.NoError(t, err)
-			got := a.AnalyzeImageConfig(context.Background(), tt.args.targetOS, tt.args.config)
+			got := a.AnalyzeImageConfig(t.Context(), tt.args.targetOS, tt.args.config)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/executable/executable_test.go
+++ b/pkg/fanal/analyzer/executable/executable_test.go
@@ -1,7 +1,6 @@
 package executable
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func Test_executableAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			a := executableAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,
 				Info:     stat,

--- a/pkg/fanal/analyzer/imgconf/apk/apk_test.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk_test.go
@@ -1,7 +1,6 @@
 package apk
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -1423,7 +1422,7 @@ func TestAnalyze(t *testing.T) {
 			t.Setenv(envApkIndexArchiveURL, v.apkIndexArchivePath)
 			a, err := newAlpineCmdAnalyzer(analyzer.ConfigAnalyzerOptions{})
 			require.NoError(t, err)
-			result, err := a.Analyze(context.Background(), analyzer.ConfigAnalysisInput{
+			result, err := a.Analyze(t.Context(), analyzer.ConfigAnalysisInput{
 				OS:     v.args.targetOS,
 				Config: v.args.config,
 			})

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -2,7 +2,6 @@ package dockerfile
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -332,7 +331,7 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a, err := newHistoryAnalyzer(analyzer.ConfigAnalyzerOptions{})
 			require.NoError(t, err)
-			got, err := a.Analyze(context.Background(), tt.input)
+			got, err := a.Analyze(t.Context(), tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/pkg/fanal/analyzer/imgconf/secret/secret_test.go
+++ b/pkg/fanal/analyzer/imgconf/secret/secret_test.go
@@ -1,7 +1,6 @@
 package secret
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -95,7 +94,7 @@ func Test_secretAnalyzer_Analyze(t *testing.T) {
 			a, err := newSecretAnalyzer(analyzer.ConfigAnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.Analyze(context.Background(), analyzer.ConfigAnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.ConfigAnalysisInput{
 				Config: tt.config,
 			})
 			if tt.wantErr {

--- a/pkg/fanal/analyzer/language/c/conan/conan_test.go
+++ b/pkg/fanal/analyzer/language/c/conan/conan_test.go
@@ -1,7 +1,6 @@
 package conan
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -216,7 +215,7 @@ func Test_conanLockAnalyzer_Analyze(t *testing.T) {
 			a, err := newConanLockAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/conda/environment/environment_test.go
+++ b/pkg/fanal/analyzer/language/conda/environment/environment_test.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -148,7 +147,7 @@ func Test_environmentAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := environmentAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/conda/meta/meta_test.go
+++ b/pkg/fanal/analyzer/language/conda/meta/meta_test.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -55,7 +54,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			a := metaAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Info:     stat,

--- a/pkg/fanal/analyzer/language/dart/pub/pubspec_test.go
+++ b/pkg/fanal/analyzer/language/dart/pub/pubspec_test.go
@@ -1,7 +1,6 @@
 package pub
 
 import (
-	"context"
 	"os"
 	"runtime"
 	"testing"
@@ -133,7 +132,7 @@ func Test_pubSpecLockAnalyzer_Analyze(t *testing.T) {
 			a, err := newPubSpecLockAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/deps/deps_test.go
@@ -1,7 +1,6 @@
 package deps
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -57,7 +56,7 @@ func Test_depsLibraryAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := depsLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/nuget/nuget_test.go
@@ -1,7 +1,6 @@
 package nuget
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -197,7 +196,7 @@ func Test_nugetLibraryAnalyzer_Analyze(t *testing.T) {
 			a, err := newNugetLibraryAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops_test.go
+++ b/pkg/fanal/analyzer/language/dotnet/packagesprops/packagesprops_test.go
@@ -1,7 +1,6 @@
 package packagesprops
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -80,7 +79,7 @@ func Test_packagesPropsAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := packagesPropsAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/golang/binary/binary_test.go
+++ b/pkg/fanal/analyzer/language/golang/binary/binary_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"context"
 	"os"
 	"runtime"
 	"testing"
@@ -83,7 +82,7 @@ func Test_gobinaryLibraryAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := gobinaryLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/golang/mod/mod_test.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod_test.go
@@ -1,7 +1,6 @@
 package mod
 
 import (
-	"context"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -302,7 +301,7 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 				}
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.PostAnalyze(ctx, analyzer.PostAnalysisInput{
 				FS: mfs,
 			})

--- a/pkg/fanal/analyzer/language/java/gradle/lockfile_test.go
+++ b/pkg/fanal/analyzer/language/java/gradle/lockfile_test.go
@@ -1,7 +1,6 @@
 package gradle
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -118,7 +117,7 @@ func Test_gradleLockAnalyzer_Analyze(t *testing.T) {
 			a, err := newGradleLockAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/java/jar/jar_test.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar_test.go
@@ -1,7 +1,6 @@
 package jar
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -133,7 +132,7 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 			javadb.Init("testdata", []name.Reference{repo}, true, false, types.RegistryOptions{Insecure: false})
 
 			a := javaLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mfs := mapfs.New()
 			err = mfs.MkdirAll(filepath.Dir(tt.inputFile), os.ModePerm)

--- a/pkg/fanal/analyzer/language/java/sbt/lockfile_test.go
+++ b/pkg/fanal/analyzer/language/java/sbt/lockfile_test.go
@@ -1,7 +1,6 @@
 package sbt
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -78,7 +77,7 @@ func Test_sbtDependencyLockAnalyzer(t *testing.T) {
 			require.NoError(t, err)
 
 			a := sbtDependencyLockAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,

--- a/pkg/fanal/analyzer/language/julia/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/julia/pkg/pkg_test.go
@@ -1,7 +1,6 @@
 package pkgjl
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -199,7 +198,7 @@ func Test_juliaAnalyzer_Analyze(t *testing.T) {
 			a, err := newJuliaAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
@@ -1,7 +1,6 @@
 package npm
 
 import (
-	"context"
 	"os"
 	"sort"
 	"testing"
@@ -235,7 +234,7 @@ func Test_npmLibraryAnalyzer_Analyze(t *testing.T) {
 			a, err := newNpmLibraryAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pkg/pkg_test.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -81,7 +80,7 @@ func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := nodePkgLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
@@ -1,7 +1,6 @@
 package pnpm
 
 import (
-	"context"
 	"os"
 	"sort"
 	"testing"
@@ -111,7 +110,7 @@ func Test_pnpmPkgLibraryAnalyzer_Analyze(t *testing.T) {
 			a, err := newPnpmAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn_test.go
@@ -1,7 +1,6 @@
 package yarn
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -822,7 +821,7 @@ func Test_yarnLibraryAnalyzer_Analyze(t *testing.T) {
 			a, err := newYarnAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/php/composer/composer_test.go
+++ b/pkg/fanal/analyzer/language/php/composer/composer_test.go
@@ -1,7 +1,6 @@
 package composer
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -159,7 +158,7 @@ func Test_composerAnalyzer_PostAnalyze(t *testing.T) {
 			a, err := newComposerAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/python/packaging/egg_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/egg_test.go
@@ -1,7 +1,6 @@
 package packaging
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -103,7 +102,7 @@ func Test_eggAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			a := &eggAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				Content:  f,
 				FilePath: tt.inputFile,
 				Info:     fileInfo,

--- a/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/packaging_test.go
@@ -1,7 +1,6 @@
 package packaging
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -133,7 +132,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 
 			a, err := newPackagingAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 				Options: analyzer.AnalysisOptions{
 					FileChecksum: tt.includeChecksum,

--- a/pkg/fanal/analyzer/language/python/pip/pip_test.go
+++ b/pkg/fanal/analyzer/language/python/pip/pip_test.go
@@ -1,7 +1,6 @@
 package pip
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -176,7 +175,7 @@ func Test_pipAnalyzer_Analyze(t *testing.T) {
 			a, err := newPipLibraryAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/python/poetry/poetry_test.go
+++ b/pkg/fanal/analyzer/language/python/poetry/poetry_test.go
@@ -1,7 +1,6 @@
 package poetry
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -557,7 +556,7 @@ func Test_poetryLibraryAnalyzer_Analyze(t *testing.T) {
 			a, err := newPoetryAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/python/uv/uv_test.go
+++ b/pkg/fanal/analyzer/language/python/uv/uv_test.go
@@ -1,7 +1,6 @@
 package uv_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -160,7 +159,7 @@ func Test_uvAnalyzer_PostAnalyze(t *testing.T) {
 			a, err := uv.NewUvAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
+++ b/pkg/fanal/analyzer/language/ruby/gemspec/gemspec_test.go
@@ -1,7 +1,6 @@
 package gemspec
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -84,7 +83,7 @@ func Test_gemspecLibraryAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := gemspecLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/rust/binary/binary_test.go
+++ b/pkg/fanal/analyzer/language/rust/binary/binary_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"context"
 	"os"
 	"runtime"
 	"testing"
@@ -63,7 +62,7 @@ func Test_rustBinaryLibraryAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := rustBinaryLibraryAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,

--- a/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
+++ b/pkg/fanal/analyzer/language/rust/cargo/cargo_test.go
@@ -1,7 +1,6 @@
 package cargo
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -546,7 +545,7 @@ func Test_cargoAnalyzer_Analyze(t *testing.T) {
 			a, err := newCargoAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
 
-			got, err := a.PostAnalyze(context.Background(), analyzer.PostAnalysisInput{
+			got, err := a.PostAnalyze(t.Context(), analyzer.PostAnalysisInput{
 				FS: os.DirFS(tt.dir),
 			})
 

--- a/pkg/fanal/analyzer/licensing/license_test.go
+++ b/pkg/fanal/analyzer/licensing/license_test.go
@@ -1,7 +1,6 @@
 package licensing
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -54,7 +53,7 @@ func Test_licenseAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 
 			a := newLicenseFileAnalyzer()
-			got, err := a.Analyze(context.TODO(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,
 				Info:     fi,

--- a/pkg/fanal/analyzer/os/alpine/alpine_test.go
+++ b/pkg/fanal/analyzer/os/alpine/alpine_test.go
@@ -1,7 +1,6 @@
 package alpine
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestAlpineReleaseOSAnalyzer_Required(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			a := alpineOSAnalyzer{}
-			res, err := a.Analyze(context.Background(), test.input)
+			res, err := a.Analyze(t.Context(), test.input)
 
 			if test.wantError != "" {
 				require.Error(t, err)

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -1,7 +1,6 @@
 package amazonlinux
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -92,7 +91,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := amazonlinuxOSAnalyzer{}
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, tt.input)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/pkg/fanal/analyzer/os/debian/debian_test.go
+++ b/pkg/fanal/analyzer/os/debian/debian_test.go
@@ -1,7 +1,6 @@
 package debian
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -52,7 +51,7 @@ func Test_debianOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/debian_version",

--- a/pkg/fanal/analyzer/os/redhatbase/alma_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/alma_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_almaOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/almalinux-release",

--- a/pkg/fanal/analyzer/os/redhatbase/centos_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/centos_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -38,7 +37,7 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 			f, err := os.Open(tt.inputFile)
 			require.NoError(t, err)
 			defer f.Close()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/centos-release",

--- a/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/fedora_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_fedoraOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/fedora-release",
 				Content:  f,

--- a/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/oracle_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_oracleOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/oracle-release",
 				Content:  f,

--- a/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/redhatbase_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_redhatOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/redhat-release",
 				Content:  f,

--- a/pkg/fanal/analyzer/os/redhatbase/rocky_test.go
+++ b/pkg/fanal/analyzer/os/redhatbase/rocky_test.go
@@ -1,7 +1,6 @@
 package redhatbase
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_rockyOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/rocky-release",
 				Content:  f,

--- a/pkg/fanal/analyzer/os/release/release_test.go
+++ b/pkg/fanal/analyzer/os/release/release_test.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -174,7 +173,7 @@ func Test_osReleaseAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := osReleaseAnalyzer{}
-			res, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			res, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: "etc/os-release",
 				Content:  f,
 			})

--- a/pkg/fanal/analyzer/os/ubuntu/esm_test.go
+++ b/pkg/fanal/analyzer/os/ubuntu/esm_test.go
@@ -1,7 +1,6 @@
 package ubuntu
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -48,7 +47,7 @@ func Test_ubuntuESMAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,

--- a/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
+++ b/pkg/fanal/analyzer/os/ubuntu/ubuntu_test.go
@@ -1,7 +1,6 @@
 package ubuntu
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test_ubuntuOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/lsb-release",
 				Content:  f,

--- a/pkg/fanal/analyzer/pkg/apk/apk_test.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk_test.go
@@ -2,7 +2,6 @@ package apk
 
 import (
 	"bufio"
-	"context"
 	"os"
 	"testing"
 
@@ -443,7 +442,7 @@ func TestParseApkInfo(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 			scanner := bufio.NewScanner(f)
-			gotPkgs, gotFiles := a.parseApkInfo(context.Background(), scanner)
+			gotPkgs, gotFiles := a.parseApkInfo(t.Context(), scanner)
 
 			assert.Equal(t, tt.wantPkgs, gotPkgs)
 			assert.Equal(t, tt.wantFiles, gotFiles)

--- a/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright_test.go
@@ -1,7 +1,6 @@
 package dpkg
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -93,7 +92,7 @@ func Test_dpkgLicenseAnalyzer_Analyze(t *testing.T) {
 			}
 			a := dpkgLicenseAnalyzer{}
 
-			license, err := a.Analyze(context.Background(), input)
+			license, err := a.Analyze(t.Context(), input)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, license)
 		})

--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
@@ -1,7 +1,6 @@
 package dpkg
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1445,7 +1444,7 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a, err := newDpkgAnalyzer(analyzer.AnalyzerOptions{})
 			require.NoError(t, err)
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mfs := mapfs.New()
 			for testPath, osPath := range tt.testFiles {

--- a/pkg/fanal/analyzer/pkg/rpm/archive_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive_test.go
@@ -1,7 +1,6 @@
 package rpm
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -79,7 +78,7 @@ func Test_rpmArchiveAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := newRPMArchiveAnalyzer()
-			got, err := a.Analyze(context.Background(), tt.input)
+			got, err := a.Analyze(t.Context(), tt.input)
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/fanal/analyzer/pkg/rpm/rpm_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm_test.go
@@ -1,7 +1,6 @@
 package rpm
 
 import (
-	"context"
 	"errors"
 	"os"
 	"strings"
@@ -56,7 +55,7 @@ func Test_rpmPkgAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := rpmPkgAnalyzer{}
-			got, err := a.Analyze(context.Background(), tt.input)
+			got, err := a.Analyze(t.Context(), tt.input)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -273,7 +272,7 @@ func Test_rpmPkgAnalyzer_listPkgs(t *testing.T) {
 			}
 
 			a := newRPMPkgAnalyzer()
-			gotPkgs, gotFiles, err := a.listPkgs(context.Background(), m)
+			gotPkgs, gotFiles, err := a.listPkgs(t.Context(), m)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/fanal/analyzer/repo/apk/apk_test.go
+++ b/pkg/fanal/analyzer/repo/apk/apk_test.go
@@ -1,7 +1,6 @@
 package apk
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -150,7 +149,7 @@ https://dl-cdn.alpinelinux.org/alpine/v3.10/main
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			a := apkRepoAnalyzer{}
-			got, err := a.Analyze(context.Background(), test.input)
+			got, err := a.Analyze(t.Context(), test.input)
 
 			if test.wantErr != "" {
 				require.Error(t, err)

--- a/pkg/fanal/analyzer/sbom/sbom_test.go
+++ b/pkg/fanal/analyzer/sbom/sbom_test.go
@@ -1,7 +1,6 @@
 package sbom
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -340,7 +339,7 @@ func Test_sbomAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := sbomAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,
 			})

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -1,7 +1,6 @@
 package secret_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -192,7 +191,7 @@ func TestSecretAnalyzer(t *testing.T) {
 			fi, err := content.Stat()
 			require.NoError(t, err)
 
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Dir:      tt.dir,
 				Content:  content,

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -1,7 +1,6 @@
 package image_test
 
 import (
-	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -2016,7 +2015,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			a, err := image2.NewArtifact(img, c, tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr, tt.name)
 				return
@@ -2065,7 +2064,7 @@ func TestArtifact_InspectWithMaxImageSize(t *testing.T) {
 			artifact, err := image2.NewArtifact(img, c, tt.artifactOpt)
 			require.NoError(t, err)
 
-			_, err = artifact.Inspect(context.Background())
+			_, err = artifact.Inspect(t.Context())
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -1,7 +1,6 @@
 package image_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -161,7 +160,7 @@ func TestArtifact_InspectRekorAttestation(t *testing.T) {
 			a, err := image2.NewArtifact(img, c, tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -304,7 +303,7 @@ func TestArtifact_inspectOCIReferrerSBOM(t *testing.T) {
 			a, err := image2.NewArtifact(img, c, tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -228,7 +227,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -638,7 +637,7 @@ func TestTerraformMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -892,7 +891,7 @@ func TestTerraformPlanSnapshotMisconfScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), opt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1204,7 +1203,7 @@ func TestCloudFormationMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1432,7 +1431,7 @@ func TestDockerfileMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1693,7 +1692,7 @@ func TestKubernetesMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1946,7 +1945,7 @@ func TestAzureARMMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -2063,7 +2062,7 @@ func TestMixedConfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
@@ -2225,7 +2224,7 @@ func TestJSONConfigScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
@@ -2387,7 +2386,7 @@ func TestYAMLConfigScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			require.NoError(t, err)
 			require.NotNil(t, got)
 

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -3,7 +3,6 @@
 package repo
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -278,7 +277,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			require.NoError(t, err)
 			defer cleanup()
 
-			ref, err := art.Inspect(context.Background())
+			ref, err := art.Inspect(t.Context())
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/fanal/artifact/sbom/sbom_test.go
+++ b/pkg/fanal/artifact/sbom/sbom_test.go
@@ -1,7 +1,6 @@
 package sbom_test
 
 import (
-	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -394,7 +393,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			a, err := sbom.NewArtifact(tt.filePath, c, artifact.Option{})
 			require.NoError(t, err)
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			if len(tt.wantErr) > 0 {
 				require.Error(t, err)
 				found := false

--- a/pkg/fanal/artifact/vm/vm_test.go
+++ b/pkg/fanal/artifact/vm/vm_test.go
@@ -1,7 +1,6 @@
 package vm_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -166,7 +165,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				aa.SetEBS(ebs)
 			}
 
-			got, err := a.Inspect(context.Background())
+			got, err := a.Inspect(t.Context())
 			defer a.Clean(got)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)

--- a/pkg/fanal/handler/handler_test.go
+++ b/pkg/fanal/handler/handler_test.go
@@ -99,7 +99,7 @@ func TestManager_CallHooks(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			err = m.PostHandle(context.TODO(), nil, &blob)
+			err = m.PostHandle(t.Context(), nil, &blob)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, blob)
 		})

--- a/pkg/fanal/handler/sysfile/filter_test.go
+++ b/pkg/fanal/handler/sysfile/filter_test.go
@@ -1,7 +1,6 @@
 package nodejs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -260,7 +259,7 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := systemFileFilteringPostHandler{}
-			err := h.Handle(context.TODO(), tt.result, tt.blob)
+			err := h.Handle(t.Context(), tt.result, tt.blob)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, tt.blob)
 		})

--- a/pkg/fanal/handler/unpackaged/unpackaged_test.go
+++ b/pkg/fanal/handler/unpackaged/unpackaged_test.go
@@ -1,7 +1,6 @@
 package unpackaged_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/package-url/packageurl-go"
@@ -89,7 +88,7 @@ func Test_unpackagedHook_Handle(t *testing.T) {
 			h, err := unpackaged.NewUnpackagedHandler(opt)
 			require.NoError(t, err)
 
-			err = h.Handle(context.Background(), tt.args.res, got)
+			err = h.Handle(t.Context(), tt.args.res, got)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -84,10 +84,7 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 	var dockerHostParam string
 
 	if runtime.GOOS != "windows" {
-		runtimeDir, err := os.MkdirTemp("", "daemon")
-		require.NoError(t, err)
-
-		dir := filepath.Join(runtimeDir, "image")
+		dir := filepath.Join(t.TempDir(), "image")
 		err = os.MkdirAll(dir, os.ModePerm)
 		require.NoError(t, err)
 
@@ -130,10 +127,7 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 		},
 	}
 
-	runtimeDir, err := os.MkdirTemp("", "daemon")
-	require.NoError(t, err)
-
-	dir := filepath.Join(runtimeDir, "image")
+	dir := filepath.Join(t.TempDir(), "image")
 	err = os.MkdirAll(dir, os.ModePerm)
 	require.NoError(t, err)
 

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -84,7 +84,8 @@ func Test_image_ConfigNameWithCustomDockerHost(t *testing.T) {
 	var dockerHostParam string
 
 	if runtime.GOOS != "windows" {
-		dir := filepath.Join(t.TempDir(), "image")
+		dir, err := os.MkdirTemp("", "image") //nolint:usetesting // Too long file paths created by t.TempDir() cause an invalid argument error with socket binding
+		require.NoError(t, err)
 		err = os.MkdirAll(dir, os.ModePerm)
 		require.NoError(t, err)
 
@@ -127,7 +128,8 @@ func Test_image_ConfigNameWithCustomPodmanHost(t *testing.T) {
 		},
 	}
 
-	dir := filepath.Join(t.TempDir(), "image")
+	dir, err := os.MkdirTemp("", "image") //nolint:usetesting // Too long file paths created by t.TempDir() cause an invalid argument error with socket binding
+	require.NoError(t, err)
 	err = os.MkdirAll(dir, os.ModePerm)
 	require.NoError(t, err)
 

--- a/pkg/fanal/image/daemon/podman_test.go
+++ b/pkg/fanal/image/daemon/podman_test.go
@@ -19,13 +19,12 @@ import (
 func setupPodmanSock(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	runtimeDir, err := os.MkdirTemp("", "daemon")
-	require.NoError(t, err)
+	runtimeDir := t.TempDir()
 
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 
 	dir := filepath.Join(runtimeDir, "podman")
-	err = os.MkdirAll(dir, os.ModePerm)
+	err := os.MkdirAll(dir, os.ModePerm)
 	require.NoError(t, err)
 
 	sockPath := filepath.Join(dir, "podman.sock")

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -275,7 +274,7 @@ func TestNewDockerImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.option.ImageSources = types.AllImageSources
-			img, cleanup, err := NewContainerImage(context.Background(), tt.args.imageName, tt.args.option)
+			img, cleanup, err := NewContainerImage(t.Context(), tt.args.imageName, tt.args.option)
 			defer cleanup()
 
 			if tt.wantErr {
@@ -393,7 +392,7 @@ func TestNewDockerImageWithPrivateRegistry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.option.ImageSources = types.AllImageSources
-			_, cleanup, err := NewContainerImage(context.Background(), tt.args.imageName, tt.args.option)
+			_, cleanup, err := NewContainerImage(t.Context(), tt.args.imageName, tt.args.option)
 			defer cleanup()
 
 			if tt.wantErr != "" {
@@ -542,7 +541,7 @@ func TestDockerPlatformArguments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			imageName := fmt.Sprintf("%s/library/alpine:3.10", serverAddr)
 			tt.args.option.ImageSources = types.AllImageSources
-			_, cleanup, err := NewContainerImage(context.Background(), imageName, tt.args.option)
+			_, cleanup, err := NewContainerImage(t.Context(), imageName, tt.args.option)
 			defer cleanup()
 
 			if tt.wantErr != "" {

--- a/pkg/fanal/image/registry/ecr/ecr_test.go
+++ b/pkg/fanal/image/registry/ecr/ecr_test.go
@@ -151,7 +151,7 @@ func TestECRGetCredential(t *testing.T) {
 		e := ECRClient{
 			Client: mockedECR{Resp: c.Resp},
 		}
-		username, password, err := e.GetCredential(context.Background())
+		username, password, err := e.GetCredential(t.Context())
 		if err != nil {
 			t.Fatalf("%d, unexpected error", err)
 		}

--- a/pkg/fanal/image/registry/token_test.go
+++ b/pkg/fanal/image/registry/token_test.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -30,7 +29,7 @@ func TestGetToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAuth := GetToken(context.Background(), tt.args.domain, tt.args.opt)
+			gotAuth := GetToken(t.Context(), tt.args.domain, tt.args.opt)
 			assert.Equal(t, tt.wantAuth, gotAuth)
 		})
 	}

--- a/pkg/iac/adapters/cloudformation/testutil/testutil.go
+++ b/pkg/iac/adapters/cloudformation/testutil/testutil.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +16,7 @@ func AdaptAndCompare[T any](t *testing.T, source string, expected any, fn adaptF
 		"main.yaml": source,
 	})
 
-	fctx, err := parser.New().ParseFile(context.TODO(), fsys, "main.yaml")
+	fctx, err := parser.New().ParseFile(t.Context(), fsys, "main.yaml")
 	require.NoError(t, err)
 
 	adapted := fn(*fctx)

--- a/pkg/iac/adapters/terraform/tftestutil/testutil.go
+++ b/pkg/iac/adapters/terraform/tftestutil/testutil.go
@@ -1,7 +1,6 @@
 package tftestutil
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aquasecurity/trivy/internal/testutil"
@@ -14,10 +13,10 @@ func CreateModulesFromSource(t *testing.T, source, ext string) terraform.Modules
 		"source" + ext: source,
 	})
 	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
-	if err := p.ParseFS(context.TODO(), "."); err != nil {
+	if err := p.ParseFS(t.Context(), "."); err != nil {
 		t.Fatal(err)
 	}
-	modules, _, err := p.EvaluateAll(context.TODO())
+	modules, _, err := p.EvaluateAll(t.Context())
 	if err != nil {
 		t.Fatalf("parse error: %s", err)
 	}

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -2,7 +2,6 @@ package rego_test
 
 import (
 	"bytes"
-	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -81,7 +80,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -113,7 +112,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": false,
@@ -148,7 +147,7 @@ deny_evil {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -178,7 +177,7 @@ deny[msg] {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -215,7 +214,7 @@ deny[res] {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -256,7 +255,7 @@ deny[res] {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -309,7 +308,7 @@ deny[res] {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -357,7 +356,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -390,7 +389,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -420,7 +419,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -455,7 +454,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -489,7 +488,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"evil": true,
@@ -526,7 +525,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "dynamic",
@@ -558,7 +557,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "test",
@@ -605,7 +604,7 @@ deny {
 	)
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 		Path: "/evil.lol",
 		Contents: map[string]any{
 			"text": "test",
@@ -719,7 +718,7 @@ deny {
 
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{})
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{})
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetFailed(), 1)
@@ -758,7 +757,7 @@ deny {
 
 	require.NoError(t, scanner.LoadPolicies(srcFS))
 
-	results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{})
+	results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{})
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetFailed(), 1)
@@ -789,7 +788,7 @@ deny {
 		rego.WithPolicyDirs("checks"),
 	)
 	require.NoError(t, scanner.LoadPolicies(fsys))
-	_, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{})
+	_, err := scanner.ScanInput(t.Context(), types.SourceYAML, rego.Input{})
 	require.NoError(t, err)
 }
 
@@ -853,7 +852,7 @@ deny {
 			scanner := rego.NewScanner(rego.WithPolicyDirs("policies"))
 			require.NoError(t, scanner.LoadPolicies(srcFS))
 
-			results, err := scanner.ScanInput(context.TODO(), types.SourceJSON, rego.Input{
+			results, err := scanner.ScanInput(t.Context(), types.SourceJSON, rego.Input{
 				Path: "/evil.lol",
 				Contents: map[string]any{
 					"text": "test",
@@ -924,7 +923,7 @@ deny {
 
 			require.NoError(t, scanner.LoadPolicies(nil))
 
-			results, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{
+			results, err := scanner.ScanInput(t.Context(), types.SourceYAML, rego.Input{
 				Path:     "test.yaml",
 				Contents: map[string]any{"service": "test"},
 			})
@@ -1009,7 +1008,7 @@ deny {
 			)
 
 			require.NoError(t, scanner.LoadPolicies(nil))
-			results, err := scanner.ScanInput(context.TODO(), types.SourceYAML, rego.Input{})
+			results, err := scanner.ScanInput(t.Context(), types.SourceYAML, rego.Input{})
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected, len(results.GetFailed()) > 0)

--- a/pkg/iac/scanners/azure/arm/parser/parser_test.go
+++ b/pkg/iac/scanners/azure/arm/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"io/fs"
 	"testing"
 
@@ -204,7 +203,7 @@ func TestParser_Parse(t *testing.T) {
 			require.NoError(t, targetFS.WriteFile(filename, []byte(tt.input), 0644))
 
 			p := New(targetFS)
-			got, err := p.ParseFS(context.Background(), ".")
+			got, err := p.ParseFS(t.Context(), ".")
 			require.NoError(t, err)
 
 			if !tt.wantDeployment {
@@ -292,7 +291,7 @@ func Test_NestedResourceParsing(t *testing.T) {
 	require.NoError(t, targetFS.WriteFile("nested.json", []byte(input), 0644))
 
 	p := New(targetFS)
-	got, err := p.ParseFS(context.Background(), ".")
+	got, err := p.ParseFS(t.Context(), ".")
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 

--- a/pkg/iac/scanners/cloudformation/parser/parser_test.go
+++ b/pkg/iac/scanners/cloudformation/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,12 +13,10 @@ import (
 )
 
 func parseFile(t *testing.T, source, name string) (FileContexts, error) {
-	tmp, err := os.MkdirTemp(os.TempDir(), "defsec")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmp) }()
+	tmp := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, name), []byte(source), 0600))
 	fs := os.DirFS(tmp)
-	return New().ParseFS(context.TODO(), fs, ".")
+	return New().ParseFS(t.Context(), fs, ".")
 }
 
 func Test_parse_yaml(t *testing.T) {
@@ -252,7 +249,7 @@ Resources:
 	}
 	p := New(WithParameters(params))
 
-	files, err := p.ParseFS(context.TODO(), fs, ".")
+	files, err := p.ParseFS(t.Context(), fs, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 
@@ -289,7 +286,7 @@ Resources:
 
 	p := New(WithParameterFiles("params.json"))
 
-	files, err := p.ParseFS(context.TODO(), fs, ".")
+	files, err := p.ParseFS(t.Context(), fs, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 
@@ -349,7 +346,7 @@ Resources:
 		WithConfigsFS(configFS),
 	)
 
-	files, err := p.ParseFS(context.TODO(), fs, ".")
+	files, err := p.ParseFS(t.Context(), fs, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 2)
 
@@ -402,7 +399,7 @@ func TestJsonWithNumbers(t *testing.T) {
 		"main.json": src,
 	})
 
-	files, err := New().ParseFS(context.TODO(), fsys, ".")
+	files, err := New().ParseFS(t.Context(), fsys, ".")
 
 	require.NoError(t, err)
 	require.Len(t, files, 1)
@@ -436,7 +433,7 @@ Conditions:
 		"main.yaml": src,
 	})
 
-	files, err := New().ParseFS(context.TODO(), fsys, ".")
+	files, err := New().ParseFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 }
@@ -453,7 +450,7 @@ Resources:
 		"main.yaml": src,
 	})
 
-	files, err := New().ParseFS(context.TODO(), fsys, ".")
+	files, err := New().ParseFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 
@@ -479,7 +476,7 @@ Resources:
 		"main.yaml": src,
 	})
 
-	files, err := New().ParseFS(context.TODO(), fsys, ".")
+	files, err := New().ParseFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 

--- a/pkg/iac/scanners/cloudformation/scanner_test.go
+++ b/pkg/iac/scanners/cloudformation/scanner_test.go
@@ -1,7 +1,6 @@
 package cloudformation
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -59,7 +58,7 @@ deny[res] {
 
 	scanner := New(rego.WithPolicyDirs("rules"))
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -216,7 +215,7 @@ Resources:
 				rego.WithPolicyNamespaces("user"),
 			)
 
-			results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+			results, err := scanner.ScanFS(t.Context(), fsys, "code")
 			require.NoError(t, err)
 
 			if tt.ignored == 0 {

--- a/pkg/iac/scanners/cloudformation/test/cf_scanning_test.go
+++ b/pkg/iac/scanners/cloudformation/test/cf_scanning_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 func Test_basic_cloudformation_scanning(t *testing.T) {
 	cfScanner := cloudformation.New(rego.WithEmbeddedPolicies(true), rego.WithEmbeddedLibraries(true))
 
-	results, err := cfScanner.ScanFS(context.TODO(), os.DirFS("./examples/bucket"), ".")
+	results, err := cfScanner.ScanFS(t.Context(), os.DirFS("./examples/bucket"), ".")
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, results.GetFailed())
@@ -24,7 +23,7 @@ func Test_basic_cloudformation_scanning(t *testing.T) {
 func Test_cloudformation_scanning_has_expected_errors(t *testing.T) {
 	cfScanner := cloudformation.New(rego.WithEmbeddedPolicies(true), rego.WithEmbeddedLibraries(true))
 
-	results, err := cfScanner.ScanFS(context.TODO(), os.DirFS("./examples/bucket"), ".")
+	results, err := cfScanner.ScanFS(t.Context(), os.DirFS("./examples/bucket"), ".")
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, results.GetFailed())

--- a/pkg/iac/scanners/dockerfile/parser/parser_test.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ RUN make /app
 CMD python /app/app.py
 `
 
-	res, err := parser.Parse(context.TODO(), strings.NewReader(input), "Dockerfile")
+	res, err := parser.Parse(t.Context(), strings.NewReader(input), "Dockerfile")
 	require.NoError(t, err)
 
 	df, ok := res.(*dockerfile.Dockerfile)
@@ -103,7 +102,7 @@ EOF`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := parser.Parse(context.TODO(), strings.NewReader(tt.src), "Dockerfile")
+			res, err := parser.Parse(t.Context(), strings.NewReader(tt.src), "Dockerfile")
 			require.NoError(t, err)
 
 			df, ok := res.(*dockerfile.Dockerfile)

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -2,7 +2,6 @@ package dockerfile_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -224,7 +223,7 @@ USER root
 
 	scanner := dockerfile.NewScanner(rego.WithPolicyDirs("rules"))
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -571,7 +570,7 @@ COPY --from=dep /binary /`
 				rego.WithRegoErrorLimits(0),
 			)
 
-			results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+			results, err := scanner.ScanFS(t.Context(), fsys, "code")
 			if tc.expectedError != "" && err != nil {
 				require.Equal(t, tc.expectedError, err.Error(), tc.name)
 			} else {
@@ -692,7 +691,7 @@ deny contains res if {
 				rego.WithEmbeddedLibraries(true),
 				rego.WithRegoErrorLimits(0),
 			)
-			results, err := scanner.ScanFS(context.TODO(), fsys, ".")
+			results, err := scanner.ScanFS(t.Context(), fsys, ".")
 			require.NoError(t, err)
 			if tt.expected {
 				testutil.AssertRuleFound(t, "dockerfile-general-maintainer-deprecated", results, "")

--- a/pkg/iac/scanners/generic/scanner_test.go
+++ b/pkg/iac/scanners/generic/scanner_test.go
@@ -1,7 +1,6 @@
 package generic_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +49,7 @@ deny[res] {
 
 	scanner := generic.NewJsonScanner(rego.WithPolicyDirs("rules"))
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+	results, err := scanner.ScanFS(t.Context(), fsys, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -119,7 +118,7 @@ deny[res] {
 
 	scanner := generic.NewYamlScanner(rego.WithPolicyDirs("rules"))
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+	results, err := scanner.ScanFS(t.Context(), fsys, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -187,7 +186,7 @@ deny[res] {
 
 	scanner := generic.NewTomlScanner(rego.WithPolicyDirs("rules"))
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+	results, err := scanner.ScanFS(t.Context(), fsys, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)

--- a/pkg/iac/scanners/helm/parser/parser_test.go
+++ b/pkg/iac/scanners/helm/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ func TestParseFS(t *testing.T) {
 	t.Run("source chart is located next to an same archived chart", func(t *testing.T) {
 		p, err := New(".")
 		require.NoError(t, err)
-		require.NoError(t, p.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", "chart-and-archived-chart")), "."))
+		require.NoError(t, p.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", "chart-and-archived-chart")), "."))
 
 		expectedFiles := []string{
 			"my-chart/Chart.yaml",
@@ -36,7 +35,7 @@ func TestParseFS(t *testing.T) {
 		require.NoError(t, err)
 
 		fsys := os.DirFS(filepath.Join("testdata", "archive-with-symlinks"))
-		require.NoError(t, p.ParseFS(context.TODO(), fsys, "chart.tar.gz"))
+		require.NoError(t, p.ParseFS(t.Context(), fsys, "chart.tar.gz"))
 
 		expectedFiles := []string{
 			"chart/Chart.yaml",
@@ -54,7 +53,7 @@ func TestParseFS(t *testing.T) {
 		require.NoError(t, err)
 
 		fsys := os.DirFS(filepath.Join("testdata", "multiple-archived-deps"))
-		require.NoError(t, p.ParseFS(context.TODO(), fsys, "."))
+		require.NoError(t, p.ParseFS(t.Context(), fsys, "."))
 
 		expectedFiles := []string{
 			"Chart.yaml",
@@ -69,7 +68,7 @@ func TestParseFS(t *testing.T) {
 		require.NoError(t, err)
 
 		fsys := os.DirFS(filepath.Join("testdata", "non-deps-archives"))
-		require.NoError(t, p.ParseFS(context.TODO(), fsys, "."))
+		require.NoError(t, p.ParseFS(t.Context(), fsys, "."))
 
 		expectedFiles := []string{
 			"Chart.yaml",

--- a/pkg/iac/scanners/helm/test/option_test.go
+++ b/pkg/iac/scanners/helm/test/option_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func Test_helm_parser_with_options_with_values_file(t *testing.T) {
 
 			helmParser, err := parser.New(chartName, opts...)
 			require.NoError(t, err)
-			require.NoError(t, helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), "."))
+			require.NoError(t, helmParser.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", chartName)), "."))
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)
 
@@ -95,7 +94,7 @@ func Test_helm_parser_with_options_with_set_value(t *testing.T) {
 
 			helmParser, err := parser.New(chartName, opts...)
 			require.NoError(t, err)
-			err = helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
+			err = helmParser.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", chartName)), ".")
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)
@@ -145,7 +144,7 @@ func Test_helm_parser_with_options_with_api_versions(t *testing.T) {
 
 			helmParser, err := parser.New(chartName, opts...)
 			require.NoError(t, err)
-			err = helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), ".")
+			err = helmParser.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", chartName)), ".")
 			require.NoError(t, err)
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)
@@ -204,7 +203,7 @@ func Test_helm_parser_with_options_with_kube_versions(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.NoError(t, helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), "."))
+			require.NoError(t, helmParser.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", chartName)), "."))
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)
 

--- a/pkg/iac/scanners/helm/test/parser_test.go
+++ b/pkg/iac/scanners/helm/test/parser_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +34,7 @@ func Test_helm_parser(t *testing.T) {
 			chartName := test.chartName
 			helmParser, err := parser.New(chartName)
 			require.NoError(t, err)
-			require.NoError(t, helmParser.ParseFS(context.TODO(), os.DirFS("testdata"), chartName))
+			require.NoError(t, helmParser.ParseFS(t.Context(), os.DirFS("testdata"), chartName))
 			manifests, err := helmParser.RenderedChartFiles()
 			require.NoError(t, err)
 
@@ -73,7 +72,7 @@ func Test_helm_parser_where_name_non_string(t *testing.T) {
 
 		helmParser, err := parser.New(chartName)
 		require.NoError(t, err)
-		require.NoError(t, helmParser.ParseFS(context.TODO(), os.DirFS(filepath.Join("testdata", chartName)), "."))
+		require.NoError(t, helmParser.ParseFS(t.Context(), os.DirFS(filepath.Join("testdata", chartName)), "."))
 	}
 }
 
@@ -161,7 +160,7 @@ func Test_helm_tarball_parser(t *testing.T) {
 
 		helmParser, err := parser.New(test.archiveFile)
 		require.NoError(t, err)
-		require.NoError(t, helmParser.ParseFS(context.TODO(), testFs, "."))
+		require.NoError(t, helmParser.ParseFS(t.Context(), testFs, "."))
 
 		manifests, err := helmParser.RenderedChartFiles()
 		require.NoError(t, err)

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func Test_helm_scanner_with_archive(t *testing.T) {
 		require.NoError(t, copyArchive(test.path, testFileName))
 
 		testFs := os.DirFS(testTemp)
-		results, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+		results, err := helmScanner.ScanFS(t.Context(), testFs, ".")
 		require.NoError(t, err)
 		require.NotNil(t, results)
 
@@ -104,7 +103,7 @@ func Test_helm_scanner_with_missing_name_can_recover(t *testing.T) {
 		require.NoError(t, copyArchive(test.path, testFileName))
 
 		testFs := os.DirFS(testTemp)
-		_, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+		_, err := helmScanner.ScanFS(t.Context(), testFs, ".")
 		require.NoError(t, err)
 	}
 }
@@ -132,7 +131,7 @@ func Test_helm_scanner_with_dir(t *testing.T) {
 		helmScanner := helm.New(rego.WithEmbeddedPolicies(true), rego.WithEmbeddedLibraries(true))
 
 		testFs := os.DirFS(filepath.Join("testdata", test.chartName))
-		results, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+		results, err := helmScanner.ScanFS(t.Context(), testFs, ".")
 		require.NoError(t, err)
 		require.NotNil(t, results)
 
@@ -224,7 +223,7 @@ deny[res] {
 
 			testFs := os.DirFS(testTemp)
 
-			results, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+			results, err := helmScanner.ScanFS(t.Context(), testFs, ".")
 			require.NoError(t, err)
 			require.NotNil(t, results)
 
@@ -270,7 +269,7 @@ func copyArchive(src, dst string) error {
 func Test_helm_chart_with_templated_name(t *testing.T) {
 	helmScanner := helm.New(rego.WithEmbeddedPolicies(true), rego.WithEmbeddedLibraries(true))
 	testFs := os.DirFS(filepath.Join("testdata", "templated-name"))
-	_, err := helmScanner.ScanFS(context.TODO(), testFs, ".")
+	_, err := helmScanner.ScanFS(t.Context(), testFs, ".")
 	require.NoError(t, err)
 }
 
@@ -302,7 +301,7 @@ deny[res] {
 		rego.WithPolicyReader(strings.NewReader(policy)),
 	)
 
-	results, err := helmScanner.ScanFS(context.TODO(), os.DirFS("testdata/simmilar-templates"), ".")
+	results, err := helmScanner.ScanFS(t.Context(), os.DirFS("testdata/simmilar-templates"), ".")
 	require.NoError(t, err)
 
 	failedResults := results.GetFailed()
@@ -348,7 +347,7 @@ deny[res] {
 		rego.WithPolicyReader(strings.NewReader(check)),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), os.DirFS("testdata/with-subchart"), ".")
+	results, err := scanner.ScanFS(t.Context(), os.DirFS("testdata/with-subchart"), ".")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 

--- a/pkg/iac/scanners/kubernetes/scanner_test.go
+++ b/pkg/iac/scanners/kubernetes/scanner_test.go
@@ -1,7 +1,6 @@
 package kubernetes_test
 
 import (
-	"context"
 	"io/fs"
 	"strings"
 	"testing"
@@ -56,7 +55,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+	results, err := scanner.ScanFS(t.Context(), fsys, "code")
 	require.NoError(t, err)
 
 	failed := results.GetFailed()
@@ -119,7 +118,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, "code")
+	results, err := scanner.ScanFS(t.Context(), fsys, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -160,7 +159,7 @@ spec:
 		rego.WithPolicyDirs("."),
 		rego.WithEmbeddedLibraries(true),
 	)
-	results, err := scanner.ScanFS(context.TODO(), fsys, ".")
+	results, err := scanner.ScanFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, results.GetFailed())
@@ -205,7 +204,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, ".")
+	results, err := scanner.ScanFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 
 	assertLines(t, file, results)
@@ -276,7 +275,7 @@ spec:
 		rego.WithPolicyDirs("checks"),
 		rego.WithPolicyFilesystem(fsys),
 	)
-	results, err := scanner.ScanFS(context.TODO(), fsys, "test/KSV001")
+	results, err := scanner.ScanFS(t.Context(), fsys, "test/KSV001")
 	require.NoError(t, err)
 
 	require.NoError(t, err)

--- a/pkg/iac/scanners/terraform/fs_test.go
+++ b/pkg/iac/scanners/terraform/fs_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ func Test_OS_FS(t *testing.T) {
 		rego.WithEmbeddedPolicies(true),
 		rego.WithEmbeddedLibraries(true),
 	)
-	results, err := s.ScanFS(context.TODO(), os.DirFS("testdata"), "fail")
+	results, err := s.ScanFS(t.Context(), os.DirFS("testdata"), "fail")
 	require.NoError(t, err)
 	assert.NotEmpty(t, results.GetFailed())
 }

--- a/pkg/iac/scanners/terraform/parser/modules_test.go
+++ b/pkg/iac/scanners/terraform/parser/modules_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"path"
 	"testing"
 
@@ -69,7 +68,7 @@ module "this" {
 				return path.Dir(p)
 			})
 
-			got, err := parser.FindRootModules(context.TODO(), modules)
+			got, err := parser.FindRootModules(t.Context(), modules)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})

--- a/pkg/iac/scanners/terraform/parser/parser_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_integration_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,9 +22,9 @@ module "registry" {
 	})
 
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -44,9 +43,9 @@ module "registry" {
 	})
 
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -67,9 +66,9 @@ module "registry" {
 	})
 
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -88,9 +87,9 @@ module "object" {
 	})
 
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bytes"
-	"context"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -77,8 +76,8 @@ check "cats_mittens_is_special" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	blocks := modules[0].GetBlocks()
@@ -178,9 +177,9 @@ output "mod_result" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, modules, 2)
@@ -240,8 +239,8 @@ output "mod_result" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 	rootModule := modules[0]
@@ -285,8 +284,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -312,8 +311,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -355,8 +354,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -403,8 +402,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -444,8 +443,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -492,8 +491,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -536,8 +535,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, modules, 1)
@@ -580,8 +579,8 @@ resource "aws_s3_bucket" "default" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 
@@ -640,8 +639,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this2" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -675,8 +674,8 @@ resource "aws_s3_bucket" "main" {
 		OptionWithTFVarsPaths("main.tfvars"),
 	)
 
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -707,9 +706,9 @@ resource "aws_s3_bucket" "this" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -741,9 +740,9 @@ resource "aws_s3_bucket" "this" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -795,9 +794,9 @@ policy_rules = {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithTFVarsPaths("main.tfvars"))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -831,9 +830,9 @@ resource "aws_s3_bucket" "this" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -863,9 +862,9 @@ data "http" "example" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -900,9 +899,9 @@ data "http" "example" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -1146,9 +1145,9 @@ resource "aws_internet_gateway" "example" {
 `,
 	})
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 
@@ -1171,9 +1170,9 @@ func TestArnAttributeOfBucketIsCorrect(t *testing.T) {
 			"main.tf": `resource "aws_s3_bucket" "this" {}`,
 		})
 		parser := New(fs, "", OptionStopOnHCLError(true))
-		require.NoError(t, parser.ParseFS(context.TODO(), "."))
+		require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-		modules, _, err := parser.EvaluateAll(context.TODO())
+		modules, _, err := parser.EvaluateAll(t.Context())
 		require.NoError(t, err)
 		require.Len(t, modules, 1)
 
@@ -1232,9 +1231,9 @@ data "aws_iam_policy_document" "this" {
 }`,
 		})
 		parser := New(fs, "", OptionStopOnHCLError(true))
-		require.NoError(t, parser.ParseFS(context.TODO(), "."))
+		require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-		modules, _, err := parser.EvaluateAll(context.TODO())
+		modules, _, err := parser.EvaluateAll(t.Context())
 		require.NoError(t, err)
 		require.Len(t, modules, 1)
 
@@ -1272,9 +1271,9 @@ func TestForEachWithObjectsOfDifferentTypes(t *testing.T) {
 `,
 	})
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 }
@@ -1307,9 +1306,9 @@ func TestCountMetaArgument(t *testing.T) {
 				"main.tf": tt.src,
 			})
 			parser := New(fsys, "", OptionStopOnHCLError(true))
-			require.NoError(t, parser.ParseFS(context.TODO(), "."))
+			require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-			modules, _, err := parser.EvaluateAll(context.TODO())
+			modules, _, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 			assert.Len(t, modules, 1)
 
@@ -1356,9 +1355,9 @@ func TestCountMetaArgumentInModule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fsys := testutil.CreateFS(t, tt.files)
 			parser := New(fsys, "", OptionStopOnHCLError(true))
-			require.NoError(t, parser.ParseFS(context.TODO(), "."))
+			require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-			modules, _, err := parser.EvaluateAll(context.TODO())
+			modules, _, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 
 			assert.Len(t, modules, tt.expectedCountModules)
@@ -1654,9 +1653,9 @@ func parse(t *testing.T, files map[string]string, opts ...Option) terraform.Modu
 	fs := testutil.CreateFS(t, files)
 	opts = append(opts, OptionStopOnHCLError(true))
 	parser := New(fs, "", opts...)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	return modules
@@ -1814,9 +1813,9 @@ func TestModuleParents(t *testing.T) {
 		OptionStopOnHCLError(true),
 		OptionWithDownloads(false),
 	)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	// modules only have 'parent'. They do not have children, so create
@@ -2093,9 +2092,9 @@ func Test_LoadLocalCachedModule(t *testing.T) {
 		OptionStopOnHCLError(true),
 		OptionWithDownloads(false),
 	)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	assert.Len(t, modules, 2)
@@ -2122,9 +2121,9 @@ func TestTFVarsFileDoesNotExist(t *testing.T) {
 		OptionWithDownloads(false),
 		OptionWithTFVarsPaths("main.tfvars"),
 	)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	_, _, err := parser.EvaluateAll(context.TODO())
+	_, _, err := parser.EvaluateAll(t.Context())
 	assert.ErrorContains(t, err, "file does not exist")
 }
 
@@ -2142,9 +2141,9 @@ variable "foo" {}
 		},
 	))
 
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -2173,8 +2172,8 @@ resource "something" "blah" {
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	require.NoError(t, parser.ParseFS(context.TODO(), "code"))
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	require.NoError(t, parser.ParseFS(t.Context(), "code"))
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -2220,9 +2219,9 @@ variable "baz" {}
 		OptionStopOnHCLError(true),
 		OptionWithTFVarsPaths("main.tfvars"),
 	)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	_, err := parser.Load(context.TODO())
+	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "Variable values was not found in the environment or variable files.")
@@ -2271,9 +2270,9 @@ func TestLoadChildModulesFromLocalCache(t *testing.T) {
 		fsys, "",
 		OptionStopOnHCLError(true),
 	)
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	assert.Len(t, modules, 5)
@@ -2299,7 +2298,7 @@ func TestLogParseErrors(t *testing.T) {
 	}
 
 	parser := New(fsys, "")
-	err := parser.ParseFS(context.TODO(), ".")
+	err := parser.ParseFS(t.Context(), ".")
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), `cause="  bucket = <"`)
@@ -2365,12 +2364,12 @@ resource "foo" "this" {
 				tt.fsys, "",
 				OptionStopOnHCLError(true),
 			)
-			require.NoError(t, parser.ParseFS(context.TODO(), "."))
+			require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-			_, err := parser.Load(context.TODO())
+			_, err := parser.Load(t.Context())
 			require.NoError(t, err)
 
-			modules, _, err := parser.EvaluateAll(context.TODO())
+			modules, _, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 
 			res := modules.GetResourcesByType("foo")[0]
@@ -2395,12 +2394,12 @@ resource "aws_s3_bucket" "example" {
 
 	parser := New(fsys, "", OptionStopOnHCLError(true))
 
-	require.NoError(t, parser.ParseFS(context.TODO(), "."))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	_, err := parser.Load(context.TODO())
+	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
 
-	modules, _, err := parser.EvaluateAll(context.TODO())
+	modules, _, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	val := modules.GetResourcesByType("aws_s3_bucket")[0].GetAttribute("bucket").GetRawValue()

--- a/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
@@ -124,7 +124,7 @@ func TestResolveModuleFromCache(t *testing.T) {
 			tt.opts.CacheDir = t.TempDir()
 			tt.opts.Logger = log.WithPrefix("test")
 
-			fsys, _, dir, _, err := tt.firstResolver.Resolve(context.Background(), nil, tt.opts)
+			fsys, _, dir, _, err := tt.firstResolver.Resolve(t.Context(), nil, tt.opts)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedSubdir, dir)
 
@@ -132,7 +132,7 @@ func TestResolveModuleFromCache(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedString, string(b))
 
-			_, _, dir, _, err = resolvers.Cache.Resolve(context.Background(), fsys, tt.opts)
+			_, _, dir, _, err = resolvers.Cache.Resolve(t.Context(), fsys, tt.opts)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedSubdir, dir)
 
@@ -151,7 +151,7 @@ func TestResolveModuleFromCacheWithDifferentSubdir(t *testing.T) {
 	repoURL := gs.URL + "/" + repo + ".git"
 
 	fsys, _, dir, _, err := resolvers.Remote.Resolve(
-		context.Background(), nil,
+		t.Context(), nil,
 		testOptions(t, "git::"+repoURL+"//modules/object"),
 	)
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestResolveModuleFromCacheWithDifferentSubdir(t *testing.T) {
 	assert.Equal(t, "# S3 bucket object", string(b))
 
 	fsys, _, dir, _, err = resolvers.Remote.Resolve(
-		context.Background(), nil,
+		t.Context(), nil,
 		testOptions(t, "git::"+repoURL+"//modules/notification"),
 	)
 	require.NoError(t, err)

--- a/pkg/iac/scanners/terraform/parser/resolvers/registry_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/registry_integration_test.go
@@ -1,7 +1,6 @@
 package resolvers_test
 
 import (
-	"context"
 	"io/fs"
 	"path/filepath"
 	"testing"
@@ -17,7 +16,7 @@ func TestResolveModuleFromOpenTofuRegistry(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	fsys, _, path, _, err := resolvers.Registry.Resolve(context.Background(), nil, resolvers.Options{
+	fsys, _, path, _, err := resolvers.Registry.Resolve(t.Context(), nil, resolvers.Options{
 		Source:          "registry.opentofu.org/terraform-aws-modules/s3-bucket/aws",
 		OriginalSource:  "registry.opentofu.org/terraform-aws-modules/s3-bucket/aws",
 		RelativePath:    "test",

--- a/pkg/iac/scanners/terraform/performance_test.go
+++ b/pkg/iac/scanners/terraform/performance_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"context"
 	"fmt"
 	"io/fs"
 	"testing"
@@ -22,14 +21,14 @@ func BenchmarkCalculate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		p := parser.New(f, "", parser.OptionStopOnHCLError(true))
-		if err := p.ParseFS(context.TODO(), "project"); err != nil {
+		if err := p.ParseFS(b.Context(), "project"); err != nil {
 			b.Fatal(err)
 		}
-		modules, _, err := p.EvaluateAll(context.TODO())
+		modules, _, err := p.EvaluateAll(b.Context())
 		if err != nil {
 			b.Fatal(err)
 		}
-		executor.New().Execute(context.TODO(), modules, "project")
+		executor.New().Execute(b.Context(), modules, "project")
 	}
 }
 

--- a/pkg/iac/scanners/terraform/scanner_integration_test.go
+++ b/pkg/iac/scanners/terraform/scanner_integration_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -35,7 +34,7 @@ module "s3_bucket" {
 		ScannerWithSkipCachedModules(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, ".")
+	results, err := scanner.ScanFS(t.Context(), fs, ".")
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetPassed(), 1)
@@ -73,7 +72,7 @@ module "s3_bucket" {
 		ScannerWithSkipCachedModules(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, ".")
+	results, err := scanner.ScanFS(t.Context(), fs, ".")
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetPassed(), 1)
@@ -114,7 +113,7 @@ deny[cause] {
 			rego.WithEmbeddedPolicies(false),
 			rego.WithEmbeddedLibraries(true),
 		)
-		results, err := scanner.ScanFS(context.TODO(), fs, "test")
+		results, err := scanner.ScanFS(t.Context(), fs, "test")
 		require.NoError(t, err)
 
 		assert.Len(t, results, 1)
@@ -129,7 +128,7 @@ deny[cause] {
 			rego.WithEmbeddedPolicies(false),
 			rego.WithEmbeddedLibraries(true),
 		)
-		results, err := scanner.ScanFS(context.TODO(), fs, "test")
+		results, err := scanner.ScanFS(t.Context(), fs, "test")
 		require.NoError(t, err)
 
 		assert.Len(t, results, 1)
@@ -182,7 +181,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 		rego.WithEmbeddedPolicies(false),
 	)
-	results, err := scanner.ScanFS(context.TODO(), fs, "test")
+	results, err := scanner.ScanFS(t.Context(), fs, "test")
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -146,7 +145,7 @@ cause := bucket.name
 				rego.WithPolicyNamespaces(test.includedNamespaces...),
 			)
 
-			results, err := scanner.ScanFS(context.TODO(), fs, "code")
+			results, err := scanner.ScanFS(t.Context(), fs, "code")
 			require.NoError(t, err)
 
 			var found bool
@@ -221,7 +220,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -304,7 +303,7 @@ deny[res] {
 		rego.WithEmbeddedLibraries(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -357,7 +356,7 @@ resource "aws_s3_bucket_public_access_block" "foo" {
 
 	scanner := New()
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	failed := results.GetFailed()
@@ -420,7 +419,7 @@ resource "aws_s3_bucket_public_access_block" "testB" {
 
 	scanner := New()
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	for _, result := range results.GetFailed() {
@@ -476,7 +475,7 @@ deny[res] {
 		rego.WithPolicyDirs("rules"),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
@@ -556,7 +555,7 @@ bucket_name = "test"
 		ScannerWithConfigsFileSystem(configsFS),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -590,7 +589,7 @@ bucket_name = "test"
 		ScannerWithConfigsFileSystem(fs),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -663,7 +662,7 @@ deny[res] {
 		ScannerWithAllDirectories(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetPassed(), 2)
@@ -732,7 +731,7 @@ deny[res] {
 		ScannerWithAllDirectories(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -800,7 +799,7 @@ deny[res] {
 		ScannerWithAllDirectories(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results, 2)
@@ -865,7 +864,7 @@ deny[res] {
 		ScannerWithAllDirectories(true),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fs, "code")
+	results, err := scanner.ScanFS(t.Context(), fs, "code")
 	require.NoError(t, err)
 
 	require.Len(t, results, 1)
@@ -905,7 +904,7 @@ resource "aws_s3_bucket" "test" {}
 			rego.WithPolicyNamespaces("user"),
 		)
 
-		results, err := scanner.ScanFS(context.TODO(), fsys, "deployments")
+		results, err := scanner.ScanFS(t.Context(), fsys, "deployments")
 		require.NoError(t, err)
 
 		assert.Empty(t, results)
@@ -919,7 +918,7 @@ resource "aws_s3_bucket" "test" {}
 			rego.WithPolicyNamespaces("user"),
 		)
 
-		results, err := scanner.ScanFS(context.TODO(), fsys, "deployments")
+		results, err := scanner.ScanFS(t.Context(), fsys, "deployments")
 		require.NoError(t, err)
 
 		assert.Empty(t, results)
@@ -933,7 +932,7 @@ resource "aws_s3_bucket" "test" {}
 			rego.WithPolicyNamespaces("user"),
 		)
 
-		results, err := scanner.ScanFS(context.TODO(), fsys, "deployments")
+		results, err := scanner.ScanFS(t.Context(), fsys, "deployments")
 		require.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -946,7 +945,7 @@ resource "aws_s3_bucket" "test" {}
 			rego.WithPolicyNamespaces("user"),
 		)
 
-		results, err := scanner.ScanFS(context.TODO(), fsys, "deployments")
+		results, err := scanner.ScanFS(t.Context(), fsys, "deployments")
 		require.NoError(t, err)
 
 		assert.Len(t, results, 2)
@@ -990,7 +989,7 @@ deny contains res if {
 		rego.WithPolicyNamespaces("test"),
 	)
 
-	results, err := scanner.ScanFS(context.TODO(), fsys, ".")
+	results, err := scanner.ScanFS(t.Context(), fsys, ".")
 	require.NoError(t, err)
 
 	assert.Len(t, results.GetFailed(), 1)
@@ -1109,7 +1108,7 @@ resource "aws_s3_bucket" "test" {
 				rego.WithPolicyNamespaces("user"),
 			)
 
-			results, err := scanner.ScanFS(context.TODO(), tt.fsys, ".")
+			results, err := scanner.ScanFS(t.Context(), tt.fsys, ".")
 			require.NoError(t, err)
 
 			failed := results.GetFailed()

--- a/pkg/iac/scanners/terraform/setup_test.go
+++ b/pkg/iac/scanners/terraform/setup_test.go
@@ -83,10 +83,10 @@ func createModulesFromSource(t *testing.T, source, ext string) terraform.Modules
 	})
 
 	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
-	if err := p.ParseFS(context.TODO(), "."); err != nil {
+	if err := p.ParseFS(t.Context(), "."); err != nil {
 		t.Fatal(err)
 	}
-	modules, _, err := p.EvaluateAll(context.TODO())
+	modules, _, err := p.EvaluateAll(t.Context())
 	if err != nil {
 		t.Fatalf("parse error: %s", err)
 	}

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,7 +59,7 @@ func TestScanner_Scan(t *testing.T) {
 			policyFS := os.DirFS(filepath.Join("testdata", tt.dir, "checks"))
 
 			s := initScanner(rego.WithPolicyFilesystem(policyFS))
-			result, err := s.Scan(context.TODO(), f)
+			result, err := s.Scan(t.Context(), f)
 			require.NoError(t, err)
 
 			failed := result.GetFailed()
@@ -117,7 +116,7 @@ func Test_ScanFS(t *testing.T) {
 				tfscanner.ScannerWithSkipCachedModules(true),
 			)
 
-			results, err := scanner.ScanFS(context.TODO(), fs, path.Join(tc.dir, "tfplan"))
+			results, err := scanner.ScanFS(t.Context(), fs, path.Join(tc.dir, "tfplan"))
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 

--- a/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
@@ -1,7 +1,6 @@
 package tfjson
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -115,7 +114,7 @@ deny[cause] {
 			so := append(tc.options, rego.WithPolicyFilesystem(fs))
 			scanner := New(so...)
 
-			results, err := scanner.ScanFS(context.TODO(), fs, "code")
+			results, err := scanner.ScanFS(t.Context(), fs, "code")
 			require.NoError(t, err)
 
 			require.Len(t, results.GetFailed(), 1)

--- a/pkg/k8s/scanner/scanner_test.go
+++ b/pkg/k8s/scanner/scanner_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -274,7 +273,7 @@ func TestScanner_Scan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			runner, err := cmd.NewRunner(ctx, flagOpts)

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"bytes"
-	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -423,7 +422,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				Severities: tc.severities,
 			}
 
-			err := Write(context.Background(), tc.report, opt)
+			err := Write(t.Context(), tc.report, opt)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, stripAnsi(output.String()), tc.name)
 		})

--- a/pkg/log/handler_test.go
+++ b/pkg/log/handler_test.go
@@ -2,7 +2,6 @@ package log_test
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -115,7 +114,7 @@ func TestContext(t *testing.T) {
 		baseLogger := log.New(log.NewHandler(&buf, &log.Options{Level: slog.LevelInfo}))
 
 		// Test logging with WithContextPrefix
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx = log.WithContextPrefix(ctx, "prefix1")
 
 		logger := baseLogger.With("key1", "value1").WithGroup("group1")
@@ -133,7 +132,7 @@ func TestContext(t *testing.T) {
 		baseLogger := log.New(log.NewHandler(&buf, &log.Options{Level: slog.LevelInfo}))
 
 		// Test logging with WithContextAttrs
-		ctx := context.Background()
+		ctx := t.Context()
 		ctx = log.WithContextAttrs(ctx, log.String("key1", "value1"))
 
 		logger := baseLogger.WithGroup("group1")

--- a/pkg/misconf/scanner_test.go
+++ b/pkg/misconf/scanner_test.go
@@ -1,7 +1,6 @@
 package misconf
 
 import (
-	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -159,7 +158,7 @@ func TestScanner_Scan(t *testing.T) {
 			s, err := NewScanner(tt.fileType, tt.fields.opt)
 			require.NoError(t, err)
 
-			misconfs, err := s.Scan(context.Background(), fsys)
+			misconfs, err := s.Scan(t.Context(), fsys)
 			require.NoError(t, err)
 			require.Len(t, misconfs, tt.misconfsExpected, "wrong number of misconfigurations found")
 			if tt.misconfsExpected == 1 {

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -1,7 +1,6 @@
 package module_test
 
 import (
-	"context"
 	"io/fs"
 	"path/filepath"
 	"runtime"
@@ -106,7 +105,7 @@ func TestManager_Register(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := module.NewManager(context.Background(), module.Options{
+			m, err := module.NewManager(t.Context(), module.Options{
 				Dir:            tt.moduleDir,
 				EnabledModules: tt.enabledModules,
 			})

--- a/pkg/oci/artifact_test.go
+++ b/pkg/oci/artifact_test.go
@@ -1,7 +1,6 @@
 package oci_test
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -117,7 +116,7 @@ func TestArtifact_Download(t *testing.T) {
 			}, nil)
 
 			artifact := oci.NewArtifact("repo", ftypes.RegistryOptions{}, oci.WithImage(img))
-			err = artifact.Download(context.Background(), tempDir, oci.DownloadOption{
+			err = artifact.Download(t.Context(), tempDir, oci.DownloadOption{
 				MediaType: tt.mediaType,
 				Quiet:     true,
 			})

--- a/pkg/parallel/pipeline_test.go
+++ b/pkg/parallel/pipeline_test.go
@@ -105,7 +105,7 @@ func TestPipeline_Do(t *testing.T) {
 				got += f
 				return nil
 			})
-			err := p.Do(context.Background())
+			err := p.Do(t.Context())
 			tt.wantErr(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/plugin/index_test.go
+++ b/pkg/plugin/index_test.go
@@ -2,7 +2,6 @@ package plugin_test
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,7 +25,7 @@ func TestManager_Update(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	manager := plugin.NewManager(plugin.WithIndexURL(ts.URL + "/index.yaml"))
-	err := manager.Update(context.Background(), plugin.Options{})
+	err := manager.Update(t.Context(), plugin.Options{})
 	require.NoError(t, err)
 
 	indexPath := filepath.Join(tempDir, ".trivy", "plugins", "index.yaml")
@@ -76,7 +75,7 @@ bar                  A bar plugin                                               
 
 			var got bytes.Buffer
 			m := plugin.NewManager(plugin.WithWriter(&got))
-			err := m.Search(context.Background(), tt.keyword)
+			err := m.Search(t.Context(), tt.keyword)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -194,7 +194,7 @@ func TestManager_Run(t *testing.T) {
 				Platforms:   tt.fields.Platforms,
 			}
 
-			err := p.Run(context.Background(), plugin.Options{
+			err := p.Run(t.Context(), plugin.Options{
 				Platform: ftypes.Platform{
 					Platform: &v1.Platform{
 						OS:           "linux",
@@ -212,7 +212,7 @@ func TestManager_Run(t *testing.T) {
 }
 
 func TestManager_Uninstall(t *testing.T) {
-	ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+	ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 	pluginName := "test_plugin"
 
 	tempDir := t.TempDir()
@@ -327,7 +327,7 @@ func TestManager_LoadAll(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("XDG_DATA_HOME", tt.dir)
 
-			got, err := plugin.NewManager().LoadAll(context.Background())
+			got, err := plugin.NewManager().LoadAll(t.Context())
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -357,7 +357,7 @@ func TestManager_Upgrade(t *testing.T) {
 		Repository: "testdata/test_plugin",
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	m := plugin.NewManager()
 
 	// verify initial version

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -5,7 +5,6 @@ package plugin_test
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +14,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -213,7 +212,7 @@ func TestManager_Install(t *testing.T) {
 			var gotLogs bytes.Buffer
 			logger := log.New(log.NewHandler(&gotLogs, nil))
 
-			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 
 			got, err := plugin.NewManager(plugin.WithLogger(logger)).Install(ctx, tt.pluginName, plugin.Options{
 				Platform: ftypes.Platform{

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1,7 +1,6 @@
 package policy_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -259,7 +258,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert results
-			got, err := c.NeedsUpdate(context.Background(), ftypes.RegistryOptions{})
+			got, err := c.NeedsUpdate(t.Context(), ftypes.RegistryOptions{})
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, got)
 		})
@@ -360,7 +359,7 @@ func TestClient_DownloadBuiltinPolicies(t *testing.T) {
 			c, err := policy.NewClient(tempDir, true, "", policy.WithClock(tt.clock), policy.WithOCIArtifact(art))
 			require.NoError(t, err)
 
-			err = c.DownloadBuiltinChecks(context.Background(), ftypes.RegistryOptions{})
+			err = c.DownloadBuiltinChecks(t.Context(), ftypes.RegistryOptions{})
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/rekor/client_test.go
+++ b/pkg/rekor/client_test.go
@@ -1,7 +1,6 @@
 package rekor_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -68,7 +67,7 @@ func TestClient_Search(t *testing.T) {
 			c, err := rekor.NewClient(ts.URL)
 			require.NoError(t, err)
 
-			got, err := c.Search(context.Background(), tt.args.hash)
+			got, err := c.Search(t.Context(), tt.args.hash)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -163,7 +162,7 @@ func TestClient_GetEntries(t *testing.T) {
 			client, err := rekor.NewClient(ts.URL)
 			require.NoError(t, err)
 
-			got, err := client.GetEntries(context.Background(), tt.args.uuids)
+			got, err := client.GetEntries(t.Context(), tt.args.uuids)
 			require.Equal(t, tt.wantErr, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -300,7 +299,7 @@ func TestGet(t *testing.T) {
 				setupDockerConfig(t, tt.args.config)
 			}
 
-			_, err = Get(context.Background(), n, tt.args.option)
+			_, err = Get(t.Context(), n, tt.args.option)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr, err)
 				return
@@ -357,7 +356,7 @@ func TestUserAgents(t *testing.T) {
 	n, err := name.ParseReference(fmt.Sprintf("%s/library/alpine:3.10", serverAddr))
 	require.NoError(t, err)
 
-	_, err = Get(context.Background(), n, types.RegistryOptions{
+	_, err = Get(t.Context(), n, types.RegistryOptions{
 		Credentials: []types.Credential{
 			{
 				Username: "test",

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -2,7 +2,6 @@ package github_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -245,7 +244,7 @@ func TestWriter_Write(t *testing.T) {
 
 			inputResults := tt.report
 
-			err := w.Write(context.Background(), inputResults)
+			err := w.Write(t.Context(), inputResults)
 			require.NoError(t, err)
 
 			var got github.DependencySnapshot

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -2,7 +2,6 @@ package report_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -87,7 +86,7 @@ func TestReportWriter_JSON(t *testing.T) {
 				},
 			}
 
-			err := jw.Write(context.Background(), inputResults)
+			err := jw.Write(t.Context(), inputResults)
 			require.NoError(t, err)
 
 			var got types.Report

--- a/pkg/report/predicate/vuln_test.go
+++ b/pkg/report/predicate/vuln_test.go
@@ -2,7 +2,6 @@ package predicate_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -98,7 +97,7 @@ func TestWriter_Write(t *testing.T) {
 
 			output := bytes.NewBuffer(nil)
 
-			ctx := clock.With(context.Background(), time.Date(2022, 7, 22, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2022, 7, 22, 12, 20, 30, 5, time.UTC))
 			writer := predicate.NewVulnWriter(output, "dev")
 
 			err := writer.Write(ctx, inputResults)

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -2,7 +2,6 @@ package report_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -738,7 +737,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 			w := report.SarifWriter{
 				Output: sarifWritten,
 			}
-			err := w.Write(context.TODO(), tt.input)
+			err := w.Write(t.Context(), tt.input)
 			require.NoError(t, err)
 
 			result := &sarif.Report{}

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -2,7 +2,6 @@ package report_test
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -194,7 +193,7 @@ func TestReportWriter_Template(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC))
 
 			t.Setenv("AWS_ACCOUNT_ID", "123456789012")
 			got := bytes.Buffer{}

--- a/pkg/result/filter_test.go
+++ b/pkg/result/filter_test.go
@@ -1,7 +1,6 @@
 package result_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -1002,7 +1001,7 @@ func TestFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeTime := time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC)
-			ctx := clock.With(context.Background(), fakeTime)
+			ctx := clock.With(t.Context(), fakeTime)
 
 			var vexSources []vex.Source
 			if tt.args.vexPath != "" {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -1,7 +1,6 @@
 package result
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 
 func TestParseIgnoreFile(t *testing.T) {
 	t.Run("happy path valid config file", func(t *testing.T) {
-		got, err := ParseIgnoreFile(context.TODO(), "testdata/.trivyignore")
+		got, err := ParseIgnoreFile(t.Context(), "testdata/.trivyignore")
 		require.NoError(t, err)
 		assert.Equal(t, "testdata/.trivyignore", got.FilePath)
 
@@ -24,7 +23,7 @@ func TestParseIgnoreFile(t *testing.T) {
 	})
 
 	t.Run("happy path valid YAML config file", func(t *testing.T) {
-		got, err := ParseIgnoreFile(context.TODO(), "testdata/.trivyignore.yaml")
+		got, err := ParseIgnoreFile(t.Context(), "testdata/.trivyignore.yaml")
 		require.NoError(t, err)
 		assert.Equal(t, "testdata/.trivyignore.yaml", got.FilePath)
 		assert.Len(t, got.Vulnerabilities, 5)
@@ -34,37 +33,37 @@ func TestParseIgnoreFile(t *testing.T) {
 	})
 
 	t.Run("empty YAML file passed", func(t *testing.T) {
-		f, err := os.CreateTemp("", "TestParseIgnoreFile-*.yaml")
+		f, err := os.CreateTemp(t.TempDir(), "TestParseIgnoreFile-*.yaml")
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
 
-		_, err = ParseIgnoreFile(context.TODO(), f.Name())
+		_, err = ParseIgnoreFile(t.Context(), f.Name())
 		require.NoError(t, err)
 	})
 
 	t.Run("invalid YAML file passed", func(t *testing.T) {
-		f, err := os.CreateTemp("", "TestParseIgnoreFile-*.yaml")
+		f, err := os.CreateTemp(t.TempDir(), "TestParseIgnoreFile-*.yaml")
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
 		_, _ = f.WriteString("this file is not a yaml file")
 
-		got, err := ParseIgnoreFile(context.TODO(), f.Name())
+		got, err := ParseIgnoreFile(t.Context(), f.Name())
 		require.ErrorContains(t, err, "yaml decode error")
 		assert.Empty(t, got)
 	})
 
 	t.Run("invalid file passed", func(t *testing.T) {
-		f, err := os.CreateTemp("", "TestParseIgnoreFile-*")
+		f, err := os.CreateTemp(t.TempDir(), "TestParseIgnoreFile-*")
 		require.NoError(t, err)
 		defer os.Remove(f.Name())
 		_, _ = f.WriteString("this file is not a valid trivyignore file")
 
-		_, err = ParseIgnoreFile(context.TODO(), f.Name())
+		_, err = ParseIgnoreFile(t.Context(), f.Name())
 		require.NoError(t, err) // TODO(simar7): We don't verify correctness, should we?
 	})
 
 	t.Run("non existing file passed", func(t *testing.T) {
-		got, err := ParseIgnoreFile(context.TODO(), "does-not-exist.yaml")
+		got, err := ParseIgnoreFile(t.Context(), "does-not-exist.yaml")
 		require.NoError(t, err)
 		assert.Empty(t, got)
 	})

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -198,7 +197,7 @@ func TestScanner_Scan(t *testing.T) {
 
 			s := NewScanner(ScannerOption{CustomHeaders: tt.customHeaders}, WithRPCClient(client))
 
-			gotResults, gotOS, err := s.Scan(context.Background(), tt.args.target, tt.args.imageID, tt.args.layerIDs, tt.args.options)
+			gotResults, gotOS, err := s.Scan(t.Context(), tt.args.target, tt.args.imageID, tt.args.layerIDs, tt.args.options)
 
 			if tt.wantErr != "" {
 				require.Error(t, err, tt.name)
@@ -242,7 +241,7 @@ func TestScanner_ScanServerInsecure(t *testing.T) {
 				},
 			})
 			s := NewScanner(ScannerOption{Insecure: tt.insecure}, WithRPCClient(c))
-			_, _, err := s.Scan(context.Background(), "dummy", "", nil, types.ScanOptions{})
+			_, _, err := s.Scan(t.Context(), "dummy", "", nil, types.ScanOptions{})
 
 			if tt.wantErr != "" {
 				require.Error(t, err)

--- a/pkg/rpc/client/headers_test.go
+++ b/pkg/rpc/client/headers_test.go
@@ -22,7 +22,7 @@ func TestWithCustomHeaders(t *testing.T) {
 		{
 			name: "happy path",
 			args: args{
-				ctx: context.Background(),
+				ctx: t.Context(),
 				customHeaders: http.Header{
 					"Trivy-Token": []string{"token"},
 				},
@@ -34,7 +34,7 @@ func TestWithCustomHeaders(t *testing.T) {
 		{
 			name: "sad path, invalid headers passed in",
 			args: args{
-				ctx: context.Background(),
+				ctx: t.Context(),
 				customHeaders: http.Header{
 					"Content-Type": []string{"token"},
 				},

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -87,7 +86,7 @@ func Test_dbWorker_update(t *testing.T) {
 			defer func() { _ = db.Close() }()
 
 			// Set a fake time
-			ctx := clock.With(context.Background(), tt.now)
+			ctx := clock.With(t.Context(), tt.now)
 
 			// Set a fake DB
 			dbPath := dbtest.ArchiveDir(t, "testdata/newdb")
@@ -182,7 +181,7 @@ func TestServer_newServeMux(t *testing.T) {
 			defer func() { _ = c.Close() }()
 
 			s := NewServer("", "", "", tt.args.token, tt.args.tokenHeader, "", nil, ftypes.RegistryOptions{})
-			ts := httptest.NewServer(s.NewServeMux(context.Background(), c, dbUpdateWg, requestWg))
+			ts := httptest.NewServer(s.NewServeMux(t.Context(), c, dbUpdateWg, requestWg))
 			defer ts.Close()
 
 			var resp *http.Response
@@ -213,7 +212,7 @@ func Test_VersionEndpoint(t *testing.T) {
 	defer func() { _ = c.Close() }()
 
 	s := NewServer("", "", "testdata/testcache", "", "", "", nil, ftypes.RegistryOptions{})
-	ts := httptest.NewServer(s.NewServeMux(context.Background(), c, dbUpdateWg, requestWg))
+	ts := httptest.NewServer(s.NewServeMux(t.Context(), c, dbUpdateWg, requestWg))
 	defer ts.Close()
 
 	resp, err := http.Get(ts.URL + "/version")

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -200,7 +200,7 @@ func TestScanServer_Scan(t *testing.T) {
 			scanner := local.NewScanner(applier, ospkg.NewScanner(), langpkg.NewScanner(), vulnerability.NewClient(db.Config{}))
 			s := NewScanServer(scanner)
 
-			got, err := s.Scan(context.Background(), tt.args.in)
+			got, err := s.Scan(t.Context(), tt.args.in)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -288,7 +288,7 @@ func TestCacheServer_PutArtifact(t *testing.T) {
 			c := cachetest.NewCache(t, tt.setUpCache)
 
 			s := NewCacheServer(c)
-			got, err := s.PutArtifact(context.Background(), tt.args.in)
+			got, err := s.PutArtifact(t.Context(), tt.args.in)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr, tt.name)
@@ -508,7 +508,7 @@ func TestCacheServer_PutBlob(t *testing.T) {
 			c := cachetest.NewCache(t, tt.setUpCache)
 
 			s := NewCacheServer(c)
-			got, err := s.PutBlob(context.Background(), tt.args.in)
+			got, err := s.PutBlob(t.Context(), tt.args.in)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr, tt.name)

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -1,7 +1,6 @@
 package cyclonedx_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -2097,7 +2096,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := cyclonedx.NewMarshaler("dev")

--- a/pkg/sbom/cyclonedx/unmarshal_test.go
+++ b/pkg/sbom/cyclonedx/unmarshal_test.go
@@ -1,7 +1,6 @@
 package cyclonedx_test
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -845,7 +844,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			require.NoError(t, err)
 
 			var got types.SBOM
-			err = sbomio.NewDecoder(cdx.BOM).Decode(context.Background(), &got)
+			err = sbomio.NewDecoder(cdx.BOM).Decode(t.Context(), &got)
 			require.NoError(t, err)
 
 			got.BOM = nil

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1,7 +1,6 @@
 package spdx_test
 
 import (
-	"context"
 	"hash/fnv"
 	"testing"
 	"time"
@@ -1481,7 +1480,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				return h.Sum64(), nil
 			}
 
-			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -1,7 +1,6 @@
 package spdx_test
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"sort"
@@ -358,7 +357,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			}
 
 			var got types.SBOM
-			err = sbomio.NewDecoder(v.BOM).Decode(context.Background(), &got)
+			err = sbomio.NewDecoder(v.BOM).Decode(t.Context(), &got)
 			require.NoError(t, err)
 
 			// Not compare BOM

--- a/pkg/scanner/local/scan_test.go
+++ b/pkg/scanner/local/scan_test.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -1247,7 +1246,7 @@ func TestScanner_Scan(t *testing.T) {
 			a := applier.NewApplier(c)
 			s := NewScanner(a, ospkg.NewScanner(), langpkg.NewScanner(), vulnerability.NewClient(db.Config{}))
 
-			gotResults, gotOS, err := s.Scan(context.Background(), tt.args.target, "", tt.args.layerIDs, tt.args.options)
+			gotResults, gotOS, err := s.Scan(t.Context(), tt.args.target, "", tt.args.layerIDs, tt.args.options)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr, tt.name)
 				return

--- a/pkg/scanner/post/post_scan_test.go
+++ b/pkg/scanner/post/post_scan_test.go
@@ -95,7 +95,7 @@ func TestScan(t *testing.T) {
 				post.DeregisterPostScanner(s.Name())
 			}()
 
-			results, err := post.Scan(context.Background(), tt.results)
+			results, err := post.Scan(t.Context(), tt.results)
 			require.Equal(t, tt.wantErr, err != nil)
 			assert.Equal(t, tt.want, results)
 		})

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -220,7 +219,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 			scanner := local.NewScanner(applier, ospkg.NewScanner(), langpkg.NewScanner(), vulnerability.NewClient(db.Config{}))
 			s := NewScanner(scanner, artifact)
 
-			ctx := clock.With(context.Background(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			got, err := s.ScanArtifact(ctx, tt.args.options)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -31,7 +31,7 @@ func TestCopyFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			src := tt.args.src
 			if tt.args.src == "" {
-				s, err := os.CreateTemp("", "src")
+				s, err := os.CreateTemp(t.TempDir(), "src")
 				require.NoError(t, err, tt.name)
 				_, err = s.Write(tt.content)
 				require.NoError(t, err, tt.name)
@@ -40,7 +40,7 @@ func TestCopyFile(t *testing.T) {
 
 			dst := tt.args.dst
 			if tt.args.dst == "" {
-				d, err := os.CreateTemp("", "dst")
+				d, err := os.CreateTemp(t.TempDir(), "dst")
 				require.NoError(t, err, tt.name)
 				dst = d.Name()
 				require.NoError(t, d.Close(), tt.name)

--- a/pkg/vex/repo/manager_test.go
+++ b/pkg/vex/repo/manager_test.go
@@ -2,7 +2,6 @@ package repo_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func TestManager_Config(t *testing.T) {
 
 			tt.setup(t, tempDir)
 
-			got, err := m.Config(context.Background())
+			got, err := m.Config(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -121,7 +120,7 @@ func TestManager_Init(t *testing.T) {
 
 			tt.setup(t, tempDir)
 
-			err := m.Init(context.Background())
+			err := m.Init(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -228,7 +227,7 @@ func TestManager_DownloadRepositories(t *testing.T) {
 			manifest.Versions[0].Locations[0].URL = tt.location
 			testutil.MustWriteJSON(t, manifestPath, manifest)
 
-			err := m.DownloadRepositories(context.Background(), tt.names, repo.Options{})
+			err := m.DownloadRepositories(t.Context(), tt.names, repo.Options{})
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -303,7 +302,7 @@ No repositories configured.
 			var buf bytes.Buffer
 			m := repo.NewManager(tempDir, repo.WithWriter(&buf))
 
-			err := m.List(context.Background())
+			err := m.List(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return

--- a/pkg/vex/repo/repo_test.go
+++ b/pkg/vex/repo/repo_test.go
@@ -2,7 +2,6 @@ package repo_test
 
 import (
 	"archive/zip"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -78,13 +77,13 @@ func TestRepository_Manifest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir, m := setupManager(t)
-			conf, err := m.Config(context.Background())
+			conf, err := m.Config(t.Context())
 			require.NoError(t, err)
 
 			r := conf.Repositories[0]
 			tt.setup(t, tempDir, &r)
 
-			got, err := r.Manifest(context.Background(), repo.Options{})
+			got, err := r.Manifest(t.Context(), repo.Options{})
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -158,13 +157,13 @@ func TestRepository_Index(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir, m := setupManager(t)
-			conf, err := m.Config(context.Background())
+			conf, err := m.Config(t.Context())
 			require.NoError(t, err)
 
 			r := conf.Repositories[0]
 			tt.setup(t, tempDir, &r)
 
-			got, err := r.Index(context.Background())
+			got, err := r.Index(t.Context())
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
@@ -294,14 +293,14 @@ func TestRepository_Update(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir, m := setupManager(t)
-			conf, err := m.Config(context.Background())
+			conf, err := m.Config(t.Context())
 			require.NoError(t, err)
 
 			r := conf.Repositories[0]
 			r.URL = ts.URL + "/vex-repository.json"
 			tt.setup(t, tempDir, &r)
 
-			ctx := clock.With(context.Background(), tt.clockTime)
+			ctx := clock.With(t.Context(), tt.clockTime)
 			err = r.Update(ctx, repo.Options{})
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)

--- a/pkg/vex/repo_test.go
+++ b/pkg/vex/repo_test.go
@@ -1,7 +1,6 @@
 package vex_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -99,7 +98,7 @@ repositories:
 			err = os.WriteFile(configPath, []byte(tt.configContent), 0644)
 			require.NoError(t, err)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			rs, err := vex.NewRepositorySet(ctx, tt.cacheDir)
 			require.NoError(t, err)
 

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -1,7 +1,6 @@
 package vex_test
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -567,7 +566,7 @@ repositories:
 			if tt.setup != nil {
 				tt.setup(t, tmpDir)
 			}
-			err := vex.Filter(context.Background(), tt.args.report, tt.args.opts)
+			err := vex.Filter(t.Context(), tt.args.report, tt.args.opts)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return


### PR DESCRIPTION
## Description
The tenv linter is deprecated since golangci-lint v1.64.0 and has been replaced by usetesting.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
