### PR TITLE
fix(misconf): add ephemeral block type to config schema

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2393,7 +2393,6 @@ resource "aws_s3_bucket" "example" {
 	}
 
 	parser := New(fsys, "", OptionStopOnHCLError(true))
-
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
 	_, err := parser.Load(t.Context())
@@ -2404,4 +2403,18 @@ resource "aws_s3_bucket" "example" {
 
 	val := modules.GetResourcesByType("aws_s3_bucket")[0].GetAttribute("bucket").GetRawValue()
 	assert.Nil(t, val)
+}
+
+func TestConfigWithEphemeralBlock(t *testing.T) {
+	fsys := fstest.MapFS{
+		"main.tf": &fstest.MapFile{Data: []byte(`ephemeral "random_password" "password" {
+  length = 16
+}`)},
+	}
+
+	parser := New(fsys, "", OptionStopOnHCLError(true))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+
+	_, err := parser.Load(t.Context())
+	require.NoError(t, err)
 }

--- a/pkg/iac/terraform/schema.go
+++ b/pkg/iac/terraform/schema.go
@@ -43,6 +43,10 @@ var Schema = &hcl.BodySchema{
 			LabelNames: []string{"type", "name"},
 		},
 		{
+			Type:       "ephemeral",
+			LabelNames: []string{"type", "name"},
+		},
+		{
 			Type: "moved",
 		},
 		{


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8515

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
