### PR TITLE
refactor(misconf): use OPA v1

### DIFF
--- a/pkg/iac/rego/build.go
+++ b/pkg/iac/rego/build.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/util"
 
 	"github.com/aquasecurity/trivy/pkg/iac/rego/schemas"
 	"github.com/aquasecurity/trivy/pkg/iac/types"

--- a/pkg/iac/rego/custom.go
+++ b/pkg/iac/rego/custom.go
@@ -1,9 +1,9 @@
 package rego
 
 import (
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/types"
 
 	checksrego "github.com/aquasecurity/trivy-checks/pkg/rego"
 )

--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/v1/ast"
 
 	checks "github.com/aquasecurity/trivy-checks"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
@@ -104,9 +104,7 @@ func LoadPoliciesFromDirs(target fs.FS, paths ...string) (map[string]*ast.Module
 			if err != nil {
 				return err
 			}
-			module, err := ast.ParseModuleWithOpts(path, string(data), ast.ParserOptions{
-				ProcessAnnotation: true,
-			})
+			module, err := ParseRegoModule(path, string(data))
 			if err != nil {
 				return fmt.Errorf("failed to parse Rego module: %w", err)
 			}

--- a/pkg/iac/rego/embed_test.go
+++ b/pkg/iac/rego/embed_test.go
@@ -3,7 +3,7 @@ package rego
 import (
 	"testing"
 
-	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -89,9 +89,7 @@ deny[res]{
 		t.Run(tc.name, func(t *testing.T) {
 			policies, err := LoadPoliciesFromDirs(checks.EmbeddedLibraryFileSystem, ".")
 			require.NoError(t, err)
-			newRule, err := ast.ParseModuleWithOpts("/rules/newrule.rego", tc.inputPolicy, ast.ParserOptions{
-				ProcessAnnotation: true,
-			})
+			newRule, err := ParseRegoModule("/rules/newrule.rego", tc.inputPolicy)
 			require.NoError(t, err)
 
 			policies["/rules/newrule.rego"] = newRule
@@ -187,9 +185,7 @@ deny[res]{
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			policies := make(map[string]*ast.Module)
-			newRule, err := ast.ParseModuleWithOpts("/rules/newrule.rego", tc.inputPolicy, ast.ParserOptions{
-				ProcessAnnotation: true,
-			})
+			newRule, err := ParseRegoModule("/rules/newrule.rego", tc.inputPolicy)
 			require.NoError(t, err)
 
 			policies["/rules/newrule.rego"] = newRule

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -7,8 +7,8 @@ import (
 	"io/fs"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -43,9 +43,7 @@ func (s *Scanner) loadPoliciesFromReaders(readers []io.Reader) (map[string]*ast.
 		if err != nil {
 			return nil, err
 		}
-		module, err := ast.ParseModuleWithOpts(moduleName, string(data), ast.ParserOptions{
-			ProcessAnnotation: true,
-		})
+		module, err := ParseRegoModule(moduleName, string(data))
 		if err != nil {
 			return nil, err
 		}
@@ -297,4 +295,11 @@ func (s *Scanner) filterModules(retriever *MetadataRetriever) error {
 
 	s.policies = filtered
 	return nil
+}
+
+func ParseRegoModule(name, input string) (*ast.Module, error) {
+	return ast.ParseModuleWithOpts(name, input, ast.ParserOptions{
+		ProcessAnnotation: true,
+		RegoVersion:       ast.RegoV0,
+	})
 }

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/iac/framework"

--- a/pkg/iac/rego/result.go
+++ b/pkg/iac/rego/result.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 	"strconv"
 
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/rego"
 
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"

--- a/pkg/iac/rego/runtime.go
+++ b/pkg/iac/rego/runtime.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/version"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/version"
 )
 
 func addRuntimeValues() *ast.Term {

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -9,10 +9,10 @@ import (
 	"io/fs"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/util"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/iac/framework"
@@ -24,7 +24,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/set"
 )
 
-var checkTypesWithSubtype = set.New[types.Source](types.SourceCloud, types.SourceDefsec, types.SourceKubernetes)
+var checkTypesWithSubtype = set.New(types.SourceCloud, types.SourceDefsec, types.SourceKubernetes)
 
 var supportedProviders = makeSupportedProviders()
 

--- a/pkg/iac/rego/store.go
+++ b/pkg/iac/rego/store.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/open-policy-agent/opa/loader"
-	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/v1/loader"
+	"github.com/open-policy-agent/opa/v1/storage"
 )
 
 // initialize a store populated with OPA data files found in dataPaths

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"golang.org/x/xerrors"
 	"k8s.io/utils/clock"
 

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -8,7 +8,8 @@ import (
 	"slices"
 	"sort"
 
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
@@ -222,6 +223,7 @@ func applyPolicy(ctx context.Context, result *types.Result, policyFile string) e
 		rego.Query("data.trivy.ignore"),
 		rego.Module("lib.rego", module),
 		rego.Module("trivy.rego", string(policy)),
+		rego.SetRegoVersion(ast.RegoV0),
 	).PrepareForEval(ctx)
 	if err != nil {
 		return xerrors.Errorf("unable to prepare for eval: %w", err)


### PR DESCRIPTION
## Description

OPA v1 was recently released and packages outside of v1 are declared deprecated. This PR updates the import of OPA packages to use v1.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
