### PR TITLE
feat(misconf): adapt AWS::EC2::VPC

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
@@ -98,6 +98,17 @@ Resources:
       MetadataOptions:
         HttpTokens: required
         HttpEndpoint: disabled
+  MyVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+    CidrBlock: 10.0.0.0/16
+  MyFlowLog:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogGroupName: FlowLogsGroup
+      ResourceId: !Ref MyVPC
+      ResourceType: VPC
+      TrafficType: ALL
 `,
 			expected: ec2.EC2{
 				Instances: []ec2.Instance{
@@ -193,6 +204,11 @@ Resources:
 						},
 					},
 				},
+				VPCs: []ec2.VPC{
+					{
+						FlowLogsEnabled: types.BoolTest(true),
+					},
+				},
 			},
 		},
 		{
@@ -237,6 +253,7 @@ Resources:
 						},
 					},
 				},
+				VPCs: []ec2.VPC{},
 			},
 		},
 		{
@@ -281,6 +298,7 @@ Resources:
 						},
 					},
 				},
+				VPCs: []ec2.VPC{},
 			},
 		},
 		{
@@ -336,6 +354,7 @@ Resources:
 						},
 					},
 				},
+				VPCs: []ec2.VPC{},
 			},
 		},
 		{
@@ -362,6 +381,30 @@ Resources:
 								ToPort:   types.IntTest(-1),
 							},
 						},
+					},
+				},
+				VPCs: []ec2.VPC{},
+			},
+		},
+		{
+			name: "VPC flow log ref to other VPC",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MyVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+    CidrBlock: 10.0.0.0/16
+  MyFlowLog:
+    Type: AWS::EC2::FlowLog
+    Properties:
+      LogGroupName: FlowLogsGroup
+      ResourceId: !Ref MyOtherVPC
+      ResourceType: VPC
+      TrafficType: ALL`,
+			expected: ec2.EC2{
+				VPCs: []ec2.VPC{
+					{
+						FlowLogsEnabled: types.BoolTest(false),
 					},
 				},
 			},

--- a/pkg/iac/adapters/cloudformation/aws/ec2/ec2.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/ec2.go
@@ -11,7 +11,7 @@ func Adapt(cfFile parser.FileContext) ec2.EC2 {
 		LaunchConfigurations: getLaunchConfigurations(cfFile),
 		LaunchTemplates:      getLaunchTemplates(cfFile),
 		Instances:            getInstances(cfFile),
-		VPCs:                 nil,
+		VPCs:                 getVPCs(cfFile),
 		NetworkACLs:          getNetworkACLs(cfFile),
 		SecurityGroups:       getSecurityGroups(cfFile),
 		Subnets:              getSubnets(cfFile),

--- a/pkg/iac/adapters/cloudformation/aws/ec2/vpc.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/vpc.go
@@ -1,0 +1,33 @@
+package ec2
+
+import (
+	"github.com/samber/lo"
+
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/ec2"
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser"
+	"github.com/aquasecurity/trivy/pkg/iac/types"
+	"github.com/aquasecurity/trivy/pkg/set"
+)
+
+func getVPCs(fctx parser.FileContext) []ec2.VPC {
+	vpcFlowLogs := getVpcGlowLogs(fctx)
+	return lo.Map(fctx.GetResourcesByType("AWS::EC2::VPC"),
+		func(resource *parser.Resource, _ int) ec2.VPC {
+			return ec2.VPC{
+				Metadata: resource.Metadata(),
+				// CloudFormation does not provide direct management for the default VPC
+				IsDefault:       types.BoolUnresolvable(resource.Metadata()),
+				FlowLogsEnabled: types.Bool(vpcFlowLogs.Contains(resource.ID()), resource.Metadata()),
+			}
+		})
+}
+
+func getVpcGlowLogs(fctx parser.FileContext) set.Set[string] {
+	ids := set.New[string]()
+	for _, resource := range fctx.GetResourcesByType("AWS::EC2::FlowLog") {
+		if resource.GetStringProperty("ResourceType").EqualTo("VPC") {
+			ids.Append(resource.GetStringProperty("ResourceId").Value())
+		}
+	}
+	return ids
+}


### PR DESCRIPTION
## Description

This PR adds adaptation to the state for the CloudFormation resource [AWS::EC2::VPC](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html).

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
