### PR TITLE
feat(misconf): adapt aws_default_security_group

### DIFF
--- a/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
@@ -72,6 +72,24 @@ func Test_AdaptVPC(t *testing.T) {
 				  "4.5.6.7/32",
 				]
 			  }
+
+			resource "aws_default_security_group" "default" {
+				vpc_id = aws_vpc.main.id
+
+				ingress {
+					protocol  = -1
+					self      = true
+					from_port = 0
+					to_port   = 0
+				}
+
+				egress {
+					from_port   = 0
+					to_port     = 0
+					protocol    = "-1"
+					cidr_blocks = ["0.0.0.0/0"]
+				}
+			}
 `,
 			expected: ec2.EC2{
 				VPCs: []ec2.VPC{
@@ -129,6 +147,24 @@ func Test_AdaptVPC(t *testing.T) {
 								},
 								FromPort: iacTypes.IntTest(-1),
 								ToPort:   iacTypes.IntTest(-1),
+							},
+						},
+					},
+					{
+						IsDefault: iacTypes.BoolTest(true),
+						IngressRules: []ec2.SecurityGroupRule{
+							{
+								Protocol: iacTypes.StringTest("-1"),
+								FromPort: iacTypes.IntTest(0),
+								ToPort:   iacTypes.IntTest(0),
+							},
+						},
+						EgressRules: []ec2.SecurityGroupRule{
+							{
+								Protocol: iacTypes.StringTest("-1"),
+								FromPort: iacTypes.IntTest(0),
+								ToPort:   iacTypes.IntTest(0),
+								CIDRs:    []iacTypes.StringValue{iacTypes.StringTest("0.0.0.0/0")},
 							},
 						},
 					},

--- a/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/vpc_test.go
@@ -20,76 +20,75 @@ func Test_AdaptVPC(t *testing.T) {
 	}{
 		{
 			name: "defined",
-			terraform: `
-			resource "aws_flow_log" "this" {
-				vpc_id = aws_vpc.main.id
-			}
-			resource "aws_default_vpc" "default" {
-				tags = {
-				  Name = "Default VPC"
-				}
-			  }
+			terraform: `resource "aws_flow_log" "this" {
+  vpc_id = aws_vpc.main.id
+}
+resource "aws_default_vpc" "default" {
+  tags = {
+    Name = "Default VPC"
+  }
+}
 
-			  resource "aws_vpc" "main" {
-				cidr_block = "4.5.6.7/32"
-			  }
+resource "aws_vpc" "main" {
+  cidr_block = "4.5.6.7/32"
+}
 
-			resource "aws_security_group" "example" {
-				name        = "http"
-				description = "Allow inbound HTTP traffic"
-			  
-				ingress {
-				  description = "Rule #1"
-				  from_port   = 80
-				  to_port     = 80
-				  protocol    = "tcp"
-				  cidr_blocks = [aws_vpc.main.cidr_block]
-				}
+resource "aws_security_group" "example" {
+  name        = "http"
+  description = "Allow inbound HTTP traffic"
 
-				egress {
-					cidr_blocks = ["1.2.3.4/32"]
-				}
-			  }
+  ingress {
+    description = "Rule #1"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
 
-			resource "aws_network_acl_rule" "example" {
-				egress         = false
-				protocol       = "tcp"
-				from_port      = 22
-				to_port        = 22
-				rule_action    = "allow"
-				cidr_block     = "10.0.0.0/16"
-			}
+  egress {
+    cidr_blocks = ["1.2.3.4/32"]
+  }
+}
 
-			resource "aws_security_group_rule" "example" {
-				type              = "ingress"
-				description = "Rule #2"
-				security_group_id = aws_security_group.example.id
-				from_port         = 22
-				to_port           = 22
-				protocol          = "tcp"
-				cidr_blocks = [
-				  "1.2.3.4/32",
-				  "4.5.6.7/32",
-				]
-			  }
+resource "aws_network_acl_rule" "example" {
+  egress      = false
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  rule_action = "allow"
+  cidr_block  = "10.0.0.0/16"
+}
 
-			resource "aws_default_security_group" "default" {
-				vpc_id = aws_vpc.main.id
+resource "aws_security_group_rule" "example" {
+  type              = "ingress"
+  description       = "Rule #2"
+  security_group_id = aws_security_group.example.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks = [
+    "1.2.3.4/32",
+    "4.5.6.7/32",
+  ]
+}
 
-				ingress {
-					protocol  = -1
-					self      = true
-					from_port = 0
-					to_port   = 0
-				}
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
 
-				egress {
-					from_port   = 0
-					to_port     = 0
-					protocol    = "-1"
-					cidr_blocks = ["0.0.0.0/0"]
-				}
-			}
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
 `,
 			expected: ec2.EC2{
 				VPCs: []ec2.VPC{
@@ -192,17 +191,16 @@ func Test_AdaptVPC(t *testing.T) {
 		},
 		{
 			name: "defaults",
-			terraform: `
-			resource "aws_security_group" "example" {
-				ingress {
-				}
+			terraform: `resource "aws_security_group" "example" {
+  ingress {
+  }
 
-				egress {
-				}
-			  }
+  egress {
+  }
+}
 
-			resource "aws_network_acl_rule" "example" {
-			}
+resource "aws_network_acl_rule" "example" {
+}
 `,
 			expected: ec2.EC2{
 				SecurityGroups: []ec2.SecurityGroup{
@@ -250,8 +248,7 @@ func Test_AdaptVPC(t *testing.T) {
 		},
 		{
 			name: "aws_flow_log refer to locals",
-			terraform: `
-locals {
+			terraform: `locals {
   vpc_id = try(aws_vpc.this.id, "")
 }
 
@@ -275,8 +272,7 @@ resource "aws_flow_log" "this" {
 		},
 		{
 			name: "ingress and egress rules",
-			terraform: `
-resource "aws_security_group" "example" {
+			terraform: `resource "aws_security_group" "example" {
   name        = "example"
   description = "example"
 }
@@ -336,50 +332,51 @@ resource "aws_vpc_security_group_ingress_rule" "test" {
 
 func TestVPCLines(t *testing.T) {
 	src := `
-	resource "aws_default_vpc" "default" {
-	  }
+resource "aws_default_vpc" "default" {
+}
 
-	resource "aws_vpc" "main" {
-		cidr_block = "4.5.6.7/32"
-	  }
+resource "aws_vpc" "main" {
+  cidr_block = "4.5.6.7/32"
+}
 
-	resource "aws_security_group" "example" {
-		name        = "http"
-		description = "Allow inbound HTTP traffic"
-	  
-		ingress {
-		  description = "HTTP from VPC"
-		  from_port   = 80
-		  to_port     = 80
-		  protocol    = "tcp"
-		  cidr_blocks = [aws_vpc.main.cidr_block]
-		}
+resource "aws_security_group" "example" {
+  name        = "http"
+  description = "Allow inbound HTTP traffic"
 
-		egress {
-			cidr_blocks = ["1.2.3.4/32"]
-		}
-	  }
+  ingress {
+    description = "HTTP from VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
 
-	resource "aws_security_group_rule" "example" {
-		type              = "ingress"
-		security_group_id = aws_security_group.example.id
-		from_port         = 22
-		to_port           = 22
-		protocol          = "tcp"
-		cidr_blocks = [
-		  "1.2.3.4/32",
-		  "4.5.6.7/32",
-		]
-	  }
-	  
-	  resource "aws_network_acl_rule" "example" {
-		egress         = false
-		protocol       = "tcp"
-		from_port      = 22
-		to_port        = 22
-		rule_action    = "allow"
-		cidr_block     = "10.0.0.0/16"
-	}`
+  egress {
+    cidr_blocks = ["1.2.3.4/32"]
+  }
+}
+
+resource "aws_security_group_rule" "example" {
+  type              = "ingress"
+  security_group_id = aws_security_group.example.id
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks = [
+    "1.2.3.4/32",
+    "4.5.6.7/32",
+  ]
+}
+
+resource "aws_network_acl_rule" "example" {
+  egress      = false
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  rule_action = "allow"
+  cidr_block  = "10.0.0.0/16"
+}
+`
 
 	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
 	adapted := Adapt(modules)


### PR DESCRIPTION
## Description

This PR adds adaptation for [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) and also fixes protocol parsing in number format.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
