### PR TITLE
fix(fs): check postAnalyzers for StaticPaths

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -540,9 +540,9 @@ func (ag AnalyzerGroup) filePatternMatch(analyzerType Type, filePath string) boo
 func (ag AnalyzerGroup) StaticPaths(disabled []Type) ([]string, bool) {
 	var paths []string
 
-	for _, a := range ag.analyzers {
+	for typ, a := range ag.groupAnalyzers() {
 		// Skip disabled analyzers
-		if slices.Contains(disabled, a.Type()) {
+		if slices.Contains(disabled, typ) {
 			continue
 		}
 
@@ -558,4 +558,15 @@ func (ag AnalyzerGroup) StaticPaths(disabled []Type) ([]string, bool) {
 
 	// Remove duplicates
 	return lo.Uniq(paths), true
+}
+
+func (ag AnalyzerGroup) groupAnalyzers() map[Type]any {
+	groupAnalyzers := lo.SliceToMap(ag.analyzers, func(a analyzer) (Type, any) {
+		return a.Type(), a
+	})
+	groupPostAnalyzers := lo.SliceToMap(ag.postAnalyzers, func(a PostAnalyzer) (Type, any) {
+		return a.Type(), a
+	})
+
+	return lo.Assign(groupAnalyzers, groupPostAnalyzers)
 }

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -2486,6 +2486,15 @@ func TestAnalyzerGroup_StaticPaths(t *testing.T) {
 			wantAllStatic: false,
 		},
 		{
+			name: "only PostAnalyzers are enabled",
+			disabledAnalyzers: []analyzer.Type{
+				analyzer.TypePip,
+				analyzer.TypeSecret,
+			},
+			want:          []string{},
+			wantAllStatic: false,
+		},
+		{
 			name:              "disable all analyzers",
 			disabledAnalyzers: append(analyzer.TypeConfigFiles, analyzer.TypePip, analyzer.TypeApk, analyzer.TypeAlpine, analyzer.TypeSecret),
 			want:              []string{},


### PR DESCRIPTION
## Description
To enable `StaticPaths` mode - all enabled analyzers must implement the `StaticPathAnalyzer` interface.
For this we need to check `analyzers`. And also `postAnalyzers` (changes in this PR)
Otherwise there may be cases when only postAnalyzser is enabled => we enable `StaticPaths` mode and skip files.

example:
Before:
```bash
➜  ./trivy -d conf ./integration/testdata/fixtures/k8s --table-mode summary
...
2025-03-13T13:55:11+06:00       DEBUG   [fs] Analyzing...       root="integration/testdata/fixtures/k8s"
2025-03-13T13:55:11+06:00       DEBUG   [fs] Analyzing files in static paths
...

Report Summary

┌────────┬──────┬───────────────────┐
│ Target │ Type │ Misconfigurations │
├────────┼──────┼───────────────────┤
│   -    │  -   │         -         │
└────────┴──────┴───────────────────┘

```
After:
```bash
➜  ./trivy -d conf ./integration/testdata/fixtures/k8s --table-mode summary
...
2025-03-13T13:55:46+06:00       DEBUG   [fs] Analyzing...       root="integration/testdata/fixtures/k8s"
2025-03-13T13:55:46+06:00       DEBUG   [misconfig] Scanning files for misconfigurations...     scanner="Kubernetes"
...

Report Summary

┌──────────────────────┬────────────┬───────────────────┐
│        Target        │    Type    │ Misconfigurations │
├──────────────────────┼────────────┼───────────────────┤
│ limited-binding.yaml │ kubernetes │         0         │
├──────────────────────┼────────────┼───────────────────┤
│ limited-pod.yaml     │ kubernetes │        15         │
├──────────────────────┼────────────┼───────────────────┤
│ limited-role.yaml    │ kubernetes │         2         │
├──────────────────────┼────────────┼───────────────────┤
│ test_nginx.yaml      │ kubernetes │        16         │
└──────────────────────┴────────────┴───────────────────┘
```

## Related PRs
- [x] #8525


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
