### PR TITLE
fix(misconf): set default values for AWS::EKS::Cluster.ResourcesVpcConfig

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/eks/cluster.go
+++ b/pkg/iac/adapters/cloudformation/aws/eks/cluster.go
@@ -15,7 +15,7 @@ func getClusters(ctx parser.FileContext) (clusters []eks.Cluster) {
 			Metadata:            r.Metadata(),
 			Logging:             getLogging(r),
 			Encryption:          getEncryptionConfig(r),
-			PublicAccessEnabled: r.GetBoolProperty("ResourcesVpcConfig.EndpointPublicAccess"),
+			PublicAccessEnabled: r.GetBoolProperty("ResourcesVpcConfig.EndpointPublicAccess", true),
 			PublicAccessCIDRs:   getPublicCIDRs(r),
 		}
 
@@ -33,6 +33,10 @@ func getPublicCIDRs(r *parser.Resource) []iacTypes.StringValue {
 	var cidrs []iacTypes.StringValue
 	for _, el := range publicAccessCidrs.AsList() {
 		cidrs = append(cidrs, el.AsStringValue())
+	}
+
+	if len(cidrs) == 0 {
+		return []iacTypes.StringValue{iacTypes.StringDefault("0.0.0.0/0", r.Metadata())}
 	}
 
 	return cidrs

--- a/pkg/iac/adapters/cloudformation/aws/eks/eks_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/eks/eks_test.go
@@ -68,7 +68,9 @@ Resources:
       Type: AWS::EKS::Cluster
   `,
 			expected: eks.EKS{
-				Clusters: []eks.Cluster{{}},
+				Clusters: []eks.Cluster{{
+					PublicAccessEnabled: types.BoolTest(true),
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

- Default value for [PublicAccessCidrs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-publicaccesscidrs) is `0.0.0.0/0`.
- Default value for [EndpointPublicAccess](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-endpointpublicaccess) is `true`.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
