### PR TITLE
feat(misconf): adapt aws_opensearch_domain

### DIFF
--- a/pkg/iac/adapters/terraform/aws/elasticsearch/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/elasticsearch/adapt.go
@@ -15,7 +15,7 @@ func Adapt(modules terraform.Modules) elasticsearch.Elasticsearch {
 func adaptDomains(modules terraform.Modules) []elasticsearch.Domain {
 	var domains []elasticsearch.Domain
 	for _, module := range modules {
-		for _, resource := range module.GetResourcesByType("aws_elasticsearch_domain") {
+		for _, resource := range module.GetResourcesByType("aws_elasticsearch_domain", "aws_opensearch_domain") {
 			domains = append(domains, adaptDomain(resource))
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/elasticsearch/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/elasticsearch/adapt_test.go
@@ -16,7 +16,7 @@ func Test_adaptDomain(t *testing.T) {
 	tests := []struct {
 		name      string
 		terraform string
-		expected  elasticsearch.Domain
+		expected  elasticsearch.Elasticsearch
 	}{
 		{
 			name: "configured",
@@ -44,25 +44,29 @@ func Test_adaptDomain(t *testing.T) {
 				}
 			  }
 `,
-			expected: elasticsearch.Domain{
-				Metadata:   iacTypes.NewTestMetadata(),
-				DomainName: iacTypes.String("domain-foo", iacTypes.NewTestMetadata()),
-				LogPublishing: elasticsearch.LogPublishing{
-					Metadata:     iacTypes.NewTestMetadata(),
-					AuditEnabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-				},
-				TransitEncryption: elasticsearch.TransitEncryption{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-				},
-				AtRestEncryption: elasticsearch.AtRestEncryption{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-				},
-				Endpoint: elasticsearch.Endpoint{
-					Metadata:     iacTypes.NewTestMetadata(),
-					EnforceHTTPS: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-					TLSPolicy:    iacTypes.String("Policy-Min-TLS-1-2-2019-07", iacTypes.NewTestMetadata()),
+			expected: elasticsearch.Elasticsearch{
+				Domains: []elasticsearch.Domain{
+					{
+						Metadata:   iacTypes.NewTestMetadata(),
+						DomainName: iacTypes.String("domain-foo", iacTypes.NewTestMetadata()),
+						LogPublishing: elasticsearch.LogPublishing{
+							Metadata:     iacTypes.NewTestMetadata(),
+							AuditEnabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						TransitEncryption: elasticsearch.TransitEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						AtRestEncryption: elasticsearch.AtRestEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						Endpoint: elasticsearch.Endpoint{
+							Metadata:     iacTypes.NewTestMetadata(),
+							EnforceHTTPS: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+							TLSPolicy:    iacTypes.String("Policy-Min-TLS-1-2-2019-07", iacTypes.NewTestMetadata()),
+						},
+					},
 				},
 			},
 		},
@@ -72,25 +76,79 @@ func Test_adaptDomain(t *testing.T) {
 			resource "aws_elasticsearch_domain" "example" {
 			  }
 `,
-			expected: elasticsearch.Domain{
-				Metadata:   iacTypes.NewTestMetadata(),
-				DomainName: iacTypes.String("", iacTypes.NewTestMetadata()),
-				LogPublishing: elasticsearch.LogPublishing{
-					Metadata:     iacTypes.NewTestMetadata(),
-					AuditEnabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+			expected: elasticsearch.Elasticsearch{
+				Domains: []elasticsearch.Domain{
+					{
+						Metadata:   iacTypes.NewTestMetadata(),
+						DomainName: iacTypes.String("", iacTypes.NewTestMetadata()),
+						LogPublishing: elasticsearch.LogPublishing{
+							Metadata:     iacTypes.NewTestMetadata(),
+							AuditEnabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+						},
+						TransitEncryption: elasticsearch.TransitEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+						},
+						AtRestEncryption: elasticsearch.AtRestEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+						},
+						Endpoint: elasticsearch.Endpoint{
+							Metadata:     iacTypes.NewTestMetadata(),
+							EnforceHTTPS: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+							TLSPolicy:    iacTypes.String("", iacTypes.NewTestMetadata()),
+						},
+					},
 				},
-				TransitEncryption: elasticsearch.TransitEncryption{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				},
-				AtRestEncryption: elasticsearch.AtRestEncryption{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				},
-				Endpoint: elasticsearch.Endpoint{
-					Metadata:     iacTypes.NewTestMetadata(),
-					EnforceHTTPS: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					TLSPolicy:    iacTypes.String("", iacTypes.NewTestMetadata()),
+			},
+		},
+		{
+			name: "opensearch",
+			terraform: `resource "aws_opensearch_domain" "example" {
+  domain_name    = "example"
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+	enforce_https = true
+	tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.example.arn
+    log_type                 = "AUDIT_LOGS"
+  }
+}
+`,
+			expected: elasticsearch.Elasticsearch{
+				Domains: []elasticsearch.Domain{
+					{
+						Metadata:   iacTypes.NewTestMetadata(),
+						DomainName: iacTypes.String("example", iacTypes.NewTestMetadata()),
+						LogPublishing: elasticsearch.LogPublishing{
+							Metadata:     iacTypes.NewTestMetadata(),
+							AuditEnabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						TransitEncryption: elasticsearch.TransitEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						AtRestEncryption: elasticsearch.AtRestEncryption{
+							Metadata: iacTypes.NewTestMetadata(),
+							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+						Endpoint: elasticsearch.Endpoint{
+							Metadata:     iacTypes.NewTestMetadata(),
+							EnforceHTTPS: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+							TLSPolicy:    iacTypes.String("Policy-Min-TLS-1-2-2019-07", iacTypes.NewTestMetadata()),
+						},
+					},
 				},
 			},
 		},
@@ -99,7 +157,7 @@ func Test_adaptDomain(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
-			adapted := adaptDomain(modules.GetBlocks()[0])
+			adapted := Adapt(modules)
 			testutil.AssertDefsecEqual(t, test.expected, adapted)
 		})
 	}


### PR DESCRIPTION
## Description

Amazon OpenSearch Service is the successor to Amazon Elasticsearch Service. For CloudFormation, we already support `AWS::OpenSearchService::Domain`.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
