### PR TITLE
feat(cli): Add available version checking

### DIFF
--- a/docs/docs/references/configuration/cli/trivy.md
+++ b/docs/docs/references/configuration/cli/trivy.md
@@ -36,6 +36,7 @@ trivy [global flags] command [flags] target
       --generate-default-config   write the default config to trivy-default.yaml
   -h, --help                      help for trivy
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_clean.md
+++ b/docs/docs/references/configuration/cli/trivy_clean.md
@@ -40,6 +40,7 @@ trivy clean [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -67,6 +67,7 @@ trivy config [flags] DIR
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_convert.md
+++ b/docs/docs/references/configuration/cli/trivy_convert.md
@@ -45,6 +45,7 @@ trivy convert [flags] RESULT_JSON
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -112,6 +112,7 @@ trivy filesystem [flags] PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -133,6 +133,7 @@ trivy image [flags] IMAGE_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -125,6 +125,7 @@ trivy kubernetes [flags] [CONTEXT]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_module.md
+++ b/docs/docs/references/configuration/cli/trivy_module.md
@@ -18,6 +18,7 @@ Manage modules
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_module_install.md
+++ b/docs/docs/references/configuration/cli/trivy_module_install.md
@@ -22,6 +22,7 @@ trivy module install [flags] REPOSITORY
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
       --module-dir string         specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_module_uninstall.md
+++ b/docs/docs/references/configuration/cli/trivy_module_uninstall.md
@@ -22,6 +22,7 @@ trivy module uninstall [flags] REPOSITORY
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
       --module-dir string         specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin.md
@@ -16,6 +16,7 @@ Manage plugins
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_info.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_info.md
@@ -20,6 +20,7 @@ trivy plugin info PLUGIN_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_install.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_install.md
@@ -33,6 +33,7 @@ trivy plugin install NAME | URL | FILE_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_list.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_list.md
@@ -20,6 +20,7 @@ trivy plugin list
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_run.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_run.md
@@ -20,6 +20,7 @@ trivy plugin run NAME | URL | FILE_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_search.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_search.md
@@ -20,6 +20,7 @@ trivy plugin search [KEYWORD]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_uninstall.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_uninstall.md
@@ -20,6 +20,7 @@ trivy plugin uninstall PLUGIN_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_update.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_update.md
@@ -20,6 +20,7 @@ trivy plugin update
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_plugin_upgrade.md
+++ b/docs/docs/references/configuration/cli/trivy_plugin_upgrade.md
@@ -20,6 +20,7 @@ trivy plugin upgrade [PLUGIN_NAMES]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_registry.md
+++ b/docs/docs/references/configuration/cli/trivy_registry.md
@@ -16,6 +16,7 @@ Manage registry authentication
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_registry_login.md
+++ b/docs/docs/references/configuration/cli/trivy_registry_login.md
@@ -30,6 +30,7 @@ trivy registry login SERVER [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_registry_logout.md
+++ b/docs/docs/references/configuration/cli/trivy_registry_logout.md
@@ -27,6 +27,7 @@ trivy registry logout SERVER [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -111,6 +111,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -113,6 +113,7 @@ trivy rootfs [flags] ROOTDIR
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -85,6 +85,7 @@ trivy sbom [flags] SBOM_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_server.md
+++ b/docs/docs/references/configuration/cli/trivy_server.md
@@ -50,6 +50,7 @@ trivy server [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_version.md
+++ b/docs/docs/references/configuration/cli/trivy_version.md
@@ -21,6 +21,7 @@ trivy version [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vex.md
+++ b/docs/docs/references/configuration/cli/trivy_vex.md
@@ -16,6 +16,7 @@
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vex_repo.md
+++ b/docs/docs/references/configuration/cli/trivy_vex_repo.md
@@ -30,6 +30,7 @@ Manage VEX repositories
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vex_repo_download.md
+++ b/docs/docs/references/configuration/cli/trivy_vex_repo_download.md
@@ -24,6 +24,7 @@ trivy vex repo download [REPO_NAMES] [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vex_repo_init.md
+++ b/docs/docs/references/configuration/cli/trivy_vex_repo_init.md
@@ -20,6 +20,7 @@ trivy vex repo init [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vex_repo_list.md
+++ b/docs/docs/references/configuration/cli/trivy_vex_repo_list.md
@@ -20,6 +20,7 @@ trivy vex repo list [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -98,6 +98,7 @@ trivy vm [flags] VM_IMAGE
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --no-notices                suppress notices about version updates and Trivy announcements
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -19,6 +19,9 @@ debug: false
 # Same as '--insecure'
 insecure: false
 
+# Same as '--no-notices'
+no-notices: false
+
 # Same as '--quiet'
 quiet: false
 

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -66,6 +66,12 @@ var (
 		Usage:      "write the default config to trivy-default.yaml",
 		Persistent: true,
 	}
+	NoNoticesFlag = Flag[bool]{
+		Name:       "no-notices",
+		ConfigName: "no-notices",
+		Usage:      "suppress notices about version updates and Trivy announcements",
+		Persistent: true,
+	}
 )
 
 // GlobalFlagGroup composes global flags
@@ -78,6 +84,7 @@ type GlobalFlagGroup struct {
 	Timeout               *Flag[time.Duration]
 	CacheDir              *Flag[string]
 	GenerateDefaultConfig *Flag[bool]
+	NoNotices             *Flag[bool]
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -90,6 +97,7 @@ type GlobalOptions struct {
 	Timeout               time.Duration
 	CacheDir              string
 	GenerateDefaultConfig bool
+	NoNotices             bool
 }
 
 func NewGlobalFlagGroup() *GlobalFlagGroup {
@@ -102,6 +110,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		Timeout:               TimeoutFlag.Clone(),
 		CacheDir:              CacheDirFlag.Clone(),
 		GenerateDefaultConfig: GenerateDefaultConfigFlag.Clone(),
+		NoNotices:             NoNoticesFlag.Clone(),
 	}
 }
 
@@ -119,6 +128,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.Timeout,
 		f.CacheDir,
 		f.GenerateDefaultConfig,
+		f.NoNotices,
 	}
 }
 

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -1,0 +1,123 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+type versionInfo struct {
+	LatestVersion string    `json:"latest_version"`
+	LatestDate    time.Time `json:"latest_date"`
+}
+
+type announcement struct {
+	FromDate     time.Time `json:"from_date"`
+	ToDate       time.Time `json:"to_date"`
+	Announcement string    `json:"announcement"`
+}
+
+type updateResponse struct {
+	Trivy         versionInfo    `json:"trivy"`
+	Announcements []announcement `json:"announcements"`
+	Warnings      []string       `json:"warnings"`
+}
+
+var (
+	updatesApi     = "https://api.trivy.cloud/check"
+	updated        atomic.Bool
+	currentVersion string
+	latestVersion  updateResponse
+)
+
+// CheckUpdate makes a best efforts request to determine the
+// latest version and any announcements
+func CheckUpdate(ctx context.Context, version string, args []string) {
+	currentVersion = version
+
+	go func() {
+		args = getFlags(args)
+
+		log.Debug("[version] Requesting latest details")
+		client := &http.Client{
+			Timeout: 3 * time.Second,
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, updatesApi, http.NoBody)
+		if err != nil {
+			log.Warnf("[version] Failed to create a request: %v", err)
+			return
+		}
+		req.Header.Set("-x-trivy-identifier", uniqueIdentifier())
+		req.Header.Set("-x-trivy-command", strings.Join(args, " "))
+		req.Header.Set("-x-trivy-os", runtime.GOOS)
+		req.Header.Set("-x-trivy-arch", runtime.GOARCH)
+		req.Header.Set("User-Agent", "trivy/"+currentVersion)
+		resp, err := client.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			log.Warnf("[version] Failed to get the latest version: %v", err)
+			return
+		}
+
+		log.Debug("[version] Details received, storing for later")
+		defer resp.Body.Close()
+		if err := json.NewDecoder(resp.Body).Decode(&latestVersion); err != nil {
+			log.Warnf("Failed to decode the response: %v", err)
+			return
+		}
+		updated.Store(true)
+		log.Debug("[version] Details ready for printing")
+	}()
+}
+
+// NotifyUpdates prints any announcements or warnings
+// to the output writer, most likely stderr
+func NotifyUpdates(output io.Writer) {
+	if !updated.Load() {
+		// the update check didn't happen in time
+		// or it had an error but we don't want to make noise
+		// about it
+		log.Debug("[version] Update check failed or didn't happen in time, check logs for more details")
+		return
+	}
+
+	var notices []string
+
+	notices = append(notices, latestVersion.Warnings...)
+	for _, announcement := range latestVersion.Announcements {
+		if time.Now().Before(announcement.ToDate) && time.Now().After(announcement.FromDate) {
+			notices = append(notices, announcement.Announcement)
+		}
+	}
+
+	if currentVersion != latestVersion.Trivy.LatestVersion {
+		notices = append(notices, fmt.Sprintf("Version %s of Trivy is now available, current version is %s", latestVersion.Trivy.LatestVersion, currentVersion))
+	}
+
+	if len(notices) > 0 {
+		fmt.Fprintf(output, "\n 📣 \x1b[34mNotices:\x1b[0m\n")
+		for _, notice := range notices {
+			fmt.Fprintf(output, "  - %s\n", notice)
+		}
+		fmt.Fprintln(output)
+	}
+}
+
+// getFlags returns the just the flag portion without the values
+func getFlags(args []string) []string {
+	var flags []string
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			flags = append(flags, strings.Split(arg, "=")[0])
+		}
+	}
+	return flags
+}

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -1,0 +1,140 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifyUpdates(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		announcements  []announcement
+		expectedOutput string
+	}{
+		{
+			name:           "New version with no announcements",
+			currentVersion: "0.58.0",
+			latestVersion:  "0.60.0",
+			expectedOutput: "\n 📣 \x1b[34mNotices:\x1b[0m\n  - Version 0.60.0 of Trivy is now available, current version is 0.58.0\n\n",
+		},
+		{
+			name:           "New version with announcements",
+			currentVersion: "0.58.0",
+			latestVersion:  "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			expectedOutput: "\n 📣 \x1b[34mNotices:\x1b[0m\n  - There are some amazing things happening right now!\n  - Version 0.60.0 of Trivy is now available, current version is 0.58.0\n\n",
+		},
+		{
+			name:           "No new version with announcements",
+			currentVersion: "0.60.0",
+			latestVersion:  "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			expectedOutput: "\n 📣 \x1b[34mNotices:\x1b[0m\n  - There are some amazing things happening right now!\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// reset the updated flag
+			updated.Store(false)
+			server := httptest.NewServer(http.HandlerFunc(createHandler(t, tt.latestVersion, tt.announcements)))
+			defer server.Close()
+			updatesApi = server.URL
+
+			CheckUpdate(t.Context(), tt.currentVersion, nil)
+			require.Eventually(t, updated.Load, time.Second*5, 500)
+
+			sb := bytes.NewBufferString("")
+			NotifyUpdates(sb)
+			assert.Equal(t, tt.expectedOutput, sb.String())
+		})
+	}
+}
+
+func TestCheckUpdate(t *testing.T) {
+	tests := []struct {
+		name                  string
+		currentVersion        string
+		expectedVersion       string
+		expectedAnnouncements []announcement
+	}{
+		{
+			name:            "new version with no announcements",
+			currentVersion:  "0.58.0",
+			expectedVersion: "0.60.0",
+		},
+		{
+			name:            "new version and a new announcement",
+			currentVersion:  "0.58.0",
+			expectedVersion: "0.60.0",
+			expectedAnnouncements: []announcement{
+				{
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// reset the updated flag
+			updated.Store(false)
+
+			server := httptest.NewServer(http.HandlerFunc(createHandler(t, tt.expectedVersion, tt.expectedAnnouncements)))
+			defer server.Close()
+			updatesApi = server.URL
+
+			CheckUpdate(t.Context(), tt.currentVersion, nil)
+			require.Eventually(t, updated.Load, time.Second*2, 500)
+			assert.Equal(t, tt.expectedVersion, latestVersion.Trivy.LatestVersion)
+			assert.ElementsMatch(t, tt.expectedAnnouncements, latestVersion.Announcements)
+
+		})
+	}
+}
+
+func createHandler(t *testing.T, expectedVersion string, announcements []announcement) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("User-Agent"), "trivy") {
+			w.WriteHeader(http.StatusForbidden)
+		}
+
+		response := updateResponse{
+			Trivy: versionInfo{
+				LatestVersion: expectedVersion,
+				LatestDate:    time.Now(),
+			},
+			Announcements: announcements,
+		}
+
+		out, err := json.Marshal(response)
+		if err != nil {
+			t.Fail()
+		}
+		w.Write(out)
+	}
+}

--- a/pkg/update/identifier.go
+++ b/pkg/update/identifier.go
@@ -1,0 +1,46 @@
+package update
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+func getMachineIdentifier() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	var macAddr string
+	for _, iface := range interfaces {
+		if iface.HardwareAddr.String() != "" {
+			macAddr = iface.HardwareAddr.String()
+			break
+		}
+	}
+	identifier := fmt.Sprintf("%s-%s-%s", hostname, macAddr, strings.ToLower(hostname))
+
+	return identifier, nil
+}
+
+func generateMachineHash(identifier string) string {
+	hash := sha256.New()
+	hash.Write([]byte(identifier))
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func uniqueIdentifier() string {
+	identifier, err := getMachineIdentifier()
+	if err != nil {
+		return ""
+	}
+
+	return generateMachineHash(fmt.Sprintf("trivy-%s", identifier))
+}

--- a/pkg/update/identifier_test.go
+++ b/pkg/update/identifier_test.go
@@ -1,0 +1,28 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateMachineHash(t *testing.T) {
+	// Test with known input
+	identifier := "test-identifier"
+	hash := generateMachineHash(identifier)
+
+	// Known hash for "test-identifier"
+	expectedHash := "115ae872eb1d3e23f9de03f7ab344193b21068812ee52eb37e8169e6d093c7ae"
+	assert.Equal(t, expectedHash, hash)
+}
+
+// This test requires some modification to the original code to make it testable
+// by injecting mocked network interfaces
+func TestGetMachineIdentifier(t *testing.T) {
+	// This is a basic test that at least ensures the function returns without error
+	// A more complete test would mock os.Hostname and net.Interfaces
+	identifier, err := getMachineIdentifier()
+	require.NoError(t, err)
+	require.NotEmpty(t, identifier)
+}


### PR DESCRIPTION
## Description

Adds a background check to `https://api.trivy.cloud/check` to see if there is new version or any relevant notices available.

The check will be suppressed if the user uses the `--no-notices` or `--quiet` envvars or flags. The docs have been updated with the new notices flag

### Example output



## Related issues
- Close #8552

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
