### PR TITLE
docs(cli): improve flag value display format

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -21,7 +21,18 @@ trivy config [flags] DIR
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -45,13 +56,20 @@ trivy config [flags] DIR
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string             registry token
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --report string                     specify a compliance report format for the output (all,summary) (default "all")
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --report string                     specify a compliance report format for the output (allowed values: all,summary) (default "all")
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --skip-check-update                 skip fetching rego check updates
       --skip-dirs strings                 specify the directories or glob patterns to skip
       --skip-files strings                specify the files or glob patterns to skip
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files

--- a/docs/docs/references/configuration/cli/trivy_convert.md
+++ b/docs/docs/references/configuration/cli/trivy_convert.md
@@ -22,18 +22,36 @@ trivy convert [flags] RESULT_JSON
       --dependency-tree            [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --exit-code int              specify exit code when any security issues are found
       --exit-on-eol int            exit with the specified code when the OS reaches end of service/life
-  -f, --format string              format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string              format
+                                   Allowed values:
+                                     - table
+                                     - json
+                                     - template
+                                     - sarif
+                                     - cyclonedx
+                                     - spdx
+                                     - spdx-json
+                                     - github
+                                     - cosign-vuln
+                                    (default "table")
   -h, --help                       help for convert
       --ignore-policy string       specify the Rego file path to evaluate each vulnerability
       --ignorefile string          specify .trivyignore file (default ".trivyignore")
       --list-all-pkgs              output all packages in the JSON report regardless of vulnerability
   -o, --output string              output file name
       --output-plugin-arg string   [EXPERIMENTAL] output plugin arguments
-      --report string              specify a report format for the output (all,summary) (default "all")
-      --scanners strings           List of scanners included when generating the json report. Used only for rendering the summary table. (vuln,misconfig,secret,license)
-  -s, --severity strings           severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+      --report string              specify a report format for the output (allowed values: all,summary) (default "all")
+      --scanners strings           List of scanners included when generating the json report. Used only for rendering the summary table. (allowed values: vuln,misconfig,secret,license)
+  -s, --severity strings           severities of security issues to be displayed
+                                   Allowed values:
+                                     - UNKNOWN
+                                     - LOW
+                                     - MEDIUM
+                                     - HIGH
+                                     - CRITICAL
+                                    (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed            [EXPERIMENTAL] show suppressed vulnerabilities
-      --table-mode strings         [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings         [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string            output template
 ```
 

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -34,14 +34,25 @@ trivy filesystem [flags] PATH
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --distro string                     [EXPERIMENTAL] specify a distribution, <family>/<version>
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -50,7 +61,17 @@ trivy filesystem [flags] PATH
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for filesystem
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
@@ -70,21 +91,35 @@ trivy filesystem [flags] PATH
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                    password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string             registry token
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --report string                     specify a compliance report format for the output (all,summary) (default "all")
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --report string                     specify a compliance report format for the output (allowed values: all,summary) (default "all")
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-check-update                 skip fetching rego check updates
       --skip-db-update                    skip updating vulnerability database
@@ -92,7 +127,7 @@ trivy filesystem [flags] PATH
       --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-vex-repo-update              [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
@@ -101,7 +136,37 @@ trivy filesystem [flags] PATH
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -71,7 +71,6 @@ trivy filesystem [flags] PATH
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -87,7 +87,6 @@ trivy image [flags] IMAGE_NAME
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")

--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -38,7 +38,7 @@ trivy image [flags] IMAGE_NAME
       --cache-ttl duration                cache TTL when using redis as cache backend
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:1")
-      --compliance string                 compliance report to generate (docker-cis-1.6.0)
+      --compliance string                 compliance report to generate (allowed values: docker-cis-1.6.0)
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking
@@ -48,7 +48,7 @@ trivy image [flags] IMAGE_NAME
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --distro string                     [EXPERIMENTAL] specify a distribution, <family>/<version>
       --docker-host string                unix domain socket path to use for docker scanning
       --download-db-only                  download/update vulnerability database but don't run a scan
@@ -57,7 +57,18 @@ trivy image [flags] IMAGE_NAME
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -66,12 +77,22 @@ trivy image [flags] IMAGE_NAME
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for image
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (misconfig,secret)
-      --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
+      --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (allowed values: misconfig,secret)
+      --image-src strings                 image source(s) to use, in priority order (allowed values: docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-deprecated-checks         include deprecated checks
       --include-non-failures              include successes, available with '--scanners misconfig'
       --input string                      input file path instead of image name
@@ -89,8 +110,15 @@ trivy image [flags] IMAGE_NAME
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                    password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --platform string                   set platform in the form os/arch if image is multi-platform capable
       --podman-host string                unix podman socket path to use for podman scanning
       --redis-ca string                   redis ca file location, if using redis as cache backend
@@ -100,13 +128,20 @@ trivy image [flags] IMAGE_NAME
       --registry-token string             registry token
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --removed-pkgs                      detect vulnerabilities of removed packages (only for Alpine)
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --report string                     specify a format for the compliance report. (all,summary) (default "summary")
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --report string                     specify a format for the compliance report. (allowed values: all,summary) (default "summary")
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-check-update                 skip fetching rego check updates
       --skip-db-update                    skip updating vulnerability database
@@ -114,7 +149,7 @@ trivy image [flags] IMAGE_NAME
       --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-vex-repo-update              [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --token string                      for authentication in client/server mode
@@ -122,7 +157,37 @@ trivy image [flags] IMAGE_NAME
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -42,7 +42,6 @@ trivy kubernetes [flags] [CONTEXT]
                                             - rke2-cis-1.24
                                             - k8s-pss-baseline-0.1
                                             - k8s-pss-restricted-0.1
-                                          
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking
@@ -81,7 +80,6 @@ trivy kubernetes [flags] [CONTEXT]
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --image-src strings                 image source(s) to use, in priority order (allowed values: docker,containerd,podman,remote) (default [docker,containerd,podman,remote])

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -34,7 +34,15 @@ trivy kubernetes [flags] [CONTEXT]
       --cache-ttl duration                cache TTL when using redis as cache backend
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:1")
-      --compliance string                 compliance report to generate (k8s-nsa-1.0,k8s-cis-1.23,eks-cis-1.4,rke2-cis-1.24,k8s-pss-baseline-0.1,k8s-pss-restricted-0.1)
+      --compliance string                 compliance report to generate
+                                          Allowed values:
+                                            - k8s-nsa-1.0
+                                            - k8s-cis-1.23
+                                            - eks-cis-1.4
+                                            - rke2-cis-1.24
+                                            - k8s-pss-baseline-0.1
+                                            - k8s-pss-restricted-0.1
+                                          
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking
@@ -43,7 +51,7 @@ trivy kubernetes [flags] [CONTEXT]
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --disable-node-collector            When the flag is activated, the node-collector job will not be executed, thus skipping misconfiguration findings on the node.
       --distro string                     [EXPERIMENTAL] specify a distribution, <family>/<version>
       --download-db-only                  download/update vulnerability database but don't run a scan
@@ -54,7 +62,7 @@ trivy kubernetes [flags] [CONTEXT]
       --exclude-owned                     exclude resources that have an owner reference
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,cyclonedx) (default "table")
+  -f, --format string                     format (allowed values: table,json,cyclonedx) (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -63,10 +71,20 @@ trivy kubernetes [flags] [CONTEXT]
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for kubernetes
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
-      --image-src strings                 image source(s) to use, in priority order (docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
+      --image-src strings                 image source(s) to use, in priority order (allowed values: docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-deprecated-checks         include deprecated checks
       --include-kinds strings             indicate the kinds included in scanning (example: node)
       --include-namespaces strings        indicate the namespaces included in scanning (example: kube-system)
@@ -85,8 +103,15 @@ trivy kubernetes [flags] [CONTEXT]
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                    password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --qps float                         specify the maximum QPS to the master from this client (default 5)
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend
@@ -94,12 +119,19 @@ trivy kubernetes [flags] [CONTEXT]
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string             registry token
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --report string                     specify a report format for the output (all,summary) (default "all")
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,rbac) (default [vuln,misconfig,secret,rbac])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --report string                     specify a report format for the output (allowed values: all,summary) (default "all")
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,rbac) (default [vuln,misconfig,secret,rbac])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-check-update                 skip fetching rego check updates
       --skip-db-update                    skip updating vulnerability database
@@ -114,7 +146,37 @@ trivy kubernetes [flags] [CONTEXT]
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -34,13 +34,24 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -49,7 +60,17 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for repository
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
@@ -69,20 +90,34 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                    password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string             registry token
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-check-update                 skip fetching rego check updates
       --skip-db-update                    skip updating vulnerability database
@@ -90,7 +125,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-vex-repo-update              [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
       --tag string                        pass the tag name to be scanned
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
@@ -100,7 +135,37 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -70,7 +70,6 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -74,7 +74,6 @@ trivy rootfs [flags] ROOTDIR
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")

--- a/docs/docs/references/configuration/cli/trivy_rootfs.md
+++ b/docs/docs/references/configuration/cli/trivy_rootfs.md
@@ -36,7 +36,7 @@ trivy rootfs [flags] ROOTDIR
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --distro string                     [EXPERIMENTAL] specify a distribution, <family>/<version>
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -44,7 +44,18 @@ trivy rootfs [flags] ROOTDIR
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -53,7 +64,17 @@ trivy rootfs [flags] ROOTDIR
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for rootfs
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
@@ -72,20 +93,34 @@ trivy rootfs [flags] ROOTDIR
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
       --password strings                  password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                    password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string             registry token
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-check-update                 skip fetching rego check updates
       --skip-db-update                    skip updating vulnerability database
@@ -93,7 +128,7 @@ trivy rootfs [flags] ROOTDIR
       --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-vex-repo-update              [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --tf-vars strings                   specify paths to override the Terraform tfvars files
@@ -102,7 +137,37 @@ trivy rootfs [flags] ROOTDIR
       --trace                             enable more verbose trace output for custom queries
       --username strings                  username. Comma-separated usernames allowed.
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -59,7 +59,6 @@ trivy sbom [flags] SBOM_PATH
                                          - will_not_fix
                                          - fix_deferred
                                          - end_of_life
-                                       
       --ignore-unfixed                 display only fixed vulnerabilities
       --ignored-licenses strings       specify a list of license to ignore
       --ignorefile string              specify .trivyignore file (default ".trivyignore")

--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -28,17 +28,38 @@ trivy sbom [flags] SBOM_PATH
       --detection-priority string      specify the detection priority:
                                          - "precise": Prioritizes precise by minimizing false positives.
                                          - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                        (precise,comprehensive) (default "precise")
+                                        (allowed values: precise,comprehensive) (default "precise")
       --distro string                  [EXPERIMENTAL] specify a distribution, <family>/<version>
       --download-db-only               download/update vulnerability database but don't run a scan
       --download-java-db-only          download/update Java index database but don't run a scan
       --exit-code int                  specify exit code when any security issues are found
       --exit-on-eol int                exit with the specified code when the OS reaches end of service/life
       --file-patterns strings          specify config file patterns
-  -f, --format string                  format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                  format
+                                       Allowed values:
+                                         - table
+                                         - json
+                                         - template
+                                         - sarif
+                                         - cyclonedx
+                                         - spdx
+                                         - spdx-json
+                                         - github
+                                         - cosign-vuln
+                                        (default "table")
   -h, --help                           help for sbom
       --ignore-policy string           specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings          comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings          comma-separated list of vulnerability status to ignore
+                                       Allowed values:
+                                         - unknown
+                                         - not_affected
+                                         - affected
+                                         - fixed
+                                         - under_investigation
+                                         - will_not_fix
+                                         - fix_deferred
+                                         - end_of_life
+                                       
       --ignore-unfixed                 display only fixed vulnerabilities
       --ignored-licenses strings       specify a list of license to ignore
       --ignorefile string              specify .trivyignore file (default ".trivyignore")
@@ -50,31 +71,75 @@ trivy sbom [flags] SBOM_PATH
       --output-plugin-arg string       [EXPERIMENTAL] output plugin arguments
       --password strings               password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
       --password-stdin                 password from stdin. Comma-separated passwords are not supported.
-      --pkg-relationships strings      list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings              list of package types (os,library) (default [os,library])
+      --pkg-relationships strings      list of package relationships
+                                       Allowed values:
+                                         - unknown
+                                         - root
+                                         - workspace
+                                         - direct
+                                         - indirect
+                                        (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings              list of package types (allowed values: os,library) (default [os,library])
       --redis-ca string                redis ca file location, if using redis as cache backend
       --redis-cert string              redis certificate file location, if using redis as cache backend
       --redis-key string               redis key file location, if using redis as cache backend
       --redis-tls                      enable redis TLS with public certificates, if using redis as cache backend
       --registry-token string          registry token
       --rekor-url string               [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sbom-sources strings           [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings               comma-separated list of what security issues to detect (vuln,license) (default [vuln])
+      --sbom-sources strings           [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings               comma-separated list of what security issues to detect (allowed values: vuln,license) (default [vuln])
       --server string                  server address in client mode
-  -s, --severity strings               severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings               severities of security issues to be displayed
+                                       Allowed values:
+                                         - UNKNOWN
+                                         - LOW
+                                         - MEDIUM
+                                         - HIGH
+                                         - CRITICAL
+                                        (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-db-update                 skip updating vulnerability database
       --skip-dirs strings              specify the directories or glob patterns to skip
       --skip-files strings             specify the files or glob patterns to skip
       --skip-java-db-update            skip updating Java index database
       --skip-vex-repo-update           [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings             [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings             [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                output template
       --token string                   for authentication in client/server mode
       --token-header string            specify a header name for token in client/server mode (default "Trivy-Token")
       --username strings               username. Comma-separated usernames allowed.
       --vex strings                    [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings   order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings   order of data sources for selecting vulnerability severity level
+                                       Allowed values:
+                                         - nvd
+                                         - redhat
+                                         - redhat-oval
+                                         - debian
+                                         - ubuntu
+                                         - alpine
+                                         - amazon
+                                         - oracle-oval
+                                         - suse-cvrf
+                                         - photon
+                                         - arch-linux
+                                         - alma
+                                         - rocky
+                                         - cbl-mariner
+                                         - azure
+                                         - ruby-advisory-db
+                                         - php-security-advisories
+                                         - nodejs-security-wg
+                                         - ghsa
+                                         - glad
+                                         - aqua
+                                         - osv
+                                         - k8s
+                                         - wolfi
+                                         - chainguard
+                                         - bitnami
+                                         - govulndb
+                                         - auto
+                                        (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -70,7 +70,6 @@ trivy vm [flags] VM_IMAGE
                                             - will_not_fix
                                             - fix_deferred
                                             - end_of_life
-                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-non-failures              include successes, available with '--scanners misconfig'

--- a/docs/docs/references/configuration/cli/trivy_vm.md
+++ b/docs/docs/references/configuration/cli/trivy_vm.md
@@ -32,7 +32,7 @@ trivy vm [flags] VM_IMAGE
       --detection-priority string         specify the detection priority:
                                             - "precise": Prioritizes precise by minimizing false positives.
                                             - "comprehensive": Aims to detect more security findings at the cost of potential false positives.
-                                           (precise,comprehensive) (default "precise")
+                                           (allowed values: precise,comprehensive) (default "precise")
       --distro string                     [EXPERIMENTAL] specify a distribution, <family>/<version>
       --download-db-only                  download/update vulnerability database but don't run a scan
       --download-java-db-only             download/update Java index database but don't run a scan
@@ -40,7 +40,18 @@ trivy vm [flags] VM_IMAGE
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
-  -f, --format string                     format (table,json,template,sarif,cyclonedx,spdx,spdx-json,github,cosign-vuln) (default "table")
+  -f, --format string                     format
+                                          Allowed values:
+                                            - table
+                                            - json
+                                            - template
+                                            - sarif
+                                            - cyclonedx
+                                            - spdx
+                                            - spdx-json
+                                            - github
+                                            - cosign-vuln
+                                           (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.
       --helm-set strings                  specify Helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
@@ -49,7 +60,17 @@ trivy vm [flags] VM_IMAGE
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for vm
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignore-status strings             comma-separated list of vulnerability status to ignore (unknown,not_affected,affected,fixed,under_investigation,will_not_fix,fix_deferred,end_of_life)
+      --ignore-status strings             comma-separated list of vulnerability status to ignore
+                                          Allowed values:
+                                            - unknown
+                                            - not_affected
+                                            - affected
+                                            - fixed
+                                            - under_investigation
+                                            - will_not_fix
+                                            - fix_deferred
+                                            - end_of_life
+                                          
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-non-failures              include successes, available with '--scanners misconfig'
@@ -62,32 +83,76 @@ trivy vm [flags] VM_IMAGE
   -o, --output string                     output file name
       --output-plugin-arg string          [EXPERIMENTAL] output plugin arguments
       --parallel int                      number of goroutines enabled for parallel scanning, set 0 to auto-detect parallelism (default 5)
-      --pkg-relationships strings         list of package relationships (unknown,root,workspace,direct,indirect) (default [unknown,root,workspace,direct,indirect])
-      --pkg-types strings                 list of package types (os,library) (default [os,library])
+      --pkg-relationships strings         list of package relationships
+                                          Allowed values:
+                                            - unknown
+                                            - root
+                                            - workspace
+                                            - direct
+                                            - indirect
+                                           (default [unknown,root,workspace,direct,indirect])
+      --pkg-types strings                 list of package types (allowed values: os,library) (default [os,library])
       --redis-ca string                   redis ca file location, if using redis as cache backend
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (terraform)
-      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (oci,rekor)
-      --scanners strings                  comma-separated list of what security issues to detect (vuln,misconfig,secret,license) (default [vuln,secret])
+      --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform)
+      --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
+      --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
       --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
       --server string                     server address in client mode
-  -s, --severity strings                  severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
+  -s, --severity strings                  severities of security issues to be displayed
+                                          Allowed values:
+                                            - UNKNOWN
+                                            - LOW
+                                            - MEDIUM
+                                            - HIGH
+                                            - CRITICAL
+                                           (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                   [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-db-update                    skip updating vulnerability database
       --skip-dirs strings                 specify the directories or glob patterns to skip
       --skip-files strings                specify the files or glob patterns to skip
       --skip-java-db-update               skip updating Java index database
       --skip-vex-repo-update              [EXPERIMENTAL] Skip VEX Repository update
-      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (summary,detailed) (default [summary,detailed])
+      --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules
       --token string                      for authentication in client/server mode
       --token-header string               specify a header name for token in client/server mode (default "Trivy-Token")
       --vex strings                       [EXPERIMENTAL] VEX sources ("repo", "oci" or file path)
-      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level (nvd,redhat,redhat-oval,debian,ubuntu,alpine,amazon,oracle-oval,suse-cvrf,photon,arch-linux,alma,rocky,cbl-mariner,azure,ruby-advisory-db,php-security-advisories,nodejs-security-wg,ghsa,glad,aqua,osv,k8s,wolfi,chainguard,bitnami,govulndb,auto) (default [auto])
+      --vuln-severity-source strings      order of data sources for selecting vulnerability severity level
+                                          Allowed values:
+                                            - nvd
+                                            - redhat
+                                            - redhat-oval
+                                            - debian
+                                            - ubuntu
+                                            - alpine
+                                            - amazon
+                                            - oracle-oval
+                                            - suse-cvrf
+                                            - photon
+                                            - arch-linux
+                                            - alma
+                                            - rocky
+                                            - cbl-mariner
+                                            - azure
+                                            - ruby-advisory-db
+                                            - php-security-advisories
+                                            - nodejs-security-wg
+                                            - ghsa
+                                            - glad
+                                            - aqua
+                                            - osv
+                                            - k8s
+                                            - wolfi
+                                            - chainguard
+                                            - bitnami
+                                            - govulndb
+                                            - auto
+                                           (default [auto])
 ```
 
 ### Options inherited from parent commands

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -246,13 +246,31 @@ func (f *Flag[T]) Add(cmd *cobra.Command) {
 	case string:
 		usage := f.Usage
 		if len(f.Values) > 0 {
-			usage += fmt.Sprintf(" (%s)", strings.Join(f.Values, ","))
+			if len(f.Values) <= 4 {
+				// Display inline for a small number of choices
+				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
+			} else {
+				// Display as a bullet list for many choices
+				usage += "\nAllowed values:\n"
+				for _, val := range f.Values {
+					usage += fmt.Sprintf("  - %s\n", val)
+				}
+			}
 		}
 		flags.StringP(f.Name, f.Shorthand, v, usage)
 	case []string:
 		usage := f.Usage
 		if len(f.Values) > 0 {
-			usage += fmt.Sprintf(" (%s)", strings.Join(f.Values, ","))
+			if len(f.Values) <= 4 {
+				// Display inline for a small number of choices
+				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
+			} else {
+				// Display as a bullet list for many choices
+				usage += "\nAllowed values:\n"
+				for _, val := range f.Values {
+					usage += fmt.Sprintf("  - %s\n", val)
+				}
+			}
 		}
 		flags.StringSliceP(f.Name, f.Shorthand, v, usage)
 	case bool:

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -251,9 +251,12 @@ func (f *Flag[T]) Add(cmd *cobra.Command) {
 				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
 			} else {
 				// Display as a bullet list for many choices
-				usage += "\nAllowed values:\n"
+				usage += "\nAllowed values:"
 				for _, val := range f.Values {
-					usage += fmt.Sprintf("  - %s\n", val)
+					usage += fmt.Sprintf("\n  - %s", val)
+				}
+				if v != "" {
+					usage += "\n"
 				}
 			}
 		}
@@ -266,9 +269,12 @@ func (f *Flag[T]) Add(cmd *cobra.Command) {
 				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
 			} else {
 				// Display as a bullet list for many choices
-				usage += "\nAllowed values:\n"
+				usage += "\nAllowed values:"
 				for _, val := range f.Values {
-					usage += fmt.Sprintf("  - %s\n", val)
+					usage += fmt.Sprintf("\n  - %s", val)
+				}
+				if len(v) != 0 {
+					usage += "\n"
 				}
 			}
 		}


### PR DESCRIPTION
## Description
This PR improves the display format of CLI flag values to enhance readability and consistency.

## Changes
Introduce a bullet list format for flags with more than four allowed values

## Examples
### Before

```
  -s, --severity strings           severities of security issues to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL) (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
  --pkg-types strings           list of package types (os,library) (default [os,library])
```

### After

```
  -s, --severity strings           severities of security issues to be displayed
                                   Allowed values:
                                     - UNKNOWN
                                     - LOW
                                     - MEDIUM
                                     - HIGH
                                     - CRITICAL
                                    (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
  --pkg-types strings           list of package types (allowed values: os,library) (default [os,library])
```


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
