### PR TITLE
fix(misconf): do not use cty.NilVal for non-nil values

### DIFF
--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -130,10 +130,16 @@ func writeBlock(tfBlock *terraform.Block, block *hclwrite.Block, causeRng types.
 	var found bool
 
 	for _, attr := range tfBlock.Attributes() {
-		if attr.GetMetadata().Range().Covers(causeRng) && !attr.IsLiteral() {
-			block.Body().SetAttributeValue(attr.Name(), attr.Value())
-			found = true
+		if !attr.GetMetadata().Range().Covers(causeRng) || attr.IsLiteral() {
+			continue
 		}
+
+		value := attr.Value()
+		if !value.IsKnown() || value.IsNull() {
+			continue
+		}
+		block.Body().SetAttributeValue(attr.Name(), value)
+		found = true
 	}
 
 	for _, child := range tfBlock.AllBlocks() {

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -288,7 +288,7 @@ func (a *Attribute) Value() (ctyVal cty.Value) {
 	}()
 	ctyVal, _ = a.hclAttribute.Expr.Value(a.ctx.Inner())
 	if !ctyVal.IsKnown() || ctyVal.IsNull() {
-		return cty.NilVal
+		return cty.DynamicVal
 	}
 	return ctyVal
 }
@@ -304,8 +304,8 @@ func (a *Attribute) NullableValue() (ctyVal cty.Value) {
 		}
 	}()
 	ctyVal, _ = a.hclAttribute.Expr.Value(a.ctx.Inner())
-	if !ctyVal.IsKnown() {
-		return cty.NilVal
+	if !ctyVal.IsKnown() || ctyVal.IsNull() {
+		return cty.NullVal(cty.DynamicPseudoType)
 	}
 	return ctyVal
 }


### PR DESCRIPTION
## Description

Now we return `cty.NilVal` as the value of the expression if its evaluation failed or returned an unknown value. The documentation says that `NilVal` is nil in the Go type system and is not a valid value in the cty type system. We should use `cty.NullVal` with a dynamic pseudo-type for null values, and in other cases we should use dynamic values `cty.DynamicVal` to allow them to be used in operations with other values.

Ref: https://github.com/zclconf/go-cty/blob/main/docs/types.md

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8563

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
