### PR TITLE
refactor(misconf): remove module outputs from parser.EvaluateAll

### DIFF
--- a/pkg/iac/adapters/terraform/tftestutil/testutil.go
+++ b/pkg/iac/adapters/terraform/tftestutil/testutil.go
@@ -3,6 +3,8 @@ package tftestutil
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
@@ -13,12 +15,8 @@ func CreateModulesFromSource(t *testing.T, source, ext string) terraform.Modules
 		"source" + ext: source,
 	})
 	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
-	if err := p.ParseFS(t.Context(), "."); err != nil {
-		t.Fatal(err)
-	}
-	modules, _, err := p.EvaluateAll(t.Context())
-	if err != nil {
-		t.Fatalf("parse error: %s", err)
-	}
+	require.NoError(t, p.ParseFS(t.Context(), "."))
+	modules, err := p.EvaluateAll(t.Context())
+	require.NoError(t, err)
 	return modules
 }

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -357,19 +357,18 @@ func inputVariableType(b *terraform.Block) cty.Type {
 	return ty
 }
 
-func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, cty.Value, error) {
-
+func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, error) {
 	e, err := p.Load(ctx)
 	if errors.Is(err, ErrNoFiles) {
-		return nil, cty.NilVal, nil
+		return nil, nil
 	} else if err != nil {
-		return nil, cty.NilVal, err
+		return nil, err
 	}
 
 	modules, fsMap := e.EvaluateAll(ctx)
 	p.logger.Debug("Finished parsing module")
 	p.fsMap = fsMap
-	return modules, e.exportOutputs(), nil
+	return modules, nil
 }
 
 func (p *Parser) GetFilesystemMap() map[string]fs.FS {

--- a/pkg/iac/scanners/terraform/parser/parser_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_integration_test.go
@@ -24,7 +24,7 @@ module "registry" {
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -45,7 +45,7 @@ module "registry" {
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -68,7 +68,7 @@ module "registry" {
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }
@@ -89,7 +89,7 @@ module "object" {
 	parser := New(fsys, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 }

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -77,7 +77,7 @@ check "cats_mittens_is_special" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	blocks := modules[0].GetBlocks()
@@ -179,7 +179,7 @@ output "mod_result" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, modules, 2)
@@ -240,7 +240,7 @@ output "mod_result" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 2)
 	rootModule := modules[0]
@@ -285,7 +285,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -312,7 +312,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -355,7 +355,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -403,7 +403,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -444,7 +444,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -492,7 +492,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -536,7 +536,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, modules, 1)
@@ -580,7 +580,7 @@ resource "aws_s3_bucket" "default" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 
@@ -640,7 +640,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this2" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -675,7 +675,7 @@ resource "aws_s3_bucket" "main" {
 	)
 
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -708,7 +708,7 @@ resource "aws_s3_bucket" "this" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -742,7 +742,7 @@ resource "aws_s3_bucket" "this" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -796,7 +796,7 @@ policy_rules = {
 	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithTFVarsPaths("main.tfvars"))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -832,7 +832,7 @@ resource "aws_s3_bucket" "this" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -864,7 +864,7 @@ data "http" "example" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -901,7 +901,7 @@ data "http" "example" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -1147,7 +1147,7 @@ resource "aws_internet_gateway" "example" {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 
@@ -1172,7 +1172,7 @@ func TestArnAttributeOfBucketIsCorrect(t *testing.T) {
 		parser := New(fs, "", OptionStopOnHCLError(true))
 		require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-		modules, _, err := parser.EvaluateAll(t.Context())
+		modules, err := parser.EvaluateAll(t.Context())
 		require.NoError(t, err)
 		require.Len(t, modules, 1)
 
@@ -1233,7 +1233,7 @@ data "aws_iam_policy_document" "this" {
 		parser := New(fs, "", OptionStopOnHCLError(true))
 		require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-		modules, _, err := parser.EvaluateAll(t.Context())
+		modules, err := parser.EvaluateAll(t.Context())
 		require.NoError(t, err)
 		require.Len(t, modules, 1)
 
@@ -1273,7 +1273,7 @@ func TestForEachWithObjectsOfDifferentTypes(t *testing.T) {
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 }
@@ -1308,7 +1308,7 @@ func TestCountMetaArgument(t *testing.T) {
 			parser := New(fsys, "", OptionStopOnHCLError(true))
 			require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-			modules, _, err := parser.EvaluateAll(t.Context())
+			modules, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 			assert.Len(t, modules, 1)
 
@@ -1357,7 +1357,7 @@ func TestCountMetaArgumentInModule(t *testing.T) {
 			parser := New(fsys, "", OptionStopOnHCLError(true))
 			require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-			modules, _, err := parser.EvaluateAll(t.Context())
+			modules, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 
 			assert.Len(t, modules, tt.expectedCountModules)
@@ -1655,7 +1655,7 @@ func parse(t *testing.T, files map[string]string, opts ...Option) terraform.Modu
 	parser := New(fs, "", opts...)
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	return modules
@@ -1911,7 +1911,7 @@ func TestModuleParents(t *testing.T) {
 	)
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	// modules only have 'parent'. They do not have children, so create
@@ -2190,7 +2190,7 @@ func Test_LoadLocalCachedModule(t *testing.T) {
 	)
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	assert.Len(t, modules, 2)
@@ -2219,7 +2219,7 @@ func TestTFVarsFileDoesNotExist(t *testing.T) {
 	)
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	_, _, err := parser.EvaluateAll(t.Context())
+	_, err := parser.EvaluateAll(t.Context())
 	assert.ErrorContains(t, err, "file does not exist")
 }
 
@@ -2239,7 +2239,7 @@ variable "foo" {}
 
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, modules, 1)
 
@@ -2269,7 +2269,7 @@ resource "something" "blah" {
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
 	require.NoError(t, parser.ParseFS(t.Context(), "code"))
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	rootModule := modules[0]
@@ -2368,7 +2368,7 @@ func TestLoadChildModulesFromLocalCache(t *testing.T) {
 	)
 	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	assert.Len(t, modules, 5)
@@ -2465,7 +2465,7 @@ resource "foo" "this" {
 			_, err := parser.Load(t.Context())
 			require.NoError(t, err)
 
-			modules, _, err := parser.EvaluateAll(t.Context())
+			modules, err := parser.EvaluateAll(t.Context())
 			require.NoError(t, err)
 
 			res := modules.GetResourcesByType("foo")[0]
@@ -2494,7 +2494,7 @@ resource "aws_s3_bucket" "example" {
 	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 
 	val := modules.GetResourcesByType("aws_s3_bucket")[0].GetAttribute("bucket").GetRawValue()
@@ -2547,7 +2547,7 @@ module "bar" {
 	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
 
-	_, _, err = parser.EvaluateAll(t.Context())
+	_, err = parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 }
 
@@ -2569,7 +2569,7 @@ resource "foo" "bar" {
 	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
 
-	modules, _, err := parser.EvaluateAll(t.Context())
+	modules, err := parser.EvaluateAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
 	foo := modules[0].GetResourcesByType("foo")[0]

--- a/pkg/iac/scanners/terraform/performance_test.go
+++ b/pkg/iac/scanners/terraform/performance_test.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/rules"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/executor"
@@ -21,13 +23,9 @@ func BenchmarkCalculate(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		p := parser.New(f, "", parser.OptionStopOnHCLError(true))
-		if err := p.ParseFS(b.Context(), "project"); err != nil {
-			b.Fatal(err)
-		}
-		modules, _, err := p.EvaluateAll(b.Context())
-		if err != nil {
-			b.Fatal(err)
-		}
+		require.NoError(b, p.ParseFS(b.Context(), "project"))
+		modules, err := p.EvaluateAll(b.Context())
+		require.NoError(b, err)
 		executor.New().Execute(b.Context(), modules, "project")
 	}
 }

--- a/pkg/iac/scanners/terraform/scanner.go
+++ b/pkg/iac/scanners/terraform/scanner.go
@@ -115,7 +115,7 @@ func (s *Scanner) ScanFS(ctx context.Context, target fs.FS, dir string) (scan.Re
 			return nil, err
 		}
 
-		modules, _, err := p.EvaluateAll(ctx)
+		modules, err := p.EvaluateAll(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -28,11 +28,9 @@ func Test_OptionWithPolicyDirs(t *testing.T) {
 		rego.WithPolicyNamespaces("user"),
 	)
 	require.NoError(t, err)
-
 	require.Len(t, results.GetFailed(), 1)
 
 	failure := results.GetFailed()[0]
-
 	assert.Equal(t, "USER-TEST-0123", failure.Rule().AVDID)
 
 	actualCode, err := failure.GetCode()

--- a/pkg/iac/scanners/terraform/setup_test.go
+++ b/pkg/iac/scanners/terraform/setup_test.go
@@ -83,13 +83,9 @@ func createModulesFromSource(t *testing.T, source, ext string) terraform.Modules
 	})
 
 	p := parser.New(fs, "", parser.OptionStopOnHCLError(true))
-	if err := p.ParseFS(t.Context(), "."); err != nil {
-		t.Fatal(err)
-	}
-	modules, _, err := p.EvaluateAll(t.Context())
-	if err != nil {
-		t.Fatalf("parse error: %s", err)
-	}
+	require.NoError(t, p.ParseFS(t.Context(), "."))
+	modules, err := p.EvaluateAll(t.Context())
+	require.NoError(t, err)
 	return modules
 }
 


### PR DESCRIPTION
## Description

This PR removes the module outputs returned by `parser.EvaluateAll` since they were not used anywhere.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
