### PR TITLE
fix(misconf): identify the chart file exactly by name

### DIFF
--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -352,4 +353,12 @@ deny[res] {
 	require.Len(t, results, 1)
 
 	assert.Empty(t, results.GetFailed())
+}
+
+func TestScaningNonHelmChartDoesNotCauseError(t *testing.T) {
+	fsys := fstest.MapFS{
+		"testChart.yaml": &fstest.MapFile{Data: []byte(`foo: bar`)},
+	}
+	_, err := helm.New().ScanFS(t.Context(), fsys, ".")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Currently, Trivy identifies a Chart file by the prefix `Chart.yaml`, which can lead to false results. For example, a file named `testChart.yaml` may be misrecognized as a Chart file when it is not. This PR changes the way a Chart file is identified, moving to an exact name match.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8588

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
