### PR TITLE
fix(misconf): Check values wholly prior to evalution

### DIFF
--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -135,9 +135,10 @@ func writeBlock(tfBlock *terraform.Block, block *hclwrite.Block, causeRng types.
 		}
 
 		value := attr.Value()
-		if !value.IsKnown() || value.IsNull() {
+		if !value.IsWhollyKnown() {
 			continue
 		}
+
 		block.Body().SetAttributeValue(attr.Name(), value)
 		found = true
 	}


### PR DESCRIPTION
## Description

Resolves a case where nested unresolvable values can trigger a panic while rendering causes.

## Related issues
- Fixes: https://github.com/aquasecurity/trivy/issues/8603


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
