### PR TITLE
fix(image): add system installed files in blob info

### DIFF
--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -436,7 +436,8 @@ func (a Artifact) inspectLayer(ctx context.Context, layerInfo LayerInfo, disable
 		CustomResources:   result.CustomResources,
 
 		// For Red Hat
-		BuildInfo: result.BuildInfo,
+		BuildInfo:            result.BuildInfo,
+		SystemInstalledFiles: result.SystemInstalledFiles,
 	}
 
 	// Call post handlers to modify blob info

--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -181,6 +181,8 @@ type BlobInfo struct {
 	// CustomResources hold analysis results from custom analyzers.
 	// It is for extensibility and not used in OSS.
 	CustomResources []CustomResource `json:",omitempty"`
+
+	SystemInstalledFiles []string `json:",omitempty"` // A list of files installed by OS package manager
 }
 
 // ArtifactDetail represents the analysis result.


### PR DESCRIPTION
This PR adds system-installed files to the blob info. We have a case where a resource is being classified as both an Executable and a package. For example, the wget resource is being classified as both an Executable (version 1.3.1) and a Debian package (version 1.24.5-2+b1), which causes false positive results.

We need to add system-installed file information to the blob info of a layer, which is eventually uploaded to the cache. While merging the layers, we will check for system-installed files and filter them out from the executables list so that system-installed files are not detected as executables.

