### PR TITLE
fix(k8s): show report for `--report all`

### DIFF
--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/aquasecurity/trivy/pkg/types"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -17,6 +18,8 @@ type TableWriter struct {
 	Output        io.Writer
 	Severities    []dbTypes.Severity
 	ColumnHeading []string
+
+	TableMode []types.TableMode // For `--report all` only
 }
 
 const (
@@ -54,6 +57,10 @@ func (tw TableWriter) Write(ctx context.Context, report Report) error {
 		t := pkgReport.NewWriter(pkgReport.Options{
 			Output:     tw.Output,
 			Severities: tw.Severities,
+			// k8s has its own summary report, so we only need to show the detailed tables here
+			TableModes: []types.TableMode{
+				types.Detailed,
+			},
 		})
 		for i, r := range report.Resources {
 			if r.Report.Results.Failed() {

--- a/pkg/k8s/report/table.go
+++ b/pkg/k8s/report/table.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"strings"
 
-	"github.com/aquasecurity/trivy/pkg/types"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	pkgReport "github.com/aquasecurity/trivy/pkg/report/table"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 type TableWriter struct {

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -183,7 +183,7 @@ var (
 	}
 )
 
-func TestReportWrite_Summary(t *testing.T) {
+func TestReportWrite_Table(t *testing.T) {
 	allSeverities := []dbTypes.Severity{
 		dbTypes.SeverityUnknown,
 		dbTypes.SeverityLow,
@@ -198,6 +198,7 @@ func TestReportWrite_Summary(t *testing.T) {
 		opt            report.Option
 		scanners       types.Scanners
 		severities     []dbTypes.Severity
+		reportType     string
 		expectedOutput string
 	}{
 		{
@@ -208,6 +209,7 @@ func TestReportWrite_Summary(t *testing.T) {
 			},
 			scanners:   types.Scanners{types.MisconfigScanner},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -231,6 +233,19 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
+			name: "Only config, critical severity for --report all",
+			report: report.Report{
+				ClusterName: "test",
+				Resources:   []report.Resource{deployOrionWithMisconfigs},
+			},
+			scanners: types.Scanners{types.MisconfigScanner},
+			severities: []dbTypes.Severity{
+				dbTypes.SeverityCritical,
+			},
+			reportType:     AllReport,
+			expectedOutput: `should be misconfigs`, // TODO fix that
+		},
+		{
 			name: "Only vuln, all serverities",
 			report: report.Report{
 				ClusterName: "test",
@@ -238,6 +253,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 			},
 			scanners:   types.Scanners{types.VulnerabilityScanner},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -261,6 +277,19 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
+			name: "Only vuln, low severity for --report all",
+			report: report.Report{
+				ClusterName: "test",
+				Resources:   []report.Resource{deployOrionWithVulns},
+			},
+			scanners: types.Scanners{types.VulnerabilityScanner},
+			severities: []dbTypes.Severity{
+				dbTypes.SeverityLow,
+			},
+			reportType:     AllReport,
+			expectedOutput: `should be vulns`, // TODO fix that
+		},
+		{
 			name: "Only rbac, all serverities",
 			report: report.Report{
 				ClusterName: "test",
@@ -268,6 +297,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 			},
 			scanners:   types.Scanners{types.RBACScanner},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -289,6 +319,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 			},
 			scanners:   types.Scanners{types.SecretScanner},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -312,6 +343,19 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
+			name: "Only secret, critical severity for --report all",
+			report: report.Report{
+				ClusterName: "test",
+				Resources:   []report.Resource{deployLuaWithSecrets},
+			},
+			scanners: types.Scanners{types.SecretScanner},
+			severities: []dbTypes.Severity{
+				dbTypes.SeverityCritical,
+			},
+			reportType:     AllReport,
+			expectedOutput: `should be secrets`, // TODO fix that!
+		},
+		{
 			name: "apiserver, only infra and serverities",
 			report: report.Report{
 				ClusterName: "test",
@@ -319,6 +363,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 			},
 			scanners:   types.Scanners{types.MisconfigScanner},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -353,6 +398,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				types.SecretScanner,
 			},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -386,6 +432,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 				types.VulnerabilityScanner,
 			},
 			severities: allSeverities,
+			reportType: SummaryReport,
 			expectedOutput: `Summary Report for test
 =======================
 
@@ -416,7 +463,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 
 			opt := report.Option{
 				Format:     "table",
-				Report:     "summary",
+				Report:     tc.reportType,
 				Output:     &output,
 				Scanners:   tc.scanners,
 				Severities: tc.severities,

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -527,6 +527,7 @@ Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TRIVY_DISABLE_VEX_NOTICE", "true")
 			output := bytes.Buffer{}
 
 			opt := report.Option{


### PR DESCRIPTION
## Description
We added `table` mode in #8177.

But `k8s` command also uses table writer for `--report all` flag.
So we need to add table modes for this flag.

`k8s` has its own summary report, so we only need to show the `detailed` tables.

### Example
Before:
```bash
➜ trivy k8s --report all        
2025-03-27T11:20:37+06:00       INFO    Loaded  file_path="trivy.yaml"
2025-03-27T11:20:45+06:00       INFO    Node scanning is enabled
2025-03-27T11:20:45+06:00       INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-03-27T11:20:45+06:00       INFO    Scanning K8s... K8s="kind-kind"
219 / 219 [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>] 100.00% 5 p/s
```

After:
```bash
➜ ./trivy k8s --report all
2025-03-27T11:18:22+06:00       INFO    Loaded  file_path="trivy.yaml"
2025-03-27T11:18:33+06:00       INFO    Node scanning is enabled
2025-03-27T11:18:33+06:00       INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-03-27T11:18:33+06:00       INFO    Scanning K8s... K8s="kind-kind"
219 / 219 [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 5 p/s

namespace: local-path-storage, deployment: local-path-provisioner
=================================================================
Total: 26 (UNKNOWN: 2, LOW: 11, MEDIUM: 13, HIGH: 0, CRITICAL: 0)
...
```

## Related Issues
- Close #8616

## Related PRs
- [x] #8177

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
