### PR TITLE
fix(debian): don't include empty licenses for `dpkgs`

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/copyright.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/copyright.go
@@ -90,6 +90,10 @@ func (a *dpkgLicenseAnalyzer) parseCopyright(r xio.ReadSeekerAt) ([]types.Licens
 			l = normalizeLicense(l)
 			if l != "" {
 				for _, lic := range licensing.SplitLicenses(l) {
+					if lic == "" {
+						continue
+					}
+
 					lic = licensing.Normalize(lic)
 					if !slices.Contains(licenses, lic) {
 						licenses = append(licenses, lic)
@@ -101,7 +105,7 @@ func (a *dpkgLicenseAnalyzer) parseCopyright(r xio.ReadSeekerAt) ([]types.Licens
 			license := commonLicenseReferenceRegexp.FindStringSubmatch(line)
 			if len(license) == 2 {
 				l := licensing.Normalize(license[1])
-				if !slices.Contains(licenses, l) {
+				if l != "" && !slices.Contains(licenses, l) {
 					licenses = append(licenses, l)
 				}
 			}

--- a/pkg/fanal/analyzer/pkg/dpkg/testdata/license-pattern-and-classifier-copyright
+++ b/pkg/fanal/analyzer/pkg/dpkg/testdata/license-pattern-and-classifier-copyright
@@ -47,7 +47,7 @@ Files: contrib/minizip/*
 Copyright: 1998-2010 Gilles Vollant
            2007-2008 Even Rouault
            2009-2010 Mathias Svensson
-License: Zlib
+License: Zlib,
 
 Files: debian/*
 Copyright: 2000-2017 Mark Brown


### PR DESCRIPTION
## Description
Don't include empty licenses in report.

Also this PR fixes problem with invalid CycloneDX files:

Before:
```bash
➜  trivy -q image --format cyclonedx mcr.microsoft.com/playwright:v1.50.0-noble -o playwright-sbom.json 

➜  cyclonedx validate --input-format json --fail-on-errors --input-version v1_6 --input-file playwright-sbom.json
Validating JSON BOM...
Validation failed:
Expected 1 matching subschema but found 0
...
```

After:
```bash
➜  ./trivy -q image --format cyclonedx mcr.microsoft.com/playwright:v1.50.0-noble -o playwright-sbom.json
➜  cyclonedx validate --input-format json --fail-on-errors --input-version v1_6 --input-file playwright-sbom.json
Validating JSON BOM...
BOM validated successfully.

```

## Related issues
- Close #8621

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
