### PR TITLE
fix(misconf): Improve logging for unsupported checks

### DIFF
--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -166,7 +166,7 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 		}
 
 		s.logger.Debug(
-			"Error occurred while parsing. Trying to fallback to embedded check",
+			"Unable to parse check. This can be due to lack of support in this version. Trying to fallback to embedded check",
 			log.FilePath(loc),
 			log.Err(e),
 		)

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -165,7 +165,7 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 			continue
 		}
 
-		s.logger.Error(
+		s.logger.Debug(
 			"Error occurred while parsing. Trying to fallback to embedded check",
 			log.FilePath(loc),
 			log.Err(e),
@@ -173,7 +173,7 @@ func (s *Scanner) fallbackChecks(compiler *ast.Compiler) {
 
 		embedded := s.findMatchedEmbeddedCheck(badPolicy)
 		if embedded == nil {
-			s.logger.Error("Failed to find embedded check, skipping", log.FilePath(loc))
+			s.logger.Debug("Failed to find embedded check, skipping", log.FilePath(loc))
 			continue
 		}
 


### PR DESCRIPTION
## Description

There's no reason to print these logs on the error stream as it is not an error but simply lack of support.

## Related issues
- Close  https://github.com/aquasecurity/trivy/issues/8632


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
