### PR TITLE
chore: typo fix to replace `rego` with `repo` on the RepoFlagGroup options error output

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -821,7 +821,7 @@ func (f *Flags) ToOptions(args []string) (Options, error) {
 	if f.RepoFlagGroup != nil {
 		opts.RepoOptions, err = f.RepoFlagGroup.ToOptions()
 		if err != nil {
-			return Options{}, xerrors.Errorf("rego flag error: %w", err)
+			return Options{}, xerrors.Errorf("repo flag error: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Description
I hate to be "that guy" but I saw a tiny really insignificant typo that could do with being corrected. It's unlikely people will even hit this or see this, but in that tiny percentage that do, they'd be saying to themselves "what rego error? I'm using repos!"

I only found this because I am going through the code to see how it fits together. I'm simply trying to make use of Trivy (without calling the cli directly) to build some tooling that makes use of the repository scan elements for a personal project. While reading through it, I came across this. So figured I'd raise it.

Nothing groundbreaking or exciting here I'm afraid!

If you want to close this and fix it within a more broad PR  (or if I'm way off base of course) I'd totally understand and would be in no way offended 😃 
But if I see things that don't quite look right and I can fix them, I fix them. I can't help it 🤣 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.