### PR TITLE
fix(secret): ignore .dist-info directories during secret scanning

### DIFF
--- a/pkg/fanal/secret/builtin-allow-rules.go
+++ b/pkg/fanal/secret/builtin-allow-rules.go
@@ -2,6 +2,11 @@ package secret
 
 var builtinAllowRules = []AllowRule{
 	{
+		ID:          "dist-info",
+		Description: "Ignore Python .dist-info metadata directories",
+		Path:        MustCompile(`\.dist-info/`),
+	},
+	{
 		ID:          "tests",
 		Description: "Avoid test files and paths",
 		Path:        MustCompile(`(^(?i)test|\/test|-test|_test|\.test)`),


### PR DESCRIPTION
### Description

According to Python packaging standards, `.dist-info` directories contain only metadata files such as version, license, and entry points. These directories are typically placed alongside installed packages in `site-packages`.

Since Trivy's secret scanner does not need to scan these metadata files, doing so can lead to false positives. Therefore, we can safely exclude `.dist-info` directories using a built-in allow rule.

Reference:
> "Each project installed from a distribution must, in addition to files, install a `.dist-info` directory located alongside importable modules and packages (commonly, the site-packages directory)."

### Changes

- Added a new built-in allow rule to exclude `.dist-info/` directories from secret scanning
- The rule follows the existing `MustCompile` pattern used for other excluded paths

### Related Links

- Rule added in: [`builtin-allow-rules.go`](https://github.com/aquasecurity/trivy/blob/bbc5a85444ec86b7bb26d6db27803d199431a8e6/pkg/fanal/secret/builtin-allow-rules.go)
- Related discussion: #8199

### Fixes

Fixes #8212

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
