### PR TITLE
fix(misconf): check if metadata is not nil

### DIFF
--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -197,13 +197,13 @@ func (s *Scanner) findMatchedEmbeddedCheck(badPolicy *ast.Module) *ast.Module {
 	}
 
 	badPolicyMeta, err := MetadataFromAnnotations(badPolicy)
-	if err != nil {
+	if err != nil || badPolicyMeta == nil {
 		return nil
 	}
 
 	for _, embeddedCheck := range s.embeddedChecks {
 		meta, err := MetadataFromAnnotations(embeddedCheck)
-		if err != nil {
+		if err != nil || meta == nil {
 			continue
 		}
 		if badPolicyMeta.AVDID != "" && badPolicyMeta.AVDID == meta.AVDID {

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -205,7 +205,11 @@ deny {
 					}`),
 			}
 
+			originalFS := checks.EmbeddedPolicyFileSystem
 			checks.EmbeddedPolicyFileSystem = embeddedChecksFS
+			t.Cleanup(func() {
+				checks.EmbeddedPolicyFileSystem = originalFS
+			})
 			err := scanner.LoadPolicies(fstest.MapFS(tt.files))
 
 			if tt.expectedErr != "" {
@@ -257,14 +261,15 @@ deny {
 func TestFallback_CheckWithoutAnnotation(t *testing.T) {
 	fsys := fstest.MapFS{
 		"check.rego": &fstest.MapFile{Data: []byte(`package builtin.test
-import data.func
-deny := func(input)
+import data.some_func
+deny := some_func(input)
 `)},
 	}
 	scanner := rego.NewScanner(
 		rego.WithPolicyDirs("."),
 		rego.WithEmbeddedLibraries(false),
+		rego.WithPolicyFilesystem(fsys),
 	)
-	err := scanner.LoadPolicies(fsys)
+	err := scanner.LoadPolicies(nil)
 	require.NoError(t, err)
 }

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -253,3 +253,18 @@ deny {
 	err := scanner.LoadPolicies(fsys)
 	require.Error(t, err)
 }
+
+func TestFallback_CheckWithoutAnnotation(t *testing.T) {
+	fsys := fstest.MapFS{
+		"check.rego": &fstest.MapFile{Data: []byte(`package builtin.test
+import data.func
+deny := func(input)
+`)},
+	}
+	scanner := rego.NewScanner(
+		rego.WithPolicyDirs("."),
+		rego.WithEmbeddedLibraries(false),
+	)
+	err := scanner.LoadPolicies(fsys)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description

This PR fixes a potential panic when falling back to embedded checks due to missing annotations.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
