### PR TITLE
fix(server): fix redis key when trying to delete blob

### DIFF
--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -142,7 +142,7 @@ func (c RedisCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 func (c RedisCache) DeleteBlobs(blobIDs []string) error {
 	var errs error
 	for _, blobID := range blobIDs {
-		key := fmt.Sprintf("%s::%s::%s", redisPrefix, artifactBucket, blobID)
+		key := fmt.Sprintf("%s::%s::%s", redisPrefix, blobBucket, blobID)
 		if err := c.client.Del(context.TODO(), key).Err(); err != nil {
 			errs = multierror.Append(errs, xerrors.Errorf("unable to delete blob %s: %w", blobID, err))
 		}

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -523,8 +523,6 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	s.Set(correctHash, "any string")
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			addr := s.Addr()
@@ -535,12 +533,18 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
 			require.NoError(t, err)
 
+			s.Set(tt.wantKey, "any string")
+
 			err = c.DeleteBlobs(tt.args.blobIDs)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
+
+			// Verify that the blobs are deleted
+			got := s.Keys()
+			assert.NotContains(t, got, tt.wantKey)
 		})
 	}
 }


### PR DESCRIPTION
## Description

When using Redis as the cache backend, when trying to delete a blob at the end of the scan (in FS scan for example) it fails.
This is because the redis key that is built in the function is built for `artifact` and not for `blob`

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/8648

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
