### PR TITLE
ci(helm): create a helm branch for patches from main

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -13,9 +13,6 @@ on:
       - main
     paths:
       - 'helm/trivy/**'
-  push:
-    tags:
-      - "v*"
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
@@ -25,7 +22,6 @@ env:
 jobs:
   # `test-chart` job starts if a PR with Helm Chart is created, merged etc.
   test-chart:
-    if: github.event_name != 'push'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -56,35 +52,6 @@ jobs:
           sed -i -e '136s,false,'true',g' ./helm/trivy/values.yaml
           ct lint-and-install --validate-maintainers=false --charts helm/trivy
 
-  # `update-chart-version` job starts if a new tag is pushed
-  update-chart-version:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Git user
-        run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Install Go tools
-        run: go install tool # GOBIN is added to the PATH by the setup-go action  
-
-      - name: Create a PR with Trivy version
-        run: mage helm:updateVersion
-        env:
-          # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
-          # This allows the created PR to trigger tests and other workflows
-          GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
 
   # `publish-chart` job starts if a PR with a new Helm Chart is merged or manually
   publish-chart:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
   # `update-chart-version` creates a new PR for updating the helm chart
   update-chart-version:
     needs: deploy-packages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,3 +55,33 @@ jobs:
 
       - name: Create deb repository
         run: ci/deploy-deb.sh
+
+  # `update-chart-version` creates a new PR for updating the helm chart
+  update-chart-version:
+    needs: deploy-packages
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git user
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install Go tools
+        run: go install tool # GOBIN is added to the PATH by the setup-go action
+
+      - name: Create a PR with Trivy version
+        run: mage helm:updateVersion
+        env:
+          # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
+          # This allows the created PR to trigger tests and other workflows
+          GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}

--- a/magefiles/helm.go
+++ b/magefiles/helm.go
@@ -22,6 +22,12 @@ func main() {
 		log.Fatalf("could not determine Trivy version: %v", err)
 	}
 
+	// Checkout the main branch to get the latest chart version, that was changed after the previous release
+	// It needs for correctly updating the chart version of patch releases
+	if err := sh.Run("git", "checkout", "main"); err != nil {
+		log.Fatalf("failed to run `git checkout main`: %w", err)
+	}
+
 	newHelmVersion, err := bumpHelmChart(chartFile, trivyVersion)
 	if err != nil {
 		log.Fatalf("could not bump Trivy version to %q: %v", trivyVersion, err)
@@ -35,9 +41,6 @@ func main() {
 		trivyVersion, newHelmVersion)
 
 	cmds := [][]string{
-		// Checkout the main branch to get the latest chart version, that was changed after the previous release
-		// It needs for correctly updating the chart version of patch releases
-		[]string{"git", "checkout", "main"},
 		[]string{"git", "switch", "-c", newBranch},
 		[]string{"git", "add", chartFile},
 		[]string{"git", "commit", "-m", title},

--- a/magefiles/helm.go
+++ b/magefiles/helm.go
@@ -35,6 +35,7 @@ func main() {
 		trivyVersion, newHelmVersion)
 
 	cmds := [][]string{
+		[]string{"git", "checkout", "main"},
 		[]string{"git", "switch", "-c", newBranch},
 		[]string{"git", "add", chartFile},
 		[]string{"git", "commit", "-m", title},

--- a/magefiles/helm.go
+++ b/magefiles/helm.go
@@ -35,6 +35,8 @@ func main() {
 		trivyVersion, newHelmVersion)
 
 	cmds := [][]string{
+		// Checkout the main branch to get the latest chart version, that was changed after the previous release
+		// It needs for correctly updating the chart version of patch releases
 		[]string{"git", "checkout", "main"},
 		[]string{"git", "switch", "-c", newBranch},
 		[]string{"git", "add", chartFile},


### PR DESCRIPTION
## Description

This PR changes the order of creating a PR for updating the Helm Chart version.

Now, the PR with the new version is created after the release workflow is fully executed, instead of being triggered by tag creation.  

Also the version update now uses the `Chart.yaml` file from the `main` branch. This ensures the correct version for a patch release, as `Chart.yaml` is usually modified after a release and does not appear in the `backport` branch.  

## Testing
* workflow for PR creating: https://github.com/aquasecurity/trivy-test/actions/runs/14251655074
* the PR was created: https://github.com/aquasecurity/trivy-test/pull/33
* workflow for patch creatinng: https://github.com/aquasecurity/trivy-test/actions/runs/14251850015
* PR for the patch: https://github.com/aquasecurity/trivy-test/pull/35

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
