### PR TITLE
test: use `aquasecurity` repository for test images

### DIFF
--- a/.github/workflows/cache-test-images.yaml
+++ b/.github/workflows/cache-test-images.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           source integration/testimages.ini
           IMAGE_LIST=$(skopeo list-tags docker://$TEST_IMAGES)
-          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags | sort' | sha256sum | cut -d' ' -f1)
+          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       ## We need to work with test image cache only for main branch
@@ -64,7 +64,7 @@ jobs:
         run: |
           source integration/testimages.ini
           IMAGE_LIST=$(skopeo list-tags docker://$TEST_VM_IMAGES)
-          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags | sort' | sha256sum | cut -d' ' -f1)
+          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       ## We need to work with test VM image cache only for main branch

--- a/.github/workflows/cache-test-images.yaml
+++ b/.github/workflows/cache-test-images.yaml
@@ -37,8 +37,6 @@ jobs:
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
-          restore-keys:
-            cache-test-images-
 
       - name: Download test images
         if: github.ref_name == 'main'
@@ -76,8 +74,6 @@ jobs:
         with:
           path: integration/testdata/fixtures/vm-images
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
-          restore-keys:
-            cache-test-vm-images-
 
       - name: Download test VM images
         if: github.ref_name == 'main'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
         run: |
           source integration/testimages.ini
           IMAGE_LIST=$(skopeo list-tags docker://$TEST_IMAGES)
-          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags | sort' | sha256sum | cut -d' ' -f1)
+          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test images from cache
@@ -138,7 +138,7 @@ jobs:
         run: |
           source integration/testimages.ini
           IMAGE_LIST=$(skopeo list-tags docker://$TEST_IMAGES)
-          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags | sort' | sha256sum | cut -d' ' -f1)
+          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test images from cache
@@ -173,7 +173,7 @@ jobs:
         run: |
           source integration/testimages.ini
           IMAGE_LIST=$(skopeo list-tags docker://$TEST_VM_IMAGES)
-          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags | sort' | sha256sum | cut -d' ' -f1)
+          DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Restore test VM images from cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,8 +94,6 @@ jobs:
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
-          restore-keys:
-            cache-test-images-
 
       - name: Run integration tests
         run: mage test:integration
@@ -148,8 +146,6 @@ jobs:
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
-          restore-keys:
-            cache-test-images-
 
       - name: Run module integration tests
         shell: bash
@@ -185,8 +181,6 @@ jobs:
         with:
           path: integration/testdata/fixtures/vm-images
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
-          restore-keys:
-            cache-test-vm-images-
 
       - name: Run vm integration tests
         run: |

--- a/integration/testimages.ini
+++ b/integration/testimages.ini
@@ -1,3 +1,3 @@
 # Configuration file for both shell scripts and Go programs
-TEST_IMAGES=ghcr.io/knqyf263/trivy-test-images
-TEST_VM_IMAGES=ghcr.io/knqyf263/trivy-test-vm-images
+TEST_IMAGES=ghcr.io/aquasecurity/trivy-test-images
+TEST_VM_IMAGES=ghcr.io/aquasecurity/trivy-test-vm-images


### PR DESCRIPTION
## Description
We used `ghcr.io/knqyf263/trivy-test-vm-images` and `ghcr.io/knqyf263/trivy-test-images` to avoid 429 errors.
But our error avoidance guide is working.
Therefore, I suggest returning to `aquasecurity`.

This will also avoid unexpected errors when the fork was changed without changes in aquasecurity, like this:
https://github.com/aquasecurity/trivy-test/actions/runs/14240065387/job/39909316221?pr=24#step:7:1750
`trivy-test-images:busybox-with-lockfile.` [has been changed](https://github.com/knqyf263/trivy-test-images/commit/7740ec2d080b0acab86a6c5cc742044d8cbb3a3b), so if tests don't use cache we will get error.

## Changes
1. use `ghcr.io/aquasecurity/trivy-test-images` instead of `ghcr.io/knqyf263/trivy-test-images`
2. use `ghcr.io/aquasecurity/trivy-test-vm-images` instead of `ghcr.io/knqyf263/trivy-test-vm-images`
3. Don't use `restore-keys` to restore images from cache
4. Use full output of `skopeo list-tags` (with repository) to calc Digest for cache key.

About 3 and 4 points:
We removed `repository` for cache key in #7816 (see https://github.com/aquasecurity/trivy/pull/7816#discussion_r1821988317 for reason)
But i found case when we don't need to do that.
When we add image archive into conteinerd (for tests)- it saves image (with name, repository,registry).
To prevent this information from affecting the tests, we are deleting it:
https://github.com/aquasecurity/trivy/blob/601846134cb820c3e78324a44c7f0332d01b9fc6/pkg/fanal/test/integration/containerd_test.go#L241-L245
But if repository of image archive != repository from `testimages.ini` we will see `image "xxx/xxxx/trivy-test-images:xxx": not found` error.

Example:
We get image `ghcr.io/knqyf263/trivy-test-images:alpine-310` image from cache, but `testimages.ini` contains `ghcr.io/aquasecurity/trivy-test-images:alpine-310`.
When we try to remove `ghcr.io/aquasecurity/trivy-test-images` - we get error, because we added `ghcr.io/knqyf263/trivy-test-images:alpine-310` into containerd.
![изображение](https://github.com/user-attachments/assets/90de027b-5ec5-4fc0-967c-52b8c771fe50)


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
