### PR TITLE
fix: enable include-non-failures by default in report conversion

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_convert.md
+++ b/docs/docs/references/configuration/cli/trivy_convert.md
@@ -37,6 +37,7 @@ trivy convert [flags] RESULT_JSON
   -h, --help                       help for convert
       --ignore-policy string       specify the Rego file path to evaluate each vulnerability
       --ignorefile string          specify .trivyignore file (default ".trivyignore")
+      --include-non-failures       include successes, available with '--scanners misconfig' (default true)
       --list-all-pkgs              output all packages in the JSON report regardless of vulnerability
   -o, --output string              output file name
       --output-plugin-arg string   [EXPERIMENTAL] output plugin arguments

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -515,10 +515,16 @@ func NewRepositoryCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 
 func NewConvertCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	convertFlags := &flag.Flags{
-		GlobalFlagGroup: globalFlags,
-		ScanFlagGroup:   &flag.ScanFlagGroup{},
-		ReportFlagGroup: flag.NewReportFlagGroup(),
+		GlobalFlagGroup:  globalFlags,
+		ScanFlagGroup:    &flag.ScanFlagGroup{},
+		ReportFlagGroup:  flag.NewReportFlagGroup(),
+		MisconfFlagGroup: &flag.MisconfFlagGroup{},
 	}
+
+	convertFlags.MisconfFlagGroup.IncludeNonFailures = flag.IncludeNonFailuresFlag.Clone()
+	// Enable this flag to include successfully passed results in the output report,
+	// ensuring consistency when the flag is not explicitly set by the user.
+	convertFlags.MisconfFlagGroup.IncludeNonFailures.Default = true
 
 	// To display the summary table, we need to enable scanners (to build columns).
 	// We can't get scanner information from the report (we don't include empty licenses and secrets in the report).


### PR DESCRIPTION
## Description

This PR adds the `include-non-failures` flag to the `convert` command. It is enabled by default so as not to modify the converted report. The user can pass `--include-non-failures=false` to exclude passed results.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8670

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
