### PR TITLE
fix(k8s): skip passed misconfigs for the summary report

### DIFF
--- a/pkg/k8s/report/summary.go
+++ b/pkg/k8s/report/summary.go
@@ -170,6 +170,9 @@ func accumulateSeverityCounts(finding Resource) (map[string]int, map[string]int,
 			vCount[rv.Severity]++
 		}
 		for _, rv := range r.Misconfigurations {
+			if rv.Status == types.MisconfStatusPassed {
+				continue
+			}
 			mCount[rv.Severity]++
 		}
 		for _, rv := range r.Secrets {

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -53,6 +53,11 @@ var (
 						Status:   types.MisconfStatusFailure,
 						Severity: "HIGH",
 					},
+					{
+						ID:       "KSV-ID103",
+						Status:   types.MisconfStatusPassed,
+						Severity: "HIGH",
+					},
 
 					{
 						ID:       "KCV-ID100",
@@ -265,7 +270,7 @@ func TestReportWrite_Table(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name: "Only config, all serverities",
+			name: "Only config, all severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{deployOrionWithMisconfigs},
@@ -319,7 +324,7 @@ See https://google.com/search?q=bad%20config
 ────────────────────────────────────────`,
 		},
 		{
-			name: "Only vuln, all serverities",
+			name: "Only vuln, all severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{deployOrionWithVulns},
@@ -371,7 +376,7 @@ Total: 1 (LOW: 1)
 └─────────┴───────────────┴──────────┴─────────┴───────────────────┴───────────────┴───────────────────────────────────────────┘`,
 		},
 		{
-			name: "Only rbac, all serverities",
+			name: "Only rbac, all severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{roleWithMisconfig},
@@ -393,7 +398,7 @@ RBAC Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
-			name: "Only secret, all serverities",
+			name: "Only secret, all severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{deployLuaWithSecrets},
@@ -424,7 +429,7 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
-			name: "apiserver, only infra and serverities",
+			name: "apiserver, only infra and severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{apiseverPodWithMisconfigAndInfra},
@@ -455,7 +460,7 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
-			name: "apiserver, vuln,config,secret and serverities",
+			name: "apiserver, vuln,config,secret and severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{apiseverPodWithMisconfigAndInfra},
@@ -490,7 +495,7 @@ Infra Assessment
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
 		{
-			name: "apiserver, all misconfig and vuln scanners and serverities",
+			name: "apiserver, all misconfig and vuln scanners and severities",
 			report: report.Report{
 				ClusterName: "test",
 				Resources:   []report.Resource{apiseverPodWithMisconfigAndInfra},


### PR DESCRIPTION
## Description
This PR removes passed misconfigs from the summary report. It's important if `--include-non-failures` is enabled.

```sh
$ minikube start
$ trivy k8s  --scanners=misconfig --report=summary --include-non-failures
```

Before:
```sh
Summary Report for minikube

Workload Assessment
┌───────────┬────────────────────┬───────────────────────┐
│ Namespace │      Resource      │   Misconfigurations   │
│           │                    ├────┬────┬────┬────┬───┤
│           │                    │ C  │ H  │ M  │ L  │ U │
├───────────┼────────────────────┼────┼────┼────┼────┼───┤
│ default   │ Service/kubernetes │ 26 │ 44 │ 25 │ 61 │   │
│           │ Node/minikube      │ 26 │ 44 │ 25 │ 61 │   │
└───────────┴────────────────────┴────┴────┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬──────────────────────────────────────────────┬───────────────────────┐
│  Namespace  │                   Resource                   │   Misconfigurations   │
│             │                                              ├────┬────┬────┬────┬───┤
│             │                                              │ C  │ H  │ M  │ L  │ U │
├─────────────┼──────────────────────────────────────────────┼────┼────┼────┼────┼───┤
│ kube-system │ Pod/kube-controller-manager-minikube         │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ ConfigMap/extension-apiserver-authentication │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ DaemonSet/kube-proxy                         │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Pod/etcd-minikube                            │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Service/kube-dns                             │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Deployment/coredns                           │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Pod/kube-apiserver-minikube                  │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Pod/kube-scheduler-minikube                  │ 26 │ 44 │ 25 │ 61 │   │
│ kube-system │ Pod/storage-provisioner                      │ 26 │ 44 │ 25 │ 61 │   │
│             │ Node/minikube                                │ 26 │ 44 │ 25 │ 61 │   │
└─────────────┴──────────────────────────────────────────────┴────┴────┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

after:
```sh
Summary Report for minikube

Workload Assessment
┌───────────┬────────────────────┬───────────────────┐
│ Namespace │      Resource      │ Misconfigurations │
│           │                    ├───┬───┬───┬───┬───┤
│           │                    │ C │ H │ M │ L │ U │
├───────────┼────────────────────┼───┼───┼───┼───┼───┤
│ default   │ Service/kubernetes │   │   │   │ 2 │   │
│           │ Node/minikube      │   │   │   │ 2 │   │
└───────────┴────────────────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬──────────────────────────────────────────────┬────────────────────┐
│  Namespace  │                   Resource                   │ Misconfigurations  │
│             │                                              ├───┬───┬───┬────┬───┤
│             │                                              │ C │ H │ M │ L  │ U │
├─────────────┼──────────────────────────────────────────────┼───┼───┼───┼────┼───┤
│ kube-system │ Service/kube-dns                             │   │   │ 1 │ 2  │   │
│ kube-system │ Pod/etcd-minikube                            │   │ 2 │ 6 │ 9  │   │
│ kube-system │ Deployment/coredns                           │   │   │ 8 │ 6  │   │
│ kube-system │ Pod/kube-controller-manager-minikube         │   │ 2 │ 6 │ 12 │   │
│ kube-system │ Pod/kube-scheduler-minikube                  │   │ 2 │ 6 │ 10 │   │
│ kube-system │ Pod/storage-provisioner                      │   │ 3 │ 7 │ 12 │   │
│ kube-system │ ConfigMap/extension-apiserver-authentication │   │   │ 1 │    │   │
│ kube-system │ Pod/kube-apiserver-minikube                  │   │ 2 │ 7 │ 19 │   │
│ kube-system │ DaemonSet/kube-proxy                         │   │ 3 │ 8 │ 12 │   │
│             │ Node/minikube                                │   │ 3 │   │ 2  │   │
└─────────────┴──────────────────────────────────────────────┴───┴───┴───┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

## Related issues
- Close #8611

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
