### PR TITLE
feat(license): scan vendor directory for license for go.mod files

### DIFF
--- a/pkg/fanal/analyzer/language/golang/mod/mod_test.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod_test.go
@@ -284,6 +284,59 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 			},
 			want: &analyzer.AnalysisResult{},
 		},
+		{
+			name: "vendor dir exists",
+			files: []string{
+				"testdata/vendor-dir-exists/mod",
+			},
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.GoModule,
+						FilePath: "go.mod",
+						Packages: types.Packages{
+							{
+								ID:           "github.com/org/repo",
+								Name:         "github.com/org/repo",
+								Relationship: types.RelationshipRoot,
+								DependsOn: []string{
+									"github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237",
+								},
+								ExternalReferences: []types.ExternalRef{
+									{
+										Type: types.RefVCS,
+										URL:  "https://github.com/org/repo",
+									},
+								},
+							},
+							{
+								ID:           "github.com/aquasecurity/go-dep-parser@v0.0.0-20220406074731-71021a481237",
+								Name:         "github.com/aquasecurity/go-dep-parser",
+								Version:      "v0.0.0-20220406074731-71021a481237",
+								Relationship: types.RelationshipDirect,
+								Licenses:     []string{"MIT"},
+								ExternalReferences: []types.ExternalRef{
+									{
+										Type: types.RefVCS,
+										URL:  "https://github.com/aquasecurity/go-dep-parser",
+									},
+								},
+								DependsOn: []string{
+									"golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+								},
+							},
+							{
+								ID:           "golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+								Name:         "golang.org/x/xerrors",
+								Version:      "v0.0.0-20200804184101-5ec99f83aff1",
+								Relationship: types.RelationshipIndirect,
+								Indirect:     true,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Setenv("GOPATH", "testdata")

--- a/pkg/fanal/analyzer/language/golang/mod/testdata/vendor-dir-exists/mod
+++ b/pkg/fanal/analyzer/language/golang/mod/testdata/vendor-dir-exists/mod
@@ -1,0 +1,9 @@
+module github.com/org/repo
+
+go 1.17
+
+require github.com/aquasecurity/go-dep-parser v0.0.0-20211110174639-8257534ffed3
+
+require golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+
+replace github.com/aquasecurity/go-dep-parser => github.com/aquasecurity/go-dep-parser v0.0.0-20220406074731-71021a481237

--- a/pkg/fanal/analyzer/language/golang/mod/testdata/vendor-dir-exists/vendor/go-dep-parser/LICENSE
+++ b/pkg/fanal/analyzer/language/golang/mod/testdata/vendor-dir-exists/vendor/go-dep-parser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Teppei Fukuda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -233,6 +233,11 @@ func (m *FS) RemoveAll(path string) error {
 	return m.root.RemoveAll(cleanPath(path))
 }
 
+// GetUnderlyingRoot returns the underlying root path of the filesystem
+func (m *FS) GetUnderlyingRoot() string {
+	return m.underlyingRoot
+}
+
 func cleanPath(path string) string {
 	// Convert the volume name like 'C:' into dir like 'C\'
 	if vol := filepath.VolumeName(path); vol != "" {


### PR DESCRIPTION
## Description
This PR adds support for scanning the `vendor` directory when detecting licenses for Go modules. Currently, Trivy only checks for licenses in `$GOPATH/pkg/mod`, but when users use `go mod vendor` command, the dependencies are stored in the `vendor` directory without their own `go.mod` files.

## Related issues
- [ISSUES - 8527](https://github.com/aquasecurity/trivy/issues/8527)


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
