### PR TITLE
ci: use `github.event.pull_request.user.login` for release PR check workflow

### DIFF
--- a/.github/workflows/release-pr-check.yaml
+++ b/.github/workflows/release-pr-check.yaml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - name: Check PR author
         id: check_author
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ "${{ github.event.pull_request.user.login }}" != "aqua-bot" ]; then
+          if [ "$PR_AUTHOR" != "aqua-bot" ]; then
             echo "::error::This branch is intended for automated backporting by bot. Please refer to the documentation:"
             echo "::error::https://trivy.dev/latest/community/maintainer/backporting/"
             exit 1

--- a/.github/workflows/release-pr-check.yaml
+++ b/.github/workflows/release-pr-check.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Check PR author
         id: check_author
         run: |
-          if [ "${{ github.actor }}" != "aqua-bot" ]; then
+          if [ "${{ github.event.pull_request.user.login }}" != "aqua-bot" ]; then
             echo "::error::This branch is intended for automated backporting by bot. Please refer to the documentation:"
             echo "::error::https://trivy.dev/latest/community/maintainer/backporting/"
             exit 1


### PR DESCRIPTION
## Description
We found that `github.actor` is `The username of the user that triggered the initial workflow run.`.
So when maintainer merges `main` branch - [release PR check workflow](https://github.com/aquasecurity/trivy/blob/main/.github/workflows/release-pr-check.yaml) shows error (e.g. https://github.com/aquasecurity/trivy/pull/8697).  

To check PR author we need to use `github.event.pull_request.user.login`.

### Example:
- currently case:
    - https://github.com/aquasecurity/trivy-test/pull/44
    - https://github.com/aquasecurity/trivy-test/actions/runs/14330442330/job/40164978575?pr=44
- with these changes
    - https://github.com/aquasecurity/trivy-test/pull/42
    - https://github.com/aquasecurity/trivy-test/actions/runs/14330459819/job/40165033194?pr=42

## Related PRs
- [x] #8240

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
