### PR TITLE
feat(misconf): support auto_provisioning_defaults in google_container_cluster

### DIFF
--- a/pkg/iac/adapters/terraform/google/gke/adapt_test.go
+++ b/pkg/iac/adapters/terraform/google/gke/adapt_test.go
@@ -77,6 +77,18 @@ resource "google_container_cluster" "example" {
   enable_autopilot = true
 
   datapath_provider = "ADVANCED_DATAPATH"
+
+  cluster_autoscaling {
+    enabled = true
+    auto_provisioning_defaults {
+      service_account  = "test"
+	  image_type = "COS_CONTAINERD"
+	  management {
+        auto_repair  = true
+        auto_upgrade = true
+      }
+    }
+  }
 }
 
 resource "google_container_node_pool" "primary_preemptible_nodes" {
@@ -102,9 +114,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 			expected: gke.GKE{
 				Clusters: []gke.Cluster{
 					{
-						Metadata: iacTypes.NewTestMetadata(),
 						NodeConfig: gke.NodeConfig{
-							Metadata:  iacTypes.NewTestMetadata(),
 							ImageType: iacTypes.String("COS_CONTAINERD", iacTypes.NewTestMetadata()),
 							WorkloadMetadataConfig: gke.WorkloadMetadataConfig{
 								Metadata:     iacTypes.NewTestMetadata(),
@@ -113,9 +123,19 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 							ServiceAccount:        iacTypes.String("", iacTypes.NewTestMetadata()),
 							EnableLegacyEndpoints: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 						},
+						AutoScaling: gke.AutoScaling{
+							Enabled: iacTypes.BoolTest(true),
+							AutoProvisioningDefaults: gke.AutoProvisioningDefaults{
+								ImageType:      iacTypes.StringTest("COS_CONTAINERD"),
+								ServiceAccount: iacTypes.StringTest("test"),
+								Management: gke.Management{
+									EnableAutoRepair:  iacTypes.BoolTest(true),
+									EnableAutoUpgrade: iacTypes.BoolTest(true),
+								},
+							},
+						},
 						NodePools: []gke.NodePool{
 							{
-								Metadata: iacTypes.NewTestMetadata(),
 								Management: gke.Management{
 									Metadata:          iacTypes.NewTestMetadata(),
 									EnableAutoRepair:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
@@ -134,19 +154,16 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 							},
 						},
 						IPAllocationPolicy: gke.IPAllocationPolicy{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+							Enabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 						},
 						MasterAuthorizedNetworks: gke.MasterAuthorizedNetworks{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+							Enabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 							CIDRs: []iacTypes.StringValue{
 								iacTypes.String("10.10.128.0/24", iacTypes.NewTestMetadata()),
 							},
 						},
 						NetworkPolicy: gke.NetworkPolicy{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+							Enabled: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 						},
 						DatapathProvider: iacTypes.String("ADVANCED_DATAPATH", iacTypes.NewTestMetadata()),
 						PrivateCluster: gke.PrivateCluster{
@@ -156,7 +173,6 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 						LoggingService:    iacTypes.String("logging.googleapis.com/kubernetes", iacTypes.NewTestMetadata()),
 						MonitoringService: iacTypes.String("monitoring.googleapis.com/kubernetes", iacTypes.NewTestMetadata()),
 						MasterAuth: gke.MasterAuth{
-							Metadata: iacTypes.NewTestMetadata(),
 							ClientCertificate: gke.ClientCertificate{
 								Metadata:         iacTypes.NewTestMetadata(),
 								IssueCertificate: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
@@ -182,7 +198,7 @@ resource "google_container_cluster" "example" {
   node_config {
     service_account = "service-account"
     metadata = {
-      disable-legacy-endpoints = true
+      disable-legacy-endpoints = "true"
     }
     image_type = "COS"
     workload_metadata_config {
@@ -194,7 +210,6 @@ resource "google_container_cluster" "example" {
 			expected: gke.GKE{
 				Clusters: []gke.Cluster{
 					{
-						Metadata: iacTypes.NewTestMetadata(),
 						NodeConfig: gke.NodeConfig{
 							Metadata:  iacTypes.NewTestMetadata(),
 							ImageType: iacTypes.String("COS", iacTypes.NewTestMetadata()),
@@ -207,17 +222,14 @@ resource "google_container_cluster" "example" {
 						},
 
 						IPAllocationPolicy: gke.IPAllocationPolicy{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+							Enabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 						},
 						MasterAuthorizedNetworks: gke.MasterAuthorizedNetworks{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-							CIDRs:    []iacTypes.StringValue{},
+							Enabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+							CIDRs:   []iacTypes.StringValue{},
 						},
 						NetworkPolicy: gke.NetworkPolicy{
-							Metadata: iacTypes.NewTestMetadata(),
-							Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+							Enabled: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 						},
 						DatapathProvider: iacTypes.StringDefault("DATAPATH_PROVIDER_UNSPECIFIED", iacTypes.NewTestMetadata()),
 						PrivateCluster: gke.PrivateCluster{
@@ -227,7 +239,6 @@ resource "google_container_cluster" "example" {
 						LoggingService:    iacTypes.String("logging.googleapis.com/kubernetes", iacTypes.NewTestMetadata()),
 						MonitoringService: iacTypes.String("monitoring.googleapis.com/kubernetes", iacTypes.NewTestMetadata()),
 						MasterAuth: gke.MasterAuth{
-							Metadata: iacTypes.NewTestMetadata(),
 							ClientCertificate: gke.ClientCertificate{
 								Metadata:         iacTypes.NewTestMetadata(),
 								IssueCertificate: iacTypes.Bool(false, iacTypes.NewTestMetadata()),

--- a/pkg/iac/providers/google/gke/gke.go
+++ b/pkg/iac/providers/google/gke/gke.go
@@ -19,6 +19,7 @@ type Cluster struct {
 	MonitoringService        iacTypes.StringValue
 	MasterAuth               MasterAuth
 	NodeConfig               NodeConfig
+	AutoScaling              AutoScaling
 	EnableShieldedNodes      iacTypes.BoolValue
 	EnableLegacyABAC         iacTypes.BoolValue
 	ResourceLabels           iacTypes.MapValue
@@ -33,6 +34,19 @@ type NodeConfig struct {
 	WorkloadMetadataConfig WorkloadMetadataConfig
 	ServiceAccount         iacTypes.StringValue
 	EnableLegacyEndpoints  iacTypes.BoolValue
+}
+
+type AutoScaling struct {
+	Metadata                 iacTypes.Metadata
+	Enabled                  iacTypes.BoolValue
+	AutoProvisioningDefaults AutoProvisioningDefaults
+}
+
+type AutoProvisioningDefaults struct {
+	Metadata       iacTypes.Metadata
+	ImageType      iacTypes.StringValue
+	ServiceAccount iacTypes.StringValue
+	Management     Management
 }
 
 type WorkloadMetadataConfig struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -6450,6 +6450,44 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.AutoProvisioningDefaults": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "imagetype": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "management": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.Management"
+        },
+        "serviceaccount": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        }
+      }
+    },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.AutoScaling": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "autoprovisioningdefaults": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.AutoProvisioningDefaults"
+        },
+        "enabled": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.ClientCertificate": {
       "type": "object",
       "properties": {
@@ -6469,6 +6507,10 @@
         "__defsec_metadata": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "autoscaling": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.gke.AutoScaling"
         },
         "datapathprovider": {
           "type": "object",


### PR DESCRIPTION
## Description

This PR adds support for the `auto_provisioning_defaults` block of a `google_container_cluster` resource.

## Related issues
- https://github.com/aquasecurity/trivy/issues/8706


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
