### PR TITLE
ci: improve PR title validation workflow

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,22 +1,23 @@
-name: "Lint PR title"
+name: "Validate PR Title"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
 
 jobs:
-  main:
+  validate:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Validate PR title
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          # Valid types
+          VALID_TYPES: |
             feat
             fix
             docs
@@ -29,13 +30,15 @@ jobs:
             chore
             revert
             release
-
-          scopes: |
+          # Valid scopes categorized by area
+          VALID_SCOPES: |
+            # Scanners
             vuln
             misconf
             secret
             license
 
+            # Targets
             image
             fs
             repo
@@ -46,6 +49,7 @@ jobs:
             vm
             plugin
 
+            # OS
             alpine
             wolfi
             chainguard
@@ -62,6 +66,7 @@ jobs:
             distroless
             windows
 
+            # Languages
             ruby
             php
             python
@@ -71,7 +76,7 @@ jobs:
             java
             go
             c
-            c\+\+
+            c++
             elixir
             dart
             swift
@@ -79,29 +84,80 @@ jobs:
             conda
             julia
 
+            # Package types
             os
             lang
 
+            # IaC
             kubernetes
             dockerfile
             terraform
             cloudformation
 
+            # Container
             docker
             podman
             containerd
             oci
 
+            # SBOM
+            sbom
+            spdx
+            cyclonedx
+
+            # Misc
             cli
             flag
-
-            cyclonedx
-            spdx
             purl
             vex
-
             helm
             report
             db
             parser
             deps
+        run: |
+          set -euo pipefail
+
+          # Convert env vars to regex alternatives, excluding comments and empty lines
+          TYPES_REGEX=$(echo "$VALID_TYPES" | grep -v '^$' | paste -sd '|')
+          SCOPES_REGEX=$(echo "$VALID_SCOPES" | grep -v '^$' | grep -v '^#' | paste -sd '|')
+          
+          # Basic format check (should match: type(scope): description or type: description)
+          FORMAT_REGEX="^[a-z]+(\([a-z0-9+]+\))?!?: .+$"
+          if ! echo "$PR_TITLE" | grep -qE "$FORMAT_REGEX"; then
+            echo "Error: Invalid PR title format"
+            echo "Expected format: <type>(<scope>): <description> or <type>: <description>"
+            echo "Examples:"
+            echo "  feat(vuln): add new vulnerability detection"
+            echo "  fix: correct parsing logic"
+            echo "  docs(kubernetes): update installation guide"
+            echo -e "\nCurrent title: $PR_TITLE"
+            exit 1
+          fi
+
+          # Extract type and scope for validation
+          TYPE=$(echo "$PR_TITLE" | sed -E 's/^([a-z]+)(\([a-z0-9+]+\))?!?: .+$/\1/')
+          SCOPE=$(echo "$PR_TITLE" | sed -E 's/^[a-z]+\(([a-z0-9+]+)\)!?: .+$/\1/; t; s/.*//')
+
+          # Validate type
+          if ! echo "$VALID_TYPES" | grep -qx "$TYPE"; then
+            echo "Error: Invalid type '${TYPE}'"
+            echo -e "\nValid types:"
+            echo "$VALID_TYPES" | grep -v '^$' | sed 's/^/- /'
+            echo -e "\nCurrent title: $PR_TITLE"
+            exit 1
+          fi
+
+          # Validate scope if present
+          if [ -n "$SCOPE" ]; then
+            if ! echo "$VALID_SCOPES" | grep -v '^#' | grep -qx "$SCOPE"; then
+              echo "Error: Invalid scope '${SCOPE}'"
+              echo -e "\nValid scopes:"
+              echo "$VALID_SCOPES" | grep -v '^$' | grep -v '^#' | sed 's/^/- /'
+              echo -e "\nCurrent title: $PR_TITLE"
+              exit 1
+            fi
+          fi
+          
+          echo "PR title validation passed ✅"
+          echo "Current title: $PR_TITLE"


### PR DESCRIPTION
## Overview
This PR improves the PR title validation workflow by enhancing security and removing external dependencies.

## Description
### Security Improvements
- Remove `pull_request_target` event to prevent potential security issues ([ref](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow))
- Remove unnecessary `GITHUB_TOKEN` usage
- Remove external action dependency (`amannn/action-semantic-pull-request`)

### Validation Improvements
- Add specific error messages for different validation failures:
  - Format validation with examples
  - Type validation with available options
  - Scope validation with categorized options
- Improve error message readability with better formatting and examples

## Tests
Tested on https://github.com/aquasecurity/trivy-test/pull/45/

- invalid format: https://github.com/aquasecurity/trivy-test/actions/runs/14380642256/job/40323362565?pr=45
- invalid type: https://github.com/aquasecurity/trivy-test/actions/runs/14380609323/job/40323264950?pr=45
- invalid scope: https://github.com/aquasecurity/trivy-test/actions/runs/14380619861/job/40323298072?pr=45
- empty scope: https://github.com/aquasecurity/trivy-test/actions/runs/14381035778/job/40324625329?pr=45
- breaking change: https://github.com/aquasecurity/trivy-test/actions/runs/14380632509/job/40323336725?pr=45

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
