### PR TITLE
fix: prevent duplicate entries in k8s table reports (#8715)

### DIFF
--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -9,15 +9,846 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-func TestSeparateMisconfigReports_NoDuplicates(t *testing.T) {
+var (
+	deployOrionWithMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Misconfigurations: []types.DetectedMisconfiguration{
+					{
+						ID:       "ID100",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "ID101",
+						Status:   types.MisconfStatusFailure,
+						Severity: "MEDIUM",
+					},
+					{
+						ID:       "ID102",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+					{
+						ID:       "ID103",
+						Status:   types.MisconfStatusFailure,
+						Severity: "CRITICAL",
+					},
+					{
+						ID:       "ID104",
+						Status:   types.MisconfStatusFailure,
+						Severity: "UNKNOWN",
+					},
+					{
+						ID:       "ID105",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "ID106",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+				},
+			},
+		},
+	}
+
+	deployOrionWithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-1111",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-2222",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-3333",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-4444",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-5555",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-6666",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-7777",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+				},
+			},
+		},
+	}
+	deployOrionWithThirdVulns = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{},
+			{},
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-1111",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-2222",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-3333",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-4444",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-5555",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-6666",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-7777",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+				},
+			},
+		},
+	}
+
+	orionDeployWithAnotherMisconfig = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Results: types.Results{
+			{
+				Misconfigurations: []types.DetectedMisconfiguration{
+					{
+						ID:       "ID201",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+				},
+			},
+		},
+	}
+
+	image1WithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Pod",
+		Name:      "multi-image-pod",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "image1",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-1111",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
+					},
+				},
+			},
+		},
+	}
+
+	image2WithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Pod",
+		Name:      "multi-image-pod",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "image2",
+				RepoTags: []string{
+					"alpine:3.17.3",
+				},
+				RepoDigests: []string{
+					"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-2222",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+				},
+			},
+		},
+	}
+
+	multiImagePodWithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Pod",
+		Name:      "multi-image-pod",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "image1",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+			{
+				ImageID: "image2",
+				RepoTags: []string{
+					"alpine:3.17.3",
+				},
+				RepoDigests: []string{
+					"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-1111",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
+					},
+				},
+			},
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-2222",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+				},
+			},
+		},
+	}
+
+	deployOrionWithBothVulnsAndMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "orion",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{
+				Misconfigurations: []types.DetectedMisconfiguration{
+					{
+						ID:       "ID100",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "ID101",
+						Status:   types.MisconfStatusFailure,
+						Severity: "MEDIUM",
+					},
+					{
+						ID:       "ID102",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+					{
+						ID:       "ID103",
+						Status:   types.MisconfStatusFailure,
+						Severity: "CRITICAL",
+					},
+					{
+						ID:       "ID104",
+						Status:   types.MisconfStatusFailure,
+						Severity: "UNKNOWN",
+					},
+					{
+						ID:       "ID105",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "ID106",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+				},
+			},
+			{
+				Vulnerabilities: []types.DetectedVulnerability{
+					{
+						VulnerabilityID: "CVE-2022-1111",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-2222",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-3333",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-4444",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-5555",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-6666",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
+					},
+					{
+						VulnerabilityID: "CVE-2022-7777",
+						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
+					},
+				},
+			},
+		},
+	}
+
+	cronjobHelloWithVulns = Resource{
+		Namespace: "default",
+		Kind:      "Cronjob",
+		Name:      "hello",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-9999"}}},
+		},
+	}
+
+	podPrometheusWithMisconfigs = Resource{
+		Namespace: "default",
+		Kind:      "Pod",
+		Name:      "prometheus",
+		Metadata: []types.Metadata{
+			{
+				ImageID: "123",
+				RepoTags: []string{
+					"alpine:3.14",
+				},
+				RepoDigests: []string{
+					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				},
+			},
+		},
+		Results: types.Results{
+			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
+		},
+	}
+
+	roleWithMisconfig = Resource{
+		Namespace: "default",
+		Kind:      "Role",
+		Name:      "system::leader-locking-kube-controller-manager",
+		Results: types.Results{
+			{
+				Misconfigurations: []types.DetectedMisconfiguration{
+					{
+						ID:       "ID100",
+						Status:   types.MisconfStatusFailure,
+						Severity: "MEDIUM",
+					},
+				},
+			},
+		},
+	}
+
+	deployLuaWithSecrets = Resource{
+		Namespace: "default",
+		Kind:      "Deploy",
+		Name:      "lua",
+		Results: types.Results{
+			{
+				Secrets: []types.DetectedSecret{
+					{
+						RuleID:   "secret1",
+						Severity: "CRITICAL",
+					},
+					{
+						RuleID:   "secret2",
+						Severity: "MEDIUM",
+					},
+				},
+			},
+		},
+	}
+
+	apiseverPodWithMisconfigAndInfra = Resource{
+		Namespace: "kube-system",
+		Kind:      "Pod",
+		Name:      "kube-apiserver",
+		Results: types.Results{
+			{
+				Misconfigurations: []types.DetectedMisconfiguration{
+					{
+						ID:       "KSV-ID100",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "KSV-ID101",
+						Status:   types.MisconfStatusFailure,
+						Severity: "MEDIUM",
+					},
+					{
+						ID:       "KSV-ID102",
+						Status:   types.MisconfStatusFailure,
+						Severity: "HIGH",
+					},
+
+					{
+						ID:       "KCV-ID100",
+						Status:   types.MisconfStatusFailure,
+						Severity: "LOW",
+					},
+					{
+						ID:       "KCV-ID101",
+						Status:   types.MisconfStatusFailure,
+						Severity: "MEDIUM",
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestReport_consolidate(t *testing.T) {
+	concatenatedResource := orionDeployWithAnotherMisconfig
+	concatenatedResource.Results[0].Misconfigurations = append(concatenatedResource.Results[0].Misconfigurations,
+		deployOrionWithMisconfigs.Results[0].Misconfigurations...)
+
+	tests := []struct {
+		name             string
+		report           Report
+		expectedFindings map[string]Resource
+	}{
+		{
+			name: "report with both misconfigs and vulnerabilities",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+					cronjobHelloWithVulns,
+					deployOrionWithMisconfigs,
+					podPrometheusWithMisconfigs,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":   deployOrionWithBothVulnsAndMisconfigs,
+				"default/cronjob/hello":  cronjobHelloWithVulns,
+				"default/pod/prometheus": podPrometheusWithMisconfigs,
+			},
+		},
+		{
+			name: "report with only misconfigurations",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithMisconfigs,
+					podPrometheusWithMisconfigs,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":   deployOrionWithMisconfigs,
+				"default/pod/prometheus": podPrometheusWithMisconfigs,
+			},
+		},
+		{
+			name: "report with only vulnerabilities",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+					cronjobHelloWithVulns,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion":  deployOrionWithVulns,
+				"default/cronjob/hello": cronjobHelloWithVulns,
+			},
+		},
+		{
+			name: "report with vulnerabilities in the third result",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithThirdVulns,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion": deployOrionWithThirdVulns,
+			},
+		},
+		{
+			name: "report with misconfigs in image and pod",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithMisconfigs,
+					orionDeployWithAnotherMisconfig,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/deploy/orion": concatenatedResource,
+			},
+		},
+		{
+			name: "report with multi image pod containing vulnerabilities",
+			report: Report{
+				Resources: []Resource{
+					image1WithVulns,
+					image2WithVulns,
+				},
+			},
+			expectedFindings: map[string]Resource{
+				"default/pod/multi-image-pod": multiImagePodWithVulns,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consolidateReport := tt.report.consolidate()
+
+			if len(consolidateReport.Findings) != len(tt.expectedFindings) {
+				t.Errorf("expected %d findings, got %d", len(tt.expectedFindings), len(consolidateReport.Findings))
+			}
+
+			for _, f := range consolidateReport.Findings {
+				key := f.fullname()
+
+				expected, found := tt.expectedFindings[key]
+				if !found {
+					t.Errorf("key not found: %s", key)
+				}
+
+				assert.Equal(t, expected, f)
+			}
+		})
+	}
+}
+
+func TestResource_fullname(t *testing.T) {
+	tests := []struct {
+		expected string
+		resource Resource
+	}{
+		{
+			"default/deploy/orion",
+			deployOrionWithBothVulnsAndMisconfigs,
+		},
+		{
+			"default/deploy/orion",
+			deployOrionWithMisconfigs,
+		},
+		{
+			"default/cronjob/hello",
+			cronjobHelloWithVulns,
+		},
+		{
+			"default/pod/prometheus",
+			podPrometheusWithMisconfigs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.resource.fullname())
+		})
+	}
+}
+
+func TestResourceFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		report   Report
+		expected bool
+	}{
+		{
+			name: "report with both misconfigs and vulnerabilities",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+					cronjobHelloWithVulns,
+					deployOrionWithMisconfigs,
+					podPrometheusWithMisconfigs,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "report with only misconfigurations",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithMisconfigs,
+					podPrometheusWithMisconfigs,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "report with only vulnerabilities",
+			report: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+					cronjobHelloWithVulns,
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "report without vulnerabilities and misconfigurations",
+			report:   Report{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.report.Failed())
+		})
+	}
+}
+
+func Test_rbacResource(t *testing.T) {
+	tests := []struct {
+		name      string
+		misConfig Resource
+		want      bool
+	}{
+		{
+			name:      "rbac Role resources",
+			misConfig: Resource{Kind: "Role"},
+			want:      true,
+		},
+		{
+			name:      "rbac ClusterRole resources",
+			misConfig: Resource{Kind: "ClusterRole"},
+			want:      true,
+		},
+		{
+			name:      "rbac RoleBinding resources",
+			misConfig: Resource{Kind: "RoleBinding"},
+			want:      true,
+		},
+		{
+			name:      "rbac ClusterRoleBinding resources",
+			misConfig: Resource{Kind: "ClusterRoleBinding"},
+			want:      true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := rbacResource(test.misConfig)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func Test_separateMisconfigReports(t *testing.T) {
+	k8sReport := Report{
+		Resources: []Resource{
+			{Kind: "Role"},
+			{Kind: "Deployment"},
+			{Kind: "StatefulSet"},
+			{
+				Kind:      "Pod",
+				Namespace: "kube-system",
+				Results: []types.Result{
+					{Misconfigurations: []types.DetectedMisconfiguration{{ID: "KCV-0001"}}},
+					{Misconfigurations: []types.DetectedMisconfiguration{{ID: "KSV-0001"}}},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		k8sReport       Report
+		scanners        types.Scanners
+		expectedReports []Report
+	}{
+		{
+			name:      "Config, Rbac, and Infra Reports",
+			k8sReport: k8sReport,
+			scanners: types.Scanners{
+				types.MisconfigScanner,
+				types.RBACScanner,
+			},
+			expectedReports: []Report{
+				// the order matter for the test
+				{
+					Resources: []Resource{
+						{Kind: "Deployment"},
+						{Kind: "StatefulSet"},
+					},
+				},
+				{Resources: []Resource{{Kind: "Pod"}}},
+				{Resources: []Resource{{Kind: "Role"}}},
+			},
+		},
+		{
+			name:      "Config and Infra for the same resource",
+			k8sReport: k8sReport,
+			scanners:  types.Scanners{types.MisconfigScanner},
+			expectedReports: []Report{
+				// the order matter for the test
+				{
+					Resources: []Resource{
+						{Kind: "Deployment"},
+						{Kind: "StatefulSet"},
+					},
+				},
+				{Resources: []Resource{{Kind: "Pod"}}},
+			},
+		},
+		{
+			name:      "Role Report Only",
+			k8sReport: k8sReport,
+			scanners:  types.Scanners{types.RBACScanner},
+			expectedReports: []Report{
+				{Resources: []Resource{{Kind: "Role"}}},
+			},
+		},
+		{
+			name:      "Config Report Only",
+			k8sReport: k8sReport,
+			scanners:  types.Scanners{types.MisconfigScanner},
+			expectedReports: []Report{
+				{
+					Resources: []Resource{
+						{Kind: "Deployment"},
+						{Kind: "StatefulSet"},
+					},
+				},
+				{
+					Resources: []Resource{
+						{Kind: "Pod"},
+					},
+				},
+			},
+		},
+		{
+			name:      "Infra Report Only",
+			k8sReport: k8sReport,
+			scanners:  types.Scanners{types.MisconfigScanner},
+			expectedReports: []Report{
+				{
+					Resources: []Resource{
+						{Kind: "Deployment"},
+						{Kind: "StatefulSet"},
+					},
+				},
+				{
+					Resources: []Resource{
+						{Kind: "Pod"},
+					},
+				},
+			},
+		},
+
+		// TODO: add vuln only
+		// TODO: add secret only
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reports := SeparateMisconfigReports(tt.k8sReport, tt.scanners)
+			assert.Equal(t, len(tt.expectedReports), len(reports))
+
+			for i := range reports {
+				assert.Equal(t, len(tt.expectedReports[i].Resources), len(reports[i].Report.Resources))
+				for j, m := range tt.expectedReports[i].Resources {
+					assert.Equal(t, m.Kind, reports[i].Report.Resources[j].Kind)
+				}
+			}
+		})
+	}
+}
+
+func TestSeparateMisconfigReports_NoDuplicatesWithMultipleScanners(t *testing.T) {
 	tests := []struct {
 		name     string
 		report   Report
 		scanners types.Scanners
-		want     []reports
+		want     int // Expected number of unique resources in all reports
 	}{
 		{
-			name: "Resource with both vulnerabilities and misconfigurations",
+			name: "Resource with both vulnerabilities and misconfigurations should not be duplicated",
 			report: Report{
 				Resources: []Resource{
 					{
@@ -56,76 +887,36 @@ func TestSeparateMisconfigReports_NoDuplicates(t *testing.T) {
 				},
 			},
 			scanners: types.Scanners{types.VulnerabilityScanner, types.MisconfigScanner},
-			want: []reports{
-				{
-					Report: Report{
-						Resources: []Resource{
-							{
-								Namespace: "default",
-								Kind:      "Deployment",
-								Name:      "app",
-								Results: types.Results{
-									{
-										Vulnerabilities: []types.DetectedVulnerability{
-											{
-												VulnerabilityID: "CVE-2020-1234",
-												PkgName:         "test-pkg",
-												Vulnerability: dbTypes.Vulnerability{
-													Severity: dbTypes.SeverityHigh.String(),
-												},
-											},
-										},
-										Misconfigurations: []types.DetectedMisconfiguration{
-											{
-												ID:       "MC-001",
-												Severity: dbTypes.SeverityMedium.String(),
-											},
-										},
-									},
-								},
-							},
-						},
-						name: "Workload Assessment",
-					},
-					Columns: []string{
-						VulnerabilitiesColumn,
-						MisconfigurationsColumn,
-						SecretsColumn,
-					},
-				},
-			},
+			want:     1, // Only one unique resource should appear
 		},
 		{
-			name: "Node with both vulnerabilities and misconfigurations",
+			name: "RBAC resource should appear only once when RBAC scanner is used",
 			report: Report{
 				Resources: []Resource{
 					{
-						Namespace: "kube-system",
-						Kind:      "NodeComponents",
-						Name:      "node1",
-						Results: types.Results{
-							{
-								Vulnerabilities: []types.DetectedVulnerability{
-									{
-										VulnerabilityID: "CVE-2020-5678",
-										PkgName:         "os-pkg",
-										Vulnerability: dbTypes.Vulnerability{
-											Severity: dbTypes.SeverityCritical.String(),
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Namespace: "kube-system",
-						Kind:      "NodeComponents",
-						Name:      "node1",
+						Namespace: "default",
+						Kind:      "Role",
+						Name:      "system-role",
 						Results: types.Results{
 							{
 								Misconfigurations: []types.DetectedMisconfiguration{
 									{
-										ID:       "MC-002",
+										ID:       "RBAC-001",
+										Severity: dbTypes.SeverityMedium.String(),
+									},
+								},
+							},
+						},
+					},
+					{
+						Namespace: "default",
+						Kind:      "Role",
+						Name:      "system-role",
+						Results: types.Results{
+							{
+								Misconfigurations: []types.DetectedMisconfiguration{
+									{
+										ID:       "RBAC-002",
 										Severity: dbTypes.SeverityHigh.String(),
 									},
 								},
@@ -134,44 +925,51 @@ func TestSeparateMisconfigReports_NoDuplicates(t *testing.T) {
 					},
 				},
 			},
-			scanners: types.Scanners{types.VulnerabilityScanner, types.MisconfigScanner},
-			want: []reports{
-				{
-					Report: Report{
-						Resources: []Resource{
+			scanners: types.Scanners{types.RBACScanner},
+			want:     1, // Only one unique RBAC resource should appear
+		},
+		{
+			name: "Multiple resources with same name but different namespaces should remain separate",
+			report: Report{
+				Resources: []Resource{
+					{
+						Namespace: "default",
+						Kind:      "Deployment",
+						Name:      "app",
+						Results: types.Results{
 							{
-								Kind: "Node",
-								Name: "node1",
-								Results: types.Results{
+								Vulnerabilities: []types.DetectedVulnerability{
 									{
-										Vulnerabilities: []types.DetectedVulnerability{
-											{
-												VulnerabilityID: "CVE-2020-5678",
-												PkgName:         "os-pkg",
-												Vulnerability: dbTypes.Vulnerability{
-													Severity: dbTypes.SeverityCritical.String(),
-												},
-											},
-										},
-										Misconfigurations: []types.DetectedMisconfiguration{
-											{
-												ID:       "MC-002",
-												Severity: dbTypes.SeverityHigh.String(),
-											},
+										VulnerabilityID: "CVE-2020-1234",
+										Vulnerability: dbTypes.Vulnerability{
+											Severity: dbTypes.SeverityHigh.String(),
 										},
 									},
 								},
 							},
 						},
-						name: "Infra Assessment",
 					},
-					Columns: []string{
-						VulnerabilitiesColumn,
-						MisconfigurationsColumn,
-						SecretsColumn,
+					{
+						Namespace: "kube-system",
+						Kind:      "Deployment",
+						Name:      "app",
+						Results: types.Results{
+							{
+								Vulnerabilities: []types.DetectedVulnerability{
+									{
+										VulnerabilityID: "CVE-2020-5678",
+										Vulnerability: dbTypes.Vulnerability{
+											Severity: dbTypes.SeverityCritical.String(),
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
+			scanners: types.Scanners{types.VulnerabilityScanner},
+			want:     2, // Two separate resources (different namespaces)
 		},
 	}
 
@@ -179,41 +977,15 @@ func TestSeparateMisconfigReports_NoDuplicates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SeparateMisconfigReports(tt.report, tt.scanners)
 
-			// For each report in the result
-			for i, report := range got {
-				// Check if we have expected report for this index
-				if i >= len(tt.want) {
-					t.Errorf("Got more reports than expected. Extra report at index %d", i)
-					continue
-				}
-
-				// Check report names match
-				assert.Equal(t, tt.want[i].Report.name, report.Report.name)
-
-				// Check columns match
-				assert.Equal(t, tt.want[i].Columns, report.Columns)
-
-				// Check resources length matches
-				assert.Equal(t, len(tt.want[i].Report.Resources), len(report.Report.Resources))
-
-				// For each resource in the report
-				for j, resource := range report.Report.Resources {
-					// Verify no duplicate entries for the same resource
-					assert.Equal(t, tt.want[i].Report.Resources[j].Namespace, resource.Namespace)
-					assert.Equal(t, tt.want[i].Report.Resources[j].Kind, resource.Kind)
-					assert.Equal(t, tt.want[i].Report.Resources[j].Name, resource.Name)
-
-					// Verify all findings are preserved
-					assert.Equal(t,
-						len(tt.want[i].Report.Resources[j].Results[0].Vulnerabilities),
-						len(resource.Results[0].Vulnerabilities),
-					)
-					assert.Equal(t,
-						len(tt.want[i].Report.Resources[j].Results[0].Misconfigurations),
-						len(resource.Results[0].Misconfigurations),
-					)
+			// Count unique resources across all reports by their fullname
+			uniqueResources := make(map[string]struct{})
+			for _, rep := range got {
+				for _, res := range rep.Report.Resources {
+					uniqueResources[res.fullname()] = struct{}{}
 				}
 			}
+
+			assert.Equal(t, tt.want, len(uniqueResources), "Expected %d unique resources, got %d", tt.want, len(uniqueResources))
 		})
 	}
 }

--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -9,831 +9,209 @@ import (
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
-var (
-	deployOrionWithMisconfigs = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "orion",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Misconfigurations: []types.DetectedMisconfiguration{
-					{
-						ID:       "ID100",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "ID101",
-						Status:   types.MisconfStatusFailure,
-						Severity: "MEDIUM",
-					},
-					{
-						ID:       "ID102",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-					{
-						ID:       "ID103",
-						Status:   types.MisconfStatusFailure,
-						Severity: "CRITICAL",
-					},
-					{
-						ID:       "ID104",
-						Status:   types.MisconfStatusFailure,
-						Severity: "UNKNOWN",
-					},
-					{
-						ID:       "ID105",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "ID106",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-				},
-			},
-		},
-	}
-
-	deployOrionWithVulns = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "orion",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-1111",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-2222",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-3333",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-4444",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-5555",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-6666",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-7777",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-				},
-			},
-		},
-	}
-	deployOrionWithThirdVulns = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "orion",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{},
-			{},
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-1111",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-2222",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-3333",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-4444",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-5555",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-6666",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-7777",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-				},
-			},
-		},
-	}
-
-	orionDeployWithAnotherMisconfig = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "orion",
-		Results: types.Results{
-			{
-				Misconfigurations: []types.DetectedMisconfiguration{
-					{
-						ID:       "ID201",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-				},
-			},
-		},
-	}
-
-	image1WithVulns = Resource{
-		Namespace: "default",
-		Kind:      "Pod",
-		Name:      "multi-image-pod",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "image1",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-1111",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
-					},
-				},
-			},
-		},
-	}
-
-	image2WithVulns = Resource{
-		Namespace: "default",
-		Kind:      "Pod",
-		Name:      "multi-image-pod",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "image2",
-				RepoTags: []string{
-					"alpine:3.17.3",
-				},
-				RepoDigests: []string{
-					"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-2222",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-				},
-			},
-		},
-	}
-
-	multiImagePodWithVulns = Resource{
-		Namespace: "default",
-		Kind:      "Pod",
-		Name:      "multi-image-pod",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "image1",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-			{
-				ImageID: "image2",
-				RepoTags: []string{
-					"alpine:3.17.3",
-				},
-				RepoDigests: []string{
-					"alpine@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-1111",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
-					},
-				},
-			},
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-2222",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-				},
-			},
-		},
-	}
-
-	deployOrionWithBothVulnsAndMisconfigs = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "orion",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{
-				Misconfigurations: []types.DetectedMisconfiguration{
-					{
-						ID:       "ID100",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "ID101",
-						Status:   types.MisconfStatusFailure,
-						Severity: "MEDIUM",
-					},
-					{
-						ID:       "ID102",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-					{
-						ID:       "ID103",
-						Status:   types.MisconfStatusFailure,
-						Severity: "CRITICAL",
-					},
-					{
-						ID:       "ID104",
-						Status:   types.MisconfStatusFailure,
-						Severity: "UNKNOWN",
-					},
-					{
-						ID:       "ID105",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "ID106",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-				},
-			},
-			{
-				Vulnerabilities: []types.DetectedVulnerability{
-					{
-						VulnerabilityID: "CVE-2022-1111",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "LOW"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-2222",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-3333",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "HIGH"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-4444",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-5555",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "UNKNOWN"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-6666",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "CRITICAL"},
-					},
-					{
-						VulnerabilityID: "CVE-2022-7777",
-						Vulnerability:   dbTypes.Vulnerability{Severity: "MEDIUM"},
-					},
-				},
-			},
-		},
-	}
-
-	cronjobHelloWithVulns = Resource{
-		Namespace: "default",
-		Kind:      "Cronjob",
-		Name:      "hello",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{Vulnerabilities: []types.DetectedVulnerability{{VulnerabilityID: "CVE-2020-9999"}}},
-		},
-	}
-
-	podPrometheusWithMisconfigs = Resource{
-		Namespace: "default",
-		Kind:      "Pod",
-		Name:      "prometheus",
-		Metadata: []types.Metadata{
-			{
-				ImageID: "123",
-				RepoTags: []string{
-					"alpine:3.14",
-				},
-				RepoDigests: []string{
-					"alpine:3.14@sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
-				},
-			},
-		},
-		Results: types.Results{
-			{Misconfigurations: []types.DetectedMisconfiguration{{ID: "ID100"}}},
-		},
-	}
-
-	roleWithMisconfig = Resource{
-		Namespace: "default",
-		Kind:      "Role",
-		Name:      "system::leader-locking-kube-controller-manager",
-		Results: types.Results{
-			{
-				Misconfigurations: []types.DetectedMisconfiguration{
-					{
-						ID:       "ID100",
-						Status:   types.MisconfStatusFailure,
-						Severity: "MEDIUM",
-					},
-				},
-			},
-		},
-	}
-
-	deployLuaWithSecrets = Resource{
-		Namespace: "default",
-		Kind:      "Deploy",
-		Name:      "lua",
-		Results: types.Results{
-			{
-				Secrets: []types.DetectedSecret{
-					{
-						RuleID:   "secret1",
-						Severity: "CRITICAL",
-					},
-					{
-						RuleID:   "secret2",
-						Severity: "MEDIUM",
-					},
-				},
-			},
-		},
-	}
-
-	apiseverPodWithMisconfigAndInfra = Resource{
-		Namespace: "kube-system",
-		Kind:      "Pod",
-		Name:      "kube-apiserver",
-		Results: types.Results{
-			{
-				Misconfigurations: []types.DetectedMisconfiguration{
-					{
-						ID:       "KSV-ID100",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "KSV-ID101",
-						Status:   types.MisconfStatusFailure,
-						Severity: "MEDIUM",
-					},
-					{
-						ID:       "KSV-ID102",
-						Status:   types.MisconfStatusFailure,
-						Severity: "HIGH",
-					},
-
-					{
-						ID:       "KCV-ID100",
-						Status:   types.MisconfStatusFailure,
-						Severity: "LOW",
-					},
-					{
-						ID:       "KCV-ID101",
-						Status:   types.MisconfStatusFailure,
-						Severity: "MEDIUM",
-					},
-				},
-			},
-		},
-	}
-)
-
-func TestReport_consolidate(t *testing.T) {
-	concatenatedResource := orionDeployWithAnotherMisconfig
-	concatenatedResource.Results[0].Misconfigurations = append(concatenatedResource.Results[0].Misconfigurations,
-		deployOrionWithMisconfigs.Results[0].Misconfigurations...)
-
-	tests := []struct {
-		name             string
-		report           Report
-		expectedFindings map[string]Resource
-	}{
-		{
-			name: "report with both misconfigs and vulnerabilities",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithVulns,
-					cronjobHelloWithVulns,
-					deployOrionWithMisconfigs,
-					podPrometheusWithMisconfigs,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/deploy/orion":   deployOrionWithBothVulnsAndMisconfigs,
-				"default/cronjob/hello":  cronjobHelloWithVulns,
-				"default/pod/prometheus": podPrometheusWithMisconfigs,
-			},
-		},
-		{
-			name: "report with only misconfigurations",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithMisconfigs,
-					podPrometheusWithMisconfigs,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/deploy/orion":   deployOrionWithMisconfigs,
-				"default/pod/prometheus": podPrometheusWithMisconfigs,
-			},
-		},
-		{
-			name: "report with only vulnerabilities",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithVulns,
-					cronjobHelloWithVulns,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/deploy/orion":  deployOrionWithVulns,
-				"default/cronjob/hello": cronjobHelloWithVulns,
-			},
-		},
-		{
-			name: "report with vulnerabilities in the third result",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithThirdVulns,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/deploy/orion": deployOrionWithThirdVulns,
-			},
-		},
-		{
-			name: "report with misconfigs in image and pod",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithMisconfigs,
-					orionDeployWithAnotherMisconfig,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/deploy/orion": concatenatedResource,
-			},
-		},
-		{
-			name: "report with multi image pod containing vulnerabilities",
-			report: Report{
-				Resources: []Resource{
-					image1WithVulns,
-					image2WithVulns,
-				},
-			},
-			expectedFindings: map[string]Resource{
-				"default/pod/multi-image-pod": multiImagePodWithVulns,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			consolidateReport := tt.report.consolidate()
-
-			if len(consolidateReport.Findings) != len(tt.expectedFindings) {
-				t.Errorf("expected %d findings, got %d", len(tt.expectedFindings), len(consolidateReport.Findings))
-			}
-
-			for _, f := range consolidateReport.Findings {
-				key := f.fullname()
-
-				expected, found := tt.expectedFindings[key]
-				if !found {
-					t.Errorf("key not found: %s", key)
-				}
-
-				assert.Equal(t, expected, f)
-			}
-		})
-	}
-}
-
-func TestResource_fullname(t *testing.T) {
-	tests := []struct {
-		expected string
-		resource Resource
-	}{
-		{
-			"default/deploy/orion",
-			deployOrionWithBothVulnsAndMisconfigs,
-		},
-		{
-			"default/deploy/orion",
-			deployOrionWithMisconfigs,
-		},
-		{
-			"default/cronjob/hello",
-			cronjobHelloWithVulns,
-		},
-		{
-			"default/pod/prometheus",
-			podPrometheusWithMisconfigs,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.resource.fullname())
-		})
-	}
-}
-
-func TestResourceFailed(t *testing.T) {
+func TestSeparateMisconfigReports_NoDuplicates(t *testing.T) {
 	tests := []struct {
 		name     string
 		report   Report
-		expected bool
+		scanners types.Scanners
+		want     []reports
 	}{
 		{
-			name: "report with both misconfigs and vulnerabilities",
+			name: "Resource with both vulnerabilities and misconfigurations",
 			report: Report{
 				Resources: []Resource{
-					deployOrionWithVulns,
-					cronjobHelloWithVulns,
-					deployOrionWithMisconfigs,
-					podPrometheusWithMisconfigs,
+					{
+						Namespace: "default",
+						Kind:      "Deployment",
+						Name:      "app",
+						Results: types.Results{
+							{
+								Vulnerabilities: []types.DetectedVulnerability{
+									{
+										VulnerabilityID: "CVE-2020-1234",
+										PkgName:         "test-pkg",
+										Vulnerability: dbTypes.Vulnerability{
+											Severity: dbTypes.SeverityHigh.String(),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Namespace: "default",
+						Kind:      "Deployment",
+						Name:      "app",
+						Results: types.Results{
+							{
+								Misconfigurations: []types.DetectedMisconfiguration{
+									{
+										ID:       "MC-001",
+										Severity: dbTypes.SeverityMedium.String(),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
-			expected: true,
+			scanners: types.Scanners{types.VulnerabilityScanner, types.MisconfigScanner},
+			want: []reports{
+				{
+					Report: Report{
+						Resources: []Resource{
+							{
+								Namespace: "default",
+								Kind:      "Deployment",
+								Name:      "app",
+								Results: types.Results{
+									{
+										Vulnerabilities: []types.DetectedVulnerability{
+											{
+												VulnerabilityID: "CVE-2020-1234",
+												PkgName:         "test-pkg",
+												Vulnerability: dbTypes.Vulnerability{
+													Severity: dbTypes.SeverityHigh.String(),
+												},
+											},
+										},
+										Misconfigurations: []types.DetectedMisconfiguration{
+											{
+												ID:       "MC-001",
+												Severity: dbTypes.SeverityMedium.String(),
+											},
+										},
+									},
+								},
+							},
+						},
+						name: "Workload Assessment",
+					},
+					Columns: []string{
+						VulnerabilitiesColumn,
+						MisconfigurationsColumn,
+						SecretsColumn,
+					},
+				},
+			},
 		},
 		{
-			name: "report with only misconfigurations",
+			name: "Node with both vulnerabilities and misconfigurations",
 			report: Report{
 				Resources: []Resource{
-					deployOrionWithMisconfigs,
-					podPrometheusWithMisconfigs,
+					{
+						Namespace: "kube-system",
+						Kind:      "NodeComponents",
+						Name:      "node1",
+						Results: types.Results{
+							{
+								Vulnerabilities: []types.DetectedVulnerability{
+									{
+										VulnerabilityID: "CVE-2020-5678",
+										PkgName:         "os-pkg",
+										Vulnerability: dbTypes.Vulnerability{
+											Severity: dbTypes.SeverityCritical.String(),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Namespace: "kube-system",
+						Kind:      "NodeComponents",
+						Name:      "node1",
+						Results: types.Results{
+							{
+								Misconfigurations: []types.DetectedMisconfiguration{
+									{
+										ID:       "MC-002",
+										Severity: dbTypes.SeverityHigh.String(),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
-			expected: true,
-		},
-		{
-			name: "report with only vulnerabilities",
-			report: Report{
-				Resources: []Resource{
-					deployOrionWithVulns,
-					cronjobHelloWithVulns,
+			scanners: types.Scanners{types.VulnerabilityScanner, types.MisconfigScanner},
+			want: []reports{
+				{
+					Report: Report{
+						Resources: []Resource{
+							{
+								Kind: "Node",
+								Name: "node1",
+								Results: types.Results{
+									{
+										Vulnerabilities: []types.DetectedVulnerability{
+											{
+												VulnerabilityID: "CVE-2020-5678",
+												PkgName:         "os-pkg",
+												Vulnerability: dbTypes.Vulnerability{
+													Severity: dbTypes.SeverityCritical.String(),
+												},
+											},
+										},
+										Misconfigurations: []types.DetectedMisconfiguration{
+											{
+												ID:       "MC-002",
+												Severity: dbTypes.SeverityHigh.String(),
+											},
+										},
+									},
+								},
+							},
+						},
+						name: "Infra Assessment",
+					},
+					Columns: []string{
+						VulnerabilitiesColumn,
+						MisconfigurationsColumn,
+						SecretsColumn,
+					},
 				},
 			},
-			expected: true,
-		},
-		{
-			name:     "report without vulnerabilities and misconfigurations",
-			report:   Report{},
-			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.report.Failed())
-		})
-	}
-}
+			got := SeparateMisconfigReports(tt.report, tt.scanners)
 
-func Test_rbacResource(t *testing.T) {
-	tests := []struct {
-		name      string
-		misConfig Resource
-		want      bool
-	}{
-		{
-			name:      "rbac Role resources",
-			misConfig: Resource{Kind: "Role"},
-			want:      true,
-		},
-		{
-			name:      "rbac ClusterRole resources",
-			misConfig: Resource{Kind: "ClusterRole"},
-			want:      true,
-		},
-		{
-			name:      "rbac RoleBinding resources",
-			misConfig: Resource{Kind: "RoleBinding"},
-			want:      true,
-		},
-		{
-			name:      "rbac ClusterRoleBinding resources",
-			misConfig: Resource{Kind: "ClusterRoleBinding"},
-			want:      true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := rbacResource(test.misConfig)
-			assert.Equal(t, test.want, got)
-		})
-	}
-}
+			// For each report in the result
+			for i, report := range got {
+				// Check if we have expected report for this index
+				if i >= len(tt.want) {
+					t.Errorf("Got more reports than expected. Extra report at index %d", i)
+					continue
+				}
 
-func Test_separateMisconfigReports(t *testing.T) {
-	k8sReport := Report{
-		Resources: []Resource{
-			{Kind: "Role"},
-			{Kind: "Deployment"},
-			{Kind: "StatefulSet"},
-			{
-				Kind:      "Pod",
-				Namespace: "kube-system",
-				Results: []types.Result{
-					{Misconfigurations: []types.DetectedMisconfiguration{{ID: "KCV-0001"}}},
-					{Misconfigurations: []types.DetectedMisconfiguration{{ID: "KSV-0001"}}},
-				},
-			},
-		},
-	}
+				// Check report names match
+				assert.Equal(t, tt.want[i].Report.name, report.Report.name)
 
-	tests := []struct {
-		name            string
-		k8sReport       Report
-		scanners        types.Scanners
-		expectedReports []Report
-	}{
-		{
-			name:      "Config, Rbac, and Infra Reports",
-			k8sReport: k8sReport,
-			scanners: types.Scanners{
-				types.MisconfigScanner,
-				types.RBACScanner,
-			},
-			expectedReports: []Report{
-				// the order matter for the test
-				{
-					Resources: []Resource{
-						{Kind: "Deployment"},
-						{Kind: "StatefulSet"},
-					},
-				},
-				{Resources: []Resource{{Kind: "Pod"}}},
-				{Resources: []Resource{{Kind: "Role"}}},
-			},
-		},
-		{
-			name:      "Config and Infra for the same resource",
-			k8sReport: k8sReport,
-			scanners:  types.Scanners{types.MisconfigScanner},
-			expectedReports: []Report{
-				// the order matter for the test
-				{
-					Resources: []Resource{
-						{Kind: "Deployment"},
-						{Kind: "StatefulSet"},
-					},
-				},
-				{Resources: []Resource{{Kind: "Pod"}}},
-			},
-		},
-		{
-			name:      "Role Report Only",
-			k8sReport: k8sReport,
-			scanners:  types.Scanners{types.RBACScanner},
-			expectedReports: []Report{
-				{Resources: []Resource{{Kind: "Role"}}},
-			},
-		},
-		{
-			name:      "Config Report Only",
-			k8sReport: k8sReport,
-			scanners:  types.Scanners{types.MisconfigScanner},
-			expectedReports: []Report{
-				{
-					Resources: []Resource{
-						{Kind: "Deployment"},
-						{Kind: "StatefulSet"},
-					},
-				},
-				{
-					Resources: []Resource{
-						{Kind: "Pod"},
-					},
-				},
-			},
-		},
-		{
-			name:      "Infra Report Only",
-			k8sReport: k8sReport,
-			scanners:  types.Scanners{types.MisconfigScanner},
-			expectedReports: []Report{
-				{
-					Resources: []Resource{
-						{Kind: "Deployment"},
-						{Kind: "StatefulSet"},
-					},
-				},
-				{
-					Resources: []Resource{
-						{Kind: "Pod"},
-					},
-				},
-			},
-		},
+				// Check columns match
+				assert.Equal(t, tt.want[i].Columns, report.Columns)
 
-		// TODO: add vuln only
-		// TODO: add secret only
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			reports := SeparateMisconfigReports(tt.k8sReport, tt.scanners)
-			assert.Equal(t, len(tt.expectedReports), len(reports))
+				// Check resources length matches
+				assert.Equal(t, len(tt.want[i].Report.Resources), len(report.Report.Resources))
 
-			for i := range reports {
-				assert.Equal(t, len(tt.expectedReports[i].Resources), len(reports[i].Report.Resources))
-				for j, m := range tt.expectedReports[i].Resources {
-					assert.Equal(t, m.Kind, reports[i].Report.Resources[j].Kind)
+				// For each resource in the report
+				for j, resource := range report.Report.Resources {
+					// Verify no duplicate entries for the same resource
+					assert.Equal(t, tt.want[i].Report.Resources[j].Namespace, resource.Namespace)
+					assert.Equal(t, tt.want[i].Report.Resources[j].Kind, resource.Kind)
+					assert.Equal(t, tt.want[i].Report.Resources[j].Name, resource.Name)
+
+					// Verify all findings are preserved
+					assert.Equal(t,
+						len(tt.want[i].Report.Resources[j].Results[0].Vulnerabilities),
+						len(resource.Results[0].Vulnerabilities),
+					)
+					assert.Equal(t,
+						len(tt.want[i].Report.Resources[j].Results[0].Misconfigurations),
+						len(resource.Results[0].Misconfigurations),
+					)
 				}
 			}
 		})


### PR DESCRIPTION
When scanning a Kubernetes cluster without specifying scan types, the table report would show duplicate entries for resources that had both vulnerabilities and misconfigurations. This change:

- Uses maps to track unique resources by their identifier
- Merges findings when a resource has multiple scan results
- Properly handles node resources by clearing their namespace
- Adds comprehensive test coverage

## Related issues
- Close #8715
