### PR TITLE
fix(report): clean buffer after flushing

### DIFF
--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -324,6 +324,43 @@ See https://google.com/search?q=bad%20config
 ────────────────────────────────────────`,
 		},
 		{
+			name: "vulns and misconfig with `--report all`",
+			report: report.Report{
+				ClusterName: "test",
+				Resources: []report.Resource{
+					deployOrionWithSingleVuln,
+					deployOrionWithSingleMisconfig,
+				},
+			},
+			scanners: types.Scanners{types.VulnerabilityScanner, types.MisconfigScanner},
+			severities: []dbTypes.Severity{
+				dbTypes.SeverityCritical, dbTypes.SeverityLow,
+			},
+			reportType: report.AllReport,
+			expectedOutput: `namespace: default, deploy: orion ()
+====================================
+Total: 1 (LOW: 1, CRITICAL: 0)
+
+┌─────────┬───────────────┬──────────┬─────────┬───────────────────┬───────────────┬───────────────────────────────────────────┐
+│ Library │ Vulnerability │ Severity │ Status  │ Installed Version │ Fixed Version │                   Title                   │
+├─────────┼───────────────┼──────────┼─────────┼───────────────────┼───────────────┼───────────────────────────────────────────┤
+│ foo/bar │ CVE-2022-1111 │ LOW      │ unknown │ v0.0.1            │ v0.0.2        │ https://avd.aquasec.com/nvd/cve-2022-1111 │
+└─────────┴───────────────┴──────────┴─────────┴───────────────────┴───────────────┴───────────────────────────────────────────┘
+
+namespace: default, deploy: orion ()
+====================================
+Tests: 1 (SUCCESSES: 0, FAILURES: 1)
+Failures: 1 (LOW: 1, CRITICAL: 0)
+
+ (LOW): Oh no, a bad config.
+════════════════════════════════════════
+Your config file is not good.
+
+See https://google.com/search?q=bad%20config
+────────────────────────────────────────`,
+		},
+
+		{
 			name: "Only vuln, all severities",
 			report: report.Report{
 				ClusterName: "test",
@@ -528,6 +565,7 @@ Infra Assessment
 └─────────────┴────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
+		{},
 	}
 
 	for _, tc := range tests {

--- a/pkg/k8s/writer_test.go
+++ b/pkg/k8s/writer_test.go
@@ -359,7 +359,6 @@ Your config file is not good.
 See https://google.com/search?q=bad%20config
 ────────────────────────────────────────`,
 		},
-
 		{
 			name: "Only vuln, all severities",
 			report: report.Report{
@@ -565,7 +564,6 @@ Infra Assessment
 └─────────────┴────────────────────┴───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN`,
 		},
-		{},
 	}
 
 	for _, tc := range tests {

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -110,6 +110,7 @@ func (tw *Writer) Write(_ context.Context, report types.Report) error {
 
 func (tw *Writer) flush() {
 	_, _ = fmt.Fprint(tw.options.Output, tw.buf.String())
+	tw.buf.Reset()
 }
 
 func (tw *Writer) render(result types.Result) {


### PR DESCRIPTION
## Description
After #8357 the rendering for table reports was introduced a buffer mechanism.

But k8s reports are displayed in separate sections (e.g., vulnerabilities, misconfigurations, etc.), printed to the screen incrementally. It allows to save memory, because k8s report can contains a lot of resources.

To prevent previously printed data from being shown again, the buffer is cleared after display data.

## Related issues
- Close #8715 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
