### PR TITLE
chore(terraform): remove os.OpenPath call from terraform file functions

### DIFF
--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -368,10 +368,11 @@ func openFile(target fs.FS, baseDir, path string) (fs.File, error) {
 	// Trivy uses a virtual file system
 	path = filepath.ToSlash(path)
 
-	if target != nil {
-		return target.Open(path)
+	if target == nil {
+		return nil, fmt.Errorf("open file %q, filesystem is nil", path)
 	}
-	return os.Open(path)
+
+	return target.Open(path)
 }
 
 func readFileBytes(target fs.FS, baseDir, path string) ([]byte, error) {

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -144,7 +144,7 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 // ParseFS parses a root module, where it exists at the root of the provided filesystem
 func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 	if p.moduleFS == nil {
-		return fmt.Errorf("module filesystem is nil, nothing to parse")
+		return errors.New("module filesystem is nil, nothing to parse")
 	}
 	dir = path.Clean(dir)
 

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -143,7 +143,9 @@ func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 
 // ParseFS parses a root module, where it exists at the root of the provided filesystem
 func (p *Parser) ParseFS(ctx context.Context, dir string) error {
-
+	if p.moduleFS == nil {
+		return fmt.Errorf("module filesystem is nil, nothing to parse")
+	}
 	dir = path.Clean(dir)
 
 	if p.projectRoot == "" {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2428,6 +2428,14 @@ func TestLoadChildModulesFromLocalCache(t *testing.T) {
 	assert.Contains(t, buf.String(), "Using module from Terraform cache .terraform/modules\tsource=\"../level_3\"")
 }
 
+func TestNilParser(t *testing.T) {
+	parser := New(
+		nil, "",
+	)
+	err := parser.ParseFS(t.Context(), ".")
+	require.Error(t, err)
+}
+
 func TestLogParseErrors(t *testing.T) {
 	var buf bytes.Buffer
 	slog.SetDefault(slog.New(log.NewHandler(&buf, nil)))


### PR DESCRIPTION
## Description

Terraform filesystem functions only have access to the filesystem specified. It should never call out to files outside the filesystem.

There is no use to default to `os.Open` when `target` is nil. If the `moduleFS` is nil, a panic (now an error) occurs in [`ParseFS`](https://github.com/Emyrk/trivy/blob/main/pkg/iac/scanners/terraform/parser/parser.go#L157). To ensure terraform only can access files in it's provided file system, `os.Open` should be removed.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
