### PR TITLE
feat(misconf): add OpenTofu file extension support

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -265,7 +265,7 @@ func IsTerraformFile(path string) bool {
 		return true
 	}
 
-	for _, ext := range []string{".tf", ".tf.json", ".tfvars"} {
+	for _, ext := range []string{".tf", ".tf.json", ".tfvars", ".tofu", ".tofu.json"} {
 		if strings.HasSuffix(path, ext) {
 			return true
 		}

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -88,6 +88,46 @@ func Test_Detection(t *testing.T) {
 			},
 		},
 		{
+			name: "tofu, no reader",
+			path: "main.tofu",
+			expected: []FileType{
+				FileTypeTerraform,
+			},
+		},
+		{
+			name: "tofu, with reader",
+			path: "main.tofu",
+			r:    strings.NewReader("some file content"),
+			expected: []FileType{
+				FileTypeTerraform,
+			},
+		},
+		{
+			name: "tofu json, no reader",
+			path: "main.tofu.json",
+			expected: []FileType{
+				FileTypeTerraform,
+				FileTypeJSON,
+			},
+		},
+		{
+			name: "tofu json, with reader",
+			path: "main.tofu.json",
+			r: strings.NewReader(`
+{
+  "variable": {
+    "example": {
+      "default": "hello"
+    }
+  }
+}
+`),
+			expected: []FileType{
+				FileTypeTerraform,
+				FileTypeJSON,
+			},
+		},
+		{
 			name: "cloudformation, no reader",
 			path: "main.yaml",
 			expected: []FileType{

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -97,8 +97,8 @@ func (p *Parser) Files() map[string]*hcl.File {
 
 func (p *Parser) ParseFile(_ context.Context, fullPath string) error {
 
-	isJSON := strings.HasSuffix(fullPath, ".tf.json")
-	isHCL := strings.HasSuffix(fullPath, ".tf")
+	isJSON := strings.HasSuffix(fullPath, ".tf.json") || strings.HasSuffix(fullPath, ".tofu.json")
+	isHCL := strings.HasSuffix(fullPath, ".tf") || strings.HasSuffix(fullPath, ".tofu")
 	if !isJSON && !isHCL {
 		return nil
 	}


### PR DESCRIPTION
Add support for OpenTofu file extensions (`.tofu` and `.tofu.json`) to enable scanning of OpenTofu infrastructure as code files.

## Description

This PR adds detection support for OpenTofu file extensions (`.tofu` and `.tofu.json`). These files are functionally identical to Terraform files but use the OpenTofu extension, allowing Trivy to scan OpenTofu infrastructure as code files.

## Checklist

- [x] I've read the https://trivy.dev/latest/community/contribute/pr/ to this repository.
- [x] I've followed the https://trivy.dev/latest/community/contribute/pr/#title in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] ~~I've updated the https://github.com/aquasecurity/trivy/blob/main/docs with the relevant information (if needed).~~
- [x] ~~I've added usage information (if the PR introduces new options)~~
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Before/After Example

### Before
OpenTofu (`.tofu`) files are not recognized as infrastructure as code files.

```
$ trivy config /path/to/directory/with/tofu/files
2025-04-16 INFO [misconfig] Misconfiguration scanning is enabled
2025-04-16 INFO Detected config files num=0
```

### After
OpenTofu (`.tofu`) files are correctly detected and scanned for security issues.

```
$ trivy config /path/to/directory/with/tofu/files
2025-04-16 INFO [misconfig] Misconfiguration scanning is enabled
2025-04-16 INFO [terraform scanner] Scanning root module file_path="."
2025-04-16 INFO Detected config files num=2
```