### PR TITLE
feat(misconf): convert AWS managed policy to document

### DIFF
--- a/pkg/iac/adapters/terraform/aws/iam/convert.go
+++ b/pkg/iac/adapters/terraform/aws/iam/convert.go
@@ -15,30 +15,36 @@ type wrappedDocument struct {
 }
 
 func ParsePolicyFromAttr(attr *terraform.Attribute, owner *terraform.Block, modules terraform.Modules) (*iam.Document, error) {
-	if attr.IsString() {
-		dataBlock, err := modules.GetBlockById(attr.Value().AsString())
-		if err != nil {
-			parsed, err := iamgo.Parse([]byte(unescapeVars(attr.Value().AsString())))
-			if err != nil {
-				return nil, err
-			}
-			return &iam.Document{
-				Parsed:   *parsed,
-				Metadata: attr.GetMetadata(),
-				IsOffset: false,
-				HasRefs:  len(attr.AllReferences()) > 0,
-			}, nil
-		}
+	if !attr.IsString() {
+		return &iam.Document{
+			Metadata: owner.GetMetadata(),
+		}, nil
+	}
 
-		if dataBlock.Type() == "data" && dataBlock.TypeLabel() == "aws_iam_policy_document" {
-			if doc, err := ConvertTerraformDocument(modules, dataBlock); err == nil {
-				return &iam.Document{
-					Metadata: dataBlock.GetMetadata(),
-					Parsed:   doc.Document,
-					IsOffset: true,
-					HasRefs:  false,
-				}, nil
-			}
+	attrValue := attr.Value().AsString()
+
+	dataBlock, err := modules.GetBlockById(attrValue)
+	if err != nil {
+		parsed, err := iamgo.Parse([]byte(unescapeVars(attrValue)))
+		if err != nil {
+			return nil, err
+		}
+		return &iam.Document{
+			Parsed:   *parsed,
+			Metadata: attr.GetMetadata(),
+			IsOffset: false,
+			HasRefs:  len(attr.AllReferences()) > 0,
+		}, nil
+	}
+
+	if dataBlock.Type() == "data" && dataBlock.TypeLabel() == "aws_iam_policy_document" {
+		if doc, err := ConvertTerraformDocument(modules, dataBlock); err == nil {
+			return &iam.Document{
+				Metadata: dataBlock.GetMetadata(),
+				Parsed:   doc.Document,
+				IsOffset: true,
+				HasRefs:  false,
+			}, nil
 		}
 	}
 

--- a/pkg/iac/adapters/terraform/aws/iam/policies.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies.go
@@ -8,9 +8,10 @@ import (
 )
 
 func parsePolicy(policyBlock *terraform.Block, modules terraform.Modules) (iam.Policy, error) {
+	nameAttr := policyBlock.GetAttribute("name")
 	policy := iam.Policy{
 		Metadata: policyBlock.GetMetadata(),
-		Name:     policyBlock.GetAttribute("name").AsStringValueOrDefault("", policyBlock),
+		Name:     nameAttr.AsStringValueOrDefault("", policyBlock),
 		Document: iam.Document{
 			Metadata: iacTypes.NewUnmanagedMetadata(),
 			Parsed:   iamgo.Document{},
@@ -19,7 +20,19 @@ func parsePolicy(policyBlock *terraform.Block, modules terraform.Modules) (iam.P
 		},
 		Builtin: iacTypes.Bool(false, policyBlock.GetMetadata()),
 	}
-	var err error
+
+	if policyBlock.Type() == "data" && policyBlock.TypeLabel() == "aws_iam_policy" &&
+		nameAttr.IsString() {
+		doc, exists := awsManagedPolicies[nameAttr.Value().AsString()]
+		if exists {
+			policy.Document = iam.Document{
+				Metadata: nameAttr.GetMetadata(),
+				Parsed:   doc,
+			}
+			return policy, nil
+		}
+	}
+
 	doc, err := ParsePolicyFromAttr(policyBlock.GetAttribute("policy"), policyBlock, modules)
 	if err != nil {
 		return policy, err
@@ -96,14 +109,58 @@ func findPolicy(modules terraform.Modules) func(resource *terraform.Block) *iam.
 
 func findAttachmentPolicy(modules terraform.Modules) func(resource *terraform.Block) *iam.Policy {
 	return func(resource *terraform.Block) *iam.Policy {
-		policyAttr := resource.GetAttribute("policy_arn")
-		if policyAttr.IsNil() {
+		attr := resource.GetAttribute("policy_arn")
+		if attr.IsNil() {
 			return nil
 		}
-		policyBlock, err := modules.GetReferencedBlock(policyAttr, resource)
-		if err != nil {
-			return nil
+
+		if attr.IsString() {
+			arn := attr.Value().AsString()
+			if doc, ok := awsManagedPolicies[arn]; ok {
+				if block, err := modules.GetReferencedBlock(attr, resource); err == nil {
+					meta := block.GetMetadata()
+					if arnAttr := block.GetAttribute("arn"); arnAttr.IsNotNil() {
+						meta = arnAttr.GetMetadata()
+					}
+					return &iam.Policy{
+						Metadata: block.GetMetadata(),
+						Document: iam.Document{
+							Metadata: meta,
+							Parsed:   doc,
+						},
+					}
+				}
+				return &iam.Policy{
+					Metadata: resource.GetMetadata(),
+					Document: iam.Document{
+						Metadata: attr.GetMetadata(),
+						Parsed:   doc,
+					},
+				}
+			}
 		}
-		return findPolicy(modules)(policyBlock)
+
+		if block, err := modules.GetReferencedBlock(attr, resource); err == nil {
+			return findPolicy(modules)(block)
+		}
+
+		return nil
 	}
 }
+
+var awsManagedPolicies = map[string]iamgo.Document{
+	// https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonS3FullAccess.html
+	"arn:aws:iam::aws:policy/AmazonS3FullAccess": s3FullAccessPolicyDocument,
+	"AmazonS3FullAccess":                         s3FullAccessPolicyDocument,
+}
+
+var s3FullAccessPolicyDocument = iamgo.NewPolicyBuilder().
+	WithVersion("2012-10-17").
+	WithStatement(
+		iamgo.NewStatementBuilder().
+			WithEffect("Allow").
+			WithActions([]string{"s3:*", "s3-object-lambda:*"}).
+			WithResources([]string{"*"}).
+			Build(),
+	).
+	Build()

--- a/pkg/iac/adapters/terraform/aws/iam/roles_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/roles_test.go
@@ -260,6 +260,84 @@ data "aws_iam_policy_document" "s3_policy" {
 				},
 			},
 		},
+		{
+			name: "attach AWS managed policy using ARN directly",
+			terraform: `resource "aws_iam_role" "test" {
+  name = "example-role"
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}`,
+			expected: []iam.Role{
+				{
+					Name: iacTypes.StringTest("example-role"),
+					Policies: []iam.Policy{
+						{
+							Document: iam.Document{
+								Parsed: s3FullAccessPolicyDocument,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "attach AWS managed policy using ARN from data source",
+			terraform: `data "aws_iam_policy" "s3_full_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role" "test" {
+  name = "example-role"
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = data.aws_iam_policy.s3_full_access.arn
+}`,
+			expected: []iam.Role{
+				{
+					Name: iacTypes.StringTest("example-role"),
+					Policies: []iam.Policy{
+						{
+							Document: iam.Document{
+								Parsed: s3FullAccessPolicyDocument,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "attach AWS managed policy using data source with policy name",
+			terraform: `data "aws_iam_policy" "s3_full_access" {
+  name = "AmazonS3FullAccess"
+}
+
+resource "aws_iam_role" "test" {
+  name = "example-role"
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = data.aws_iam_policy.s3_full_access.arn
+}`,
+			expected: []iam.Role{
+				{
+					Name: iacTypes.StringTest("example-role"),
+					Policies: []iam.Policy{
+						{
+							Name: iacTypes.StringTest("AmazonS3FullAccess"),
+							Document: iam.Document{
+								Parsed: s3FullAccessPolicyDocument,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

This PR adds support for converting AWS managed policies by their ARN or name into full IAM documents. For now, the conversion is only implemented for `AmazonS3FullAccess` policies as part of the `AVD-AWS-0345` enhancement. No changes are required on the check side as it already works with IAM documents. An alternative solution is to export ARN policies to Rego and convert them in checks.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8752

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
