### PR TITLE
docs(vuln): address linting error in rego policy

### DIFF
--- a/docs/docs/configuration/filtering.md
+++ b/docs/docs/configuration/filtering.md
@@ -471,7 +471,7 @@ package trivy
 
 default ignore = false
 
-ignore {
+ignore if {
 	input.CweIDs[_] == "CWE-20"
 }
 ```


### PR DESCRIPTION
## Description

addresses linting error in rego vulnerability filtering policy

validated with https://play.openpolicyagent.org/

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
