### PR TITLE
chore(deps): bump golangci-lint to v2.1.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Lint
         id: lint
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
-          version: v1.64
-          args: --verbose --out-format=line-number
+          version: v2.1
+          args: --verbose
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,159 +1,185 @@
-linters-settings:
-  depguard:
-    rules:
-      main:
-        list-mode: lax
-        deny:
-          # Cannot use gomodguard, which examines go.mod, as "golang.org/x/exp/slices" is not a module and doesn't appear in go.mod.
-          - pkg: "golang.org/x/exp/slices"
-            desc: "Use 'slices' instead"
-          - pkg: "golang.org/x/exp/maps"
-            desc: "Use 'maps' or 'github.com/samber/lo' instead"
-  dupl:
-    threshold: 100
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/aquasecurity/)
-      - blank
-      - dot
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    disabled-checks:
-      - appendAssign
-      - unnamedResult
-      - whyNoLint
-      - indexAlloc
-      - octalLiteral
-      - hugeParam
-      - rangeValCopy
-      - regexpSimplify
-      - sloppyReassign
-      - commentedOutCode
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-      - experimental
-      - opinionated
-    settings:
-      ruleguard:
-        failOn: all
-        rules: '${configDir}/misc/lint/rules.go'
-  gocyclo:
-    min-complexity: 20
-  gofmt:
-    simplify: false
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/hashicorp/go-version:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
-        - github.com/Masterminds/semver:
-            recommendations:
-              - github.com/aquasecurity/go-version
-            reason: "`aquasecurity/go-version` is designed for our use-cases"
-  gosec:
-    excludes:
-      - G101
-      - G114
-      - G115
-      - G204
-      - G304
-      - G402
-  govet:
-    disable:
-      - shadow
-  misspell:
-    locale: US
-    ignore-words:
-      - behaviour
-      - licence
-      - optimise
-      - simmilar
-  perfsprint:
-    # Optimizes even if it requires an int or uint type cast.
-    int-conversion: true
-    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
-    err-error: true
-    # Optimizes `fmt.Errorf`.
-    errorf: true
-    # Optimizes `fmt.Sprintf` with only one argument.
-    sprintf1: false
-    # Optimizes into strings concatenation.
-    strconcat: false
-  revive:
-    ignore-generated-header: true
-  testifylint:
-    enable-all: true
 linters:
-  disable-all: true
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            # Cannot use gomodguard, which examines go.mod, as "golang.org/x/exp/slices" is not a module and doesn't appear in go.mod.
+            - pkg: "golang.org/x/exp/slices"
+              desc: "Use 'slices' instead"
+            - pkg: "golang.org/x/exp/maps"
+              desc: "Use 'maps' or 'github.com/samber/lo' instead"
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - unnamedResult
+        - whyNoLint
+        - importShadow # FIXME
+        - indexAlloc
+        - octalLiteral
+        - hugeParam
+        - rangeValCopy
+        - regexpSimplify
+        - sloppyReassign
+        - commentedOutCode
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+        - experimental
+        - opinionated
+      settings:
+        ruleguard:
+          failOn: all
+          rules: '${base-path}/misc/lint/rules.go'
+    gocyclo:
+      min-complexity: 20
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/hashicorp/go-version:
+              recommendations:
+                - github.com/aquasecurity/go-version
+              reason: "`aquasecurity/go-version` is designed for our use-cases"
+          - github.com/Masterminds/semver:
+              recommendations:
+                - github.com/aquasecurity/go-version
+              reason: "`aquasecurity/go-version` is designed for our use-cases"
+    gosec:
+      excludes:
+        - G101
+        - G114
+        - G115
+        - G204
+        - G304
+        - G402
+    govet:
+      disable:
+        - shadow
+    misspell:
+      locale: US
+      ignore-rules:
+        - behaviour
+        - licence
+        - optimise
+        - simmilar
+    perfsprint:
+      # Optimizes even if it requires an int or uint type cast.
+      int-conversion: true
+      # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+      err-error: true
+      # Optimizes `fmt.Errorf`.
+      errorf: true
+      # Optimizes `fmt.Sprintf` with only one argument.
+      sprintf1: false
+      # Optimizes into strings concatenation.
+      strconcat: false
+    testifylint:
+      enable-all: true
+
+  default: none
+
   enable:
     - bodyclose
     - depguard
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - gomodguard
     - gosec
     - govet
     - ineffassign
     - misspell
     - perfsprint
-    - revive
-    - usetesting
+#    - revive  # FIXME more than 50 new issues
     - testifylint
-    - typecheck
     - unconvert
     - unused
     - usestdlibvars
+    - usetesting
+
+  exclusions:
+    generated: lax
+    paths:
+      - "examples/*"
+      - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions
+    rules:
+      - path: ".*_test.go$"
+        linters:
+          - goconst
+          - gosec
+          - unused
+      - path: ".*_test.go$"
+        linters:
+          - govet
+        text: "copylocks:"
+      - path: ".*_test.go$"
+        linters:
+          - gocritic
+        text: "commentFormatting:"
+      - path: ".*_test.go$"
+        linters:
+          - gocritic
+        text: "exitAfterDefer:"
+      - path: ".*_test.go$"
+        linters:
+          - gocritic
+        text: "importShadow:"
+      - linters:
+          - perfsprint
+        text: "fmt.Sprint"
+      - linters:
+          - goconst
+        text: "string `each` has 3 occurrences, make it a constant"  # FIXME
+      - linters:
+          - testifylint
+        text: "(len|empty|equal-values)"  # FIXME
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    warn-unused: true
 
 run:
   go: '1.24'
   timeout: 30m
 
 issues:
-  exclude-files:
-    - "examples/*"
-  exclude-dirs:
-    - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions
-  exclude-rules:
-    - path: ".*_test.go$"
-      linters:
-        - goconst
-        - gosec
-        - unused
-    - path: ".*_test.go$"
-      linters:
-        - govet
-      text: "copylocks:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "commentFormatting:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "exitAfterDefer:"
-    - path: ".*_test.go$"
-      linters:
-        - gocritic
-      text: "importShadow:"
-    - linters:
-        - perfsprint
-      text: "fmt.Sprint"
-  exclude-use-default: false
   max-same-issues: 0
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+
+  exclusions:
+    generated: lax
+    paths:
+      - examples/*
+      - pkg/iac/scanners/terraform/parser/funcs # copies of Terraform functions
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/aquasecurity/)
+        - blank
+        - dot
+    gofmt:
+      simplify: false
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+
+version: "2"

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -91,7 +91,7 @@ func (t Tool) GolangciLint() error {
 }
 
 func (Tool) matchGolangciLintVersion(bin, version string) bool {
-	out, err := sh.Output(bin, "version", "--format", "json")
+	out, err := sh.Output(bin, "version", "--json")
 	if err != nil {
 		slog.Error("Unable to get golangci-lint version", slog.Any("err", err))
 		return false

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -79,7 +79,7 @@ func (Tool) PipTools() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v1.64.2"
+	const version = "v2.1.2"
 	bin := filepath.Join(GOBIN, "golangci-lint")
 	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil


### PR DESCRIPTION
## Description

bump golangci-lint to v2.1.2

## Related issues
- Closes #8663

## Related PRs
- [ ] #8663

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
