### PR TITLE
fix(misconf): perform operations on attribute safely

### DIFF
--- a/pkg/iac/adapters/terraform/aws/codebuild/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/codebuild/adapt.go
@@ -39,7 +39,7 @@ func adaptProject(resource *terraform.Block) codebuild.Project {
 		project.ArtifactSettings.Metadata = artifactsBlock.GetMetadata()
 		typeAttr := artifactsBlock.GetAttribute("type")
 		encryptionDisabledAttr := artifactsBlock.GetAttribute("encryption_disabled")
-		hasArtifacts = typeAttr.NotEqual("NO_ARTIFACTS")
+		hasArtifacts = !typeAttr.Equals("NO_ARTIFACTS")
 		if encryptionDisabledAttr.IsTrue() && hasArtifacts {
 			project.ArtifactSettings.EncryptionEnabled = types.Bool(false, artifactsBlock.GetMetadata())
 		} else {

--- a/pkg/iac/adapters/terraform/aws/ec2/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/adapt.go
@@ -62,7 +62,7 @@ func getInstances(modules terraform.Modules) []ec2.Instance {
 		}
 
 		for _, resource := range modules.GetResourcesByType("aws_ebs_encryption_by_default") {
-			if resource.GetAttribute("enabled").NotEqual(false) {
+			if !resource.GetAttribute("enabled").Equals(false) {
 				instance.RootBlockDevice.Encrypted = types.BoolDefault(true, resource.GetMetadata())
 				for i := 0; i < len(instance.EBSBlockDevices); i++ {
 					ebs := instance.EBSBlockDevices[i]

--- a/pkg/iac/adapters/terraform/aws/ec2/autoscaling.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/autoscaling.go
@@ -37,7 +37,7 @@ func adaptLaunchConfigurations(modules terraform.Modules) []ec2.LaunchConfigurat
 		for _, resource := range module.GetResourcesByType("aws_launch_configuration") {
 			launchConfig := adaptLaunchConfiguration(resource)
 			for _, resource := range module.GetResourcesByType("aws_ebs_encryption_by_default") {
-				if resource.GetAttribute("enabled").NotEqual(false) {
+				if !resource.GetAttribute("enabled").Equals(false) {
 					launchConfig.RootBlockDevice.Encrypted = iacTypes.BoolDefault(true, resource.GetMetadata())
 					for i := 0; i < len(launchConfig.EBSBlockDevices); i++ {
 						ebs := launchConfig.EBSBlockDevices[i]

--- a/pkg/iac/adapters/terraform/aws/s3/bucket.go
+++ b/pkg/iac/adapters/terraform/aws/s3/bucket.go
@@ -263,7 +263,7 @@ func isEncrypted(sseConfgihuration *terraform.Block) iacTypes.BoolValue {
 
 func hasLogging(b *terraform.Block) iacTypes.BoolValue {
 	if loggingBlock := b.GetBlock("logging"); loggingBlock.IsNotNil() {
-		if targetAttr := loggingBlock.GetAttribute("target_bucket"); targetAttr.IsNotNil() && targetAttr.IsNotEmpty() {
+		if targetAttr := loggingBlock.GetAttribute("target_bucket"); targetAttr.IsNotNil() && !targetAttr.IsEmpty() {
 			return iacTypes.Bool(true, targetAttr.GetMetadata())
 		}
 		return iacTypes.BoolDefault(false, loggingBlock.GetMetadata())


### PR DESCRIPTION
## Description

This PR wraps operations in a safeOp function that checks that the attribute value is non-null and known before performing the operation. This is only done for operations that really need to work with a known value rather than an expression directly.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8779

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
