### PR TITLE
refactor(ubuntu): update time handling for fixing time

### DIFF
--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
+	"github.com/aquasecurity/trivy/pkg/clock"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -85,7 +86,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
-		osVer = s.versionFromEolDates(osVer)
+		osVer = s.versionFromEolDates(ctx, osVer)
 		advisories, err := s.vs.Get(osVer, pkg.SrcName)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get Ubuntu advisories: %w", err)
@@ -136,7 +137,7 @@ func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType
 }
 
 // versionFromEolDates checks if actual (not ESM) version is not outdated
-func (s *Scanner) versionFromEolDates(osVer string) string {
+func (s *Scanner) versionFromEolDates(ctx context.Context, osVer string) string {
 	if _, ok := eolDates[osVer]; ok {
 		return osVer
 	}
@@ -147,7 +148,7 @@ func (s *Scanner) versionFromEolDates(osVer string) string {
 	// then we need to get vulnerabilities for `18.04`
 	// if `18.04` is outdated - we need to use `18.04-ESM` (we will return error until we add `18.04-ESM` to eolDates)
 	ver := strings.TrimRight(osVer, "-ESM")
-	if eol, ok := eolDates[ver]; ok && time.Now().Before(eol) { // TODO: time.Now() should be replaced with clock.Now()
+	if eol, ok := eolDates[ver]; ok && clock.Now(ctx).Before(eol) {
 		return ver
 	}
 	return osVer

--- a/pkg/detector/ospkg/ubuntu/ubuntu_test.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu_test.go
@@ -175,11 +175,13 @@ func TestScanner_Detect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := clock.With(t.Context(), time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC))
+
 			_ = dbtest.InitDB(t, tt.fixtures)
 			defer db.Close()
 
 			s := ubuntu.NewScanner()
-			got, err := s.Detect(nil, tt.args.osVer, nil, tt.args.pkgs)
+			got, err := s.Detect(ctx, tt.args.osVer, nil, tt.args.pkgs)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return


### PR DESCRIPTION
## Description
This PR updates the time handling in Ubuntu detector to use `clock.Now()` instead of `time.Now()` to fix test failures caused by Ubuntu 20.04 reaching EOL. This change enables a fixed time for testing, making the tests more reliable and deterministic.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
