### PR TITLE
fix(misconf): filter null nodes when parsing json manifest

### DIFF
--- a/pkg/iac/scanners/kubernetes/parser/manifest.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 
+	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
 
 	xjson "github.com/aquasecurity/trivy/pkg/x/json"
@@ -16,6 +17,16 @@ type Manifest struct {
 func NewManifest(path string, root *ManifestNode) *Manifest {
 	root.Walk(func(n *ManifestNode) {
 		n.Path = path
+		switch v := n.Value.(type) {
+		case []*ManifestNode:
+			n.Value = lo.Filter(v, func(vv *ManifestNode, _ int) bool {
+				return vv != nil
+			})
+		case map[string]*ManifestNode:
+			n.Value = lo.OmitBy(v, func(k string, vv *ManifestNode) bool {
+				return vv == nil
+			})
+		}
 	})
 	return &Manifest{
 		Path:    path,

--- a/pkg/iac/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_node.go
@@ -185,12 +185,15 @@ func (n *ManifestNode) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	case '0':
 		nodeType = TagInt
 		valPtr = new(uint64)
-	case '[', 'n':
+	case '[':
 		valPtr = new([]*ManifestNode)
 		nodeType = TagSlice
 	case '{':
 		valPtr = new(map[string]*ManifestNode)
 		nodeType = TagMap
+	case 'n':
+		// TODO: UnmarshalJSONFrom is called only for the root null
+		return dec.SkipValue()
 	case 0:
 		return dec.SkipValue()
 	default:

--- a/pkg/iac/scanners/kubernetes/parser/manifest_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_test.go
@@ -15,7 +15,8 @@ func TestJsonManifestToRego(t *testing.T) {
   "apiVersion": "v1",
   "kind": "Pod",
   "metadata": {
-    "name": "hello-cpu-limit"
+    "name": "hello-cpu-limit",
+    "foo": null
   },
   "spec": {
     "containers": [
@@ -23,7 +24,8 @@ func TestJsonManifestToRego(t *testing.T) {
         "command": [
           "sh",
           "-c",
-          "echo 'Hello' && sleep 1h"
+          "echo 'Hello' && sleep 1h",
+          null
         ],
         "image": "busybox",
         "name": "hello"
@@ -41,7 +43,7 @@ func TestJsonManifestToRego(t *testing.T) {
 			"filepath":  filePath,
 			"offset":    0,
 			"startline": 1,
-			"endline":   20,
+			"endline":   22,
 		},
 		"apiVersion": "v1",
 		"kind":       "Pod",
@@ -50,7 +52,7 @@ func TestJsonManifestToRego(t *testing.T) {
 				"filepath":  filePath,
 				"offset":    0,
 				"startline": 4,
-				"endline":   6,
+				"endline":   7,
 			},
 			"name": "hello-cpu-limit",
 		},
@@ -58,16 +60,16 @@ func TestJsonManifestToRego(t *testing.T) {
 			"__defsec_metadata": map[string]any{
 				"filepath":  filePath,
 				"offset":    0,
-				"startline": 7,
-				"endline":   19,
+				"startline": 8,
+				"endline":   21,
 			},
 			"containers": []any{
 				map[string]any{
 					"__defsec_metadata": map[string]any{
 						"filepath":  filePath,
 						"offset":    0,
-						"startline": 9,
-						"endline":   17,
+						"startline": 10,
+						"endline":   19,
 					},
 					"command": []any{
 						"sh",


### PR DESCRIPTION
## Description

This PR fixes a panic that occurred when a node in the JSON manifest was `null`. Since `UnmarshalJSONFrom` is only called on the root node and does not handle nested `null` values, we now filter out `null` nodes during the manifest traversal after parsing.

https://github.com/aquasecurity/trivy-operator/actions/runs/14701034441/job/41250488412?pr=2528

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
