### PR TITLE
feat(license): prefer vendor directory for license detection when ava…

### DIFF
--- a/pkg/fanal/analyzer/language/golang/mod/mod.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod.go
@@ -130,11 +130,31 @@ func (a *gomodAnalyzer) fillAdditionalData(apps []types.Application) error {
 	}
 
 	// $GOPATH/pkg/mod
-	modPath := filepath.Join(gopath, "pkg", "mod")
-	if !fsutils.DirExists(modPath) {
-		a.logger.Debug("GOPATH not found. Need 'go mod download' to fill licenses and dependency relationships",
-			log.String("GOPATH", modPath))
-		return nil
+	// modPath := filepath.Join(gopath, "pkg", "mod")
+	// if !fsutils.DirExists(modPath) {
+	// 	a.logger.Debug("GOPATH not found. Need 'go mod download' to fill licenses and dependency relationships",
+	// 		log.String("GOPATH", modPath))
+	// 	return nil
+	// Determine where to scan for modules: prefer vendor/ if it exists
+	modPath := ""
+
+	vendorDir := filepath.Join(".", "vendor")
+	if fsutils.DirExists(vendorDir) {
+	    a.logger.Debug("Scanning licenses from vendor directory")
+	    modPath = vendorDir
+	} else {
+	    gopath := os.Getenv("GOPATH")
+	    if gopath == "" {
+	        gopath = build.Default.GOPATH
+	    }
+	    modPath = filepath.Join(gopath, "pkg", "mod")
+
+	    if !fsutils.DirExists(modPath) {
+	        a.logger.Debug("Falling back to GOPATH/pkg/mod",
+	            log.String("GOPATH", modPath))
+	        return nil
+	    }
+	}
 	}
 
 	licenses := make(map[string][]string)


### PR DESCRIPTION
### What this PR does

- Enhance license detection for Go modules.
- Prefer scanning `vendor/` directory if it exists before falling back to `$GOPATH/pkg/mod`.
- Improves Trivy's behavior for Go projects that use vendoring.

### Why is this needed?

- Some projects vendor dependencies locally using `go mod vendor`.
- Vendored dependencies contain LICENSE files but not go.mod files.
- This PR ensures LICENSE files inside `vendor/` are correctly detected and classified.

### Testing done

- Built Trivy locally (`mage build`).
- Created a test project with `go mod vendor` and `github.com/google/uuid` dependency.
- Confirmed LICENSE file was detected correctly from `vendor/` directory using:

```bash
./dist/trivy fs --scanners license ~/Desktop/trivy-test/vendor-test
