### PR TITLE
feat(misconf): add misconfiguration location to junit template

### DIFF
--- a/contrib/junit.tpl
+++ b/contrib/junit.tpl
@@ -15,6 +15,7 @@
     {{- end }}
     </testsuite>
 
+{{- $target := .Target }}
 {{- if .MisconfSummary }}
     <testsuite tests="{{ add .MisconfSummary.Successes .MisconfSummary.Failures }}" failures="{{ .MisconfSummary.Failures }}" name="{{  .Target }}" errors="0" time="">
 {{- else }}
@@ -28,7 +29,23 @@
         {{ range .Misconfigurations }}
         <testcase classname="{{ .Type }}" name="[{{ .Severity }}] {{ .ID }}" time="">
         {{- if (eq .Status "FAIL") }}
-            <failure message="{{ escapeXML .Title }}" type="description">{{ escapeXML .Description }}</failure>
+            <failure message="{{ escapeXML .Title }}" type="description">&#xA;
+                {{- $target }}:
+                {{- with .CauseMetadata }}
+                    {{- .StartLine }}
+                    {{- if lt .StartLine .EndLine }}:{{ .EndLine }}{{ end }}:&#xA;&#xA;Occurrences:&#xA;
+                    {{- range $i := .Occurrences -}}
+                    via {{ .Filename }}:
+                    {{- .Location.StartLine }}
+                    {{- if lt .Location.StartLine .Location.EndLine }}:{{ .Location.EndLine }}{{ end }} ({{ .Resource }})&#xA;
+                    {{- end -}}
+                    &#xA;Code:&#xA;
+                    {{- range .Code.Lines }}
+                    {{- if .IsCause }}{{ escapeXML .Content }}&#xA;{{- end }}
+                    {{- end }}&#xA;
+                {{- end }}
+                {{- escapeXML .Description }}
+            </failure>
         {{- end }}
         </testcase>
     {{- end }}


### PR DESCRIPTION
## Description

### Before
```xml
...
    <testsuite tests="9" failures="9" name="main.tf" errors="0" time="">
        <properties>
            <property name="type" value="terraform"></property>
        </properties>
        <testcase classname="Terraform Security Check" name="[HIGH] AVD-AWS-0086" time="">
            <failure message="S3 Access block should block public ACL" type="description">S3 buckets should block public ACLs on buckets and any objects they contain. By blocking, PUTs with fail if the object has any public ACL a.&#xA;</failure>
        </testcase>
        <testcase classname="Terraform Security Check" name="[HIGH] AVD-AWS-0087" time="">
            <failure message="S3 Access block should block public policy" type="description">S3 bucket policy should have block public policy to prevent users from putting a policy that enable public access.&#xA;</failure>
        </testcase>
...
```

### After
```xml
...
    <testsuite tests="10" failures="10" name="main.tf" errors="0" time="">
        <properties>
            <property name="type" value="terraform"></property>
        </properties>
        <testcase classname="Terraform Security Check" name="[HIGH] AVD-AWS-0086" time="">
            <failure message="S3 Access block should block public ACL" type="description">&#xA;main.tf:1:3:&#xA;&#xA;Code:&#xA;resource &#34;aws_s3_bucket&#34; &#34;name&#34; {&#xA;  bucket = &#34;te.st&#34;&#xA;}&#xA;&#xA;S3 buckets should block public ACLs on buckets and any objects they contain. By blocking, PUTs with fail if the object has any public ACL a.&#xA;
            </failure>
        </testcase>
        <testcase classname="Terraform Security Check" name="[HIGH] AVD-AWS-0087" time="">
            <failure message="S3 Access block should block public policy" type="description">&#xA;main.tf:1:3:&#xA;&#xA;Code:&#xA;resource &#34;aws_s3_bucket&#34; &#34;name&#34; {&#xA;  bucket = &#34;te.st&#34;&#xA;}&#xA;&#xA;S3 bucket policy should have block public policy to prevent users from putting a policy that enable public access.&#xA;
            </failure>
        </testcase>
...
```

html produced by [xunit-viewer](https://github.com/lukejpreston/xunit-viewer):
<img width="988" alt="image" src="https://github.com/user-attachments/assets/9166201b-5d0e-43d2-8305-bbd3df8a0636" />

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8790

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
