### PR TITLE
fix(java): exclude dev dependencies in gradle lockfile

### DIFF
--- a/pkg/dependency/parser/gradle/lockfile/parse.go
+++ b/pkg/dependency/parser/gradle/lockfile/parse.go
@@ -34,9 +34,8 @@ func (Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, 
 		}
 
 		name := strings.Join(dep[:2], ":")
-		version := strings.Split(dep[2], "=")[0] // remove classPaths
+		version, classPathsString, _ := strings.Cut(dep[2], "=")
 
-		classPathsString := strings.Split(dep[2], "=")[1]
 		classPaths := strings.Split(classPathsString, ",")
 		dev := true
 

--- a/pkg/dependency/parser/gradle/lockfile/parse.go
+++ b/pkg/dependency/parser/gradle/lockfile/parse.go
@@ -35,10 +35,23 @@ func (Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, 
 
 		name := strings.Join(dep[:2], ":")
 		version := strings.Split(dep[2], "=")[0] // remove classPaths
+
+		classPathsString := strings.Split(dep[2], "=")[1]
+		classPaths := strings.Split(classPathsString, ",")
+		dev := true
+
+		for _, classPath := range classPaths {
+			if !strings.HasPrefix(classPath, "test") {
+				dev = false
+				break
+			}
+		}
+
 		pkgs = append(pkgs, ftypes.Package{
 			ID:      dependency.ID(ftypes.Gradle, name, version),
 			Name:    name,
 			Version: version,
+			Dev:     dev,
 			Locations: []ftypes.Location{
 				{
 					StartLine: lineNum,

--- a/pkg/dependency/parser/gradle/lockfile/parse_test.go
+++ b/pkg/dependency/parser/gradle/lockfile/parse_test.go
@@ -25,6 +25,7 @@ func TestParser_Parse(t *testing.T) {
 					ID:      "cglib:cglib-nodep:2.1.2",
 					Name:    "cglib:cglib-nodep",
 					Version: "2.1.2",
+					Dev:     false,
 					Locations: []ftypes.Location{
 						{
 							StartLine: 4,
@@ -33,9 +34,10 @@ func TestParser_Parse(t *testing.T) {
 					},
 				},
 				{
-					ID:      "org.springframework:spring-asm:3.1.3.RELEASE",
-					Name:    "org.springframework:spring-asm",
-					Version: "3.1.3.RELEASE",
+					ID:      "junit:junit:4.13.2",
+					Name:    "junit:junit",
+					Version: "4.13.2",
+					Dev:     true,
 					Locations: []ftypes.Location{
 						{
 							StartLine: 5,
@@ -44,13 +46,26 @@ func TestParser_Parse(t *testing.T) {
 					},
 				},
 				{
-					ID:      "org.springframework:spring-beans:5.0.5.RELEASE",
-					Name:    "org.springframework:spring-beans",
-					Version: "5.0.5.RELEASE",
+					ID:      "org.springframework:spring-asm:3.1.3.RELEASE",
+					Name:    "org.springframework:spring-asm",
+					Version: "3.1.3.RELEASE",
+					Dev:     false,
 					Locations: []ftypes.Location{
 						{
 							StartLine: 6,
 							EndLine:   6,
+						},
+					},
+				},
+				{
+					ID:      "org.springframework:spring-beans:5.0.5.RELEASE",
+					Name:    "org.springframework:spring-beans",
+					Version: "5.0.5.RELEASE",
+					Dev:     false,
+					Locations: []ftypes.Location{
+						{
+							StartLine: 7,
+							EndLine:   7,
 						},
 					},
 				},

--- a/pkg/dependency/parser/gradle/lockfile/testdata/happy.lockfile
+++ b/pkg/dependency/parser/gradle/lockfile/testdata/happy.lockfile
@@ -2,6 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 cglib:cglib-nodep:2.1.2=testRuntimeClasspath,classpath
+junit:junit:4.13.2=testCompileClasspath,testRuntimeClasspath
  org.springframework:spring-asm:3.1.3.RELEASE=classpath
 org.springframework:spring-beans:5.0.5.RELEASE=compileClasspath, runtimeClasspath
  # io.grpc:grpc-api:1.21.1=classpath


### PR DESCRIPTION
## Description
We need to mark development dependencies while scanning gradle lockfiles so that they are not included in the final scans

## Related issues
- Close #8755 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
