### PR TITLE
fix(misconf): check if for-each is known when expanding dyn block

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1591,6 +1591,15 @@ resource "test_resource" "test" {
 }`,
 			expected: []any{},
 		},
+		{
+			name: "unknown for-each",
+			src: `resource "test_resource" "test" {
+  dynamic "foo" {
+    for_each = lookup(foo, "") ? [] : []
+  }
+}`,
+			expected: []any{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -583,7 +583,7 @@ func (b *Block) ExpandBlock() error {
 		if child.Type() == "dynamic" {
 			blocks, err := child.expandDynamic()
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				errs = multierror.Append(errs, fmt.Errorf("block %q: %w", child.TypeLabel(), err))
 				continue
 			}
 			expanded = append(expanded, blocks...)
@@ -610,6 +610,10 @@ func (b *Block) expandDynamic() ([]*Block, error) {
 	forEachVal, err := b.validateForEach()
 	if err != nil {
 		return nil, fmt.Errorf("invalid for-each in %s block: %w", b.FullLocalName(), err)
+	}
+
+	if !forEachVal.IsKnown() {
+		return nil, errors.New("for-each must be known")
 	}
 
 	var (


### PR DESCRIPTION
## Description

In one PR, we started storing unknown values in context to preserve their type instead of converting them to a dynamic value. After that, using an unknown value in `for-each` started to cause panic because the dynamic block expansion didn't check that the value was known. This PR adds a check that the value is known.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8805

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
