### PR TITLE
fix: use-any from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -101,6 +101,7 @@ linters:
           arguments:
             - preserve-scope
         - name: unused-parameter
+        - name: use-any
 
     testifylint:
       enable-all: true
@@ -129,7 +130,6 @@ linters:
   exclusions:
     generated: lax
     paths:
-      - "examples/*"
       - "pkg/iac/scanners/terraform/parser/funcs" # copies of Terraform functions
     rules:
       - path: ".*_test.go$"
@@ -154,9 +154,6 @@ linters:
           - gocritic
         text: "importShadow:"
       - linters:
-          - perfsprint
-        text: "fmt.Sprint"
-      - linters:
           - goconst
         text: "string `each` has 3 occurrences, make it a constant"  # FIXME
     presets:
@@ -177,9 +174,6 @@ formatters:
 
   exclusions:
     generated: lax
-    paths:
-      - examples/*
-      - pkg/iac/scanners/terraform/parser/funcs # copies of Terraform functions
 
   settings:
     gci:
@@ -191,8 +185,5 @@ formatters:
         - dot
     gofmt:
       simplify: false
-      rewrite-rules:
-        - pattern: interface{}
-          replacement: any
 
 version: "2"


### PR DESCRIPTION
## Description

Fixes [use-any](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-any) rule from revive

It also removes exclusions that are useless

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
