### PR TITLE
docs: change in java.md: fix the Trity -to-> Trivy typo

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -105,7 +105,7 @@ But there is no reliable way to determine direct dependencies (even using other 
 Therefore, we mark all dependencies as indirect to use logic to guess direct dependencies and build a dependency tree.
 
 ### Licenses
-Trity also can detect licenses for dependencies.
+Trivy also can detect licenses for dependencies.
 
 Make sure that you have cache[^8] directory to find licenses from `*.pom` dependency files.
 


### PR DESCRIPTION
docs: change in java.md: fix the Trity -to-> Trivy typo

## Description
Trivial typo in the documentation (java.md) - Trivy misspelled as Trity.

## Related issues
too trivial to open an issue

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
