### PR TITLE
fix(redhat): trim invalid suffix from content_sets in manifest parsing

### DIFF
--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -3,12 +3,14 @@ package redhat
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
+	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
@@ -109,6 +111,9 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 		nvr = fmt.Sprintf("%s-%s", pkg.BuildInfo.Nvr, pkg.BuildInfo.Arch)
 	}
 
+	// Clean content sets from generic suffixes (__8, __9, etc.)
+	contentSets = cleanContentSets(contentSets)
+
 	advisories, err := s.vs.Get(pkgName, contentSets, []string{nvr})
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get Red Hat advisories: %w", err)
@@ -196,4 +201,16 @@ func addModularNamespace(name, label string) string {
 		}
 	}
 	return name
+}
+
+// Match generic version suffixes like "__8", "__9", "__10", but preserve EUS suffixes like "__9_DOT_2"
+var genericSuffixPattern = regexp.MustCompile(`__\d+$`)
+
+// cleanContentSets removes generic suffixes like "__8" from content sets
+// These are Red Hat image build artifacts and not valid repository names
+// cf. https://github.com/aquasecurity/trivy-db/issues/435
+func cleanContentSets(contentSets []string) []string {
+	return lo.Map(contentSets, func(cs string, _ int) string {
+		return genericSuffixPattern.ReplaceAllString(cs, "")
+	})
 }

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -203,11 +203,17 @@ func addModularNamespace(name, label string) string {
 	return name
 }
 
-// Match generic version suffixes like "__8", "__9", "__10", but preserve EUS suffixes like "__9_DOT_2"
+// Match generic version suffixes like "__8", "__9", "__10", but preserve EUS suffixes like "__9_DOT_2".
+// Examples:
+//   - Matches: "repo__8", "repo__10"
+//   - Does not match: "repo__9_DOT_2", "repo__10_DOT_1"
 var genericSuffixPattern = regexp.MustCompile(`__\d+$`)
 
-// cleanContentSets removes generic suffixes like "__8" from content sets
-// These are Red Hat image build artifacts and not valid repository names
+// cleanContentSets removes generic suffixes like "__8" from content sets.
+// These are Red Hat image build artifacts and not valid repository names.
+// Examples:
+//   Input:  []string{"repo__8", "repo__9_DOT_2", "repo__10"}
+//   Output: []string{"repo", "repo__9_DOT_2", "repo"}
 // cf. https://github.com/aquasecurity/trivy-db/issues/435
 func cleanContentSets(contentSets []string) []string {
 	return lo.Map(contentSets, func(cs string, _ int) string {

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -212,8 +212,10 @@ var genericSuffixPattern = regexp.MustCompile(`__\d+$`)
 // cleanContentSets removes generic suffixes like "__8" from content sets.
 // These are Red Hat image build artifacts and not valid repository names.
 // Examples:
-//   Input:  []string{"repo__8", "repo__9_DOT_2", "repo__10"}
-//   Output: []string{"repo", "repo__9_DOT_2", "repo"}
+//
+//	Input:  []string{"repo__8", "repo__9_DOT_2", "repo__10"}
+//	Output: []string{"repo", "repo__9_DOT_2", "repo"}
+//
 // cf. https://github.com/aquasecurity/trivy-db/issues/435
 func cleanContentSets(contentSets []string) []string {
 	return lo.Map(contentSets, func(cs string, _ int) string {

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -420,6 +420,56 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "content sets with invalid suffix",
+			fixtures: []string{
+				"testdata/fixtures/redhat.yaml",
+				"testdata/fixtures/cpe.yaml",
+			},
+			args: args{
+				osVer: "8.3",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "vim-minimal",
+						Version:    "7.4.160",
+						Release:    "5.el8",
+						Epoch:      2,
+						Arch:       "x86_64",
+						SrcName:    "vim",
+						SrcVersion: "7.4.160",
+						SrcRelease: "5.el8",
+						SrcEpoch:   2,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{
+								"rhel-8-for-x86_64-baseos-rpms__8",
+								"rhel-8-for-x86_64-appstream-rpms__8",
+							},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2019-12735",
+					VendorIDs: []string{
+						"RHSA-2019:1619",
+					},
+					PkgName:          "vim-minimal",
+					InstalledVersion: "2:7.4.160-5.el8",
+					FixedVersion:     "2:7.4.160-7.el8_7",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityMedium.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
This patch addresses a parsing error when scanning certain Red Hat images whose `/root/buildinfo/content_manifests/*.json` files include malformed content set names with an extra “__<digits>” suffix (e.g. `ubi-8-for-x86_64-baseos-rpms__8`). Those invalid entries prevent Trivy from mapping content sets to CPE indices and cause scan failures.

## Changes
- Before mapping each `content_set` to a CPE, strip any trailing `__<number>` suffix using a regex (`__\d+$`).  
- Leave correctly formatted names untouched.  
- Add unit tests covering

## Related issues
- Closes aquasecurity/trivy-db#435
 
## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
