### PR TITLE
fix(redhat): save contentSets for OS packages in fs/vm modes

### DIFF
--- a/docs/docs/advanced/container/unpacked-filesystem.md
+++ b/docs/docs/advanced/container/unpacked-filesystem.md
@@ -114,10 +114,3 @@ Total: 20 (UNKNOWN: 0, LOW: 2, MEDIUM: 10, HIGH: 8, CRITICAL: 0)
 ```
 
 </details>
-
-!!! warning
-    This method may show false positives for RHEL-based images that use Red Hat's own security advisories (RHEL, CentOS, etc.).
-    
-    This is due to `content_sets`, which can be different for multiple layers.
-    But when all files from layers are combined, we cannot correctly match packages with their `content_sets`.
-    

--- a/docs/docs/advanced/container/unpacked-filesystem.md
+++ b/docs/docs/advanced/container/unpacked-filesystem.md
@@ -114,3 +114,10 @@ Total: 20 (UNKNOWN: 0, LOW: 2, MEDIUM: 10, HIGH: 8, CRITICAL: 0)
 ```
 
 </details>
+
+!!! warning
+    This method may show false positives for RHEL-based images that use Red Hat's own security advisories (RHEL, CentOS, etc.).
+    
+    This is due to `content_sets`, which can be different for multiple layers.
+    But when all files from layers are combined, we cannot correctly match packages with their `content_sets`.
+    

--- a/docs/docs/coverage/os/rhel.md
+++ b/docs/docs/coverage/os/rhel.md
@@ -22,6 +22,19 @@ Trivy detects packages that have been installed through package managers such as
 ## Vulnerability
 Red Hat offers its own security advisories, and these are utilized when scanning Red Hat Enterprise Linux (RHEL) for vulnerabilities.
 
+### Content manifests
+Red Hat advisory database uses content manifests.
+
+Therefore, to work with these advisories, Trivy searches for content manifests for packages within one layer 
+(manifests can differ from layer to layer even in one image) and searches for vulnerabilities.
+
+If the image doesn't have content manifests, Trivy uses [default value][content-set-default] based on the RHEL version.
+
+
+!!! warning
+    In case of scanning the image as a filesystem (e.g. [unpacked-filesystem](../../advanced/container/unpacked-filesystem.md)) -
+    there is no way to get the correct content manifests for packages (since the file system will store only the last manifest), which can lead to false positives.
+
 ### Data Source
 See [here](../../scanner/vulnerability.md#data-sources).
 
@@ -82,3 +95,5 @@ Trivy identifies licenses by examining the metadata of RPM packages.
 [NVD]: https://nvd.nist.gov/vuln/detail/CVE-2023-0464
 
 [vulnerability statuses]: ../../configuration/filtering.md#by-status
+
+[content-set-default]: https://github.com/aquasecurity/trivy/blob/c80310d7690d8aeb7d3d77416c18c0c8b9aebe17/pkg/detector/ospkg/redhat/redhat.go#L25-L42

--- a/docs/docs/coverage/os/rhel.md
+++ b/docs/docs/coverage/os/rhel.md
@@ -23,17 +23,11 @@ Trivy detects packages that have been installed through package managers such as
 Red Hat offers its own security advisories, and these are utilized when scanning Red Hat Enterprise Linux (RHEL) for vulnerabilities.
 
 ### Content manifests
-Red Hat advisory database uses content manifests.
+Red Hat’s security advisories use CPEs to identify product sets. For example, even packages installed in the same container image can have different CPEs. 
+For this reason, Red Hat’s container images include stored content manifests, which we convert to CPEs, and perform vulnerability scanning.
 
-Therefore, to work with these advisories, Trivy searches for content manifests for packages within one layer 
-(manifests can differ from layer to layer even in one image) and searches for vulnerabilities.
-
-If the image doesn't have content manifests, Trivy uses [default value][content-set-default] based on the RHEL version.
-
-
-!!! warning
-    In case of scanning the image as a filesystem (e.g. [unpacked-filesystem](../../advanced/container/unpacked-filesystem.md)) -
-    there is no way to get the correct content manifests for packages (since the file system will store only the last manifest), which can lead to false positives.
+Since this system ties each content manifest to its packages on a per-layer basis, 
+if layers get merged (for instance, by using `docker run` or `docker export`) we can no longer determine the correct CPE, which may lead to false detection.
 
 ### Data Source
 See [here](../../scanner/vulnerability.md#data-sources).

--- a/docs/docs/target/rootfs.md
+++ b/docs/docs/target/rootfs.md
@@ -14,6 +14,9 @@ $ trivy rootfs /path/to/rootfs
     You should use `trivy fs` to scan your local projects in CI/CD.
     See [here](../scanner/vulnerability.md) for the differences.
 
+!!! note
+    Scanning vulnerabilities for `Red Hat` has a limitation, see the [Red Hat](../coverage/os/rhel.md#content-manifests) page for details.
+
 ## Performance Optimization
 
 By default, Trivy traverses all files from the specified root directory to find target files for scanning.

--- a/docs/docs/target/vm.md
+++ b/docs/docs/target/vm.md
@@ -150,6 +150,9 @@ See [here](../scanner/vulnerability.md) for the detail.
 $ trivy vm [YOUR_VM_IMAGE]
 ```
 
+!!! note
+    Scanning `Red Hat` has a limitation, see the [Red Hat](../coverage/os/rhel.md#content-manifests) page for details.
+
 ### Misconfigurations
 It is supported, but it is not useful in most cases.
 As mentioned [here](../scanner/misconfiguration/index.md), Trivy mainly supports Infrastructure as Code (IaC) files for misconfigurations.

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -207,6 +207,9 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 		Secrets:           result.Secrets,
 		Licenses:          result.Licenses,
 		CustomResources:   result.CustomResources,
+
+		// For Red Hat
+		BuildInfo: result.BuildInfo,
 	}
 
 	if err = a.handlerManager.PostHandle(ctx, result, &blobInfo); err != nil {

--- a/pkg/fanal/artifact/vm/vm.go
+++ b/pkg/fanal/artifact/vm/vm.go
@@ -157,6 +157,9 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 		Secrets:         result.Secrets,
 		Licenses:        result.Licenses,
 		CustomResources: result.CustomResources,
+
+		// For Red Hat
+		BuildInfo: result.BuildInfo,
 	}
 
 	if err = a.handlerManager.PostHandle(ctx, result, &blobInfo); err != nil {


### PR DESCRIPTION
## Description
See #8819

Before:
```
➜  trivy -q fs -f json --list-all-pkgs /tmp/8200/ubi8/blobs/sha256 | jq  ' .Results[].Packages[1]'
{
  "ID": "basesystem@11-5.el8.noarch",
  "Name": "basesystem",
  "Identifier": {
    "PURL": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=redhat-8.6",
    "UID": "e67141531362fa78"
  },
  "Version": "11",
  "Release": "5.el8",
  "Arch": "noarch",
  "SrcName": "basesystem",
  "SrcVersion": "11",
  "SrcRelease": "5.el8",
  "Licenses": [
    "Public Domain"
  ],
  "Maintainer": "Red Hat, Inc.",
  "DependsOn": [
    "filesystem@3.8-6.el8.aarch64",
    "setup@2.12.2-6.el8.noarch"
  ],
  "Layer": {},
  "Digest": "md5:31bc067a6462aacd3b891681bdb27512"
}
```

after:
```
➜  ./trivy -q fs -f json --list-all-pkgs /tmp/8200/ubi8/blobs/sha256 | jq  ' .Results[].Packages[1]'
{
  "ID": "basesystem@11-5.el8.noarch",
  "Name": "basesystem",
  "Identifier": {
    "PURL": "pkg:rpm/redhat/basesystem@11-5.el8?arch=noarch&distro=redhat-8.6",
    "UID": "e67141531362fa78"
  },
  "Version": "11",
  "Release": "5.el8",
  "Arch": "noarch",
  "SrcName": "basesystem",
  "SrcVersion": "11",
  "SrcRelease": "5.el8",
  "Licenses": [
    "Public Domain"
  ],
  "Maintainer": "Red Hat, Inc.",
  "BuildInfo": {
    "ContentSets": [
      "rhel-8-for-aarch64-baseos-rpms",
      "rhel-8-for-aarch64-appstream-rpms"
    ],
    "Nvr": "ubi8-minimal-container-8.6-994",
    "Arch": "aarch64"
  },
  "DependsOn": [
    "filesystem@3.8-6.el8.aarch64",
    "setup@2.12.2-6.el8.noarch"
  ],
  "Layer": {},
  "Digest": "md5:31bc067a6462aacd3b891681bdb27512"
}

```

## Related issues
- Close #8819

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
