### PR TITLE
docs(java):  Update info about dev deps in gradle lock

### DIFF
--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -12,12 +12,12 @@ Each artifact supports the following scanners:
 
 The following table provides an outline of the features Trivy offers.
 
-| Artifact         |    Internet access    | Dev dependencies | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
-|------------------|:---------------------:|:----------------:|:------------------------------------:|:--------:|:----------------------------------------:|
-| JAR/WAR/PAR/EAR  |     Trivy Java DB     |     Include      |                  -                   |    -     |                Not needed                |
-| pom.xml          | Maven repository [^1] |     Exclude      |                  ✓                   |  ✓[^7]   |                    -                     |
-| *gradle.lockfile |           -           |     Exclude      |                  ✓                   |    ✓     |                Not needed                |
-| *.sbt.lock       |           -           |     Exclude      |                  -                   |    ✓     |                Not needed                |
+| Artifact         |    Internet access    |    Dev dependencies    | [Dependency graph][dependency-graph] | Position | [Detection Priority][detection-priority] |
+|------------------|:---------------------:|:----------------------:|:------------------------------------:|:--------:|:----------------------------------------:|
+| JAR/WAR/PAR/EAR  |     Trivy Java DB     |        Include         |                  -                   |    -     |                Not needed                |
+| pom.xml          | Maven repository [^1] |        Exclude         |                  ✓                   |  ✓[^7]   |                    -                     |
+| *gradle.lockfile |           -           | [Exclude](#gradlelock) |                  ✓                   |    ✓     |                Not needed                |
+| *.sbt.lock       |           -           |        Exclude         |                  -                   |    ✓     |                Not needed                |
 
 These may be enabled or disabled depending on the target.
 See [here](./index.md) for the detail.
@@ -96,8 +96,8 @@ If you need to show them, use the `--include-dev-deps` flag.
 !!!note
     All necessary files are checked locally. Gradle file scanning doesn't require internet access.
 
-Trivy identifies and marks development dependencies and skips them by default.
-If you need to show them, use the `--include-dev-deps` flag.
+By default, Trivy doesn't report development dependencies. 
+Use the `--include-dev-deps` flag to include them in the results.
 
 ### Dependency-tree
 !!! warning "EXPERIMENTAL"

--- a/docs/docs/coverage/language/java.md
+++ b/docs/docs/coverage/language/java.md
@@ -96,6 +96,9 @@ If you need to show them, use the `--include-dev-deps` flag.
 !!!note
     All necessary files are checked locally. Gradle file scanning doesn't require internet access.
 
+Trivy identifies and marks development dependencies and skips them by default.
+If you need to show them, use the `--include-dev-deps` flag.
+
 ### Dependency-tree
 !!! warning "EXPERIMENTAL"
     This feature might change without preserving backwards compatibility.

--- a/docs/docs/references/configuration/cli/trivy_filesystem.md
+++ b/docs/docs/references/configuration/cli/trivy_filesystem.md
@@ -75,7 +75,7 @@ trivy filesystem [flags] PATH
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
-      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
+      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn, gradle)
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)

--- a/docs/docs/references/configuration/cli/trivy_repository.md
+++ b/docs/docs/references/configuration/cli/trivy_repository.md
@@ -74,7 +74,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --ignored-licenses strings          specify a list of license to ignore
       --ignorefile string                 specify .trivyignore file (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
-      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn)
+      --include-dev-deps                  include development dependencies in the report (supported: npm, yarn, gradle)
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
       --license-confidence-level float    specify license classifier's confidence level (default 0.9)

--- a/pkg/flag/package_flags.go
+++ b/pkg/flag/package_flags.go
@@ -10,7 +10,7 @@ var (
 	IncludeDevDepsFlag = Flag[bool]{
 		Name:       "include-dev-deps",
 		ConfigName: "pkg.include-dev-deps",
-		Usage:      "include development dependencies in the report (supported: npm, yarn)",
+		Usage:      "include development dependencies in the report (supported: npm, yarn, gradle)",
 	}
 	PkgTypesFlag = Flag[[]string]{
 		Name:       "pkg-types",


### PR DESCRIPTION
## Description
We are now marking development dependencies while scanning gradle lockfiles so that they are not included in the final scans. So need to update the related docs as well

## Related issues
- Close #8755

## Related PRs
- [x] #8803 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
