### PR TITLE
chore: add an issue template for maintainers

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintainer.md
+++ b/.github/ISSUE_TEMPLATE/maintainer.md
@@ -1,0 +1,11 @@
+---
+name: Maintainer
+about: Create an issue by maintainers
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Are you a maintainer of the Trivy project?
+If not, please open [a discussion](https://github.com/aquasecurity/trivy/discussions); if you are, please review [the guideline](https://trivy.dev/latest/community/contribute/discussion/).


### PR DESCRIPTION
### Description
Due to recent changes on GitHub, maintainers are currently unable to create issues directly. This is inconvenient, so we're temporarily adding a dedicated issue template for maintainers. You can test it [here](https://github.com/aquasecurity/trivy-test/issues/new/choose).

### Caveat
Ideally, the maintainer template would appear at the bottom of the list, but based on my research, it's not possible to place external links at the top. As a result, the maintainer template appears first.
