### PR TITLE
docs(vuln): remove OSV for Python from data sources

### DIFF
--- a/docs/docs/scanner/vulnerability.md
+++ b/docs/docs/scanner/vulnerability.md
@@ -120,7 +120,6 @@ See [here](../coverage/language/index.md#supported-languages) for the supported 
 | PHP      | [PHP Security Advisories Database][php]             |       ✅        |     -     |
 |          | [GitHub Advisory Database (Composer)][php-ghsa]     |       ✅        |     -     |
 | Python   | [GitHub Advisory Database (pip)][python-ghsa]       |       ✅        |     -     |
-|          | [Open Source Vulnerabilities (PyPI)][python-osv]    |       ✅        |     -     |
 | Ruby     | [Ruby Advisory Database][ruby]                      |       ✅        |     -     |
 |          | [GitHub Advisory Database (RubyGems)][ruby-ghsa]    |       ✅        |     -     |
 | Node.js  | [Ecosystem Security Working Group][nodejs]          |       ✅        |     -     |


### PR DESCRIPTION
## Description
We [removed](https://github.com/aquasecurity/trivy-db/pull/345) Python advisories from OSV from trivy-db.


## Related PRs
- [x] aquasecurity/trivy-db/pull/345

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
