### PR TITLE
fix: filter all files when processing files installed from package managers

### DIFF
--- a/pkg/fanal/handler/sysfile/filter.go
+++ b/pkg/fanal/handler/sysfile/filter.go
@@ -17,32 +17,13 @@ func init() {
 
 const version = 1
 
-var (
-	defaultSystemFiles = []string{
-		// TODO: Google Distroless removes /var/lib/dpkg/info/*.list, so we cannot know which files are installed by dpkg.
-		//       We have to hardcode these files at the moment, but should look for the better way.
-		"/usr/lib/python2.7/argparse.egg-info",
-		"/usr/lib/python2.7/lib-dynload/Python-2.7.egg-info",
-		"/usr/lib/python2.7/wsgiref.egg-info",
-	}
-
-	affectedTypes = []types.LangType{
-		// ruby
-		types.GemSpec,
-
-		// python
-		types.PythonPkg,
-
-		// conda
-		types.CondaPkg,
-
-		// node.js
-		types.NodePkg,
-
-		// Go binaries
-		types.GoBinary,
-	}
-)
+var defaultSystemFiles = []string{
+	// TODO: Google Distroless removes /var/lib/dpkg/info/*.list, so we cannot know which files are installed by dpkg.
+	//       We have to hardcode these files at the moment, but should look for the better way.
+	"/usr/lib/python2.7/argparse.egg-info",
+	"/usr/lib/python2.7/lib-dynload/Python-2.7.egg-info",
+	"/usr/lib/python2.7/wsgiref.egg-info",
+}
 
 type systemFileFilteringPostHandler struct{}
 
@@ -67,7 +48,7 @@ func (h systemFileFilteringPostHandler) Handle(_ context.Context, result *analyz
 	for _, app := range blob.Applications {
 		// If the lang-specific package was installed by OS package manager, it should not be taken.
 		// Otherwise, the package version will be wrong, then it will lead to false positive.
-		if slices.Contains(systemFiles, app.FilePath) && slices.Contains(affectedTypes, app.Type) {
+		if slices.Contains(systemFiles, app.FilePath) {
 			continue
 		}
 

--- a/pkg/fanal/handler/sysfile/filter_test.go
+++ b/pkg/fanal/handler/sysfile/filter_test.go
@@ -219,42 +219,6 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 			},
 			want: &types.BlobInfo{},
 		},
-		{
-			name: "Rust will not be skipped",
-			result: &analyzer.AnalysisResult{
-				SystemInstalledFiles: []string{
-					"app/Cargo.lock",
-				},
-			},
-			blob: &types.BlobInfo{
-				Applications: []types.Application{
-					{
-						Type:     types.Cargo,
-						FilePath: "app/Cargo.lock",
-						Packages: types.Packages{
-							{
-								Name:    "ghash",
-								Version: "0.4.4",
-							},
-						},
-					},
-				},
-			},
-			want: &types.BlobInfo{
-				Applications: []types.Application{
-					{
-						Type:     types.Cargo,
-						FilePath: "app/Cargo.lock",
-						Packages: types.Packages{
-							{
-								Name:    "ghash",
-								Version: "0.4.4",
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
We didn't find reason why we skip only specific language types when filter files installed from package managers.
So we need to remove this logic.

If users will need to scan these files - they can use `--detection-priority` flag.

## Related discussions
- Close #8795

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
