### PR TITLE
feat: add function to unregister post analyzers

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -112,6 +112,10 @@ func DeregisterAnalyzer(t Type) {
 	delete(analyzers, t)
 }
 
+func DeregisterPostAnalyzer(t Type) {
+	delete(postAnalyzers, t)
+}
+
 // CustomGroup returns a group name for custom analyzers
 // This is mainly intended to be used in Aqua products.
 type CustomGroup interface {


### PR DESCRIPTION
## Description

Analogous to `DeregisterAnalyzer` but for post analyzers:

https://github.com/aquasecurity/trivy/blob/c9ba460a9b89646e139bc679883d103a7c49b9a0/pkg/fanal/analyzer/analyzer.go#L110-L113