### PR TITLE
fix(vex): use `lo.IsNil` to check `VEX` from OCI artifact

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -111,7 +111,7 @@ func New(ctx context.Context, report *types.Report, opts Options) (*Client, erro
 			v, err = NewOCI(report)
 			if err != nil {
 				return nil, xerrors.Errorf("VEX OCI error: %w", err)
-			} else if v == nil {
+			} else if lo.IsNil(v) {
 				continue
 			}
 		case TypeSBOMReference:


### PR DESCRIPTION
## Description
see #8857

## Related issues
- Close #8857

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
