### PR TITLE
refactor(db): change logic to detect wrong DB

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -60,9 +60,10 @@ func initDB(t *testing.T) string {
 	defer dbtest.Close()
 
 	err = metadata.NewClient(db.Dir(cacheDir)).Update(metadata.Metadata{
-		Version:    db.SchemaVersion,
-		NextUpdate: time.Now().Add(24 * time.Hour),
-		UpdatedAt:  time.Now(),
+		Version:      db.SchemaVersion,
+		NextUpdate:   time.Now().Add(24 * time.Hour),
+		UpdatedAt:    time.Now(),
+		DownloadedAt: time.Now(),
 	})
 	require.NoError(t, err)
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -114,9 +114,6 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 	// So we need to delete this DB and re-download it.
 	if meta.DownloadedAt.IsZero() {
 		log.ErrorContext(ctx, "The DownloadAt field is empty. Trivy-db was not downloaded correctly and must be re-downloaded.")
-		if err = os.RemoveAll(db.Path(c.dbDir)); err != nil {
-			return true, xerrors.Errorf("unable to clear vulnerability database: %w", err)
-		}
 
 		noRequiredFiles = true
 		meta = metadata.Metadata{Version: db.SchemaVersion}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -115,15 +115,15 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 	// - trivy-db was corrupted while copying from tmp directory to cache directory. We should update this trivy-db.
 	// We can't detect these cases, so we will show warning for users who use oras + air-gapped.
 	if meta.DownloadedAt.IsZero() {
-		meta = metadata.Metadata{Version: db.SchemaVersion}
+		meta = metadata.Metadata{Version: meta.Version}
 		if !skip {
-			log.WarnContext(ctx, "Trivy-db may be corrupted and will be re-downloaded. If you used `oras` to download DB - use the `--skip-db-update` flag to skip updating DB.")
+			log.WarnContext(ctx, "Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB.")
 		}
 	}
 
 	if skip && noRequiredFiles {
 		log.ErrorContext(ctx, "The first run cannot skip downloading DB")
-		return false, xerrors.New("--skip-update cannot be specified on the first run")
+		return false, xerrors.New("--skip-db-update cannot be specified on the first run")
 	}
 
 	if db.SchemaVersion < meta.Version {
@@ -152,7 +152,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 func (c *Client) validate(meta metadata.Metadata) error {
 	if db.SchemaVersion != meta.Version {
 		log.Error("The local DB has an old schema version which is not supported by the current version of Trivy CLI. DB needs to be updated.")
-		return xerrors.Errorf("--skip-update cannot be specified with the old DB schema. Local DB: %d, Expected: %d",
+		return xerrors.Errorf("--skip-db-update cannot be specified with the old DB schema. Local DB: %d, Expected: %d",
 			meta.Version, db.SchemaVersion)
 	}
 	return nil

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -114,11 +114,9 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 	// - trivy-db was downloaded with `oras`. In this case user can use `--skip-db-update` (like for air-gapped) or re-download trivy-db.
 	// - trivy-db was corrupted while copying from tmp directory to cache directory. We should update this trivy-db.
 	// We can't detect these cases, so we will show warning for users who use oras + air-gapped.
-	if meta.DownloadedAt.IsZero() {
-		meta = metadata.Metadata{Version: meta.Version}
-		if !skip {
-			log.WarnContext(ctx, "Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB.")
-		}
+	if meta.DownloadedAt.IsZero() && !skip {
+		log.WarnContext(ctx, "Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB.")
+		return true, nil
 	}
 
 	if skip && noRequiredFiles {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -157,6 +157,18 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name:         "DownloadedAt is zero, skip is true, old schema version",
+			dbFileExists: true,
+			skip:         true,
+			metadata: metadata.Metadata{
+				Version:      0,
+				DownloadedAt: time.Time{}, // zero time
+				NextUpdate:   timeNextUpdateDay1,
+			},
+			wantErr: "--skip-db-update cannot be specified with the old DB schema. Local DB: 0, Expected: 2",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -136,8 +136,9 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "DownloadedAt is zero, skip is false",
-			skip: false,
+			name:         "DownloadedAt is zero, skip is false",
+			dbFileExists: true,
+			skip:         false,
 			metadata: metadata.Metadata{
 				Version:      db.SchemaVersion,
 				DownloadedAt: time.Time{}, // zero time
@@ -146,15 +147,15 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "DownloadedAt is zero, skip is true",
-			skip: true,
+			name:         "DownloadedAt is zero, skip is true",
+			dbFileExists: true,
+			skip:         true,
 			metadata: metadata.Metadata{
 				Version:      db.SchemaVersion,
 				DownloadedAt: time.Time{}, // zero time
 				NextUpdate:   timeNextUpdateDay1,
 			},
-			want:    false,
-			wantErr: "--skip-update cannot be specified on the first run",
+			want: false,
 		},
 	}
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -59,7 +59,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 			want: true,
 		},
 		{
-			name:         "happy path with --skip-update",
+			name:         "happy path with --skip-db-update",
 			dbFileExists: true,
 			metadata: metadata.Metadata{
 				Version:      db.SchemaVersion,
@@ -91,20 +91,20 @@ func TestClient_NeedsUpdate(t *testing.T) {
 				db.SchemaVersion+1, db.SchemaVersion),
 		},
 		{
-			name:         "--skip-update without trivy.db on the first run",
+			name:         "--skip-db-update without trivy.db on the first run",
 			dbFileExists: false,
 			skip:         true,
-			wantErr:      "--skip-update cannot be specified on the first run",
+			wantErr:      "--skip-db-update cannot be specified on the first run",
 		},
 		{
-			name:         "--skip-update without metadata.json on the first run",
+			name:         "--skip-db-update without metadata.json on the first run",
 			dbFileExists: true,
 			metadata:     metadata.Metadata{},
 			skip:         true,
-			wantErr:      "--skip-update cannot be specified on the first run",
+			wantErr:      "--skip-db-update cannot be specified on the first run",
 		},
 		{
-			name:         "--skip-update with different schema version",
+			name:         "--skip-db-update with different schema version",
 			dbFileExists: true,
 			metadata: metadata.Metadata{
 				Version:      0,
@@ -112,7 +112,7 @@ func TestClient_NeedsUpdate(t *testing.T) {
 				DownloadedAt: timeDownloadAt,
 			},
 			skip: true,
-			wantErr: fmt.Sprintf("--skip-update cannot be specified with the old DB schema. Local DB: %d, Expected: %d",
+			wantErr: fmt.Sprintf("--skip-db-update cannot be specified with the old DB schema. Local DB: %d, Expected: %d",
 				0, db.SchemaVersion),
 		},
 		{


### PR DESCRIPTION
## Description
We update the `DownloadAt` field after downloading (and copying) the DB to the cache folder.
Instead of deleting `metadata.json` before each download - we will check the field.

### Nuances
There are 2 cases when the `DownloadAt` field is zero.
But we cannot determine which case it is:
1. When copying after download was interrupted.
In this case, we mark this DB as requiring updating and show a warning about this case:
```
➜  ./trivy -d image alpine                 
...
2025-05-15T14:58:44+06:00       WARN    [vulndb] Trivy-db may be corrupted and will be re-downloaded. If you used `oras` to download DB - use the `--skip-db-update` flag to skip updating DB.
2025-05-15T14:58:44+06:00       INFO    [vulndb] Need to update DB
2025-05-15T14:58:44+06:00       INFO    [vulndb] Downloading vulnerability DB...
2025-05-15T14:58:44+06:00       INFO    [vulndb] Downloading artifact...        repo="mirror.gcr.io/aquasec/trivy-db:2"
...
```
2. When trivy-db was downloaded using `oras`. 
In most case it required for air-gapped environment. So in most cases users will use `--skip-db-update` flag.
For this flag we will hide warning and just skip db update:
```
➜ ./trivy -d image --skip-db-update alpine
2025-05-15T15:00:55+06:00       INFO    Loaded  file_path="trivy.yaml"
2025-05-15T15:00:55+06:00       DEBUG   Cache dir       dir="/Users/dmitriy/Library/Caches/trivy"
2025-05-15T15:00:55+06:00       DEBUG   Cache dir       dir="/Users/dmitriy/Library/Caches/trivy"
2025-05-15T15:00:55+06:00       DEBUG   Parsed severities       severities=[UNKNOWN LOW MEDIUM HIGH CRITICAL]
2025-05-15T15:00:55+06:00       DEBUG   Ignore statuses statuses=[]
2025-05-15T15:00:55+06:00       DEBUG   [vulndb] Skipping DB update...
2025-05-15T15:00:55+06:00       DEBUG   DB info schema=2 updated_at=2025-05-15T06:21:59.924882312Z next_update=2025-05-16T06:21:59.924882172Z downloaded_at=0001-01-01T00:00:00Z

```


## Related discussions
- Close #8786

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
