### PR TITLE
feat(misconf): Add support for Minimum Version Support

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -23,26 +23,27 @@ import (
 const annotationScopePackage = "package"
 
 type StaticMetadata struct {
-	Deprecated         bool
-	ID                 string
-	AVDID              string
-	Title              string
-	ShortCode          string
-	Aliases            []string
-	Description        string
-	Severity           string
-	RecommendedActions string
-	PrimaryURL         string
-	References         []string
-	InputOptions       InputOptions
-	Package            string
-	Frameworks         map[framework.Framework][]string
-	Provider           string
-	Service            string
-	Library            bool
-	CloudFormation     *scan.EngineMetadata
-	Terraform          *scan.EngineMetadata
-	Examples           string
+	Deprecated              bool
+	ID                      string
+	AVDID                   string
+	Title                   string
+	ShortCode               string
+	Aliases                 []string
+	Description             string
+	Severity                string
+	RecommendedActions      string
+	PrimaryURL              string
+	References              []string
+	InputOptions            InputOptions
+	Package                 string
+	Frameworks              map[framework.Framework][]string
+	Provider                string
+	Service                 string
+	Library                 bool
+	CloudFormation          *scan.EngineMetadata
+	Terraform               *scan.EngineMetadata
+	Examples                string
+	MinimumSupportedVersion string
 }
 
 func NewStaticMetadata(pkgPath string, inputOpt InputOptions) *StaticMetadata {
@@ -80,11 +81,16 @@ func (sm *StaticMetadata) populate(meta map[string]any) error {
 	upd(&sm.RecommendedActions, "recommended_actions")
 	upd(&sm.RecommendedActions, "recommended_action")
 	upd(&sm.Examples, "examples")
+	upd(&sm.MinimumSupportedVersion, "minimum_supported_version")
 
 	if raw, ok := meta["deprecated"]; ok {
 		if dep, ok := raw.(bool); ok {
 			sm.Deprecated = dep
 		}
+	}
+
+	if raw, ok := meta["minimum_supported_version"]; ok {
+		sm.MinimumSupportedVersion = raw.(string)
 	}
 
 	if raw, ok := meta["severity"]; ok {
@@ -265,23 +271,24 @@ func (sm *StaticMetadata) ToRule() scan.Rule {
 	}
 
 	return scan.Rule{
-		Deprecated:     sm.Deprecated,
-		AVDID:          sm.AVDID,
-		Aliases:        append(sm.Aliases, sm.ID),
-		ShortCode:      sm.ShortCode,
-		Summary:        sm.Title,
-		Explanation:    sm.Description,
-		Impact:         "",
-		Resolution:     sm.RecommendedActions,
-		Provider:       providers.Provider(provider),
-		Service:        cmp.Or(sm.Service, "general"),
-		Links:          sm.References,
-		Severity:       severity.Severity(sm.Severity),
-		RegoPackage:    sm.Package,
-		Frameworks:     sm.Frameworks,
-		CloudFormation: sm.CloudFormation,
-		Terraform:      sm.Terraform,
-		Examples:       sm.Examples,
+		Deprecated:              sm.Deprecated,
+		AVDID:                   sm.AVDID,
+		Aliases:                 append(sm.Aliases, sm.ID),
+		ShortCode:               sm.ShortCode,
+		Summary:                 sm.Title,
+		Explanation:             sm.Description,
+		Impact:                  "",
+		Resolution:              sm.RecommendedActions,
+		Provider:                providers.Provider(provider),
+		Service:                 cmp.Or(sm.Service, "general"),
+		Links:                   sm.References,
+		Severity:                severity.Severity(sm.Severity),
+		RegoPackage:             sm.Package,
+		Frameworks:              sm.Frameworks,
+		CloudFormation:          sm.CloudFormation,
+		Terraform:               sm.Terraform,
+		Examples:                sm.Examples,
+		MinimumSupportedVersion: sm.MinimumSupportedVersion,
 	}
 }
 

--- a/pkg/iac/rego/metadata_test.go
+++ b/pkg/iac/rego/metadata_test.go
@@ -14,20 +14,21 @@ import (
 func Test_UpdateStaticMetadata(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
 		sm := StaticMetadata{
-			ID:                 "i",
-			AVDID:              "a",
-			Title:              "t",
-			ShortCode:          "sc",
-			Aliases:            []string{"a", "b", "c"},
-			Description:        "d",
-			Severity:           "s",
-			RecommendedActions: "ra",
-			PrimaryURL:         "pu",
-			References:         []string{"r"},
-			Package:            "pkg",
-			Provider:           "pr",
-			Service:            "srvc",
-			Library:            false,
+			ID:                      "i",
+			AVDID:                   "a",
+			Title:                   "t",
+			ShortCode:               "sc",
+			Aliases:                 []string{"a", "b", "c"},
+			Description:             "d",
+			Severity:                "s",
+			RecommendedActions:      "ra",
+			PrimaryURL:              "pu",
+			References:              []string{"r"},
+			Package:                 "pkg",
+			Provider:                "pr",
+			Service:                 "srvc",
+			Library:                 false,
+			MinimumSupportedVersion: "v1.2.3",
 		}
 
 		require.NoError(t, sm.populate(
@@ -47,6 +48,7 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 				"frameworks": map[string]any{
 					"all": []any{"aa"},
 				},
+				"minimum_supported_version": "v1.2.3",
 			},
 		))
 
@@ -60,6 +62,7 @@ func Test_UpdateStaticMetadata(t *testing.T) {
 			Severity:           "S_N",
 			RecommendedActions: "ra_n",
 			PrimaryURL:         "pu",
+			MinimumSupportedVersion: "v1.2.3",
 			References:         []string{"r", "r_n"},
 			Package:            "pkg",
 			Provider:           "pr_n",
@@ -248,6 +251,7 @@ func TestMetadataFromAnnotations(t *testing.T) {
 #   id: test-001
 #   avd_id: test-001
 #   severity: LOW
+#   minimum_supported_version: 1.2.3
 #   input:
 #     selector:
 #     - type: yaml
@@ -265,6 +269,7 @@ package user.test
 						},
 					},
 				},
+				MinimumSupportedVersion: "1.2.3",
 				Package: "data.user.test",
 				Frameworks: map[framework.Framework][]string{
 					"default": {},

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -36,25 +36,26 @@ type TerraformCustomCheck struct {
 }
 
 type Rule struct {
-	Deprecated     bool                             `json:"deprecated"`
-	AVDID          string                           `json:"avd_id"`
-	Aliases        []string                         `json:"aliases"`
-	ShortCode      string                           `json:"short_code"`
-	Summary        string                           `json:"summary"`
-	Explanation    string                           `json:"explanation"`
-	Impact         string                           `json:"impact"`
-	Resolution     string                           `json:"resolution"`
-	Provider       providers.Provider               `json:"provider"`
-	Service        string                           `json:"service"`
-	Links          []string                         `json:"links"`
-	Severity       severity.Severity                `json:"severity"`
-	Terraform      *EngineMetadata                  `json:"terraform,omitempty"`
-	CloudFormation *EngineMetadata                  `json:"cloud_formation,omitempty"`
-	Examples       string                           `json:"-"`
-	CustomChecks   CustomChecks                     `json:"-"`
-	RegoPackage    string                           `json:"-"`
-	Frameworks     map[framework.Framework][]string `json:"frameworks"`
-	Check          CheckFunc                        `json:"-"`
+	Deprecated              bool                             `json:"deprecated"`
+	AVDID                   string                           `json:"avd_id"`
+	Aliases                 []string                         `json:"aliases"`
+	ShortCode               string                           `json:"short_code"`
+	Summary                 string                           `json:"summary"`
+	Explanation             string                           `json:"explanation"`
+	Impact                  string                           `json:"impact"`
+	Resolution              string                           `json:"resolution"`
+	Provider                providers.Provider               `json:"provider"`
+	Service                 string                           `json:"service"`
+	Links                   []string                         `json:"links"`
+	Severity                severity.Severity                `json:"severity"`
+	Terraform               *EngineMetadata                  `json:"terraform,omitempty"`
+	CloudFormation          *EngineMetadata                  `json:"cloud_formation,omitempty"`
+	Examples                string                           `json:"-"`
+	CustomChecks            CustomChecks                     `json:"-"`
+	RegoPackage             string                           `json:"-"`
+	Frameworks              map[framework.Framework][]string `json:"frameworks"`
+	Check                   CheckFunc                        `json:"-"`
+	MinimumSupportedVersion string                           `json:"minimum_supported_version"`
 }
 
 func (r Rule) IsDeprecated() bool {

--- a/pkg/version/app/version.go
+++ b/pkg/version/app/version.go
@@ -5,3 +5,7 @@ var ver = "dev"
 func Version() string {
 	return ver
 }
+
+func SetVersion(v string) {
+	ver = v
+}


### PR DESCRIPTION
## Description

Adds support to checks to allow the minimum trivy version required to be set.

Signed-off-by: Simar <simar@linux.com>

### Example check
```rego
# title: "dummy title"
# description: "some description"
# scope: package
# schemas:
# - input: schema["input"]
# custom:
#   minimum_supported_version: "1.2.3"
package builtin.foo.ABC123
deny {
    input.evil
}
```

In this case a Trivy version of >=1.2.3 is required to run this check.

## Related issues
- Implements: https://github.com/aquasecurity/trivy/issues/8637


## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
