### PR TITLE
fix(cli): don't use allow values for `--compliance` flag

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_image.md
+++ b/docs/docs/references/configuration/cli/trivy_image.md
@@ -38,7 +38,7 @@ trivy image [flags] IMAGE_NAME
       --cache-ttl duration                cache TTL when using redis as cache backend
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:1")
-      --compliance string                 compliance report to generate (allowed values: docker-cis-1.6.0)
+      --compliance string                 compliance report to generate (built-in compliance's: docker-cis-1.6.0)
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -35,7 +35,7 @@ trivy kubernetes [flags] [CONTEXT]
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:1")
       --compliance string                 compliance report to generate
-                                          Allowed values:
+                                          Built-in compliance's:
                                             - k8s-nsa-1.0
                                             - k8s-cis-1.23
                                             - eks-cis-1.4

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -252,7 +252,7 @@ func NewImageCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ReportFormat = report
 
 	compliance := flag.ComplianceFlag.Clone()
-	compliance.Values = []string{types.ComplianceDockerCIS160}
+	compliance.Usage = fmt.Sprintf("%s (built-in compliance's: %s)", compliance.Usage, types.ComplianceDockerCIS160)
 	reportFlagGroup.Compliance = compliance // override usage as the accepted values differ for each subcommand.
 
 	packageFlagGroup := flag.NewPackageFlagGroup()
@@ -995,18 +995,15 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	imageFlags := &flag.ImageFlagGroup{ImageSources: flag.SourceFlag.Clone()}
 
 	reportFlagGroup := flag.NewReportFlagGroup()
+	reportFlagGroup.ExitOnEOL = nil // disable '--exit-on-eol'
+	reportFlagGroup.TableMode = nil // disable '--table-mode's
 	compliance := flag.ComplianceFlag.Clone()
-	compliance.Values = []string{
-		types.ComplianceK8sNsa10,
-		types.ComplianceK8sCIS123,
-		types.ComplianceEksCIS14,
-		types.ComplianceRke2CIS124,
-		types.ComplianceK8sPSSBaseline01,
-		types.ComplianceK8sPSSRestricted01,
+	var compliances string
+	for _, val := range types.BuildInK8sCompiances {
+		compliances += fmt.Sprintf("\n  - %s", val)
 	}
+	compliance.Usage = fmt.Sprintf("%s\nBuilt-in compliance's:%s", compliance.Usage, compliances)
 	reportFlagGroup.Compliance = compliance // override usage as the accepted values differ for each subcommand.
-	reportFlagGroup.ExitOnEOL = nil         // disable '--exit-on-eol'
-	reportFlagGroup.TableMode = nil         // disable '--table-mode'
 
 	formatFlag := flag.FormatFlag.Clone()
 	formatFlag.Values = xstrings.ToStringSlice([]types.Format{

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -999,7 +999,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.TableMode = nil // disable '--table-mode's
 	compliance := flag.ComplianceFlag.Clone()
 	var compliances string
-	for _, val := range types.BuildInK8sCompiances {
+	for _, val := range types.BuiltInK8sCompiances {
 		compliances += fmt.Sprintf("\n  - %s", val)
 	}
 	compliance.Usage = fmt.Sprintf("%s\nBuilt-in compliance's:%s", compliance.Usage, compliances)

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -74,7 +74,7 @@ const (
 	FormatCosignVuln Format = "cosign-vuln"
 )
 
-var BuildInK8sCompiances = []string{
+var BuiltInK8sCompiances = []string{
 	ComplianceK8sNsa10,
 	ComplianceK8sCIS123,
 	ComplianceEksCIS14,

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -74,6 +74,15 @@ const (
 	FormatCosignVuln Format = "cosign-vuln"
 )
 
+var BuildInK8sCompiances = []string{
+	ComplianceK8sNsa10,
+	ComplianceK8sCIS123,
+	ComplianceEksCIS14,
+	ComplianceRke2CIS124,
+	ComplianceK8sPSSBaseline01,
+	ComplianceK8sPSSRestricted01,
+}
+
 var (
 	SupportedFormats = []Format{
 		FormatTable,


### PR DESCRIPTION
## Description
We don't need to use allowed values for `--complience` flag, because in this case users can't use custom compliance.
See more info in #8876.

So this PR removes allowed values and added built-in compiance's in flag description:
```
➜  ./trivy image --help | grep "\-\-compliance"   
      --compliance string          compliance report to generate (built-in compliance's: docker-cis-1.6.0)
➜  ./trivy k8s --help | grep "\-\-compliance" -A 7
      --compliance string          compliance report to generate
                                   Built-in compliance's:
                                     - k8s-nsa-1.0
                                     - k8s-cis-1.23
                                     - eks-cis-1.4
                                     - rke2-cis-1.24
                                     - k8s-pss-baseline-0.1
                                     - k8s-pss-restricted-0.1

```


## Related issues
- Close #8876

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
