### PR TITLE
fix: julia parser panicing

### DIFF
--- a/pkg/dependency/parser/julia/manifest/parse.go
+++ b/pkg/dependency/parser/julia/manifest/parse.go
@@ -140,6 +140,9 @@ func decodeDependency(man *primitiveManifest, dep primitiveDependency, metadata 
 		var possibleUuids []string
 		for _, depName := range possibleDeps {
 			primDep := man.Dependencies[depName]
+			if len(primDep) == 0 {
+				return primitiveDependency{}, xerrors.Errorf("Dependency %q has invalid format (parsed no deps): %s", depName, primDep)
+			}
 			if len(primDep) > 1 {
 				return primitiveDependency{}, xerrors.Errorf("Dependency %q has invalid format (parsed multiple deps): %s", depName, primDep)
 			}

--- a/pkg/dependency/parser/julia/manifest/parse_test.go
+++ b/pkg/dependency/parser/julia/manifest/parse_test.go
@@ -17,6 +17,7 @@ func TestParse(t *testing.T) {
 		file     string // Test input file
 		want     []ftypes.Package
 		wantDeps []ftypes.Dependency
+		wantErr  string
 	}{
 		{
 			name:     "Manifest v1.6",
@@ -60,6 +61,16 @@ func TestParse(t *testing.T) {
 			want:     juliaV10FormatPkgs,
 			wantDeps: juliaV10FormatDeps,
 		},
+		{
+			name:    "Manifest file doesn't contain child dependency of another dependency",
+			file:    "testdata/missed-child-dep/Manifest.toml",
+			wantErr: "has invalid format (parsed no deps)",
+		},
+		{
+			name:    "Manifest file contains multiple dependencies with same name",
+			file:    "testdata/multiple-same-deps/Manifest.toml",
+			wantErr: "has invalid format (parsed multiple deps)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +79,11 @@ func TestParse(t *testing.T) {
 			require.NoError(t, err)
 
 			gotPkgs, gotDeps, err := NewParser().Parse(f)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
 			require.NoError(t, err)
 
 			sort.Sort(ftypes.Packages(tt.want))

--- a/pkg/dependency/parser/julia/manifest/testdata/missed-child-dep/Manifest.toml
+++ b/pkg/dependency/parser/julia/manifest/testdata/missed-child-dep/Manifest.toml
@@ -1,0 +1,16 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/pkg/dependency/parser/julia/manifest/testdata/multiple-same-deps/Manifest.toml
+++ b/pkg/dependency/parser/julia/manifest/testdata/multiple-same-deps/Manifest.toml
@@ -1,0 +1,11 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d8"


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0

goroutine 60 [running]:
github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest.decodeDependency(0xc009103b90, {{{0x83faa00, 0xc0091516b0}, {0xc009190b20, 0x2, 0x2}}, {0xc0085fa245, 0x24}, {0x0, 0x0}, ...}, ...)
        github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest/parse.go:146 +0x66d
github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest.decodeManifest(0xc009103b90, 0xc00582bbc0)
        github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest/parse.go:122 +0x25e
github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest.(*Parser).Parse(0xa6a0f40?, {0xa704f00, 0xc006cc4388})
        github.com/aquasecurity/trivy/pkg/dependency/parser/julia/manifest/parse.go:59 +0x32d
github.com/aquasecurity/trivy/pkg/fanal/analyzer/language.Parse({0x92fd8db, 0x5}, {0xc000fcec00, 0x54}, {0xa6a0f40?, 0xc006cc4388?}, {0xa6a9600, 0xe1bee80})
        github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/analyze.go:55 +0xd7
github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg.juliaAnalyzer.parseJuliaManifest(...)
        github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg/pkg.go:102
github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg.juliaAnalyzer.PostAnalyze.func2({0xc000fcec00, 0x54}, {0x54?, 0xc00917c2d0?}, {0xa6a0f40?, 0xc006cc4388?})
        github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg/pkg.go:62 +0x8a
github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg.juliaAnalyzer.PostAnalyze.WalkDir.func3({0xc000fcec00, 0x54}, {0xa71be98, 0xc000cff310}, {0x0?, 0x0?})
        github.com/aquasecurity/trivy/pkg/utils/fsutils/fs.go:88 +0x214
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc000fcec00, 0x54}, {0xa71be98, 0xc000cff310}, 0xc00582c9a0)
        io/fs/walk.go:73 +0x6c
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00917c280, 0x46}, {0xa71be98, 0xc00458e2a8}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00540eac0, 0x32}, {0xa71be98, 0xc004421068}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00371b1a0, 0x29}, {0xa71be98, 0xc004420c08}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00371b110, 0x24}, {0xa71be98, 0xc004420668}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc006bc90e0, 0x1e}, {0xa71be98, 0xc0044202a8}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc0038b7380, 0x12}, {0xa71be98, 0xc0036ea708}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00657dab0, 0x9}, {0xa71be98, 0xc001182b68}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xc00657da5a, 0x3}, {0xa71be98, 0xc001182848}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.walkDir({0xa6a1940, 0xc003ebf008}, {0xa66d8d8, 0x1}, {0xa71b268, 0xc000ae9650}, 0xc00582c9a0)
        io/fs/walk.go:95 +0x2bc
io/fs.WalkDir({0xa6a1940, 0xc003ebf008}, {0xa66d8d8, 0x1}, 0xc00582c9a0)
        io/fs/walk.go:122 +0x9a
github.com/aquasecurity/trivy/pkg/utils/fsutils.WalkDir(...)
        github.com/aquasecurity/trivy/pkg/utils/fsutils/fs.go:75
github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg.juliaAnalyzer.PostAnalyze({{0xa6a9600?, 0xe1bee80?}, 0xc0012129e0?}, {0x2c?, 0x47?}, {{0xa6a1940, 0xc003ebf008}, {0x0, 0x0, 0x0}, ...})
        github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/julia/pkg/pkg.go:60 +0x186
github.com/aquasecurity/trivy/pkg/fanal/analyzer.AnalyzerGroup.PostAnalyze({0xc001212480, {0xc00078f800, 0x1d, 0x20}, {0xc0003ff980, 0x6, 0x8}, 0xc0017baf60, {0x9309192, 0x7}}, ...)
        github.com/aquasecurity/trivy/pkg/fanal/analyzer/analyzer.go:521 +0x399
github.com/aquasecurity/trivy/pkg/fanal/artifact/image.Artifact.inspectLayer({0xc001212e20, {0xa74afa0, 0xc000464dc0}, {0x7f39f846d008, 0xc000eb2210}, {{0xe1bee80, 0x0, 0x0}, {0xe1bee80, 0x0, ...}}, ...}, ...)
        github.com/aquasecurity/trivy/pkg/fanal/artifact/image/image.go:415 +0x7a9
github.com/aquasecurity/trivy/pkg/fanal/artifact/image.Artifact.inspect.func1({0xa71b038, 0xc000d3e460}, {0xc000f23f40, 0x47})
        github.com/aquasecurity/trivy/pkg/fanal/artifact/image/image.go:332 +0x23c
github.com/aquasecurity/trivy/pkg/parallel.(*Pipeline[...]).Do.func2()
        github.com/aquasecurity/trivy/pkg/parallel/pipeline.go:82 +0xa4
golang.org/x/sync/errgroup.(*Group).Go.func1()
        golang.org/x/sync@v0.12.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        golang.org/x/sync@v0.12.0/errgroup/errgroup.go:75 +0x93
```

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
