### PR TITLE
fix(cli): disable `--skip-dir` and `--skip-files` flags for `sbom` command

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_sbom.md
+++ b/docs/docs/references/configuration/cli/trivy_sbom.md
@@ -98,8 +98,6 @@ trivy sbom [flags] SBOM_PATH
                                         (default [UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL])
       --show-suppressed                [EXPERIMENTAL] show suppressed vulnerabilities
       --skip-db-update                 skip updating vulnerability database
-      --skip-dirs strings              specify the directories or glob patterns to skip
-      --skip-files strings             specify the files or glob patterns to skip
       --skip-java-db-update            skip updating Java index database
       --skip-vex-repo-update           [EXPERIMENTAL] Skip VEX Repository update
       --table-mode strings             [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -1169,6 +1169,8 @@ func NewSBOMCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	scanFlagGroup := flag.NewScanFlagGroup()
 	scanFlagGroup.Scanners = scanners // allow only 'vuln' and 'license' options for '--scanners'
 	scanFlagGroup.Parallel = nil      // disable '--parallel'
+	scanFlagGroup.SkipFiles = nil     // disable `--skip-files` since `sbom` command only supports scanning one file.
+	scanFlagGroup.SkipDirs = nil      // disable `--skip-dirs` since `sbom` command only supports scanning one file.
 
 	licenseFlagGroup := flag.NewLicenseFlagGroup()
 	// License full-scan and confidence-level are for file content only


### PR DESCRIPTION
## Description
The `sbom` command can only scan a single SBOM file.
So we need to disable the `--skip-dir` and `--skip-files` flags.

## Related discussions
- Close #8882

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
