### PR TITLE
fix(debian): add debian sid mapping to debian detector

### DIFF
--- a/pkg/detector/ospkg/debian/debian.go
+++ b/pkg/detector/ospkg/debian/debian.go
@@ -39,6 +39,10 @@ var (
 		"12":  time.Date(2028, 6, 10, 23, 59, 59, 0, time.UTC),
 		"13":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}
+
+	sidVersions = map[string]string{
+		"trixie/sid": "13",
+	}
 )
 
 // Scanner implements the Debian scanner
@@ -56,6 +60,10 @@ func NewScanner() *Scanner {
 // Detect scans and return vulnerabilities using Debian scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
 	osVer = osver.Major(osVer)
+
+	if sidVer, ok := sidVersions[osVer]; ok {
+		osVer = sidVer
+	}
 
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
 		log.Int("pkg_num", len(pkgs)))

--- a/pkg/detector/ospkg/debian/debian_test.go
+++ b/pkg/detector/ospkg/debian/debian_test.go
@@ -87,6 +87,62 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name: "sid",
+			fixtures: []string{
+				"testdata/fixtures/data-source.yaml",
+				"testdata/fixtures/sid.yaml",
+			},
+			args: args{
+				osVer: "trixie/sid",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "htpasswd",
+						Version:    "2.4.24",
+						SrcName:    "apache2",
+						SrcVersion: "2.4.24",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "htpasswd",
+					VulnerabilityID:  "CVE-2020-11985",
+					VendorIDs:        []string{"DSA-4884-1"},
+					InstalledVersion: "2.4.24",
+					FixedVersion:     "2.4.25-1",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+				{
+					PkgName:          "htpasswd",
+					VulnerabilityID:  "CVE-2021-31618",
+					InstalledVersion: "2.4.24",
+					Status:           dbTypes.StatusWillNotFix,
+					SeveritySource:   vulnerability.Debian,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityMedium.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+			},
+		},
+		{
 			name: "invalid bucket",
 			fixtures: []string{
 				"testdata/fixtures/invalid.yaml",

--- a/pkg/detector/ospkg/debian/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/debian/testdata/fixtures/data-source.yaml
@@ -5,3 +5,8 @@
         ID: "debian"
         Name: "Debian Security Tracker"
         URL: "https://salsa.debian.org/security-tracker-team/security-tracker"
+    - key: debian 13
+      value:
+        ID: "debian"
+        Name: "Debian Security Tracker"
+        URL: "https://salsa.debian.org/security-tracker-team/security-tracker"

--- a/pkg/detector/ospkg/debian/testdata/fixtures/sid.yaml
+++ b/pkg/detector/ospkg/debian/testdata/fixtures/sid.yaml
@@ -1,0 +1,17 @@
+- bucket: debian 13
+  pairs:
+    - bucket: apache2
+      pairs:
+        - key: CVE-2012-3499
+          value:
+            FixedVersion: "2.2.22-13"
+        - key: CVE-2020-11985
+          value:
+            FixedVersion: "2.4.25-1"
+            VendorIDs:
+              - DSA-4884-1
+        - key: CVE-2021-31618
+          value:
+            FixedVersion: ""
+            Severity: 2
+            Status: 5


### PR DESCRIPTION
## Description
Support scanning debian sId versions.
I currently added just trixie sid, assuming that we don't want to support old sid versions ( since they probably no longer exist). But I made it so when adding a new eol date to the debian mapping, adding a new sid version will be right next to it.

## Related issues
- Close #8889 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
