### PR TITLE
refactor(license): simplify compound license scanning

### DIFF
--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -24,16 +24,16 @@ func parse(license string) (Expression, error) {
 	return l.result, nil
 }
 
-func Normalize(license string, funcs ...NormalizeFunc) (string, error) {
+func Normalize(license string, funcs ...NormalizeFunc) (Expression, error) {
 	expr, err := parse(license)
 	if err != nil {
-		return "", xerrors.Errorf("license (%s) parse error: %w", license, err)
+		return nil, xerrors.Errorf("license (%s) parse error: %w", license, err)
 	}
 	for _, fn := range funcs {
 		expr = normalize(expr, fn)
 	}
 
-	return expr.String(), nil
+	return expr, nil
 }
 
 func normalize(expr Expression, fn NormalizeFunc) Expression {

--- a/pkg/licensing/expression/expression_test.go
+++ b/pkg/licensing/expression/expression_test.go
@@ -50,7 +50,7 @@ func TestNormalize(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equalf(t, tt.want, got, "NormalizeWithExpression(%v)", tt.license)
+			assert.Equalf(t, tt.want, got.String(), "NormalizeWithExpression(%v)", tt.license)
 		})
 	}
 }

--- a/pkg/licensing/scanner.go
+++ b/pkg/licensing/scanner.go
@@ -23,7 +23,7 @@ func NewScanner(categories map[types.LicenseCategory][]string) Scanner {
 }
 
 func (s *Scanner) Scan(licenseName string) (types.LicenseCategory, string) {
-	expr, err := expression.Normalize(licenseName)
+	expr, err := expression.Normalize(licenseName, NormalizeLicense)
 	if err != nil {
 		return types.CategoryUnknown, ""
 	}

--- a/pkg/licensing/scanner_test.go
+++ b/pkg/licensing/scanner_test.go
@@ -69,6 +69,18 @@ func TestScanner_Scan(t *testing.T) {
 			wantSeverity: "HIGH",
 		},
 		{
+			name: "unnormalized license",
+			categories: map[types.LicenseCategory][]string{
+				types.CategoryRestricted: {
+					expression.BSD3Clause,
+					expression.MIT,
+				},
+			},
+			licenseName:  "MIT License",
+			wantCategory: types.CategoryRestricted,
+			wantSeverity: "HIGH",
+		},
+		{
 			name: "compound OR license",
 			categories: map[types.LicenseCategory][]string{
 				types.CategoryForbidden: {

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -473,7 +473,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 		return "", nil
 	}
 
-	return normalizedLicense, lo.Ternary(len(otherLicenses) > 0, lo.Values(otherLicenses), nil)
+	return normalizedLicense.String(), lo.Ternary(len(otherLicenses) > 0, lo.Values(otherLicenses), nil)
 }
 
 // newOtherLicense create new OtherLicense for license not included in the SPDX license list


### PR DESCRIPTION
## Description
- Refactored the `Scan` method to utilize the new `Normalize` function, returning an expression instead of a string.
- Updated the `detectCategory` method to handle both simple and compound license expressions more effectively.
- Removed the deprecated `traverseLicenseExpression` and `compoundLicenseToCategory` methods to streamline the code.
- Removed `visited` as it's too much for a single license.
- Adjusted tests to reflect normalization signature changes and ensure license category detection accuracy.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/8816


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
