### PR TITLE
refactor(terraform): simplify AllReferences method signature in Attribute

### DIFF
--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -718,22 +718,11 @@ func (a *Attribute) ReferencesBlock(b *Block) bool {
 	return false
 }
 
-// nolint
-func (a *Attribute) AllReferences(blocks ...*Block) []*Reference {
+func (a *Attribute) AllReferences() []*Reference {
 	if a == nil {
 		return nil
 	}
-	refs := a.referencesFromExpression(a.hclAttribute.Expr)
-	for _, block := range blocks {
-		for _, ref := range refs {
-			if ref.TypeLabel() == "each" {
-				if forEachAttr := block.GetAttribute("for_each"); forEachAttr.IsNotNil() {
-					refs = append(refs, forEachAttr.AllReferences()...)
-				}
-			}
-		}
-	}
-	return refs
+	return a.referencesFromExpression(a.hclAttribute.Expr)
 }
 
 func (a *Attribute) referencesFromExpression(expr hcl.Expression) []*Reference {


### PR DESCRIPTION
## Description

This PR simplifies the signature of the `AllReferences` method in `Attribute`, since no arguments were passed to this method anywhere.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
