### PR TITLE
feat: terraform parser option to set current working directory

### DIFF
--- a/pkg/iac/scanners/terraform/parser/option.go
+++ b/pkg/iac/scanners/terraform/parser/option.go
@@ -28,6 +28,12 @@ func OptionWithLogger(log *log.Logger) Option {
 	}
 }
 
+func OptionWithWorkingDirectoryPath(cwd string) Option {
+	return func(p *Parser) {
+		p.cwd = &cwd
+	}
+}
+
 func OptionsWithTfVars(vars map[string]cty.Value) Option {
 	return func(p *Parser) {
 		p.tfvars = vars

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -52,6 +52,9 @@ type Parser struct {
 	fsMap             map[string]fs.FS
 	configsFS         fs.FS
 	skipPaths         []string
+	// cwd is optional, if provided it will be used instead of 'os.Getwd'
+	// for populating 'path.cwd' in terraform
+	cwd *string
 }
 
 // New creates a new Parser
@@ -293,9 +296,14 @@ func (p *Parser) Load(_ context.Context) (*evaluator, error) {
 		)
 	}
 
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, err
+	var workingDir string
+	if p.cwd != nil {
+		workingDir = *p.cwd
+	} else {
+		workingDir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	p.logger.Debug("Working directory for module evaluation", log.FilePath(workingDir))


### PR DESCRIPTION
## Description

Terraform `path.cwd` intends to be the directory `terraform` was executed from. This value should be controllable by the caller. Especially when using in memory file systems, the actual filesystem is irrelevant.

In the my use case, ideally I would not leak any information of the actual file system of the host executing the terraform scanning.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
