### PR TITLE
feat(redhat): Add support for RHEL 10.

### DIFF
--- a/docs/docs/coverage/os/index.md
+++ b/docs/docs/coverage/os/index.md
@@ -14,7 +14,7 @@ Trivy supports operating systems for
 | [Alpine Linux](alpine.md)             | 2.2 - 2.7, 3.0 - 3.21, edge         | apk              |
 | [Wolfi Linux](wolfi.md)               | (n/a)                               | apk              |
 | [Chainguard](chainguard.md)           | (n/a)                               | apk              |
-| [Red Hat Enterprise Linux](rhel.md)   | 6, 7, 8                             | dnf/yum/rpm      |
+| [Red Hat Enterprise Linux](rhel.md)   | 6, 7, 8, 9, 10                      | dnf/yum/rpm      |
 | [CentOS](centos.md)[^1]               | 6, 7, 8                             | dnf/yum/rpm      |
 | [AlmaLinux](alma.md)                  | 8, 9                                | dnf/yum/rpm      |
 | [Rocky Linux](rocky.md)               | 8, 9                                | dnf/yum/rpm      |

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -41,15 +41,20 @@ var (
 			"rhel-9-for-x86_64-baseos-rpms",
 			"rhel-9-for-x86_64-appstream-rpms",
 		},
+		"10": {
+			"rhel-10-for-x86_64-baseos-rpms",
+			"rhel-10-for-x86_64-appstream-rpms",
+		},
 	}
 	redhatEOLDates = map[string]time.Time{
 		"4": time.Date(2017, 5, 31, 23, 59, 59, 0, time.UTC),
 		"5": time.Date(2020, 11, 30, 23, 59, 59, 0, time.UTC),
 		"6": time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC),
 		// N/A
-		"7": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
-		"8": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
-		"9": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"7":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"8":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"9":  time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
+		"10": time.Date(3000, 1, 1, 23, 59, 59, 0, time.UTC),
 	}
 	centosEOLDates = map[string]time.Time{
 		"3": time.Date(2010, 10, 31, 23, 59, 59, 0, time.UTC),


### PR DESCRIPTION
## Description

This adds RHEL 10 support that Red Hat has officially released this week at the Red Hat summit.

These before/after were tested with the image `registry.access.redhat.com/ubi10/ubi:latest`:

Before:
```
2025-05-23T23:18:58Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-23T23:18:58Z    WARN    This OS version is not on the EOL list  family="redhat" version="10"
2025-05-23T23:18:58Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=172
```

After:
```
2025-05-23T23:20:24Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-23T23:20:24Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=172
```

Also, I tested this with more complex RHEL 10 images we have started to build internally in Amadeus (actually any image that is built from `registry.access.redhat.com/ubi10/ubi:latest` in which we `dnf install -y` anything, for example `procps` . Before it used to fail with errors like:

```
2025-05-23T23:32:10Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-23T23:32:10Z    WARN    This OS version is not on the EOL list  family="redhat" version="10"
2025-05-23T23:32:10Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=173
2025-05-23T23:32:10Z    FATAL   Fatal error
  - run error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.Run
        /remote/users/rgeissler/wk/tmp/trivy/pkg/commands/artifact/run.go:386
  - image scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.run
        /remote/users/rgeissler/wk/tmp/trivy/pkg/commands/artifact/run.go:424
  - scan error:
    github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scanArtifact
        /remote/users/rgeissler/wk/tmp/trivy/pkg/commands/artifact/run.go:263
  - scan failed:
    github.com/aquasecurity/trivy/pkg/commands/artifact.(*runner).scan
        /remote/users/rgeissler/wk/tmp/trivy/pkg/commands/artifact/run.go:653
  - scan failed:
    github.com/aquasecurity/trivy/pkg/scan.Service.ScanArtifact 
        /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/service.go:177
  - failed to detect vulnerabilities:
    github.com/aquasecurity/trivy/pkg/scan/local.Service.ScanTarget
        /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/local/service.go:137
  - unable to scan OS packages:
    github.com/aquasecurity/trivy/pkg/scan/local.Service.scanVulnerabilities
        /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/local/service.go:187
  - failed vulnerability detection of OS packages:
    github.com/aquasecurity/trivy/pkg/scan/ospkg.(*scanner).Scan
        /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/ospkg/scan.go:57
  - failed detection:
    github.com/aquasecurity/trivy/pkg/detector/ospkg.Detect
        /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/detect.go:85
  - redhat vulnerability detection error:
    github.com/aquasecurity/trivy/pkg/detector/ospkg/redhat.(*Scanner).Detect
        /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/redhat/redhat.go:94
  - failed to get Red Hat advisories:
    github.com/aquasecurity/trivy/pkg/detector/ospkg/redhat.(*Scanner).detect
        /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/redhat/redhat.go:119
  - Oops: unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details
    Time: 2025-05-23 23:32:10.952595377 +0000 UTC
    Domain: redhat
    Tags: oval
    Trace: 01JVZQTT2VQ970CXEMCBXKJKJB
    Context:
      * package_name: procps-ng
      * repositories: []
      * nvrs: []
    Stacktrace:
      Oops: unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details
        --- at /remote/users/rgeissler/wk/go-build-artefacts/pkg/mod/github.com/aquasecurity/trivy-db@v0.0.0-20250227071930-8bd8a9b89e2d/pkg/vulnsrc/redhat-oval/redhat-oval.go:265 VulnSrc.Get()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/redhat/redhat.go:117 Scanner.detect()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/redhat/redhat.go:92 Scanner.Detect()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/detector/ospkg/detect.go:83 Detect()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/ospkg/scan.go:53 scanner.Scan()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/local/service.go:182 Service.scanVulnerabilities()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/local/service.go:135 Service.ScanTarget()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/local/service.go:112 Service.Scan()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/scan/service.go:175 Service.ScanArtifact()
        --- at /remote/users/rgeissler/wk/tmp/trivy/pkg/commands/artifact/run.go:651 runner.scan()
```

and after it can scan such images without problem:

```
2025-05-23T23:33:13Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-23T23:33:13Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=173
2025-05-23T23:33:14Z    INFO    Number of language-specific files       num=0
2025-05-23T23:33:14Z    DEBUG   Specified ignore file does not exist    file=".trivyignore"
2025-05-23T23:33:14Z    DEBUG   [vex] VEX filtering is disabled

Report Summary

┌────────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                     Target                                     │  Type  │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ cc04e97c33c8a9508dcac9ab5d7ddfc6451f94667cc86b5e9278ae1b57b5445e (redhat 10.0) │ redhat │        0        │    -    │
└────────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
