### PR TITLE
fix(redhat): Also try to find buildinfo in root layer (layer 0)

### DIFF
--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -71,7 +71,7 @@ func lookupBuildInfo(index int, layers []ftypes.BlobInfo) *ftypes.BuildInfo {
 
 	// Customer's layers build on top of Red Hat image are also missing content sets
 	//   - it needs to be shared from the last Red Hat's layers which contains content sets
-	for i := index - 1; i >= 1; i-- {
+	for i := index - 1; i >= 0; i-- {
 		if layers[i].BuildInfo != nil {
 			return layers[i].BuildInfo
 		}


### PR DESCRIPTION
## Description

This is a followup of #8910 where @knqyf263 rightfully pointed out that we shall not need a default content set for recent RHEL. Indeed there was another bug. This is required for future RHEL 10 support, yet RHEL 10 support is still partial.

Let's consider this Dockerfile:

```
[root@05f6cdd76f60 rhel10]# cat Dockerfile
FROM registry.access.redhat.com/ubi10/ubi:latest

RUN dnf install -y procps
```

We can build it, and look at the history of this image like this:

```
[root@05f6cdd76f60 rhel10]# docker build .                                                                                                                                                                            [+] Building 0.1s (6/6) FINISHED                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                             0.0s
 => => transferring dockerfile: 113B                                                                                                                                                                             0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi10/ubi:latest                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                  0.0s
 => [1/2] FROM registry.access.redhat.com/ubi10/ubi:latest                                                                                                                                                       0.0s
 => CACHED [2/2] RUN dnf install -y procps                                                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                                                           0.0s
 => => exporting layers                                                                                                                                                                                          0.0s
 => => writing image sha256:487ca6b14c8ad8efc9e821b85ac153b6a419ae9c9e591a33b23cd4f2a08601a4                                                                                                                     0.0s
 
 
[root@05f6cdd76f60 rhel10]# docker history sha256:487ca6b14c8ad8efc9e821b85ac153b6a419ae9c9e591a33b23cd4f2a08601a4
 IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
487ca6b14c8a   2 hours ago   RUN /bin/sh -c dnf install -y procps # build…   21.5MB    buildkit.dockerfile.v0
<missing>      12 days ago   /bin/sh -c #(nop) LABEL "build-date"="2025-0…   209MB
<missing>      12 days ago   /bin/sh -c #(nop) COPY file:2c9300aa2a82321b…   0B
<missing>      12 days ago   /bin/sh -c #(nop) CMD ["/bin/bash"]             0B
<missing>      12 days ago   /bin/sh -c #(nop) COPY file:973b743e3299d521…   0B
<missing>      12 days ago   /bin/sh -c #(nop) COPY dir:0458d10eb8f5b6ec8…   0B                                                                                                                                       <missing>      12 days ago   /bin/sh -c #(nop) ENV container oci             0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL io.openshift.tags="b…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL io.openshift.expose-…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL io.k8s.display-name=…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL io.k8s.description="…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL description="The Uni…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL summary="Provides th…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL com.redhat.license_t…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL com.redhat.component…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL url="https://www.red…   0B
<missing>      12 days ago   /bin/sh -c #(nop) LABEL maintainer="Red Hat,…   0B
```

We can see the resulting image has 2 "real" layers:
 - The original RHEL 10 layer from Red Hat (209MB). This one happens to contain a content set, and thus some valid "build info".
 - The customer layer, which is installing the `procps` (actually `procps-ng`) package. This layer has no "build info".

In the logic of `lookupBuildInfo` in `pkg/fanal/applier/docker.go` we currently assume that the layer 0 never has any build info, but that layer 1 has. Maybe it was true in the past, but it no longer is the case now. Looking at the logic, in the fina loop trying to find build info for the customer layer, it's ok to try to look for build info in layer 0. At best it will find a valid build info. At worst it will be `nil` and the loop will exit, returning `nil` in the final statement. So I believe this change is valid both for new RHEL 10 images and also "old" RHEL images which didn't have any build info in layer 0.

Before the change:
```
[root@05f6cdd76f60 rhel10]# (cd ../trivy/ && go run github.com/magefile/mage@latest build) && rm -rf /root/.cache/trivy && ../trivy/trivy image sha256:487ca6b14c8ad8efc9e821b85ac153b6a419ae9c9e591a33b23cd4f2a08601a4
2025-05-26T23:12:17Z    WARN    [vulndb] Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB. 
2025-05-26T23:12:17Z    INFO    [vulndb] Need to update DB
2025-05-26T23:12:17Z    INFO    [vulndb] Downloading vulnerability DB...
2025-05-26T23:12:17Z    INFO    [vulndb] Downloading artifact...        repo="mirror.gcr.io/aquasec/trivy-db:2"
64.26 MiB / 64.26 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24.24 MiB p/s 2.9s
2025-05-26T23:12:20Z    INFO    [vulndb] Artifact successfully downloaded       repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-05-26T23:12:20Z    INFO    [vuln] Vulnerability scanning is enabled
2025-05-26T23:12:20Z    INFO    [secret] Secret scanning is enabled
2025-05-26T23:12:20Z    INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-05-26T23:12:20Z    INFO    [secret] Please see also https://trivy.dev/dev/docs/scanner/secret#recommendation for faster secret detection
2025-05-26T23:12:27Z    INFO    [python] Licenses acquired from one or more METADATA files may be subject to additional terms. Use `--debug` flag to see all affected packages.
2025-05-26T23:12:27Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-26T23:12:27Z    WARN    This OS version is not on the EOL list  family="redhat" version="10"
2025-05-26T23:12:27Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=173
2025-05-26T23:12:28Z    FATAL   Fatal error     run error: image scan error: scan error: scan failed: scan failed: failed to detect vulnerabilities: unable to scan OS packages: failed vulnerability detection of OS packages: failed detection: redhat vulnerability detection error: failed to get Red Hat advisories: unable to find CPE indices. See https://github.com/aquasecurity/trivy-db/issues/435 for details
```

After the change:
```
[root@05f6cdd76f60 rhel10]# (cd ../trivy/ && go run github.com/magefile/mage@latest build) && rm -rf /root/.cache/trivy && ../trivy/trivy image sha256:487ca6b14c8ad8efc9e821b85ac153b6a419ae9c9e591a33b23cd4f2a08601a
4
2025-05-26T23:13:03Z    WARN    [vulndb] Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB.
2025-05-26T23:13:03Z    INFO    [vulndb] Need to update DB
2025-05-26T23:13:03Z    INFO    [vulndb] Downloading vulnerability DB...
2025-05-26T23:13:03Z    INFO    [vulndb] Downloading artifact...        repo="mirror.gcr.io/aquasec/trivy-db:2"
64.26 MiB / 64.26 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 19.64 MiB p/s 3.5s
2025-05-26T23:13:07Z    INFO    [vulndb] Artifact successfully downloaded       repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-05-26T23:13:07Z    INFO    [vuln] Vulnerability scanning is enabled
2025-05-26T23:13:07Z    INFO    [secret] Secret scanning is enabled
2025-05-26T23:13:07Z    INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-05-26T23:13:07Z    INFO    [secret] Please see also https://trivy.dev/dev/docs/scanner/secret#recommendation for faster secret detection
2025-05-26T23:13:14Z    INFO    [python] Licenses acquired from one or more METADATA files may be subject to additional terms. Use `--debug` flag to see all affected packages.
2025-05-26T23:13:15Z    INFO    Detected OS     family="redhat" version="10.0"
2025-05-26T23:13:15Z    WARN    This OS version is not on the EOL list  family="redhat" version="10"
2025-05-26T23:13:15Z    INFO    [redhat] Detecting RHEL/CentOS vulnerabilities...       os_version="10" pkg_num=173
2025-05-26T23:13:15Z    INFO    Number of language-specific files       num=0

Report Summary

┌─────────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                     Target                                      │  Type  │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ sha256:487ca6b14c8ad8efc9e821b85ac153b6a419ae9c9e591a33b23cd4f2a08601a4 (redhat │ redhat │        0        │    -    │
│ 10.0)                                                                           │        │                 │         │
└─────────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```


## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
