### PR TITLE
refactor(cloudformation): remove unused ScanFile method from Scanner

### DIFF
--- a/pkg/iac/scanners/cloudformation/scanner.go
+++ b/pkg/iac/scanners/cloudformation/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"sort"
 
 	adapter "github.com/aquasecurity/trivy/pkg/iac/adapters/cloudformation"
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
@@ -99,33 +98,6 @@ func (s *Scanner) ScanFS(ctx context.Context, fsys fs.FS, dir string) (results s
 		}
 		results = append(results, fileResults...)
 	}
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Rule().AVDID < results[j].Rule().AVDID
-	})
-	return results, nil
-}
-
-func (s *Scanner) ScanFile(ctx context.Context, fsys fs.FS, path string) (scan.Results, error) {
-
-	cfCtx, err := s.parser.ParseFile(ctx, fsys, path)
-	if err != nil {
-		return nil, err
-	}
-
-	rs, err := s.InitRegoScanner(fsys, s.options)
-	if err != nil {
-		return nil, fmt.Errorf("init rego scanner: %w", err)
-	}
-
-	results, err := s.scanFileContext(ctx, rs, cfCtx, fsys)
-	if err != nil {
-		return nil, err
-	}
-	results.SetSourceAndFilesystem("", fsys, false)
-
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Rule().AVDID < results[j].Rule().AVDID
-	})
 	return results, nil
 }
 


### PR DESCRIPTION
## Description

Removed unused `ScanFile` method in `CloudFormation` scanner. Its functionality is fully covered by the `ScanFS` method.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
