### PR TITLE
refactor(terraform): remove result sorting from scanner

### DIFF
--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -93,7 +92,6 @@ func (e *Executor) Execute(ctx context.Context, modules terraform.Modules, baseP
 
 	results = e.filterResults(results)
 
-	e.sortResults(results)
 	for i, res := range results {
 		if res.Status() != scan.StatusFailed {
 			continue
@@ -194,19 +192,6 @@ func (e *Executor) filterResults(results scan.Results) scan.Results {
 	}
 
 	return results
-}
-
-func (e *Executor) sortResults(results []scan.Result) {
-	sort.Slice(results, func(i, j int) bool {
-		switch {
-		case results[i].Rule().LongID() < results[j].Rule().LongID():
-			return true
-		case results[i].Rule().LongID() > results[j].Rule().LongID():
-			return false
-		default:
-			return results[i].Range().String() > results[j].Range().String()
-		}
-	})
 }
 
 func ignoreByParams(params map[string]string, modules terraform.Modules, m *types.Metadata) bool {


### PR DESCRIPTION
## Description

Removed result sorting from Terraform scanner, as it makes no sense at this stage. Sorting is done later - after scanning and result mapping is complete, where it is really needed.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
