### PR TITLE
feat(apk): add maintainer field extraction

### DIFF
--- a/pkg/fanal/analyzer/analyzer_test.go
+++ b/pkg/fanal/analyzer/analyzer_test.go
@@ -342,6 +342,7 @@ func TestAnalyzerGroup_AnalyzeFile(t *testing.T) {
 								SrcName:    "musl",
 								SrcVersion: "1.1.24-r2",
 								Licenses:   []string{"MIT"},
+								Maintainer: "Timo Teräs <timo.teras@iki.fi>",
 								Arch:       "x86_64",
 								Digest:     "sha1:cb2316a189ebee5282c4a9bd98794cc2477a74c6",
 								InstalledFiles: []string{

--- a/pkg/fanal/analyzer/pkg/apk/apk.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk.go
@@ -108,6 +108,8 @@ func (a alpinePkgAnalyzer) parseApkInfo(ctx context.Context, scanner *bufio.Scan
 			if d != "" {
 				pkg.Digest = d
 			}
+		case "m:":
+			pkg.Maintainer = line[2:]
 		}
 
 		if pkg.Name != "" && pkg.Version != "" {

--- a/pkg/fanal/analyzer/pkg/apk/apk_test.go
+++ b/pkg/fanal/analyzer/pkg/apk/apk_test.go
@@ -19,6 +19,7 @@ var pkgs = []types.Package{
 		SrcName:    "musl",
 		SrcVersion: "1.1.14-r10",
 		Licenses:   []string{"MIT"},
+		Maintainer: "Timo Teräs <timo.teras@iki.fi>",
 		Arch:       "x86_64",
 		Digest:     "sha1:d68b402f35f57750f49156b0cb4e886a2ad35d2d",
 		InstalledFiles: []string{
@@ -33,6 +34,7 @@ var pkgs = []types.Package{
 		SrcName:    "busybox",
 		SrcVersion: "1.24.2-r9",
 		Licenses:   []string{"GPL-2.0-only"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		DependsOn:  []string{"musl@1.1.14-r10"},
 		Arch:       "x86_64",
 		Digest:     "sha1:ca124719267cd0bedc2f4cb850a286ac13f0ad44",
@@ -51,6 +53,7 @@ var pkgs = []types.Package{
 		SrcName:    "alpine-baselayout",
 		SrcVersion: "3.0.3-r0",
 		Licenses:   []string{"GPL-2.0-only"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		DependsOn: []string{
 			"busybox@1.24.2-r9",
 			"musl@1.1.14-r10",
@@ -92,6 +95,7 @@ var pkgs = []types.Package{
 		SrcName:    "alpine-keys",
 		SrcVersion: "1.1-r0",
 		Licenses:   []string{"GPL-2.0-or-later"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		Arch:       "x86_64",
 		Digest:     "sha1:4def7ffaee6aeba700c1d62570326f75cbb8fa25",
 		InstalledFiles: []string{
@@ -109,6 +113,7 @@ var pkgs = []types.Package{
 		SrcName:    "zlib",
 		SrcVersion: "1.2.8-r2",
 		Licenses:   []string{"Zlib"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		DependsOn:  []string{"musl@1.1.14-r10"},
 		Arch:       "x86_64",
 		Digest:     "sha1:efd04d34d40aa8eb331480127364c27a8ba760ef",
@@ -124,6 +129,7 @@ var pkgs = []types.Package{
 		SrcName:    "openssl",
 		SrcVersion: "1.0.2h-r1",
 		Licenses:   []string{"OpenSSL"},
+		Maintainer: "Timo Teras <timo.teras@iki.fi>",
 		DependsOn: []string{
 			"musl@1.1.14-r10",
 			"zlib@1.2.8-r2",
@@ -155,6 +161,7 @@ var pkgs = []types.Package{
 		SrcName:    "openssl",
 		SrcVersion: "1.0.2h-r1",
 		Licenses:   []string{"OpenSSL"},
+		Maintainer: "Timo Teras <timo.teras@iki.fi>",
 		Digest:     "sha1:7120f337e93b2b4c44e0f5f31a15b60dc678ca14",
 		DependsOn: []string{
 			"libcrypto1.0@1.0.2h-r1",
@@ -173,6 +180,7 @@ var pkgs = []types.Package{
 		SrcName:    "apk-tools",
 		SrcVersion: "2.6.7-r0",
 		Licenses:   []string{"GPL-2.0-only"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		Digest:     "sha1:0990c0acd62b4175818c3a4cc60ed11f14e23bd8",
 		DependsOn: []string{
 			"libcrypto1.0@1.0.2h-r1",
@@ -192,6 +200,7 @@ var pkgs = []types.Package{
 		SrcName:    "pax-utils",
 		SrcVersion: "1.1.6-r0",
 		Licenses:   []string{"GPL-2.0-only"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		Digest:     "sha1:f9bab817c5ad93e92a6218bc0f7596b657c02d90",
 		DependsOn:  []string{"musl@1.1.14-r10"},
 		Arch:       "x86_64",
@@ -210,6 +219,7 @@ var pkgs = []types.Package{
 			"BSD-3-Clause",
 			"GPL-2.0-or-later",
 		},
+		Maintainer: "Timo Teräs <timo.teras@iki.fi>",
 		Digest: "sha1:608aa1dd39eff7bc6615d3e5e33383750f8f5ecc",
 		DependsOn: []string{
 			"musl@1.1.14-r10",
@@ -231,6 +241,7 @@ var pkgs = []types.Package{
 		SrcName:    "libc-dev",
 		SrcVersion: "0.7-r0",
 		Licenses:   []string{"GPL-2.0-or-later"},
+		Maintainer: "Natanael Copa <ncopa@alpinelinux.org>",
 		Digest:     "sha1:9055bc7afd76cf2672198042f72fc4a5ed4fa961",
 		DependsOn:  []string{"musl-utils@1.1.14-r10"},
 		Arch:       "x86_64",
@@ -243,6 +254,7 @@ var pkgs = []types.Package{
 		SrcName:    "pkgconf",
 		SrcVersion: "1.6.0-r0",
 		Licenses:   []string{"ISC"},
+		Maintainer: "William Pitcock <nenolod@dereferenced.org>",
 		Digest:     "sha1:e6242ac29589c8a84a4b179b491ea7c29fce66a9",
 		DependsOn:  []string{"musl@1.1.14-r10"},
 		Arch:       "x86_64",
@@ -261,6 +273,7 @@ var pkgs = []types.Package{
 		SrcName:    "sqlite",
 		SrcVersion: "3.26.0-r3",
 		Licenses:   []string{"Public-Domain"},
+		Maintainer: "Carlo Landmeter <clandmeter@gmail.com>",
 		Digest:     "sha1:1464946c3a5f0dd5a67ca1af930fc17af7a74474",
 		DependsOn:  []string{"musl@1.1.14-r10"},
 		Arch:       "x86_64",
@@ -276,6 +289,7 @@ var pkgs = []types.Package{
 		SrcName:    "test-parent",
 		SrcVersion: "2.9.11_pre20061021-r2",
 		Licenses:   []string{"Public-Domain"},
+		Maintainer: "Carlo Landmeter <clandmeter@gmail.com>",
 		Digest:     "sha1:f0bf315ec54828188910e4a665c00bc48bdbdd7d",
 		DependsOn: []string{
 			"pkgconf@1.6.0-r0",
@@ -300,6 +314,7 @@ var pkgs = []types.Package{
 			"MIT",
 			"MPL-2.0",
 		},
+		Maintainer: "Jakub Jirutka <jakub@jirutka.cz>",
 		Digest: "sha1:593154f80c440685448e0f52479725d7bc9b678d",
 		DependsOn: []string{
 			"musl@1.1.14-r10",


### PR DESCRIPTION
## Description

Add support for extracting maintainer information from APK packages by parsing the `m:` field in `/lib/apk/db/installed`, similar to how dpkg extracts maintainer information.

This implementation follows the APK specification (https://wiki.alpinelinux.org/wiki/Apk_spec) and provides consistent maintainer information across different package managers in Trivy.

## Changes

- Added parsing of the `m:` (maintainer) field in the APK analyzer
- Updated test cases to verify maintainer extraction works correctly
- All existing tests continue to pass

## Related issues

This addresses the request to add maintainer field extraction for APK packages, similar to the existing dpkg maintainer extraction functionality.

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).