### PR TITLE
fix(cli): Correctly check for semver versions for trivy version check

### DIFF
--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -141,19 +141,18 @@ func (v *VersionChecker) PrintNotices(output io.Writer) {
 		}
 	}
 
-
-	cv, err := semver.Parse(v.currentVersion)
+	cv, err := semver.Parse(strings.TrimPrefix(v.currentVersion, "v"))
 	if err != nil {
 		return
 	}
 
-	lv, err := semver.Parse(v.LatestVersion())
+	lv, err := semver.Parse(strings.TrimPrefix(v.LatestVersion(), "v"))
 	if err != nil {
 		return
 	}
 
-	if cv.LessThan(lv){
-		notices = append(notices, fmt.Sprintf("Version %s of Trivy is now available, current version is %s", v.latestVersion.Trivy.LatestVersion, v.currentVersion))
+	if cv.LessThan(lv) {
+		notices = append(notices, fmt.Sprintf("Version %s of Trivy is now available, current version is %s", lv, cv))
 	}
 
 	if len(notices) > 0 {

--- a/pkg/notification/notice_test.go
+++ b/pkg/notification/notice_test.go
@@ -30,6 +30,13 @@ func TestPrintNotices(t *testing.T) {
 			expectedOutput:   "\n📣 \x1b[34mNotices:\x1b[0m\n  - Version 0.60.0 of Trivy is now available, current version is 0.58.0\n\nTo suppress version checks, run Trivy scans with the --skip-version-check flag\n\n",
 		},
 		{
+			name:             "New version available but includes a prefixed version number",
+			options:          []Option{WithCurrentVersion("0.58.0")},
+			latestVersion:    "v0.60.0",
+			responseExpected: true,
+			expectedOutput:   "\n📣 \x1b[34mNotices:\x1b[0m\n  - Version 0.60.0 of Trivy is now available, current version is 0.58.0\n\nTo suppress version checks, run Trivy scans with the --skip-version-check flag\n\n",
+		},
+		{
 			name: "new version available but --quiet mode enabled",
 			options: []Option{
 				WithCurrentVersion("0.58.0"),


### PR DESCRIPTION
## Description

Correctly compare semantic versioning to avoid issues where version string might not be correctly set on the server side.

## Related discussions
- https://github.com/aquasecurity/trivy/discussions/8947


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
