### PR TITLE
fix(config): Add missing version check flags

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_config.md
+++ b/docs/docs/references/configuration/cli/trivy_config.md
@@ -18,6 +18,7 @@ trivy config [flags] DIR
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking
+      --disable-telemetry                 disable sending anonymous usage data to Aqua
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
@@ -70,6 +71,7 @@ trivy config [flags] DIR
       --skip-check-update                 skip fetching rego check updates
       --skip-dirs strings                 specify the directories or glob patterns to skip
       --skip-files strings                specify the files or glob patterns to skip
+      --skip-version-check                suppress notices about version updates and Trivy announcements
       --table-mode strings                [EXPERIMENTAL] tables that will be displayed in 'table' format (allowed values: summary,detailed) (default [summary,detailed])
   -t, --template string                   output template
       --tf-exclude-downloaded-modules     exclude misconfigurations for downloaded terraform modules

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -688,9 +688,11 @@ func NewServerCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 func NewConfigCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	scanFlags := &flag.ScanFlagGroup{
 		// Enable only '--skip-dirs' and '--skip-files' and disable other flags
-		SkipDirs:     flag.SkipDirsFlag.Clone(),
-		SkipFiles:    flag.SkipFilesFlag.Clone(),
-		FilePatterns: flag.FilePatternsFlag.Clone(),
+		SkipDirs:         flag.SkipDirsFlag.Clone(),
+		SkipFiles:        flag.SkipFilesFlag.Clone(),
+		FilePatterns:     flag.FilePatternsFlag.Clone(),
+		SkipVersionCheck: flag.SkipVersionCheckFlag.Clone(),
+		DisableTelemetry: flag.DisableTelemetryFlag.Clone(),
 	}
 
 	reportFlagGroup := flag.NewReportFlagGroup()


### PR DESCRIPTION
Add flags to suppress telemetry and version checking in for the `config`
command.

This command only takes a subset of the scanFlags, so need to include
these `--skip-version-check` and `--disable-telemetry` explicitly

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
