### PR TITLE
refactor(misconf): Deprecate LongID

### DIFF
--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -19,7 +19,7 @@ func AssertRuleFound(t *testing.T, ruleID string, results scan.Results, message 
 	found := ruleIDInResults(ruleID, results.GetFailed())
 	assert.True(t, found, append([]any{message}, args...)...)
 	for _, result := range results.GetFailed() {
-		if result.Rule().LongID() == ruleID {
+		if result.Rule().AVDID == ruleID {
 			m := result.Metadata()
 			meta := &m
 			for meta != nil {
@@ -49,7 +49,7 @@ func AssertRuleNotFailed(t *testing.T, ruleID string, results scan.Results, mess
 
 func ruleIDInResults(ruleID string, results scan.Results) bool {
 	for _, res := range results {
-		if res.Rule().LongID() == ruleID {
+		if res.Rule().AVDID == ruleID {
 			return true
 		}
 	}

--- a/pkg/iac/scan/flat.go
+++ b/pkg/iac/scan/flat.go
@@ -8,7 +8,6 @@ import (
 type FlatResult struct {
 	Deprecated      bool               `json:"deprecated,omitempty"`
 	RuleID          string             `json:"rule_id"`
-	LongID          string             `json:"long_id"`
 	RuleSummary     string             `json:"rule_description"`
 	RuleProvider    providers.Provider `json:"rule_provider"`
 	RuleService     string             `json:"rule_service"`
@@ -51,7 +50,6 @@ func (r *Result) Flatten() FlatResult {
 	return FlatResult{
 		Deprecated:      r.rule.Deprecated,
 		RuleID:          r.rule.AVDID,
-		LongID:          r.Rule().LongID(),
 		RuleSummary:     r.rule.Summary,
 		RuleProvider:    r.rule.Provider,
 		RuleService:     r.rule.Service,

--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -269,7 +269,6 @@ func (r *Results) AddIgnored(source any, descriptions ...string) {
 func (r *Results) Ignore(ignoreRules ignore.Rules, ignores map[string]ignore.Ignorer) {
 	for i, result := range *r {
 		allIDs := []string{
-			result.Rule().LongID(),
 			result.Rule().AVDID,
 			strings.ToLower(result.Rule().AVDID),
 			result.Rule().ShortCode,

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -63,7 +63,7 @@ func (r Rule) IsDeprecated() bool {
 }
 
 func (r Rule) HasID(id string) bool {
-	if r.AVDID == id || r.LongID() == id {
+	if r.AVDID == id {
 		return true
 	}
 	for _, alias := range r.Aliases {
@@ -72,10 +72,6 @@ func (r Rule) HasID(id string) bool {
 		}
 	}
 	return false
-}
-
-func (r Rule) LongID() string {
-	return strings.ToLower(fmt.Sprintf("%s-%s-%s", r.Provider, r.Service, r.ShortCode))
 }
 
 func (r Rule) ServiceDisplayName() string {

--- a/pkg/iac/scanners/cloudformation/scanner.go
+++ b/pkg/iac/scanners/cloudformation/scanner.go
@@ -121,7 +121,7 @@ func (s *Scanner) scanFileContext(ctx context.Context, regoScanner *rego.Scanner
 
 	for _, ignored := range results.GetIgnored() {
 		s.logger.Info("Ignore finding",
-			log.String("rule", ignored.Rule().LongID()),
+			log.String("rule", ignored.Rule().AVDID),
 			log.String("range", ignored.Range().String()),
 		)
 	}

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -694,9 +694,9 @@ deny contains res if {
 			results, err := scanner.ScanFS(t.Context(), fsys, ".")
 			require.NoError(t, err)
 			if tt.expected {
-				testutil.AssertRuleFound(t, "dockerfile-general-maintainer-deprecated", results, "")
+				testutil.AssertRuleFound(t, "USER-TEST-0001", results, "")
 			} else {
-				testutil.AssertRuleNotFailed(t, "dockerfile-general-maintainer-deprecated", results, "")
+				testutil.AssertRuleNotFailed(t, "USER-TEST-0001", results, "")
 			}
 		})
 	}

--- a/pkg/iac/scanners/terraform/count_test.go
+++ b/pkg/iac/scanners/terraform/count_test.go
@@ -156,9 +156,9 @@ variable "things" {
 			assert.Len(t, results.GetFailed(), test.expected)
 
 			if test.expected > 0 {
-				testutil.AssertRuleFound(t, "aws-s3-non-empty-bucket", results, "false negative found")
+				testutil.AssertRuleFound(t, "USER-TEST-0123", results, "false negative found")
 			} else {
-				testutil.AssertRuleNotFound(t, "aws-s3-non-empty-bucket", results, "false positive found")
+				testutil.AssertRuleNotFound(t, "USER-TEST-0123", results, "false positive found")
 			}
 		})
 	}

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -85,7 +85,7 @@ func (e *Executor) Execute(ctx context.Context, modules terraform.Modules, baseP
 
 	for _, ignored := range results.GetIgnored() {
 		e.logger.Info("Ignore finding",
-			log.String("rule", ignored.Rule().LongID()),
+			log.String("rule", ignored.Rule().AVDID),
 			log.String("range", ignored.Range().String()),
 		)
 	}

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -129,7 +129,7 @@ resource "aws_s3_bucket" "test" {}
 		{
 			name: "rule above the finding",
 			source: `resource "aws_s3_bucket" "test" {
-	# %s:ignore:aws-s3-non-empty-bucket
+	# %s:ignore:USER-TEST-0123
     bucket = ""
 }`,
 			assertLength: 0,
@@ -137,27 +137,27 @@ resource "aws_s3_bucket" "test" {}
 		{
 			name: "rule with breached expiration date",
 			source: `resource "aws_s3_bucket" "test" {
-    bucket = "" # %s:ignore:aws-s3-non-empty-bucket:exp:2000-01-02
+    bucket = "" # %s:ignore:USER-TEST-0123:exp:2000-01-02
 }`,
 			assertLength: 1,
 		},
 		{
 			name: "rule with unbreached expiration date",
 			source: `resource "aws_s3_bucket" "test" {
-    bucket = "" # %s:ignore:aws-s3-non-empty-bucket:exp:2221-01-02
+    bucket = "" # %s:ignore:USER-TEST-0123:exp:2221-01-02
 }`,
 			assertLength: 0,
 		},
 		{
 			name: "rule with invalid expiration date",
 			source: `resource "aws_s3_bucket" "test" {
-   bucket = "" # %s:ignore:aws-s3-non-empty-bucket:exp:2221-13-02
+   bucket = "" # %s:ignore:USER-TEST-0123:exp:2221-13-02
 }`,
 			assertLength: 1,
 		},
 		{
 			name: "rule above block with unbreached expiration date",
-			source: `#%s:ignore:aws-s3-non-empty-bucket:exp:2221-01-02
+			source: `#%s:ignore:USER-TEST-0123:exp:2221-01-02
 resource "aws_s3_bucket" "test" {}`,
 			assertLength: 0,
 		},
@@ -509,25 +509,25 @@ func Test_IgnoreByWorkspace(t *testing.T) {
 	}{
 		{
 			name: "with expiry and workspace",
-			src: `# tfsec:ignore:aws-s3-non-empty-bucket:exp:2221-01-02:ws:testworkspace
+			src: `# tfsec:ignore:USER-TEST-0123:exp:2221-01-02:ws:testworkspace
 resource "aws_s3_bucket" "test" {}`,
 			expectedFailed: 0,
 		},
 		{
 			name: "bad workspace",
-			src: `# tfsec:ignore:aws-s3-non-empty-bucket:exp:2221-01-02:ws:otherworkspace
+			src: `# tfsec:ignore:USER-TEST-0123:exp:2221-01-02:ws:otherworkspace
 resource "aws_s3_bucket" "test" {}`,
 			expectedFailed: 1,
 		},
 		{
 			name: "with expiry and workspace, trivy prefix",
-			src: `# trivy:ignore:aws-s3-non-empty-bucket:exp:2221-01-02:ws:testworkspace
+			src: `# trivy:ignore:USER-TEST-0123:exp:2221-01-02:ws:testworkspace
 resource "aws_s3_bucket" "test" {}`,
 			expectedFailed: 0,
 		},
 		{
 			name: "bad workspace, trivy prefix",
-			src: `# trivy:ignore:aws-s3-non-empty-bucket:exp:2221-01-02:ws:otherworkspace
+			src: `# trivy:ignore:USER-TEST-0123:exp:2221-01-02:ws:otherworkspace
 resource "aws_s3_bucket" "test" {}`,
 			expectedFailed: 1,
 		},
@@ -572,7 +572,7 @@ func Test_IgnoreInlineByAVDID(t *testing.T) {
 	for _, tc := range testCases {
 		ids := []string{
 			"USER-TEST-0123", strings.ToLower("user-test-0123"),
-			"non-empty-bucket", "aws-s3-non-empty-bucket",
+			"non-empty-bucket",
 		}
 
 		for _, id := range ids {
@@ -581,7 +581,7 @@ func Test_IgnoreInlineByAVDID(t *testing.T) {
 					rego.WithPolicyReader(strings.NewReader(emptyBucketCheck)),
 					rego.WithPolicyNamespaces("user"),
 				)
-				testutil.AssertRuleNotFailed(t, "aws-s3-non-empty-bucket", results, "")
+				testutil.AssertRuleNotFailed(t, "USER-TEST-0123", results, "")
 			})
 		}
 	}
@@ -617,5 +617,5 @@ resource "aws_s3_bucket" "test" {
 		rego.WithPolicyNamespaces("user"),
 	)
 	require.NoError(t, err)
-	testutil.AssertRuleNotFailed(t, "aws-s3-non-empty-bucket", results, "")
+	testutil.AssertRuleNotFailed(t, "USER-TEST-0123", results, "")
 }

--- a/pkg/iac/scanners/terraform/json_test.go
+++ b/pkg/iac/scanners/terraform/json_test.go
@@ -64,9 +64,9 @@ func TestScanningJSON(t *testing.T) {
 				rego.WithPolicyNamespaces("user"),
 			)
 			if test.expected {
-				testutil.AssertRuleFound(t, "aws-s3-non-empty-bucket", results, "false negative found")
+				testutil.AssertRuleFound(t, "USER-TEST-0123", results, "false negative found")
 			} else {
-				testutil.AssertRuleNotFound(t, "aws-s3-non-empty-bucket", results, "false positive found")
+				testutil.AssertRuleNotFound(t, "USER-TEST-0123", results, "false positive found")
 			}
 		})
 	}

--- a/pkg/iac/scanners/terraform/module_test.go
+++ b/pkg/iac/scanners/terraform/module_test.go
@@ -69,7 +69,7 @@ resource "aws_s3_bucket" "test" {}`,
 			name: "ignore misconfig in module",
 			files: map[string]string{
 				"/project/main.tf": `
-#tfsec:ignore:aws-s3-non-empty-bucket
+#tfsec:ignore:USER-TEST-0123
 module "something" {
 	source = "../modules/problem"
 }
@@ -371,9 +371,9 @@ resource "aws_s3_bucket" "test" {
 			)
 			require.NoError(t, err)
 			if tt.expected {
-				testutil.AssertRuleFound(t, "aws-s3-non-empty-bucket", results, "")
+				testutil.AssertRuleFound(t, "USER-TEST-0123", results, "")
 			} else {
-				testutil.AssertRuleNotFailed(t, "aws-s3-non-empty-bucket", results, "")
+				testutil.AssertRuleNotFailed(t, "USER-TEST-0123", results, "")
 			}
 		})
 	}

--- a/pkg/iac/scanners/terraform/performance_test.go
+++ b/pkg/iac/scanners/terraform/performance_test.go
@@ -45,7 +45,7 @@ module "something" {
 			continue
 		}
 		for i, bad := range rule.GetRule().Terraform.BadExamples {
-			filename := fmt.Sprintf("/modules/problem/%s-%d.tf", rule.GetRule().LongID(), i)
+			filename := fmt.Sprintf("/modules/problem/%s-%d.tf", rule.GetRule().AVDID, i)
 			files[filename] = bad
 		}
 	}


### PR DESCRIPTION
## Description

In order to reduce complexity we will be keeping two kinds of IDs going forwards:

1. avd_id
2. short_code

## Related PRs
- https://github.com/aquasecurity/trivy-checks/pull/430

## Related Discussions
TODO


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
