### PR TITLE
feat(k8s): add REGO policy filtering for Kubernetes artifacts

### DIFF
--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -89,8 +89,8 @@ trivy kubernetes [flags] [CONTEXT]
       --include-namespaces strings        indicate the namespaces included in scanning (example: kube-system)
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
-      --k8s-filter-data strings           specify paths to data files for Kubernetes REGO filtering
-      --k8s-filter-policy string          specify the path to REGO policy file for Kubernetes resource filtering
+      --k8s-skip-data strings             specify paths to additional REGO files for Kubernetes skipping (can use same package name)
+      --k8s-skip-policy string            specify the path to REGO policy file to skip Kubernetes resources before scanning
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
       --list-all-pkgs                     output all packages in the JSON report regardless of vulnerability

--- a/docs/docs/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/docs/references/configuration/cli/trivy_kubernetes.md
@@ -89,6 +89,8 @@ trivy kubernetes [flags] [CONTEXT]
       --include-namespaces strings        indicate the namespaces included in scanning (example: kube-system)
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
+      --k8s-filter-data strings           specify paths to data files for Kubernetes REGO filtering
+      --k8s-filter-policy string          specify the path to REGO policy file for Kubernetes resource filtering
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
       --kubeconfig string                 specify the kubeconfig file path to use
       --list-all-pkgs                     output all packages in the JSON report regardless of vulnerability

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -181,11 +181,11 @@ kubernetes:
   # Same as '--exclude-namespaces'
   excludeNamespaces: []
 
-  # Same as '--k8s-filter-data'
-  filter-data: []
+  # Same as '--k8s-skip-data'
+  skip-data: []
 
-  # Same as '--k8s-filter-policy'
-  filter-policy: ""
+  # Same as '--k8s-skip-policy'
+  skip-policy: ""
 
   # Same as '--include-kinds'
   includeKinds: []

--- a/docs/docs/references/configuration/config-file.md
+++ b/docs/docs/references/configuration/config-file.md
@@ -181,6 +181,12 @@ kubernetes:
   # Same as '--exclude-namespaces'
   excludeNamespaces: []
 
+  # Same as '--k8s-filter-data'
+  filter-data: []
+
+  # Same as '--k8s-filter-policy'
+  filter-policy: ""
+
   # Same as '--include-kinds'
   includeKinds: []
 

--- a/examples/k8s-filter-policies/README.md
+++ b/examples/k8s-filter-policies/README.md
@@ -1,0 +1,161 @@
+# Kubernetes REGO Filter Policies
+
+This directory contains example REGO policies for filtering Kubernetes resources during Trivy scans.
+
+## Feature Overview
+
+The Kubernetes REGO filtering feature allows you to skip scanning specific Kubernetes resources based on custom REGO rules. This is useful for:
+
+- Excluding system resources that are not relevant to security scans
+- Filtering out test/development resources in multi-environment clusters
+- Skipping resources with zero replicas (addressed issue #8078)
+- Applying custom business logic for resource selection
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Filter out deployments with zero replicas
+trivy k8s --k8s-filter-policy=deployment-zero-replicas.rego cluster
+
+# Filter out system resources
+trivy k8s --k8s-filter-policy=system-resources.rego cluster
+
+# Use multiple data files with a policy
+trivy k8s --k8s-filter-policy=custom.rego --k8s-filter-data=config.rego cluster
+```
+
+### Multiple Policies
+
+You can combine multiple policies by creating a comprehensive policy file that imports or includes multiple rules.
+
+## Policy Structure
+
+All Kubernetes filter policies must:
+
+1. Use the package `trivy.kubernetes`
+2. Define rules under the `ignore` decision
+3. Return a boolean value (true to ignore the resource)
+
+### Input Format
+
+The input to your REGO policy will be a Kubernetes artifact with the following structure:
+
+```json
+{
+  "kind": "Deployment",
+  "namespace": "default", 
+  "name": "my-app",
+  "labels": {
+    "app": "my-app",
+    "version": "v1.0.0"
+  },
+  "annotations": {
+    "deployment.kubernetes.io/revision": "1"
+  },
+  "spec": {
+    "replicas": 3,
+    "template": {
+      "spec": {
+        "containers": [...]
+      }
+    }
+  }
+}
+```
+
+## Example Policies
+
+### 1. deployment-zero-replicas.rego
+Filters out Deployments with zero replicas (addresses issue #8078).
+
+### 2. system-resources.rego  
+Excludes system-level resources like those in kube-system namespace.
+
+### 3. environment-based.rego
+Filters resources based on environment labels and annotations.
+
+### 4. workload-specific.rego
+Advanced filtering based on workload specifications and states.
+
+## Writing Custom Policies
+
+### Basic Filter
+```rego
+package trivy.kubernetes
+
+ignore {
+    input.namespace == "test"
+}
+```
+
+### Label-based Filter
+```rego
+package trivy.kubernetes
+
+ignore {
+    input.labels["environment"] == "dev"
+}
+```
+
+### Spec-based Filter
+```rego
+package trivy.kubernetes
+
+ignore {
+    input.kind == "Deployment"
+    input.spec.replicas == 0
+}
+```
+
+### Complex Conditions
+```rego
+package trivy.kubernetes
+
+ignore {
+    input.kind in ["Pod", "Deployment"]
+    startswith(input.namespace, "temp-")
+    input.labels["temporary"] == "true"
+}
+```
+
+## Testing Policies
+
+You can test your REGO policies using the OPA CLI:
+
+```bash
+# Test a policy with sample input
+opa eval -d policy.rego -i input.json "data.trivy.kubernetes.ignore"
+```
+
+## Integration with CI/CD
+
+These policies can be integrated into CI/CD pipelines:
+
+```yaml
+# Example GitHub Actions step
+- name: Scan Kubernetes with filtering
+  run: |
+    trivy k8s \
+      --k8s-filter-policy=.trivy/k8s-filter.rego \
+      --format=sarif \
+      --output=trivy-k8s.sarif \
+      cluster
+```
+
+## Troubleshooting
+
+- **Policy not working**: Ensure the package name is exactly `trivy.kubernetes`
+- **Syntax errors**: Validate your REGO syntax with `opa fmt` and `opa test`
+- **No resources filtered**: Check that your conditions match the actual resource structure
+- **Too many resources filtered**: Add debug logging to understand which rules are matching
+
+## Contributing
+
+When contributing new example policies:
+
+1. Include clear comments explaining the use case
+2. Add usage examples in the policy file
+3. Test the policy with real Kubernetes resources
+4. Update this README with the new policy description

--- a/examples/k8s-filter-policies/README.md
+++ b/examples/k8s-filter-policies/README.md
@@ -1,13 +1,13 @@
-# Kubernetes REGO Filter Policies
+# Kubernetes REGO Skip Policies
 
-This directory contains example REGO policies for filtering Kubernetes resources during Trivy scans.
+This directory contains example REGO policies for skipping Kubernetes resources during Trivy scans.
 
 ## Feature Overview
 
-The Kubernetes REGO filtering feature allows you to skip scanning specific Kubernetes resources based on custom REGO rules. This is useful for:
+The Kubernetes REGO skipping feature allows you to skip scanning specific Kubernetes resources based on custom REGO rules. This is useful for:
 
 - Excluding system resources that are not relevant to security scans
-- Filtering out test/development resources in multi-environment clusters
+- Skipping test/development resources in multi-environment clusters
 - Skipping resources with zero replicas (addressed issue #8078)
 - Applying custom business logic for resource selection
 
@@ -16,14 +16,14 @@ The Kubernetes REGO filtering feature allows you to skip scanning specific Kuber
 ### Basic Usage
 
 ```bash
-# Filter out deployments with zero replicas
-trivy k8s --k8s-filter-policy=deployment-zero-replicas.rego cluster
+# Skip deployments with zero replicas
+trivy k8s --k8s-skip-policy=deployment-zero-replicas.rego cluster
 
-# Filter out system resources
-trivy k8s --k8s-filter-policy=system-resources.rego cluster
+# Skip system resources
+trivy k8s --k8s-skip-policy=system-resources.rego cluster
 
-# Use multiple data files with a policy
-trivy k8s --k8s-filter-policy=custom.rego --k8s-filter-data=config.rego cluster
+# Use additional REGO files with a policy
+trivy k8s --k8s-skip-policy=custom.rego --k8s-skip-data=config.rego cluster
 ```
 
 ### Multiple Policies
@@ -32,11 +32,11 @@ You can combine multiple policies by creating a comprehensive policy file that i
 
 ## Policy Structure
 
-All Kubernetes filter policies must:
+All Kubernetes skip policies must:
 
 1. Use the package `trivy.kubernetes`
 2. Define rules under the `ignore` decision
-3. Return a boolean value (true to ignore the resource)
+3. Return a boolean value (true to skip the resource)
 
 ### Input Format
 
@@ -68,20 +68,20 @@ The input to your REGO policy will be a Kubernetes artifact with the following s
 ## Example Policies
 
 ### 1. deployment-zero-replicas.rego
-Filters out Deployments with zero replicas (addresses issue #8078).
+Skips Deployments with zero replicas (addresses issue #8078).
 
 ### 2. system-resources.rego  
-Excludes system-level resources like those in kube-system namespace.
+Skips system-level resources like those in kube-system namespace.
 
 ### 3. environment-based.rego
-Filters resources based on environment labels and annotations.
+Skips resources based on environment labels and annotations.
 
 ### 4. workload-specific.rego
-Advanced filtering based on workload specifications and states.
+Advanced skipping based on workload specifications and states.
 
 ## Writing Custom Policies
 
-### Basic Filter
+### Basic Skip Rule
 ```rego
 package trivy.kubernetes
 
@@ -90,7 +90,7 @@ ignore {
 }
 ```
 
-### Label-based Filter
+### Label-based Skip Rule
 ```rego
 package trivy.kubernetes
 
@@ -99,7 +99,7 @@ ignore {
 }
 ```
 
-### Spec-based Filter
+### Spec-based Skip Rule
 ```rego
 package trivy.kubernetes
 
@@ -135,10 +135,10 @@ These policies can be integrated into CI/CD pipelines:
 
 ```yaml
 # Example GitHub Actions step
-- name: Scan Kubernetes with filtering
+- name: Scan Kubernetes with skipping
   run: |
     trivy k8s \
-      --k8s-filter-policy=.trivy/k8s-filter.rego \
+      --k8s-skip-policy=.trivy/k8s-skip.rego \
       --format=sarif \
       --output=trivy-k8s.sarif \
       cluster
@@ -148,8 +148,8 @@ These policies can be integrated into CI/CD pipelines:
 
 - **Policy not working**: Ensure the package name is exactly `trivy.kubernetes`
 - **Syntax errors**: Validate your REGO syntax with `opa fmt` and `opa test`
-- **No resources filtered**: Check that your conditions match the actual resource structure
-- **Too many resources filtered**: Add debug logging to understand which rules are matching
+- **No resources skipped**: Check that your conditions match the actual resource structure
+- **Too many resources skipped**: Add debug logging to understand which rules are matching
 
 ## Contributing
 

--- a/examples/k8s-filter-policies/deployment-zero-replicas.rego
+++ b/examples/k8s-filter-policies/deployment-zero-replicas.rego
@@ -1,0 +1,13 @@
+# Example REGO policy to filter out Kubernetes Deployments with zero replicas
+# This addresses the specific use case mentioned in issue #8078
+
+package trivy.kubernetes
+
+# Filter out deployments with zero replicas
+ignore {
+	input.kind == "Deployment"
+	input.spec.replicas == 0
+}
+
+# Usage:
+# trivy k8s --k8s-filter-policy=deployment-zero-replicas.rego cluster

--- a/examples/k8s-filter-policies/environment-based.rego
+++ b/examples/k8s-filter-policies/environment-based.rego
@@ -1,0 +1,28 @@
+# Example REGO policy to filter resources based on environment
+# This policy demonstrates filtering based on labels and annotations
+
+package trivy.kubernetes
+
+# Filter out test environment resources
+ignore {
+	input.labels["environment"] in ["test", "staging", "dev"]
+}
+
+# Filter out resources marked for skipping
+ignore {
+	input.annotations["trivy.skip"] == "true"
+}
+
+# Filter out temporary/debug resources
+ignore {
+	startswith(input.name, "debug-")
+}
+
+# Filter out canary deployments
+ignore {
+	input.kind == "Deployment"
+	input.labels["deployment-type"] == "canary"
+}
+
+# Usage:
+# trivy k8s --k8s-filter-policy=environment-based.rego cluster

--- a/examples/k8s-filter-policies/system-resources.rego
+++ b/examples/k8s-filter-policies/system-resources.rego
@@ -1,0 +1,27 @@
+# Example REGO policy to filter out system Kubernetes resources
+# This policy excludes resources commonly found in system namespaces
+
+package trivy.kubernetes
+
+# Filter out resources in system namespaces
+ignore {
+	input.namespace in [
+		"kube-system", 
+		"kube-public", 
+		"kube-node-lease",
+		"local-path-storage"
+	]
+}
+
+# Filter out daemon sets (often system-level)
+ignore {
+	input.kind == "DaemonSet"
+}
+
+# Filter out resources with system labels
+ignore {
+	input.labels["app.kubernetes.io/managed-by"] in ["kubeadm", "kops"]
+}
+
+# Usage:
+# trivy k8s --k8s-filter-policy=system-resources.rego cluster

--- a/examples/k8s-filter-policies/workload-specific.rego
+++ b/examples/k8s-filter-policies/workload-specific.rego
@@ -1,0 +1,37 @@
+# Example REGO policy for workload-specific filtering
+# This policy shows advanced filtering based on workload specifications
+
+package trivy.kubernetes
+
+# Filter out suspended CronJobs
+ignore {
+	input.kind == "CronJob"
+	input.spec.suspend == true
+}
+
+# Filter out services without selectors (external services)
+ignore {
+	input.kind == "Service"
+	not input.spec.selector
+}
+
+# Filter out completed jobs
+ignore {
+	input.kind == "Job"
+	input.spec.completions == input.spec.parallelism
+}
+
+# Filter out deployments with very low resource requests (likely test deployments)
+ignore {
+	input.kind == "Deployment"
+	input.spec.template.spec.containers[_].resources.requests.memory == "1Mi"
+}
+
+# Filter out StatefulSets with 0 replicas
+ignore {
+	input.kind == "StatefulSet"
+	input.spec.replicas == 0
+}
+
+# Usage:
+# trivy k8s --k8s-filter-policy=workload-specific.rego cluster

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -91,6 +91,16 @@ var (
 		Default:    10,
 		Usage:      "specify the maximum burst for throttle",
 	}
+	K8sFilterPolicyFlag = Flag[string]{
+		Name:       "k8s-filter-policy",
+		ConfigName: "kubernetes.filter-policy",
+		Usage:      "specify the path to REGO policy file for Kubernetes resource filtering",
+	}
+	K8sFilterDataFlag = Flag[[]string]{
+		Name:       "k8s-filter-data",
+		ConfigName: "kubernetes.filter-data",
+		Usage:      "specify paths to data files for Kubernetes REGO filtering",
+	}
 )
 
 type K8sFlagGroup struct {
@@ -109,6 +119,8 @@ type K8sFlagGroup struct {
 	IncludeNamespaces      *Flag[[]string]
 	QPS                    *Flag[float64]
 	Burst                  *Flag[int]
+	K8sFilterPolicy        *Flag[string]
+	K8sFilterData          *Flag[[]string]
 }
 
 type K8sOptions struct {
@@ -127,6 +139,8 @@ type K8sOptions struct {
 	QPS                    float32
 	SkipImages             bool
 	Burst                  int
+	K8sFilterPolicy        string
+	K8sFilterData          []string
 }
 
 func NewK8sFlagGroup() *K8sFlagGroup {
@@ -146,6 +160,8 @@ func NewK8sFlagGroup() *K8sFlagGroup {
 		QPS:                    QPS.Clone(),
 		SkipImages:             SkipImages.Clone(),
 		Burst:                  Burst.Clone(),
+		K8sFilterPolicy:        K8sFilterPolicyFlag.Clone(),
+		K8sFilterData:          K8sFilterDataFlag.Clone(),
 	}
 }
 
@@ -170,6 +186,8 @@ func (f *K8sFlagGroup) Flags() []Flagger {
 		f.QPS,
 		f.SkipImages,
 		f.Burst,
+		f.K8sFilterPolicy,
+		f.K8sFilterData,
 	}
 }
 
@@ -211,6 +229,8 @@ func (f *K8sFlagGroup) ToOptions(opts *Options) error {
 		ExcludeNamespaces:      f.ExcludeNamespaces.Value(),
 		IncludeNamespaces:      f.IncludeNamespaces.Value(),
 		Burst:                  f.Burst.Value(),
+		K8sFilterPolicy:        f.K8sFilterPolicy.Value(),
+		K8sFilterData:          f.K8sFilterData.Value(),
 	}
 	return nil
 }

--- a/pkg/flag/kubernetes_flags.go
+++ b/pkg/flag/kubernetes_flags.go
@@ -91,15 +91,15 @@ var (
 		Default:    10,
 		Usage:      "specify the maximum burst for throttle",
 	}
-	K8sFilterPolicyFlag = Flag[string]{
-		Name:       "k8s-filter-policy",
-		ConfigName: "kubernetes.filter-policy",
-		Usage:      "specify the path to REGO policy file for Kubernetes resource filtering",
+	K8sSkipPolicyFlag = Flag[string]{
+		Name:       "k8s-skip-policy",
+		ConfigName: "kubernetes.skip-policy",
+		Usage:      "specify the path to REGO policy file to skip Kubernetes resources before scanning",
 	}
-	K8sFilterDataFlag = Flag[[]string]{
-		Name:       "k8s-filter-data",
-		ConfigName: "kubernetes.filter-data",
-		Usage:      "specify paths to data files for Kubernetes REGO filtering",
+	K8sSkipDataFlag = Flag[[]string]{
+		Name:       "k8s-skip-data",
+		ConfigName: "kubernetes.skip-data",
+		Usage:      "specify paths to additional REGO files for Kubernetes skipping (can use same package name)",
 	}
 )
 
@@ -119,8 +119,8 @@ type K8sFlagGroup struct {
 	IncludeNamespaces      *Flag[[]string]
 	QPS                    *Flag[float64]
 	Burst                  *Flag[int]
-	K8sFilterPolicy        *Flag[string]
-	K8sFilterData          *Flag[[]string]
+	K8sSkipPolicy          *Flag[string]
+	K8sSkipData            *Flag[[]string]
 }
 
 type K8sOptions struct {
@@ -139,8 +139,8 @@ type K8sOptions struct {
 	QPS                    float32
 	SkipImages             bool
 	Burst                  int
-	K8sFilterPolicy        string
-	K8sFilterData          []string
+	K8sSkipPolicy          string
+	K8sSkipData            []string
 }
 
 func NewK8sFlagGroup() *K8sFlagGroup {
@@ -160,8 +160,8 @@ func NewK8sFlagGroup() *K8sFlagGroup {
 		QPS:                    QPS.Clone(),
 		SkipImages:             SkipImages.Clone(),
 		Burst:                  Burst.Clone(),
-		K8sFilterPolicy:        K8sFilterPolicyFlag.Clone(),
-		K8sFilterData:          K8sFilterDataFlag.Clone(),
+		K8sSkipPolicy:          K8sSkipPolicyFlag.Clone(),
+		K8sSkipData:            K8sSkipDataFlag.Clone(),
 	}
 }
 
@@ -186,8 +186,8 @@ func (f *K8sFlagGroup) Flags() []Flagger {
 		f.QPS,
 		f.SkipImages,
 		f.Burst,
-		f.K8sFilterPolicy,
-		f.K8sFilterData,
+		f.K8sSkipPolicy,
+		f.K8sSkipData,
 	}
 }
 
@@ -229,8 +229,8 @@ func (f *K8sFlagGroup) ToOptions(opts *Options) error {
 		ExcludeNamespaces:      f.ExcludeNamespaces.Value(),
 		IncludeNamespaces:      f.IncludeNamespaces.Value(),
 		Burst:                  f.Burst.Value(),
-		K8sFilterPolicy:        f.K8sFilterPolicy.Value(),
-		K8sFilterData:          f.K8sFilterData.Value(),
+		K8sSkipPolicy:          f.K8sSkipPolicy.Value(),
+		K8sSkipData:            f.K8sSkipData.Value(),
 	}
 	return nil
 }

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -224,10 +224,10 @@ func (r *runner) filterArtifacts(ctx context.Context, artifacts []*k8sArtifacts.
 // convertArtifactToFilterInput converts a k8s artifact to the format expected by REGO filter
 func convertArtifactToFilterInput(artifact *k8sArtifacts.Artifact) filter.K8sArtifact {
 	// Extract metadata, spec from the raw object if available
-	var spec interface{}
+	var spec any
 	var labels, annotations map[string]string
 
-	if artifact.RawResource != nil && len(artifact.RawResource) > 0 {
+	if len(artifact.RawResource) > 0 {
 		// Try to extract spec from the unstructured object
 		if specField, exists := artifact.RawResource["spec"]; exists {
 			spec = specField
@@ -235,10 +235,10 @@ func convertArtifactToFilterInput(artifact *k8sArtifacts.Artifact) filter.K8sArt
 
 		// Extract metadata (labels and annotations)
 		if metadata, exists := artifact.RawResource["metadata"]; exists {
-			if metadataMap, ok := metadata.(map[string]interface{}); ok {
+			if metadataMap, ok := metadata.(map[string]any); ok {
 				// Extract labels
 				if labelsField, exists := metadataMap["labels"]; exists {
-					if labelsMap, ok := labelsField.(map[string]interface{}); ok {
+					if labelsMap, ok := labelsField.(map[string]any); ok {
 						labels = make(map[string]string)
 						for k, v := range labelsMap {
 							if strVal, ok := v.(string); ok {
@@ -250,7 +250,7 @@ func convertArtifactToFilterInput(artifact *k8sArtifacts.Artifact) filter.K8sArt
 
 				// Extract annotations
 				if annotationsField, exists := metadataMap["annotations"]; exists {
-					if annotationsMap, ok := annotationsField.(map[string]interface{}); ok {
+					if annotationsMap, ok := annotationsField.(map[string]any); ok {
 						annotations = make(map[string]string)
 						for k, v := range annotationsMap {
 							if strVal, ok := v.(string); ok {

--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -86,10 +86,10 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 		}
 		r.flagOpts.ScanOptions.Scanners = scanners
 	}
-	// Apply REGO filtering if configured
+	// Apply REGO skipping if configured
 	filteredArtifacts, err := r.filterArtifacts(ctx, artifacts)
 	if err != nil {
-		return xerrors.Errorf("artifact filtering error: %w", err)
+		return xerrors.Errorf("artifact skipping error: %w", err)
 	}
 
 	var rpt report.Report
@@ -163,11 +163,11 @@ func validateReportArguments(opts flag.Options) error {
 	return nil
 }
 
-// filterArtifacts applies REGO-based filtering to Kubernetes artifacts
+// filterArtifacts applies REGO-based skipping to Kubernetes artifacts
 func (r *runner) filterArtifacts(ctx context.Context, artifacts []*k8sArtifacts.Artifact) ([]*k8sArtifacts.Artifact, error) {
-	// Check if REGO filtering is enabled
-	if r.flagOpts.K8sFilterPolicy == "" {
-		return artifacts, nil // No filtering needed
+	// Check if REGO skipping is enabled
+	if r.flagOpts.K8sSkipPolicy == "" {
+		return artifacts, nil // No skipping needed
 	}
 
 	// Create REGO filter
@@ -202,7 +202,7 @@ func (r *runner) filterArtifacts(ctx context.Context, artifacts []*k8sArtifacts.
 
 		if shouldIgnore {
 			ignoredCount++
-			log.DebugContext(ctx, "Artifact filtered out by REGO policy",
+			log.DebugContext(ctx, "Artifact skipped by REGO policy",
 				log.String("kind", artifact.Kind),
 				log.String("namespace", artifact.Namespace),
 				log.String("name", artifact.Name))
@@ -212,9 +212,9 @@ func (r *runner) filterArtifacts(ctx context.Context, artifacts []*k8sArtifacts.
 	}
 
 	if ignoredCount > 0 {
-		log.InfoContext(ctx, "Filtered K8s artifacts using REGO policy",
+		log.InfoContext(ctx, "Skipped K8s artifacts using REGO policy",
 			log.Int("total", len(artifacts)),
-			log.Int("ignored", ignoredCount),
+			log.Int("skipped", ignoredCount),
 			log.Int("remaining", len(filteredArtifacts)))
 	}
 

--- a/pkg/k8s/filter/rego.go
+++ b/pkg/k8s/filter/rego.go
@@ -42,7 +42,7 @@ func NewRegoFilter(ctx context.Context, opts flag.K8sOptions) (*RegoFilter, erro
 	regoOptions := []func(*rego.Rego){
 		rego.Query("data.trivy.kubernetes.ignore"),
 		rego.Module("trivy-k8s.rego", string(policy)),
-		rego.SetRegoVersion(ast.RegoV0),
+		rego.SetRegoVersion(ast.RegoLatest),
 	}
 
 	// Add data files if specified

--- a/pkg/k8s/filter/rego.go
+++ b/pkg/k8s/filter/rego.go
@@ -19,7 +19,7 @@ type K8sArtifact struct {
 	Name        string            `json:"name"`
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
-	Spec        interface{}       `json:"spec,omitempty"`
+	Spec        any               `json:"spec,omitempty"`
 }
 
 // RegoFilter handles REGO-based filtering for Kubernetes artifacts
@@ -91,7 +91,7 @@ func (f *RegoFilter) ShouldIgnore(ctx context.Context, artifact K8sArtifact) (bo
 }
 
 // ConvertToK8sArtifact converts common Kubernetes resource fields to K8sArtifact
-func ConvertToK8sArtifact(kind, namespace, name string, labels, annotations map[string]string, spec interface{}) K8sArtifact {
+func ConvertToK8sArtifact(kind, namespace, name string, labels, annotations map[string]string, spec any) K8sArtifact {
 	// Ensure maps are not nil to avoid JSON marshaling issues
 	if labels == nil {
 		labels = make(map[string]string)

--- a/pkg/k8s/filter/rego.go
+++ b/pkg/k8s/filter/rego.go
@@ -1,0 +1,111 @@
+package filter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/flag"
+)
+
+// K8sArtifact represents Kubernetes resource metadata for REGO filtering
+type K8sArtifact struct {
+	Kind        string            `json:"kind"`
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	Spec        interface{}       `json:"spec,omitempty"`
+}
+
+// RegoFilter handles REGO-based filtering for Kubernetes artifacts
+type RegoFilter struct {
+	query rego.PreparedEvalQuery
+}
+
+// NewRegoFilter creates a new REGO filter instance
+func NewRegoFilter(ctx context.Context, opts flag.K8sOptions) (*RegoFilter, error) {
+	if opts.K8sFilterPolicy == "" {
+		return nil, nil // No policy specified, no filtering needed
+	}
+
+	policy, err := os.ReadFile(opts.K8sFilterPolicy)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to read the K8s filter policy file: %w", err)
+	}
+
+	// Create rego query
+	regoOptions := []func(*rego.Rego){
+		rego.Query("data.trivy.kubernetes.ignore"),
+		rego.Module("trivy-k8s.rego", string(policy)),
+		rego.SetRegoVersion(ast.RegoV0),
+	}
+
+	// Add data files if specified
+	for _, dataFile := range opts.K8sFilterData {
+		data, err := os.ReadFile(dataFile)
+		if err != nil {
+			return nil, xerrors.Errorf("unable to read K8s filter data file %s: %w", dataFile, err)
+		}
+
+		// Use the file name as the module name
+		moduleName := filepath.Base(dataFile)
+		regoOptions = append(regoOptions, rego.Module(moduleName, string(data)))
+	}
+
+	query, err := rego.New(regoOptions...).PrepareForEval(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("unable to prepare K8s filter policy for eval: %w", err)
+	}
+
+	return &RegoFilter{query: query}, nil
+}
+
+// ShouldIgnore evaluates if the given Kubernetes artifact should be ignored based on REGO policy
+func (f *RegoFilter) ShouldIgnore(ctx context.Context, artifact K8sArtifact) (bool, error) {
+	if f == nil {
+		return false, nil // No filter configured
+	}
+
+	results, err := f.query.Eval(ctx, rego.EvalInput(artifact))
+	if err != nil {
+		return false, xerrors.Errorf("unable to evaluate K8s filter policy: %w", err)
+	}
+
+	if len(results) == 0 {
+		// Handle undefined result - default to not ignoring
+		return false, nil
+	}
+
+	ignore, ok := results[0].Expressions[0].Value.(bool)
+	if !ok {
+		// Handle unexpected result type
+		return false, xerrors.New("K8s filter policy must return boolean")
+	}
+
+	return ignore, nil
+}
+
+// ConvertToK8sArtifact converts common Kubernetes resource fields to K8sArtifact
+func ConvertToK8sArtifact(kind, namespace, name string, labels, annotations map[string]string, spec interface{}) K8sArtifact {
+	// Ensure maps are not nil to avoid JSON marshaling issues
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	return K8sArtifact{
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Labels:      labels,
+		Annotations: annotations,
+		Spec:        spec,
+	}
+}

--- a/pkg/k8s/filter/rego.go
+++ b/pkg/k8s/filter/rego.go
@@ -84,7 +84,7 @@ func (f *RegoFilter) ShouldIgnore(ctx context.Context, artifact K8sArtifact) (bo
 	ignore, ok := results[0].Expressions[0].Value.(bool)
 	if !ok {
 		// Handle unexpected result type
-		return false, xerrors.New("K8s filter policy must return boolean")
+		return false, xerrors.Errorf("K8s filter policy must return boolean, but got %T", results[0].Expressions[0].Value)
 	}
 
 	return ignore, nil

--- a/pkg/k8s/filter/rego_test.go
+++ b/pkg/k8s/filter/rego_test.go
@@ -1,0 +1,280 @@
+package filter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/flag"
+)
+
+func TestNewRegoFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    flag.K8sOptions
+		wantNil bool
+		wantErr bool
+	}{
+		{
+			name:    "no policy specified",
+			opts:    flag.K8sOptions{},
+			wantNil: true,
+			wantErr: false,
+		},
+		{
+			name: "valid policy file",
+			opts: flag.K8sOptions{
+				K8sFilterPolicy: "testdata/valid-policy.rego",
+			},
+			wantNil: false,
+			wantErr: false,
+		},
+		{
+			name: "invalid policy file path",
+			opts: flag.K8sOptions{
+				K8sFilterPolicy: "nonexistent.rego",
+			},
+			wantNil: false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test policy file if needed
+			if tt.opts.K8sFilterPolicy == "testdata/valid-policy.rego" {
+				createTestPolicy(t, tt.opts.K8sFilterPolicy)
+			}
+
+			filter, err := NewRegoFilter(context.Background(), tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.wantNil {
+				assert.Nil(t, filter)
+			} else if !tt.wantErr {
+				assert.NotNil(t, filter)
+			}
+		})
+	}
+}
+
+func TestRegoFilter_ShouldIgnore(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     string
+		artifact   K8sArtifact
+		wantIgnore bool
+		wantErr    bool
+	}{
+		{
+			name: "ignore deployments with zero replicas",
+			policy: `
+package trivy.kubernetes
+
+ignore {
+	input.kind == "Deployment"
+	input.spec.replicas == 0
+}
+`,
+			artifact: K8sArtifact{
+				Kind:      "Deployment",
+				Namespace: "default",
+				Name:      "test-app",
+				Spec: map[string]interface{}{
+					"replicas": 0,
+				},
+			},
+			wantIgnore: true,
+			wantErr:    false,
+		},
+		{
+			name: "don't ignore deployments with replicas > 0",
+			policy: `
+package trivy.kubernetes
+
+ignore {
+	input.kind == "Deployment"
+	input.spec.replicas == 0
+}
+`,
+			artifact: K8sArtifact{
+				Kind:      "Deployment",
+				Namespace: "default",
+				Name:      "test-app",
+				Spec: map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+			wantIgnore: false,
+			wantErr:    false,
+		},
+		{
+			name: "ignore pods with specific labels",
+			policy: `
+package trivy.kubernetes
+
+ignore {
+	input.kind == "Pod"
+	input.labels["environment"] == "test"
+}
+`,
+			artifact: K8sArtifact{
+				Kind:      "Pod",
+				Namespace: "default",
+				Name:      "test-pod",
+				Labels: map[string]string{
+					"environment": "test",
+				},
+			},
+			wantIgnore: true,
+			wantErr:    false,
+		},
+		{
+			name: "ignore resources in specific namespace",
+			policy: `
+package trivy.kubernetes
+
+ignore {
+	input.namespace == "kube-system"
+}
+`,
+			artifact: K8sArtifact{
+				Kind:      "Pod",
+				Namespace: "kube-system",
+				Name:      "system-pod",
+			},
+			wantIgnore: true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary policy file
+			tmpFile, err := os.CreateTemp("", "test-policy-*.rego")
+			require.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+
+			_, err = tmpFile.WriteString(tt.policy)
+			require.NoError(t, err)
+			tmpFile.Close()
+
+			opts := flag.K8sOptions{
+				K8sFilterPolicy: tmpFile.Name(),
+			}
+
+			filter, err := NewRegoFilter(context.Background(), opts)
+			require.NoError(t, err)
+			require.NotNil(t, filter)
+
+			ignore, err := filter.ShouldIgnore(context.Background(), tt.artifact)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantIgnore, ignore)
+			}
+		})
+	}
+}
+
+func TestRegoFilter_ShouldIgnore_NilFilter(t *testing.T) {
+	var filter *RegoFilter = nil
+	artifact := K8sArtifact{
+		Kind:      "Pod",
+		Namespace: "default",
+		Name:      "test-pod",
+	}
+
+	ignore, err := filter.ShouldIgnore(context.Background(), artifact)
+	assert.NoError(t, err)
+	assert.False(t, ignore)
+}
+
+func TestConvertToK8sArtifact(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind         string
+		namespace    string
+		resourceName string
+		labels       map[string]string
+		annotations  map[string]string
+		spec         interface{}
+		want         K8sArtifact
+	}{
+		{
+			name:         "basic conversion with nil maps",
+			kind:         "Pod",
+			namespace:    "default",
+			resourceName: "test-pod",
+			labels:       nil,
+			annotations:  nil,
+			spec:         nil,
+			want: K8sArtifact{
+				Kind:        "Pod",
+				Namespace:   "default",
+				Name:        "test-pod",
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+				Spec:        nil,
+			},
+		},
+		{
+			name:         "conversion with labels and annotations",
+			kind:         "Deployment",
+			namespace:    "production",
+			resourceName: "app-deployment",
+			labels:       map[string]string{"app": "web", "version": "v1"},
+			annotations:  map[string]string{"deployment.kubernetes.io/revision": "1"},
+			spec:         map[string]interface{}{"replicas": 3},
+			want: K8sArtifact{
+				Kind:        "Deployment",
+				Namespace:   "production",
+				Name:        "app-deployment",
+				Labels:      map[string]string{"app": "web", "version": "v1"},
+				Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+				Spec:        map[string]interface{}{"replicas": 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertToK8sArtifact(tt.kind, tt.namespace, tt.resourceName, tt.labels, tt.annotations, tt.spec)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Helper function to create test policy file
+func createTestPolicy(t *testing.T, policyPath string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(policyPath), 0755)
+	require.NoError(t, err)
+
+	policy := `
+package trivy.kubernetes
+
+ignore {
+	input.kind == "Deployment"
+	input.spec.replicas == 0
+}
+`
+	err = os.WriteFile(policyPath, []byte(policy), 0644)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(filepath.Dir(policyPath))
+	})
+}

--- a/pkg/k8s/filter/rego_test.go
+++ b/pkg/k8s/filter/rego_test.go
@@ -27,7 +27,7 @@ func TestNewRegoFilter(t *testing.T) {
 		{
 			name: "valid policy file",
 			opts: flag.K8sOptions{
-				K8sFilterPolicy: "testdata/valid-policy.rego",
+				K8sSkipPolicy: "testdata/valid-policy.rego",
 			},
 			wantNil: false,
 			wantErr: false,
@@ -35,7 +35,7 @@ func TestNewRegoFilter(t *testing.T) {
 		{
 			name: "invalid policy file path",
 			opts: flag.K8sOptions{
-				K8sFilterPolicy: "nonexistent.rego",
+				K8sSkipPolicy: "nonexistent.rego",
 			},
 			wantNil: false,
 			wantErr: true,
@@ -45,8 +45,8 @@ func TestNewRegoFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create test policy file if needed
-			if tt.opts.K8sFilterPolicy == "testdata/valid-policy.rego" {
-				createTestPolicy(t, tt.opts.K8sFilterPolicy)
+			if tt.opts.K8sSkipPolicy == "testdata/valid-policy.rego" {
+				createTestPolicy(t, tt.opts.K8sSkipPolicy)
 			}
 
 			filter, err := NewRegoFilter(t.Context(), tt.opts)
@@ -168,7 +168,7 @@ ignore {
 			tmpFile.Close()
 
 			opts := flag.K8sOptions{
-				K8sFilterPolicy: tmpFile.Name(),
+				K8sSkipPolicy: tmpFile.Name(),
 			}
 
 			filter, err := NewRegoFilter(t.Context(), opts)


### PR DESCRIPTION
## Description
Add support for filtering Kubernetes resources using custom REGO rules before scanning. This allows users to exclude specific resources based on metadata, labels, annotations, and spec fields.

Key features:
- New CLI flags: --k8s-filter-policy and --k8s-filter-data
- REGO-based filtering with package trivy.kubernetes
- Pre-scan artifact filtering for improved efficiency
- Comprehensive test coverage and example policies

Addresses the specific use case of filtering deployments with zero replicas while providing flexible filtering for any Kubernetes resource.

## Related issues
- Close #8078

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
