### PR TITLE
chore: fix errors and typos in docs

### DIFF
--- a/docs/docs/coverage/language/c.md
+++ b/docs/docs/coverage/language/c.md
@@ -31,5 +31,5 @@ To correctly detection licenses, ensure that the cache directory contains all de
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
 
 [^1]: The local cache should contain the dependencies used. See [licenses](#licenses).
-[^2]: `conan.lock` is default name. To scan a custom filename use [file-patterns](../../configuration/skipping.md#file-patterns).
+[^2]: `conan.lock` is default name. To scan a custom filename use [file-patterns](../../configuration/skipping.md#customizing-file-handling).
 [^3]: For `conan.lock` in version 2, indirect dependencies are included in analysis but not flagged explicitly in dependency tree

--- a/docs/docs/coverage/language/elixir.md
+++ b/docs/docs/coverage/language/elixir.md
@@ -24,4 +24,4 @@ In order to detect dependencies, Trivy searches for `mix.lock`[^1].
 [hex]: https://hex.pm/
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
 
-[^1]: `mix.lock` is default name. To scan a custom filename use [file-patterns](../../configuration/skipping.md#file-patterns)
+[^1]: `mix.lock` is default name. To scan a custom filename use [file-patterns](../../configuration/skipping.md#customizing-file-handling)

--- a/docs/docs/coverage/language/index.md
+++ b/docs/docs/coverage/language/index.md
@@ -67,5 +67,5 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 [^5]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning
 [^6]: ✅ means "enabled" and `-` means "disabled" in the filesystem scanning
 [^7]: ✅ means "enabled" and `-` means "disabled" in the git repository scanning
-[^8]: To scan a filename other than the default filename use [file-patterns](../../configuration/skipping.md#file-patterns)
+[^8]: To scan a filename other than the default filename use [file-patterns](../../configuration/skipping.md#customizing-file-handling)
 [^9]: `Directory.Packages.props` and  legacy `Packages.props` file names are supported

--- a/docs/docs/scanner/misconfiguration/config/config.md
+++ b/docs/docs/scanner/misconfiguration/config/config.md
@@ -35,7 +35,7 @@ cd examples/misconf/custom-data
 trivy config --config-check ./my-check --data ./data --namespaces user ./configs
 ```
 
-For more details, see [Custom Data](./custom/data.md).
+For more details, see [Custom Data](../custom/data.md).
 
 ### Passing namespaces
 By default, Trivy evaluates checks defined in `builtin.*`.
@@ -120,7 +120,7 @@ Resources:
 ```
 
 !!!note
-Ignore rules for Helm files should be placed before the YAML object, since only it contains the location data needed for ignoring.
+    Ignore rules for Helm files should be placed before the YAML object, since only it contains the location data needed for ignoring.
 
 Example for Helm:
 ```yaml
@@ -133,7 +133,7 @@ Example for Helm:
             runAsGroup: 3000
           image: "your-repository/your-image:your-tag"
           imagePullPolicy: "Always"
-
+```
           
 #### Expiration Date
 

--- a/docs/docs/scanner/misconfiguration/custom/schema.md
+++ b/docs/docs/scanner/misconfiguration/custom/schema.md
@@ -117,64 +117,64 @@ By default, scanning JSON and YAML configurations is disabled, since Trivy does 
 
 
 !!! example
-```bash
-$ cat iac/serverless.yaml
-service: serverless-rest-api-with-pynamodb
-
-frameworkVersion: ">=2.24.0"
-
-plugins:
-  - serverless-python-requirements
-...
-
-$ cat serverless.rego
-# METADATA
-# title: Serverless Framework service name not starting with "aws-"
-# description: Ensure that Serverless Framework service names start with "aws-"
-# schemas:
-#   - input: schema["serverless-schema"]
-# custom:
-#   id: SF001
-#   severity: LOW
-package user.serverless001
-
-deny[res] {
-    not startswith(input.service, "aws-")
-    res := result.new(
-        sprintf("Service name %q is not allowed", [input.service]),
-        input.service
-    )
-}
-
-$ trivy config --misconfig-scanners=json,yaml --config-check ./serverless.rego --check-namespaces user ./iac
-serverless.yaml (yaml)
-
-Tests: 4 (SUCCESSES: 3, FAILURES: 1)
-Failures: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
-
-LOW: Service name "serverless-rest-api-with-pynamodb" is not allowed
-═════════════════════════════════════════════════════════════════════════════════════════════════════════
-Ensure that Serverless Framework service names start with "aws-"
-```
+    ```bash
+    $ cat iac/serverless.yaml
+    service: serverless-rest-api-with-pynamodb
+    
+    frameworkVersion: ">=2.24.0"
+    
+    plugins:
+      - serverless-python-requirements
+    ...
+    
+    $ cat serverless.rego
+    # METADATA
+    # title: Serverless Framework service name not starting with "aws-"
+    # description: Ensure that Serverless Framework service names start with "aws-"
+    # schemas:
+    #   - input: schema["serverless-schema"]
+    # custom:
+    #   id: SF001
+    #   severity: LOW
+    package user.serverless001
+    
+    deny[res] {
+        not startswith(input.service, "aws-")
+        res := result.new(
+            sprintf("Service name %q is not allowed", [input.service]),
+            input.service
+        )
+    }
+    
+    $ trivy config --misconfig-scanners=json,yaml --config-check ./serverless.rego --check-namespaces user ./iac
+    serverless.yaml (yaml)
+    
+    Tests: 4 (SUCCESSES: 3, FAILURES: 1)
+    Failures: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
+    
+    LOW: Service name "serverless-rest-api-with-pynamodb" is not allowed
+    ═════════════════════════════════════════════════════════════════════════════════════════════════════════
+    Ensure that Serverless Framework service names start with "aws-"
+    ```
 
 !!! note
-In the case above, the custom check specified has a metadata annotation for the input schema `input: schema["serverless-schema"]`. This allows Trivy to type check the input IaC files provided.
+    In the case above, the custom check specified has a metadata annotation for the input schema `input: schema["serverless-schema"]`. This allows Trivy to type check the input IaC files provided.
 
 Optionally, you can also pass schemas using the `config-file-schemas` flag. Trivy will use these schemas for file filtering and type checking in Rego checks.
 
 !!! example
-```bash
-$ trivy config --misconfig-scanners=json,yaml --config-check ./serverless.rego --check-namespaces user --config-file-schemas ./serverless-schema.json ./iac
-```
+    ```bash
+    $ trivy config --misconfig-scanners=json,yaml --config-check ./serverless.rego --check-namespaces user --config-file-schemas ./serverless-schema.json ./iac
+    ```
 
 If the `--config-file-schemas` flag is specified Trivy ensures that each input IaC config file being scanned is type-checked against the schema. If the input file does not match any of the passed schemas, it will be ignored.
 
-If the schema is specified in the check metadata and is in the directory specified in the `--config-check` argument, it will be automatically loaded as specified [here](./custom/schema.md#custom-checks-with-custom-schemas), and will only be used for type checking in Rego.
+If the schema is specified in the check metadata and is in the directory specified in the `--config-check` argument, it will be automatically loaded as specified [here](./schema.md#custom-checks-with-custom-schemas), and will only be used for type checking in Rego.
 
 !!! note
-If a user specifies the `--config-file-schemas` flag, all input IaC config files are ensured that they pass type-checking. It is not required to pass an input schema in case type checking is not required. This is helpful for scenarios where you simply want to write a Rego check and pass in IaC input for it. Such a use case could include scanning for a new service which Trivy might not support just yet.
+    If a user specifies the `--config-file-schemas` flag, all input IaC config files are ensured that they pass type-checking. It is not required to pass an input schema in case type checking is not required. This is helpful for scenarios where you simply want to write a Rego check and pass in IaC input for it. Such a use case could include scanning for a new service which Trivy might not support just yet.
 
 !!! tip
-It is also possible to specify multiple input schemas with `--config-file-schema` flag as it can accept a comma seperated list of file paths or a directory as input. In the case of multiple schemas being specified, all of them will be evaluated against all the input files.
+    It is also possible to specify multiple input schemas with `--config-file-schema` flag as it can accept a comma seperated list of file paths or a directory as input. In the case of multiple schemas being specified, all of them will be evaluated against all the input files.
 
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -999,7 +999,7 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.TableMode = nil // disable '--table-mode's
 	compliance := flag.ComplianceFlag.Clone()
 	var compliances string
-	for _, val := range types.BuiltInK8sCompiances {
+	for _, val := range types.BuiltInK8sCompliances {
 		compliances += fmt.Sprintf("\n  - %s", val)
 	}
 	compliance.Usage = fmt.Sprintf("%s\nBuilt-in compliance's:%s", compliance.Usage, compliances)

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -74,7 +74,7 @@ const (
 	FormatCosignVuln Format = "cosign-vuln"
 )
 
-var BuiltInK8sCompiances = []string{
+var BuiltInK8sCompliances = []string{
 	ComplianceK8sNsa10,
 	ComplianceK8sCIS123,
 	ComplianceEksCIS14,


### PR DESCRIPTION
## Description
This PR fixes found mistakes:
- name of `BuiltInK8sCompliances` array
- incorrect links in docs
- incorrect indents in docs

## Related discussion
- Close #8949

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
