### PR TITLE
chore(k8s): update comments with deprecated command format

### DIFF
--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -133,16 +133,11 @@ func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) er
 // even though the default value of "--report" is "all".
 //
 // e.g.
-// $ trivy k8s --report all cluster
-// $ trivy k8s --report all all
+// $ trivy k8s --report all
 //
 // Or they can use "--format json" with implicit "--report all".
 //
-// e.g. $ trivy k8s --format json cluster // All the results are shown in JSON
-//
-// Single resource scanning is allowed with implicit "--report all".
-//
-// e.g. $ trivy k8s pod myapp
+// e.g. $ trivy k8s --format json // All the results are shown in JSON
 func validateReportArguments(opts flag.Options) error {
 	if opts.ReportFormat == "all" &&
 		!viper.IsSet("report") &&


### PR DESCRIPTION
## Description
There was introduced the new Kubernetes scanning user experience in Trivy v0.51 (https://github.com/aquasecurity/trivy/discussions/6605). but some comments still point to the old command format.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
