### PR TITLE
feat(terraform): add partial evaluation for policy templates

### DIFF
--- a/pkg/iac/adapters/terraform/aws/iam/convert.go
+++ b/pkg/iac/adapters/terraform/aws/iam/convert.go
@@ -3,6 +3,8 @@ package iam
 import (
 	"strings"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/aquasecurity/iamgo"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/iam"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
@@ -15,6 +17,13 @@ type wrappedDocument struct {
 }
 
 func ParsePolicyFromAttr(attr *terraform.Attribute, owner *terraform.Block, modules terraform.Modules) (*iam.Document, error) {
+	attr.RewriteExpr(func(e hclsyntax.Expression) hclsyntax.Expression {
+		if te, ok := e.(*hclsyntax.TemplateExpr); ok {
+			return &terraform.PartialTemplateExpr{TemplateExpr: te}
+		}
+		return e
+	})
+
 	if !attr.IsString() {
 		return &iam.Document{
 			Metadata: owner.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/iam/policies_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies_test.go
@@ -404,7 +404,11 @@ data "aws_iam_policy_document" "policy" {
 		},
 		{
 			name: "policy is template with unknown part",
-			terraform: `resource "aws_iam_policy" "test" {
+			terraform: `variable "action" {
+ default = null
+}
+
+resource "aws_iam_policy" "test" {
   name = "test"
 
   policy = <<EOF
@@ -414,7 +418,7 @@ data "aws_iam_policy_document" "policy" {
         {
             "Effect": "Allow",
             "Action": [
-                "s3:put*",
+                "${var.action}",
                 "s3:get*",
                 "s3:list*"
             ],
@@ -441,7 +445,7 @@ EOF
 						builder := iamgo.NewPolicyBuilder().
 							WithStatement(
 								iamgo.NewStatementBuilder().
-									WithActions([]string{"s3:put*", "s3:get*", "s3:list*"}).
+									WithActions([]string{"__UNRESOLVED__", "s3:get*", "s3:list*"}).
 									WithResources([]string{"*"}).
 									WithEffect("Allow").
 									Build(),

--- a/pkg/iac/adapters/terraform/aws/iam/policies_test.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies_test.go
@@ -402,6 +402,69 @@ data "aws_iam_policy_document" "policy" {
 				},
 			},
 		},
+		{
+			name: "policy is template with unknown part",
+			terraform: `resource "aws_iam_policy" "test" {
+  name = "test"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:put*",
+                "s3:get*",
+                "s3:list*"
+            ],
+            "Resource": "*"
+        },
+         {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:DescribeStream",
+                "kinesis:GetRecords"
+            ],
+            "Resource": [
+                "${aws_kinesis_stream.stepfunction_ecs_kinesis_stream.arn}"
+            ]
+        }
+    ]
+}
+EOF
+}`,
+			expected: []iam.Policy{
+				{
+					Name: iacTypes.StringTest("test"),
+					Document: func() iam.Document {
+						builder := iamgo.NewPolicyBuilder().
+							WithStatement(
+								iamgo.NewStatementBuilder().
+									WithActions([]string{"s3:put*", "s3:get*", "s3:list*"}).
+									WithResources([]string{"*"}).
+									WithEffect("Allow").
+									Build(),
+							).
+							WithStatement(
+								iamgo.NewStatementBuilder().
+									WithActions([]string{"kinesis:DescribeStream", "kinesis:GetRecords"}).
+									WithResources([]string{"__UNRESOLVED__"}).
+									WithEffect("Allow").
+									Build(),
+							).
+							WithVersion("2012-10-17")
+
+						return iam.Document{
+							Parsed:   builder.Build(),
+							Metadata: iacTypes.NewTestMetadata(),
+							IsOffset: false,
+							HasRefs:  true,
+						}
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

This PR adds partial evaluation of template expressions used when writing AWS policies in Terraform. Those parts of the template that could not be evaluated due to errors or unknown values are replaced with `__UNRESOLVED__` literal.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/8797

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
