### PR TITLE
fix: don't show corrupted trivy-db warning for first run

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -110,11 +110,12 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 		meta = metadata.Metadata{Version: db.SchemaVersion}
 	}
 
-	// There are 2 cases when DownloadAt field is zero:
+	// There are 3 cases when DownloadAt field is zero:
+	// - metadata file was not created yet. This is the first run of Trivy.
 	// - trivy-db was downloaded with `oras`. In this case user can use `--skip-db-update` (like for air-gapped) or re-download trivy-db.
 	// - trivy-db was corrupted while copying from tmp directory to cache directory. We should update this trivy-db.
 	// We can't detect these cases, so we will show warning for users who use oras + air-gapped.
-	if meta.DownloadedAt.IsZero() && !skip {
+	if !noRequiredFiles && meta.DownloadedAt.IsZero() && !skip {
 		log.WarnContext(ctx, "Trivy DB may be corrupted and will be re-downloaded. If you manually downloaded DB - use the `--skip-db-update` flag to skip updating DB.")
 		return true, nil
 	}
@@ -131,10 +132,11 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 	}
 
 	if skip {
-		log.DebugContext(ctx, "Skipping DB update...")
 		if err = c.validate(meta); err != nil {
 			return false, xerrors.Errorf("validate error: %w", err)
 		}
+
+		log.DebugContext(ctx, "Skipping DB update...")
 		return false, nil
 	}
 

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +16,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/db"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 func TestClient_NeedsUpdate(t *testing.T) {


### PR DESCRIPTION
## Description
- Remove corrupted warning for first run.
- don't show `Skipping DB update...` for invalid matadata.json file.

## Related issues
- Close #8990

## Related PRs
- [x] #8864

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
