### PR TITLE
feat(alpine): add EOL date for Alpine 3.22

### DIFF
--- a/docs/docs/coverage/os/index.md
+++ b/docs/docs/coverage/os/index.md
@@ -11,7 +11,7 @@ Trivy supports operating systems for
 
 | OS                                    | Supported Versions                  | Package Managers |
 |---------------------------------------|-------------------------------------|------------------|
-| [Alpine Linux](alpine.md)             | 2.2 - 2.7, 3.0 - 3.21, edge         | apk              |
+| [Alpine Linux](alpine.md)             | 2.2 - 2.7, 3.0 - 3.22, edge         | apk              |
 | [Wolfi Linux](wolfi.md)               | (n/a)                               | apk              |
 | [Chainguard](chainguard.md)           | (n/a)                               | apk              |
 | [MinimOS](minimos.md)                 | (n/a)                               | apk              |

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -48,6 +48,7 @@ var eolDates = map[string]time.Time{
 	"3.19": time.Date(2025, 11, 1, 23, 59, 59, 0, time.UTC),
 	"3.20": time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC),
 	"3.21": time.Date(2026, 12, 5, 23, 59, 59, 0, time.UTC),
+	"3.22": time.Date(2027, 4, 30, 23, 59, 59, 0, time.UTC),
 	"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 }
 


### PR DESCRIPTION
## Description

[Alpine Linux 3.22](https://alpinelinux.org/releases/) was released on 2025-05-30 and is expected to go out of support on 2027-05-01.

Vulnerabilities affecting Alpine 3.22 are already being ingested into the Trivy DB:

```
$ ./trivy i docker.io/library/alpine:3.22 2>&1 | grep Detecting
2025-06-05T11:41:02+01:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.22" repository="3.22" pkg_num=16
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
