### PR TITLE
docs: fix assets with versioning

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -5,8 +5,8 @@
 {% endblock %}
 
 {% block hero %}
-<link rel='stylesheet' id='main-style-css' href='/assets/css/trivy_v1_styles.min.css' type='text/css' media='all' />
-<script type='text/javascript' src='/assets/javascripts/trivy_v1_homepage.js' id='trivy_v1_homepage-js'></script>
+<link rel='stylesheet' id='main-style-css' href='{{ base_url }}/assets/css/trivy_v1_styles.min.css' type='text/css' media='all' />
+<script type='text/javascript' src='{{ base_url }}/assets/javascripts/trivy_v1_homepage.js' id='trivy_v1_homepage-js'></script>
 
 <div class="trivy_v1_homepage_wrap">
 
@@ -18,7 +18,7 @@
                     <div class="header_title_wrap">
                         <div class="header_title_content_wrap">
                             <div class="page_logo">
-                                <img src="/assets/images/trivy_logo_horizontal_white.svg" height="100" alt="Trivy Logo">
+                                <img src="{{ base_url }}/assets/images/trivy_logo_horizontal_white.svg" height="100" alt="Trivy Logo">
                             </div>
                             <h1 class="title page_title is-spaced fadeInUp">
                                 The all-in-one open source security scanner

--- a/docs/overrides/partners.html
+++ b/docs/overrides/partners.html
@@ -5,8 +5,8 @@
 {% endblock %}
 
 {% block hero %}
-<link rel='stylesheet' id='main-style-css' href='/assets/css/trivy_v1_styles.min.css' type='text/css' media='all' />
-<script type='text/javascript' src='/assets/javascripts/trivy_v1_homepage.js' id='trivy_v1_homepage-js'></script>
+<link rel='stylesheet' id='main-style-css' href='{{ base_url }}/assets/css/trivy_v1_styles.min.css' type='text/css' media='all' />
+<script type='text/javascript' src='{{ base_url }}/assets/javascripts/trivy_v1_homepage.js' id='trivy_v1_homepage-js'></script>
 
 <div class="trivy_v1_homepage_wrap partners_wrap">
 
@@ -23,11 +23,11 @@
 								Trivy Partners Program
 							</h1>
 							<h2 class="subtitle page_subtitle fadeInUp animationDelay_1">
-								Align with the world’s most trusted open-source scanner. This premium program gives you priority support, co-branding rights, and access to millions of users who rely on Trivy to secure their cloud-native environments. Don’t just integrate; Lead.
+								Align with the world's most trusted open-source scanner. This premium program gives you priority support, co-branding rights, and access to millions of users who rely on Trivy to secure their cloud-native environments. Don't just integrate; Lead.
 							</h2>
 						</div><!-- header_title_content_wrap -->	
 						
-						<div class="header_title_content_wrap partners_hero_stage_image"><img src="/assets/images/partners_hero_stage_full.svg" alt="" loading="lazy"></div>
+						<div class="header_title_content_wrap partners_hero_stage_image"><img src="{{ base_url }}/assets/images/partners_hero_stage_full.svg" alt="" loading="lazy"></div>
 						
 					</div><!-- header_title_wrap -->					
 					
@@ -52,9 +52,9 @@
 
 		<h3 class="title generic_title partners_logos_title">Join the Trivy Partners Community</h3>
 		<div class="partners_logos">
-			<div class="logo_item"><a href="https://minimus.io" target="_blank"><img src="/assets/images/partner_logo_minimus.svg" width="100" height="100" alt="Minimus Logo" loading="lazy"></a></div>
-			<div class="logo_item"><a href="https://root.io" target="_blank"><img src="/assets/images/partner_logo_root.svg" width="100" height="100" alt="Root Logo" loading="lazy"></a></div>
-			<div class="logo_item"><a href="https://echohq.com" target="_blank"><img src="/assets/images/partner_logo_echo.svg" width="100" height="100" alt="Echo Logo" loading="lazy"></a></div>
+			<div class="logo_item"><a href="https://minimus.io" target="_blank"><img src="{{ base_url }}/assets/images/partner_logo_minimus.svg" width="100" height="100" alt="Minimus Logo" loading="lazy"></a></div>
+			<div class="logo_item"><a href="https://root.io" target="_blank"><img src="{{ base_url }}/assets/images/partner_logo_root.svg" width="100" height="100" alt="Root Logo" loading="lazy"></a></div>
+			<div class="logo_item"><a href="https://echohq.com" target="_blank"><img src="{{ base_url }}/assets/images/partner_logo_echo.svg" width="100" height="100" alt="Echo Logo" loading="lazy"></a></div>
 		</div>
 	</div><!-- partners_logos_wrap -->
 	<!-- logos ends -->


### PR DESCRIPTION
## Description
in #8988 I made the assets URL absolute to fix the loading in the partners page (it was attempting to load assets from `/partners/assets`), but I didn't account for the version selector that adds the version to the path. when I (and the approvers) tested the webiste locally we couldn't reproduce this since version selector isn't available in the free mkdocs-material image. 
I think that adding the `{{ base_url }}` should fix that. I didn't test it though. I thought about creating the PR and then manually triggering the docs dev workflow from the PR branch, but it doesn't trigger manually. I guess we could merge and see the result in dev, since the current dev is broken anyway.

## Related PRs
-  #8988

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
