### PR TITLE
fix(nodejs): correctly parse `packages` array of `bun.lock` file

### DIFF
--- a/pkg/dependency/parser/nodejs/bun/parse.go
+++ b/pkg/dependency/parser/nodejs/bun/parse.go
@@ -74,10 +74,7 @@ func (p *ParsedPackage) UnmarshalJSON(data []byte) error {
 	if len(raw) > 3 {
 		metaRaw = raw[2]
 	}
-	if err := json.Unmarshal(metaRaw, &p.Meta); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(metaRaw, &p.Meta)
 }
 
 func (p *Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {

--- a/pkg/dependency/parser/nodejs/bun/parse.go
+++ b/pkg/dependency/parser/nodejs/bun/parse.go
@@ -58,10 +58,24 @@ func (p *ParsedPackage) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if len(raw) > 2 {
-		if err := json.Unmarshal(raw[2], &p.Meta); err != nil {
-			return err
-		}
+	// When package contains only package field [pkg: string]
+	// cf. https://github.com/oven-sh/bun/blob/61e03a275885b9b48f7a28f6dfbbbe1156eedca6/packages/bun-types/bun.d.ts#L7751
+	if len(raw) == 1 {
+		return nil
+	}
+
+	// Meta can be 2 or 3 array elements
+	// [pkg: string, info: BunLockFilePackageInfo]
+	// [pkg: string, info: BunLockFilePackageInfo, bunTag: string]
+	// [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+	// [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string]
+	// cf.https://github.com/oven-sh/bun/blob/61e03a275885b9b48f7a28f6dfbbbe1156eedca6/packages/bun-types/bun.d.ts#L7745-L7755
+	metaRaw := raw[1]
+	if len(raw) > 3 {
+		metaRaw = raw[2]
+	}
+	if err := json.Unmarshal(metaRaw, &p.Meta); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/dependency/parser/nodejs/bun/testdata/bun_happy.lock
+++ b/pkg/dependency/parser/nodejs/bun/testdata/bun_happy.lock
@@ -19,11 +19,11 @@
 
     "@types/node": ["@types/node@22.15.18", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg=="],
 
-    "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
+    "bun-types": ["bun-types@1.2.13", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@6.21.0"],
 
     "zod": ["zod@3.24.4", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
   }


### PR DESCRIPTION
## Description
`packages` array can use a different structure - https://bun.sh/reference/bun/BunLockFilePackageArray

So we need to parse `dependencies` from 2 or 3 elements of `package` array to avoid errors and missing dependencies

## Related issues
- Close #8995

## Related PRs
- [x] #8851

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
