### PR TITLE
refactor(misconf): set Trivy version by default in Rego scanner

### DIFF
--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/set"
+	"github.com/aquasecurity/trivy/pkg/version/app"
 )
 
 var checkTypesWithSubtype = set.New(types.SourceCloud, types.SourceDefsec, types.SourceKubernetes)
@@ -100,6 +101,7 @@ func NewScanner(opts ...options.ScannerOption) *Scanner {
 		customSchemas:    make(map[string][]byte),
 		disabledCheckIDs: set.New[string](),
 		moduleMetadata:   make(map[string]*StaticMetadata),
+		trivyVersion:     app.Version(),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
## Description

This PR sets a default Trivy version in the Rego scanner, simplifying usage by removing the need for consumers to explicitly specify the version via an option.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
