### PR TITLE
fix(debian): parse Built-Using field in dpkg deb

### DIFF
--- a/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
+++ b/pkg/fanal/analyzer/pkg/dpkg/dpkg_test.go
@@ -1379,6 +1379,26 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:      "only built using",
+			testFiles: map[string]string{"./testdata/dpkg_builtusing": "var/lib/dpkg/status"},
+			want: &analyzer.AnalysisResult{
+				PackageInfos: []types.PackageInfo{
+					{
+						FilePath: "var/lib/dpkg/status",
+						Packages: []types.Package{
+							{
+								ID: "helloworld@1.0-1", Name: "helloworld", Version: "1.0", Release: "1",
+								SrcName: "helloworld", SrcVersion: "1.0", SrcRelease: "1",
+								Maintainer: "Your Name <you@email.com>", Arch: "amd64",
+								DependsOn: []string{
+									"python3@2.13.3-0ubuntu1",
+								}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "happy path with digests",
 			testFiles: map[string]string{
 				"./testdata/digest-status":    "var/lib/dpkg/status",

--- a/pkg/fanal/analyzer/pkg/dpkg/testdata/dpkg_builtusing
+++ b/pkg/fanal/analyzer/pkg/dpkg/testdata/dpkg_builtusing
@@ -1,0 +1,11 @@
+Package: helloworld
+Status: install ok installed
+Priority: optional
+Section: base
+Maintainer: Your Name <you@email.com>
+Architecture: amd64
+Version: 1.0-1
+Description: Hello World
+ When you need some sunshine, just run this
+ small program!
+Built-Using: python3 (= 2.13.3-0ubuntu1)


### PR DESCRIPTION
## Description

The deb package specification includes the `Built-Using` field for packages that are incorporated into other releases (see https://www.debian.org/doc/debian-policy/ch-relationships.html#s-built-using). This PR adds the `Built-Using` packages as dependencies.

developed using claude-4-sonnet

prompt

I added a test to dpkg_test

i want to write to go in dpkg.go to handle the `Built-Using` field and add the dependencies

## Related issues
- Close #9008

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
