### PR TITLE
fix(misconf): correct Azure value-to-time conversion in AsTimeValue

### DIFF
--- a/pkg/iac/scanners/azure/value_test.go
+++ b/pkg/iac/scanners/azure/value_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -11,4 +12,41 @@ import (
 func Test_ValueAsInt(t *testing.T) {
 	val := NewValue(int64(10), types.NewTestMetadata())
 	assert.Equal(t, 10, val.AsInt())
+}
+
+func Test_ValueAsTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      any
+		expected time.Time
+	}{
+		{
+			name:     "string",
+			val:      "2023-12-15T14:45:00Z",
+			expected: time.Date(2023, 12, 15, 14, 45, 0, 0, time.UTC),
+		},
+		{
+			name:     "int",
+			val:      int64(200),
+			expected: time.Unix(200, 0),
+		},
+		{
+			name:     "float",
+			val:      float64(100),
+			expected: time.Unix(100, 0),
+		},
+		{
+			name:     "invalid type",
+			val:      nil,
+			expected: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := NewValue(tt.val, types.NewTestMetadata())
+			got := val.AsTimeValue(types.NewTestMetadata()).Value()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
 }


### PR DESCRIPTION
## Description

Time represented as int or float was not parsed because of early return from the method.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
