### PR TITLE
feat(sbom): add manufacturer field to CycloneDX tools metadata

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	ToolVendor = "aquasecurity"
-	ToolName   = "trivy"
-	Namespace  = ToolVendor + ":" + ToolName + ":"
+	ToolVendor       = "aquasecurity"
+	ToolName         = "trivy"
+	ToolManufacturer = "Aqua Security Software Ltd."
+	Namespace        = ToolVendor + ":" + ToolName + ":"
 
 	// https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times
 	timeLayout = "2006-01-02T15:04:05+00:00"
@@ -88,10 +89,11 @@ func (m *Marshaler) Metadata(ctx context.Context) *cdx.Metadata {
 		Tools: &cdx.ToolsChoice{
 			Components: &[]cdx.Component{
 				{
-					Type:    cdx.ComponentTypeApplication,
-					Group:   ToolVendor,
-					Name:    ToolName,
-					Version: m.appVersion,
+					Type:         cdx.ComponentTypeApplication,
+					Group:        ToolVendor,
+					Name:         ToolName,
+					Version:      m.appVersion,
+					Manufacturer: &cdx.OrganizationalEntity{Name: ToolManufacturer},
 				},
 			},
 		},

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -1531,10 +1531,11 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 					Tools: &cdx.ToolsChoice{
 						Components: &[]cdx.Component{
 							{
-								Type:    cdx.ComponentTypeApplication,
-								Name:    "trivy",
-								Group:   "aquasecurity",
-								Version: "dev",
+								Type:         cdx.ComponentTypeApplication,
+								Name:         "trivy",
+								Group:        "aquasecurity",
+								Version:      "dev",
+								Manufacturer: &cdx.OrganizationalEntity{Name: "Aqua Security Software Ltd."},
 							},
 						},
 					},


### PR DESCRIPTION




## Description
The manufacturer field improves human readability while keeping the existing group field for technical namespace purposes.
- Add ToolManufacturer constant with value 'Aqua Security Software Ltd.'
- Include manufacturer field in CycloneDX metadata tools component
- Update test to expect the new manufacturer field

## Related issues
- Close #9014 


## Checklist
- [✅ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [✅ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [✅ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
