### PR TITLE
feat(cli): add version constraints to annoucements

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -171,7 +171,7 @@ func (r *runner) Close(ctx context.Context) error {
 
 	// silently check if there is notifications
 	if r.versionChecker != nil {
-		r.versionChecker.PrintNotices(os.Stderr)
+		r.versionChecker.PrintNotices(ctx, os.Stderr)
 	}
 
 	return errs

--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -108,7 +108,6 @@ func (v *VersionChecker) PrintNotices(output io.Writer) {
 	}
 
 	logger := log.WithPrefix("notification")
-	logger.Debug("Printing notices")
 	var notices []string
 
 	cv, err := v.CurrentVersion()
@@ -133,6 +132,7 @@ func (v *VersionChecker) PrintNotices(output io.Writer) {
 	}
 
 	if len(notices) > 0 {
+		logger.Debug("Printing notices")
 		fmt.Fprintf(output, "\n📣 \x1b[34mNotices:\x1b[0m\n")
 		for _, notice := range notices {
 			fmt.Fprintf(output, "  - %s\n", notice)

--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -102,7 +102,7 @@ func (v *VersionChecker) RunUpdateCheck(ctx context.Context, args []string) {
 
 // PrintNotices prints any announcements or warnings
 // to the output writer, most likely stderr
-func (v *VersionChecker) PrintNotices(output io.Writer) {
+func (v *VersionChecker) PrintNotices(ctx context.Context, output io.Writer) {
 	if !v.responseReceived {
 		return
 	}
@@ -122,7 +122,7 @@ func (v *VersionChecker) PrintNotices(output io.Writer) {
 
 	notices = append(notices, v.Warnings()...)
 	for _, announcement := range v.Announcements() {
-		if announcement.shouldDisplay(time.Now(), cv) {
+		if announcement.shouldDisplay(ctx, cv) {
 			notices = append(notices, announcement.Announcement)
 		}
 	}

--- a/pkg/notification/notice_test.go
+++ b/pkg/notification/notice_test.go
@@ -62,8 +62,8 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
-					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -76,13 +76,94 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
-					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
 			responseExpected: true,
 			expectedOutput:   "\n📣 \x1b[34mNotices:\x1b[0m\n  - There are some amazing things happening right now!\n\nTo suppress version checks, run Trivy scans with the --skip-version-check flag\n\n",
+		},
+		{
+			name:          "No new version with announcement that fails announcement version constraints",
+			options:       []Option{WithCurrentVersion("0.60.0")},
+			latestVersion: "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromVersion:  ptrString("0.61.0"),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			responseExpected: true,
+			expectedOutput:   "",
+		},
+		{
+			name:          "No new version with announcement where current version is greater than to_version",
+			options:       []Option{WithCurrentVersion("0.60.0")},
+			latestVersion: "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					ToVersion:    ptrString("0.59.0"),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			responseExpected: true,
+			expectedOutput:   "",
+		},
+		{
+			name:          "No new version with announcement that satisfies version constraint but outside date range",
+			options:       []Option{WithCurrentVersion("0.60.0")},
+			latestVersion: "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     ptrTime(time.Date(2024, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromVersion:  ptrString("0.60.0"),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			responseExpected: true,
+			expectedOutput:   "",
+		},
+		{
+			name:          "No new version with multiple announcements, one of which is valid",
+			options:       []Option{WithCurrentVersion("0.60.0")},
+			latestVersion: "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					Announcement: "There are some amazing things happening right now!",
+				},
+				{
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromVersion:  ptrString("0.61.0"),
+					Announcement: "This announcement should not be displayed",
+				},
+			},
+			responseExpected: true,
+			expectedOutput:   "\n📣 \x1b[34mNotices:\x1b[0m\n  - There are some amazing things happening right now!\n\nTo suppress version checks, run Trivy scans with the --skip-version-check flag\n\n",
+		},
+		{
+			name:             "No new version with no announcements and quiet mode",
+			options:          []Option{WithCurrentVersion("0.60.0"), WithQuietMode(true)},
+			latestVersion:    "0.60.0",
+			announcements:    []announcement{},
+			responseExpected: false,
+			expectedOutput:   "",
+		},
+		{
+			name:             "No new version with no announcements",
+			options:          []Option{WithCurrentVersion("0.60.0")},
+			latestVersion:    "0.60.0",
+			announcements:    []announcement{},
+			responseExpected: true,
+			expectedOutput:   "",
 		},
 	}
 
@@ -141,8 +222,8 @@ func TestCheckForNotices(t *testing.T) {
 			expectedVersion: "0.60.0",
 			expectedAnnouncements: []announcement{
 				{
-					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
-					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
+					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -161,7 +242,9 @@ func TestCheckForNotices(t *testing.T) {
 			v.RunUpdateCheck(t.Context(), nil)
 			require.Eventually(t, func() bool { return v.done }, time.Second*5, 500)
 			require.Eventually(t, func() bool { return v.responseReceived }, time.Second*5, 500)
-			assert.Equal(t, tt.expectedVersion, v.LatestVersion())
+			latestVersion, err := v.LatestVersion()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedVersion, latestVersion.String())
 			assert.ElementsMatch(t, tt.expectedAnnouncements, v.Announcements())
 
 			if tt.expectNoMetrics {
@@ -246,4 +329,9 @@ func TestFlexibleDate(t *testing.T) {
 			assert.Equal(t, tt.expected.Unix(), ft.Unix())
 		})
 	}
+}
+
+// ptrTime returns a pointer to the given time.Time value.
+func ptrTime(t time.Time) *time.Time {
+	return &t
 }

--- a/pkg/notification/notice_test.go
+++ b/pkg/notification/notice_test.go
@@ -62,8 +62,8 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -76,8 +76,22 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					Announcement: "There are some amazing things happening right now!",
+				},
+			},
+			responseExpected: true,
+			expectedOutput:   "\n📣 \x1b[34mNotices:\x1b[0m\n  - There are some amazing things happening right now!\n\nTo suppress version checks, run Trivy scans with the --skip-version-check flag\n\n",
+		},
+		{
+			name:          "No new version with announcements and zero time",
+			options:       []Option{WithCurrentVersion("0.60.0")},
+			latestVersion: "0.60.0",
+			announcements: []announcement{
+				{
+					FromDate:     time.Time{},
+					ToDate:       time.Time{},
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -90,9 +104,9 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
-					FromVersion:  ptrString("0.61.0"),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromVersion:  "0.61.0",
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -105,9 +119,9 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
-					ToVersion:    ptrString("0.59.0"),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					ToVersion:    "0.59.0",
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -120,9 +134,9 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2024, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
-					FromVersion:  ptrString("0.60.0"),
+					FromDate:     time.Date(2024, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromVersion:  "0.60.0",
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -135,14 +149,14 @@ func TestPrintNotices(t *testing.T) {
 			latestVersion: "0.60.0",
 			announcements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
 					Announcement: "There are some amazing things happening right now!",
 				},
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
-					FromVersion:  ptrString("0.61.0"),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+					FromVersion:  "0.61.0",
 					Announcement: "This announcement should not be displayed",
 				},
 			},
@@ -180,7 +194,7 @@ func TestPrintNotices(t *testing.T) {
 			require.Eventually(t, func() bool { return v.responseReceived == tt.responseExpected }, time.Second*5, 500)
 
 			sb := bytes.NewBufferString("")
-			v.PrintNotices(sb)
+			v.PrintNotices(t.Context(), sb)
 			assert.Equal(t, tt.expectedOutput, sb.String())
 
 			// check metrics are sent
@@ -222,8 +236,8 @@ func TestCheckForNotices(t *testing.T) {
 			expectedVersion: "0.60.0",
 			expectedAnnouncements: []announcement{
 				{
-					FromDate:     ptrTime(time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC)),
-					ToDate:       ptrTime(time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC)),
+					FromDate:     time.Date(2025, 2, 2, 12, 0, 0, 0, time.UTC),
+					ToDate:       time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
 					Announcement: "There are some amazing things happening right now!",
 				},
 			},
@@ -329,9 +343,4 @@ func TestFlexibleDate(t *testing.T) {
 			assert.Equal(t, tt.expected.Unix(), ft.Unix())
 		})
 	}
-}
-
-// ptrTime returns a pointer to the given time.Time value.
-func ptrTime(t time.Time) *time.Time {
-	return &t
 }

--- a/pkg/notification/response.go
+++ b/pkg/notification/response.go
@@ -1,0 +1,56 @@
+package notification
+
+import (
+	"time"
+
+	"github.com/aquasecurity/go-version/pkg/semver"
+)
+
+// flexibleTime is a custom time type that can handle
+// different date formats in JSON. It implements the
+// UnmarshalJSON method to parse the date string into a time.Time object.
+type flexibleTime struct {
+	time.Time
+}
+
+type versionInfo struct {
+	LatestVersion string       `json:"latest_version"`
+	LatestDate    flexibleTime `json:"latest_date"`
+}
+
+type announcement struct {
+	FromDate     *time.Time `json:"from_date"`
+	ToDate       *time.Time `json:"to_date"`
+	FromVersion  *string    `json:"from_version"`
+	ToVersion    *string    `json:"to_version"`
+	Announcement string     `json:"announcement"`
+}
+
+type updateResponse struct {
+	Trivy         versionInfo    `json:"trivy"`
+	Announcements []announcement `json:"announcements"`
+	Warnings      []string       `json:"warnings"`
+}
+
+// shoudDisplay checks if the announcement should be displayed
+// based on the current time and version. If version and date constraints are provided
+// they are checked against the current time and version.
+func (a *announcement) shouldDisplay(now time.Time, currentVersion semver.Version) bool {
+	if a.FromDate != nil && now.Before(*a.FromDate) {
+		return false
+	}
+	if a.ToDate != nil && now.After(*a.ToDate) {
+		return false
+	}
+	if a.FromVersion != nil {
+		if fromVersion, err := semver.Parse(*a.FromVersion); err == nil && currentVersion.LessThan(fromVersion) {
+			return false
+		}
+	}
+	if a.ToVersion != nil {
+		if toVersion, err := semver.Parse(*a.ToVersion); err == nil && currentVersion.GreaterThanOrEqual(toVersion) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/notification/response_test.go
+++ b/pkg/notification/response_test.go
@@ -1,0 +1,181 @@
+package notification
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/go-version/pkg/semver"
+)
+
+func TestAnnouncementShouldDisplay(t *testing.T) {
+	tests := []struct {
+		name           string
+		announcement   announcement
+		now            time.Time
+		currentVersion string
+		expected       bool
+	}{
+		{
+			name: "Announcement with valid from_date and current date before it",
+			announcement: announcement{
+				FromDate:     ptrTime(time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)),
+				Announcement: "Upcoming feature",
+			},
+			now:            time.Date(2023, 9, 30, 0, 0, 0, 0, time.UTC),
+			currentVersion: "1.0.0",
+			expected:       false,
+		},
+		{
+			name: "Announcement with valid to_date and current date after it",
+			announcement: announcement{
+				ToDate:       ptrTime(time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)),
+				Announcement: "Past feature",
+			},
+			now:            time.Date(2023, 10, 2, 0, 0, 0, 0, time.UTC),
+			currentVersion: "1.0.0",
+			expected:       false,
+		},
+		{
+			name: "Announcement with valid from_date and current date after it and before to_date",
+			announcement: announcement{
+				FromDate:     ptrTime(time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)),
+				ToDate:       ptrTime(time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)),
+				Announcement: "Ongoing feature",
+			},
+			now:            time.Date(2023, 10, 15, 0, 0, 0, 0, time.UTC),
+			currentVersion: "1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with valid from_version and current version greater than it",
+			announcement: announcement{
+				FromVersion:  ptrString("1.1.0"),
+				Announcement: "New feature",
+			},
+			now:            time.Now(),
+			currentVersion: "1.2.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with valid from_version and current version equal to it",
+			announcement: announcement{
+				FromVersion:  ptrString("1.0.0"),
+				Announcement: "New feature",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with valid to_version and current version less than it",
+			announcement: announcement{
+				ToVersion:    ptrString("1.2.0"),
+				Announcement: "Upcoming feature",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with valid to_version and current version equal to it",
+			announcement: announcement{
+				ToVersion:    ptrString("1.0.0"),
+				Announcement: "Upcoming feature",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0",
+			expected:       false,
+		},
+		{
+			name: "Announcement with valid from_version and valid to_version",
+			announcement: announcement{
+				FromVersion:  ptrString("1.0.0"),
+				ToVersion:    ptrString("1.2.0"),
+				Announcement: "Feature announcement",
+			},
+			now:            time.Date(2023, 10, 15, 0, 0, 0, 0, time.UTC),
+			currentVersion: "1.1.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with no date or version constraints",
+			announcement: announcement{
+				Announcement: "General announcement",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with all constraints but current version meets them",
+			announcement: announcement{
+				FromDate:     ptrTime(time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)),
+				ToDate:       ptrTime(time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC)),
+				FromVersion:  ptrString("1.0.0"),
+				ToVersion:    ptrString("1.2.0"),
+				Announcement: "Feature announcement",
+			},
+			now:            time.Date(2023, 10, 15, 0, 0, 0, 0, time.UTC),
+			currentVersion: "1.1.0",
+			expected:       true,
+		},
+		{
+			name: "Announcement with version having 'v' prefix",
+			announcement: announcement{
+				FromVersion:  ptrString("v1.0.0"),
+				Announcement: "Version prefix handling",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Current version with 'v' prefix",
+			announcement: announcement{
+				FromVersion:  ptrString("1.0.0"),
+				Announcement: "Version prefix handling",
+			},
+			now:            time.Now(),
+			currentVersion: "v1.0.0",
+			expected:       true,
+		},
+		{
+			name: "Pre-release version comparison",
+			announcement: announcement{
+				FromVersion:  ptrString("1.0.0"),
+				ToVersion:    ptrString("1.2.0"),
+				Announcement: "Pre-release handling",
+			},
+			now:            time.Now(),
+			currentVersion: "1.1.0-beta.1",
+			expected:       true,
+		},
+		{
+			name: "Build metadata in version",
+			announcement: announcement{
+				FromVersion:  ptrString("1.0.0"),
+				Announcement: "Build metadata handling",
+			},
+			now:            time.Now(),
+			currentVersion: "1.0.0+build.1",
+			expected:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentVersion, err := semver.Parse(strings.TrimPrefix(tt.currentVersion, "v"))
+			require.NoError(t, err)
+			got := tt.announcement.shouldDisplay(tt.now, currentVersion)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func ptrString(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Description

This optional constraint will be useful to prevent showing announcements in versions of Trivy where the announcement is not appropriate - for example when the announcement is that "from v0.64.0 x will happen", this shouldn't be shown in 0.64.0+
    
When date and version constraints are provided by the backend, both will be taken into account when deciding whether to print the announcements.
    
Version checking leverages the aqua go version semver parsing, if the version in the announcement isn't valid, the announcement won't be shown

## Related issues
- Close #9022

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.

