### PR TITLE
docs: add PR review policy for maintainers

### DIFF
--- a/docs/community/maintainer/pr-review.md
+++ b/docs/community/maintainer/pr-review.md
@@ -1,0 +1,16 @@
+# Pull Request Review Policy
+
+This document outlines the review policy for pull requests in the Trivy project.
+
+## Core Principles
+
+### 1. All Changes Through Pull Requests
+All changes to the `main` branch must be made through pull requests. Direct commits to `main` are not allowed.
+
+### 2. Required Approvals
+Every pull request requires approval from at least one CODEOWNER before merging.
+
+### 3. Merge Responsibility
+- **General Rule**: The pull request author should click the merge button after receiving required approvals
+- **Exception**: For urgent fixes (hotfixes), a CODEOWNER may merge the PR directly
+- **External Contributors**: Pull requests from external contributors should be merged by a CODEOWNER

--- a/docs/community/maintainer/pr-review.md
+++ b/docs/community/maintainer/pr-review.md
@@ -5,10 +5,18 @@ This document outlines the review policy for pull requests in the Trivy project.
 ## Core Principles
 
 ### 1. All Changes Through Pull Requests
-All changes to the `main` branch must be made through pull requests. Direct commits to `main` are not allowed.
+All changes to the `main` branch must be made through pull requests.
+Direct commits to `main` are not allowed.
 
 ### 2. Required Approvals
 Every pull request requires approval from at least one CODEOWNER before merging.
+
+For changes that span multiple domains (e.g., both vulnerability and misconfiguration scanning), approval from at least one code owner from each affected domain is required.
+
+When a pull request is created by the only code owner of a domain, approval from any other maintainer is required.
+
+When a code owner wants additional input from other owners or maintainers, they should comment requesting feedback and wait for others to approve before providing their own approval.
+This prevents accidental merging by the PR author.
 
 ### 3. Merge Responsibility
 - **General Rule**: The pull request author should click the merge button after receiving required approvals

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,6 +224,7 @@ nav:
           - Overview: community/contribute/checks/overview.md
           - Add Service Support: community/contribute/checks/service-support.md
       - Maintainer:
+          - PR Review: community/maintainer/pr-review.md
           - Release Flow: community/maintainer/release-flow.md
           - Backporting: community/maintainer/backporting.md
           - Help Wanted: community/maintainer/help-wanted.md


### PR DESCRIPTION
## Summary
- Add PR review policy document to clearly define the review process
- Update mkdocs.yml to include the new policy page in the maintainer section

## Changes
- Create `docs/community/maintainer/pr-review.md` with core principles:
  - All changes must go through pull requests
  - At least one CODEOWNER approval required
  - Clear merge responsibility guidelines (author merges, except for hotfixes and external contributions)