### PR TITLE
fix(sbom): remove unnecessary OS detection check in SBOM decoding

### DIFF
--- a/pkg/sbom/io/decode_test.go
+++ b/pkg/sbom/io/decode_test.go
@@ -1,0 +1,259 @@
+package io_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/sbom/core"
+	sbomio "github.com/aquasecurity/trivy/pkg/sbom/io"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+var (
+	apkToolsComponent = &core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "apk-tools",
+		Version: "2.14.10-r4",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:    packageurl.TypeApk,
+				Name:    "apk-tools",
+				Version: "2.14.10-r4",
+				Qualifiers: packageurl.Qualifiers{
+					{Key: "arch", Value: "aarch64"},
+					{Key: "distro", Value: "wolfi-20230201"},
+				},
+			},
+		},
+		Licenses: []string{"GPL-2.0-only"},
+	}
+
+	busyboxComponent = &core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "busybox",
+		Version: "1.37.0-r42",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:    packageurl.TypeApk,
+				Name:    "busybox",
+				Version: "1.37.0-r42",
+				Qualifiers: packageurl.Qualifiers{
+					{Key: "arch", Value: "aarch64"},
+					{Key: "distro", Value: "wolfi-20230201"},
+				},
+			},
+		},
+		Licenses: []string{"GPL-2.0-only"},
+	}
+
+	caCertificatesComponent = &core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "ca-certificates-bundle",
+		Version: "20241121-r42",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:    packageurl.TypeApk,
+				Name:    "ca-certificates-bundle",
+				Version: "20241121-r42",
+				Qualifiers: packageurl.Qualifiers{
+					{Key: "arch", Value: "aarch64"},
+					{Key: "distro", Value: "wolfi-20230201"},
+				},
+			},
+		},
+		Licenses: []string{"MPL-2.0"},
+	}
+
+	wolfiOSComponent = &core.Component{
+		Type:    core.TypeOS,
+		Name:    "wolfi",
+		Version: "20230201",
+	}
+
+	rpmTestComponent = &core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "rpm-package",
+		Version: "2.0.0",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:    packageurl.TypeRPM,
+				Name:    "rpm-package",
+				Version: "2.0.0",
+			},
+		},
+		Licenses: []string{"GPL-2.0"},
+	}
+)
+
+func TestDecoder_Decode_OSPackages(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupBOM func() *core.BOM
+		wantSBOM types.SBOM
+		wantErr  string
+	}{
+		{
+			name: "OS packages with OS metadata should be included",
+			setupBOM: func() *core.BOM {
+				bom := core.NewBOM(core.Options{})
+				bom.SerialNumber = "test-with-os"
+				bom.Version = 1
+
+				// Add OS component
+				bom.AddComponent(wolfiOSComponent)
+
+				// Add APK package
+				bom.AddComponent(busyboxComponent)
+
+				// Create relationship between OS and package
+				bom.AddRelationship(wolfiOSComponent, busyboxComponent, core.RelationshipContains)
+				return bom
+			},
+			wantSBOM: types.SBOM{
+				Metadata: types.Metadata{
+					OS: &ftypes.OS{
+						Family: ftypes.Wolfi,
+						Name:   "20230201",
+					},
+				},
+				Packages: []ftypes.PackageInfo{
+					{
+						Packages: ftypes.Packages{
+							{
+								ID:         "busybox@1.37.0-r42",
+								Name:       "busybox",
+								Version:    "1.37.0-r42",
+								Arch:       "aarch64",
+								SrcName:    "busybox",
+								SrcVersion: "1.37.0-r42",
+								Licenses:   []string{"GPL-2.0-only"},
+								Identifier: ftypes.PkgIdentifier{
+									PURL: busyboxComponent.PkgIdentifier.PURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple OS packages without OS metadata should be included",
+			setupBOM: func() *core.BOM {
+				bom := core.NewBOM(core.Options{})
+				bom.SerialNumber = "test-multiple-no-os"
+				bom.Version = 1
+
+				// Add multiple APK packages
+				bom.AddComponent(apkToolsComponent)
+				bom.AddComponent(busyboxComponent)
+				bom.AddComponent(caCertificatesComponent)
+
+				return bom
+			},
+			wantSBOM: types.SBOM{
+				Metadata: types.Metadata{
+					OS: nil, // No OS detected
+				},
+				Packages: []ftypes.PackageInfo{
+					{
+						Packages: ftypes.Packages{
+							{
+								ID:         "apk-tools@2.14.10-r4",
+								Name:       "apk-tools",
+								Version:    "2.14.10-r4",
+								Arch:       "aarch64",
+								SrcName:    "apk-tools",
+								SrcVersion: "2.14.10-r4",
+								Licenses:   []string{"GPL-2.0-only"},
+								Identifier: ftypes.PkgIdentifier{
+									PURL: apkToolsComponent.PkgIdentifier.PURL,
+								},
+							},
+							{
+								ID:         "busybox@1.37.0-r42",
+								Name:       "busybox",
+								Version:    "1.37.0-r42",
+								Arch:       "aarch64",
+								SrcName:    "busybox",
+								SrcVersion: "1.37.0-r42",
+								Licenses:   []string{"GPL-2.0-only"},
+								Identifier: ftypes.PkgIdentifier{
+									PURL: busyboxComponent.PkgIdentifier.PURL,
+								},
+							},
+							{
+								ID:         "ca-certificates-bundle@20241121-r42",
+								Name:       "ca-certificates-bundle",
+								Version:    "20241121-r42",
+								Arch:       "aarch64",
+								SrcName:    "ca-certificates-bundle",
+								SrcVersion: "20241121-r42",
+								Licenses:   []string{"MPL-2.0"},
+								Identifier: ftypes.PkgIdentifier{
+									PURL: caCertificatesComponent.PkgIdentifier.PURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple OS package types should return error",
+			setupBOM: func() *core.BOM {
+				bom := core.NewBOM(core.Options{})
+				bom.SerialNumber = "test-multiple-os-types"
+				bom.Version = 1
+
+				// Add APK package
+				bom.AddComponent(apkToolsComponent)
+
+				// Add RPM package
+				bom.AddComponent(rpmTestComponent)
+
+				return bom
+			},
+			wantErr: "multiple types of OS packages in SBOM are not supported",
+		},
+		{
+			name: "empty BOM should have no packages",
+			setupBOM: func() *core.BOM {
+				bom := core.NewBOM(core.Options{})
+				bom.SerialNumber = "test-empty"
+				bom.Version = 1
+				return bom
+			},
+			wantSBOM: types.SBOM{
+				Metadata: types.Metadata{
+					OS: nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bom := tt.setupBOM()
+			decoder := sbomio.NewDecoder(bom)
+			var gotSBOM types.SBOM
+
+			err := decoder.Decode(context.Background(), &gotSBOM)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			// Set BOM for comparison (it's set by the decoder)
+			tt.wantSBOM.BOM = gotSBOM.BOM
+
+			// Compare the entire SBOM structure
+			assert.Equal(t, tt.wantSBOM, gotSBOM)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Remove the OS detection check that prevented OS packages from being processed when OS metadata is not available in SBOMs. This eliminates excessive warning messages when scanning container images with embedded SBOMs and improves the usability of the `trivy sbom` subcommand.

## Background

The OS detection check was originally added as validation for the `trivy sbom` subcommand to ensure vulnerability scanning accuracy when OS information was missing from SBOM files. However, with the introduction of the `--distro` option, users can now specify the OS distribution manually, making this strict validation unnecessary.

Additionally, this check causes excessive warning messages when scanning container images that contain embedded SBOM files, even though the OS information is correctly detected from other sources like `/etc/os-release`.

## Changes

- Remove OS detection check in `pkg/sbom/io/decode.go:392` that was blocking OS packages without OS metadata
- Remove unused `context.Context` parameter from `addOrphanPkgs` function  
- Add comprehensive tests to verify OS packages are processed regardless of OS metadata availability

## Before/After Examples

### Container Image Scanning (wolfi-base)

**Before:**
```bash
$ trivy image cgr.dev/chainguard/wolfi-base --cache-backend memory
2025-06-12T13:29:57+04:00	WARN	[sbom] Ignore the OS package as no OS is detected.	file_path="var/lib/db/sbom/apk-tools-2.14.10-r4.spdx.json"
2025-06-12T13:29:57+04:00	WARN	[sbom] Ignore the OS package as no OS is detected.	file_path="var/lib/db/sbom/ca-certificates-bundle-20241121-r42.spdx.json"
2025-06-12T13:29:57+04:00	WARN	[sbom] Ignore the OS package as no OS is detected.	file_path="var/lib/db/sbom/busybox-1.37.0-r42.spdx.json"
...15 warning messages total...
2025-06-12T13:29:57+04:00	INFO	Detected OS	family="wolfi" version="20230201"
2025-06-12T13:29:57+04:00	INFO	[wolfi] Detecting vulnerabilities...	pkg_num=15
```

**After:**
```bash
$ trivy image cgr.dev/chainguard/wolfi-base --cache-backend memory
2025-06-12T13:30:50+04:00	INFO	Detected OS	family="wolfi" version="20230201"
2025-06-12T13:30:50+04:00	INFO	[wolfi] Detecting vulnerabilities...	pkg_num=15
```

- **Result**: 15 warning messages eliminated while maintaining identical package detection
- **Impact**: Clean output with no functionality loss since OS is correctly detected from `/etc/os-release`

### SBOM File Scanning (`trivy sbom` subcommand)

**Before:**
```bash
$ trivy sbom apk-tools.spdx.json --cache-backend memory
2025-06-12T13:41:39+04:00	WARN	[sbom] Ignore the OS package as no OS is detected.	file_path="apk-tools.spdx.json"
2025-06-12T13:41:39+04:00	INFO	Detected OS	family="none" version=""
# No OS packages processed for vulnerability scanning
```

**After:**
```bash
$ trivy sbom apk-tools.spdx.json --cache-backend memory  
2025-06-12T13:42:20+04:00	INFO	Detected OS	family="none" version=""
# OS packages now included in scan results

# With --distro option for vulnerability scanning:
$ trivy sbom apk-tools.spdx.json --distro wolfi-20230201
2025-06-12T13:42:30+04:00	INFO	[wolfi] Detecting vulnerabilities...	pkg_num=1
```

- **Result**: OS packages are now processed even without OS metadata in SBOM files
- **Impact**: Users can leverage `--distro` option for vulnerability scanning of SBOMs without OS information

## Benefits

1. **Eliminates noise**: Removes 15+ warning messages when scanning container images with embedded SBOMs
2. **Improves `trivy sbom` usability**: OS packages in SBOM files are now processed regardless of OS metadata availability
3. **Maintains accuracy**: Package detection from traditional sources (`/var/lib/apk/db/installed`, `/etc/os-release`) remains unaffected  
4. **Enables flexible vulnerability scanning**: Users can specify `--distro` for vulnerability scanning when OS information is missing from SBOM files