### PR TITLE
chore(deps): update Docker to v28.2.2 and fix compatibility issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -357,7 +357,7 @@ require (
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/shirou/gopsutil/v4 v4.25.1 // indirect
+	github.com/shirou/gopsutil/v4 v4.25.4 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sigstore/cosign/v2 v2.2.4 // indirect
 	github.com/sigstore/protobuf-specs v0.4.1 // indirect
@@ -450,3 +450,5 @@ tool (
 	golang.org/x/tools/cmd/goyacc
 	sigs.k8s.io/kind
 )
+
+replace github.com/testcontainers/testcontainers-go => ../../testcontainers/testcontainers-go

--- a/go.mod
+++ b/go.mod
@@ -450,5 +450,3 @@ tool (
 	golang.org/x/tools/cmd/goyacc
 	sigs.k8s.io/kind
 )
-
-replace github.com/testcontainers/testcontainers-go => ../../testcontainers/testcontainers-go

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aquasecurity/go-version v0.0.1
 	github.com/aquasecurity/iamgo v0.0.10
 	github.com/aquasecurity/table v1.10.0
-	github.com/aquasecurity/testdocker v0.0.0-20240730042311-4642e94c7fc8
+	github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17
 	github.com/aquasecurity/tml v0.6.1
 	github.com/aquasecurity/trivy-checks v1.11.3-0.20250604022615-9a7efa7c9169
 	github.com/aquasecurity/trivy-db v0.0.0-20250529093513-a12dfc204b6e
@@ -41,8 +41,8 @@ require (
 	github.com/containerd/containerd/v2 v2.1.1
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v28.1.1+incompatible
-	github.com/docker/docker v28.1.1+incompatible
+	github.com/docker/cli v28.2.2+incompatible
+	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,8 @@ require (
 	modernc.org/sqlite v1.37.0
 )
 
+require github.com/moby/docker-image-spec v1.3.1
+
 require (
 	cel.dev/expr v0.20.0 // indirect
 	cloud.google.com/go v0.118.3 // indirect
@@ -307,7 +309,6 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/buildkit v0.21.1
+	github.com/moby/docker-image-spec v1.3.1
 	github.com/open-policy-agent/opa v1.4.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -130,8 +131,6 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	modernc.org/sqlite v1.37.0
 )
-
-require github.com/moby/docker-image-spec v1.3.1
 
 require (
 	cel.dev/expr v0.20.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.37.0
+	github.com/testcontainers/testcontainers-go v0.37.1-0.20250602105123-1720acdcb24e
 	github.com/testcontainers/testcontainers-go/modules/localstack v0.37.0
 	github.com/tetratelabs/wazero v1.9.0
 	github.com/twitchtv/twirp v8.1.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1796,8 +1796,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
-github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
-github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
+github.com/shirou/gopsutil/v4 v4.25.4 h1:cdtFO363VEOOFrUCjZRh4XVJkb548lyF0q0uTeMqYPw=
+github.com/shirou/gopsutil/v4 v4.25.4/go.mod h1:xbuxyoZj+UsgnZrENu3lQivsngRR5BdjbJwf2fv4szA=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
@@ -1887,8 +1887,6 @@ github.com/tchap/go-patricia/v2 v2.3.2 h1:xTHFutuitO2zqKAQ5rCROYgUb7Or/+IC3fts9/
 github.com/tchap/go-patricia/v2 v2.3.2/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=
 github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
-github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
-github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0 h1:lqwknybf56hBLi2YsKs01VLSUK8qXnIcG1FM/6/L5qI=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0/go.mod h1:RIsXAxAUiaDNfsGsYcZB1TyDn2mqy52lO0HrGFts8cs=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.37.0 h1:nPuxUYseqS0eYJg7KDJd95PhoMhdpTnSNtkDLwWFngo=

--- a/go.sum
+++ b/go.sum
@@ -1887,8 +1887,8 @@ github.com/tchap/go-patricia/v2 v2.3.2 h1:xTHFutuitO2zqKAQ5rCROYgUb7Or/+IC3fts9/
 github.com/tchap/go-patricia/v2 v2.3.2/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=
 github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
-github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
-github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
+github.com/testcontainers/testcontainers-go v0.37.1-0.20250602105123-1720acdcb24e h1:3BJRUBZwFIvJAtXuoTnCKHRlZE5ici2xhxKWJ9IMtvY=
+github.com/testcontainers/testcontainers-go v0.37.1-0.20250602105123-1720acdcb24e/go.mod h1:dXagtaeZPsX4KI9nkj2NyC+S2/t6QxQgzk2Y1/IuROc=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0 h1:lqwknybf56hBLi2YsKs01VLSUK8qXnIcG1FM/6/L5qI=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0/go.mod h1:RIsXAxAUiaDNfsGsYcZB1TyDn2mqy52lO0HrGFts8cs=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.37.0 h1:nPuxUYseqS0eYJg7KDJd95PhoMhdpTnSNtkDLwWFngo=

--- a/go.sum
+++ b/go.sum
@@ -796,8 +796,8 @@ github.com/aquasecurity/jfather v0.0.8 h1:tUjPoLGdlkJU0qE7dSzd1MHk2nQFNPR0ZfF+6s
 github.com/aquasecurity/jfather v0.0.8/go.mod h1:Ag+L/KuR/f8vn8okUi8Wc1d7u8yOpi2QTaGX10h71oY=
 github.com/aquasecurity/table v1.10.0 h1:gPWV28qp9XSlvXdT3ku8yKQoZE6II0vsmegKpW+dB08=
 github.com/aquasecurity/table v1.10.0/go.mod h1:eqOmvjjB7AhXFgFqpJUEE/ietg7RrMSJZXyTN8E/wZw=
-github.com/aquasecurity/testdocker v0.0.0-20240730042311-4642e94c7fc8 h1:b43UVqYjz7qDqK+cVOtF2Lk6CxjytYItP6Pgf3wGsNE=
-github.com/aquasecurity/testdocker v0.0.0-20240730042311-4642e94c7fc8/go.mod h1:wXA9k3uuaxY3yu7gxrxZDPo/04FEMJtwyecdAlYrEIo=
+github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17 h1:/xWTD1YaNdjvFdClrz5t3GutwVcyJPsMkYzHWlbE3ys=
+github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17/go.mod h1:6kYuX29QyBWHJejvbKkA4yzz8EUX/Fn+GmQ09JAZ5lY=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
 github.com/aquasecurity/trivy-checks v1.11.3-0.20250604022615-9a7efa7c9169 h1:TckzIxUX7lZaU9f2lNxCN0noYYP8fzmSQf6a4JdV83w=
@@ -1011,12 +1011,12 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/docker/cli v28.1.1+incompatible h1:eyUemzeI45DY7eDPuwUcmDyDj1pM98oD5MdSpiItp8k=
-github.com/docker/cli v28.1.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsyN9SdInc1A=
+github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.1.1+incompatible h1:49M11BFLsVO1gxY9UX9p/zwkE/rswggs8AdFmXQw51I=
-github.com/docker/docker v28.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=
+github.com/docker/docker v28.2.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/go.sum
+++ b/go.sum
@@ -1887,6 +1887,8 @@ github.com/tchap/go-patricia/v2 v2.3.2 h1:xTHFutuitO2zqKAQ5rCROYgUb7Or/+IC3fts9/
 github.com/tchap/go-patricia/v2 v2.3.2/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=
 github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
+github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
+github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0 h1:lqwknybf56hBLi2YsKs01VLSUK8qXnIcG1FM/6/L5qI=
 github.com/testcontainers/testcontainers-go/modules/k3s v0.37.0/go.mod h1:RIsXAxAUiaDNfsGsYcZB1TyDn2mqy52lO0HrGFts8cs=
 github.com/testcontainers/testcontainers-go/modules/localstack v0.37.0 h1:nPuxUYseqS0eYJg7KDJd95PhoMhdpTnSNtkDLwWFngo=

--- a/integration/docker_engine_test.go
+++ b/integration/docker_engine_test.go
@@ -278,7 +278,10 @@ func TestDockerEngine(t *testing.T) {
 			}
 
 			if tt.maxImageSize != "" {
-				osArgs = append(osArgs, []string{"--max-image-size", tt.maxImageSize}...)
+				osArgs = append(osArgs, []string{
+					"--max-image-size",
+					tt.maxImageSize,
+				}...)
 			}
 
 			osArgs = append(osArgs, tt.input)
@@ -286,12 +289,8 @@ func TestDockerEngine(t *testing.T) {
 			// Run Trivy
 			runTest(t, osArgs, tt.golden, "", types.FormatJSON, runOptions{
 				wantErr: tt.wantErr,
-				// Container field was removed in Docker Engine v26.0
-				// cf. https://github.com/docker/cli/blob/v26.1.3/docs/deprecated.md#container-and-containerconfig-fields-in-image-inspect
-				override: overrideFuncs(overrideUID, func(t *testing.T, want, got *types.Report) {
-					got.Metadata.ImageConfig.Container = ""
-					want.Metadata.ImageConfig.Container = ""
-				}),
+				// Image config fields were removed
+				override: overrideFuncs(overrideUID, overrideDockerRemovedFields),
 			})
 		})
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -375,3 +375,19 @@ func overrideUID(t *testing.T, want, got *types.Report) {
 		}
 	}
 }
+
+// overrideDockerRemovedFields clears image config fields that were removed from Docker API
+// cf. https://github.com/moby/moby/blob/d0ad1357a141c795e1e0490e3fed00ddabcb91b9/docs/api/version-history.md
+func overrideDockerRemovedFields(t *testing.T, want, got *types.Report) {
+	// Clear Container field (removed in Docker API v1.45)
+	got.Metadata.ImageConfig.Container = ""
+	want.Metadata.ImageConfig.Container = ""
+
+	// Clear Image field (removed in Docker API v1.50)
+	got.Metadata.ImageConfig.Config.Image = ""
+	want.Metadata.ImageConfig.Config.Image = ""
+
+	// Clear Hostname field (removed in Docker API v1.50)
+	got.Metadata.ImageConfig.Config.Hostname = ""
+	want.Metadata.ImageConfig.Config.Hostname = ""
+}

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -22,6 +22,7 @@ import (
 	dockerClient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/samber/lo"
@@ -266,6 +267,9 @@ func inspect(ctx context.Context, img client.Image, ref reference.Reference) (do
 		Comment:     lastHistory.Comment,
 		Created:     created,
 		Author:      lastHistory.Author,
+		Config: &dockerspec.DockerOCIImageConfig{
+			ImageConfig: imgConfig.Config,
+		},
 		ContainerConfig: &container.Config{
 			User:         imgConfig.Config.User,
 			ExposedPorts: portSet,

--- a/pkg/fanal/image/daemon/containerd.go
+++ b/pkg/fanal/image/daemon/containerd.go
@@ -16,8 +16,9 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
-	api "github.com/docker/docker/api/types"
+	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	dockerimage "github.com/docker/docker/api/types/image"
 	dockerClient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -212,7 +213,7 @@ func readImageConfig(ctx context.Context, img client.Image) (ocispec.Image, ocis
 }
 
 // ported from https://github.com/containerd/nerdctl/blob/d110fea18018f13c3f798fa6565e482f3ff03591/pkg/inspecttypes/dockercompat/dockercompat.go#L279-L321
-func inspect(ctx context.Context, img client.Image, ref reference.Reference) (api.ImageInspect, []v1.History, reference.Reference, error) {
+func inspect(ctx context.Context, img client.Image, ref reference.Reference) (dockerimage.InspectResponse, []v1.History, reference.Reference, error) {
 	if _, ok := ref.(reference.Digested); ok {
 		ref = familiarNamed(img.Name())
 	}
@@ -229,7 +230,7 @@ func inspect(ctx context.Context, img client.Image, ref reference.Reference) (ap
 
 	imgConfig, imgConfigDesc, err := readImageConfig(ctx, img)
 	if err != nil {
-		return api.ImageInspect{}, nil, nil, err
+		return dockerimage.InspectResponse{}, nil, nil, err
 	}
 
 	var lastHistory ocispec.History
@@ -258,14 +259,14 @@ func inspect(ctx context.Context, img client.Image, ref reference.Reference) (ap
 		created = lastHistory.Created.Format(time.RFC3339Nano)
 	}
 
-	return api.ImageInspect{
+	return dockerimage.InspectResponse{
 		ID:          imgConfigDesc.Digest.String(),
 		RepoTags:    []string{fmt.Sprintf("%s:%s", repository, tag)},
 		RepoDigests: []string{fmt.Sprintf("%s@%s", repository, img.Target().Digest)},
 		Comment:     lastHistory.Comment,
 		Created:     created,
 		Author:      lastHistory.Author,
-		Config: &container.Config{
+		ContainerConfig: &container.Config{
 			User:         imgConfig.Config.User,
 			ExposedPorts: portSet,
 			Env:          imgConfig.Config.Env,
@@ -277,7 +278,7 @@ func inspect(ctx context.Context, img client.Image, ref reference.Reference) (ap
 		},
 		Architecture: imgConfig.Architecture,
 		Os:           imgConfig.OS,
-		RootFS: api.RootFS{
+		RootFS: dockertypes.RootFS{
 			Type: imgConfig.RootFS.Type,
 			Layers: lo.Map(imgConfig.RootFS.DiffIDs, func(d digest.Digest, _ int) string {
 				return d.String()

--- a/pkg/fanal/image/daemon/docker.go
+++ b/pkg/fanal/image/daemon/docker.go
@@ -37,10 +37,10 @@ func DockerImage(ref name.Reference, host string) (Image, func(), error) {
 	// or
 	// <image_name>@<digest> pattern like "alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
 	imageID := ref.Name()
-	inspect, _, err := c.ImageInspectWithRaw(context.Background(), imageID)
+	inspect, err := c.ImageInspect(context.Background(), imageID)
 	if err != nil {
 		imageID = ref.String() // <image_id> pattern like `5ac716b05a9c`
-		inspect, _, err = c.ImageInspectWithRaw(context.Background(), imageID)
+		inspect, err = c.ImageInspect(context.Background(), imageID)
 		if err != nil {
 			return nil, cleanup, xerrors.Errorf("unable to inspect the image (%s): %w", imageID, err)
 		}

--- a/pkg/fanal/image/daemon/docker_test.go
+++ b/pkg/fanal/image/daemon/docker_test.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
@@ -12,9 +11,8 @@ import (
 
 func TestDockerImage(t *testing.T) {
 	type fields struct {
-		Image   v1.Image
-		opener  opener
-		inspect types.ImageInspect
+		Image  v1.Image
+		opener opener
 	}
 	tests := []struct {
 		name      string

--- a/pkg/fanal/image/daemon/image.go
+++ b/pkg/fanal/image/daemon/image.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	dockerimage "github.com/docker/docker/api/types/image"
+	dimage "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -61,7 +61,7 @@ func imageOpener(ctx context.Context, ref string, f *os.File, imageSave imageSav
 type image struct {
 	v1.Image
 	opener  opener
-	inspect dockerimage.InspectResponse
+	inspect dimage.InspectResponse
 	history []v1.History
 }
 
@@ -227,7 +227,7 @@ func (img *image) imageConfig(config dockerspec.DockerOCIImageConfig) v1.Config 
 	return c
 }
 
-func configHistory(dhistory []dockerimage.HistoryResponseItem) []v1.History {
+func configHistory(dhistory []dimage.HistoryResponseItem) []v1.History {
 	// Fill only required metadata
 	var history []v1.History
 
@@ -247,7 +247,7 @@ func configHistory(dhistory []dockerimage.HistoryResponseItem) []v1.History {
 
 // emptyLayer tries to determine if the layer is empty from the history API, but may return a wrong result.
 // The non-empty layers will be compared to diffIDs later so that results can be validated.
-func emptyLayer(history dockerimage.HistoryResponseItem) bool {
+func emptyLayer(history dimage.HistoryResponseItem) bool {
 	if history.Size != 0 {
 		return false
 	}

--- a/pkg/fanal/image/daemon/image_test.go
+++ b/pkg/fanal/image/daemon/image_test.go
@@ -190,7 +190,6 @@ func Test_image_ConfigFile(t *testing.T) {
 				},
 				Config: v1.Config{
 					Cmd:         []string{"/bin/sh"},
-					Image:       "sha256:74df73bb19fbfc7fb5ab9a8234b3d98ee2fb92df5b824496679802685205ab8c",
 					Env:         []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 					ArgsEscaped: true,
 				},

--- a/pkg/fanal/image/daemon/podman_test.go
+++ b/pkg/fanal/image/daemon/podman_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	dockerimage "github.com/docker/docker/api/types/image"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +48,7 @@ func TestPodmanImage(t *testing.T) {
 	type fields struct {
 		Image   v1.Image
 		opener  opener
-		inspect types.ImageInspect
+		inspect dockerimage.InspectResponse
 	}
 	tests := []struct {
 		name           string

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -101,7 +101,6 @@ func TestNewDockerImage(t *testing.T) {
 				Config: v1.Config{
 					Cmd:         []string{"/bin/sh"},
 					Env:         []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
-					Image:       "sha256:74df73bb19fbfc7fb5ab9a8234b3d98ee2fb92df5b824496679802685205ab8c",
 					ArgsEscaped: true,
 				},
 				OSVersion: "",
@@ -144,7 +143,6 @@ func TestNewDockerImage(t *testing.T) {
 				Config: v1.Config{
 					Cmd:         []string{"/bin/sh"},
 					Env:         []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
-					Image:       "sha256:74df73bb19fbfc7fb5ab9a8234b3d98ee2fb92df5b824496679802685205ab8c",
 					ArgsEscaped: true,
 				},
 				OSVersion: "",

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -332,6 +332,7 @@ func localImageTestWithNamespace(t *testing.T, namespace string) {
 						Env: []string{
 							"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 						},
+						ArgsEscaped: true,
 					},
 					History: []v1.History{
 						{
@@ -492,6 +493,7 @@ func localImageTestWithNamespace(t *testing.T, namespace string) {
 							"/bin/sh",
 							"/docker-entrypoint.sh",
 						},
+						ArgsEscaped: true,
 					},
 					History: []v1.History{
 						{
@@ -782,7 +784,7 @@ func TestContainerd_PullImage(t *testing.T) {
 						Env: []string{
 							"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 						},
-						ArgsEscaped: false,
+						ArgsEscaped: true,
 					},
 					History: []v1.History{
 						{


### PR DESCRIPTION
## Summary
This PR updates Docker dependencies from v28.1.1 to v28.2.2 and addresses API compatibility issues that emerged with recent Docker versions, including fixing container cleanup errors in integration tests.

## Changes

### 1. Docker API Updates
- Replace deprecated `ImageInspectWithRaw` with `ImageInspect` API
- Update Docker dependencies to v28.2.2
- Update testdocker to v0.0.0-20250616060700-ba6845ac6d17 for Docker v28.2.2 compatibility (see aquasecurity/testdocker#26)
- Remove usage of removed container configuration fields

### 2. Fix ArgsEscaped field expectations in containerd tests
- **Files**: `pkg/fanal/test/integration/containerd_test.go`
- **Issue**: Docker v28 API changes affected how the `ArgsEscaped` field is populated in image config
- **Solution**: Updated test expectations to expect `ArgsEscaped: true` instead of `false`

### 3. Update testcontainers-go to fix container cleanup error
- **Files**: `go.mod`, `go.sum`
- **Issue**: Docker API changes in [moby/moby#50030](https://github.com/moby/moby/pull/50030) affected how `errdefs.ErrConflict` errors are handled
- **Solution**: Updated testcontainers-go to commit `1720acdcb24ef79dd34188da22da05e6cf72773c` which includes the fix from [testcontainers/testcontainers-go#3194](https://github.com/testcontainers/testcontainers-go/pull/3194)

## API Changes Addressed
Recent Docker versions have deprecated `ImageInspectWithRaw` in favor of `ImageInspect`. Additionally, certain fields in the image inspection response have been removed or moved to align with OCI specifications:
- Deprecated fields like `Hostname`, `Domainname`, `AttachStdin`, `AttachStdout`, `AttachStderr`, `Tty`, `OpenStdin`, `StdinOnce`, `Image`, `NetworkDisabled`, `MacAddress`

## Test Results

### Before fixes:
```
--- FAIL: TestContainerd_LocalImage (7.31s)
    --- FAIL: TestContainerd_LocalImage/alpine_3.10 (0.94s)
    --- FAIL: TestContainerd_LocalImage/vulnimage (4.97s)
```

```
=== NAME  TestClientServerWithRedis
    Error: terminate: Error response from daemon: removal of container X is already in progress
```

### After fixes:
```
--- PASS: TestContainerd_LocalImage (12.26s)
    --- PASS: TestContainerd_LocalImage/alpine_3.10 (2.36s)
    --- PASS: TestContainerd_LocalImage/vulnimage (5.71s)
--- PASS: TestContainerd_LocalImage_Alternative_Namespace (9.44s)
    --- PASS: TestContainerd_LocalImage_Alternative_Namespace/alpine_3.10 (1.35s)
    --- PASS: TestContainerd_LocalImage_Alternative_Namespace/vulnimage (5.63s)
```

```
--- PASS: TestClientServerWithRedis (5.01s)
    --- PASS: TestClientServerWithRedis/alpine_3.9 (0.33s)
    --- PASS: TestClientServerWithRedis/sad_path (0.58s)
```