### PR TITLE
fix: resolve Maven parent properties in POM parsing

### DIFF
--- a/pkg/dependency/parser/java/pom/pom.go
+++ b/pkg/dependency/parser/java/pom/pom.go
@@ -61,6 +61,13 @@ func (p *pom) projectProperties() map[string]string {
 	props["groupId"] = p.content.GroupId
 	props["version"] = p.content.Version
 
+	// NOTE: Add parent properties to support Maven property resolution for ${parent.version},
+	// ${project.parent.version}, ${parent.groupId}, and ${project.parent.groupId} expressions.
+	// These are commonly used in multi-module Maven projects where child modules reference
+	// parent POM properties for dependency management and version consistency.
+	props["parent.version"] = p.content.Parent.Version
+	props["parent.groupId"] = p.content.Parent.GroupId
+
 	// https://maven.apache.org/pom.html#properties
 	projectProperties := make(map[string]string)
 	for k, v := range props {


### PR DESCRIPTION
## Description

Add support for ${parent.version} and ${parent.groupId} property resolution in multi-module Maven projects. This fixes dependency analysis failures for child modules that reference parent POM properties.

## Related discussion

- Closes https://github.com/aquasecurity/trivy/discussions/9039

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
