### PR TITLE
fix(misconf): .Config.User always takes precedence over USER in .History

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -117,6 +117,7 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 		dockerfile.WriteString(strings.TrimSpace(createdBy) + "\n")
 	}
 
+	// The user can be changed from the config file or with the `--user` flag (for docker CLI), so we need to add this user to avoid incorrect user detection
 	if cfg.Config.User != "" {
 		user := fmt.Sprintf("USER %s", cfg.Config.User)
 		dockerfile.WriteString(user)

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -76,7 +76,6 @@ func (a *historyAnalyzer) Analyze(ctx context.Context, input analyzer.ConfigAnal
 
 func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 	dockerfile := new(bytes.Buffer)
-	var userFound bool
 	baseLayerIndex := image.GuessBaseImageIndex(cfg.History)
 	for i := baseLayerIndex + 1; i < len(cfg.History); i++ {
 		h := cfg.History[i]
@@ -101,7 +100,6 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 		case strings.HasPrefix(h.CreatedBy, "USER"):
 			// USER instruction
 			createdBy = h.CreatedBy
-			userFound = true
 		case strings.HasPrefix(h.CreatedBy, "HEALTHCHECK"):
 			// HEALTHCHECK instruction
 			createdBy = buildHealthcheckInstruction(cfg.Config.Healthcheck)
@@ -119,7 +117,7 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 		dockerfile.WriteString(strings.TrimSpace(createdBy) + "\n")
 	}
 
-	if !userFound && cfg.Config.User != "" {
+	if cfg.Config.User != "" {
 		user := fmt.Sprintf("USER %s", cfg.Config.User)
 		dockerfile.WriteString(user)
 	}

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -168,6 +168,10 @@ func Test_historyAnalyzer_Analyze(t *testing.T) {
 							EmptyLayer: false,
 						},
 						{
+							CreatedBy:  "USER root", // .Config.User takes precedence over this line
+							EmptyLayer: true,
+						},
+						{
 							CreatedBy:  `HEALTHCHECK &{["CMD-SHELL" "curl -sS 127.0.0.1 || exit 1"] "10s" "3s" "0s" '\x00'}`,
 							EmptyLayer: true,
 						},


### PR DESCRIPTION
## Description
In #6070 a change was made inject a "fake" `USER <name>` line when reconstructing the `Dockerfile` from an OCI/Docker image manifest/config. 

However, it only used this value when a `USER <name>` directive was _not_ found in the history. This is incorrect, in practice the `Config.User` value always takes precedence/is used by a container runtime. This PR ensures that if a value is configured, it is always appended to the reconstructed history.

We ran into this because we had an odd image which contained `USER root` in the Dockerfile history but was actually configured to run as `nonroot` in the final rendered image config (not built via Buildkit). 

## Related issues
I didn't create an issue for this, just the fix PR.

## Related PRs
- #6070 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
