### PR TITLE
feat: reject unsupported artifact types in remote image retrieval

### DIFF
--- a/pkg/fanal/image/remote_test.go
+++ b/pkg/fanal/image/remote_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"context"
 	"io"
 	"log"
 	"net/http/httptest"
@@ -149,7 +148,7 @@ func Test_tryRemote(t *testing.T) {
 			name:       "image not found",
 			imageName:  "test/notfound:latest",
 			wantErr:    "NAME_UNKNOWN",
-			setupImage: func(t *testing.T, ref name.Reference) {},
+			setupImage: func(*testing.T, name.Reference) {},
 		},
 	}
 
@@ -163,7 +162,7 @@ func Test_tryRemote(t *testing.T) {
 			// Set up the image in registry if needed
 			tt.setupImage(t, ref)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			got, cleanup, err := tryRemote(ctx, fullImageName, ref, types.ImageOptions{
 				RegistryOptions: types.RegistryOptions{
 					Insecure: true,

--- a/pkg/fanal/image/remote_test.go
+++ b/pkg/fanal/image/remote_test.go
@@ -1,11 +1,22 @@
 package image
 
 import (
+	"context"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
 func Test_implicitReference_TagName(t *testing.T) {
@@ -79,6 +90,103 @@ func Test_implicitReference_RepositoryName(t *testing.T) {
 
 			got := ref.RepositoryName()
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_tryRemote(t *testing.T) {
+	// Create a test image
+	img, err := random.Image(1024, 5)
+	require.NoError(t, err)
+
+	// Get the image digest for test expectations
+	digest, err := img.Digest()
+	require.NoError(t, err)
+
+	// Set up registry server with null logger to suppress log output
+	nullLogger := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(nullLogger)))
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		imageName  string
+		setupImage func(t *testing.T, ref name.Reference)
+		wantName   string
+		wantErr    string
+	}{
+		{
+			name:      "successful image retrieval",
+			imageName: "test/alpine:3.10",
+			setupImage: func(t *testing.T, ref name.Reference) {
+				err := remote.Write(ref, img)
+				require.NoError(t, err)
+			},
+			wantName: "/test/alpine:3.10",
+		},
+		{
+			name:      "helm chart config media type",
+			imageName: "test/helm:chart",
+			setupImage: func(t *testing.T, ref name.Reference) {
+				configFile, err := img.ConfigFile()
+				require.NoError(t, err)
+
+				// Create a new config with helm chart media type
+				imageToWrite, err := mutate.Config(img, configFile.Config)
+				require.NoError(t, err)
+
+				imageToWrite = mutate.ConfigMediaType(imageToWrite, "application/vnd.cncf.helm.chart")
+
+				err = remote.Write(ref, imageToWrite)
+				require.NoError(t, err)
+			},
+			wantErr: "unsupported artifact type",
+		},
+		{
+			name:       "image not found",
+			imageName:  "test/notfound:latest",
+			wantErr:    "NAME_UNKNOWN",
+			setupImage: func(t *testing.T, ref name.Reference) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Parse the image name with the test server address
+			fullImageName := u.Host + "/" + tt.imageName
+			ref, err := name.ParseReference(fullImageName)
+			require.NoError(t, err)
+
+			// Set up the image in registry if needed
+			tt.setupImage(t, ref)
+
+			ctx := context.Background()
+			got, cleanup, err := tryRemote(ctx, fullImageName, ref, types.ImageOptions{
+				RegistryOptions: types.RegistryOptions{
+					Insecure: true,
+				},
+			})
+			t.Cleanup(cleanup)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Contains(t, got.Name(), tt.wantName)
+
+			// Verify RepoTags and RepoDigests contain expected values
+			repoTags := got.RepoTags()
+			repoDigests := got.RepoDigests()
+			assert.Len(t, repoTags, 1)
+			assert.Contains(t, repoTags[0], tt.imageName)
+			assert.Len(t, repoDigests, 1)
+			assert.Contains(t, repoDigests[0], digest.String())
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Add validation to reject OCI artifacts that are not regular container images during remote image retrieval.

## Issues
- Close https://github.com/aquasecurity/trivy/issues/9053

## Changes
- Add artifact type validation in `tryRemote` function
- Return error when `ArtifactType` is not empty (indicating non-container artifacts like Helm charts, WASM modules)
- Add comprehensive tests for the `tryRemote` function including:
  - Successful image retrieval
  - Image not found scenarios  
  - Unsupported artifact type validation

## Test Results
Manual testing confirms the validation works correctly:

```bash
$ ./trivy image --scanners vuln --image-src remote ghcr.io/knqyf263/helm-test-chart:0.1.0
2025-06-19T12:40:53+04:00    INFO    [vuln] Vulnerability scanning is enabled

To suppress version checks, run Trivy scans with the --skip-version-check flag

2025-06-19T12:40:54+04:00    FATAL    Fatal error    run error: image scan error: scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to find the specified image "ghcr.io/knqyf263/helm-test-chart:0.1.0" in ["remote"]: 1 error occurred:
    * remote error: unsupported artifact type "application/vnd.cncf.helm.config.v1+json" for image "ghcr.io/knqyf263/helm-test-chart:0.1.0"
```

The error message correctly identifies the Helm chart as an unsupported artifact type.