### PR TITLE
fix(sbom): use correct field for licenses in CycloneDX reports

### DIFF
--- a/integration/testdata/conda-cyclonedx.json.golden
+++ b/integration/testdata/conda-cyclonedx.json.golden
@@ -43,7 +43,7 @@
       "licenses": [
         {
           "license": {
-            "name": "OpenSSL"
+            "id": "OpenSSL"
           }
         }
       ],
@@ -73,7 +73,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],

--- a/integration/testdata/fluentd-multiple-lockfiles-short.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles-short.cdx.json.golden
@@ -147,7 +147,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],

--- a/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
@@ -715,7 +715,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-or-later"
+            "id": "GFDL-1.3-or-later"
           }
         }
       ],
@@ -1003,7 +1003,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-only"
+            "id": "GFDL-1.3-only"
           }
         }
       ],
@@ -1060,7 +1060,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.2-only"
+            "id": "GFDL-1.2-only"
           }
         },
         {
@@ -2481,7 +2481,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-no-invariants-or-later"
+            "id": "GFDL-1.3-no-invariants-or-later"
           }
         },
         {
@@ -2548,7 +2548,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-no-invariants-or-later"
+            "id": "GFDL-1.3-no-invariants-or-later"
           }
         },
         {
@@ -2696,7 +2696,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-only"
+            "id": "GFDL-1.3-only"
           }
         },
         {
@@ -3791,7 +3791,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-or-later"
+            "id": "GFDL-1.3-or-later"
           }
         }
       ],
@@ -4569,7 +4569,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-only"
+            "id": "GFDL-1.3-only"
           }
         }
       ],
@@ -4758,7 +4758,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.2-or-later"
+            "id": "GFDL-1.2-or-later"
           }
         },
         {
@@ -4783,7 +4783,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.2-only"
+            "id": "GFDL-1.2-only"
           }
         }
       ],
@@ -5544,7 +5544,7 @@
         },
         {
           "license": {
-            "name": "GFDL-1.3-or-later"
+            "id": "GFDL-1.3-or-later"
           }
         }
       ],

--- a/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
@@ -3425,7 +3425,7 @@
         },
         {
           "license": {
-            "id": "GPL-2.0-with-autoconf-exception+"
+            "name": "GPL-2.0-only WITH autoconf-exception+"
           }
         },
         {

--- a/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
@@ -88,7 +88,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -131,12 +131,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -179,7 +179,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -222,7 +222,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -270,7 +270,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -317,12 +317,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -332,62 +332,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -434,17 +434,17 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "MPL-2.0"
+            "id": "MPL-2.0"
           }
         }
       ],
@@ -487,7 +487,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -534,7 +534,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -581,7 +581,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         }
       ],
@@ -624,7 +624,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -667,7 +667,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -710,7 +710,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
@@ -766,17 +766,17 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
@@ -829,12 +829,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         }
       ],
@@ -881,12 +881,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -896,62 +896,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -998,7 +998,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -1050,12 +1050,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -1065,17 +1065,17 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "Artistic-2.0"
+            "id": "Artistic-2.0"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         }
       ],
@@ -1122,7 +1122,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
@@ -1132,22 +1132,22 @@
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
@@ -1162,22 +1162,22 @@
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -1224,12 +1224,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -1276,7 +1276,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -1323,7 +1323,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1366,17 +1366,17 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1419,22 +1419,22 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -1481,12 +1481,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1529,22 +1529,22 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -1595,17 +1595,17 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-1.0-only"
+            "id": "GPL-1.0-only"
           }
         }
       ],
@@ -1656,17 +1656,17 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-1.0-only"
+            "id": "GPL-1.0-only"
           }
         }
       ],
@@ -1717,12 +1717,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -1732,62 +1732,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -1834,12 +1834,12 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1886,12 +1886,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1938,12 +1938,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -1990,17 +1990,17 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -2163,12 +2163,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         }
       ],
@@ -2215,12 +2215,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -2230,62 +2230,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -2332,7 +2332,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -2419,12 +2419,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -2471,12 +2471,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
@@ -2486,12 +2486,12 @@
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -2538,12 +2538,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
@@ -2553,12 +2553,12 @@
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -2605,22 +2605,22 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -2671,27 +2671,27 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -2701,27 +2701,27 @@
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         }
       ],
@@ -2768,12 +2768,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
@@ -2783,17 +2783,17 @@
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -2880,17 +2880,17 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
@@ -2900,17 +2900,17 @@
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -2957,7 +2957,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
@@ -2972,7 +2972,7 @@
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
@@ -2982,7 +2982,7 @@
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         }
       ],
@@ -3029,17 +3029,17 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -3096,12 +3096,12 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
@@ -3121,7 +3121,7 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -3136,12 +3136,12 @@
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
@@ -3156,7 +3156,7 @@
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -3203,12 +3203,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -3218,62 +3218,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -3400,17 +3400,17 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
@@ -3420,12 +3420,12 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-with-autoconf-exception+"
+            "id": "GPL-2.0-with-autoconf-exception+"
           }
         },
         {
@@ -3435,7 +3435,7 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -3487,7 +3487,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
@@ -3497,12 +3497,12 @@
         },
         {
           "license": {
-            "name": "ISC"
+            "id": "ISC"
           }
         },
         {
           "license": {
-            "name": "ISC+IBM"
+            "name": "ISC-IBM"
           }
         },
         {
@@ -3554,7 +3554,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -3601,7 +3601,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -3648,7 +3648,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -3695,7 +3695,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -3786,7 +3786,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -3838,22 +3838,22 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
@@ -3883,7 +3883,7 @@
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
@@ -3898,27 +3898,27 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "Artistic-2.0"
+            "id": "Artistic-2.0"
           }
         },
         {
           "license": {
-            "name": "zlib-acknowledgement"
+            "id": "zlib-acknowledgement"
           }
         },
         {
           "license": {
-            "name": "GPL-1.0-or-later"
+            "id": "GPL-1.0-or-later"
           }
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
@@ -3933,12 +3933,12 @@
         },
         {
           "license": {
-            "name": "GPL-1.0-only"
+            "id": "GPL-1.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -3985,7 +3985,7 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -4032,12 +4032,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -4084,12 +4084,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -4136,12 +4136,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -4188,12 +4188,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -4240,12 +4240,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -4255,62 +4255,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -4477,27 +4477,27 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
@@ -4507,7 +4507,7 @@
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -4554,17 +4554,17 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -4656,27 +4656,27 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
@@ -4686,7 +4686,7 @@
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -4733,12 +4733,12 @@
       "licenses": [
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
@@ -4748,12 +4748,12 @@
         },
         {
           "license": {
-            "name": "GPL-2+ with distribution exception"
+            "name": "GPL-2.0-or-later WITH distribution-exception"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
@@ -4763,22 +4763,22 @@
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -4830,12 +4830,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -4845,62 +4845,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -4947,7 +4947,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
@@ -4999,27 +4999,27 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "Zlib"
+            "id": "Zlib"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -5066,7 +5066,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -5117,7 +5117,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -5164,12 +5164,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -5179,62 +5179,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -5401,7 +5401,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -5492,7 +5492,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -5539,7 +5539,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
@@ -5591,7 +5591,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -5638,7 +5638,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -5685,7 +5685,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         }
       ],
@@ -5732,12 +5732,12 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         }
       ],
@@ -5784,12 +5784,12 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         },
         {
@@ -5799,7 +5799,7 @@
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         }
       ],
@@ -5846,7 +5846,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         }
       ],
@@ -5893,22 +5893,22 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
@@ -5938,7 +5938,7 @@
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
@@ -5953,27 +5953,27 @@
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "Artistic-2.0"
+            "id": "Artistic-2.0"
           }
         },
         {
           "license": {
-            "name": "zlib-acknowledgement"
+            "id": "zlib-acknowledgement"
           }
         },
         {
           "license": {
-            "name": "GPL-1.0-or-later"
+            "id": "GPL-1.0-or-later"
           }
         },
         {
           "license": {
-            "name": "CC0-1.0"
+            "id": "CC0-1.0"
           }
         },
         {
@@ -5988,12 +5988,12 @@
         },
         {
           "license": {
-            "name": "GPL-1.0-only"
+            "id": "GPL-1.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -6040,12 +6040,12 @@
       "licenses": [
         {
           "license": {
-            "name": "Ruby"
+            "id": "Ruby"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         }
       ],
@@ -6092,7 +6092,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6135,7 +6135,7 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         }
       ],
@@ -6182,12 +6182,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -6234,12 +6234,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         }
       ],
@@ -6326,12 +6326,12 @@
       "licenses": [
         {
           "license": {
-            "name": "GPL-2.0-or-later"
+            "id": "GPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-2.0-only"
+            "id": "GPL-2.0-only"
           }
         },
         {
@@ -6341,62 +6341,62 @@
         },
         {
           "license": {
-            "name": "BSD-4-Clause"
+            "id": "BSD-4-Clause"
           }
         },
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         },
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-or-later"
+            "id": "LGPL-2.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-or-later"
+            "id": "LGPL-2.1-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-or-later"
+            "id": "GPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-or-later"
+            "id": "LGPL-3.0-or-later"
           }
         },
         {
           "license": {
-            "name": "GPL-3.0-only"
+            "id": "GPL-3.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.0-only"
+            "id": "LGPL-2.0-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-2.1-only"
+            "id": "LGPL-2.1-only"
           }
         },
         {
           "license": {
-            "name": "LGPL-3.0-only"
+            "id": "LGPL-3.0-only"
           }
         }
       ],
@@ -6443,7 +6443,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Zlib"
+            "id": "Zlib"
           }
         }
       ],
@@ -6497,7 +6497,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6535,7 +6535,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -6573,7 +6573,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6642,7 +6642,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6680,17 +6680,17 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         },
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         },
         {
           "license": {
-            "name": "MPL-2.0"
+            "id": "MPL-2.0"
           }
         }
       ],
@@ -6728,7 +6728,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -6766,7 +6766,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -6804,7 +6804,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -6842,7 +6842,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6880,7 +6880,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -6918,7 +6918,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -6956,7 +6956,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-3-Clause"
+            "id": "BSD-3-Clause"
           }
         }
       ],
@@ -6994,7 +6994,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7032,7 +7032,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7070,7 +7070,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7108,7 +7108,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7146,7 +7146,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7184,7 +7184,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7222,7 +7222,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7260,7 +7260,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7329,7 +7329,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7367,7 +7367,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7405,7 +7405,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7443,7 +7443,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7481,7 +7481,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7519,7 +7519,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7557,7 +7557,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7595,7 +7595,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7633,7 +7633,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7671,7 +7671,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7709,7 +7709,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7747,7 +7747,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7785,7 +7785,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7823,7 +7823,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7861,7 +7861,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7899,7 +7899,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -7937,7 +7937,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -7975,7 +7975,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8013,7 +8013,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -8051,7 +8051,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8089,7 +8089,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8127,7 +8127,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8165,7 +8165,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -8203,7 +8203,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8241,7 +8241,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         }
       ],
@@ -8279,7 +8279,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8317,7 +8317,7 @@
       "licenses": [
         {
           "license": {
-            "name": "Apache-2.0"
+            "id": "Apache-2.0"
           }
         }
       ],
@@ -8355,7 +8355,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8393,7 +8393,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8431,7 +8431,7 @@
       "licenses": [
         {
           "license": {
-            "name": "BSD-2-Clause"
+            "id": "BSD-2-Clause"
           }
         }
       ],
@@ -8469,7 +8469,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8507,7 +8507,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -8545,7 +8545,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],

--- a/integration/testdata/npm-cyclonedx.json.golden
+++ b/integration/testdata/npm-cyclonedx.json.golden
@@ -69,7 +69,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -144,7 +144,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -185,7 +185,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -209,7 +209,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],
@@ -233,7 +233,7 @@
       "licenses": [
         {
           "license": {
-            "name": "MIT"
+            "id": "MIT"
           }
         }
       ],

--- a/pkg/licensing/expression/types.go
+++ b/pkg/licensing/expression/types.go
@@ -14,7 +14,7 @@ var (
 
 type Expression interface {
 	String() string
-	IsSPDXExpression() bool
+	IsSPDXLicense() bool
 }
 
 type Token struct {
@@ -43,9 +43,9 @@ func (s SimpleExpr) String() string {
 	return s.License
 }
 
-// IsSPDXExpression returns true if the expression is a valid SPDX license or exception.
-func (s SimpleExpr) IsSPDXExpression() bool {
-	return ValidateSPDXLicense(s.String()) || ValidateSPDXException(s.String())
+// IsSPDXLicense returns true if the expression is a valid SPDX license.
+func (s SimpleExpr) IsSPDXLicense() bool {
+	return ValidateSPDXLicense(s.String())
 }
 
 type CompoundExpr struct {
@@ -88,10 +88,10 @@ func (c CompoundExpr) String() string {
 	return fmt.Sprintf("%s %s %s", left, c.conjunction.literal, right)
 }
 
-func (c CompoundExpr) IsSPDXExpression() bool {
+func (c CompoundExpr) IsSPDXLicense() bool {
 	if c.conjunction.token == WITH {
 		// e.g. A WITH B
-		return c.left.IsSPDXExpression() && ValidateSPDXException(c.right.String())
+		return c.left.IsSPDXLicense() && ValidateSPDXException(c.right.String())
 	}
-	return c.left.IsSPDXExpression() && c.right.IsSPDXExpression()
+	return c.left.IsSPDXLicense() && c.right.IsSPDXLicense()
 }

--- a/pkg/licensing/expression/types.go
+++ b/pkg/licensing/expression/types.go
@@ -14,7 +14,7 @@ var (
 
 type Expression interface {
 	String() string
-	IsSPDXLicense() bool
+	IsSPDXExpression() bool
 }
 
 type Token struct {
@@ -43,8 +43,7 @@ func (s SimpleExpr) String() string {
 	return s.License
 }
 
-// IsSPDXLicense returns true if the expression is a valid SPDX license.
-func (s SimpleExpr) IsSPDXLicense() bool {
+func (s SimpleExpr) IsSPDXExpression() bool {
 	return ValidateSPDXLicense(s.String())
 }
 
@@ -88,10 +87,10 @@ func (c CompoundExpr) String() string {
 	return fmt.Sprintf("%s %s %s", left, c.conjunction.literal, right)
 }
 
-func (c CompoundExpr) IsSPDXLicense() bool {
+func (c CompoundExpr) IsSPDXExpression() bool {
 	if c.conjunction.token == WITH {
 		// e.g. A WITH B
-		return c.left.IsSPDXLicense() && ValidateSPDXException(c.right.String())
+		return c.left.IsSPDXExpression() && ValidateSPDXException(c.right.String())
 	}
-	return c.left.IsSPDXLicense() && c.right.IsSPDXLicense()
+	return c.left.IsSPDXExpression() && c.right.IsSPDXExpression()
 }

--- a/pkg/licensing/expression/types.go
+++ b/pkg/licensing/expression/types.go
@@ -14,7 +14,7 @@ var (
 
 type Expression interface {
 	String() string
-	IsSPDXExpression() bool
+	IsSPDXLicense() bool
 }
 
 type Token struct {
@@ -43,9 +43,8 @@ func (s SimpleExpr) String() string {
 	return s.License
 }
 
-// IsSPDXExpression returns true if the expression is a valid SPDX license or exception.
-func (s SimpleExpr) IsSPDXExpression() bool {
-	return ValidateSPDXLicense(s.String()) || ValidateSPDXException(s.String())
+func (s SimpleExpr) IsSPDXLicense() bool {
+	return ValidateSPDXLicense(s.String())
 }
 
 type CompoundExpr struct {
@@ -88,10 +87,10 @@ func (c CompoundExpr) String() string {
 	return fmt.Sprintf("%s %s %s", left, c.conjunction.literal, right)
 }
 
-func (c CompoundExpr) IsSPDXExpression() bool {
+func (c CompoundExpr) IsSPDXLicense() bool {
 	if c.conjunction.token == WITH {
 		// e.g. A WITH B
-		return c.left.IsSPDXExpression() && ValidateSPDXException(c.right.String())
+		return c.left.IsSPDXLicense() && ValidateSPDXException(c.right.String())
 	}
-	return c.left.IsSPDXExpression() && c.right.IsSPDXExpression()
+	return c.left.IsSPDXLicense() && c.right.IsSPDXLicense()
 }

--- a/pkg/licensing/expression/types.go
+++ b/pkg/licensing/expression/types.go
@@ -14,7 +14,7 @@ var (
 
 type Expression interface {
 	String() string
-	IsSPDXLicense() bool
+	IsSPDXExpression() bool
 }
 
 type Token struct {
@@ -43,8 +43,9 @@ func (s SimpleExpr) String() string {
 	return s.License
 }
 
-func (s SimpleExpr) IsSPDXLicense() bool {
-	return ValidateSPDXLicense(s.String())
+// IsSPDXExpression returns true if the expression is a valid SPDX license or exception.
+func (s SimpleExpr) IsSPDXExpression() bool {
+	return ValidateSPDXLicense(s.String()) || ValidateSPDXException(s.String())
 }
 
 type CompoundExpr struct {
@@ -87,10 +88,10 @@ func (c CompoundExpr) String() string {
 	return fmt.Sprintf("%s %s %s", left, c.conjunction.literal, right)
 }
 
-func (c CompoundExpr) IsSPDXLicense() bool {
+func (c CompoundExpr) IsSPDXExpression() bool {
 	if c.conjunction.token == WITH {
 		// e.g. A WITH B
-		return c.left.IsSPDXLicense() && ValidateSPDXException(c.right.String())
+		return c.left.IsSPDXExpression() && ValidateSPDXException(c.right.String())
 	}
-	return c.left.IsSPDXLicense() && c.right.IsSPDXLicense()
+	return c.left.IsSPDXExpression() && c.right.IsSPDXExpression()
 }

--- a/pkg/licensing/expression/types.go
+++ b/pkg/licensing/expression/types.go
@@ -14,6 +14,7 @@ var (
 
 type Expression interface {
 	String() string
+	IsSPDXExpression() bool
 }
 
 type Token struct {
@@ -40,6 +41,11 @@ func (s SimpleExpr) String() string {
 		return s.License + "+"
 	}
 	return s.License
+}
+
+// IsSPDXExpression returns true if the expression is a valid SPDX license or exception.
+func (s SimpleExpr) IsSPDXExpression() bool {
+	return ValidateSPDXLicense(s.String()) || ValidateSPDXException(s.String())
 }
 
 type CompoundExpr struct {
@@ -80,4 +86,12 @@ func (c CompoundExpr) String() string {
 		}
 	}
 	return fmt.Sprintf("%s %s %s", left, c.conjunction.literal, right)
+}
+
+func (c CompoundExpr) IsSPDXExpression() bool {
+	if c.conjunction.token == WITH {
+		// e.g. A WITH B
+		return c.left.IsSPDXExpression() && ValidateSPDXException(c.right.String())
+	}
+	return c.left.IsSPDXExpression() && c.right.IsSPDXExpression()
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -26,6 +26,7 @@ const (
 	PrefixVulnerabilityDB  = "vulndb"
 	PrefixJavaDB           = "javadb"
 	PrefixSPDX             = "spdx"
+	PrefixCycloneDX        = "cyclonedx"
 )
 
 // Logger is an alias of slog.Logger

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -319,7 +319,7 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 		onceValidateSPDXLicense.Do(func() {
 			_, compoundExpr := expr.(expression.CompoundExpr)
 			switch {
-			case !expr.IsSPDXLicense():
+			case !expr.IsSPDXExpression():
 				// Use licenseChoice.license.name for invalid SPDX ID / SPDX expression
 				licenseChoice.License = &cdx.License{Name: expr.String()}
 			case compoundExpr:

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -307,6 +307,10 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 		}
 	}
 
+	// e.g. GPL-3.0-with-autoconf-exception
+	license = strings.ReplaceAll(license, "-with-", " WITH ")
+	license = strings.ReplaceAll(license, "-WITH-", " WITH ")
+
 	var invalidSPDX, spdxExpression bool
 	validateSPDXLicense := func(expr expression.Expression) expression.Expression {
 		// We already found that the license is invalid

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -319,7 +319,7 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 	}
 
 	// The license is not a valid SPDX ID or SPDX expression
-	if !normalizedLicenses.IsSPDXLicense() {
+	if !normalizedLicenses.IsSPDXExpression() {
 		// Use LicenseChoice.License.Name for invalid SPDX ID / SPDX expression
 		return cdx.LicenseChoice{
 			License: &cdx.License{Name: normalizedLicenses.String()},

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -319,7 +319,7 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 		onceValidateSPDXLicense.Do(func() {
 			_, compoundExpr := expr.(expression.CompoundExpr)
 			switch {
-			case !expr.IsSPDXExpression():
+			case !expr.IsSPDXLicense():
 				// Use licenseChoice.license.name for invalid SPDX ID / SPDX expression
 				licenseChoice.License = &cdx.License{Name: expr.String()}
 			case compoundExpr:

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -307,8 +307,7 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 		}
 	}
 
-	var invalidSPDX bool
-	var spdxExpression bool
+	var invalidSPDX, spdxExpression bool
 	validateSPDXLicense := func(expr expression.Expression) expression.Expression {
 		// We already found that the license is invalid
 		// So we can skip further checks
@@ -341,25 +340,23 @@ func (m *Marshaler) normalizeLicense(license string) cdx.LicenseChoice {
 		return cdx.LicenseChoice{}
 	}
 
-	var licenseChoice cdx.LicenseChoice
 	switch {
 	case invalidSPDX:
 		// Use licenseChoice.license.name for invalid SPDX ID / SPDX expression
-		licenseChoice.License = &cdx.License{
-			Name: normalizedLicense.String(),
+		return cdx.LicenseChoice{
+			License: &cdx.License{Name: normalizedLicense.String()},
 		}
 	case spdxExpression:
 		// Use licenseChoice.expression for valid SPDX expression (with any conjunction)
 		// e.g. "GPL-2.0 WITH Classpath-exception-2.0" or "GPL-2.0 AND MIT"
-		licenseChoice.Expression = normalizedLicense.String()
+		return cdx.LicenseChoice{Expression: normalizedLicense.String()}
 	default:
 		// Use licenseChoice.license.id for valid SPDX ID
-		licenseChoice.License = &cdx.License{
-			ID: normalizedLicense.String(),
+		return cdx.LicenseChoice{
+			License: &cdx.License{ID: normalizedLicense.String()},
 		}
 	}
 
-	return licenseChoice
 }
 
 func (*Marshaler) Properties(properties []core.Property) *[]cdx.Property {

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -2155,6 +2155,17 @@ func TestMarshaler_Licenses(t *testing.T) {
 			},
 		},
 		{
+			name:    "SPDX license with wrong exception",
+			license: "GPL-2.0-with-autoconf-exception+",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						Name: "GPL-2.0-only WITH autoconf-exception+",
+					},
+				},
+			},
+		},
+		{
 			name:    "SPDX expression",
 			license: "GPL-3.0-only OR AFL 2.0 with Linux-syscall-note AND GPL-3.0-only",
 			want: &cdx.Licenses{

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -2105,3 +2105,87 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshaler_Licenses(t *testing.T) {
+	tests := []struct {
+		name    string
+		license string
+		want    *cdx.Licenses
+	}{
+		{
+			name:    "SPDX ID",
+			license: "MIT",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						ID: "MIT",
+					},
+				},
+			},
+		},
+		{
+			name:    "Unknown SPDX ID",
+			license: "no-spdx-id-license",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						Name: "no-spdx-id-license",
+					},
+				},
+			},
+		},
+		{
+			name:    "text license",
+			license: "text://text of license",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						Name: "text of license",
+					},
+				},
+			},
+		},
+		{
+			name:    "SPDX license with exception",
+			license: "AFL 2.0 with Linux-syscall-note",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					Expression: "AFL-2.0 WITH Linux-syscall-note",
+				},
+			},
+		},
+		{
+			name:    "SPDX expression",
+			license: "GPL-3.0-only OR AFL 2.0 with Linux-syscall-note AND GPL-3.0-only",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					Expression: "GPL-3.0-only OR AFL-2.0 WITH Linux-syscall-note AND GPL-3.0-only",
+				},
+			},
+		},
+		{
+			name:    "invalid SPDX expression",
+			license: "wrong-spdx-id OR GPL-3.0-only",
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						Name: "wrong-spdx-id OR GPL-3.0-only",
+					},
+				},
+			},
+		},
+		{
+			name:    "empty license",
+			license: "",
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marshaler := cyclonedx.NewMarshaler("dev")
+			got := marshaler.Licenses([]string{tt.license})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -509,7 +509,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{
 								License: &cdx.License{
-									Name: "GPLv3+",
+									ID: "GPL-3.0-or-later",
 								},
 							},
 						},
@@ -1026,7 +1026,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{
 								License: &cdx.License{
-									Name: "GPLv2+",
+									ID: "GPL-2.0-or-later",
 								},
 							},
 						},
@@ -1072,7 +1072,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{
 								License: &cdx.License{
-									Name: "GPLv2+",
+									ID: "GPL-2.0-or-later",
 								},
 							},
 						},
@@ -2003,7 +2003,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						Licenses: &cdx.Licenses{
 							cdx.LicenseChoice{
 								License: &cdx.License{
-									Name: "MIT",
+									ID: "MIT",
 								},
 							},
 						},

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -436,7 +436,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 		var licenseName string
 		switch e := expr.(type) {
 		case expression.SimpleExpr:
-			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXLicense() {
+			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXExpression() {
 				return e
 			}
 
@@ -448,7 +448,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			}
 
 			// Check that license and exception are valid
-			if e.IsSPDXLicense() {
+			if e.IsSPDXExpression() {
 				// Use SimpleExpr for a valid SPDX license with an exception,
 				// to avoid parsing the license and exception separately.
 				return expression.SimpleExpr{License: e.String()}

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -436,7 +436,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 		var licenseName string
 		switch e := expr.(type) {
 		case expression.SimpleExpr:
-			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXExpression() {
+			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXLicense() {
 				return e
 			}
 
@@ -448,10 +448,10 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			}
 
 			// Check that license and exception are valid
-			if e.IsSPDXExpression() {
+			if e.IsSPDXLicense() {
 				// Use SimpleExpr for a valid SPDX license with an exception,
 				// to avoid parsing the license and exception separately.
-				return e
+				return expression.SimpleExpr{License: e.String()}
 			}
 
 			licenseName = e.String()

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -436,11 +436,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 		var licenseName string
 		switch e := expr.(type) {
 		case expression.SimpleExpr:
-			if strings.HasPrefix(e.License, LicenseRefPrefix) {
-				return e
-			}
-
-			if expression.ValidateSPDXLicense(e.License) || expression.ValidateSPDXException(e.License) {
+			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXExpression() {
 				return e
 			}
 
@@ -452,7 +448,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			}
 
 			// Check that license and exception are valid
-			if expression.ValidateSPDXLicense(e.Left().String()) && expression.ValidateSPDXException(e.Right().String()) {
+			if e.IsSPDXExpression() {
 				// Use SimpleExpr for a valid SPDX license with an exception,
 				// to avoid parsing the license and exception separately.
 				return e

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -435,13 +435,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 
 	// SPDX exception will be normalized as a SimpleExpr, so we need to check them separately.
 	foundSPDXExceptions := set.New[string]()
-	var validSPDXExpresion bool
 	replaceOtherLicenses := func(expr expression.Expression) expression.Expression {
-		// Don't check nested licenses if the expression is already valid SPDX expression.
-		if validSPDXExpresion {
-			return expr
-		}
-
 		var licenseName string
 		switch e := expr.(type) {
 		case expression.SimpleExpr:
@@ -460,7 +454,6 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			// Check that license and exception are valid
 			if e.IsSPDXLicense() {
 				foundSPDXExceptions.Append(e.Right().String())
-				validSPDXExpresion = true
 				// Use SimpleExpr for a valid SPDX license with an exception,
 				// to avoid parsing the license and exception separately.s
 				return e

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	sbomio "github.com/aquasecurity/trivy/pkg/sbom/io"
-	"github.com/aquasecurity/trivy/pkg/set"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/uuid"
 )
@@ -433,14 +432,11 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 		return fmt.Sprintf("(%s)", license)
 	}), " AND ")
 
-	// SPDX exception will be normalized as a SimpleExpr, so we need to check them separately.
-	foundSPDXExceptions := set.New[string]()
 	replaceOtherLicenses := func(expr expression.Expression) expression.Expression {
 		var licenseName string
 		switch e := expr.(type) {
 		case expression.SimpleExpr:
-			// Check if the license is a valid SPDX license or an exception or already replaced to OtherLicense
-			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXLicense() || foundSPDXExceptions.Contains(e.String()) {
+			if strings.HasPrefix(e.License, LicenseRefPrefix) || e.IsSPDXExpression() {
 				return e
 			}
 
@@ -452,10 +448,9 @@ func (m *Marshaler) normalizeLicenses(licenses []string) (string, []*spdx.OtherL
 			}
 
 			// Check that license and exception are valid
-			if e.IsSPDXLicense() {
-				foundSPDXExceptions.Append(e.Right().String())
+			if e.IsSPDXExpression() {
 				// Use SimpleExpr for a valid SPDX license with an exception,
-				// to avoid parsing the license and exception separately.s
+				// to avoid parsing the license and exception separately.
 				return e
 			}
 

--- a/pkg/sbom/spdx/marshal_private_test.go
+++ b/pkg/sbom/spdx/marshal_private_test.go
@@ -70,10 +70,24 @@ func TestMarshaler_normalizeLicenses(t *testing.T) {
 		{
 			name: "happy path with WITH operator",
 			input: []string{
-				"AFL 2.0",
+				"GPLv2",
+				"AFL 3.0 with wrong-exceptions",
+				"LGPL 2.0 and unknown-license and GNU LESSER",
 				"AFL 3.0 with Autoconf-exception-3.0",
 			},
-			wantLicenseName: "AFL-2.0 AND AFL-3.0 WITH Autoconf-exception-3.0",
+			wantLicenseName: "GPL-2.0-only AND LicenseRef-51373b28fab165e9 AND LGPL-2.0-only AND LicenseRef-a0bb0951a6dfbdbe AND LGPL-2.1-only AND AFL-3.0 WITH Autoconf-exception-3.0",
+			wantOtherLicenses: []*spdx.OtherLicense{
+				{
+					LicenseIdentifier: "LicenseRef-51373b28fab165e9",
+					LicenseName:       "AFL-3.0 WITH wrong-exceptions",
+					ExtractedText:     `This component is licensed under "AFL-3.0 WITH wrong-exceptions"`,
+				},
+				{
+					LicenseIdentifier: "LicenseRef-a0bb0951a6dfbdbe",
+					LicenseName:       "unknown-license",
+					ExtractedText:     `This component is licensed under "unknown-license"`,
+				},
+			},
 		},
 		{
 			name: "happy path with non-SPDX exception",

--- a/pkg/sbom/spdx/marshal_private_test.go
+++ b/pkg/sbom/spdx/marshal_private_test.go
@@ -70,24 +70,10 @@ func TestMarshaler_normalizeLicenses(t *testing.T) {
 		{
 			name: "happy path with WITH operator",
 			input: []string{
-				"GPLv2",
-				"AFL 3.0 with wrong-exceptions",
-				"LGPL 2.0 and unknown-license and GNU LESSER",
+				"AFL 2.0",
 				"AFL 3.0 with Autoconf-exception-3.0",
 			},
-			wantLicenseName: "GPL-2.0-only AND LicenseRef-51373b28fab165e9 AND LGPL-2.0-only AND LicenseRef-a0bb0951a6dfbdbe AND LGPL-2.1-only AND AFL-3.0 WITH Autoconf-exception-3.0",
-			wantOtherLicenses: []*spdx.OtherLicense{
-				{
-					LicenseIdentifier: "LicenseRef-51373b28fab165e9",
-					LicenseName:       "AFL-3.0 WITH wrong-exceptions",
-					ExtractedText:     `This component is licensed under "AFL-3.0 WITH wrong-exceptions"`,
-				},
-				{
-					LicenseIdentifier: "LicenseRef-a0bb0951a6dfbdbe",
-					LicenseName:       "unknown-license",
-					ExtractedText:     `This component is licensed under "unknown-license"`,
-				},
-			},
+			wantLicenseName: "AFL-2.0 AND AFL-3.0 WITH Autoconf-exception-3.0",
 		},
 		{
 			name: "happy path with non-SPDX exception",


### PR DESCRIPTION
## Description
We need to use one of three correct field for component license (see #9042 for more details)

### Solution
Normalize and check each package license:
1. Single license:
   1.1. valid SPDX ID use licenseChoise.License.ID
   1.2. text license - use licenseChoise.License.Name
   1.3. invalid SPDX ID - use licenseChoise.License.Name
2. SPDX expression:
   1.4. all parts of expression are valid SPDX IDs/SPDX exceptions - use licenseChoise.Expression
   1.5. for other cases use licenseChoise.License.Name

### Examples of changes:
CycloneDX report for `centos:8`:
Before
```
...
          "license": {
            "name": "GPLv2+"
          }
...
          "license": {
            "name": "Public Domain"
          }
...
      "licenses": [
        {
          "license": {
            "name": "GPLv2+ and LGPLv2+"
          }
        }
...
          "license": {
            "name": "BSD with advertising"
          }
```
After:
```
...
          "license": {
            "id": "GPL-2.0-or-later"
          }
...
          "license": {
            "name": "Public-Domain"
          }
...
      "licenses": [
        {
          "expression": "GPL-2.0-or-later AND LGPL-2.0-or-later"
        }
...
          "license": {
            "name": "BSD-3-Clause WITH advertising"
          }
```
## Related issues
- Close #9042

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
