### PR TITLE
refactor(misconf): rewrite Rego module filtering using functional filters

### DIFF
--- a/pkg/iac/rego/filter.go
+++ b/pkg/iac/rego/filter.go
@@ -1,0 +1,85 @@
+package rego
+
+import (
+	"github.com/open-policy-agent/opa/v1/ast"
+
+	"github.com/aquasecurity/go-version/pkg/semver"
+	"github.com/aquasecurity/trivy/pkg/iac/framework"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+type RegoModuleFilter func(module *ast.Module, metadata *StaticMetadata) bool
+
+// TrivyVersionFilter returns a filter that allows only those modules,
+// that are compatible with the given version of Trivy.
+func TrivyVersionFilter(trivyVer string) RegoModuleFilter {
+	if trivyVer == "dev" {
+		return func(_ *ast.Module, _ *StaticMetadata) bool {
+			return true
+		}
+	}
+
+	tv, tverr := semver.Parse(trivyVer)
+	if tverr != nil {
+		log.Warn(
+			"Failed to parse Trivy version - cannot confirm if all modules will work with current version",
+			log.Prefix("rego"),
+			log.String("trivy_version", trivyVer),
+			log.Err(tverr),
+		)
+		return func(_ *ast.Module, _ *StaticMetadata) bool {
+			return true
+		}
+	}
+	return func(module *ast.Module, metadata *StaticMetadata) bool {
+		return isMinimumVersionSupported(metadata, module, tv)
+	}
+}
+
+func isMinimumVersionSupported(metadata *StaticMetadata, module *ast.Module, tv semver.Version) bool {
+	// to ensure compatibility with old modules without minimum trivy version
+	if metadata.MinimumTrivyVersion == "" {
+		return true
+	}
+
+	mmsv, err := semver.Parse(metadata.MinimumTrivyVersion)
+	if err != nil {
+		log.Warn(
+			"Failed to parse minimum trivy version - skipping as cannot confirm if module will work with current version",
+			log.Prefix("rego"),
+			log.FilePath(module.Package.Location.File),
+			log.Err(err),
+		)
+		return false
+	}
+
+	if tv.LessThan(mmsv) {
+		log.Warn(
+			"Module will be skipped as current version of Trivy is older than minimum trivy version required - please update Trivy to use this module",
+			log.Prefix("rego"),
+			log.FilePath(module.Package.Location.File),
+			log.String("minimum_trivy_version", metadata.MinimumTrivyVersion),
+		)
+		return false
+	}
+	return true
+}
+
+// FrameworksFilter returns a filter that allows only modules
+// associated with the specified frameworks.
+func FrameworksFilter(frameworks []framework.Framework) RegoModuleFilter {
+	return func(_ *ast.Module, metadata *StaticMetadata) bool {
+		return metadata.matchAnyFramework(frameworks)
+	}
+}
+
+// IncludeDeprecatedFilter returns a filter that allows deprecated modules
+// if the include flag is true.
+func IncludeDeprecatedFilter(include bool) RegoModuleFilter {
+	return func(_ *ast.Module, metadata *StaticMetadata) bool {
+		if metadata.Deprecated && !include {
+			return false
+		}
+		return true
+	}
+}

--- a/pkg/iac/rego/filter_test.go
+++ b/pkg/iac/rego/filter_test.go
@@ -1,0 +1,137 @@
+package rego_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/iac/framework"
+	"github.com/aquasecurity/trivy/pkg/iac/rego"
+)
+
+func TestTrivyVersionFilter(t *testing.T) {
+	module := &ast.Module{Package: &ast.Package{Location: ast.NewLocation(nil, "/test.rego", 1, 1)}}
+
+	tests := []struct {
+		name       string
+		trivyVer   string
+		minVersion string
+		expected   bool
+	}{
+		{"no minimum version", "0.1.0", "", true},
+		{"compatible version", "0.20.0", "0.19.0", true},
+		{"incompatible version", "0.18.0", "0.19.0", false},
+		{"invalid min version", "0.20.0", "invalid", false},
+		{"invalid trivy version", "invalid", "0.19.0", true},
+		{"empty trivy version", "", "0.19.0", true},
+		{"dev trivy version", "dev", "0.19.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := rego.TrivyVersionFilter(tt.trivyVer)
+			metadata := &rego.StaticMetadata{
+				MinimumTrivyVersion: tt.minVersion,
+			}
+			result := filter(module, metadata)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFrameworksFilter(t *testing.T) {
+	module := &ast.Module{}
+
+	tests := []struct {
+		name     string
+		moduleFw map[framework.Framework][]string
+		filterFw []framework.Framework
+		expected bool
+	}{
+		{
+			name: "match single",
+			moduleFw: map[framework.Framework][]string{
+				framework.CIS_AWS_1_2: {"2.5"},
+			},
+			filterFw: []framework.Framework{framework.CIS_AWS_1_2},
+			expected: true,
+		},
+		{
+			name: "match one of many",
+			moduleFw: map[framework.Framework][]string{
+				framework.CIS_AWS_1_2: {"2.5"},
+				framework.CIS_AWS_1_4: {"4.5"},
+			},
+			filterFw: []framework.Framework{framework.CIS_AWS_1_2},
+			expected: true,
+		},
+		{
+			name: "no match",
+			moduleFw: map[framework.Framework][]string{
+				framework.CIS_AWS_1_2: {"2.5"},
+			},
+			filterFw: []framework.Framework{"PCI"},
+			expected: false,
+		},
+		{
+			name: "empty filter",
+			moduleFw: map[framework.Framework][]string{
+				framework.CIS_AWS_1_2: {"2.5"},
+			},
+			filterFw: nil,
+			expected: false,
+		},
+		{
+			name: "has default framework and empty filter",
+			moduleFw: map[framework.Framework][]string{
+				framework.Default:     {},
+				framework.CIS_AWS_1_2: {"2.5"},
+			},
+			filterFw: nil,
+			expected: true,
+		},
+		{
+			name:     "empty module frameworks",
+			moduleFw: nil,
+			filterFw: []framework.Framework{framework.Default},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &rego.StaticMetadata{
+				Frameworks: tt.moduleFw,
+			}
+			filter := rego.FrameworksFilter(tt.filterFw)
+			result := filter(module, metadata)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIncludeDeprecatedFilter(t *testing.T) {
+	module := &ast.Module{}
+
+	tests := []struct {
+		name       string
+		include    bool
+		deprecated bool
+		expected   bool
+	}{
+		{"include false, not deprecated", false, false, true},
+		{"include false, deprecated", false, true, false},
+		{"include true, deprecated", true, true, true},
+		{"include true, not deprecated", true, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &rego.StaticMetadata{Deprecated: tt.deprecated}
+			filter := rego.IncludeDeprecatedFilter(tt.include)
+			result := filter(module, metadata)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -13,7 +13,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/samber/lo"
 
-	"github.com/aquasecurity/go-version/pkg/semver"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/set"
 	"github.com/aquasecurity/trivy/pkg/version/doc"
@@ -297,32 +296,6 @@ func (s *Scanner) handleModulesMetadata(path string, module *ast.Module) {
 	s.moduleMetadata[path] = metadata
 }
 
-func (s *Scanner) IsMinimumVersionSupported(metadata *StaticMetadata, module *ast.Module, tv semver.Version) bool {
-	if metadata.MinimumTrivyVersion == "" { // to ensure compatibility with old modules without minimum trivy version
-		return true
-	}
-
-	mmsv, err := semver.Parse(metadata.MinimumTrivyVersion)
-	if err != nil {
-		s.logger.Warn(
-			"Failed to parse minimum trivy version - skipping as cannot confirm if module will work with current version",
-			log.FilePath(module.Package.Location.File),
-			log.Err(err),
-		)
-		return false
-	}
-
-	if tv.LessThan(mmsv) {
-		s.logger.Warn(
-			"Module will be skipped as current version of Trivy is older than minimum trivy version required - please update Trivy to use this module",
-			log.FilePath(module.Package.Location.File),
-			log.String("minimum_trivy_version", metadata.MinimumTrivyVersion),
-		)
-		return false
-	}
-	return true
-}
-
 // moduleHasLegacyMetadataFormat checks if the module has a legacy metadata format.
 // Returns true if the metadata is represented as a “__rego_metadata__” rule,
 // which was used before annotations were introduced.
@@ -344,50 +317,35 @@ func moduleHasLegacyInputFormat(module *ast.Module) bool {
 // filterModules filters the Rego modules based on metadata.
 func (s *Scanner) filterModules() error {
 	filtered := make(map[string]*ast.Module)
-	tv, tverr := semver.Parse(s.trivyVersion)
-	if tverr != nil && s.trivyVersion != "dev" {
-		s.logger.Warn(
-			"Failed to parse Trivy version - cannot confirm if all modules will work with current version",
-			log.String("trivy_version", s.trivyVersion),
-			log.Err(tverr),
-		)
-	}
 
 	for name, module := range s.policies {
 		metadata, err := s.metadataForModule(context.Background(), name, module, nil)
 		if err != nil {
 			return fmt.Errorf("retrieve metadata for module %s: %w", name, err)
 		}
-
-		if metadata != nil {
-			if tverr == nil && !s.IsMinimumVersionSupported(metadata, module, tv) {
-				continue
-			}
-
-			if s.isModuleApplicable(module, metadata, name) {
-				filtered[name] = module
-			}
+		if metadata == nil {
+			continue
 		}
+
+		if !lo.EveryBy(s.moduleFilters, func(filter RegoModuleFilter) bool {
+			return filter(module, metadata)
+		}) {
+			continue
+		}
+
+		if len(metadata.InputOptions.Selectors) == 0 && !metadata.Library {
+			s.logger.Warn(
+				"Module has no input selectors - it will be loaded for all inputs",
+				log.FilePath(module.Package.Location.File),
+				log.String("module", name),
+			)
+		}
+
+		filtered[name] = module
 	}
 
 	s.policies = filtered
 	return nil
-}
-
-func (s *Scanner) isModuleApplicable(module *ast.Module, metadata *StaticMetadata, name string) bool {
-	if !metadata.hasAnyFramework(s.frameworks) {
-		return false
-	}
-
-	if len(metadata.InputOptions.Selectors) == 0 && !metadata.Library {
-		s.logger.Warn(
-			"Module has no input selectors - it will be loaded for all inputs",
-			log.FilePath(module.Package.Location.File),
-			log.String("module", name),
-		)
-	}
-
-	return true
 }
 
 func ParseRegoModule(name, input string) (*ast.Module, error) {

--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -179,7 +179,7 @@ func (sm *StaticMetadata) updateAliases(meta map[string]any) {
 	}
 }
 
-func (sm *StaticMetadata) hasAnyFramework(frameworks []framework.Framework) bool {
+func (sm *StaticMetadata) matchAnyFramework(frameworks []framework.Framework) bool {
 	if len(frameworks) == 0 {
 		frameworks = []framework.Framework{framework.Default}
 	}

--- a/pkg/iac/rego/options.go
+++ b/pkg/iac/rego/options.go
@@ -125,7 +125,7 @@ func WithFrameworks(frameworks ...framework.Framework) options.ScannerOption {
 func WithTrivyVersion(version string) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if ss, ok := s.(*Scanner); ok {
-			ss.trivyVersion = version
+			ss.moduleFilters = append(ss.moduleFilters, TrivyVersionFilter(version))
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR refactors Rego module filtering to use composable functional filters. This improves readability, maintainability, and makes testing individual filters easier. Unit tests are added for all filters.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
