### PR TITLE
docs: add explanation for how to use non-system certificates

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -1,21 +1,22 @@
 # Troubleshooting
 
 ## Scan
+
 ### Timeout
 
 !!! error
-    ``` bash
+`bash
     $ trivy image ...
     ...
     analyze error: timeout: context deadline exceeded
-    ```
+   `
 
 Your scan may time out. Java takes a particularly long time to scan. Try increasing the value of the ---timeout option such as `--timeout 15m`.
 
 ### Unable to initialize an image scanner
 
 !!! error
-    ```bash
+`bash
     $ trivy image ...
     ...
     2024-01-19T08:15:33.288Z	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: 4 errors occurred:
@@ -23,54 +24,60 @@ Your scan may time out. Java takes a particularly long time to scan. Try increas
 	* containerd error: containerd socket not found: /run/containerd/containerd.sock
 	* podman error: unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
 	* remote error: GET https://index.docker.io/v2/ContainerImageName: MANIFEST_UNKNOWN: manifest unknown; unknown tag=0.1
-    ```
-    
+    `
+
 It means Trivy is unable to find the container image in the following places:
 
-* Docker Engine
-* containerd
-* Podman
-* A remote registry
+- Docker Engine
+- containerd
+- Podman
+- A remote registry
 
 Please see error messages for details of each error.
 
 Common mistakes include the following, depending on where you are pulling images from:
 
 #### Common
+
 - Typos in the image name
-    - Common mistake :)
+  - Common mistake :)
 - Forgetting to specify the registry
-    - By default, it is considered to be Docker Hub ( `index.docker.io` ).
+  - By default, it is considered to be Docker Hub ( `index.docker.io` ).
 
 #### Docker Engine
+
 - Incorrect Docker host
-    - If the Docker daemon's socket path is not `/var/run/docker.sock`, you need to specify the `--docker-host` flag or the `DOCKER_HOST` environment variable.
-      The same applies when using TCP; you must specify the correct host address.
+  - If the Docker daemon's socket path is not `/var/run/docker.sock`, you need to specify the `--docker-host` flag or the `DOCKER_HOST` environment variable.
+    The same applies when using TCP; you must specify the correct host address.
 
 #### containerd
+
 - Incorrect containerd address
-    - If you are using a non-default path, you need to specify the `CONTAINERD_ADDRESS` environment variable.
-      Please refer to [this documentation](../target/container_image.md#containerd).
+  - If you are using a non-default path, you need to specify the `CONTAINERD_ADDRESS` environment variable.
+    Please refer to [this documentation](../target/container_image.md#containerd).
 - Incorrect namespace
-    - If you are using a non-default namespace, you need to specify the `CONTAINERD_NAMESPACE` environment variable.
-      Please refer to [this documentation](../target/container_image.md#containerd).
-    - 
+  - If you are using a non-default namespace, you need to specify the `CONTAINERD_NAMESPACE` environment variable.
+    Please refer to [this documentation](../target/container_image.md#containerd).
+  -
+
 #### Podman
+
 - Podman socket configuration
-    - You need to enable the Podman socket. Please refer to [this documentation](../target/container_image.md#podman).
+  - You need to enable the Podman socket. Please refer to [this documentation](../target/container_image.md#podman).
 
 #### Container Registry
+
 - Unauthenticated
-    - If you are using a private container registry, you need to authenticate. Please refer to [this documentation](../advanced/private-registries/index.md).
+  - If you are using a private container registry, you need to authenticate. Please refer to [this documentation](../advanced/private-registries/index.md).
 - Using a proxy
-    - If you are using a proxy within your network, you need to correctly set the `HTTP_PROXY`, `HTTPS_PROXY`, etc., environment variables.
+  - If you are using a proxy within your network, you need to correctly set the `HTTP_PROXY`, `HTTPS_PROXY`, etc., environment variables.
 - Use of a self-signed certificate in the registry
-    - Because certificate verification will fail, you need to either trust that certificate or use the `--insecure` flag (not recommended in production).
+  - Because certificate verification will fail, you need to either trust that certificate or use the `--insecure` flag (not recommended in production).
 
 ### Certification
 
 !!! error
-    Error: x509: certificate signed by unknown authority
+Error: x509: certificate signed by unknown authority
 
 `TRIVY_INSECURE` can be used to allow insecure connections to a container registry when using SSL.
 
@@ -78,15 +85,26 @@ Common mistakes include the following, depending on where you are pulling images
 $ TRIVY_INSECURE=true trivy image [YOUR_IMAGE]
 ```
 
+Alternatively, you can specify the location of your certificate using `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variables.
+
+```
+$ SSL_CERT_FILE=/path/to/cert trivy image [YOUR_IMAGE]
+```
+
+```
+$ SSL_CERT_DIR=/path/to/certs trivy image [YOUR_IMAGE]
+```
+
 ### GitHub Rate limiting
+
 Trivy uses GitHub API for [VEX repositories](../supply-chain/vex/repo.md).
 
 !!! error
-    ``` bash
+`bash
     $ trivy image --vex repo ...
     ...
     API rate limit exceeded for xxx.xxx.xxx.xxx.
-    ```
+   `
 
 Specify GITHUB_TOKEN for [authentication](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28)
 
@@ -95,17 +113,17 @@ $ GITHUB_TOKEN=XXXXXXXXXX trivy image --vex repo [YOUR_IMAGE]
 ```
 
 !!! note
-    `GITHUB_TOKEN` doesn't help with the rate limit for the vulnerability database and other assets.
-    See https://github.com/aquasecurity/trivy/discussions/8009
+`GITHUB_TOKEN` doesn't help with the rate limit for the vulnerability database and other assets.
+See https://github.com/aquasecurity/trivy/discussions/8009
 
 ### Unable to open JAR files
 
 !!! error
-    ``` bash
+`bash
     $ trivy image ...
     ...
     failed to analyze file: failed to analyze usr/lib/jvm/java-1.8-openjdk/lib/tools.jar: unable to open usr/lib/jvm/java-1.8-openjdk/lib/tools.jar: failed to open: unable to read the file: stream error: stream ID 9; PROTOCOL_ERROR; received from peer
-    ```
+   `
 
 Currently, we're investigating this issue. As a temporary mitigation, you may be able to avoid this issue by downloading the Java DB in advance.
 
@@ -116,8 +134,10 @@ $ trivy image [YOUR_JAVA_IMAGE]
 ```
 
 ### Running in parallel takes same time as series run
+
 When running trivy on multiple images simultaneously, it will take same time as running trivy in series.
 This is because of a limitation of boltdb.
+
 > Bolt obtains a file lock on the data file so multiple processes cannot open the same database at the same time. Opening an already open Bolt database will cause it to hang until the other process closes it.
 
 Reference : [boltdb: Opening a database][boltdb].
@@ -127,19 +147,17 @@ Reference : [boltdb: Opening a database][boltdb].
 ### Multiple Trivy servers
 
 !!! error
-    ```
-    $ trivy image --server http://xxx.com:xxxx test-image
+`    $ trivy image --server http://xxx.com:xxxx test-image
     ...
     - twirp error internal: failed scan, test-image: failed to apply layers: layer cache missing: sha256:*****
-    ```
-To run multiple Trivy servers, you need to use Redis as the cache backend so that those servers can share the cache. 
+   `
+To run multiple Trivy servers, you need to use Redis as the cache backend so that those servers can share the cache.
 Follow [this instruction][redis-cache] to do so.
-
 
 ### Problems with `/tmp` on remote Git repository scans
 
 !!! error
-    FATAL repository scan error: scan error: unable to initialize a scanner: unable to initialize a filesystem scanner: git clone error: write /tmp/fanal-remote...
+FATAL repository scan error: scan error: unable to initialize a scanner: unable to initialize a filesystem scanner: git clone error: write /tmp/fanal-remote...
 
 Trivy clones remote Git repositories under the `/tmp` directory before scanning them. If `/tmp` doesn't work for you, you can change it by setting the `TMPDIR` environment variable.
 
@@ -152,11 +170,11 @@ $ TMPDIR=/my/custom/path trivy repo ...
 ### Running out of space during image scans
 
 !!! error
-    ``` bash
+`bash
     image scan failed:
     failed to copy the image:
     write /tmp/fanal-3323732142: no space left on device
-    ```
+   `
 
 Trivy uses a temporary directory during image scans.
 The directory path would be determined as follows:
@@ -180,39 +198,40 @@ Although these files are deleted after the scan is complete, they can temporaril
 In such cases, there are currently three workarounds:
 
 1. Use a temporary directory with sufficient capacity
- 
-    This is the same as explained above.
- 
+
+   This is the same as explained above.
+
 2. Specify a small value for `--parallel`
- 
-    By default, multiple layers are processed in parallel.
-    If each layer contains large files, disk space may be consumed rapidly.
-    By specifying a small value such as `--parallel 1`, parallelism is reduced, which can mitigate the issue.
+
+   By default, multiple layers are processed in parallel.
+   If each layer contains large files, disk space may be consumed rapidly.
+   By specifying a small value such as `--parallel 1`, parallelism is reduced, which can mitigate the issue.
 
 3. Specify `--skip-files` or `--skip-dirs`
- 
-    If the container image contains large files that do not need to be scanned, you can skip their processing by specifying --skip-files or --skip-dirs. 
-    For more details, please refer to [this documentation](../configuration/skipping.md).
+
+   If the container image contains large files that do not need to be scanned, you can skip their processing by specifying --skip-files or --skip-dirs.
+   For more details, please refer to [this documentation](../configuration/skipping.md).
 
 ## DB
+
 ### Old DB schema
 
 !!! error
-    --skip-update cannot be specified with the old DB schema.
+--skip-update cannot be specified with the old DB schema.
 
 Trivy v0.23.0 or later requires Trivy DB v2. Please update your local database or follow [the instruction of air-gapped environment][air-gapped].
 
 ### Error downloading vulnerability DB
 
 !!! error
-    FATAL failed to download vulnerability DB
+FATAL failed to download vulnerability DB
 
 If Trivy is running behind corporate firewall, refer to the necessary connectivity requirements as described [here][network].
 
 ### Denied
 
 !!! error
-    GET https://ghcr.io/token?scope=repository%3Aaquasecurity%2Ftrivy-db%3Apull&service=ghcr.io: DENIED: denied
+GET https://ghcr.io/token?scope=repository%3Aaquasecurity%2Ftrivy-db%3Apull&service=ghcr.io: DENIED: denied
 
 Your local GHCR (GitHub Container Registry) token might be expired.
 Please remove the token and try downloading the DB again.
@@ -228,9 +247,11 @@ unset GITHUB_TOKEN
 ```
 
 ## Homebrew
+
 ### Scope error
+
 !!! error
-    Error: Your macOS keychain GitHub credentials do not have sufficient scope!
+Error: Your macOS keychain GitHub credentials do not have sufficient scope!
 
 ```
 $ brew tap aquasecurity/trivy
@@ -249,8 +270,9 @@ $ printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase
 ```
 
 ### Already installed
+
 !!! error
-    Error: aquasecurity/trivy/trivy 64 already installed
+Error: aquasecurity/trivy/trivy 64 already installed
 
 ```
 $ brew upgrade
@@ -266,8 +288,8 @@ $ brew unlink trivy && brew uninstall trivy
 $ brew install aquasecurity/trivy/trivy
 ```
 
-
 ## Others
+
 ### Unknown error
 
 Try again after running `trivy clean --all`:


### PR DESCRIPTION
## Description

The documentation now mentions that the `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variables can be used to specify the location of your certificate. These could be used before, but was never stated as so within the official documentation.

## Related issues
- Close <https://github.com/aquasecurity/trivy/issues/8440>

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
