### PR TITLE
Spdx id license ignore

### DIFF
--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/clock"
+	"github.com/aquasecurity/trivy/pkg/licensing/expression"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/purl"
 )
@@ -178,7 +179,55 @@ func (c *IgnoreConfig) MatchSecret(secretID, filePath string) *IgnoreFinding {
 }
 
 func (c *IgnoreConfig) MatchLicense(licenseID, filePath string) *IgnoreFinding {
-	return c.Licenses.Match(licenseID, filePath, nil)
+	// First try exact match for the full expression
+	if finding := c.Licenses.Match(licenseID, filePath, nil); finding != nil {
+		return finding
+	}
+
+	// Try to parse as SPDX expression and check individual components
+	expr, err := expression.Normalize(licenseID)
+	if err != nil {
+		// If parsing fails, not a valid SPDX expression
+		return nil
+	}
+
+	// Extract license IDs from the expression
+	var licenseIDs []string
+	extractFromExpression(expr, &licenseIDs)
+
+	// If we have multiple components, check if all are ignored
+	if len(licenseIDs) > 1 {
+		for _, id := range licenseIDs {
+			if c.Licenses.Match(id, filePath, nil) == nil {
+				return nil // If any component is not ignored, don't ignore the expression
+			}
+		}
+		// All components are ignored, return a match
+		return &IgnoreFinding{
+			ID:        licenseID,
+			Statement: "All license components are individually ignored",
+		}
+	}
+
+	return nil
+}
+
+// extractFromExpression recursively walks the expression tree to extract license IDs
+func extractFromExpression(expr expression.Expression, licenseIDs *[]string) {
+	switch e := expr.(type) {
+	case expression.SimpleExpr:
+		// Use the String() method to get the complete license ID including any suffix
+		*licenseIDs = append(*licenseIDs, e.String())
+	case expression.CompoundExpr:
+		// For WITH expressions, treat as a single license
+		if e.Conjunction() == expression.TokenWith {
+			*licenseIDs = append(*licenseIDs, expr.String())
+		} else {
+			// For AND/OR expressions, recursively extract from both sides
+			extractFromExpression(e.Left(), licenseIDs)
+			extractFromExpression(e.Right(), licenseIDs)
+		}
+	}
 }
 
 func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -29,7 +29,7 @@ func TestParseIgnoreFile(t *testing.T) {
 		assert.Len(t, got.Vulnerabilities, 5)
 		assert.Len(t, got.Misconfigurations, 3)
 		assert.Len(t, got.Secrets, 3)
-		assert.Len(t, got.Licenses, 1)
+		assert.Len(t, got.Licenses, 3)
 	})
 
 	t.Run("empty YAML file passed", func(t *testing.T) {

--- a/pkg/result/testdata/.trivyignore.yaml
+++ b/pkg/result/testdata/.trivyignore.yaml
@@ -38,3 +38,5 @@ licenses:
   - id: GPL-3.0
     paths:
       - "usr/share/gcc/python/libstdcxx/v6/__init__.py"
+  - id: MIT
+  - id: LGPLv2+


### PR DESCRIPTION
## Description

Using license IDs to ignore SPDX expressions.

Previously, `--ignored-licenses LGPLv2+,MIT` would ignore those two licenses individually, but would not ignore combined licenses like `LGPLv2+ and MIT`.

### Before changes

```
$ trivy image --exit-code 1 --scanners license mysql --debug

...
├────────────────────────────────┤                                                              │                │          │
│ bzip2-libs                     │                                                              │                │          │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ ca-certificates                │ MIT AND GPL-2.0-or-later                                     │ unknown        │ UNKNOWN  │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ coreutils-single               │ GPLv3+                                                       │ restricted     │ HIGH     │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┤                │          │
...
```

```
$ trivy image --exit-code 1 --scanners license --ignored-licenses MIT,GPL-2.0-or-later mysql --debug

...
├────────────────────────────────┤                                                              │                │          │
│ bzip2-libs                     │                                                              │                │          │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ ca-certificates                │ MIT AND GPL-2.0-or-later                                     │ unknown        │ UNKNOWN  │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ coreutils-single               │ GPLv3+                                                       │ restricted     │ HIGH     │
├────────────────────────────────┼──────────────────────────────────────────────────────────────┤                │          │
...
```
The `ca-certificates` package *should* be ignored, but isn't.

### After changes

```
$ ./trivy image --exit-code 1 --scanners license mysql --debug

...
├──────────────────────────┤                                                              │                │          │
│ bzip2-libs               │                                                              │                │          │
├──────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ ca-certificates          │ MIT AND GPL-2.0-or-later                                     │ restricted     │ HIGH     │
├──────────────────────────┼──────────────────────────────────────────────────────────────┤                │          │
│ coreutils-single         │ GPLv3+                                                       │                │          │
├──────────────────────────┼──────────────────────────────────────────────────────────────┤                │          │
...
```

```
$ ./trivy image --exit-code 1 --scanners license --ignored-licenses MIT,GPL-2.0-or-later mysql --debug

...
├──────────────────────────┤                                                              │                │          │
│ bzip2-libs               │                                                              │                │          │
├──────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
│ coreutils-single         │ GPLv3+                                                       │ restricted     │ HIGH     │
├──────────────────────────┼──────────────────────────────────────────────────────────────┤                │          │
│ crypto-policies          │ LGPL-2.1-or-later                                            │                │          │
├──────────────────────────┼──────────────────────────────────────────────────────────────┼────────────────┼──────────┤
...
```


## Related issues
- Close #9045 

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
