### PR TITLE
docs(python): fix type with METADATA file name

### DIFF
--- a/docs/docs/coverage/language/index.md
+++ b/docs/docs/coverage/language/index.md
@@ -61,7 +61,7 @@ Example: [Dockerfile](https://github.com/aquasecurity/trivy-ci-test/blob/main/Do
 [license]: ../../scanner/license.md
 
 [^1]: `*.egg-info`, `*.egg-info/PKG-INFO`, `*.egg` and `EGG-INFO/PKG-INFO`
-[^2]: `.dist-info/META-DATA`
+[^2]: `.dist-info/METADATA`
 [^3]: `*.jar`, `*.war`, `*.par` and `*.ear`
 [^4]: ✅ means "enabled" and `-` means "disabled" in the image scanning
 [^5]: ✅ means "enabled" and `-` means "disabled" in the rootfs scanning

--- a/docs/docs/coverage/language/python.md
+++ b/docs/docs/coverage/language/python.md
@@ -148,7 +148,7 @@ See [here](https://packaging.python.org/en/latest/discussions/package-formats/) 
 Trivy looks for `*.egg-info`, `*.egg-info/PKG-INFO`, `*.egg` and `EGG-INFO/PKG-INFO` to identify Python packages.
 
 ### Wheel
-Trivy looks for `.dist-info/META-DATA` to identify Python packages.
+Trivy looks for `.dist-info/METADATA` to identify Python packages.
 
 [^1]: Trivy checks `python`, `python3`, `python2` and `python.exe` file names.
 


### PR DESCRIPTION
## Description
Fix typo (`META-DATA`) in `wheel` file name.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
