### PR TITLE
fix(alma): parse epochs from rpmqa file

### DIFF
--- a/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpmqa_test.go
@@ -21,7 +21,8 @@ func TestParseMarinerDistrolessManifest(t *testing.T) {
 			name: "happy path",
 			content: `mariner-release	2.0-12.cm2	1653816591	1653753130	Microsoft Corporation	(none)	580	noarch	0	mariner-release-2.0-12.cm2.src.rpm
 filesystem	1.1-9.cm2	1653816591	1653628924	Microsoft Corporation	(none)	7596	x86_64	0	filesystem-1.1-9.cm2.src.rpm
-glibc	2.35-2.cm2	1653816591	1653628955	Microsoft Corporation	(none)	10855265	x86_64	0	glibc-2.35-2.cm2.src.rpm`,
+glibc	2.35-2.cm2	1653816591	1653628955	Microsoft Corporation	(none)	10855265	x86_64	0	glibc-2.35-2.cm2.src.rpm
+ca-certificates-base	3.0.0-8.azl3	1748892790	1735838940	Microsoft Corporation	(none)	130628	noarch	1	ca-certificates-3.0.0-8.azl3.src.rpm`,
 			wantPkgs: []types.Package{
 				{
 					Name:       "mariner-release",
@@ -49,6 +50,17 @@ glibc	2.35-2.cm2	1653816591	1653628955	Microsoft Corporation	(none)	10855265	x86
 					SrcName:    "glibc",
 					SrcVersion: "2.35",
 					SrcRelease: "2.cm2",
+				},
+				{
+					Name:       "ca-certificates-base",
+					Version:    "3.0.0",
+					Epoch:      1,
+					Release:    "8.azl3",
+					Arch:       "noarch",
+					SrcName:    "ca-certificates",
+					SrcEpoch:   1,
+					SrcVersion: "3.0.0",
+					SrcRelease: "8.azl3",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Update the `/var/lib/rpmmanifest/container-manifest-2` file parsing to extract the epoch number.

## Related issues
- Closes https://github.com/aquasecurity/trivy/issues/9100

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [] I've included a "before" and "after" example to the description (if the PR is a user interface change).
