### PR TITLE
chore: drop FreeBSD 32-bit support

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -35,7 +35,8 @@ builds:
       - freebsd
     goarch:
       # modernc.org/sqlite doesn't support freebsd/arm64, etc.
-      - 386
+      # Also, freebsd/386 is no longer supported in modernc.org/libc
+      # See: https://gitlab.com/cznic/libc/-/issues/45
       - amd64
   - id: build-macos
     main: ./cmd/trivy/


### PR DESCRIPTION
## Summary
This PR removes FreeBSD 32-bit (386) support from Trivy's build configuration.

## Motivation
FreeBSD 32-bit builds are failing due to type mismatches in the `modernc.org/libc` library, which is a dependency of Trivy. The upstream library has compatibility issues with FreeBSD 32-bit architectures that cause build failures.

## Details
- Removed `386` architecture from the `build-bsd` section in `goreleaser.yml`
- Added a comment explaining why FreeBSD 32-bit is no longer supported
- No changes needed for `goreleaser-canary.yml` as it doesn't build for FreeBSD

## Related Issue
Upstream issue: https://gitlab.com/cznic/libc/-/issues/45

The issue shows multiple type mismatch errors when building on FreeBSD 32-bit:
- Cannot use `int64` values where `int32` is expected
- Type mismatches between `uint64` and `size_t`
- These errors prevent successful compilation on FreeBSD 32-bit platforms