### PR TITLE
fix(rootio): check full version to detect `root.io` packages

### DIFF
--- a/pkg/detector/ospkg/rootio/provider.go
+++ b/pkg/detector/ospkg/rootio/provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/driver"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
 )
 
 var (
@@ -37,7 +38,7 @@ func isRootIOEnvironment(osFamily ftypes.OSType, pkgs []ftypes.Package) bool {
 // hasPackageWithPattern checks if any package version matches the specified pattern
 func hasPackageWithPattern(pkgs []ftypes.Package, pattern *regexp.Regexp) bool {
 	for _, pkg := range pkgs {
-		if pattern.MatchString(pkg.Version) {
+		if pattern.MatchString(utils.FormatVersion(pkg)) {
 			return true
 		}
 	}

--- a/pkg/detector/ospkg/rootio/provider_test.go
+++ b/pkg/detector/ospkg/rootio/provider_test.go
@@ -21,7 +21,7 @@ func TestProvider(t *testing.T) {
 			name:     "Debian with .root.io package",
 			osFamily: ftypes.Debian,
 			pkgs: []ftypes.Package{
-				{Name: "libc6", Version: "2.31-13+deb11u4.root.io"},
+				{Name: "libc6", Version: "2.31", Release: "13+deb11u4.root.io"},
 				{Name: "bash", Version: "5.1-2+deb11u1"},
 			},
 			want: true,


### PR DESCRIPTION
## Description
`apk` packages use only `Version` field.
But `dpkg` packages use `Version` + `Release` + `Epoch`.
We need to build correct version to find `Root.io` suffixes.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
