### PR TITLE
feat(report): add partialFingerprints using CodeQl algorithim to SARIF

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -49,25 +49,27 @@ type SarifWriter struct {
 	Version       string
 	run           *sarif.Run
 	locationCache map[string][]location
+	lineHashCache map[string]map[int]string
 	Target        string
 }
 
 type sarifData struct {
-	title            string
-	vulnerabilityId  string
-	shortDescription string
-	fullDescription  string
-	helpText         string
-	helpMarkdown     string
-	resourceClass    types.ResultClass
-	severity         string
-	url              *url.URL
-	resultIndex      int
-	artifactLocation *url.URL
-	locationMessage  string
-	message          string
-	cvssScore        string
-	locations        []location
+	title              string
+	vulnerabilityId    string
+	shortDescription   string
+	fullDescription    string
+	helpText           string
+	helpMarkdown       string
+	resourceClass      types.ResultClass
+	severity           string
+	url                *url.URL
+	resultIndex        int
+	artifactLocation   *url.URL
+	locationMessage    string
+	message            string
+	cvssScore          string
+	locations          []location
+	partialFingerprint string
 }
 
 type location struct {
@@ -110,6 +112,12 @@ func (sw *SarifWriter) addSarifResult(data *sarifData) {
 		WithMessage(sarif.NewTextMessage(data.message)).
 		WithLevel(toSarifErrorLevel(data.severity)).
 		WithLocations(toSarifLocations(data.locations, data.artifactLocation.String(), data.locationMessage))
+
+	if data.partialFingerprint != "" {
+		result = result.WithPartialFingerPrints(map[string]any{
+			"primaryLocationLineHash": data.partialFingerprint,
+		})
+	}
 	sw.run.AddResult(result)
 }
 
@@ -132,6 +140,7 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 	sw.run.Tool.Driver.WithVersion(sw.Version)
 	sw.run.Tool.Driver.WithFullName("Trivy Vulnerability Scanner")
 	sw.locationCache = make(map[string][]location)
+	sw.lineHashCache = make(map[string]map[int]string)
 	if report.ArtifactType == ftypes.TypeContainerImage {
 		sw.run.Properties = sarif.Properties{
 			"imageName":   report.ArtifactName,
@@ -158,19 +167,29 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			if vuln.PkgPath != "" {
 				path = ToPathUri(vuln.PkgPath, res.Class)
 			}
+
+			locs := sw.getLocations(vuln.PkgName, vuln.InstalledVersion, path, res.Packages)
+			absBase, _ := filepath.Abs(sw.Target)
+
+			lineHash := ""
+			if len(locs) > 0 && locs[0].startLine > 0 {
+				lineHash = sw.getLineFingerprint(absBase, res.Target, locs[0].startLine)
+			}
+
 			sw.addSarifResult(&sarifData{
-				title:            "vulnerability",
-				vulnerabilityId:  vuln.VulnerabilityID,
-				severity:         vuln.Severity,
-				cvssScore:        getCVSSScore(vuln),
-				url:              toUri(vuln.PrimaryURL),
-				resourceClass:    res.Class,
-				artifactLocation: toUri(path),
-				locationMessage:  fmt.Sprintf("%v: %v@%v", path, vuln.PkgName, vuln.InstalledVersion),
-				locations:        sw.getLocations(vuln.PkgName, vuln.InstalledVersion, path, res.Packages),
-				resultIndex:      getRuleIndex(vuln.VulnerabilityID, ruleIndexes),
-				shortDescription: vuln.Title,
-				fullDescription:  fullDescription,
+				title:              "vulnerability",
+				vulnerabilityId:    vuln.VulnerabilityID,
+				severity:           vuln.Severity,
+				cvssScore:          getCVSSScore(vuln),
+				url:                toUri(vuln.PrimaryURL),
+				resourceClass:      res.Class,
+				artifactLocation:   toUri(path),
+				locationMessage:    fmt.Sprintf("%v: %v@%v", path, vuln.PkgName, vuln.InstalledVersion),
+				locations:          locs,
+				partialFingerprint: lineHash,
+				resultIndex:        getRuleIndex(vuln.VulnerabilityID, ruleIndexes),
+				shortDescription:   vuln.Title,
+				fullDescription:    fullDescription,
 				helpText: fmt.Sprintf("Vulnerability %v\nSeverity: %v\nPackage: %v\nFixed Version: %v\nLink: [%v](%v)\n%v",
 					vuln.VulnerabilityID, vuln.Severity, vuln.PkgName, vuln.FixedVersion, vuln.VulnerabilityID, vuln.PrimaryURL, vuln.Description),
 				helpMarkdown: fmt.Sprintf("**Vulnerability %v**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|%v|%v|%v|[%v](%v)|\n\n%v",
@@ -181,6 +200,9 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 		}
 		for _, misconf := range res.Misconfigurations {
 			locationURI := clearURI(res.Target)
+			absBase, _ := filepath.Abs(sw.Target)
+			lineHash := sw.getLineFingerprint(absBase, res.Target, misconf.CauseMetadata.StartLine)
+
 			sw.addSarifResult(&sarifData{
 				title:            "misconfiguration",
 				vulnerabilityId:  misconf.ID,
@@ -196,9 +218,10 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 						endLine:   misconf.CauseMetadata.EndLine,
 					},
 				},
-				resultIndex:      getRuleIndex(misconf.ID, ruleIndexes),
-				shortDescription: misconf.Title,
-				fullDescription:  misconf.Description,
+				partialFingerprint: lineHash,
+				resultIndex:        getRuleIndex(misconf.ID, ruleIndexes),
+				shortDescription:   misconf.Title,
+				fullDescription:    misconf.Description,
 				helpText: fmt.Sprintf("Misconfiguration %v\nType: %s\nSeverity: %v\nCheck: %v\nMessage: %v\nLink: [%v](%v)\n%s",
 					misconf.ID, misconf.Type, misconf.Severity, misconf.Title, misconf.Message, misconf.ID, misconf.PrimaryURL, misconf.Description),
 				helpMarkdown: fmt.Sprintf("**Misconfiguration %v**\n| Type | Severity | Check | Message | Link |\n| --- | --- | --- | --- | --- |\n|%v|%v|%v|%s|[%v](%v)|\n\n%v",
@@ -208,6 +231,10 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			})
 		}
 		for _, secret := range res.Secrets {
+
+			absBase, _ := filepath.Abs(sw.Target)
+			lineHash := sw.getLineFingerprint(absBase, res.Target, secret.StartLine)
+
 			sw.addSarifResult(&sarifData{
 				title:            "secret",
 				vulnerabilityId:  secret.RuleID,
@@ -223,9 +250,10 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 						endLine:   secret.EndLine,
 					},
 				},
-				resultIndex:      getRuleIndex(secret.RuleID, ruleIndexes),
-				shortDescription: secret.Title,
-				fullDescription:  secret.Match,
+				partialFingerprint: lineHash,
+				resultIndex:        getRuleIndex(secret.RuleID, ruleIndexes),
+				shortDescription:   secret.Title,
+				fullDescription:    secret.Match,
 				helpText: fmt.Sprintf("Secret %v\nSeverity: %v\nMatch: %s",
 					secret.Title, secret.Severity, secret.Match),
 				helpMarkdown: fmt.Sprintf("**Secret %v**\n| Severity | Match |\n| --- | --- |\n|%v|%v|",
@@ -437,4 +465,38 @@ func severityToScore(severity string) string {
 	default:
 		return "0.0"
 	}
+}
+
+// getLineFingerprint tries to resolve the full path and generate a fingerprint for the given line.
+func (sw *SarifWriter) getLineFingerprint(base, target string, line int) string {
+	absFullPath := target
+	if !filepath.IsAbs(target) {
+		absFullPath = filepath.Join(base, target)
+	}
+	absFullPath, err := filepath.Abs(absFullPath)
+	if err != nil {
+		log.WithPrefix("sarif").Error("Failed to resolve absolute path for fingerprinting", log.String("file", absFullPath), log.Err(err))
+		return ""
+	}
+
+	// use or initialize the hash cache for this file
+	lines, ok := sw.lineHashCache[absFullPath]
+	if !ok {
+		lines = make(map[int]string)
+		sw.lineHashCache[absFullPath] = lines
+	}
+
+	// return cached fingerprint if available
+	if fp, ok := lines[line]; ok {
+		return fp
+	}
+
+	// generate and cache the fingerprint
+	fp, err := generateCodeQLFingerprint(absFullPath, line)
+	if err != nil {
+		log.WithPrefix("sarif").Error("Could not generate partialFingerprint", log.String("file", absFullPath), log.Err(err))
+		return ""
+	}
+	lines[line] = fp
+	return fp
 }

--- a/pkg/report/sarif_fingerprints.go
+++ b/pkg/report/sarif_fingerprints.go
@@ -1,0 +1,142 @@
+package report
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+)
+
+const (
+	blockSize = 100
+	mod       = 37
+	eof       = 65535
+	tab       = '\t'
+	space     = ' '
+	lfeed     = '\n'
+	cret      = '\r'
+)
+
+// computeFirstMod computes mod^blockSize as an int64.
+func computeFirstMod() int64 {
+	firstMod := int64(1)
+	for i := 0; i < blockSize; i++ {
+		firstMod *= mod
+	}
+	return firstMod
+}
+
+// generateFingerprintFromReader returns the fingerprint (hash:suffix) for a given file and 1-based line number.
+func generateFingerprintFromReader(r io.Reader, targetLine int) (string, error) {
+
+	// Notes on the fingerprint algorithm:
+	// - This fingerprinting algorithm is based on the CodeQL implementation for line tracking.
+	// - For each line, it computes a rolling hash over the previous 100 non-whitespace characters (including the current line).
+	// - If the same hash appears more than once (e.g., for duplicate lines in the same context), a numeric suffix is appended to disambiguate them.
+	// - This approach allows for stable, position-independent identification of lines across file changes, useful for tracking code evolves.
+
+	var window [blockSize]int64
+	var lineNumbers [blockSize]int
+	var targetHash string
+	var targetSuffix int
+
+	for i := range lineNumbers {
+		lineNumbers[i] = -1
+	}
+
+	hashRaw := int64(0)
+	firstMod := computeFirstMod()
+	index := 0
+	lineNumber := 0
+	lineStart := true
+	prevCR := false
+	hashCounts := make(map[string]int)
+
+	// output the current hash and line number
+	outputHash := func() {
+		hashValue := strconv.FormatUint(uint64(hashRaw), 16)
+		suffix := hashCounts[hashValue] + 1
+		hashCounts[hashValue] = suffix
+		if lineNumbers[index] == targetLine {
+			targetHash = hashValue
+			targetSuffix = suffix
+		}
+		lineNumbers[index] = -1
+	}
+
+	// update the current hash value and increment the index in the window
+	updateHash := func(current int64) {
+		begin := window[index]
+		window[index] = current
+		hashRaw = mod*hashRaw + current - firstMod*begin
+		index = (index + 1) % blockSize
+	}
+
+	// process a single character
+	processCharacter := func(current int64) {
+		// skip tabs, spaces, and line feeds that come directly after a carriage return
+		if current == space || current == tab || (prevCR && current == lfeed) {
+			prevCR = false
+			return
+		}
+		// replace CR with LF
+		if current == cret {
+			current = lfeed
+			prevCR = true
+		} else {
+			prevCR = false
+		}
+		if lineNumbers[index] != -1 {
+			outputHash()
+		}
+		if lineStart {
+			lineStart = false
+			lineNumber++
+			lineNumbers[index] = lineNumber
+		}
+		if current == lfeed {
+			lineStart = true
+		}
+		updateHash(current)
+	}
+
+	reader := bufio.NewReader(r)
+	for {
+		r, size, err := reader.ReadRune()
+		if err != nil {
+			break
+		}
+		processCharacter(int64(r))
+		// ff multi-byte, skip remaining bytes
+		if size > 1 {
+			for i := 1; i < size; i++ {
+				_, _ = reader.ReadByte()
+			}
+		}
+	}
+	processCharacter(eof)
+
+	// flush the remaining lines
+	for i := 0; i < blockSize; i++ {
+		if lineNumbers[index] != -1 {
+			outputHash()
+		}
+		updateHash(0)
+	}
+
+	if targetHash == "" {
+		return "", fmt.Errorf("line %d not found in input", targetLine)
+	}
+	return targetHash + ":" + strconv.Itoa(targetSuffix), nil
+}
+
+// Wrapper function to generate a fingerprint from a file.
+func generateCodeQLFingerprint(filename string, targetLine int) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	return generateFingerprintFromReader(file, targetLine)
+}

--- a/pkg/report/sarif_fingerprints_test.go
+++ b/pkg/report/sarif_fingerprints_test.go
@@ -1,0 +1,87 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test fingerprint generation where lines are duplicated but the previous 100 characters differ.
+// This should result in a different hash for each line, even if the content is the same.
+func Test_generateFingerprintFromReader(t *testing.T) {
+	const testData = `def SomeFunction():
+	print("Hello, World!")
+	print("This is a test.")
+	print("Hello, World!")
+	print("It's cool to see how this works.")
+`
+
+	tests := []struct {
+		name       string
+		line       int
+		wantPrefix string
+		wantErr    bool
+	}{
+		{
+			name:       "first print statement",
+			line:       2,
+			wantPrefix: "a50e3d4e70d33bd8",
+			wantErr:    false,
+		},
+		{
+			name:       "second print statement",
+			line:       3,
+			wantPrefix: "307130b053b79a79",
+			wantErr:    false,
+		},
+		{
+			name:       "third print statement (duplicate)",
+			line:       4,
+			wantPrefix: "3561eccc8d202756",
+			wantErr:    false,
+		},
+		{
+			name:       "non-existent line",
+			line:       10,
+			wantPrefix: "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generateFingerprintFromReader(strings.NewReader(testData), tt.line)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			parts := strings.SplitN(got, ":", 2)
+			require.Len(t, parts, 2)
+			require.Equal(t, tt.wantPrefix, parts[0])
+			require.NotEmpty(t, parts[1])
+		})
+	}
+}
+
+// Test that the suffix is different for identical lines at the same position in the rolling window.
+// As the hash is based on the previous 100 characters, we need to repetition to ensure the suffix changes as the hash is the same.
+func Test_generateFingerprintFromReader_identicalHashes(t *testing.T) {
+	const longLine1 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz 0123456789 !@#$%^&*()_+-=[]{},.<>/?|:; 1234567890 ABCDEF\n" // 100 chars
+	const testData = longLine1 + longLine1
+
+	// Both lines are identical and start at the same position in the rolling window
+	fp1, err := generateFingerprintFromReader(strings.NewReader(testData), 1)
+	require.NoError(t, err)
+	fp2, err := generateFingerprintFromReader(strings.NewReader(testData), 2)
+	require.NoError(t, err)
+
+	parts1 := strings.SplitN(fp1, ":", 2)
+	parts2 := strings.SplitN(fp2, ":", 2)
+	require.Len(t, parts1, 2)
+	require.Len(t, parts2, 2)
+
+	require.Equal(t, parts1[0], parts2[0], "Hashes should be equal for identical lines at same window position")
+	require.NotEqual(t, parts1[1], parts2[1], "Suffix should be different for duplicate hashes")
+}


### PR DESCRIPTION
## Description

Adds the `partialFingerprints` element to SARIF results using the same hashing algorithm used by the CodeQL action.

The algorithm creates a hash for each line based a 100 char non-whitespace sliding window which includes the current line. This method seems to be ideal for tracking code in context where lines are being added or deleted. Should a single file result in the same hash for multiple lines, it will append a different suffix as a unique instance identifier.

The use of `partialFingerprints` in this way aligns with the GitHub Advanced Security [documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#including-data-for-fingerprint-generation) and helps reduce duplicate alerts being created for the same code, especially in the context of say a local terraform module.

As the hash generation requires reading the original source file from disk I've attempted to handle this properly. If there are issues the fingerprint is simply omitted.

## Related issues
- Close #9070

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
