### PR TITLE
fix: also check `filepath` when removing duplicate packages

### DIFF
--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -238,7 +238,9 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 	// De-duplicate same debian packages from different dirs
 	// cf. https://github.com/aquasecurity/trivy/issues/8297
 	mergedLayer.Packages = xslices.ZeroToNil(lo.UniqBy(mergedLayer.Packages, func(pkg ftypes.Package) string {
-		return cmp.Or(pkg.ID, fmt.Sprintf("%s@%s", pkg.Name, utils.FormatVersion(pkg)))
+		id := cmp.Or(pkg.ID, fmt.Sprintf("%s@%s", pkg.Name, utils.FormatVersion(pkg)))
+		// To avoid deduplicating packages with the same ID but from different locations (e.g. RPM archives), check the file path.
+		return fmt.Sprintf("%s/%s", id, pkg.FilePath)
 	}))
 
 	for _, app := range mergedLayer.Applications {

--- a/pkg/fanal/applier/docker_test.go
+++ b/pkg/fanal/applier/docker_test.go
@@ -258,7 +258,7 @@ func TestApplyLayers(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path with duplicate of debian packages",
+			name: "happy path with duplicate packages",
 			inputLayers: []types.BlobInfo{
 				{
 					SchemaVersion: 2,
@@ -273,6 +273,36 @@ func TestApplyLayers(t *testing.T) {
 									Name:    "libssl1.1",
 									Version: "1.1.1n",
 									Release: "0+deb11u3",
+								},
+							},
+						},
+						{
+							FilePath: "foo/socat-1.7.3.2-2.el7.x86_64.rpm",
+							Packages: types.Packages{
+								{
+									Name:       "socat",
+									Version:    "1.7.3.2",
+									Release:    "2.el7",
+									Arch:       "x86_64",
+									SrcName:    "socat",
+									SrcVersion: "1.7.3.2",
+									SrcRelease: "2.el7",
+									FilePath:   "foo/socat-1.7.3.2-2.el7.x86_64.rpm",
+								},
+							},
+						},
+						{
+							FilePath: "bar/socat-1.7.3.2-2.el7.x86_64.rpm",
+							Packages: types.Packages{
+								{
+									Name:       "socat",
+									Version:    "1.7.3.2",
+									Release:    "2.el7",
+									Arch:       "x86_64",
+									SrcName:    "socat",
+									SrcVersion: "1.7.3.2",
+									SrcRelease: "2.el7",
+									FilePath:   "bar/socat-1.7.3.2-2.el7.x86_64.rpm",
 								},
 							},
 						},
@@ -309,6 +339,38 @@ func TestApplyLayers(t *testing.T) {
 						},
 						Layer: types.Layer{
 							DiffID: "sha256:96e320b34b5478d8b369ca43ffaa88ff6dd9499ec72b792ca21b1e8b0c55670f",
+						},
+					},
+					{
+						Name:       "socat",
+						Version:    "1.7.3.2",
+						Release:    "2.el7",
+						Arch:       "x86_64",
+						SrcName:    "socat",
+						SrcVersion: "1.7.3.2",
+						SrcRelease: "2.el7",
+						FilePath:   "bar/socat-1.7.3.2-2.el7.x86_64.rpm",
+						Layer: types.Layer{
+							DiffID: "sha256:96e320b34b5478d8b369ca43ffaa88ff6dd9499ec72b792ca21b1e8b0c55670f",
+						},
+						Identifier: types.PkgIdentifier{
+							UID: "bfb68335f6284b36",
+						},
+					},
+					{
+						Name:       "socat",
+						Version:    "1.7.3.2",
+						Release:    "2.el7",
+						Arch:       "x86_64",
+						SrcName:    "socat",
+						SrcVersion: "1.7.3.2",
+						SrcRelease: "2.el7",
+						FilePath:   "foo/socat-1.7.3.2-2.el7.x86_64.rpm",
+						Layer: types.Layer{
+							DiffID: "sha256:96e320b34b5478d8b369ca43ffaa88ff6dd9499ec72b792ca21b1e8b0c55670f",
+						},
+						Identifier: types.PkgIdentifier{
+							UID: "4d8db4fac0caf460",
 						},
 					},
 				},


### PR DESCRIPTION
## Description
We added filter to remove duplicate OS packages in #8298.
But there are cases when we don't need to remove duplicates, e.g. when we found 2 same rpm archives from different locations.
That is why we need to check `Package.FilePath` when removing duplicate packages. 

## Related PRs
- [x] #8298


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
