### PR TITLE
fix(terraform): `for_each` on a map returns a resource for every key

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -317,7 +317,7 @@ func (e *evaluator) expandBlockForEaches(blocks terraform.Blocks) terraform.Bloc
 
 		forEachAttr := block.GetAttribute("for_each")
 
-		if forEachAttr.IsNil() || block.IsExpanded() || !isBlockSupportsForEachMetaArgument(block) || e.shouldDeferForEachExpansion(forEachAttr, block) {
+		if forEachAttr.IsNil() || block.IsExpanded() || !isBlockSupportsForEachMetaArgument(block) || e.shouldDeferForEachExpansion(forEachAttr) {
 			forEachFiltered = append(forEachFiltered, block)
 			continue
 		}
@@ -654,7 +654,7 @@ func isForEachKey(key cty.Value) bool {
 	return key.Type().Equals(cty.Number) || key.Type().Equals(cty.String)
 }
 
-func (e *evaluator) shouldDeferForEachExpansion(forEachAttr *terraform.Attribute, block *terraform.Block) bool {
+func (e *evaluator) shouldDeferForEachExpansion(forEachAttr *terraform.Attribute) bool {
 	// Check if the for_each references a local value
 	for _, ref := range forEachAttr.AllReferences() {
 		if ref.BlockType().Name() == "locals" {

--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -567,7 +567,7 @@ func (e *evaluator) getValuesByBlockType(blockType string) cty.Value {
 
 			// Data blocks should all be loaded into the top level 'values'
 			// object. The hierarchy of the map is:
-			//  values = map[<type>]map[<n>] =
+			//  values = map[<type>]map[<name>] =
 			//              Block -> Block's attributes as a cty.Object
 			//              Tuple(Block) -> Instances of the block
 			//              Object(Block) -> Field values are instances of the block


### PR DESCRIPTION
## Description
for_each was being evaluated before the locals were evaluated which
was making it iterate over a `cty.DynamicPseudoType` which meant it
was iterating over the keys of a single instance resource instead of
the values of the for_each.

See the tests added for proof of the problem.   I've left the debug log
lines in because they were useful fixing the issue but I can remove them
if we don't want them.

You can see this when running `--debug`:

```
❯ go run cmd/trivy/main.go conf ../tfparse/tests/terraform/for_each --debug
2025-07-07T15:00:57-04:00	DEBUG	[terraform evaluator] Expanded block into clones via 'for_each' attribute.	module="root" block="aws_iam_role_policy_attachment.administrative_policy_attachment" clones=4
```
We expect 2 clones, not 4 with my example.   With this PR:

```
2025-07-07T15:05:46-04:00	DEBUG	[terraform evaluator] Expanded block into clones via 'for_each' attribute.	module="root" block="aws_iam_role_policy_attachment.administrative_policy_attachment" clones=2
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9187

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
