### PR TITLE
chore: Update release workflow to trigger version updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,3 +85,32 @@ jobs:
           # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
           # This allows the created PR to trigger tests and other workflows
           GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+
+  # `trigger-version-update` triggers the `update_version` workflow in the `trivy-telemetry` repository
+  # and the trivy-downloads repository.
+  trigger-version-update:
+    needs: deploy-packages
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Trigger update_version workflow in trivy-telemetry
+        env:
+          # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
+          # This allows triggering workflows in other repositories
+          GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+        run: |
+          gh workflow run update_version.yml \
+            --repo aquasecurity/trivy-telemetry \
+            --ref main \
+            --field version=${{ github.ref_name }}
+
+      - name: Trigger update_version workflow in trivy-downloads
+        env:
+          # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
+          # This allows triggering workflows in other repositories
+          GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+        run: |
+          gh workflow run update_version.yml \
+            --repo aquasecurity/trivy-downloads \
+            --ref main \
+            --field version=${{ github.ref_name }} \
+            --field artifact=trivy


### PR DESCRIPTION
## Description
When the release workflow is run, after it is successfully completed we want to `worfklow_dispatch` the updater worfklows in trivy_telemetry and trivy_downloads to update the config and deploy the updates to the cloudflare workers

This addition uses the gh cli available on GitHub runners with the `ORG_REPO_TOKEN` to trigger the workflows on the repositories, passing the version (`github.ref_name`) and in the case of the download, the artifact (`trivy`).

This has been tested using a test workflow to ensure that the `ORG_REPO_TOKEN` is able to do the required trigger and it has been confirmed to [work](https://github.com/aquasecurity/trivy/actions/runs/16140193897/job/45545738450?pr=9161).

## Related issues
- Close #9148


## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
