### PR TITLE
chore: add debug log to show image source location

### DIFF
--- a/pkg/fanal/image/image.go
+++ b/pkg/fanal/image/image.go
@@ -25,7 +25,7 @@ var imageSourceFuncs = map[types.ImageSource]imageSourceFunc{
 
 func NewContainerImage(ctx context.Context, imageName string, opt types.ImageOptions) (types.Image, func(), error) {
 	ctx = log.WithContextPrefix(ctx, log.PrefixContainerImage)
-	
+
 	if len(opt.ImageSources) == 0 {
 		return nil, func() {}, xerrors.New("no image sources supplied")
 	}


### PR DESCRIPTION
## Description

This change adds debug logging to clearly show which image source (docker, remote, containerd, podman) was used to find an image during scanning.

The main benefits are:
- Users can easily identify when their image is being pulled from an unexpected source
- Especially helpful when users expect to use local images but a remote registry is used instead (and vice versa)

The implementation:
- Adds `[image]` prefix to logs using `log.WithContextPrefix` and `log.PrefixContainerImage`
- Uses context-aware logging with `DebugContext` and `WarnContext`
- Shows both image name and source in the debug message

## Before/After

### Before
```
2025-07-08T14:42:05+04:00	DEBUG	[image] Detected image ID	image_id="sha256:5a3b4d76fdf28473d4a7b7d0aadb65147bc4e5d870fb5cf57f837fda315ecd6d"
```

### After
```
2025-07-08T14:42:05+04:00	DEBUG	[image] Image found	image="debian:11" source="docker"
2025-07-08T14:42:05+04:00	DEBUG	[image] Detected image ID	image_id="sha256:5a3b4d76fdf28473d4a7b7d0aadb65147bc4e5d870fb5cf57f837fda315ecd6d"
```

Users can now clearly see that the image was found from the "docker" source rather than being pulled from a remote registry.

## Related issues
None

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).