### PR TITLE
ci: optimize golangci-lint performance with cache-based strategy

### DIFF
--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Run golangci-lint for caching
         uses: golangci/golangci-lint-action@v7.0.0

--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -1,4 +1,9 @@
-name: Cache test images and lint
+name: Cache test assets
+# This workflow runs on the main branch to create caches that can be accessed by PRs.
+# GitHub Actions cache isolation restricts access:
+# - PRs can only restore caches from: current branch, base branch, and default branch (main)
+# - PRs cannot restore caches from sibling branches or other PR branches
+# - By creating caches on the main branch, all PRs can benefit from shared cache
 on:
   push:
     branches: [main]

--- a/.github/workflows/cache-test-images.yaml
+++ b/.github/workflows/cache-test-images.yaml
@@ -1,7 +1,7 @@
-name: Cache test images
+name: Cache test images and lint
 on:
-  schedule:
-    - cron: "0 0 * * *" # Run this workflow every day at 00:00 to avoid cache deletion.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -22,7 +22,6 @@ jobs:
         run: go install tool # GOBIN is added to the PATH by the setup-go action
 
       - name: Generate image list digest
-        if: github.ref_name == 'main'
         id: image-digest
         run: |
           source integration/testimages.ini
@@ -30,16 +29,13 @@ jobs:
           DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags += ["containerd"] | .Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
-      ## We need to work with test image cache only for main branch
       - name: Restore and save test images cache
-        if: github.ref_name == 'main'
         uses: actions/cache@v4
         with:
           path: integration/testdata/fixtures/images
           key: cache-test-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Download test images
-        if: github.ref_name == 'main'
         run: mage test:fixtureContainerImages
 
   test-vm-images:
@@ -59,7 +55,6 @@ jobs:
         run: go install tool # GOBIN is added to the PATH by the setup-go action
 
       - name: Generate image list digest
-        if: github.ref_name == 'main'
         id: image-digest
         run: |
           source integration/testimages.ini
@@ -67,14 +62,30 @@ jobs:
           DIGEST=$(echo "$IMAGE_LIST" | jq '.Tags |= sort' | sha256sum | cut -d' ' -f1)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
-      ## We need to work with test VM image cache only for main branch
       - name: Restore and save test VM images cache
-        if: github.ref_name == 'main'
         uses: actions/cache@v4
         with:
           path: integration/testdata/fixtures/vm-images
           key: cache-test-vm-images-${{ steps.image-digest.outputs.digest }}
 
       - name: Download test VM images
-        if: github.ref_name == 'main'
         run: mage test:fixtureVMImages
+
+  lint-cache:
+    name: Cache lint results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.1.6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint for caching
+        uses: golangci/golangci-lint-action@v7.0.0
+        with:
+          version: v2.1
+          args: --verbose

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: v2.1
-          args: --verbose ${{ github.base_ref && format('--new-from-merge-base=origin/{0} --whole-files', github.base_ref) || '' }}
+          args: --verbose
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,8 @@ jobs:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0  # Fetch full history for proper diff analysis
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -41,7 +43,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: v2.1
-          args: --verbose
+          args: --verbose ${{ github.event_name == 'pull_request' && format('--new-from-merge-base=origin/{0} --whole-files', github.base_ref) || '' }}
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,6 @@ jobs:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4.1.6
-        with:
-          fetch-depth: 0  # Fetch full history for proper diff analysis
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -43,7 +41,8 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: v2.1
-          args: --verbose ${{ github.event_name == 'pull_request' && format('--new-from-merge-base=origin/{0} --whole-files', github.base_ref) || '' }}
+          args: --verbose
+          skip-save-cache: true  # Restore cache from main branch but don't save new cache
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: v2.1
-          args: --verbose
+          args: --verbose ${{ github.base_ref && format('--new-from-merge-base=origin/{0} --whole-files', github.base_ref) || '' }}
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed


### PR DESCRIPTION
## Summary

This PR optimizes golangci-lint performance in CI by implementing a cache-based strategy.

## Changes

### Cache Strategy Implementation
- **Added `cache-test-assets.yaml`**: Creates lint cache on main branch pushes
- **Modified `test.yaml`**: PRs restore cache from main branch but skip saving new cache (`skip-save-cache: true`)
- **Cache isolation**: To work around GitHub Actions cache restrictions, where PRs cannot access caches in other branches, the new workflow stores cache in the main branch

### Considerations
- **Trigger change**: Changed from daily cron to main branch push
    - - **Reduced 429 errors**: Even if test images cache misses occur, Trivy DB migrated to mirror.gcr.io reduces rate limiting risks
- **Reduced cache eviction**: By disabling lint cache saves in PRs, test image caches are less likely to be evicted

## Performance Results

### Fork Verification
Verified the optimization in fork: https://github.com/knqyf263/trivy/actions/runs/16188373483/job/45698332853

**Before optimization**: ~8 minutes
**After optimization**: ~ 3 minutes

### Expected Benefits
- **Faster CI**: PRs benefit from cached lint analysis from the main branch
- **Storage optimization**: Eliminates redundant cache creation per PR

## Rationale

### Why Cache Strategy Over Differential Linting

Initially attempted `--new-from-merge-base` for differential linting, but this approach had limitations:
- Full git history fetch overhead (`fetch-depth: 0`)
- Ineffective file filtering with `--whole-files`
- Performance not improved

The cache-based approach provides more reliable performance improvements by leveraging golangci-lint's built-in caching mechanism.