### PR TITLE
fix(aws): update amazon linux 2 EOL date

### DIFF
--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -21,7 +21,7 @@ var (
 		// https://aws.amazon.com/jp/blogs/aws/update-on-amazon-linux-ami-end-of-life/
 		"1": time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
 		// https://aws.amazon.com/amazon-linux-2/faqs/?nc1=h_ls
-		"2": time.Date(2025, 6, 30, 23, 59, 59, 0, time.UTC),
+		"2": time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC),
 		// Amazon Linux 2022 was renamed to 2023. AL2022 is not currently supported.
 		"2023": time.Date(2028, 3, 15, 23, 59, 59, 0, time.UTC),
 	}


### PR DESCRIPTION
## Description

This pull request will fix the EOL date for Amazon Linux 2. Amazon has extended the EOL date for AL2 to **30th Jun 2026**

https://aws.amazon.com/amazon-linux-2/faqs/#topic-0
https://repost.aws/questions/QU8_7ivy19Q7Wq3CKUE5b7Jw/amazon-linux-2-motd-says-eol-is-2025-06-30

## Related issues
- None

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
