### PR TITLE
ci: delete cache after artifacts upload in canary workflow

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -23,12 +23,14 @@ jobs:
     name: Upload binaries
     needs: build-binaries # run this job after 'build-binaries' job completes
     runs-on: ubuntu-latest
+    env:
+      CACHE_KEY: ${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}
     steps:
       - name: Restore Trivy binaries from cache
         uses: actions/cache@v4
         with:
           path: dist/
-          key: ${{ runner.os }}-bins-${{github.workflow}}-${{github.sha}}
+          key: ${{ env.CACHE_KEY }}
 
         # Upload artifacts
       - name: Upload artifacts (trivy_Linux-64bit)
@@ -58,3 +60,9 @@ jobs:
           name: trivy_macOS-ARM64
           path: dist/trivy_*_macOS-ARM64.tar.gz
           if-no-files-found: error
+
+      - name: Delete cache after upload
+        run: |
+          gh cache delete "$CACHE_KEY" --confirm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Add cache deletion step after uploading artifacts in canary workflow to prevent unnecessary cache accumulation.

This change adds a cleanup step that deletes the cache entry after all artifacts are successfully uploaded, preventing the cache from taking up storage space unnecessarily. Since GitHub Actions has a 10GB cache limit, removing unused caches helps prevent important caches from being evicted.

## Changes
- Add `CACHE_KEY` environment variable at job level to avoid duplication
- Add cache deletion step using GitHub CLI after all artifacts are uploaded

## Benefits
- Prevents cache accumulation that wastes storage space
- Avoids hitting GitHub's 10GB cache limit which could cause important caches to be evicted
- Improves maintainability by using environment variables instead of duplicating cache keys

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).