### PR TITLE
fix(vuln): save package-specific severity before severity selection

### DIFF
--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -88,6 +88,18 @@ func (c Client) FillInfo(vulns []types.DetectedVulnerability, severitySources []
 			continue
 		}
 
+		// The vendor might provide package-specific severity like Debian.
+		// For example, CVE-2015-2328 in Debian has "unimportant" for mongodb and "low" for pcre3.
+		// In that case, we keep the severity as is.
+		if vulns[i].SeveritySource != "" {
+			// Store package-specific severity in vendor severities
+			if vuln.VendorSeverity == nil {
+				vuln.VendorSeverity = make(dbTypes.VendorSeverity)
+			}
+			s, _ := dbTypes.NewSeverity(vulns[i].Severity) // skip error handling because `SeverityUnknown` will be returned in case of error
+			vuln.VendorSeverity[vulns[i].SeveritySource] = s
+		}
+
 		// Detect the data source
 		dataSource := lo.FromPtr(vulns[i].DataSource)
 
@@ -95,21 +107,6 @@ func (c Client) FillInfo(vulns []types.DetectedVulnerability, severitySources []
 		severity, severitySource := c.getSeverity(vulnID, &vuln, dataSource, severitySources)
 		if severity == dbTypes.SeverityUnknown.String() {
 			noSeverityIDs = append(noSeverityIDs, vulnID)
-		}
-
-		// The vendor might provide package-specific severity like Debian.
-		// For example, CVE-2015-2328 in Debian has "unimportant" for mongodb and "low" for pcre3.
-		// In that case, we keep the severity as is.
-		if vulns[i].SeveritySource != "" {
-			severity = vulns[i].Severity
-			severitySource = vulns[i].SeveritySource
-
-			// Store package-specific severity in vendor severities
-			if vuln.VendorSeverity == nil {
-				vuln.VendorSeverity = make(dbTypes.VendorSeverity)
-			}
-			s, _ := dbTypes.NewSeverity(severity) // skip error handling because `SeverityUnknown` will be returned in case of error
-			vuln.VendorSeverity[severitySource] = s
 		}
 
 		// Add the vulnerability detail

--- a/pkg/vulnerability/vulnerability_test.go
+++ b/pkg/vulnerability/vulnerability_test.go
@@ -211,6 +211,11 @@ func TestClient_FillInfo(t *testing.T) {
 					Vulnerability: dbTypes.Vulnerability{
 						Severity: dbTypes.SeverityLow.String(),
 					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
 				},
 			},
 			expectedVulnerabilities: []types.DetectedVulnerability{
@@ -230,6 +235,56 @@ func TestClient_FillInfo(t *testing.T) {
 						PublishedDate:    utils.MustTimeParse("2001-01-01T01:01:00Z"),
 					},
 					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2019-0001",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+			},
+		},
+		{
+			name:     "happy path, with package-specific severity, but use NVD severity",
+			fixtures: []string{"testdata/fixtures/vulnerability.yaml"},
+			vulnSeveritySources: []dbTypes.SourceID{
+				"nvd",
+			},
+			vulns: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-0001",
+					SeveritySource:  vulnerability.Debian,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityCritical.String(),
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
+				},
+			},
+			expectedVulnerabilities: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-0001",
+					Status:          dbTypes.StatusAffected,
+					SeveritySource:  vulnerability.NVD,
+					Vulnerability: dbTypes.Vulnerability{
+						Title:       "dos",
+						Description: "dos vulnerability",
+						Severity:    dbTypes.SeverityLow.String(),
+						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+							vulnerability.Debian: dbTypes.SeverityCritical,
+							vulnerability.GHSA:   dbTypes.SeverityHigh,
+							vulnerability.NVD:    dbTypes.SeverityLow,
+						},
+						References: []string{"http://example.com"},
+					},
+					PrimaryURL: "https://avd.aquasec.com/nvd/cve-2022-0001",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Debian,
+						Name: "Debian Security Tracker",
+						URL:  "https://salsa.debian.org/security-tracker-team/security-tracker",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Refactored vulnerability severity processing logic to fix package-specific severity handling. The changes move the package-specific severity processing earlier in the flow and ensure vendor severities are properly stored before the main severity selection logic runs.

## Reason
The original code had a logical issue where package-specific severity handling was interfering with the main severity selection process. When a vulnerability had a SeveritySource set (indicating package-specific severity), the code was overriding the selected severity and source, but this happened after the main severity selection logic had already run.

## Benefits
- Correct vendor severity storage: Package-specific severities are now properly stored in VendorSeverity map before main processing
- Improved severity selection: Main severity selection logic (getSeverity) now runs with complete vendor severity data available
- Better separation of concerns: Package-specific severity handling is now clearly separated from main severity selection
- Preserved existing behavior: All existing functionality is maintained while fixing the logical flow issue

## Examples:
Before:
```bash
➜  trivy -q image debian -f json --vuln-severity-source nvd | grep SeveritySource | sort -u
          "SeveritySource": "debian",
          "SeveritySource": "nvd",
```
After:
```bash
➜  ./trivy -q image debian -f json --vuln-severity-source nvd | grep SeveritySource | sort -u
          "SeveritySource": "nvd",
```


## Related issues
- Close #9191

## Related PRs
- [x] #8269

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
