### PR TITLE
feat(misconf): add private ip google access attribute to subnetwork

### DIFF
--- a/pkg/iac/adapters/terraform/google/compute/networks.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks.go
@@ -33,6 +33,7 @@ func adaptNetworks(modules terraform.Modules) (networks []compute.Network) {
 			Name:           subnetworkBlock.GetAttribute("name").AsStringValueOrDefault("", subnetworkBlock),
 			Purpose:        subnetworkBlock.GetAttribute("purpose").AsStringValueOrDefault(defaultSubnetPurpose, subnetworkBlock),
 			EnableFlowLogs: iacTypes.BoolDefault(false, subnetworkBlock.GetMetadata()),
+			PrivateIPGoogleAccess: subnetworkBlock.GetAttribute("private_ip_google_access").AsBoolValueOrDefault(false, subnetworkBlock),
 		}
 
 		// logging

--- a/pkg/iac/adapters/terraform/google/compute/networks.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks.go
@@ -29,10 +29,10 @@ func adaptNetworks(modules terraform.Modules) (networks []compute.Network) {
 	for _, subnetworkBlock := range modules.GetResourcesByType("google_compute_subnetwork") {
 
 		subnetwork := compute.SubNetwork{
-			Metadata:       subnetworkBlock.GetMetadata(),
-			Name:           subnetworkBlock.GetAttribute("name").AsStringValueOrDefault("", subnetworkBlock),
-			Purpose:        subnetworkBlock.GetAttribute("purpose").AsStringValueOrDefault(defaultSubnetPurpose, subnetworkBlock),
-			EnableFlowLogs: iacTypes.BoolDefault(false, subnetworkBlock.GetMetadata()),
+			Metadata:              subnetworkBlock.GetMetadata(),
+			Name:                  subnetworkBlock.GetAttribute("name").AsStringValueOrDefault("", subnetworkBlock),
+			Purpose:               subnetworkBlock.GetAttribute("purpose").AsStringValueOrDefault(defaultSubnetPurpose, subnetworkBlock),
+			EnableFlowLogs:        iacTypes.BoolDefault(false, subnetworkBlock.GetMetadata()),
 			PrivateIPGoogleAccess: subnetworkBlock.GetAttribute("private_ip_google_access").AsBoolValueOrDefault(false, subnetworkBlock),
 		}
 

--- a/pkg/iac/adapters/terraform/google/compute/networks_test.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks_test.go
@@ -122,6 +122,34 @@ func Test_adaptNetworks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "private_ip_google_access_enabled",
+			terraform: `
+			resource "google_compute_subnetwork" "example" {
+				name          = "test-subnetwork"
+				network       = google_compute_network.example.id
+				private_ip_google_access = true
+			}
+			resource "google_compute_network" "example" {
+				name = "test-network"
+			}
+			`,
+			expected: []compute.Network{
+				{
+					Metadata: iacTypes.NewTestMetadata(),
+					Firewall: nil,
+					Subnetworks: []compute.SubNetwork{
+						{
+							Metadata:              iacTypes.NewTestMetadata(),
+							Name:                  iacTypes.String("test-subnetwork", iacTypes.NewTestMetadata()),
+							Purpose:               iacTypes.StringDefault("PRIVATE_RFC_1918", iacTypes.NewTestMetadata()),
+							EnableFlowLogs:        iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+							PrivateIPGoogleAccess: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/iac/providers/google/compute/subnetwork.go
+++ b/pkg/iac/providers/google/compute/subnetwork.go
@@ -5,9 +5,9 @@ import (
 )
 
 type SubNetwork struct {
-	Metadata       iacTypes.Metadata
-	Name           iacTypes.StringValue
-	Purpose        iacTypes.StringValue
-	EnableFlowLogs iacTypes.BoolValue
+	Metadata              iacTypes.Metadata
+	Name                  iacTypes.StringValue
+	Purpose               iacTypes.StringValue
+	EnableFlowLogs        iacTypes.BoolValue
 	PrivateIPGoogleAccess iacTypes.BoolValue
 }

--- a/pkg/iac/providers/google/compute/subnetwork.go
+++ b/pkg/iac/providers/google/compute/subnetwork.go
@@ -9,4 +9,5 @@ type SubNetwork struct {
 	Name           iacTypes.StringValue
 	Purpose        iacTypes.StringValue
 	EnableFlowLogs iacTypes.BoolValue
+	PrivateIPGoogleAccess iacTypes.BoolValue
 }

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -3924,6 +3924,19 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.aws.sam.AccessLogging": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "cloudwatchloggrouparn": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.aws.sam.Application": {
       "type": "object",
       "properties": {
@@ -5508,6 +5521,19 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.synapse.Workspace": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "enablemanagedvirtualnetwork": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.cloudstack.CloudStack": {
       "type": "object",
       "properties": {
@@ -6292,6 +6318,30 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.ServiceAccount": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "email": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "isdefault": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+          }
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.ShieldedVMConfig": {
       "type": "object",
       "properties": {
@@ -6331,10 +6381,6 @@
         "purpose": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        },
-        "privateipgoogleaccess": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
         }
       }
     },
@@ -7062,6 +7108,45 @@
         "ipconfiguration": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.sql.IPConfiguration"
+        }
+      }
+    },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.google.storage.Bucket": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Binding"
+          }
+        },
+        "enableuniformbucketlevelaccess": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "encryption": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.storage.BucketEncryption"
+        },
+        "location": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Member"
+          }
+        },
+        "name": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         }
       }
     },

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -6381,6 +6381,10 @@
         "purpose": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "privateipgoogleaccess": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
         }
       }
     },

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -6378,13 +6378,13 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         },
-        "purpose": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        },
         "privateipgoogleaccess": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "purpose": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         }
       }
     },

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -3924,19 +3924,6 @@
         }
       }
     },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.aws.sam.AccessLogging": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "cloudwatchloggrouparn": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        }
-      }
-    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.aws.sam.Application": {
       "type": "object",
       "properties": {
@@ -5521,19 +5508,6 @@
         }
       }
     },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.synapse.Workspace": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "enablemanagedvirtualnetwork": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
-        }
-      }
-    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.cloudstack.CloudStack": {
       "type": "object",
       "properties": {
@@ -6318,30 +6292,6 @@
         }
       }
     },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.ServiceAccount": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "email": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        },
-        "isdefault": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
-        },
-        "scopes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-          }
-        }
-      }
-    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.ShieldedVMConfig": {
       "type": "object",
       "properties": {
@@ -6381,6 +6331,10 @@
         "purpose": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "privateipgoogleaccess": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
         }
       }
     },
@@ -7108,45 +7062,6 @@
         "ipconfiguration": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.sql.IPConfiguration"
-        }
-      }
-    },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.google.storage.Bucket": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "bindings": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Binding"
-          }
-        },
-        "enableuniformbucketlevelaccess": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
-        },
-        "encryption": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.storage.BucketEncryption"
-        },
-        "location": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        },
-        "members": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.iam.Member"
-          }
-        },
-        "name": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         }
       }
     },


### PR DESCRIPTION
## Description
Added private ip google access attribute to subnetwork in order to test it in a new check.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
