### PR TITLE
fix(cli): panic: attempt to get os.Args[1] when len(os.Args) < 2

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -126,7 +126,7 @@ func NewRunner(ctx context.Context, cliOptions flag.Options, opts ...RunnerOptio
 		TraceHTTP: cliOptions.TraceHTTP,
 	}))
 	// get the sub command that is being used or fallback to "trivy"
-	commandName := lo.TernaryF(len(os.Args) > 1, func() string { return os.Args[1] }, func() string { return "trivy" })
+	commandName := lo.NthOr(os.Args, 1, "trivy")
 	r.versionChecker = notification.NewVersionChecker(commandName, &cliOptions)
 
 	// Update the vulnerability database if needed.

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -126,7 +126,7 @@ func NewRunner(ctx context.Context, cliOptions flag.Options, opts ...RunnerOptio
 		TraceHTTP: cliOptions.TraceHTTP,
 	}))
 	// get the sub command that is being used or fallback to "trivy"
-	commandName := lo.Ternary(len(os.Args) > 1, os.Args[1], "trivy")
+	commandName := lo.TernaryF(len(os.Args) > 1, func() string { return os.Args[1] }, func() string { return "trivy" })
 	r.versionChecker = notification.NewVersionChecker(commandName, &cliOptions)
 
 	// Update the vulnerability database if needed.


### PR DESCRIPTION
## Description
When running with the number of cli args < 2 panic "Runtime Error: Index out of range [1] with Length 1" on the file 
https://github.com/aquasecurity/trivy/blob/60723e6cfce82ede2863cf545a189c581246f4e9/pkg/commands/artifact/run.go#L129
I replaced the call to lo.Ternary with lo.TernaryF, thereby eliminating the call to os.Args[1] when len(os.Args) < 2

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
