### PR TITLE
feat(alma): add AlmaLinux 10 support

### DIFF
--- a/docs/docs/coverage/os/index.md
+++ b/docs/docs/coverage/os/index.md
@@ -18,7 +18,7 @@ Trivy supports operating systems for
 | [Red Hat Enterprise Linux](rhel.md)   | 6, 7, 8, 9                          | dnf/yum/rpm      |
 | [Red Hat Enterprise Linux](rhel.md)   | 10 (SBOM only)                      | dnf/yum/rpm      |
 | [CentOS](centos.md)[^1]               | 6, 7, 8                             | dnf/yum/rpm      |
-| [AlmaLinux](alma.md)                  | 8, 9                                | dnf/yum/rpm      |
+| [AlmaLinux](alma.md)                  | 8, 9, 10                            | dnf/yum/rpm      |
 | [Rocky Linux](rocky.md)               | 8, 9                                | dnf/yum/rpm      |
 | [Oracle Linux](oracle.md)             | 5, 6, 7, 8                          | dnf/yum/rpm      |
 | [Azure Linux (CBL-Mariner)](azure.md) | 1.0, 2.0, 3.0                       | tdnf/dnf/yum/rpm |

--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -22,6 +22,7 @@ var (
 		// https://endoflife.date/almalinux
 		"8": time.Date(2029, 3, 1, 23, 59, 59, 0, time.UTC),
 		"9": time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC),
+		"10": time.Date(2035, 5, 31, 23, 59, 59, 0, time.UTC),
 	}
 )
 

--- a/pkg/detector/ospkg/alma/alma.go
+++ b/pkg/detector/ospkg/alma/alma.go
@@ -20,8 +20,8 @@ var (
 	eolDates = map[string]time.Time{
 		// Source:
 		// https://endoflife.date/almalinux
-		"8": time.Date(2029, 3, 1, 23, 59, 59, 0, time.UTC),
-		"9": time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC),
+		"8":  time.Date(2029, 3, 1, 23, 59, 59, 0, time.UTC),
+		"9":  time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC),
 		"10": time.Date(2035, 5, 31, 23, 59, 59, 0, time.UTC),
 	}
 )


### PR DESCRIPTION
## Description
This pr adds vul support for almalinux 10

Scanning AlmaLinux:10 image 

## Example
`almalinux:10` with manually installed `git-core-2.47.1-2.el9_6.aarch64.rpm `:
```bash
➜  ./trivy image almalinux:10-with-git-core 
2025-07-17T12:52:24+06:00       INFO    [vuln] Vulnerability scanning is enabled
2025-07-17T12:52:24+06:00       INFO    [secret] Secret scanning is enabled
2025-07-17T12:52:24+06:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-07-17T12:52:24+06:00       INFO    [secret] Please see also https://trivy.dev/dev/docs/scanner/secret#recommendation for faster secret detection
2025-07-17T12:52:24+06:00       INFO    Detected OS     family="alma" version="10.0"
2025-07-17T12:52:24+06:00       INFO    [alma] Detecting vulnerabilities...     os_version="10" pkg_num=143
2025-07-17T12:52:24+06:00       INFO    Number of language-specific files       num=0

Report Summary

┌────────────────────────────────────────┬──────┬─────────────────┬─────────┐
│                 Target                 │ Type │ Vulnerabilities │ Secrets │
├────────────────────────────────────────┼──────┼─────────────────┼─────────┤
│ almalinux:10-with-git-core (alma 10.0) │ alma │        1        │    -    │
└────────────────────────────────────────┴──────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


almalinux:10-with-git-core (alma 10.0)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌──────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬───────────────────────────────────────────────────────┐
│ Library  │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                         Title                         │
├──────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼───────────────────────────────────────────────────────┤
│ git-core │ CVE-2024-52005 │ MEDIUM   │ fixed  │ 2.47.1-2.el9_6    │ 2.47.1-2.el10_0 │ git: The sideband payload is passed unfiltered to the │
│          │                │          │        │                   │                 │ terminal in git...                                    │
│          │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-52005            │
└──────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴───────────────────────────────────────────────────────┘

```

## Related issues
- Close #9189

## Related PRs
- https://github.com/aquasecurity/vuln-list-update/pull/359


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
