### PR TITLE
fix(nodejs): don't use prerelease logic for compare npm constraints 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
-	github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083
+	github.com/aquasecurity/go-npm-version v0.0.2
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/aquasecurity/go-version v0.0.1
 	github.com/aquasecurity/iamgo v0.0.10

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
-	github.com/aquasecurity/go-npm-version v0.0.1
+	github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/aquasecurity/go-version v0.0.1
 	github.com/aquasecurity/iamgo v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
-github.com/aquasecurity/go-npm-version v0.0.1 h1:2i/MM+A4KI8AJrqJa/Cwsa4qyljA8S/qngPyQiIVHcA=
-github.com/aquasecurity/go-npm-version v0.0.1/go.mod h1:hxbJZtKlO4P8sZ9nztizR6XLoE33O+BkPmuYQ4ACyz0=
+github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083 h1:/x8/8BP79pW+8ZApxKuZjSXyWwSxxjbzuCh/599rexQ=
+github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083/go.mod h1:DXyKqRe2yb83peANMjQr8dGDkHanEgoFv8BOQdWlSUQ=
 github.com/aquasecurity/go-pep440-version v0.0.1 h1:8VKKQtH2aV61+0hovZS3T//rUF+6GDn18paFTVS0h0M=
 github.com/aquasecurity/go-pep440-version v0.0.1/go.mod h1:3naPe+Bp6wi3n4l5iBFCZgS0JG8vY6FT0H4NGhFJ+i4=
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,8 @@ github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986 h1:2a30
 github.com/aquasecurity/bolt-fixtures v0.0.0-20200903104109-d34e7f983986/go.mod h1:NT+jyeCzXk6vXR5MTkdn4z64TgGfE5HMLC8qfj5unl8=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce/go.mod h1:HXgVzOPvXhVGLJs4ZKO817idqr/xhwsTcj17CLYY74s=
-github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083 h1:/x8/8BP79pW+8ZApxKuZjSXyWwSxxjbzuCh/599rexQ=
-github.com/aquasecurity/go-npm-version v0.0.2-0.20250716070109-f686488af083/go.mod h1:DXyKqRe2yb83peANMjQr8dGDkHanEgoFv8BOQdWlSUQ=
+github.com/aquasecurity/go-npm-version v0.0.2 h1:6sNIaeW4Hw8Xg51nPoD3VSo/5qmFSu0VL809iehEOvc=
+github.com/aquasecurity/go-npm-version v0.0.2/go.mod h1:DXyKqRe2yb83peANMjQr8dGDkHanEgoFv8BOQdWlSUQ=
 github.com/aquasecurity/go-pep440-version v0.0.1 h1:8VKKQtH2aV61+0hovZS3T//rUF+6GDn18paFTVS0h0M=
 github.com/aquasecurity/go-pep440-version v0.0.1/go.mod h1:3naPe+Bp6wi3n4l5iBFCZgS0JG8vY6FT0H4NGhFJ+i4=
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=

--- a/pkg/detector/library/compare/npm/compare.go
+++ b/pkg/detector/library/compare/npm/compare.go
@@ -23,7 +23,7 @@ func (n Comparer) MatchVersion(currentVersion, constraint string) (bool, error) 
 		return false, xerrors.Errorf("npm version error (%s): %s", currentVersion, err)
 	}
 
-	c, err := npm.NewConstraints(constraint)
+	c, err := npm.NewConstraints(constraint, npm.WithPreRelease(true))
 	if err != nil {
 		return false, xerrors.Errorf("npm constraint error (%s): %s", constraint, err)
 	}

--- a/pkg/detector/library/compare/npm/compare_test.go
+++ b/pkg/detector/library/compare/npm/compare_test.go
@@ -31,6 +31,17 @@ func TestNpmComparer_IsVulnerable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "prerelease",
+			args: args{
+				currentVersion: "1.45.1-lts.1",
+				advisory: dbTypes.Advisory{
+					VulnerableVersions: []string{">=1.4.4-lts.1, <2.0.0"},
+					PatchedVersions:    []string{"2.0.0"},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "no patch",
 			args: args{
 				currentVersion: "1.2.3",
@@ -68,8 +79,12 @@ func TestNpmComparer_IsVulnerable(t *testing.T) {
 			args: args{
 				currentVersion: "2.0.0",
 				advisory: dbTypes.Advisory{
-					VulnerableVersions: []string{">=1.7.0 <1.7.16", ">=1.8.0 <1.8.8", ">=2.0.0 <2.0.8", ">=3.0.0-beta.1 <3.0.0-beta.7"},
-					PatchedVersions:    []string{">=3.0.0-beta.7", ">=2.0.8 <3.0.0-beta.1", ">=1.8.8 <2.0.0", ">=1.7.16 <1.8.0"},
+					VulnerableVersions: []string{
+						">=1.7.0 <1.7.16", ">=1.8.0 <1.8.8", ">=2.0.0 <2.0.8", ">=3.0.0-beta.1 <3.0.0-beta.7",
+					},
+					PatchedVersions: []string{
+						">=3.0.0-beta.7", ">=2.0.8 <3.0.0-beta.1", ">=1.8.8 <2.0.0", ">=1.7.16 <1.8.0",
+					},
 				},
 			},
 			want: true,


### PR DESCRIPTION
## Description
This PR updates the NPM vulnerability comparison logic to include prerelease versions when matching constraints. The change enables proper detection of vulnerabilities in packages with prerelease versions (e.g., 1.45.1-lts.1).

## Reason
GitHub advisory database don't use npm semver rules for prerelease versions - https://github.com/github/advisory-database/issues/5795#issuecomment-3044749160
But the current implementation was not properly handling prerelease versions when evaluating vulnerability constraints. This meant that packages with prerelease versions could be incorrectly assessed as safe when they should be flagged as vulnerable.

## Example
before:
```bash
➜ trivy -q rootfs package.json 

Report Summary

┌──────────────┬──────────┬─────────────────┬─────────┐
│    Target    │   Type   │ Vulnerabilities │ Secrets │
├──────────────┼──────────┼─────────────────┼─────────┤
│ package.json │ node-pkg │        0        │    -    │
└──────────────┴──────────┴─────────────────┴─────────┘
```
After:
```bash
➜  ./trivy -q rootfs package.json --table-mode detailed

Node.js (node-pkg)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 3, CRITICAL: 0)

┌───────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│        Library        │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├───────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ multer (package.json) │ CVE-2025-47935 │ HIGH     │ fixed  │ 1.4.4-lts.1       │ 2.0.0         │ Multer vulnerable to Denial of Service via memory leaks from │
│                       │                │          │        │                   │               │ unclosed streams...                                          │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-47935                   │
│                       ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│                       │ CVE-2025-47944 │          │        │                   │               │ Multer vulnerable to Denial of Service from maliciously      │
│                       │                │          │        │                   │               │ crafted requests                                             │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-47944                   │
│                       ├────────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│                       │ CVE-2025-48997 │          │        │                   │ 2.0.1         │ multer: Multer vulnerable to Denial of Service via unhandled │
│                       │                │          │        │                   │               │ exception                                                    │
│                       │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-48997                   │
└───────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘

```

## Related issues
- Close #9144

## Related PRs
- [x] aquasecurity/go-npm-version/pull/4

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
