### PR TITLE
fix(server): add HTTP transport setup to server mode

### DIFF
--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -12,11 +12,18 @@ import (
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/module"
 	rpcServer "github.com/aquasecurity/trivy/pkg/rpc/server"
+	xhttp "github.com/aquasecurity/trivy/pkg/x/http"
 )
 
 // Run runs the scan
 func Run(ctx context.Context, opts flag.Options) (err error) {
 	log.InitLogger(opts.Debug, opts.Quiet)
+
+	// Set the default HTTP transport
+	xhttp.SetDefaultTransport(xhttp.NewTransport(xhttp.Options{
+		Insecure: opts.Insecure,
+		Timeout:  opts.Timeout,
+	}))
 
 	// configure cache dir
 	cacheClient, cleanup, err := cache.New(opts.CacheOpts())


### PR DESCRIPTION
## Description

This fixes the broken `--insecure` flag in server mode since v0.64.0. The issue was caused by PR #9058 which centralized HTTP transport configuration but only updated client mode (`pkg/commands/artifact/run.go`), not server mode (`pkg/commands/server/run.go`).

### Root Cause

The centralized HTTP transport system in `pkg/x/http` requires `xhttp.SetDefaultTransport()` to be called to configure TLS settings. While this was properly implemented in client mode, it was missing in server mode, causing the `--insecure` flag to be ignored.

### Solution

Added the missing HTTP transport setup in `pkg/commands/server/run.go`:

```go
// Set the default HTTP transport
xhttp.SetDefaultTransport(xhttp.NewTransport(xhttp.Options{
    Insecure: opts.Insecure,
    Timeout:  opts.Timeout,
}))
```

This mirrors the pattern already implemented in `pkg/commands/artifact/run.go`.

### Verification

Tested with mitmproxy to simulate TLS certificate issues:

**❌ Without --insecure flag (Expected failure):**
```
HTTPS_PROXY=http://localhost:8080 ./trivy server --listen localhost:8081 --token test123
```
Result: Failed with "tls: failed to verify certificate: x509: certificate signed by unknown authority"

**✅ With --insecure flag (Expected success):**
```
HTTPS_PROXY=http://localhost:8080 ./trivy server --listen localhost:8081 --token test123 --insecure
```
Result: Server started successfully, bypassed TLS verification, and downloaded 66.7MB database file.

## Future Plans
- Add E2E tests to prevent these issues

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9218

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).