### PR TITLE
chore: update template URL for brew formula

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -103,9 +103,9 @@ nfpms:
     contents:
      - src: contrib/*.tpl
        dst: /usr/local/share/trivy/templates
-    rpm:
-      signature:
-         key_file: '{{ .Env.GPG_FILE }}'
+    # rpm:
+    #   signature:
+    #      key_file: '{{ .Env.GPG_FILE }}'
 
 archives:
   - id: archive
@@ -141,6 +141,7 @@ brews:
       name: homebrew-trivy
     homepage: "https://github.com/aquasecurity/trivy"
     description: "Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues"
+    url_template: "https://get.trivy.dev/trivy?version={{ .Version }}&os={{ tolower .Os }}&arch={{ tolower .Arch }}"
     test: |
       system "#{bin}/trivy", "--version"
 


### PR DESCRIPTION
This PR updates the formula generated by goreleaser to have the
get.trivy.dev download url to count the downloads
