### PR TITLE
chore: update template URL for brew formula

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -141,6 +141,7 @@ brews:
       name: homebrew-trivy
     homepage: "https://github.com/aquasecurity/trivy"
     description: "Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues"
+    url_template: "https://get.trivy.dev/trivy?version={{ .Version }}&os={{ tolower .Os }}&arch={{ tolower .Arch }}"
     test: |
       system "#{bin}/trivy", "--version"
 


### PR DESCRIPTION
## Description

This PR updates the formula generated by goreleaser to have the
get.trivy.dev download url to count the downloads

The change updates the formula to have the following verifiable links

- https://get.trivy.dev/trivy?version=0.64.1&os=darwin&arch=amd64
- https://get.trivy.dev/trivy?version=0.64.1&os=darwin&arch=arm64
- https://get.trivy.dev/trivy?version=0.64.1&os=linux&arch=amd64
- https://get.trivy.dev/trivy?version=0.64.1&os=linux&arch=arm64


### Testing on Apple silicon

```bash 
brew install --formula ./dist/homebrew/trivy.rb
```

gives the result below, showing that the download is 302'd through get.trivy.dev

```
==> Fetching trivy
==> Downloading https://get.trivy.dev/trivy?version=0.64.1&os=darwin&arch=arm64
==> Downloading from https://release-assets.githubusercontent.com/github-production-release-asset/180687624/8224c94c-adea-44e9-a283-14269b29751f?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-07-18T14%3A12%3A08Z&rscd=attachment%3B+filename%3Dtrivy_0.64.1_macO
####################################################################################################################################################################################################################################################### 100.0%
🍺  /opt/homebrew/Cellar/trivy/0.64.1: 6 files, 144.6MB, built in 1 second
==> Running `brew cleanup trivy`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

validating

```bash
trivy -v 
Version: 0.64.1
Vulnerability DB:
  Version: 2
  UpdatedAt: 2025-07-17 06:27:32.633038153 +0000 UTC
  NextUpdate: 2025-07-18 06:27:32.633037982 +0000 UTC
  DownloadedAt: 2025-07-17 11:52:43.931896 +0000 UTC
Java DB:
  Version: 1
  UpdatedAt: 2025-07-08 02:50:21.697780173 +0000 UTC
  NextUpdate: 2025-07-11 02:50:21.697779992 +0000 UTC
  DownloadedAt: 2025-07-08 14:21:54.764166 +0000 UTC
Check Bundle:
  Digest: sha256:a471e90b7c7335e914ec9075b74cf8f65e4c91e6cecfa7e39c587382808d2684
  DownloadedAt: 2025-07-14 11:19:24.88316 +0000 UTC
```

## Related issues

- Close #9219

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
