### PR TITLE
Fix cross-result dependencies in SBOM generation

### DIFF
--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -364,23 +364,6 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						},
 					},
 					{
-						BOMRef:     "3ff14136-e09f-4df9-80ea-000000000005",
-						Type:       cdx.ComponentTypeLibrary,
-						Name:       "actionpack",
-						Version:    "7.0.0",
-						PackageURL: "pkg:gem/actionpack@7.0.0",
-						Properties: &[]cdx.Property{
-							{
-								Name:  "aquasecurity:trivy:PkgID",
-								Value: "actionpack@7.0.0",
-							},
-							{
-								Name:  "aquasecurity:trivy:PkgType",
-								Value: "bundler",
-							},
-						},
-					},
-					{
 						BOMRef:  "3ff14136-e09f-4df9-80ea-000000000007",
 						Type:    cdx.ComponentTypeApplication,
 						Name:    "app/Gemfile.lock",
@@ -467,6 +450,23 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 							{
 								Name:  "aquasecurity:trivy:PkgID",
 								Value: "actioncontroller@7.0.0",
+							},
+							{
+								Name:  "aquasecurity:trivy:PkgType",
+								Value: "bundler",
+							},
+						},
+					},
+					{
+						BOMRef:     "pkg:gem/actionpack@7.0.0",
+						Type:       cdx.ComponentTypeLibrary,
+						Name:       "actionpack",
+						Version:    "7.0.0",
+						PackageURL: "pkg:gem/actionpack@7.0.0",
+						Properties: &[]cdx.Property{
+							{
+								Name:  "aquasecurity:trivy:PkgID",
+								Value: "actionpack@7.0.0",
 							},
 							{
 								Name:  "aquasecurity:trivy:PkgType",
@@ -564,10 +564,6 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 						},
 					},
 					{
-						Ref:          "3ff14136-e09f-4df9-80ea-000000000005",
-						Dependencies: &[]string{},
-					},
-					{
 						Ref: "3ff14136-e09f-4df9-80ea-000000000007",
 						Dependencies: &[]string{
 							"3ff14136-e09f-4df9-80ea-000000000008",
@@ -597,8 +593,12 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 					{
 						Ref: "pkg:gem/actioncontroller@7.0.0",
 						Dependencies: &[]string{
-							"3ff14136-e09f-4df9-80ea-000000000005",
+							"pkg:gem/actionpack@7.0.0",
 						},
+					},
+					{
+						Ref:          "pkg:gem/actionpack@7.0.0",
+						Dependencies: &[]string{},
 					},
 					{
 						Ref:          "pkg:golang/golang.org/x/crypto@v0.0.0-20210421170649-83a5a9bb288b",


### PR DESCRIPTION
## Description

The issue was that SBOM dependency graph plotting was missing dependencies that existed across different results (e.g., multimodule Maven projects where module-b depends on a shared library from module-a). The root cause was that dependency resolution was only looking within individual results, not across all results in the report.

**More Context**

Previously, SBOM generators (CycloneDX/SPDX) only looked for dependencies inside each individual scan result. In multimodule projects (e.g. Maven), a module B depending on a library from module A was silently dropped, leading to incomplete SBOM dependency graphs.

Please refer https://github.com/aquasecurity/trivy/issues/8516 for more details.

**Changes**
* `Encode()` now aggregates packages from all scan results before encoding.
* The idea is to collect all packages across every result. Build two maps:
_Local_: maps each package to its containing result for proper grouping.
_Global_: maps every package ID to its PURL for dependency resolution.
When encoding dependencies, let's first check the local map (same-result), then fall back to the global map for cross-result links.
* `encodePackages()` will now resolve dependencies across different results, not just within the current one.
* `actioncontroller` => `actionpack` dependency now correctly resolves to the PURL `pkg:gem/actionpack@7.0.0` instead of a broken UUID reference

## Tests
All existing SBOM I/O, CycloneDX, SPDX, and container-scan tests pass without regressions.

## Related issues
[Issue#8516](https://github.com/aquasecurity/trivy/issues/8516)
Thank you @DmitriyLewen. Appreciate if you can review my PR

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
