### PR TITLE
fix(license): handle WITH operator for `LaxSplitLicenses`

### DIFF
--- a/pkg/licensing/normalize_test.go
+++ b/pkg/licensing/normalize_test.go
@@ -364,6 +364,14 @@ func TestLaxSplitLicense(t *testing.T) {
 				"GPL-2.0-or-later",
 			},
 		},
+		{
+			license: "GPL-2.0-only WITH Classpath-exception-2.0 AND MPL-2.0 ASL 2.0",
+			wantLicenses: []string{
+				"GPL-2.0-only WITH Classpath-exception-2.0",
+				"MPL-2.0",
+				"Apache-2.0",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.license, func(t *testing.T) {


### PR DESCRIPTION
## Description
We shouldn't split licenses that contain `WITH` operator.

Before:
```bash
➜  trivy -q image --format json --list-all-pkgs --cache-backend memory azul/zulu-openjdk-alpine:21-jre-headless-latest | jq '.Results[].Packages[] | select(.ID=="zulu21-ca-jre-headless@21.0.8-r1") | .Licenses'  

[
  "GPL-2.0-only",
  "WITH",
  "Classpath-exception-2.0"
]
```

After:
```bash
➜  ./trivy -q image --format json --list-all-pkgs --cache-backend memory azul/zulu-openjdk-alpine:21-jre-headless-latest | jq '.Results[].Packages[] | select(.ID=="zulu21-ca-jre-headless@21.0.8-r1") | .Licenses'

[
  "GPL-2.0-only WITH Classpath-exception-2.0"
]

```

## Related issues
- Close #9230


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
