### PR TITLE
ci: move runner.os context from job-level env to step-level in canary workflow

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -23,14 +23,12 @@ jobs:
     name: Upload binaries
     needs: build-binaries # run this job after 'build-binaries' job completes
     runs-on: ubuntu-latest
-    env:
-      CACHE_KEY: ${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}
     steps:
       - name: Restore Trivy binaries from cache
         uses: actions/cache@v4
         with:
           path: dist/
-          key: ${{ env.CACHE_KEY }}
+          key: ${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}
 
         # Upload artifacts
       - name: Upload artifacts (trivy_Linux-64bit)
@@ -63,6 +61,6 @@ jobs:
 
       - name: Delete cache after upload
         run: |
-          gh cache delete "$CACHE_KEY" --confirm
+          gh cache delete "${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}" --confirm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Delete cache after upload
         run: |
-          gh cache delete "${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}" --confirm
+          gh cache delete "$CACHE_KEY" --confirm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CACHE_KEY: ${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
## Description
Fix the canary workflow failure by properly using `runner.os` context at step level instead of job level. This addresses the GitHub Actions error: "Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.os" (example: https://github.com/aquasecurity/trivy/actions/runs/16429522113)

## Verification
This fix has been verified to work correctly in the GitHub Actions run in the fork: TODO

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

