### PR TITLE
ci: remove invalid `--confirm` flag from `gh cache delete` command in canary builds

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -63,6 +63,6 @@ jobs:
 
       - name: Delete cache after upload
         run: |
-          gh cache delete "$CACHE_KEY" --confirm
+          gh cache delete "$CACHE_KEY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR fixes the canary build failure by removing the invalid `--confirm` flag from the `gh cache delete` command.

The canary build was failing with:
```
Run gh cache delete "$CACHE_KEY" --confirm
unknown flag: --confirm

Usage:  gh cache delete [<cache-id> | <cache-key> | --all] [flags]
```

The `gh cache delete` command does not have a `--confirm` flag, so this PR removes it.

## Error
- Fixes the canary build failure at https://github.com/aquasecurity/trivy/actions/runs/16442985211/job/46469323654

## PRs
- https://github.com/aquasecurity/trivy/pull/9233

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).