### PR TITLE
fix(misconf): correctly parse empty port ranges in google_compute_firewall

### DIFF
--- a/pkg/iac/adapters/arm/network/adapt_test.go
+++ b/pkg/iac/adapters/arm/network/adapt_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/trivy/pkg/iac/adapters/arm/adaptertest"
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/azure/network"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
@@ -42,9 +43,7 @@ func TestAdapt(t *testing.T) {
 				SecurityGroups: []network.SecurityGroup{{
 					Rules: []network.SecurityGroupRule{{
 						DestinationAddresses: []types.StringValue{types.StringTest("")},
-						DestinationPorts:     []network.PortRange{{Start: types.IntTest(0), End: types.IntTest(65535)}},
 						SourceAddresses:      []types.StringValue{types.StringTest("")},
-						SourcePorts:          []network.PortRange{{Start: types.IntTest(0), End: types.IntTest(65535)}},
 					}},
 				}},
 			},
@@ -111,7 +110,7 @@ func TestAdapt(t *testing.T) {
 							types.StringTest("10.0.2.0/24"),
 							types.StringTest("10.0.0.0/24"),
 						},
-						SourcePorts: []network.PortRange{
+						SourcePorts: []common.PortRange{
 							{
 								Start: types.IntTest(1000),
 								End:   types.IntTest(2000),
@@ -130,7 +129,7 @@ func TestAdapt(t *testing.T) {
 							types.StringTest("172.16.2.0/24"),
 							types.StringTest("172.16.0.0/16"),
 						},
-						DestinationPorts: []network.PortRange{
+						DestinationPorts: []common.PortRange{
 							{
 								Start: types.IntTest(8080),
 								End:   types.IntTest(8080),

--- a/pkg/iac/adapters/common/network.go
+++ b/pkg/iac/adapters/common/network.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"strconv"
+	"strings"
+
+	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
+)
+
+type PortRange struct {
+	Metadata iacTypes.Metadata
+	Start    iacTypes.IntValue
+	End      iacTypes.IntValue
+}
+
+func NewPortRange(start, end int, meta iacTypes.Metadata) PortRange {
+	return PortRange{
+		Metadata: meta,
+		Start:    iacTypes.Int(start, meta),
+		End:      iacTypes.Int(end, meta),
+	}
+}
+
+func FullPortRange(meta iacTypes.Metadata) PortRange {
+	return NewPortRange(0, 65535, meta)
+}
+
+func InvalidPortRange(meta iacTypes.Metadata) PortRange {
+	return NewPortRange(-1, -1, meta)
+}
+
+func (r PortRange) Valid() bool {
+	return !r.Start.EqualTo(-1) && !r.End.EqualTo(-1)
+}
+
+type parseConfig struct {
+	allowWildcard bool
+}
+
+type ParseOption func(*parseConfig)
+
+func WithWildcard() ParseOption {
+	return func(cfg *parseConfig) {
+		cfg.allowWildcard = true
+	}
+}
+
+func ParsePortRange(input string, meta iacTypes.Metadata, opts ...ParseOption) PortRange {
+	cfg := &parseConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	input = strings.TrimSpace(input)
+
+	switch {
+	case input == "*" && cfg.allowWildcard:
+		return FullPortRange(meta)
+	case strings.Contains(input, "-"):
+		parts := strings.SplitN(input, "-", 2)
+		if len(parts) != 2 {
+			return InvalidPortRange(meta)
+		}
+		start, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+		end, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err1 != nil || err2 != nil {
+			return InvalidPortRange(meta)
+		}
+		return NewPortRange(start, end, meta)
+
+	default:
+		val, err := strconv.Atoi(input)
+		if err != nil {
+			return InvalidPortRange(meta)
+		}
+		return NewPortRange(val, val, meta)
+	}
+}

--- a/pkg/iac/adapters/common/network_test.go
+++ b/pkg/iac/adapters/common/network_test.go
@@ -1,0 +1,93 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
+	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
+)
+
+func TestParsePortRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		options  []common.ParseOption
+		expected common.PortRange
+		valid    bool
+	}{
+		{
+			name:  "single port",
+			input: "80",
+			expected: common.PortRange{
+				Start: iacTypes.IntTest(80),
+				End:   iacTypes.IntTest(80),
+			},
+			valid: true,
+		},
+		{
+			name:  "port range",
+			input: "1000-2000",
+			expected: common.PortRange{
+				Start: iacTypes.IntTest(1000),
+				End:   iacTypes.IntTest(2000),
+			},
+			valid: true,
+		},
+		{
+			name:  "port range with spaces",
+			input: " 22 - 80 ",
+			expected: common.PortRange{
+				Start: iacTypes.IntTest(22),
+				End:   iacTypes.IntTest(80),
+			},
+			valid: true,
+		},
+		{
+			name:    "wildcard allowed",
+			input:   "*",
+			options: []common.ParseOption{common.WithWildcard()},
+			expected: common.PortRange{
+				Start: iacTypes.IntTest(0),
+				End:   iacTypes.IntTest(65535),
+			},
+			valid: true,
+		},
+		{
+			name:  "wildcard disallowed",
+			input: "*",
+			valid: false,
+		},
+		{
+			name:  "invalid string",
+			input: "abc",
+			valid: false,
+		},
+		{
+			name:  "incomplete range",
+			input: "80-",
+			valid: false,
+		},
+		{
+			name:  "double dash",
+			input: "--",
+			valid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := iacTypes.NewTestMetadata()
+			pr := common.ParsePortRange(tc.input, meta, tc.options...)
+
+			if tc.valid {
+				assert.True(t, pr.Valid())
+				tc.expected.Metadata = meta
+				assert.Equal(t, tc.expected, pr)
+			} else {
+				assert.False(t, pr.Valid())
+			}
+		})
+	}
+}

--- a/pkg/iac/adapters/terraform/azure/network/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/network/adapt_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy/internal/testutil"
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
 	"github.com/aquasecurity/trivy/pkg/iac/adapters/terraform/tftestutil"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/azure/network"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
@@ -62,14 +63,14 @@ func Test_Adapt(t *testing.T) {
 								DestinationAddresses: []iacTypes.StringValue{
 									iacTypes.String("*", iacTypes.NewTestMetadata()),
 								},
-								SourcePorts: []network.PortRange{
+								SourcePorts: []common.PortRange{
 									{
 										Metadata: iacTypes.NewTestMetadata(),
 										Start:    iacTypes.IntTest(0),
 										End:      iacTypes.IntTest(65535),
 									},
 								},
-								DestinationPorts: []network.PortRange{
+								DestinationPorts: []common.PortRange{
 									{
 										Metadata: iacTypes.NewTestMetadata(),
 										Start:    iacTypes.IntTest(3389),

--- a/pkg/iac/adapters/terraform/google/compute/networks_test.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/trivy/internal/testutil"
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
 	"github.com/aquasecurity/trivy/pkg/iac/adapters/terraform/tftestutil"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/google/compute"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
@@ -57,7 +58,7 @@ func Test_adaptNetworks(t *testing.T) {
 									IsAllow:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
 									Protocol: iacTypes.String("icmp", iacTypes.NewTestMetadata()),
 									Enforced: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-									Ports: []compute.PortRange{
+									Ports: []common.PortRange{
 										{
 											Start: iacTypes.IntTest(80),
 											End:   iacTypes.IntTest(80),
@@ -171,7 +172,7 @@ func Test_adaptNetworks(t *testing.T) {
 									Enforced: iacTypes.BoolTest(true),
 									IsAllow:  iacTypes.BoolTest(true),
 									Protocol: iacTypes.StringTest("tcp"),
-									Ports: []compute.PortRange{
+									Ports: []common.PortRange{
 										{
 											Start: iacTypes.IntTest(0),
 											End:   iacTypes.IntTest(65535),

--- a/pkg/iac/providers/azure/network/network.go
+++ b/pkg/iac/providers/azure/network/network.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
@@ -19,16 +20,10 @@ type SecurityGroupRule struct {
 	Outbound             iacTypes.BoolValue
 	Allow                iacTypes.BoolValue
 	SourceAddresses      []iacTypes.StringValue
-	SourcePorts          []PortRange
+	SourcePorts          []common.PortRange
 	DestinationAddresses []iacTypes.StringValue
-	DestinationPorts     []PortRange
+	DestinationPorts     []common.PortRange
 	Protocol             iacTypes.StringValue
-}
-
-type PortRange struct {
-	Metadata iacTypes.Metadata
-	Start    iacTypes.IntValue
-	End      iacTypes.IntValue
 }
 
 type NetworkWatcherFlowLog struct {

--- a/pkg/iac/providers/google/compute/firewall.go
+++ b/pkg/iac/providers/google/compute/firewall.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/common"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
@@ -18,13 +19,7 @@ type FirewallRule struct {
 	Enforced iacTypes.BoolValue
 	IsAllow  iacTypes.BoolValue
 	Protocol iacTypes.StringValue
-	Ports    []PortRange
-}
-
-type PortRange struct {
-	Metadata iacTypes.Metadata
-	Start    iacTypes.IntValue
-	End      iacTypes.IntValue
+	Ports    []common.PortRange
 }
 
 type IngressRule struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -43,6 +43,23 @@
     }
   },
   "definitions": {
+    "github.com.aquasecurity.trivy.pkg.iac.adapters.common.PortRange": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "end": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+        },
+        "start": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.aws.AWS": {
       "type": "object",
       "properties": {
@@ -5244,23 +5261,6 @@
         }
       }
     },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.PortRange": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "end": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
-        },
-        "start": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
-        }
-      }
-    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.RetentionPolicy": {
       "type": "object",
       "properties": {
@@ -5316,7 +5316,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.PortRange"
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.adapters.common.PortRange"
           }
         },
         "outbound": {
@@ -5338,7 +5338,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.PortRange"
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.adapters.common.PortRange"
           }
         }
       }
@@ -6135,7 +6135,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.PortRange"
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.adapters.common.PortRange"
           }
         },
         "protocol": {
@@ -6264,23 +6264,6 @@
         "subnetwork": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.SubNetwork"
-        }
-      }
-    },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.google.compute.PortRange": {
-      "type": "object",
-      "properties": {
-        "__defsec_metadata": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
-        },
-        "end": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
-        },
-        "start": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.IntValue"
         }
       }
     },


### PR DESCRIPTION
## Description

This PR fixes port parsing for the [google_compute_firewall](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) resource. Previously, when the ports field was omitted, Trivy did not assign any port range. However, according to the official [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#ports-1):

> If not specified, this rule applies to connections through any port.

Now, Trivy correctly treats missing ports as allowing all ports.

Additional changes:
Minor refactoring was done to unify the port parsing logic across providers.

Compatibility:
The resulting Rego schema remains unchanged except for updating references to the new PortRange definition. This update is fully backward-compatible.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
