### PR TITLE
ci: specify repository for `gh cache delete` in canary worklfow

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Delete cache after upload
         run: |
-          gh cache delete "$CACHE_KEY"
+          gh cache delete "$CACHE_KEY" --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CACHE_KEY: ${{ runner.os }}-bins-${{ github.workflow }}-${{ github.sha }}


### PR DESCRIPTION
## Description
We don't do `checkout` in canary workflow.
That is why we need to specify repository for `gh cache delete`

## Related PRs
- [x] #9236


## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
