### PR TITLE
fix: prevent graceful shutdown message on normal exit

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -42,8 +42,7 @@ func run() error {
 	}
 
 	// Set up signal handling for graceful shutdown
-	ctx, stop := commands.NotifyContext(context.Background())
-	defer stop()
+	ctx := commands.NotifyContext(context.Background())
 
 	app := commands.NewApp()
 	return app.ExecuteContext(ctx)

--- a/pkg/commands/signal.go
+++ b/pkg/commands/signal.go
@@ -15,7 +15,7 @@ import (
 // When a signal is received, Trivy will attempt to gracefully shut down by canceling
 // the context and waiting for all operations to complete. If users want to force an
 // immediate exit, they can send a second SIGINT or SIGTERM signal.
-func NotifyContext(parent context.Context) (context.Context, context.CancelFunc) {
+func NotifyContext(parent context.Context) context.Context {
 	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 
 	// Start a goroutine to handle cleanup when context is done
@@ -33,5 +33,5 @@ func NotifyContext(parent context.Context) (context.Context, context.CancelFunc)
 		stop()
 	}()
 
-	return ctx, stop
+	return ctx
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the graceful shutdown message "Received signal, attempting graceful shutdown..." was being displayed even during normal program exits.

## Related issues
- Related to #9242

## Summary

The issue was caused by the `defer stop()` call in `main.go` which was canceling the context on normal exit, triggering the shutdown message in the signal handler goroutine.

### Changes made:
1. Modified `NotifyContext()` to return only the context (removed the stop function)
2. Removed the `defer stop()` call from `main.go`

Now the graceful shutdown message only appears when an actual signal (SIGINT or SIGTERM) is received, not during normal program termination.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).