### PR TITLE
fix(secret): add UTF-8 validation in secret scanner to prevent protobuf marshalling errors

### DIFF
--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	lineSep = []byte{'\n'}
+	lineSep      = []byte{'\n'}
 	warnUTF8Once = sync.OnceFunc(func() {
 		log.WithPrefix(log.PrefixSecret).Warn("Invalid UTF-8 sequences detected in file content, replacing with empty string")
 	})
@@ -567,8 +567,8 @@ func sanitizeUTF8String(data []byte) string {
 	if utf8.Valid(data) {
 		return string(data)
 	}
-	
+
 	warnUTF8Once()
-	
+
 	return strings.ToValidUTF8(string(data), "")
 }

--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -570,5 +570,5 @@ func sanitizeUTF8String(data []byte) string {
 
 	warnUTF8Once()
 
-	return strings.ToValidUTF8(string(data), "")
+	return strings.ToValidUTF8(string(data), string(utf8.RuneError))
 }

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -1433,8 +1433,8 @@ func TestSecretScanner(t *testing.T) {
 								},
 								{
 									Number:      2,
-									Content:     "# Comment with invalid UTF-8: ",
-									Highlighted: "# Comment with invalid UTF-8: ",
+									Content:     "# Comment with invalid UTF-8: �",
+									Highlighted: "# Comment with invalid UTF-8: �",
 								},
 							},
 						},

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -1406,6 +1406,42 @@ func TestSecretScanner(t *testing.T) {
 				Findings: []types.SecretFinding{wantFindingTokenInsideJs},
 			},
 		},
+		{
+			name:          "invalid UTF-8 sequences in secrets",
+			configPath:    filepath.Join("testdata", "skip-test.yaml"),
+			inputFilePath: filepath.Join("testdata", "invalid-utf8.txt"),
+			want: types.Secret{
+				FilePath: filepath.Join("testdata", "invalid-utf8.txt"),
+				Findings: []types.SecretFinding{
+					{
+						RuleID:    "github-pat",
+						Category:  secret.CategoryGitHub,
+						Title:     "GitHub Personal Access Token",
+						Severity:  "CRITICAL",
+						StartLine: 1,
+						EndLine:   1,
+						Match:     "token=****************************************",
+						Code: types.Code{
+							Lines: []types.Line{
+								{
+									Number:      1,
+									Content:     "token=****************************************",
+									Highlighted: "token=****************************************",
+									IsCause:     true,
+									FirstCause:  true,
+									LastCause:   true,
+								},
+								{
+									Number:      2,
+									Content:     "# Comment with invalid UTF-8: ",
+									Highlighted: "# Comment with invalid UTF-8: ",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/fanal/secret/testdata/invalid-utf8.txt
+++ b/pkg/fanal/secret/testdata/invalid-utf8.txt
@@ -1,0 +1,3 @@
+token=ghp_abcdef1234567890ABCDEF1234567890abcd
+# Comment with invalid UTF-8: €‚ƒ
+token2=ghp_1234567890abcdef1234567890ABCDEFşÿabcd


### PR DESCRIPTION
## Description
This PR adds UTF-8 validation to the secret scanner to prevent protobuf marshalling errors when scanning files with invalid UTF-8 content, such as translation files.

The issue occurred when scanning repositories like [juice-shop](https://github.com/juice-shop/juice-shop) that contain files with invalid UTF-8 sequences. The secret scanner would fail with 'string field contains invalid UTF-8' when marshalling results to protobuf format.

```
$ trivy repo https://github.com/juice-shop/juice-shop --server http://localhost:4954
...
2025-07-28T10:13:33+04:00       FATAL   Fatal error     repo scan error: scan error: scan failed: failed analysis: remote repository error: failed to store blob (sha256:e3e730cdeff2f1c66082bc550dcdd2226b8070382f6451040a13d203e1ff5325) in cache: unable to store cache on the server: twirp error internal: failed to marshal proto request: string field contains invalid UTF-8
```

## Changes
Added UTF-8 validation using `strings.ToValidUTF8()` in secret scanner

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9254

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change)