### PR TITLE
fix(cli): ensure correct command is picked by telemetry

### DIFF
--- a/pkg/k8s/commands/run.go
+++ b/pkg/k8s/commands/run.go
@@ -62,7 +62,7 @@ func newRunner(flagOpts flag.Options, cluster string) *runner {
 }
 
 func (r *runner) run(ctx context.Context, artifacts []*k8sArtifacts.Artifact) error {
-	runner, err := cmd.NewRunner(ctx, r.flagOpts)
+	runner, err := cmd.NewRunner(ctx, r.flagOpts, cmd.TargetK8s)
 	if err != nil {
 		if errors.Is(err, cmd.SkipScan) {
 			return nil

--- a/pkg/k8s/scanner/scanner_test.go
+++ b/pkg/k8s/scanner/scanner_test.go
@@ -276,7 +276,7 @@ func TestScanner_Scan(t *testing.T) {
 			ctx := t.Context()
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
-			runner, err := cmd.NewRunner(ctx, flagOpts)
+			runner, err := cmd.NewRunner(ctx, flagOpts, cmd.TargetK8s)
 			require.NoError(t, err)
 
 			scanner := NewScanner(tt.clusterName, runner, flagOpts)


### PR DESCRIPTION
## Description

Suppose the user has an unexpected ordering of flags in their Trivy command. In that case, the simple approach of reading the first OS argument fails, and the information in the `Trivy-Command` header for telemetry is incorrect.

Rather than using the `os.Args`, this PR passes the `targetKind` into the `NewRunner` creation so that it can be used as the command name

### Example

Taking the following example

```bash
trivy -d image nginx
```

**Before**
`call req.Header.Get("Trivy-Command")` would result in `-d` as the first `os.Arg` would be returned

**With Change**
With this change, we now get consistently the correct command
`call req.Header.Get("Trivy-Command")` returns "image"


## Closes
- #9259 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).





