### PR TITLE
feat(flag): add schema validation for `--server` flag

### DIFF
--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -2,7 +2,10 @@ package flag
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
+
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/log"
 )
@@ -110,8 +113,35 @@ func (f *RemoteFlagGroup) Flags() []Flagger {
 	}
 }
 
+func validateServerSchema(serverAddr string) error {
+	if serverAddr == "" {
+		return nil
+	}
+
+	parsedURL, err := url.Parse(serverAddr)
+	if err != nil {
+		return xerrors.Errorf("invalid server address format: %w", err)
+	}
+
+	if parsedURL.Scheme == "" {
+		return xerrors.Errorf("server address must include HTTP or HTTPS schema (e.g., http://localhost:4954 or https://localhost:4954)")
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return xerrors.Errorf("server address must use HTTP or HTTPS schema, got '%s' (e.g., use http://localhost:4954 instead of %s)", parsedURL.Scheme, serverAddr)
+	}
+
+	return nil
+}
+
 func (f *RemoteFlagGroup) ToOptions(opts *Options) error {
 	serverAddr := f.ServerAddr.Value()
+
+	// Validate server schema
+	if err := validateServerSchema(serverAddr); err != nil {
+		return err
+	}
+
 	customHeaders := splitCustomHeaders(f.CustomHeaders.Value())
 	listen := f.Listen.Value()
 	token := f.Token.Value()

--- a/pkg/flag/remote_flags.go
+++ b/pkg/flag/remote_flags.go
@@ -113,27 +113,6 @@ func (f *RemoteFlagGroup) Flags() []Flagger {
 	}
 }
 
-func validateServerSchema(serverAddr string) error {
-	if serverAddr == "" {
-		return nil
-	}
-
-	parsedURL, err := url.Parse(serverAddr)
-	if err != nil {
-		return xerrors.Errorf("invalid server address format: %w", err)
-	}
-
-	if parsedURL.Scheme == "" {
-		return xerrors.Errorf("server address must include HTTP or HTTPS schema (e.g., http://localhost:4954 or https://localhost:4954)")
-	}
-
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return xerrors.Errorf("server address must use HTTP or HTTPS schema, got '%s' (e.g., use http://localhost:4954 instead of %s)", parsedURL.Scheme, serverAddr)
-	}
-
-	return nil
-}
-
 func (f *RemoteFlagGroup) ToOptions(opts *Options) error {
 	serverAddr := f.ServerAddr.Value()
 
@@ -188,4 +167,23 @@ func splitCustomHeaders(headers []string) http.Header {
 		result.Set(s[0], s[1])
 	}
 	return result
+}
+
+func validateServerSchema(serverAddr string) error {
+	if serverAddr == "" {
+		return nil
+	}
+
+	parsedURL, err := url.Parse(serverAddr)
+	if err != nil {
+		return xerrors.Errorf("invalid server address format: %w", err)
+	}
+
+	if parsedURL.Scheme == "" {
+		return xerrors.Errorf("server address must include HTTP or HTTPS schema (e.g., http://localhost:4954 or https://localhost:4954)")
+	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return xerrors.Errorf("server address must use HTTP or HTTPS schema, got '%s' (e.g., use http://localhost:4954 instead of %s)", parsedURL.Scheme, serverAddr)
+	}
+
+	return nil
 }

--- a/pkg/flag/remote_flags_test.go
+++ b/pkg/flag/remote_flags_test.go
@@ -24,6 +24,7 @@ func TestRemoteFlagGroup_ToOptions(t *testing.T) {
 		fields   fields
 		want     flag.RemoteOptions
 		wantLogs []string
+		wantErr  string
 	}{
 		{
 			name: "happy",
@@ -93,6 +94,37 @@ func TestRemoteFlagGroup_ToOptions(t *testing.T) {
 				`"--token-header" should be used with "--token"`,
 			},
 		},
+		{
+			name: "server address without schema",
+			fields: fields{
+				Server: "localhost:8080",
+			},
+			wantErr: "server address must include HTTP or HTTPS schema",
+		},
+		{
+			name: "server address with invalid schema",
+			fields: fields{
+				Server: "ftp://localhost:8080",
+			},
+			wantErr: "server address must use HTTP or HTTPS schema, got 'ftp'",
+		},
+		{
+			name: "server address with malformed URL",
+			fields: fields{
+				Server: "http://[::1:8080",
+			},
+			wantErr: "invalid server address format",
+		},
+		{
+			name: "server address with https schema",
+			fields: fields{
+				Server: "https://localhost:4954",
+			},
+			want: flag.RemoteOptions{
+				CustomHeaders: http.Header{},
+				ServerAddr:    "https://localhost:4954",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -112,6 +144,12 @@ func TestRemoteFlagGroup_ToOptions(t *testing.T) {
 			}
 			flags := flag.Flags{f}
 			got, err := flags.ToOptions(nil)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got.RemoteOptions)
 

--- a/pkg/flag/remote_flags_test.go
+++ b/pkg/flag/remote_flags_test.go
@@ -99,7 +99,7 @@ func TestRemoteFlagGroup_ToOptions(t *testing.T) {
 			fields: fields{
 				Server: "localhost:8080",
 			},
-			wantErr: "server address must include HTTP or HTTPS schema",
+			wantErr: "server address must use HTTP or HTTPS schema, got 'localhost'",
 		},
 		{
 			name: "server address with invalid schema",
@@ -118,11 +118,13 @@ func TestRemoteFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "server address with https schema",
 			fields: fields{
-				Server: "https://localhost:4954",
+				Server:      "https://localhost:4954",
+				TokenHeader: "Trivy-Token",
 			},
 			want: flag.RemoteOptions{
 				CustomHeaders: http.Header{},
 				ServerAddr:    "https://localhost:4954",
+				TokenHeader:   "Trivy-Token",
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Add validation to ensure the `--server` flag includes HTTP or HTTPS schema. When the schema is missing, return a user-friendly error message suggesting proper usage (e.g., http://localhost:4954 instead of localhost:4954).

## Error Examples

### Without schema (missing protocol)
```bash
$ trivy image --server localhost:4954 alpine:latest
2025-07-29T17:28:51+04:00	FATAL	Fatal error	flag error: unable to convert flags to options: server address must include HTTP or HTTPS schema (e.g., http://localhost:4954 or https://localhost:4954)
```

### With invalid schema (FTP)
```bash
$ trivy image --server ftp://localhost:4954 alpine:latest
2025-07-29T17:30:04+04:00	FATAL	Fatal error	flag error: unable to convert flags to options: server address must use HTTP or HTTPS schema, got 'ftp' (e.g., use http://localhost:4954 instead of ftp://localhost:4954)
```

### Valid usage (works correctly)
```bash
$ trivy image --server http://localhost:4954 alpine:latest
$ trivy image --server https://example.com:8443 alpine:latest
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9269

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).