### PR TITLE
refactor(terraform): make Scan method of Terraform plan scanner private

### DIFF
--- a/pkg/iac/scanners/terraformplan/snapshot/scanner.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner.go
@@ -63,10 +63,10 @@ func (s *Scanner) ScanFile(ctx context.Context, fsys fs.FS, filepath string) (sc
 		return nil, err
 	}
 	defer file.Close()
-	return s.Scan(ctx, file)
+	return s.scan(ctx, file)
 }
 
-func (s *Scanner) Scan(ctx context.Context, reader io.Reader) (scan.Results, error) {
+func (s *Scanner) scan(ctx context.Context, reader io.Reader) (scan.Results, error) {
 	snap, err := parseSnapshot(reader)
 	if err != nil {
 		return nil, err

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
@@ -3,7 +3,6 @@ package snapshot
 import (
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"testing"
 
@@ -13,64 +12,8 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/scan"
-	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 	tfscanner "github.com/aquasecurity/trivy/pkg/iac/scanners/terraform"
 )
-
-func initScanner(opts ...options.ScannerOption) *Scanner {
-	defaultOpts := []options.ScannerOption{
-		rego.WithEmbeddedPolicies(false),
-		rego.WithEmbeddedLibraries(true),
-		rego.WithPolicyNamespaces("user"),
-		rego.WithPolicyDirs("."),
-		rego.WithRegoErrorLimits(0),
-		tfscanner.ScannerWithSkipCachedModules(true),
-	}
-
-	opts = append(opts, defaultOpts...)
-	return New(opts...)
-}
-
-func TestScanner_Scan(t *testing.T) {
-	tests := []struct {
-		dir         string
-		expectedIDs []string
-	}{
-		{
-			dir:         "just-resource",
-			expectedIDs: []string{"ID001"},
-		},
-		{
-			dir:         "with-local-module",
-			expectedIDs: []string{"ID001"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.dir, func(t *testing.T) {
-			f, err := os.Open(filepath.Join("testdata", tt.dir, "tfplan"))
-			require.NoError(t, err)
-			defer f.Close()
-
-			policyFS := os.DirFS(filepath.Join("testdata", tt.dir, "checks"))
-
-			s := initScanner(rego.WithPolicyFilesystem(policyFS))
-			result, err := s.Scan(t.Context(), f)
-			require.NoError(t, err)
-
-			failed := result.GetFailed()
-
-			assert.Len(t, failed, len(tt.expectedIDs))
-
-			ids := lo.Map(failed, func(res scan.Result, _ int) string {
-				return res.Rule().AVDID
-			})
-			sort.Strings(ids)
-
-			assert.Equal(t, tt.expectedIDs, ids)
-		})
-	}
-}
 
 func Test_ScanFS(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Description

This change makes the Scan method of the Terraform plan scanner private.
It reduces the exposed API surface, improves internal encapsulation, and removes the need for dedicated tests for Scan, since its logic closely mirrors that of ScanFile.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
