### PR TITLE
feat(terraform): use .terraform cache for remote modules in plan scanning

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -31,7 +31,7 @@ type evaluator struct {
 	ctx               *tfcontext.Context
 	blocks            terraform.Blocks
 	inputVars         map[string]cty.Value
-	moduleMetadata    *modulesMetadata
+	moduleMetadata    *ModulesMetadata
 	projectRootPath   string // root of the current scan
 	modulePath        string
 	moduleName        string
@@ -50,7 +50,7 @@ func newEvaluator(
 	moduleName string,
 	blocks terraform.Blocks,
 	inputVars map[string]cty.Value,
-	moduleMetadata *modulesMetadata,
+	moduleMetadata *ModulesMetadata,
 	workspace string,
 	ignores ignore.Rules,
 	logger *log.Logger,

--- a/pkg/iac/scanners/terraform/parser/load_module_metadata.go
+++ b/pkg/iac/scanners/terraform/parser/load_module_metadata.go
@@ -6,19 +6,21 @@ import (
 	"path"
 )
 
-const manifestSnapshotFile = ".terraform/modules/modules.json"
+const ManifestSnapshotFile = ".terraform/modules/modules.json"
 
-type modulesMetadata struct {
-	Modules []struct {
-		Key     string `json:"Key"`
-		Source  string `json:"Source"`
-		Version string `json:"Version"`
-		Dir     string `json:"Dir"`
-	} `json:"Modules"`
+type ModulesMetadata struct {
+	Modules []ModuleMetadata `json:"Modules"`
 }
 
-func loadModuleMetadata(target fs.FS, fullPath string) (*modulesMetadata, string, error) {
-	metadataPath := path.Join(fullPath, manifestSnapshotFile)
+type ModuleMetadata struct {
+	Key     string `json:"Key"`
+	Source  string `json:"Source"`
+	Version string `json:"Version"`
+	Dir     string `json:"Dir"`
+}
+
+func loadModuleMetadata(target fs.FS, fullPath string) (*ModulesMetadata, string, error) {
+	metadataPath := path.Join(fullPath, ManifestSnapshotFile)
 
 	f, err := target.Open(metadataPath)
 	if err != nil {
@@ -26,7 +28,7 @@ func loadModuleMetadata(target fs.FS, fullPath string) (*modulesMetadata, string
 	}
 	defer f.Close()
 
-	var metadata modulesMetadata
+	var metadata ModulesMetadata
 	if err := json.NewDecoder(f).Decode(&metadata); err != nil {
 		return nil, metadataPath, err
 	}

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner.go
@@ -78,6 +78,7 @@ func (s *Scanner) Scan(ctx context.Context, reader io.Reader) (scan.Results, err
 
 	s.inner.AddParserOptions(
 		tfparser.OptionsWithTfVars(snap.inputVariables),
+		tfparser.OptionWithDownloads(false),
 	)
 	return s.inner.ScanFS(ctx, fsys, ".")
 }


### PR DESCRIPTION
## Description

This PR updates the Terraform plan scanner to load remote modules from the local .terraform directory instead of downloading them from external sources like the Terraform Registry or GitHub. This makes scanning more reliable and independent of network availability.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
