### PR TITLE
refactor: simplify Detect function signature

### DIFF
--- a/pkg/scan/ospkg/scan.go
+++ b/pkg/scan/ospkg/scan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	"golang.org/x/xerrors"
 
@@ -50,8 +49,7 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.
 		return result, false, nil
 	}
 
-	vulns, eosl, err := ospkgDetector.Detect(ctx, "", target.OS.Family, target.OS.Name, target.Repository, time.Time{},
-		target.Packages)
+	vulns, eosl, err := ospkgDetector.Detect(ctx, target, opts)
 	if err != nil {
 		// Return a result for those who want to override the error handling.
 		return result, false, xerrors.Errorf("failed vulnerability detection of OS packages: %w", err)


### PR DESCRIPTION
## Description

This PR simplifies the `Detect` function signature in `pkg/detector/ospkg` by removing unused parameters and using `types.ScanTarget` to pass scan target information.

### Changes:
1. Removed the unused second parameter (was always an empty string `""`)
2. Removed the unused `time.Time` parameter (was always `time.Time{}`)
3. Consolidated individual parameters (`osFamily`, `osName`, `repo`, `pkgs`) into a single `types.ScanTarget` parameter

### Before
```go
func Detect(ctx context.Context, _, osFamily ftypes.OSType, osName string, repo *ftypes.Repository, _ time.Time, pkgs []ftypes.Package)
```

### After
```go
func Detect(ctx context.Context, target types.ScanTarget, _ types.ScanOptions)
```

### Benefits:
- Makes the function signature cleaner and more maintainable
- Aligns with the pattern used by other scanners in the codebase (e.g., `langpkg.Scanner`)
- Improves extensibility - if new fields are added to `ScanTarget`, the function signature doesn't need to change

## Related issues
- N/A (refactoring)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).