### PR TITLE
refactor(misconf): replace github.com/liamg/memoryfs with internal mapfs and testing/fstest

### DIFF
--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -3,11 +3,10 @@ package testutil
 import (
 	"encoding/json"
 	"io/fs"
-	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
-	"github.com/liamg/memoryfs"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,15 +56,12 @@ func ruleIDInResults(ruleID string, results scan.Results) bool {
 }
 
 func CreateFS(t *testing.T, files map[string]string) fs.FS {
-	memfs := memoryfs.New()
+	fsys := fstest.MapFS{}
 	for name, content := range files {
 		name := strings.TrimPrefix(name, "/")
-		err := memfs.MkdirAll(filepath.Dir(name), 0o700)
-		require.NoError(t, err)
-		err = memfs.WriteFile(name, []byte(content), 0o644)
-		require.NoError(t, err)
+		fsys[name] = &fstest.MapFile{Data: []byte(content)}
 	}
-	return memfs
+	return fsys
 }
 
 func AssertDefsecEqual(t *testing.T, expected, actual any) {

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -3,38 +3,25 @@ package rego_test
 import (
 	"bytes"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
 
-	"github.com/liamg/memoryfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/rego"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 	"github.com/aquasecurity/trivy/pkg/iac/severity"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
-func CreateFS(t *testing.T, files map[string]string) fs.FS {
-	memfs := memoryfs.New()
-	for name, content := range files {
-		name := strings.TrimPrefix(name, "/")
-		err := memfs.MkdirAll(filepath.Dir(name), 0o700)
-		require.NoError(t, err)
-		err = memfs.WriteFile(name, []byte(content), 0o644)
-		require.NoError(t, err)
-	}
-	return memfs
-}
-
 func Test_RegoScanning_Deny(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 # METADATA
 # title: Custom policy
@@ -128,7 +115,7 @@ deny {
 }
 
 func Test_RegoScanning_Allow(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -176,7 +163,7 @@ func Test_RegoScanning_WithRuntimeValues(t *testing.T) {
 
 	t.Setenv("DEFSEC_RUNTIME_VAL", "AOK")
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -220,7 +207,7 @@ deny_evil {
 }
 
 func Test_RegoScanning_WithDenyMessage(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -267,7 +254,7 @@ deny[msg] {
 }
 
 func Test_RegoScanning_WithDenyMetadata_ImpliedPath(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 # METADATA
 # title: Custom policy
@@ -322,7 +309,7 @@ deny[res] {
 }
 
 func Test_RegoScanning_WithDenyMetadata_PersistedPath(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 # METADATA
 # title: Custom policy
@@ -378,7 +365,7 @@ deny[res] {
 }
 
 func Test_RegoScanning_WithStaticMetadata(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 package defsec.test
 
@@ -439,7 +426,7 @@ deny[res] {
 }
 
 func Test_RegoScanning_WithMatchingInputSelector(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -487,7 +474,7 @@ deny {
 }
 
 func Test_RegoScanning_WithNonMatchingInputSelector(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 package defsec.test
 
@@ -521,7 +508,7 @@ deny {
 
 func Test_RegoScanning_NoTracingByDefault(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -567,7 +554,7 @@ deny {
 
 func Test_RegoScanning_GlobalTracingEnabled(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -617,7 +604,7 @@ deny {
 
 func Test_RegoScanning_PerResultTracingEnabled(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -663,7 +650,7 @@ deny {
 
 func Test_dynamicMetadata(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 package defsec.test
 
@@ -695,7 +682,7 @@ deny {
 
 func Test_staticMetadata(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `
 package defsec.test
 
@@ -727,7 +714,7 @@ deny {
 
 func Test_annotationMetadata(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: i am a title
 # description: i am a description
@@ -782,7 +769,7 @@ deny {
 
 func Test_RegoScanning_WithInvalidInputSchema(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # schemas:
 # - input: schema["input"]
@@ -802,7 +789,7 @@ deny {
 
 func Test_RegoScanning_WithValidInputSchema(t *testing.T) {
 
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # schemas:
 # - input: schema["input"]
@@ -821,7 +808,7 @@ deny {
 }
 
 func Test_RegoScanning_WithFilepathToSchema(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # schemas:
 # - input: schema["dockerfile"]
@@ -846,7 +833,7 @@ deny {
 }
 
 func Test_RegoScanning_CustomData(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -871,7 +858,7 @@ deny {
 `,
 	})
 
-	dataFS := CreateFS(t, map[string]string{
+	dataFS := testutil.CreateFS(t, map[string]string{
 		"data/data.json": `{
 	"settings": {
 		"DS123":{
@@ -899,7 +886,7 @@ deny {
 }
 
 func Test_RegoScanning_InvalidFS(t *testing.T) {
-	srcFS := CreateFS(t, map[string]string{
+	srcFS := testutil.CreateFS(t, map[string]string{
 		"policies/test.rego": `# METADATA
 # title: Custom policy
 # description: Custom policy for testing
@@ -924,7 +911,7 @@ deny {
 `,
 	})
 
-	dataFS := CreateFS(t, map[string]string{
+	dataFS := testutil.CreateFS(t, map[string]string{
 		"data/data.json": `{
 	"settings": {
 		"DS123":{

--- a/pkg/iac/scanners/azure/arm/parser/parser_test.go
+++ b/pkg/iac/scanners/azure/arm/parser/parser_test.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"io/fs"
 	"testing"
+	"testing/fstest"
 
-	"github.com/liamg/memoryfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,12 +24,10 @@ func createMetadata(targetFS fs.FS, filename string, start, end int, ref string,
 func TestParser_Parse(t *testing.T) {
 	filename := "example.json"
 
-	targetFS := memoryfs.New()
-
 	tests := []struct {
 		name           string
 		input          string
-		want           func() azure2.Deployment
+		want           func(fsys fs.FS) azure2.Deployment
 		wantDeployment bool
 	}{
 		{
@@ -47,11 +45,11 @@ func TestParser_Parse(t *testing.T) {
   },
   "resources": []
 }`,
-			want: func() azure2.Deployment {
-				root := createMetadata(targetFS, filename, 0, 0, "", nil).WithInternal(resolver.NewResolver())
-				metadata := createMetadata(targetFS, filename, 1, 13, "", &root)
-				parametersMetadata := createMetadata(targetFS, filename, 4, 11, "parameters", &metadata)
-				storageMetadata := createMetadata(targetFS, filename, 5, 10, "parameters.storagePrefix", &parametersMetadata)
+			want: func(fsys fs.FS) azure2.Deployment {
+				root := createMetadata(fsys, filename, 0, 0, "", nil).WithInternal(resolver.NewResolver())
+				metadata := createMetadata(fsys, filename, 1, 13, "", &root)
+				parametersMetadata := createMetadata(fsys, filename, 4, 11, "parameters", &metadata)
+				storageMetadata := createMetadata(fsys, filename, 5, 10, "parameters.storagePrefix", &parametersMetadata)
 
 				return azure2.Deployment{
 					Metadata:    metadata,
@@ -60,9 +58,9 @@ func TestParser_Parse(t *testing.T) {
 						{
 							Variable: azure2.Variable{
 								Name:  "storagePrefix",
-								Value: azure2.NewValue("x", createMetadata(targetFS, filename, 7, 7, "parameters.storagePrefix.defaultValue", &storageMetadata)),
+								Value: azure2.NewValue("x", createMetadata(fsys, filename, 7, 7, "parameters.storagePrefix.defaultValue", &storageMetadata)),
 							},
-							Default:    azure2.NewValue("x", createMetadata(targetFS, filename, 7, 7, "parameters.storagePrefix.defaultValue", &storageMetadata)),
+							Default:    azure2.NewValue("x", createMetadata(fsys, filename, 7, 7, "parameters.storagePrefix.defaultValue", &storageMetadata)),
 							Decorators: nil,
 						},
 					},
@@ -117,20 +115,20 @@ func TestParser_Parse(t *testing.T) {
 }
 ]
 }`,
-			want: func() azure2.Deployment {
-				rootMetadata := createMetadata(targetFS, filename, 0, 0, "", nil).WithInternal(resolver.NewResolver())
-				fileMetadata := createMetadata(targetFS, filename, 1, 45, "", &rootMetadata)
-				resourcesMetadata := createMetadata(targetFS, filename, 5, 44, "resources", &fileMetadata)
+			want: func(fsys fs.FS) azure2.Deployment {
+				rootMetadata := createMetadata(fsys, filename, 0, 0, "", nil).WithInternal(resolver.NewResolver())
+				fileMetadata := createMetadata(fsys, filename, 1, 45, "", &rootMetadata)
+				resourcesMetadata := createMetadata(fsys, filename, 5, 44, "resources", &fileMetadata)
 
-				resourceMetadata := createMetadata(targetFS, filename, 6, 43, "resources[0]", &resourcesMetadata)
+				resourceMetadata := createMetadata(fsys, filename, 6, 43, "resources[0]", &resourcesMetadata)
 
-				propertiesMetadata := createMetadata(targetFS, filename, 27, 42, "resources[0].properties", &resourceMetadata)
+				propertiesMetadata := createMetadata(fsys, filename, 27, 42, "resources[0].properties", &resourceMetadata)
 
-				customDomainMetadata := createMetadata(targetFS, filename, 29, 33, "resources[0].properties.customDomain", &propertiesMetadata)
-				networkACLListMetadata := createMetadata(targetFS, filename, 34, 41, "resources[0].properties.networkAcls", &propertiesMetadata)
+				customDomainMetadata := createMetadata(fsys, filename, 29, 33, "resources[0].properties.customDomain", &propertiesMetadata)
+				networkACLListMetadata := createMetadata(fsys, filename, 34, 41, "resources[0].properties.networkAcls", &propertiesMetadata)
 
-				networkACL0Metadata := createMetadata(targetFS, filename, 35, 37, "resources[0].properties.networkAcls[0]", &networkACLListMetadata)
-				networkACL1Metadata := createMetadata(targetFS, filename, 38, 40, "resources[0].properties.networkAcls[1]", &networkACLListMetadata)
+				networkACL0Metadata := createMetadata(fsys, filename, 35, 37, "resources[0].properties.networkAcls[0]", &networkACLListMetadata)
+				networkACL1Metadata := createMetadata(fsys, filename, 38, 40, "resources[0].properties.networkAcls[1]", &networkACLListMetadata)
 
 				return azure2.Deployment{
 					Metadata:    fileMetadata,
@@ -140,44 +138,44 @@ func TestParser_Parse(t *testing.T) {
 							Metadata: resourceMetadata,
 							APIVersion: azure2.NewValue(
 								"2022-05-01",
-								createMetadata(targetFS, filename, 8, 8, "resources[0].apiVersion", &resourceMetadata),
+								createMetadata(fsys, filename, 8, 8, "resources[0].apiVersion", &resourceMetadata),
 							),
 							Type: azure2.NewValue(
 								"Microsoft.Storage/storageAccounts",
-								createMetadata(targetFS, filename, 7, 7, "resources[0].type", &resourceMetadata),
+								createMetadata(fsys, filename, 7, 7, "resources[0].type", &resourceMetadata),
 							),
 							Kind: azure2.NewValue(
 								"string",
-								createMetadata(targetFS, filename, 18, 18, "resources[0].kind", &resourceMetadata),
+								createMetadata(fsys, filename, 18, 18, "resources[0].kind", &resourceMetadata),
 							),
 							Name: azure2.NewValue(
 								"myResource",
-								createMetadata(targetFS, filename, 9, 9, "resources[0].name", &resourceMetadata),
+								createMetadata(fsys, filename, 9, 9, "resources[0].name", &resourceMetadata),
 							),
 							Location: azure2.NewValue(
 								"string",
-								createMetadata(targetFS, filename, 10, 10, "resources[0].location", &resourceMetadata),
+								createMetadata(fsys, filename, 10, 10, "resources[0].location", &resourceMetadata),
 							),
 							Properties: azure2.NewValue(
 								map[string]azure2.Value{
-									"allowSharedKeyAccess": azure2.NewValue(false, createMetadata(targetFS, filename, 28, 28, "resources[0].properties.allowSharedKeyAccess", &propertiesMetadata)),
+									"allowSharedKeyAccess": azure2.NewValue(false, createMetadata(fsys, filename, 28, 28, "resources[0].properties.allowSharedKeyAccess", &propertiesMetadata)),
 									"customDomain": azure2.NewValue(
 										map[string]azure2.Value{
-											"name":             azure2.NewValue("string", createMetadata(targetFS, filename, 30, 30, "resources[0].properties.customDomain.name", &customDomainMetadata)),
-											"useSubDomainName": azure2.NewValue(false, createMetadata(targetFS, filename, 31, 31, "resources[0].properties.customDomain.useSubDomainName", &customDomainMetadata)),
-											"number":           azure2.NewValue(int64(123), createMetadata(targetFS, filename, 32, 32, "resources[0].properties.customDomain.number", &customDomainMetadata)),
+											"name":             azure2.NewValue("string", createMetadata(fsys, filename, 30, 30, "resources[0].properties.customDomain.name", &customDomainMetadata)),
+											"useSubDomainName": azure2.NewValue(false, createMetadata(fsys, filename, 31, 31, "resources[0].properties.customDomain.useSubDomainName", &customDomainMetadata)),
+											"number":           azure2.NewValue(int64(123), createMetadata(fsys, filename, 32, 32, "resources[0].properties.customDomain.number", &customDomainMetadata)),
 										}, customDomainMetadata),
 									"networkAcls": azure2.NewValue(
 										[]azure2.Value{
 											azure2.NewValue(
 												map[string]azure2.Value{
-													"bypass": azure2.NewValue("AzureServices1", createMetadata(targetFS, filename, 36, 36, "resources[0].properties.networkAcls[0].bypass", &networkACL0Metadata)),
+													"bypass": azure2.NewValue("AzureServices1", createMetadata(fsys, filename, 36, 36, "resources[0].properties.networkAcls[0].bypass", &networkACL0Metadata)),
 												},
 												networkACL0Metadata,
 											),
 											azure2.NewValue(
 												map[string]azure2.Value{
-													"bypass": azure2.NewValue("AzureServices2", createMetadata(targetFS, filename, 39, 39, "resources[0].properties.networkAcls[1].bypass", &networkACL1Metadata)),
+													"bypass": azure2.NewValue("AzureServices2", createMetadata(fsys, filename, 39, 39, "resources[0].properties.networkAcls[1].bypass", &networkACL1Metadata)),
 												},
 												networkACL1Metadata,
 											),
@@ -196,9 +194,10 @@ func TestParser_Parse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NoError(t, targetFS.WriteFile(filename, []byte(tt.input), 0o644))
-
-			p := New(targetFS)
+			fsys := fstest.MapFS{
+				filename: &fstest.MapFile{Data: []byte(tt.input)},
+			}
+			p := New(fsys)
 			got, err := p.ParseFS(t.Context(), ".")
 			require.NoError(t, err)
 
@@ -208,7 +207,7 @@ func TestParser_Parse(t *testing.T) {
 			}
 
 			require.Len(t, got, 1)
-			want := tt.want()
+			want := tt.want(fsys)
 			g := got[0]
 
 			require.Equal(t, want, g)
@@ -281,11 +280,11 @@ func Test_NestedResourceParsing(t *testing.T) {
 }
 `
 
-	targetFS := memoryfs.New()
+	fsys := fstest.MapFS{
+		"nested.json": &fstest.MapFile{Data: []byte(input)},
+	}
 
-	require.NoError(t, targetFS.WriteFile("nested.json", []byte(input), 0o644))
-
-	p := New(targetFS)
+	p := New(fsys)
 	got, err := p.ParseFS(t.Context(), ".")
 	require.NoError(t, err)
 	require.Len(t, got, 1)
@@ -302,24 +301,3 @@ func Test_NestedResourceParsing(t *testing.T) {
 
 	assert.Equal(t, "queueServices/queues", queue.Type.AsString())
 }
-
-//
-// func Test_JsonFile(t *testing.T) {
-//
-// 	input, err := os.ReadFile("testdata/postgres.json")
-// 	require.NoError(t, err)
-//
-// 	targetFS := memoryfs.New()
-//
-// 	require.NoError(t, targetFS.WriteFile("postgres.json", input, 0o644))
-//
-// 	p := New(targetFS, options.ParserWithDebug(os.Stderr))
-// 	got, err := p.ParseFS(context.Background(), ".")
-// 	require.NoError(t, err)
-//
-// 	got[0].Resources[3].Name.Resolve()
-//
-// 	name := got[0].Resources[3].Name.AsString()
-// 	assert.Equal(t, "myserver", name)
-//
-// }

--- a/pkg/iac/scanners/terraformplan/snapshot/snapshot.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/snapshot.go
@@ -12,9 +12,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/liamg/memoryfs"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/aquasecurity/trivy/pkg/mapfs"
 	iox "github.com/aquasecurity/trivy/pkg/x/io"
 )
 
@@ -200,7 +200,7 @@ func (s *snapshot) getOrCreateModuleSnapshot(key string) *snapshotModule {
 }
 
 func (s *snapshot) toFS() (fs.FS, error) {
-	fsys := memoryfs.New()
+	fsys := mapfs.New()
 
 	for _, module := range s.modules {
 		if err := fsys.MkdirAll(module.dir, fs.ModePerm); err != nil && !errors.Is(err, os.ErrExist) {
@@ -211,7 +211,7 @@ func (s *snapshot) toFS() (fs.FS, error) {
 			if module.dir != "" {
 				filePath = path.Join(module.dir, filename)
 			}
-			if err := fsys.WriteFile(filePath, file, fs.ModePerm); err != nil {
+			if err := fsys.WriteVirtualFile(filePath, file, fs.ModePerm); err != nil {
 				return nil, fmt.Errorf("failed to add file: %w", err)
 			}
 		}

--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 
-	"github.com/liamg/memoryfs"
-
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/mapfs"
 )
 
 type Parser struct {
@@ -50,9 +50,9 @@ func (p *Parser) Parse(reader io.Reader) (*PlanFile, error) {
 
 }
 
-func (p *PlanFile) ToFS() (*memoryfs.FS, error) {
+func (p *PlanFile) ToFS() (fs.FS, error) {
 
-	rootFS := memoryfs.New()
+	rootFS := mapfs.New()
 
 	var fileResources []string
 
@@ -66,7 +66,7 @@ func (p *PlanFile) ToFS() (*memoryfs.FS, error) {
 	}
 
 	fileContent := strings.Join(fileResources, "\n\n")
-	if err := rootFS.WriteFile("main.tf", []byte(fileContent), os.ModePerm); err != nil {
+	if err := rootFS.WriteVirtualFile("main.tf", []byte(fileContent), os.ModePerm); err != nil {
 		return nil, err
 	}
 	return rootFS, nil

--- a/pkg/iac/types/fskey_test.go
+++ b/pkg/iac/types/fskey_test.go
@@ -4,8 +4,8 @@ import (
 	"io/fs"
 	"os"
 	"testing"
+	"testing/fstest"
 
-	"github.com/liamg/memoryfs"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aquasecurity/trivy/pkg/set"
@@ -16,8 +16,8 @@ func Test_FSKey(t *testing.T) {
 	systems := []fs.FS{
 		os.DirFS("."),
 		os.DirFS(".."),
-		memoryfs.New(),
-		memoryfs.New(),
+		fstest.MapFS{},
+		fstest.MapFS{},
 	}
 
 	keys := set.New[string]()


### PR DESCRIPTION
## Description

This PR replaces the use of `github.com/liamg/memoryfs` with the internal `mapfs` package and the standard `testing/fstest`.

After the integration of trivy-iac and defsec into trivy, memoryfs remains used only in the iac package. This change removes that dependency, aligning the codebase with trivy’s own virtual FS implementation.

## Related PRs
- https://github.com/aquasecurity/trivy/pull/9281

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
