### PR TITLE
fix(fs): avoid shadowing errors in file.glob

### DIFF
--- a/pkg/mapfs/file.go
+++ b/pkg/mapfs/file.go
@@ -254,13 +254,16 @@ func (f *file) glob(pattern string) ([]string, error) {
 
 	var err error
 	f.files.Range(func(name string, sub *file) bool {
-		if ok, err := filepath.Match(parts[0], name); err != nil {
+		var ok bool
+		ok, err = filepath.Match(parts[0], name)
+		if err != nil {
 			return false
 		} else if ok {
 			if len(parts) == 1 {
 				entries = append(entries, name)
 			} else {
-				subEntries, err := sub.glob(strings.Join(parts[1:], separator))
+				var subEntries []string
+				subEntries, err = sub.glob(strings.Join(parts[1:], separator))
 				if err != nil {
 					return false
 				}

--- a/pkg/mapfs/fs_test.go
+++ b/pkg/mapfs/fs_test.go
@@ -394,6 +394,11 @@ func TestFS_Glob(t *testing.T) {
 			pattern: "nosuch",
 			wantErr: assert.NoError,
 		},
+		{
+			name:    "invalid pattern",
+			pattern: "[abc",
+			wantErr: assert.Error,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

This PR fixes error shadowing in file.glob and ensures invalid glob patterns. Also adds a test case for malformed patterns.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
