### PR TITLE
fix(misconf): preserve original paths of remote submodules from .terraform

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -169,7 +169,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 	p.logger.Debug("Parsing FS", log.FilePath(slashed))
 	fileInfos, err := fs.ReadDir(p.moduleFS, slashed)
 	if err != nil {
-		return err
+		return fmt.Errorf("read dir: %w", err)
 	}
 
 	var paths []string


### PR DESCRIPTION
## Description

The current logic for resolving paths to submodules from sources like GitHub, Bitbucket, and registry-based modules (e.g., hashicorp/consul/aws//modules/consul-cluster) is incorrect.

For such modules, Trivy checks whether the module path from metadata ends with the relative path from the module source. If it doesn’t, Trivy appends the relative path to the existing metadata path. This workaround only works reliably for registry modules, where the source is clean and doesn’t contain additional parameters.

However, this logic breaks for Git-based modules, since their sources often include query parameters (e.g., ?ref=v1.2.0), which causes incorrect path resolution.

This logic is unnecessary because the metadata in .terraform/modules/modules.json already contains the full and correct path to the module. No further path manipulation is needed.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9297

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
