### PR TITLE
fix(misconf): use correct field log_bucket instead of target_bucket in gcp bucket

### DIFF
--- a/pkg/iac/adapters/terraform/google/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/google/storage/adapt.go
@@ -121,7 +121,7 @@ func (a *adapter) adaptBucketResource(resourceBlock *terraform.Block) storage.Bu
 
 	if logBlock := resourceBlock.GetBlock("logging"); logBlock.IsNotNil() {
 		bucket.Logging.Metadata = logBlock.GetMetadata()
-		bucket.Logging.LogBucket = logBlock.GetAttribute("target_bucket").AsStringValueOrDefault("", logBlock)
+		bucket.Logging.LogBucket = logBlock.GetAttribute("log_bucket").AsStringValueOrDefault("", logBlock)
 		bucket.Logging.LogObjectPrefix = logBlock.GetAttribute("log_object_prefix").AsStringValueOrDefault("", logBlock)
 	}
 

--- a/pkg/iac/adapters/terraform/google/storage/adapt_test.go
+++ b/pkg/iac/adapters/terraform/google/storage/adapt_test.go
@@ -147,7 +147,7 @@ func Test_Adapt(t *testing.T) {
 			  location = "US"
 
 			  logging {
-			    target_bucket = "access-logs-bucket"
+			    log_bucket = "access-logs-bucket"
 			  }
 
 			  versioning {
@@ -188,7 +188,7 @@ func Test_Adapt(t *testing.T) {
 			  location = "US"
 
 			  logging {
-			    target_bucket = "access-logs-bucket"
+			    log_bucket = "access-logs-bucket"
 			    log_object_prefix = "access-logs/"
 			  }
 			}`,


### PR DESCRIPTION
## Description

See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#log_bucket-1

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
