### PR TITLE
fix: suppress debug log for context cancellation errors

### DIFF
--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -81,8 +81,14 @@ func (v *VersionChecker) RunUpdateCheck(ctx context.Context) {
 
 		req.Header.Set("User-Agent", fmt.Sprintf("trivy/%s", v.currentVersion))
 		resp, err := client.Do(req)
-		if err != nil || resp.StatusCode != http.StatusOK {
-			logger.Debug("Failed getting response from Trivy api", log.Err(err))
+		if err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				logger.Debug("Failed getting response from Trivy api", log.Err(err))
+			}
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			logger.Debug("Unexpected status code from Trivy api", log.Int("status_code", resp.StatusCode))
 			return
 		}
 

--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -86,8 +86,7 @@ func (v *VersionChecker) RunUpdateCheck(ctx context.Context) {
 				logger.Debug("Failed getting response from Trivy api", log.Err(err))
 			}
 			return
-		}
-		if resp.StatusCode != http.StatusOK {
+		} else if resp.StatusCode != http.StatusOK {
 			logger.Debug("Unexpected status code from Trivy api", log.Int("status_code", resp.StatusCode))
 			return
 		}


### PR DESCRIPTION
## Description

Do not log context.Canceled and context.DeadlineExceeded errors as debug messages when the version check API request is interrupted. These errors are expected when scans complete before the API request finishes and should not be logged as failures.

Before this fix, the following debug message would appear:

```
DEBUG [notification] Failed getting response from Trivy api err="Get \"https://check.trivy.dev/updates\": context canceled"
```

After this fix, context cancellation errors are silently handled as expected behavior.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).