### PR TITLE
chore(deps): bump alpine from 3.21.4 to 3.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.21.4
+FROM alpine:3.22.1
 RUN apk --no-cache add ca-certificates git
-COPY trivy /usr/local/bin/trivy
+COPY trivy /usr/local/bin/
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.22.1
 RUN apk --no-cache add ca-certificates git
-COPY trivy /usr/local/bin/
+COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -6,6 +6,6 @@ RUN apk --no-cache add ca-certificates git
 # example architecture folder: dist/trivy_canary_build_linux_arm64/trivy
 # GoReleaser adds _v* to the folder name, but only when GOARCH is amd64
 ARG TARGETARCH
-COPY "dist/trivy_canary_build_linux_${TARGETARCH}*/trivy" /usr/local/bin/
+COPY "dist/trivy_canary_build_linux_${TARGETARCH}*/trivy" /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,11 +1,11 @@
-FROM alpine:3.21.4
+FROM alpine:3.22.1
 RUN apk --no-cache add ca-certificates git
 
 # binaries were created with GoReleaser
 # need to copy binaries from folder with correct architecture
 # example architecture folder: dist/trivy_canary_build_linux_arm64/trivy
-# GoReleaser adds _v* to the folder name, but only when GOARCH is amd64 
+# GoReleaser adds _v* to the folder name, but only when GOARCH is amd64
 ARG TARGETARCH
-COPY "dist/trivy_canary_build_linux_${TARGETARCH}*/trivy" /usr/local/bin/trivy
+COPY "dist/trivy_canary_build_linux_${TARGETARCH}*/trivy" /usr/local/bin/
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]


### PR DESCRIPTION
## Description

Docker images should respect the process signals trivy supports since 0.65.0.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
