### PR TITLE
refactor(fs): use underlyingPath to determine virtual files more reliably

### DIFF
--- a/pkg/mapfs/file.go
+++ b/pkg/mapfs/file.go
@@ -28,7 +28,7 @@ type file struct {
 }
 
 func (f *file) isVirtual() bool {
-	return len(f.data) != 0 || f.stat.IsDir()
+	return f.underlyingPath == "" || f.stat.IsDir()
 }
 
 func (f *file) Open(name string) (fs.File, error) {
@@ -59,7 +59,7 @@ func (f *file) open() (fs.File, error) {
 			fileStat: f.stat,
 			entry:    entries,
 		}, nil
-	case len(f.data) != 0: // Virtual file
+	case f.isVirtual(): // Virtual file
 		return &openMapFile{
 			path:   f.stat.name,
 			file:   f,

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -1,6 +1,7 @@
 package mapfs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -98,7 +99,7 @@ func (m *FS) FilterFunc(fn func(path string, d fs.DirEntry) (bool, error)) (*FS,
 			return xerrors.Errorf("unable to get %s: %w", path, err)
 		}
 		// Virtual file
-		if f.underlyingPath == "" {
+		if f.isVirtual() {
 			return newFS.WriteVirtualFile(path, f.data, f.stat.mode)
 		}
 		return newFS.WriteFile(path, f.underlyingPath)
@@ -197,6 +198,9 @@ func (m *FS) Open(name string) (fs.File, error) {
 
 // WriteFile creates a mapping between path and underlyingPath.
 func (m *FS) WriteFile(path, underlyingPath string) error {
+	if underlyingPath == "" {
+		return errors.New("underlying path must not be empty")
+	}
 	return m.root.WriteFile(cleanPath(path), underlyingPath)
 }
 


### PR DESCRIPTION
## Description

Previously, empty virtual files (with zero length) were not recognized as virtual, causing errors when opening or calling Stat on them. This was due to virtual files being identified based on their size. This PR changes the criteria: a file is now considered virtual if it has no underlyingPath.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
