### PR TITLE
feat: add timeout handling for cache database operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aquasecurity/testdocker v0.0.0-20250616060700-ba6845ac6d17
 	github.com/aquasecurity/tml v0.6.1
 	github.com/aquasecurity/trivy-checks v1.11.3-0.20250604022615-9a7efa7c9169
-	github.com/aquasecurity/trivy-db v0.0.0-20250723062229-56ec1e482238
+	github.com/aquasecurity/trivy-db v0.0.0-20250731052236-c7c831e2254d
 	github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48
 	github.com/aquasecurity/trivy-kubernetes v0.9.1
 	github.com/aws/aws-sdk-go-v2 v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -829,8 +829,8 @@ github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gw
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
 github.com/aquasecurity/trivy-checks v1.11.3-0.20250604022615-9a7efa7c9169 h1:TckzIxUX7lZaU9f2lNxCN0noYYP8fzmSQf6a4JdV83w=
 github.com/aquasecurity/trivy-checks v1.11.3-0.20250604022615-9a7efa7c9169/go.mod h1:nT69xgRcBD4NlHwTBpWMYirpK5/Zpl8M+XDOgmjMn2k=
-github.com/aquasecurity/trivy-db v0.0.0-20250723062229-56ec1e482238 h1:ZT7cZan/iS/nD7D6CG4/AVdtqArKi9GtovlL4lEi/RY=
-github.com/aquasecurity/trivy-db v0.0.0-20250723062229-56ec1e482238/go.mod h1:upAJqDQkN5FdIJbtJMpokncGNhYAPGkpoCbaGciWPt4=
+github.com/aquasecurity/trivy-db v0.0.0-20250731052236-c7c831e2254d h1:Lc+p2CLARivVF48o7uRoFPaahNCvNFyBfeby0JqAMXo=
+github.com/aquasecurity/trivy-db v0.0.0-20250731052236-c7c831e2254d/go.mod h1:upAJqDQkN5FdIJbtJMpokncGNhYAPGkpoCbaGciWPt4=
 github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48 h1:JVgBIuIYbwG+ekC5lUHUpGJboPYiCcxiz06RCtz8neI=
 github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48/go.mod h1:Ldya37FLi0e/5Cjq2T5Bty7cFkzUDwTcPeQua+2M8i8=
 github.com/aquasecurity/trivy-kubernetes v0.9.1 h1:bSErQcavKXDh7XMwbGX7Vy//jR5+xhe/bOgfn9G+9lQ=

--- a/pkg/cache/fs.go
+++ b/pkg/cache/fs.go
@@ -2,8 +2,10 @@ package cache
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	bolt "go.etcd.io/bbolt"
@@ -11,6 +13,8 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
+
+const defaultFSCacheTimeout = 5 * time.Second
 
 var _ Cache = &FSCache{}
 
@@ -25,9 +29,15 @@ func NewFSCache(cacheDir string) (FSCache, error) {
 		return FSCache{}, xerrors.Errorf("failed to create cache dir: %w", err)
 	}
 
-	db, err := bolt.Open(filepath.Join(dir, "fanal.db"), 0o600, nil)
+	db, err := bolt.Open(filepath.Join(dir, "fanal.db"), 0o600, &bolt.Options{
+		Timeout: defaultFSCacheTimeout,
+	})
 	if err != nil {
-		return FSCache{}, xerrors.Errorf("unable to open DB: %w", err)
+		// Check if the error is due to timeout (database locked by another process)
+		if errors.Is(err, bolt.ErrTimeout) {
+			return FSCache{}, xerrors.Errorf("cache may be in use by another process: %w", err)
+		}
+		return FSCache{}, xerrors.Errorf("unable to open cache DB: %w", err)
 	}
 
 	err = db.Update(func(tx *bolt.Tx) error {


### PR DESCRIPTION
## Description

This PR adds timeout handling to the cache database operations to prevent Trivy from hanging indefinitely when another process has locked the database.

### Changes:
- Add 5-second timeout for BoltDB cache operations
- Return clearer error messages:
  - Timeout errors: "cache may be in use by another process"
  - Other errors: "unable to open cache DB"
- Update troubleshooting documentation with lock error guidance

### Before:
When another process locks the cache database, Trivy hangs indefinitely with no output.

### After:
```
$ trivy image alpine:latest
2025-08-04T12:00:00.000+0000    FATAL   cache may be in use by another process: timeout
```

## Related issues
- Fixes cases where Trivy hangs indefinitely when another process has locked the cache database

## Related PRs
- [x] https://github.com/aquasecurity/trivy-db/pull/560

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).