### PR TITLE
fix(image): use standardized HTTP client for ECR authentication

### DIFF
--- a/pkg/fanal/image/registry/ecr/ecr.go
+++ b/pkg/fanal/image/registry/ecr/ecr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/image/registry/intf"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
+	xhttp "github.com/aquasecurity/trivy/pkg/x/http"
 )
 
 type ecrAPI interface {
@@ -80,7 +81,9 @@ func determineRegion(domain string) string {
 
 func (e *ECRClient) GetCredential(ctx context.Context) (username, password string, err error) {
 	input := &ecr.GetAuthorizationTokenInput{}
-	result, err := e.Client.GetAuthorizationToken(ctx, input)
+	result, err := e.Client.GetAuthorizationToken(ctx, input, func(options *ecr.Options) {
+		options.HTTPClient = xhttp.Client()
+	})
 	if err != nil {
 		return "", "", xerrors.Errorf("failed to get authorization token: %w", err)
 	}


### PR DESCRIPTION
## Description
This change standardizes the HTTP client configuration for ECR authentication by using `xhttp.Client()` instead of relying on AWS SDK's default HTTP client. This change ensures consistent HTTP client behavior across all Trivy components

## Related issues
Issue is not created yet, will include once created

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
