### PR TITLE
fix(misconf): ensure ignore rules respect subdirectory chart paths

### DIFF
--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -124,7 +124,7 @@ func (s *Scanner) getScanResults(ctx context.Context, path string, target fs.FS)
 	for _, file := range chartFiles {
 		s.logger.Debug("Processing rendered chart file", log.FilePath(file.TemplateFilePath))
 
-		ignoreRules := ignore.Parse(file.ManifestContent, file.TemplateFilePath, "")
+		ignoreRules := ignore.Parse(file.ManifestContent, file.TemplateFilePath, helmParser.ChartSource)
 		manifests, err := kparser.Parse(ctx, strings.NewReader(file.ManifestContent), file.TemplateFilePath)
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal yaml: %w", err)

--- a/pkg/iac/scanners/helm/test/parser_test.go
+++ b/pkg/iac/scanners/helm/test/parser_test.go
@@ -150,12 +150,9 @@ func Test_helm_tarball_parser(t *testing.T) {
 
 		t.Logf("Running test: %s", test.testName)
 
-		testPath := filepath.Join("testdata", test.archiveFile)
-		testFs := fsysForAcrhive(t, testPath)
-
 		helmParser, err := parser.New(test.archiveFile)
 		require.NoError(t, err)
-		require.NoError(t, helmParser.ParseFS(t.Context(), testFs, "."))
+		require.NoError(t, helmParser.ParseFS(t.Context(), os.DirFS("testdata"), test.archiveFile))
 
 		manifests, err := helmParser.RenderedChartFiles()
 		require.NoError(t, err)

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,14 +20,13 @@ import (
 func TestScanner_ScanFS(t *testing.T) {
 	tests := []struct {
 		name   string
-		fsys   fs.FS
+		target string
 		opts   []options.ScannerOption
 		assert func(t *testing.T, results scan.Results)
 	}{
 		{
-			name: "archived chart",
-			// TODO: Scan the archive directly
-			fsys: fsysForAcrhive(t, filepath.Join("testdata", "mysql-8.8.26.tar")),
+			name:   "archived chart",
+			target: filepath.Join("testdata", "mysql-8.8.26.tar"),
 			assert: assertIds([]string{
 				"AVD-KSV-0001", "AVD-KSV-0003",
 				"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
@@ -40,8 +37,8 @@ func TestScanner_ScanFS(t *testing.T) {
 			}),
 		},
 		{
-			name: "chart in directory",
-			fsys: os.DirFS(filepath.Join("testdata", "testchart")),
+			name:   "chart in directory",
+			target: filepath.Join("testdata", "testchart"),
 			assert: func(t *testing.T, results scan.Results) {
 				assertIds([]string{
 					"AVD-KSV-0001", "AVD-KSV-0003",
@@ -57,13 +54,13 @@ func TestScanner_ScanFS(t *testing.T) {
 				assert.Len(t, ignored, 1)
 
 				assert.Equal(t, "AVD-KSV-0018", ignored[0].Rule().AVDID)
-				assert.Equal(t, "templates/deployment.yaml", ignored[0].Metadata().Range().GetFilename())
+				assert.Equal(t, "testchart/templates/deployment.yaml", ignored[0].Metadata().Range().GetFilename())
 			},
 		},
 		{
 			// TODO: The chart name isn't actually empty
-			name: "scanner with missing chart name can recover",
-			fsys: fsysForAcrhive(t, filepath.Join("testdata", "aws-cluster-autoscaler-bad.tar.gz")),
+			name:   "scanner with missing chart name can recover",
+			target: filepath.Join("testdata", "aws-cluster-autoscaler-bad.tar.gz"),
 			assert: assertIds([]string{
 				"AVD-KSV-0014", "AVD-KSV-0023", "AVD-KSV-0030",
 				"AVD-KSV-0104", "AVD-KSV-0003", "AVD-KSV-0018",
@@ -74,8 +71,8 @@ func TestScanner_ScanFS(t *testing.T) {
 			}),
 		},
 		{
-			name: "with custom check",
-			fsys: fsysForAcrhive(t, filepath.Join("testdata", "mysql-8.8.26.tar")),
+			name:   "with custom check",
+			target: filepath.Join("testdata", "mysql-8.8.26.tar"),
 			opts: []options.ScannerOption{
 				rego.WithPolicyNamespaces("user"),
 				rego.WithPolicyReader(strings.NewReader(`package user.kubernetes.ID001
@@ -109,16 +106,16 @@ deny[res] {
 			}),
 		},
 		{
-			name: "template-based name",
-			fsys: os.DirFS(filepath.Join("testdata", "templated-name")),
+			name:   "template-based name",
+			target: filepath.Join("testdata", "templated-name"),
 			opts: []options.ScannerOption{
 				rego.WithEmbeddedLibraries(false),
 				rego.WithEmbeddedPolicies(false),
 			},
 		},
 		{
-			name: "failed result contains the code",
-			fsys: os.DirFS("testdata/simmilar-templates"),
+			name:   "failed result contains the code",
+			target: filepath.Join("testdata", "simmilar-templates"),
 			opts: []options.ScannerOption{
 				rego.WithEmbeddedPolicies(false),
 				rego.WithEmbeddedLibraries(true),
@@ -149,8 +146,8 @@ deny[res] {
 			},
 		},
 		{
-			name: "scan the subchart once",
-			fsys: os.DirFS(filepath.Join("testdata", "with-subchart")),
+			name:   "scan the subchart once",
+			target: filepath.Join("testdata", "with-subchart"),
 			opts: []options.ScannerOption{
 				rego.WithEmbeddedPolicies(false),
 				rego.WithEmbeddedLibraries(true),
@@ -188,7 +185,8 @@ deny[res] {
 			}
 			opts = append(opts, tt.opts...)
 			scanner := helm.New(opts...)
-			results, err := scanner.ScanFS(t.Context(), tt.fsys, ".")
+			fsys := os.DirFS(filepath.Dir(tt.target))
+			results, err := scanner.ScanFS(t.Context(), fsys, filepath.Base(tt.target))
 			require.NoError(t, err)
 
 			if tt.assert != nil {
@@ -208,21 +206,6 @@ func assertIds(expected []string) func(t *testing.T, results scan.Results) {
 		}
 		assert.ElementsMatch(t, expected, errorCodes.Items())
 	}
-}
-
-func fsysForAcrhive(t *testing.T, src string) fs.FS {
-	in, err := os.Open(src)
-	require.NoError(t, err)
-	defer in.Close()
-
-	tmpDir := t.TempDir()
-	out, err := os.Create(filepath.Join(tmpDir, filepath.Base(src)))
-	require.NoError(t, err)
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	require.NoError(t, err)
-	return os.DirFS(tmpDir)
 }
 
 func TestScaningNonHelmChartDoesNotCauseError(t *testing.T) {


### PR DESCRIPTION
## Description
This PR fixes the ignoring of misfigurations in Helm charts when the chart is in a subdirectory. The `archived chart` test case caught this when refactoring the test.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
