### PR TITLE
docs: update links to Semaphore pages

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -43,11 +43,11 @@ The Dagger module for Trivy provides functions for scanning container images fro
 
 
 ## Semaphore (Community)
-[Semaphore](https://semaphoreci.com/) is a CI/CD service.
+[Semaphore](https://semaphore.io/) is a CI/CD service.
 
 You can use Trivy in Semaphore for scanning code, containers, infrastructure, and Kubernetes in Semaphore workflow.
 
-👉 Get it at: <https://semaphoreci.com/blog/continuous-container-vulnerability-testing-with-trivy>
+👉 Get it at: <https://docs.semaphore.io/using-semaphore/recipes/trivy>
 
 ## CircleCI (Community)
 [CircleCI](https://circleci.com/) is a CI/CD service.


### PR DESCRIPTION
## Description

This change only affects the Trivy Docs

At Semaphore, we have changed the Semaphore domain from semaphoreci.com to semaphore.io. We have also added new docs with an integration with Trivy. This change updates the links to the correct domains and URLs

## Related issues
- No related issues

## Related PRs
- No related issues
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
