### PR TITLE
fix(plugin): don't remove plugins when updating index.yaml file

### DIFF
--- a/pkg/plugin/index.go
+++ b/pkg/plugin/index.go
@@ -34,9 +34,17 @@ type Index struct {
 
 func (m *Manager) Update(ctx context.Context, opts Options) error {
 	m.logger.InfoContext(ctx, "Updating the plugin index...", log.String("url", m.indexURL))
-	if _, err := downloader.Download(ctx, m.indexURL, filepath.Dir(m.indexPath), "",
-		downloader.Options{Insecure: opts.Insecure}); err != nil {
+
+	// Download the index file to a temporary directory and copy it to the plugins directory,
+	// to avoid removing installed plugins.
+	tempDir, err := downloader.DownloadToTempDir(ctx, m.indexURL, downloader.Options{Insecure: opts.Insecure})
+	if err != nil {
 		return xerrors.Errorf("unable to download the plugin index: %w", err)
+	}
+
+	_, err = fsutils.CopyFile(filepath.Join(tempDir, "index.yaml"), m.indexPath)
+	if err != nil {
+		return xerrors.Errorf("unable to copy the plugin index file: %w", err)
 	}
 	return nil
 }

--- a/pkg/plugin/index.go
+++ b/pkg/plugin/index.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,11 @@ func (m *Manager) Update(ctx context.Context, opts Options) error {
 	tempDir, err := downloader.DownloadToTempDir(ctx, m.indexURL, downloader.Options{Insecure: opts.Insecure})
 	if err != nil {
 		return xerrors.Errorf("unable to download the plugin index: %w", err)
+	}
+
+	err = os.MkdirAll(filepath.Dir(m.indexPath), fs.ModePerm)
+	if err != nil {
+		return xerrors.Errorf("failed to create plugin index dir: %w", err)
 	}
 
 	_, err = fsutils.CopyFile(filepath.Join(tempDir, "index.yaml"), m.indexPath)


### PR DESCRIPTION
## Description

  Fixes plugin directory removal during index updates by changing the download strategy for index.yaml files. Previously, the plugin manager would use downloader.Download() which could inadvertently remove the entire plugin directory
  during index updates.
See the following code:
https://github.com/aquasecurity/trivy/blob/8f5b56005a4e8752976524750089dc9ea2c91e40/pkg/downloader/download.go#L58-L60
This change ensures that installed plugins are preserved when updating the plugin index.

  The fix implements a safer approach by:
  - Downloading the index file to a temporary directory using downloader.DownloadToTempDir()
  - Explicitly copying only the index.yaml file to the plugin directory using fsutils.CopyFile()

### Examples:
Before:
```bash
➜ trivy plugin list
Installed Plugins:
  Name:    referrer
  Version: 0.3.1

➜ trivy plugin update
2025-08-20T12:35:54+06:00	INFO	[plugin] Updating the plugin index...	url="https://aquasecurity.github.io/trivy-plugin-index/v1/index.yaml"
➜ trivy plugin list  
No Installed Plugins
```
After:
```bash
➜ ./trivy plugin list
Installed Plugins:
  Name:    referrer
  Version: 0.3.1

➜ ./trivy plugin update
2025-08-20T12:38:36+06:00       INFO    [plugin] Updating the plugin index...   url="https://aquasecurity.github.io/trivy-plugin-index/v1/index.yaml"
➜ ./trivy plugin list  
Installed Plugins:
  Name:    referrer
  Version: 0.3.1

```

## Related issues
- Close #9357

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
