### PR TITLE
fix: persistent flag option typo

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -317,7 +317,7 @@ func (f *Flag[T]) Bind(cmd *cobra.Command) error {
 
 	// Bind CLI flags
 	flag := cmd.Flags().Lookup(f.Name)
-	if f == nil {
+	if flag == nil {
 		// Lookup local persistent flags
 		flag = cmd.PersistentFlags().Lookup(f.Name)
 	}


### PR DESCRIPTION
## Description

I found typo when reading the trivy source code.
https://github.com/aquasecurity/trivy/blob/main/pkg/flag/options.go#L319-L323

## Related issues
- [GitHub Discussion](https://github.com/aquasecurity/trivy/discussions/9369)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
