### PR TITLE
fix: create temp file under composite fs dir

### DIFF
--- a/pkg/fanal/analyzer/fs.go
+++ b/pkg/fanal/analyzer/fs.go
@@ -36,7 +36,7 @@ func NewCompositeFS() (*CompositeFS, error) {
 func (c *CompositeFS) CopyFileToTemp(opener Opener, _ os.FileInfo) (string, error) {
 	// Create a temporary file to which the file in the layer will be copied
 	// so that all the files will not be loaded into memory
-	f, err := xos.CreateTemp("", "analyzer-file-")
+	f, err := xos.CreateTemp(c.dir, "analyzer-file-")
 	if err != nil {
 		return "", xerrors.Errorf("create temp error: %w", err)
 	}


### PR DESCRIPTION
## Description

Previously, files were saved under /tmp/analyzer-fs-*/file-*, and since Cleanup removed /tmp/analyzer-fs-*, the cleanup process completed successfully.

However, due to the following commit, analyzer-composite-* and analyzer-file-* are now placed separately under /tmp/trivy-*. 
https://github.com/aquasecurity/trivy/commit/8f5b56005a4e8752976524750089dc9ea2c91e40

Considering the previous behavior, I think analyzer-file-* should be created under /tmp/trivy-*/analyzer-composite-*/. 

## Related issues

## Related PRs

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
