### PR TITLE
fix(repo): preserve RepoMetadata on FS cache hit

### DIFF
--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -190,10 +190,11 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 			// Cache hit
 			a.logger.DebugContext(ctx, "Cache hit", log.String("key", cacheKey))
 			return artifact.Reference{
-				Name:    cmp.Or(a.artifactOption.Original, a.rootPath),
-				Type:    a.artifactOption.Type,
-				ID:      cacheKey,
-				BlobIDs: []string{cacheKey},
+				Name:         cmp.Or(a.artifactOption.Original, a.rootPath),
+				Type:         a.artifactOption.Type,
+				ID:           cacheKey,
+				BlobIDs:      []string{cacheKey},
+				RepoMetadata: a.repoMetadata,
 			}, nil
 		}
 	}

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -276,6 +276,15 @@ func TestArtifact_Inspect(t *testing.T) {
 				BlobIDs: []string{
 					"sha256:dc7c6039424c9fce969d3c2972d261af442a33f13e7494464386dbe280612d4c",
 				},
+				RepoMetadata: artifact.RepoMetadata{
+					RepoURL:   "https://github.com/aquasecurity/trivy-test-repo/",
+					Branch:    "main",
+					Tags:      []string{"v0.0.1"},
+					Commit:    "8a19b492a589955c3e70c6ad8efd1e4ec6ae0d35",
+					CommitMsg: "Update README.md",
+					Author:    "Teppei Fukuda <knqyf263@gmail.com>",
+					Committer: "GitHub <noreply@github.com>",
+				},
 			},
 			wantBlobInfo: &types.BlobInfo{
 				SchemaVersion: types.BlobJSONSchemaVersion,


### PR DESCRIPTION
## Description

This PR fixes an inconsistency where local FS Artifact.Inspect() returned an artifact.Reference without RepoMetadata on cache hits. As a result, repository context (repo URL, branch, tags, commit, author, etc.) was lost when the result came
from cache, diverging from the non-cached path.

Changes:

- Populate RepoMetadata from a.repoMetadata in the cache-hit path of pkg/fanal/artifact/local/fs.go.
- Update pkg/fanal/artifact/repo/git_test.go to assert RepoMetadata fields (RepoURL, Branch, Tags, Commit, CommitMsg, Author, Committer).

### Examples:
Before:
```bash 
➜ trivy repo -f json -o repo.test --cache-dir .cache --scanners=secret -q https://github.com/test/repo/
➜ jq '.Metadata.RepoURL' repo.test    
"https://github.com/test/repo/"


➜ trivy repo -f json -o repo.test --cache-dir .cache --scanners=secret -q https://github.com/test/repo/
➜ jq '.Metadata.RepoURL' repo.test    
null

``` 
After:
```bash 
➜ trivy repo -f json -o repo.test --cache-dir .cache --scanners=secret -q https://github.com/test/repo/
➜ jq '.Metadata.RepoURL' repo.test    
"https://github.com/test/repo/"


➜ trivy repo -f json -o repo.test --cache-dir .cache --scanners=secret -q https://github.com/test/repo/
➜ jq '.Metadata.RepoURL' repo.test    
"https://github.com/test/repo/"

``` 

## Related issues
- Close #9388

## Related PRs
- [x] #9252

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
