### PR TITLE
fix(db): Dowload database when missing but metadata still exists

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -146,7 +146,7 @@ func (c *Client) NeedsUpdate(ctx context.Context, cliVersion string, skip bool) 
 		return true, nil
 	}
 
-	return !c.isNewDB(ctx, meta), nil
+	return noRequiredFiles || !c.isNewDB(ctx, meta), nil
 }
 
 func (c *Client) validate(meta metadata.Metadata) error {

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -219,6 +219,19 @@ func TestClient_NeedsUpdate(t *testing.T) {
 				"The local DB has an old schema version which is not supported by the current version of Trivy CLI. DB needs to be updated.",
 			},
 		},
+		{
+			name:         "trivy.db is missing but metadata with recent DownloadedAt",
+			dbFileExists: false,
+			metadata: metadata.Metadata{
+				Version:      db.SchemaVersion,
+				NextUpdate:   timeNextUpdateDay1,
+				DownloadedAt: time.Date(2019, 9, 30, 23, 30, 0, 0, time.UTC),
+			},
+			want: true,
+			wantLogs: []string{
+				"There is no db file",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
In the case where the trivy database has been deleted, but the metadata.json is still there and the database has not yet expired, the database is not downloaded.
Steps to reproduce:
```bash
trivy -d --cache-dir /tmp/trivy-cache image --download-db-only --db-repository ghcr.io/aquasecurity/trivy-db
rm /tmp/trivy-cache/db/trivy.db
trivy -d --cache-dir /tmp/trivy-cache image --download-db-only --db-repository ghcr.io/aquasecurity/trivy-db
```
This PR contains a change so that the database will be downloaded if `trivy.db` is missing even if the metadata is correct.
See also discussion [here](https://github.com/aquasecurity/trivy/discussions/9364).


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
