### PR TITLE
feat(purl): generate OCI PURLs for local images without digests

### DIFF
--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -375,7 +375,7 @@ func TestNewPackageURL(t *testing.T) {
 			},
 		},
 		{
-			name: "container local",
+			name: "container without tags and digests",
 			typ:  purl.TypeOCI,
 			metadata: types.Metadata{
 				RepoTags:    []string{},
@@ -421,17 +421,74 @@ func TestNewPackageURL(t *testing.T) {
 			},
 		},
 		{
-			name: "sad path",
+			name: "local image with tag only",
 			typ:  purl.TypeOCI,
 			metadata: types.Metadata{
 				RepoTags: []string{
-					"cblmariner2preview.azurecr.io/base/core:2.0.20220124-amd64",
+					"alpine:3.14",
 				},
-				RepoDigests: []string{
-					"sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+				ImageConfig: v1.ConfigFile{
+					Architecture: "amd64",
 				},
 			},
-			wantErr: "failed to parse digest",
+			want: &purl.PackageURL{
+				Type:      packageurl.TypeOCI,
+				Namespace: "",
+				Name:      "alpine",
+				Version:   "",
+				Qualifiers: packageurl.Qualifiers{
+					{
+						Key:   "repository_url",
+						Value: "index.docker.io/library/alpine",
+					},
+					{
+						Key:   "tag",
+						Value: "3.14",
+					},
+					{
+						Key:   "arch",
+						Value: "amd64",
+					},
+				},
+			},
+		},
+		{
+			name: "local image with latest tag (not included)",
+			typ:  purl.TypeOCI,
+			metadata: types.Metadata{
+				RepoTags: []string{
+					"nginx:latest",
+				},
+				ImageConfig: v1.ConfigFile{
+					Architecture: "amd64",
+				},
+			},
+			want: &purl.PackageURL{
+				Type:      packageurl.TypeOCI,
+				Namespace: "",
+				Name:      "nginx",
+				Version:   "",
+				Qualifiers: packageurl.Qualifiers{
+					{
+						Key:   "repository_url",
+						Value: "index.docker.io/library/nginx",
+					},
+					{
+						Key:   "arch",
+						Value: "amd64",
+					},
+				},
+			},
+		},
+		{
+			name: "sad path - invalid reference",
+			typ:  purl.TypeOCI,
+			metadata: types.Metadata{
+				RepoDigests: []string{
+					"invalid:::digest///format",
+				},
+			},
+			wantErr: "failed to parse reference",
 		},
 		{
 			name: "julia project",


### PR DESCRIPTION
## Description

This PR ensures that Trivy always generates a valid OCI PURL for container images, even when scanning local images without `RepoDigests` (images that haven't been pushed to any registry). Previously, Trivy would not generate a PURL for such images, which breaks OpenVEX matching that expects product IDs in OCI PURL format.

### Key Changes

- **Refactored `parseOCI` function** to handle both remote and local images using a unified approach with `cn.ParseReference`
- **For local images (without RepoDigests)**: Generate PURL with empty version and include tag as a qualifier
- **For remote images (with RepoDigests)**: Continue to use digest as version (unchanged behavior)
- **Eliminated code duplication** by using a type switch to differentiate between Digest and Tag references

### PURL Format

- **With RepoDigests**: `pkg:oci/<name>@sha256:<digest>?repository_url=<host/path>&arch=<arch>`
- **Without RepoDigests**: `pkg:oci/<name>?repository_url=<host/path>&tag=<tag>&arch=<arch>`
  - Note: `tag` qualifier is omitted for "latest" tag

### Rationale

Based on discussions in the PURL specification community ([package-url/purl-spec#127](https://github.com/package-url/purl-spec/issues/127)), the maintainers have indicated that:
- Default location can be optional for a given PURL type
- `repository_url` should be treated as a hint rather than a mandatory locator
- This approach allows for "decoupling location from identity"

## Related issues
- Addresses the issue where local images don't have PURL, breaking OpenVEX compatibility

## Before and After Examples

### Before (local image without RepoDigests)
```json
{
  "metadata": {
    "component": {
      "type": "container",
      "name": "test:latest",
      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
      "purl": null
    }
  }
}
```

### After (local image without RepoDigests)
```json
{
  "metadata": {
    "component": {
      "type": "container",
      "name": "test:latest",
      "bom-ref": "pkg:oci/test?arch=arm64&repository_url=index.docker.io%2Flibrary%2Ftest",
      "purl": "pkg:oci/test?arch=arm64&repository_url=index.docker.io%2Flibrary%2Ftest"
    }
  }
}
```

### After (local image with specific tag)
```json
{
  "metadata": {
    "component": {
      "type": "container",
      "name": "python:3.11.6-slim-seal",
      "bom-ref": "pkg:oci/python?arch=amd64&repository_url=index.docker.io%2Flibrary%2Fpython&tag=3.11.6-slim-seal",
      "purl": "pkg:oci/python?arch=amd64&repository_url=index.docker.io%2Flibrary%2Fpython&tag=3.11.6-slim-seal"
    }
  }
}
```

### Remote image behavior remains unchanged
```json
{
  "metadata": {
    "component": {
      "type": "container",
      "name": "ghcr.io/aquasecurity/trivy:0.64.1",
      "purl": "pkg:oci/trivy@sha256%3Aa8ca29078522f30393bdb34225e4c0994d38f37083be81a42da3a2a7e1488e9e?arch=arm64&repository_url=ghcr.io%2Faquasecurity%2Ftrivy"
    }
  }
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).