### PR TITLE
test: add HTTP basic authentication to git test server

### DIFF
--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -3,10 +3,12 @@
 package repo
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,7 +24,7 @@ import (
 )
 
 func TestNewArtifact(t *testing.T) {
-	ts := gittest.NewTestServer(t)
+	ts := gittest.NewTestServer(t, gittest.Options{})
 	defer ts.Close()
 
 	type args struct {
@@ -164,7 +166,7 @@ func TestNewArtifact(t *testing.T) {
 }
 
 func TestArtifact_Inspect(t *testing.T) {
-	ts := gittest.NewTestServer(t)
+	ts := gittest.NewTestServer(t, gittest.Options{})
 	defer ts.Close()
 
 	tests := []struct {
@@ -328,6 +330,178 @@ func TestArtifact_Inspect(t *testing.T) {
 			assert.Equal(t, tt.wantBlobInfo, &blobInfo, "cache content mismatch")
 		})
 	}
+}
+
+// setupAuthTestServer creates a test server with authentication and returns parsed URL with /test-repo.git path
+func setupAuthTestServer(t *testing.T, username, password string) *url.URL {
+	t.Helper()
+	ts := gittest.NewTestServer(t, gittest.Options{
+		Username: username,
+		Password: password,
+	})
+	t.Cleanup(ts.Close)
+
+	tsURL, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	tsURL.Path = "/test-repo.git"
+
+	return tsURL
+}
+
+// testInspectArtifact is a helper function to inspect an artifact and assert the results
+func testInspectArtifact(t *testing.T, target, wantRepoURL, wantErr string) {
+	t.Helper()
+	art, cleanup, err := NewArtifact(target, cache.NewMemoryCache(), walker.NewFS(), artifact.Option{})
+	t.Cleanup(cleanup)
+
+	if wantErr != "" {
+		require.ErrorContains(t, err, wantErr)
+		return
+	}
+	require.NoError(t, err)
+
+	// Verify Inspect works
+	ref, err := art.Inspect(t.Context())
+	require.NoError(t, err)
+
+	// Verify the RepoURL
+	assert.Equal(t, wantRepoURL, ref.RepoMetadata.RepoURL)
+
+	// Verify we have blob IDs (indicating successful scan)
+	assert.NotEmpty(t, ref.BlobIDs)
+}
+
+func TestArtifact_InspectWithAuth(t *testing.T) {
+	const (
+		testUsername = "testuser"
+		testPassword = "testpass"
+	)
+
+	// Test with environment variable authentication (GITHUB_TOKEN, GITLAB_TOKEN)
+	t.Run("environment variable authentication", func(t *testing.T) {
+		const testGitUsername = "fanal-aquasecurity-scan" // This is the username used by Trivy
+
+		// Setup test server with authentication
+		tsURL := setupAuthTestServer(t, testGitUsername, testPassword)
+
+		tests := []struct {
+			name        string
+			target      string
+			envVars     map[string]string
+			wantErr     string
+			wantRepoURL string
+		}{
+			{
+				name:   "success with GITHUB_TOKEN",
+				target: tsURL.String(),
+				envVars: map[string]string{
+					"GITHUB_TOKEN": testPassword,
+				},
+				wantRepoURL: tsURL.String(),
+			},
+			{
+				name:   "success with GITLAB_TOKEN",
+				target: tsURL.String(),
+				envVars: map[string]string{
+					"GITLAB_TOKEN": testPassword,
+				},
+				wantRepoURL: tsURL.String(),
+			},
+			{
+				name:    "failure without token",
+				target:  tsURL.String(),
+				wantErr: "authentication required",
+			},
+			{
+				name:   "failure with wrong token",
+				target: tsURL.String(),
+				envVars: map[string]string{
+					"GITHUB_TOKEN": "wrongpassword",
+				},
+				wantErr: "authentication required",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Set test environment variables
+				for key, value := range tt.envVars {
+					t.Setenv(key, value)
+				}
+
+				// Test using helper function
+				testInspectArtifact(t, tt.target, tt.wantRepoURL, tt.wantErr)
+			})
+		}
+	})
+
+	// Test with URL-embedded authentication
+	t.Run("URL embedded authentication", func(t *testing.T) {
+		// Setup test server with authentication
+		tsURL := setupAuthTestServer(t, testUsername, testPassword)
+
+		// Helper function to generate target URL with credentials
+		makeTarget := func(username, password string) string {
+			u := *tsURL // Copy the URL
+			if username != "" && password != "" {
+				u.User = url.UserPassword(username, password)
+			}
+			return u.String()
+		}
+
+		tests := []struct {
+			name        string
+			target      string
+			wantRepoURL string
+			wantErr     string
+		}{
+			{
+				name:        "success with embedded credentials",
+				target:      makeTarget(testUsername, testPassword),
+				wantRepoURL: makeTarget(testUsername, testPassword), // TODO: username/password should be stripped
+			},
+			{
+				name:    "failure with wrong password",
+				target:  makeTarget(testUsername, "wrongpass"),
+				wantErr: "authentication required",
+			},
+			{
+				name:    "failure without credentials",
+				target:  makeTarget("", ""),
+				wantErr: "authentication required",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Test using helper function
+				testInspectArtifact(t, tt.target, tt.wantRepoURL, tt.wantErr)
+			})
+		}
+	})
+
+	// Test cloning with embedded credentials and then scanning the local directory
+	t.Run("clone with credentials then scan local", func(t *testing.T) {
+		// Setup test server with authentication
+		tsURL := setupAuthTestServer(t, testUsername, testPassword)
+
+		// Add credentials to URL
+		tsURL.User = url.UserPassword(testUsername, testPassword)
+		targetWithCreds := tsURL.String()
+
+		// Clone the repository with URL-embedded credentials
+		cloneDir := filepath.Join(t.TempDir(), "cloned-repo")
+
+		// Use go-git directly to clone with URL-embedded credentials
+		_, err := git.PlainClone(cloneDir, false, &git.CloneOptions{
+			URL: targetWithCreds,
+		})
+		require.NoError(t, err)
+
+		// Scan and verify the local cloned directory
+		// TODO: The credentials in the URL should be stripped in the RepoURL
+		testInspectArtifact(t, cloneDir, targetWithCreds, "")
+	})
 }
 
 func Test_newURL(t *testing.T) {

--- a/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
@@ -51,7 +51,7 @@ func buildGitSource(repoURL string) string { return "git::" + repoURL }
 func TestResolveModuleFromCache(t *testing.T) {
 
 	repo := "terraform-aws-s3-bucket"
-	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket")
+	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket", gittest.Options{})
 	defer gs.Close()
 
 	repoURL := gs.URL + "/" + repo + ".git"
@@ -141,7 +141,7 @@ func TestResolveModuleFromCache(t *testing.T) {
 
 func TestResolveModuleFromCacheWithDifferentSubdir(t *testing.T) {
 	repo := "terraform-aws-s3-bucket"
-	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket")
+	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket", gittest.Options{})
 	defer gs.Close()
 
 	repoURL := gs.URL + "/" + repo + ".git"

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 func setupGitRepository(t *testing.T, repo, dir string) *httptest.Server {
-	gs := gittest.NewServer(t, repo, dir)
+	gs := gittest.NewServer(t, repo, dir, gittest.Options{})
 
 	worktree := t.TempDir()
-	r := gittest.Clone(t, gs, repo, worktree)
+	r := gittest.Clone(t, gs, repo, worktree, gittest.Options{})
 
 	// git tag
 	gittest.SetTag(t, r, "v0.2.0")


### PR DESCRIPTION
## Description

Add HTTP basic authentication functionality to the Git test server in gittest package. This allows testing authentication scenarios in Git repository scanning.

## Key Changes

- Added `Options` struct with `Username` and `Password` fields to configure authentication
- Modified `NewServer` and `NewTestServer` to accept `Options` parameter directly
- Implemented authentication using gitkit's `AuthFunc`
- Added tests for both environment variable and URL-embedded authentication
 
## Test Coverage

The implementation includes tests for:
- Environment variable authentication (GITHUB_TOKEN, GITLAB_TOKEN)
- URL-embedded credentials (username:password@host format)
- Authentication failure scenarios
- Local repository scanning after authenticated clone

## Checklist

- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).