### PR TITLE
fix(aws): use `BuildableClient` insead of `xhttp.Client`

### DIFF
--- a/pkg/fanal/image/registry/ecr/ecr.go
+++ b/pkg/fanal/image/registry/ecr/ecr.go
@@ -31,9 +31,10 @@ type ECRClient struct {
 }
 
 func getSession(domain, region string, option types.RegistryOptions) (aws.Config, error) {
-	// We should use BuildableClient to set custom Transport
-	// cf. https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-http.html
-	// Because there are problem with connection to IMDS for default transport.
+	// Use BuildableClient to configure a custom Transport.
+	// See: https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-http.html
+	// This is required because the xhttp.Client can cause issues when accessing IMDS.
+	// cf. https://github.com/aquasecurity/trivy/discussions/9429
 	client := awshttp.NewBuildableClient().WithTransportOptions(func(transport *http.Transport) {
 		transport.TLSClientConfig.InsecureSkipVerify = option.Insecure
 	})


### PR DESCRIPTION
## Description
There is a problem with `xhttp.Client` — Trivy `aws-sdk` cannot connect to `IMDS`.  
That is why some users cannot get credentials.  

The `aws` docs recommend using `BuildableClient` — https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-http.html  

This PR changes `xhttp.Client` to `BuildableClient` with the insecure option.

## Related issues
- Close #9437

## Related PRs
- [x] #9322 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
