### PR TITLE
docs(report): add nuanses about secret/license scanner in summary table

### DIFF
--- a/docs/docs/configuration/reporting.md
+++ b/docs/docs/configuration/reporting.md
@@ -118,6 +118,11 @@ Nuances of table contents:
     - `-` means that the scanner didn't scan this target.
     - `0` means that the scanner scanned this target, but found no security issues.
 
+!!! Note
+    For the secret/license scanner, the Trivy report contains only findings.
+    Therefore, we can’t say for sure whether Trivy scanned at least one file or simply didn’t find any findings.
+    That’s why, for these scanners, the summary table uses “-” if no findings are found.
+
 <details>
 <summary>Report Summary</summary>
 


### PR DESCRIPTION
## Description
Add information about using `-` for the secret/license scanner in the summary table when no findings are found.

## Related issues
- Close #9440

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
