### PR TITLE
chore: Update release flow to include chocolatey

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,3 +115,15 @@ jobs:
             --ref main \
             --field version=${{ github.ref_name }} \
             --field artifact=trivy
+
+      - name: Trigger version update and release workflow in trivy-chocolatey
+        env:
+          # Use ORG_REPO_TOKEN instead of GITHUB_TOKEN
+          # This allows triggering workflows in other repositories
+          GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --repo aquasecurity/trivy-chocolatey \
+            --ref main \
+            --field version=${{ github.ref_name }} \
+            --field artifact=trivy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
         run: |
           gh workflow run update_version.yml \
-            --repo aquasecurity/trivy-telemetry \
+            --repo ${{ github.repository_owner }}/trivy-telemetry \
             --ref main \
             --field version=${{ github.ref_name }}
 
@@ -111,7 +111,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
         run: |
           gh workflow run update_version.yml \
-            --repo aquasecurity/trivy-downloads \
+            --repo ${{ github.repository_owner }}/trivy-downloads \
             --ref main \
             --field version=${{ github.ref_name }} \
             --field artifact=trivy
@@ -123,6 +123,6 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
         run: |
           gh workflow run release.yml \
-            --repo aquasecurity/trivy-chocolatey \
+            --repo ${{ github.repository_owner }}/trivy-chocolatey \
             --ref main \
             --field version=${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,5 +125,4 @@ jobs:
           gh workflow run release.yml \
             --repo aquasecurity/trivy-chocolatey \
             --ref main \
-            --field version=${{ github.ref_name }} \
-            --field artifact=trivy
+            --field version=${{ github.ref_name }}


### PR DESCRIPTION
## Description

When performing a release, we need to trigger the release mechanism in trivy-chocolatey to push a new package.

This update adds a new section to us gh workflow to trigger the workflow_dispatch trigger with the latest version (ref_name) as the version.

## Related issues
- Close #9461

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.

