### PR TITLE
fix(vex): don't  suppress vulns for packages with infinity loop

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -192,8 +192,8 @@ func reachRoot(leaf *core.Component, components map[uuid.UUID]*core.Component, p
 			return false
 		case c.Root:
 			return true
-		case len(parents[c.ID()]) == 0:
-			// Should never reach here as all components other than the root should have at least one parent.
+		case lo.Every(lo.Keys(visited), parents[c.ID()]):
+			// Should never go here, since all components except the root must have at least one parent and be related to the root component.
 			// If it does, it means the component tree is not connected due to a bug in the SBOM generation.
 			// In this case, so as not to filter out all the vulnerabilities accidentally, return true for fail-safe.
 			return true


### PR DESCRIPTION
## Description

  This PR fixes an infinite loop issue in the VEX (Vulnerability Exchange) component tree traversal logic. The problem occurred when determining if a package component can reach the root component in dependency graphs with circular
  dependencies.

## Key Changes:
  - Modified the reachRoot function in pkg/vex/vex.go to detect circular dependencies by checking if all parent components have already been visited
  - Replaced the simple length check len(parents[c.ID()]) == 0 with a more robust circular dependency detection using lo.Every(lo.Keys(visited), parents[c.ID()])
  - Added comprehensive test coverage for the infinity loop scenario with OS packages that have circular dependencies
  - Updated test data to include a baseFilesPackage for testing circular dependency scenarios

##  Technical Details:
  The fix prevents infinite loops when packages have circular dependencies (e.g., bash depends on base-files and base-files depends on bash). Instead of getting stuck in an endless loop, the algorithm now detects when it has visited all
  parent components and safely returns true for fail-safe behavior.

##  Example
```
➜ trivy -q image --table-mode detailed registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2

registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2 (sles 15.7)

Total: 10 (UNKNOWN: 1, LOW: 0, MEDIUM: 4, HIGH: 5, CRITICAL: 0)

┌───────────────────────┬──────────────────────┬──────────┬────────┬───────────────────────┬───────────────────────┬───────────────────────────────────────────┐
│        Library        │    Vulnerability     │ Severity │ Status │   Installed Version   │     Fixed Version     │                   Title                   │
├───────────────────────┼──────────────────────┼──────────┼────────┼───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ container-suseconnect │ SUSE-SU-2025:02889-1 │ UNKNOWN  │ fixed  │ 2.5.5-150000.4.67.1   │ 2.5.5-150000.4.69.1   │ Security update for container-suseconnect │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ glibc                 │ SUSE-SU-2025:02964-1 │ MEDIUM   │        │ 2.38-150600.14.32.1   │ 2.38-150600.14.37.1   │ Security update for glibc                 │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgcrypt20           │ SUSE-SU-2025:02719-1 │          │        │ 1.11.0-150700.3.5     │ 1.11.0-150700.5.7.1   │ Security update for libgcrypt             │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgnutls30           │ SUSE-SU-2025:02595-1 │ HIGH     │        │ 3.8.3-150600.4.6.2    │ 3.8.3-150600.4.9.1    │ Security update for gnutls                │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libpython3_6m1_0      │ SUSE-SU-2025:02778-1 │          │        │ 3.6.15-150300.10.84.1 │ 3.6.15-150300.10.97.1 │ Security update for python3               │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libsqlite3-0          │ SUSE-SU-2025:02672-1 │          │        │ 3.49.1-150000.3.27.1  │ 3.50.2-150000.3.33.1  │ Security update for sqlite3               │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libxml2-2             │ SUSE-SU-2025:02617-1 │          │        │ 2.12.10-150700.4.3.1  │ 2.12.10-150700.4.6.1  │ Security update for libxml2               │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ pam                   │ SUSE-SU-2025:02970-1 │ MEDIUM   │        │ 1.3.0-150000.6.83.1   │ 1.3.0-150000.6.86.1   │ Security update for pam                   │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ python3-base          │ SUSE-SU-2025:02778-1 │ HIGH     │        │ 3.6.15-150300.10.84.1 │ 3.6.15-150300.10.97.1 │ Security update for python3               │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ update-alternatives   │ SUSE-SU-2025:02734-1 │ MEDIUM   │        │ 1.19.0.4-150000.4.4.1 │ 1.19.0.4-150000.4.7.1 │ Security update for dpkg                  │
└───────────────────────┴──────────────────────┴──────────┴────────┴───────────────────────┴───────────────────────┴───────────────────────────────────────────┘
➜ cat scan.openvex.json| jq .statements
[
  {
    "vulnerability": {
      "name": "SUSE-SU-2025:02536-1"
    },
    "timestamp": "2025-08-04T14:27:44.671662369Z",
    "products": [
      {
        "@id": "pkg:oci/libguestfs-tools?repository_url=registry.suse.com/suse/sles/15.7/libguestfs-tools",
        "subcomponents": [
          {
            "@id": "pkg:rpm/suse/boost-license1_66_0"
          }
        ]
      }
    ],
    "status": "not_affected",
    "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
  }
]
```
Before (Trivy supresses vulns for `python3-base` and `libpython3_6m1_0):
```
➜ trivy -q image --table-mode detailed --vex scan.openvex.json registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2 

registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2 (sles 15.7)

Total: 8 (UNKNOWN: 1, LOW: 0, MEDIUM: 4, HIGH: 3, CRITICAL: 0)

┌───────────────────────┬──────────────────────┬──────────┬────────┬───────────────────────┬───────────────────────┬───────────────────────────────────────────┐
│        Library        │    Vulnerability     │ Severity │ Status │   Installed Version   │     Fixed Version     │                   Title                   │
├───────────────────────┼──────────────────────┼──────────┼────────┼───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ container-suseconnect │ SUSE-SU-2025:02889-1 │ UNKNOWN  │ fixed  │ 2.5.5-150000.4.67.1   │ 2.5.5-150000.4.69.1   │ Security update for container-suseconnect │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ glibc                 │ SUSE-SU-2025:02964-1 │ MEDIUM   │        │ 2.38-150600.14.32.1   │ 2.38-150600.14.37.1   │ Security update for glibc                 │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgcrypt20           │ SUSE-SU-2025:02719-1 │          │        │ 1.11.0-150700.3.5     │ 1.11.0-150700.5.7.1   │ Security update for libgcrypt             │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgnutls30           │ SUSE-SU-2025:02595-1 │ HIGH     │        │ 3.8.3-150600.4.6.2    │ 3.8.3-150600.4.9.1    │ Security update for gnutls                │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libsqlite3-0          │ SUSE-SU-2025:02672-1 │          │        │ 3.49.1-150000.3.27.1  │ 3.50.2-150000.3.33.1  │ Security update for sqlite3               │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libxml2-2             │ SUSE-SU-2025:02617-1 │          │        │ 2.12.10-150700.4.3.1  │ 2.12.10-150700.4.6.1  │ Security update for libxml2               │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ pam                   │ SUSE-SU-2025:02970-1 │ MEDIUM   │        │ 1.3.0-150000.6.83.1   │ 1.3.0-150000.6.86.1   │ Security update for pam                   │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ update-alternatives   │ SUSE-SU-2025:02734-1 │          │        │ 1.19.0.4-150000.4.4.1 │ 1.19.0.4-150000.4.7.1 │ Security update for dpkg                  │
└───────────────────────┴──────────────────────┴──────────┴────────┴───────────────────────┴───────────────────────┴───────────────────────────────────────────┘

```
after:
```
➜ ./trivy -q image --table-mode detailed --vex scan.openvex.json registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2

registry.suse.com/suse/sles/15.7/libguestfs-tools:1.5.2-150700.3.5.2 (sles 15.7)

Total: 10 (UNKNOWN: 1, LOW: 0, MEDIUM: 4, HIGH: 5, CRITICAL: 0)

┌───────────────────────┬──────────────────────┬──────────┬────────┬───────────────────────┬───────────────────────┬───────────────────────────────────────────┐
│        Library        │    Vulnerability     │ Severity │ Status │   Installed Version   │     Fixed Version     │                   Title                   │
├───────────────────────┼──────────────────────┼──────────┼────────┼───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ container-suseconnect │ SUSE-SU-2025:02889-1 │ UNKNOWN  │ fixed  │ 2.5.5-150000.4.67.1   │ 2.5.5-150000.4.69.1   │ Security update for container-suseconnect │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ glibc                 │ SUSE-SU-2025:02964-1 │ MEDIUM   │        │ 2.38-150600.14.32.1   │ 2.38-150600.14.37.1   │ Security update for glibc                 │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgcrypt20           │ SUSE-SU-2025:02719-1 │          │        │ 1.11.0-150700.3.5     │ 1.11.0-150700.5.7.1   │ Security update for libgcrypt             │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libgnutls30           │ SUSE-SU-2025:02595-1 │ HIGH     │        │ 3.8.3-150600.4.6.2    │ 3.8.3-150600.4.9.1    │ Security update for gnutls                │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libpython3_6m1_0      │ SUSE-SU-2025:02778-1 │          │        │ 3.6.15-150300.10.84.1 │ 3.6.15-150300.10.97.1 │ Security update for python3               │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libsqlite3-0          │ SUSE-SU-2025:02672-1 │          │        │ 3.49.1-150000.3.27.1  │ 3.50.2-150000.3.33.1  │ Security update for sqlite3               │
├───────────────────────┼──────────────────────┤          │        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ libxml2-2             │ SUSE-SU-2025:02617-1 │          │        │ 2.12.10-150700.4.3.1  │ 2.12.10-150700.4.6.1  │ Security update for libxml2               │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ pam                   │ SUSE-SU-2025:02970-1 │ MEDIUM   │        │ 1.3.0-150000.6.83.1   │ 1.3.0-150000.6.86.1   │ Security update for pam                   │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ python3-base          │ SUSE-SU-2025:02778-1 │ HIGH     │        │ 3.6.15-150300.10.84.1 │ 3.6.15-150300.10.97.1 │ Security update for python3               │
├───────────────────────┼──────────────────────┼──────────┤        ├───────────────────────┼───────────────────────┼───────────────────────────────────────────┤
│ update-alternatives   │ SUSE-SU-2025:02734-1 │ MEDIUM   │        │ 1.19.0.4-150000.4.4.1 │ 1.19.0.4-150000.4.7.1 │ Security update for dpkg                  │
└───────────────────────┴──────────────────────┴──────────┴────────┴───────────────────────┴───────────────────────┴───────────────────────────────────────────┘

```

## Related Issues
- Close https://github.com/aquasecurity/trivy/issues/9526

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
