### PR TITLE
ci(deps): add 3-day cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "github.com/aquasecurity/trivy-*" ## `trivy-*` dependencies are updated manually
     groups:


### PR DESCRIPTION
## Description

Add a 3-day cooldown period for Go module dependency updates in Dependabot configuration to protect against supply chain attacks and early-release bugs.

Recent supply chain attacks have shown that malicious packages are often detected and removed within hours or days of publication:
- npm debug and chalk packages compromised
- S1ngularity campaign targeting NX packages  
- Various other incidents across package ecosystems

The cooldown period provides:
1. **Supply chain protection**: Buffer time for security scanners and the community to detect malicious code
2. **Stability**: Avoid immediate bugs in fresh releases

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).