### PR TITLE
docs: Fix typo in terraform docs

### DIFF
--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -94,7 +94,7 @@ We have lots of examples in the [documentation](https://trivy.dev/latest/docs/sc
 
 ## Secret and vulnerability scans
 
-The `trivy config` command does not perform secrete and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets and misconfiguraction through the following flags: 
+The `trivy config` command does not perform secret and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets and misconfiguraction through the following flags: 
 
 ```
 trivy fs --scanners secret,misconfig ./


### PR DESCRIPTION
## Description

Fixes a minor typo I noticed in the Terraform docs yesterday.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
