### PR TITLE
fix(misconf): unmark cty values before access

### DIFF
--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -391,12 +391,10 @@ func (a *Attribute) valueToStrings(value cty.Value) (results []iacTypes.StringVa
 			results = []iacTypes.StringValue{iacTypes.StringUnresolvable(a.metadata)}
 		}
 	}()
-	if value.IsNull() {
+	if value.IsNull() || !value.IsKnown() {
 		return []iacTypes.StringValue{iacTypes.StringUnresolvable(a.metadata)}
 	}
-	if !value.IsKnown() {
-		return []iacTypes.StringValue{iacTypes.StringUnresolvable(a.metadata)}
-	}
+
 	if value.Type().IsListType() || value.Type().IsTupleType() || value.Type().IsSetType() {
 		for _, val := range value.AsValueSlice() {
 			results = append(results, a.valueToString(val))
@@ -828,7 +826,9 @@ func safeOp[T any](a *Attribute, fn func(cty.Value) T) T {
 		return res
 	}
 
-	return fn(val)
+	unmarked, _ := val.UnmarkDeep()
+
+	return fn(unmarked)
 }
 
 // RewriteExpr applies the given function `transform` to the expression of the attribute,

--- a/pkg/iac/terraform/context/context.go
+++ b/pkg/iac/terraform/context/context.go
@@ -142,5 +142,10 @@ func mergeObjects(a, b cty.Value) cty.Value {
 }
 
 func isNotEmptyObject(val cty.Value) bool {
-	return !val.IsNull() && val.IsKnown() && val.Type().IsObjectType() && val.LengthInt() > 0
+	if val.IsNull() || !val.IsKnown() || !val.Type().IsObjectType() {
+		return false
+	}
+
+	unmarked, _ := val.Unmark()
+	return unmarked.LengthInt() > 0
 }


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9343

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
