### PR TITLE
fix(misconf): wrap legacy ENV values in quotes to preserve spaces

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -103,8 +103,10 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 		case strings.HasPrefix(h.CreatedBy, "HEALTHCHECK"):
 			// HEALTHCHECK instruction
 			createdBy = buildHealthcheckInstruction(cfg.Config.Healthcheck)
+		case strings.HasPrefix(h.CreatedBy, "ENV"):
+			createdBy = restoreEnvLine(h.CreatedBy)
 		default:
-			for _, prefix := range []string{"ARG", "ENV", "ENTRYPOINT"} {
+			for _, prefix := range []string{"ARG", "ENTRYPOINT"} {
 				if strings.HasPrefix(h.CreatedBy, prefix) {
 					createdBy = h.CreatedBy
 					break
@@ -157,6 +159,21 @@ var copyInRe = regexp.MustCompile(`\b((?:file|dir):\S+) in `)
 
 func normalizeCopyCreatedBy(input string) string {
 	return copyInRe.ReplaceAllString(input, `$1 `)
+}
+
+// restoreEnvLine normalizes a Dockerfile ENV instruction from image history.
+//
+// Legacy Dockerfiles may use ENV in the form: "ENV key val1 val2".
+// Docker stores this in image history as: "ENV key=val1 val2".
+// This can cause parsing errors, because extra tokens are treated as separate keys.
+// restoreEnvLine converts such lines into a valid "key=value" format
+// and wraps the value in quotes to preserve internal spaces and tabs.
+func restoreEnvLine(createdBy string) string {
+	parts := strings.SplitN(createdBy, "=", 2)
+	if len(parts) != 2 {
+		return createdBy
+	}
+	return fmt.Sprintf("%s=%q", parts[0], parts[1])
 }
 
 func (a *historyAnalyzer) Required(_ types.OS) bool {

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -169,11 +169,11 @@ func normalizeCopyCreatedBy(input string) string {
 // restoreEnvLine converts such lines into a valid "key=value" format
 // and wraps the value in quotes to preserve internal spaces and tabs.
 func restoreEnvLine(createdBy string) string {
-	parts := strings.SplitN(createdBy, "=", 2)
-	if len(parts) != 2 {
+	k, v, ok := strings.Cut(createdBy, "=")
+	if !ok {
 		return createdBy
 	}
-	return fmt.Sprintf("%s=%q", parts[0], parts[1])
+	return fmt.Sprintf("%s=%q", k, v)
 }
 
 func (a *historyAnalyzer) Required(_ types.OS) bool {

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -166,8 +166,9 @@ func normalizeCopyCreatedBy(input string) string {
 // Legacy Dockerfiles may use ENV in the form: "ENV key val1 val2".
 // Docker stores this in image history as: "ENV key=val1 val2".
 // This can cause parsing errors, because extra tokens are treated as separate keys.
-// restoreEnvLine converts such lines into a valid "key=value" format
+// restoreEnvLine converts such lines into a valid `ENV <key>="<value>"` format
 // and wraps the value in quotes to preserve internal spaces and tabs.
+// e.g. `ENV tags=latest v0.0.0` -> `ENV key="latest v0.0.0"`
 func restoreEnvLine(createdBy string) string {
 	k, v, ok := strings.Cut(createdBy, "=")
 	if !ok {

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -430,7 +430,7 @@ func Test_ImageConfigToDockerfile(t *testing.T) {
 				},
 			},
 			expected: `ARG TAG=latest
-ENV TAG=latest
+ENV TAG="latest"
 ENTRYPOINT ["/bin/sh" "-c" "echo test"]
 `,
 		},
@@ -453,6 +453,17 @@ ENTRYPOINT ["/bin/sh" "-c" "echo test"]
 ADD file:24d346633efc860b5011cefa5c0af73006e74e5dfb3c5c0e9cb0e90a927931e1 readme
 ENTRYPOINT ["/bin/sh"]
 `,
+		},
+		{
+			name: "legacy env format",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "ENV TEST=foo bar",
+					},
+				},
+			},
+			expected: "ENV TEST=\"foo bar\"\n",
 		},
 	}
 


### PR DESCRIPTION
## Description

Some Dockerfiles use legacy ENV in the form:
```dockerfile
ENV key val1 val2
```

Docker stores this in image history as:
```dockerfile
❯ docker history --no-trunc --format '{{json .}}' diss-9494 | jq -r '.CreatedBy'
ENV TEST=val1 val2
...
```

This can cause parsing errors, because extra tokens (e.g., `val2`) are treated as separate keys.

This PR fixes the issue by wrapping ENV values in quotes, preserving internal spaces, so that the Dockerfile parser correctly interprets legacy ENV instructions.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9496

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
