### PR TITLE
fix(k8s): use in-memory cache for parallel scan

### DIFF
--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -96,6 +96,7 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 	if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner, types.SecretScanner) && !s.opts.SkipImages {
 		onItem := func(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, error) {
 			opts := s.opts
+			opts.CacheBackend = "memory" // use in-memory cache for parallel scan
 			opts.Credentials = make([]ftypes.Credential, len(s.opts.Credentials))
 			copy(opts.Credentials, s.opts.Credentials)
 			// add image private registry credential auto detected from workload imagePullsecret / serviceAccount

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -96,7 +96,10 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 	if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner, types.SecretScanner) && !s.opts.SkipImages {
 		onItem := func(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, error) {
 			opts := s.opts
-			opts.CacheBackend = "memory" // use in-memory cache for parallel scan
+			if opts.CacheBackend == string(cache.TypeFS) {
+				// Use in-memory cache for parallel scan to avoid lock contention on the cache DB file
+				opts.CacheBackend = string(cache.TypeMemory)
+			}
 			opts.Credentials = make([]ftypes.Credential, len(s.opts.Credentials))
 			copy(opts.Credentials, s.opts.Credentials)
 			// add image private registry credential auto detected from workload imagePullsecret / serviceAccount


### PR DESCRIPTION
## Description
This PR introduces an in-memory cache for parallel scan operations in order to avoid lock contention on the cache database file.

A similar approach is already implemented for misconfiguration scanning: https://github.com/aquasecurity/trivy/blob/aff03ebab2e7874dd997e20b4ec9962a41eae7bb/pkg/k8s/scanner/scanner.go#L178-L180

Before:
```sh
$ trivy k8s --report=summary --scanners=vuln -q --include-namespaces kube-system
2025-09-22T11:42:05+06:00       ERROR   Error during vulnerabilities or misconfiguration scan   err="scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to initialize fs cache: cache may be in use by another process: timeout"
2025-09-22T11:42:05+06:00       ERROR   Error during vulnerabilities or misconfiguration scan   err="scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to initialize fs cache: cache may be in use by another process: timeout"
2025-09-22T11:42:05+06:00       ERROR   Error during vulnerabilities or misconfiguration scan   err="scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to initialize fs cache: cache may be in use by another process: timeout"
2025-09-22T11:42:05+06:00       ERROR   Error during vulnerabilities or misconfiguration scan   err="scan error: unable to initialize a scan service: unable to initialize an image scan service: unable to initialize fs cache: cache may be in use by another process: timeout"

Summary Report for minikube


Workload Assessment
┌───────────┬──────────┬───────────────────┐
│ Namespace │ Resource │  Vulnerabilities  │
│           │          ├───┬───┬───┬───┬───┤
│           │          │ C │ H │ M │ L │ U │
└───────────┴──────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬─────────────────────────────────────────┬──────────────────────┐
│  Namespace  │                Resource                 │   Vulnerabilities    │
│             │                                         ├───┬────┬────┬────┬───┤
│             │                                         │ C │ H  │ M  │ L  │ U │
├─────────────┼─────────────────────────────────────────┼───┼────┼────┼────┼───┤
│ kube-system │ ControlPlaneComponents/k8s.io/apiserver │   │    │    │ 1  │   │
│ kube-system │ Pod/storage-provisioner                 │ 5 │ 56 │ 42 │ 1  │   │
│ kube-system │ DaemonSet/kube-proxy                    │   │ 1  │ 1  │ 16 │   │
└─────────────┴─────────────────────────────────────────┴───┴────┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```
After:
```sh
./trivy k8s --report=summary --scanners=vuln -q --include-namespaces kube-system

Summary Report for minikube


Workload Assessment
┌───────────┬──────────┬───────────────────┐
│ Namespace │ Resource │  Vulnerabilities  │
│           │          ├───┬───┬───┬───┬───┤
│           │          │ C │ H │ M │ L │ U │
└───────────┴──────────┴───┴───┴───┴───┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN


Infra Assessment
┌─────────────┬─────────────────────────────────────────┬──────────────────────┐
│  Namespace  │                Resource                 │   Vulnerabilities    │
│             │                                         ├───┬────┬────┬────┬───┤
│             │                                         │ C │ H  │ M  │ L  │ U │
├─────────────┼─────────────────────────────────────────┼───┼────┼────┼────┼───┤
│ kube-system │ ControlPlaneComponents/k8s.io/apiserver │   │    │    │ 1  │   │
│ kube-system │ Pod/storage-provisioner                 │ 5 │ 56 │ 42 │ 1  │   │
│ kube-system │ DaemonSet/kube-proxy                    │   │ 1  │ 1  │ 16 │   │
│ kube-system │ Pod/etcd-minikube                       │   │ 14 │ 6  │    │   │
│ kube-system │ Deployment/coredns                      │   │ 5  │ 9  │    │   │
└─────────────┴─────────────────────────────────────────┴───┴────┴────┴────┴───┘
Severities: C=CRITICAL H=HIGH M=MEDIUM L=LOW U=UNKNOWN
```

## Related issues
- Close #9503 

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
