### PR TITLE
feat(cloudformation): support default values and list results in Fn::FindInMap

### DIFF
--- a/pkg/iac/scanners/cloudformation/parser/fn_find_in_map.go
+++ b/pkg/iac/scanners/cloudformation/parser/fn_find_in_map.go
@@ -1,45 +1,80 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/cftypes"
 )
 
-func ResolveFindInMap(property *Property) (resolved *Property, success bool) {
+func ResolveFindInMap(property *Property) (*Property, bool) {
 	if !property.isFunction() {
 		return property, true
 	}
 
 	refValue := property.AsMap()["Fn::FindInMap"].AsList()
 
-	if len(refValue) != 3 {
-		return abortIntrinsic(property, "Fn::FindInMap should have exactly 3 values, returning original Property")
+	if len(refValue) < 3 || len(refValue) > 4 {
+		return abortIntrinsic(property, "Fn::FindInMap expects 3 or 4 arguments")
+	}
+
+	if property.ctx == nil {
+		return abortIntrinsic(property, "property context is missing")
+	}
+
+	var defaultValue any
+	if len(refValue) == 4 {
+		if m := refValue[3].AsMap(); m != nil {
+			if defProp, exists := m["DefaultValue"]; exists && defProp != nil {
+				defaultValue = defProp.RawValue()
+			}
+		}
 	}
 
 	mapName := refValue[0].AsString()
-	topLevelKey := refValue[1].AsString()
-	secondaryLevelKey := refValue[2].AsString()
+	topKey := refValue[1].AsString()
+	secKey := refValue[2].AsString()
 
-	if property.ctx == nil {
-		return abortIntrinsic(property, "the property does not have an attached context, returning original Property")
+	value, err := resolveMapping(property.ctx, mapName, topKey, secKey)
+	if err != nil {
+		if defaultValue == nil {
+			return abortIntrinsic(property, err.Error())
+		}
+		value = defaultValue
 	}
 
-	m, ok := property.ctx.Mappings[mapName]
+	switch v := value.(type) {
+	case string:
+		return property.deriveResolved(cftypes.String, v), true
+	case []any:
+		elems := make([]*Property, len(v))
+		for i, el := range v {
+			elems[i] = property.deriveResolved(cftypes.String, el)
+		}
+		return property.deriveResolved(cftypes.List, elems), true
+	default:
+		return abortIntrinsic(property, fmt.Sprintf("unsupported type in mapping: %T", v))
+	}
+}
+
+func resolveMapping(ctx *FileContext, mapName, topKey, secKey string) (any, error) {
+	m, ok := ctx.Mappings[mapName]
 	if !ok {
-		return abortIntrinsic(property, "could not find map %s, returning original Property")
+		return nil, fmt.Errorf("map %s not found", mapName)
 	}
-
-	mapContents := m.(map[string]any)
-
-	k, ok := mapContents[topLevelKey]
+	mapContents, ok := m.(map[string]any)
 	if !ok {
-		return abortIntrinsic(property, "could not find %s in the %s map, returning original Property", topLevelKey, mapName)
+		return nil, fmt.Errorf("map %s has invalid type", mapName)
 	}
 
+	k, ok := mapContents[topKey]
+	if !ok {
+		return nil, fmt.Errorf("key %s not found in map %s", topKey, mapName)
+	}
 	mapValues := k.(map[string]any)
 
-	prop, ok := mapValues[secondaryLevelKey]
+	prop, ok := mapValues[secKey]
 	if !ok {
-		return abortIntrinsic(property, "could not find a value for %s in %s, returning original Property", secondaryLevelKey, topLevelKey)
+		return nil, fmt.Errorf("key %s not found in %s", secKey, topKey)
 	}
-	return property.deriveResolved(cftypes.String, prop), true
+	return prop, nil
 }


### PR DESCRIPTION
## Description

Add support for Fn::FindInMap enhancements, including default values ([docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/intrinsic-function-reference-findinmap-enhancements.html)).
Also support list values in Mappings, as allowed: "The values can be of type String or List." ([docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html#mappings-section-structure-syntax)).

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
