### PR TITLE
fix(nodejs): parse workspaces as objects for package-lock.json files

### DIFF
--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
+	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/packagejson"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/utils"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -46,7 +47,7 @@ type Package struct {
 	Resolved             string            `json:"resolved"`
 	Dev                  bool              `json:"dev"`
 	Link                 bool              `json:"link"`
-	Workspaces           []string          `json:"workspaces"`
+	Workspaces           any               `json:"workspaces"`
 	xjson.Location
 }
 
@@ -206,7 +207,7 @@ func (p *Parser) resolveLinks(packages map[string]Package) {
 		rootPkg.Dependencies = make(map[string]string)
 	}
 
-	workspaces := rootPkg.Workspaces
+	workspaces := packagejson.ParseWorkspaces(rootPkg.Workspaces)
 	// Changing the map during the map iteration causes unexpected behavior,
 	// so we need to iterate over the cloned `packages` map, but change the original `packages` map.
 	for pkgPath, pkg := range maps.Clone(packages) {

--- a/pkg/dependency/parser/nodejs/npm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_test.go
@@ -42,6 +42,12 @@ func TestParse(t *testing.T) {
 			wantDeps: npmV3WithWorkspaceDeps,
 		},
 		{
+			name:     "lock version v3 with workspace as object",
+			file:     "testdata/package-lock_v3_with_workspace_as_object.json",
+			want:     npmV3WithWorkspaceAsObjectPkgs,
+			wantDeps: nil,
+		},
+		{
 			name:     "lock version v3 with peer dependencies",
 			file:     "testdata/package-lock_v3_with_peer.json",
 			want:     npmV3WithPeerDependenciesPkgs,

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -1442,6 +1442,45 @@ var (
 			DependsOn: []string{"debug@2.6.9"},
 		},
 	}
+
+	npmV3WithWorkspaceAsObjectPkgs = []ftypes.Package{
+		{
+			ID:           "testapp@1.0.0",
+			Name:         "testapp",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipDirect,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+					URL:  "testapp",
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 26,
+					EndLine:   31,
+				},
+			},
+		},
+		{
+			ID:           "lodash@4.17.21",
+			Name:         "lodash",
+			Version:      "4.17.21",
+			Relationship: ftypes.RelationshipIndirect,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+					URL:  "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 16,
+					EndLine:   21,
+				},
+			},
+		},
+	}
 	// docker run --name node --rm -it node@sha256:51dd437f31812df71108b81385e2945071ec813d5815fa3403855669c8f3432b sh
 	// mkdir node_v3_with_peer && cd node_v3_with_peer
 	// npm init --force

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_workspace_as_object.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_workspace_as_object.json
@@ -1,0 +1,33 @@
+{
+  "name": "node_v3_with_workspace_as_object",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_v3_with_workspace_as_object",
+      "version": "1.0.0",
+      "workspaces": {
+        "packages": [
+          "testapp"
+        ]
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/testapp": {
+      "resolved": "testapp",
+      "link": true
+    },
+    "testapp": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    }
+  }
+}

--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -65,7 +65,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 		Dependencies:         pkgJSON.Dependencies,
 		OptionalDependencies: pkgJSON.OptionalDependencies,
 		DevDependencies:      pkgJSON.DevDependencies,
-		Workspaces:           parseWorkspaces(pkgJSON.Workspaces),
+		Workspaces:           ParseWorkspaces(pkgJSON.Workspaces),
 	}, nil
 }
 
@@ -86,14 +86,18 @@ func parseLicense(val any) []string {
 	return nil
 }
 
-// parseWorkspaces returns slice of workspaces
-func parseWorkspaces(val any) []string {
+// ParseWorkspaces returns slice of workspaces
+// `workspaces` field supports 2 types -
+// string array and map with `packages` key only
+// cf. https://github.com/npm/map-workspaces#usage
+func ParseWorkspaces(val any) []string {
 	// Workspaces support 2 types - https://github.com/SchemaStore/schemastore/blob/d9516961f8a5b0e65a457808070147b5a866f60b/src/schemas/json/package.json#L777
 	switch ws := val.(type) {
 	// Workspace as object (map[string][]string)
 	// e.g. "workspaces": {"packages": ["packages/*", "plugins/*"]},
 	case map[string]any:
-		// Take only workspaces for `packages` - https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
+		// Take only workspaces for `packages`:
+		// cf . https://github.com/npm/map-workspaces#usage
 		if pkgsWorkspaces, ok := ws["packages"]; ok {
 			return lo.Map(pkgsWorkspaces.([]any), func(workspace any, _ int) string {
 				return workspace.(string)


### PR DESCRIPTION
## Description
This PR fixes npm workspace parsing to properly handle workspace configurations defined as objects rather than just string arrays. The npm workspaces field supports two formats:
  - String array: "workspaces": ["packages/*", "plugins/*"]
  - Object format: "workspaces": {"packages": ["packages/*", "plugins/*"]}

### Changes Made
  - Updated npm lock parser: Changed Workspaces field type from []string to any in the Package struct to accommodate both formats
  - Exported ParseWorkspaces function: Made the workspace parsing function public so it can be reused across npm-related parsers
  - Enhanced workspace parsing logic: The ParseWorkspaces function now properly extracts workspace paths from both string arrays and object configurations
  - Added comprehensive test coverage: Included test data and test cases for workspace-as-object format

  The fix ensures that npm lock files with workspace configurations using the object format (with packages key) are parsed correctly, preventing potential issues in dependency analysis.

### Example
before:
```bash
➜  trivy -d fs /Users/dmitriy/work/tmp/6129/package-lock.json -f json --list-all-pkgs | grep '"ID"' | wc -l
...
2025-09-24T12:57:37+06:00       DEBUG   Walk error      file_path="package-lock.json" err="parse error: failed to parse package-lock.json: decode error: json: cannot unmarshal JSON object into Go []string within \"/packages/node_modules~1@bpmn-io~1cm-theme/workspaces\""
...
       0
```

after:
```bash
➜ ./trivy -q fs /Users/dmitriy/work/tmp/6129/package-lock.json -f json --list-all-pkgs | grep '"ID"' | wc -l
      23
```

## Related issues
- Close #9517

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
