### PR TITLE
fix: close file descriptors and pipes on error paths

### DIFF
--- a/pkg/fanal/artifact/vm/file.go
+++ b/pkg/fanal/artifact/vm/file.go
@@ -35,11 +35,18 @@ type ImageFile struct {
 	reader   *io.SectionReader
 }
 
-func newFile(filePath string, storage Storage) (*ImageFile, error) {
+func newFile(filePath string, storage Storage) (imgFile *ImageFile, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, xerrors.Errorf("file open error: %w", err)
 	}
+
+	// Close file on error
+	defer func() {
+		if err != nil && f != nil {
+			f.Close()
+		}
+	}()
 
 	c, err := lru.New[string, []byte](storageFILECacheSize)
 	if err != nil {

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -579,10 +579,23 @@ func (o *Options) GetUsedFlags() []Flagger {
 	return o.usedFlags
 }
 
-func (o *Options) outputPluginWriter(ctx context.Context) (io.Writer, func() error, error) {
+func (o *Options) outputPluginWriter(ctx context.Context) (writer io.Writer, cleanup func() error, err error) {
 	pluginName := strings.TrimPrefix(o.Output, "plugin=")
 
 	pr, pw := io.Pipe()
+
+	// Close pipes on error
+	defer func() {
+		if err != nil {
+			if pr != nil {
+				pr.Close()
+			}
+			if pw != nil {
+				pw.Close()
+			}
+		}
+	}()
+
 	wait, err := plugin.Start(ctx, pluginName, plugin.Options{
 		Args:  o.OutputPluginArgs,
 		Stdin: pr,
@@ -591,7 +604,7 @@ func (o *Options) outputPluginWriter(ctx context.Context) (io.Writer, func() err
 		return nil, nil, xerrors.Errorf("plugin start: %w", err)
 	}
 
-	cleanup := func() error {
+	cleanup = func() error {
 		if err = pw.Close(); err != nil {
 			return xerrors.Errorf("failed to close pipe: %w", err)
 		}


### PR DESCRIPTION
## Description

This PR fixes resource leaks where file descriptors and pipes are not properly closed on error paths.

## Related issues

- Fixes #9535

## Related PRs

Remove this section if you don't have related PRs.

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Changes

1. **pkg/fanal/artifact/vm/file.go**: Added proper cleanup using defer to ensure file descriptors are closed when errors occur
2. **pkg/flag/options.go**: Added proper cleanup using defer to ensure pipes are closed when errors occur

Both functions now use named error returns with defer statements to guarantee resource cleanup on all error paths.