### PR TITLE
fix: validate backport branch name

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -44,8 +44,12 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          BRANCH_NAME=$(echo $COMMENT_BODY | grep -oE '@aqua-bot backport\s+(\S+)' | awk '{print $3}')
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          BRANCH_NAME=$(echo "$COMMENT_BODY" | grep -oE '@aqua-bot backport\s+(\S+)' | awk '{print $3}')
+          if [[ -z "$BRANCH_NAME" || ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Error: Invalid branch name extracted (unsafe characters detected)." >&2
+            exit 1
+          fi
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Set up Git user
         run: |

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -45,7 +45,7 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           BRANCH_NAME=$(echo "$COMMENT_BODY" | grep -oE '@aqua-bot backport\s+(\S+)' | awk '{print $3}')
-          if [[ -z "$BRANCH_NAME" || ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+          if [[ -z "$BRANCH_NAME" || "$BRANCH_NAME" == *".."* || ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]]; then
             echo "Error: Invalid branch name extracted (unsafe characters detected)." >&2
             exit 1
           fi


### PR DESCRIPTION
## Description
- validate the backport workflow’s extracted branch name before exporting to `GITHUB_ENV`
- reject empty or unsafe names while allowing dotted release branches like `release/v0.53.1`
- verified on knqyf263/trivy#69 that safe names proceed (workflow run [18117590123](https://github.com/knqyf263/trivy/actions/runs/18117590123)) and unsafe names abort immediately (run [18117630437](https://github.com/knqyf263/trivy/actions/runs/18117630437) and [18121474365](https://github.com/knqyf263/trivy/actions/runs/18121474365))

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).