### PR TITLE
feat(image): using SrcVersion instead of Version for echo detector

### DIFF
--- a/pkg/detector/ospkg/echo/echo.go
+++ b/pkg/detector/ospkg/echo/echo.go
@@ -36,7 +36,7 @@ func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pk
 		if err != nil {
 			return nil, xerrors.Errorf("failed to get echo advisories: %w", err)
 		}
-		formattedInstalledVersion := utils.FormatVersion(pkg)
+		formattedInstalledVersion := utils.FormatSrcVersion(pkg)
 		installedVersion, err := version.NewVersion(formattedInstalledVersion)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to parse installed version: %w", err)

--- a/pkg/detector/ospkg/echo/echo_test.go
+++ b/pkg/detector/ospkg/echo/echo_test.go
@@ -152,6 +152,7 @@ func TestScanner_Detect(t *testing.T) {
 						SrcName:    "nginx",
 						SrcVersion: "1.14.2",
 						Release:    "1ubuntu1",
+						SrcRelease: "1ubuntu1",
 						Layer: ftypes.Layer{
 							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 						},
@@ -163,6 +164,7 @@ func TestScanner_Detect(t *testing.T) {
 						Version:    "2.4.24",
 						SrcVersion: "2.4.24",
 						Release:    "2",
+						SrcRelease: "2",
 						Layer: ftypes.Layer{
 							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 						},
@@ -226,7 +228,7 @@ func TestScanner_Detect(t *testing.T) {
 			name: "happy path - no matching packages",
 			args: args{
 				pkgs: []ftypes.Package{
-					{ID: "echo", Version: "1.0.0"},
+					{ID: "echo", Version: "1.0.0", SrcVersion: "1.0.0", SrcName: "echo"},
 				},
 			},
 			want: nil,
@@ -239,7 +241,7 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			args: args{
 				pkgs: []ftypes.Package{
-					{SrcName: "apache2", Version: "1.0.0"},
+					{SrcName: "apache2", Version: "1.0.0", SrcVersion: "1.0.0"},
 				},
 			},
 			wantErr: "failed to get echo advisories",


### PR DESCRIPTION
## Description
Fixed a bug with echo detection where we use SrcVersion instead of Version

## Related issues
- Close #9551 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
