### PR TITLE
fix(sbom): Don’t panic on SBOM format if scanned CycloneDX file has empty metadata

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -108,6 +108,7 @@ func (m *Marshaler) Metadata(ctx context.Context) *cdx.Metadata {
 
 func (m *Marshaler) MarshalRoot() (*cdx.Component, error) {
 	root := m.bom.Root()
+	// Since we reuse the scanned SBOM, the root component (metadata.component) can be empty.
 	if root == nil {
 		m.logger.Debug("Root component not found")
 		return nil, nil

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -107,7 +107,12 @@ func (m *Marshaler) Metadata(ctx context.Context) *cdx.Metadata {
 }
 
 func (m *Marshaler) MarshalRoot() (*cdx.Component, error) {
-	return m.MarshalComponent(m.bom.Root())
+	root := m.bom.Root()
+	if root == nil {
+		m.logger.Debug("Root component not found")
+		return nil, nil
+	}
+	return m.MarshalComponent(root)
 }
 
 func (m *Marshaler) MarshalComponent(component *core.Component) (*cdx.Component, error) {


### PR DESCRIPTION
##  Description

  This PR fixes a panic that occurs when processing SBOM files that don't have a root component. The issue was in the CycloneDX marshaler where it would attempt to marshal a nil `metadata.component` without proper validation.


## Related issues
- Close #9561

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/9439

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
