### PR TITLE
refactor(misconf): add ID to scan.Rule

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -272,6 +272,7 @@ func (sm *StaticMetadata) ToRule() scan.Rule {
 
 	return scan.Rule{
 		Deprecated:          sm.Deprecated,
+		ID:                  sm.ID,
 		AVDID:               sm.AVDID,
 		Aliases:             append(sm.Aliases, sm.ID),
 		ShortCode:           sm.ShortCode,

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -38,6 +38,7 @@ type TerraformCustomCheck struct {
 
 type Rule struct {
 	Deprecated          bool                             `json:"deprecated"`
+	ID                  string                           `json:"id"`
 	AVDID               string                           `json:"avd_id"`
 	Aliases             []string                         `json:"aliases"`
 	ShortCode           string                           `json:"short_code"`

--- a/pkg/iac/scanners/cloudformation/scanner_test.go
+++ b/pkg/iac/scanners/cloudformation/scanner_test.go
@@ -64,6 +64,7 @@ deny[res] {
 	require.Len(t, results.GetFailed(), 1)
 
 	assert.Equal(t, scan.Rule{
+		ID:             "DS006",
 		AVDID:          "AVD-DS-0006",
 		Aliases:        []string{"DS006"},
 		ShortCode:      "no-self-referencing-copy-from",

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -237,6 +237,7 @@ USER root
 	assert.Equal(
 		t,
 		scan.Rule{
+			ID:             "DS006",
 			AVDID:          "AVD-DS-0006",
 			Aliases:        []string{"DS006"},
 			ShortCode:      "no-self-referencing-copy-from",
@@ -586,6 +587,7 @@ COPY --from=dep /binary /`
 				assert.Equal(
 					t,
 					scan.Rule{
+						ID:             "DS006",
 						AVDID:          "AVD-DS-0006",
 						Aliases:        []string{"DS006"},
 						ShortCode:      "no-self-referencing-copy-from",

--- a/pkg/iac/scanners/generic/scanner_test.go
+++ b/pkg/iac/scanners/generic/scanner_test.go
@@ -55,6 +55,7 @@ deny[res] {
 	require.Len(t, results.GetFailed(), 1)
 
 	assert.Equal(t, scan.Rule{
+		ID:             "ABC123",
 		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",
@@ -124,6 +125,7 @@ deny[res] {
 	require.Len(t, results.GetFailed(), 1)
 
 	assert.Equal(t, scan.Rule{
+		ID:             "ABC123",
 		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",
@@ -192,6 +194,7 @@ deny[res] {
 	require.Len(t, results.GetFailed(), 1)
 
 	assert.Equal(t, scan.Rule{
+		ID:             "ABC123",
 		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",


### PR DESCRIPTION
## Description

This PR adds the `ID` field to the `Rule` struct.

The ID field will be needed in `avd-generator` to add the ID to the existing aliases, for example:

```yaml
aliases: [
  "/cspm/aws/s3/s3-bucket-logging",
  "/misconfig/aws/s3-bucket-logging",
  "/misconfig/s3-bucket-logging",
  "/misconfig/avd-aws-0089",
  "/misconfig/aws/s3/avd-aws-0089",
]
```

This allows referencing a check by ID, e.g., `misconfig/{ID}`, and ensures a smooth migration from the AVDID field to ID.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
