### PR TITLE
refactor(misconf): mark AVDID fields as deprecated and use ID internally

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.18.0
-appVersion: 0.66.0
+version: 0.19.0
+appVersion: 0.67.0
 description: Trivy helm chart
 keywords:
   - scanner

--- a/pkg/fanal/types/misconf.go
+++ b/pkg/fanal/types/misconf.go
@@ -67,7 +67,8 @@ type Line struct {
 }
 
 type PolicyMetadata struct {
-	ID                 string   `json:",omitempty"`
+	ID string `json:",omitempty"`
+	// Deprecated: Use the ID field instead.
 	AVDID              string   `json:",omitempty"`
 	Type               string   `json:",omitempty"`
 	Title              string   `json:",omitempty"`

--- a/pkg/iac/rego/embed_test.go
+++ b/pkg/iac/rego/embed_test.go
@@ -116,7 +116,7 @@ func Test_RegisterDeprecatedRule(t *testing.T) {
 	}{
 		{
 			name: "deprecated check",
-			id:   "AVD-DEP-0001",
+			id:   "DEP-0001",
 			inputPolicy: `# METADATA
 # title: "deprecated check"
 # description: "some description"
@@ -124,7 +124,7 @@ func Test_RegisterDeprecatedRule(t *testing.T) {
 # schemas:
 # - input: schema["dockerfile"]
 # custom:
-#   avd_id: AVD-DEP-0001
+#   id: DEP-0001
 #   input:
 #     selector:
 #     - type: dockerfile
@@ -139,7 +139,7 @@ deny[res]{
 		},
 		{
 			name: "not a deprecated check",
-			id:   "AVD-NOTDEP-0001",
+			id:   "NOTDEP-0001",
 			inputPolicy: `# METADATA
 # title: "not a deprecated check"
 # description: "some description"
@@ -147,7 +147,7 @@ deny[res]{
 # schemas:
 # - input: schema["dockerfile"]
 # custom:
-#   avd_id: AVD-NOTDEP-0001
+#   id: NOTDEP-0001
 #   input:
 #     selector:
 #     - type: dockerfile
@@ -161,7 +161,7 @@ deny[res]{
 		},
 		{
 			name: "invalid deprecation value",
-			id:   "AVD-BADDEP-0001",
+			id:   "BADDEP-0001",
 			inputPolicy: `# METADATA
 # title: "badly deprecated check"
 # description: "some description"
@@ -169,7 +169,7 @@ deny[res]{
 # schemas:
 # - input: schema["dockerfile"]
 # custom:
-#   avd_id: AVD-BADDEP-0001
+#   id: BADDEP-0001
 #   input:
 #     selector:
 #     - type: dockerfile
@@ -196,7 +196,7 @@ deny[res]{
 			})
 
 			for _, rule := range rules.GetRegistered() {
-				if rule.AVDID == tc.id {
+				if rule.ID == tc.id {
 					assert.Equal(t, tc.expected.Deprecated, rule.GetRule().Deprecated, tc.name)
 				}
 			}

--- a/pkg/iac/rego/load.go
+++ b/pkg/iac/rego/load.go
@@ -206,7 +206,8 @@ func (s *Scanner) findMatchedEmbeddedCheck(badPolicy *ast.Module) *ast.Module {
 		if err != nil || meta == nil {
 			continue
 		}
-		if badPolicyMeta.AVDID != "" && badPolicyMeta.AVDID == meta.AVDID {
+		if (badPolicyMeta.AVDID != "" && badPolicyMeta.AVDID == meta.AVDID) ||
+			(badPolicyMeta.ID != "" && badPolicyMeta.ID == meta.ID) {
 			return embeddedCheck
 		}
 	}

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -141,7 +141,7 @@ deny {
 # schemas:
 # - input: schema["fooschema"]
 # custom:
-#   avd_id: test-001
+#   id: test-001
 package builtin.test2
 
 deny {

--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -23,8 +23,9 @@ import (
 const annotationScopePackage = "package"
 
 type StaticMetadata struct {
-	Deprecated          bool
-	ID                  string
+	Deprecated bool
+	ID         string
+	// Deprecated: Use the ID field instead.
 	AVDID               string
 	Title               string
 	ShortCode           string

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -30,8 +30,7 @@ func Test_RegoScanning_Deny(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -78,8 +77,7 @@ func Test_RegoScanning_AbsolutePolicyPath_Deny(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -123,8 +121,7 @@ func Test_RegoScanning_Allow(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -171,8 +168,7 @@ func Test_RegoScanning_WithRuntimeValues(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -215,8 +211,7 @@ func Test_RegoScanning_WithDenyMessage(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -263,8 +258,7 @@ func Test_RegoScanning_WithDenyMetadata_ImpliedPath(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -318,8 +312,7 @@ func Test_RegoScanning_WithDenyMetadata_PersistedPath(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -371,7 +364,6 @@ package defsec.test
 
 __rego_metadata__ := {
 	"id": "AA001",
-	"avd_id": "AVD-XX-9999",
 	"title": "This is a title",
 	"short_code": "short-code",
 	"severity": "LOW",
@@ -416,8 +408,7 @@ deny[res] {
 	assert.Equal(t, "/blah.txt", failure.Metadata().Range().GetFilename())
 	assert.Equal(t, 123, failure.Metadata().Range().GetStartLine())
 	assert.Equal(t, 456, failure.Metadata().Range().GetEndLine())
-	assert.Equal(t, "AVD-XX-9999", failure.Rule().AVDID)
-	assert.True(t, failure.Rule().HasID("AA001"))
+	assert.Equal(t, "AA001", failure.Rule().ID)
 	assert.Equal(t, "This is a title", failure.Rule().Summary)
 	assert.Equal(t, severity.Low, failure.Rule().Severity)
 	assert.Equal(t, "This is a recommendation", failure.Rule().Resolution)
@@ -434,8 +425,7 @@ func Test_RegoScanning_WithMatchingInputSelector(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -516,8 +506,7 @@ func Test_RegoScanning_NoTracingByDefault(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -562,8 +551,7 @@ func Test_RegoScanning_GlobalTracingEnabled(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -612,8 +600,7 @@ func Test_RegoScanning_PerResultTracingEnabled(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -722,7 +709,6 @@ func Test_annotationMetadata(t *testing.T) {
 # - https://google.com
 # custom:
 #   id: EG123
-#   avd_id: AVD-EG-0123
 #   severity: LOW
 #   recommended_action: have a cup of tea
 package defsec.test
@@ -762,7 +748,6 @@ deny {
 	assert.Equal(t, "i am a description", failure.Explanation)
 	require.Len(t, failure.Links, 1)
 	assert.Equal(t, "https://google.com", failure.Links[0])
-	assert.Equal(t, "AVD-EG-0123", failure.AVDID)
 	assert.Equal(t, severity.Low, failure.Severity)
 	assert.Equal(t, "have a cup of tea", failure.Resolution)
 }
@@ -841,8 +826,7 @@ func Test_RegoScanning_CustomData(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -894,8 +878,7 @@ func Test_RegoScanning_InvalidFS(t *testing.T) {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -974,7 +957,6 @@ func Test_RegoScanning_WithDeprecatedCheck(t *testing.T) {
 # - https://google.com
 # custom:
 #   id: EG123
-#   avd_id: AVD-EG-0123
 #   severity: LOW
 #   recommended_action: have a cup of tea
 #   deprecated: %v

--- a/pkg/iac/rego/testdata/embedded/my-check1.rego
+++ b/pkg/iac/rego/testdata/embedded/my-check1.rego
@@ -2,7 +2,7 @@
 # schemas:
 # - input: schema["fooschema"]
 # custom:
-#   avd_id: test-001
+#   id: test-001
 
 package builtin.test
 

--- a/pkg/iac/scan/flat.go
+++ b/pkg/iac/scan/flat.go
@@ -5,7 +5,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/severity"
 )
 
+// TODO: This struct is not currently serialized to JSON,
+// so JSON tags may be removed if unused.
 type FlatResult struct {
+	// TODO: The following fields are currently unused:
+	// Deprecated, RuleID, LongID, RuleSummary, Impact, RangeAnnotation
 	Deprecated      bool               `json:"deprecated,omitempty"`
 	RuleID          string             `json:"rule_id"`
 	LongID          string             `json:"long_id"`

--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -269,6 +269,8 @@ func (r *Results) AddIgnored(source any, descriptions ...string) {
 func (r *Results) Ignore(ignoreRules ignore.Rules, ignores map[string]ignore.Ignorer) {
 	for i, result := range *r {
 		allIDs := []string{
+			result.Rule().ID,
+			strings.ToLower(result.Rule().ID),
 			result.Rule().LongID(),
 			result.Rule().AVDID,
 			strings.ToLower(result.Rule().AVDID),

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -66,7 +66,7 @@ func (r Rule) IsDeprecated() bool {
 }
 
 func (r Rule) HasID(id string) bool {
-	if r.AVDID == id || r.LongID() == id {
+	if r.ID == id || r.AVDID == id || r.LongID() == id {
 		return true
 	}
 	return slices.Contains(r.Aliases, id)

--- a/pkg/iac/scan/rule.go
+++ b/pkg/iac/scan/rule.go
@@ -37,7 +37,8 @@ type TerraformCustomCheck struct {
 }
 
 type Rule struct {
-	Deprecated          bool                             `json:"deprecated"`
+	Deprecated bool `json:"deprecated"`
+	// Deprecated: Use the ID field instead.
 	AVDID               string                           `json:"avd_id"`
 	Aliases             []string                         `json:"aliases"`
 	ShortCode           string                           `json:"short_code"`

--- a/pkg/iac/scanners/cloudformation/scanner_test.go
+++ b/pkg/iac/scanners/cloudformation/scanner_test.go
@@ -28,7 +28,6 @@ Resources:
 
 __rego_metadata__ := {
 	"id": "DS006",
-	"avd_id": "AVD-DS-0006",
 	"title": "COPY '--from' referring to the current image",
 	"short_code": "no-self-referencing-copy-from",
 	"version": "v1.0.0",
@@ -65,7 +64,6 @@ deny[res] {
 
 	assert.Equal(t, scan.Rule{
 		ID:             "DS006",
-		AVDID:          "AVD-DS-0006",
 		Aliases:        []string{"DS006"},
 		ShortCode:      "no-self-referencing-copy-from",
 		Summary:        "COPY '--from' referring to the current image",
@@ -108,8 +106,7 @@ const bucketNameCheck = `# METADATA
 # schemas:
 # - input: schema["cloud"]
 # custom:
-#   id: AVD-AWS-001
-#   avd_id: AVD-AWS-001
+#   id: AWS-001
 #   provider: aws
 #   service: s3
 #   severity: LOW
@@ -156,7 +153,7 @@ Resources:
 			name: "rule before resource",
 			src: `---
 Resources:
-#trivy:ignore:AVD-AWS-001
+#trivy:ignore:AWS-001
   S3Bucket:
     Type: 'AWS::S3::Bucket'
     Properties:
@@ -171,7 +168,7 @@ Resources:
   S3Bucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-#trivy:ignore:AVD-AWS-001
+#trivy:ignore:AWS-001
       BucketName: test-bucket
 `,
 			ignored: 1,
@@ -183,7 +180,7 @@ Resources:
   S3Bucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-      BucketName: test-bucket  #trivy:ignore:AVD-AWS-001
+      BucketName: test-bucket  #trivy:ignore:AWS-001
 `,
 			ignored: 1,
 		},
@@ -198,7 +195,7 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256 #trivy:ignore:AVD-AWS-001
+              SSEAlgorithm: AES256 #trivy:ignore:AWS-001
 `,
 			ignored: 1,
 		},

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -27,7 +27,6 @@ const DS006PolicyWithDockerfileSchema = `# METADATA
 # - https://docs.docker.com/develop/develop-images/multistage-build/
 # custom:
 #   id: DS006
-#   avd_id: AVD-DS-0006
 #   severity: CRITICAL
 #   short_code: no-self-referencing-copy-from
 #   recommended_action: "Change the '--from' so that it will not refer to itself"
@@ -83,7 +82,6 @@ const DS006PolicyWithMyFancyDockerfileSchema = `# METADATA
 # - https://docs.docker.com/develop/develop-images/multistage-build/
 # custom:
 #   id: DS006
-#   avd_id: AVD-DS-0006
 #   severity: CRITICAL
 #   short_code: no-self-referencing-copy-from
 #   recommended_action: "Change the '--from' so that it will not refer to itself"
@@ -139,7 +137,6 @@ const DS006PolicyWithOldSchemaSelector = `# METADATA
 # - https://docs.docker.com/develop/develop-images/multistage-build/
 # custom:
 #   id: DS006
-#   avd_id: AVD-DS-0006
 #   severity: CRITICAL
 #   short_code: no-self-referencing-copy-from
 #   recommended_action: "Change the '--from' so that it will not refer to itself"
@@ -188,7 +185,6 @@ const DS006LegacyWithOldStyleMetadata = `package builtin.dockerfile.DS006
 
 __rego_metadata__ := {
 	"id": "DS006",
-	"avd_id": "AVD-DS-0006",
 	"title": "COPY '--from' referring to the current image",
 	"short_code": "no-self-referencing-copy-from",
 	"version": "v1.0.0",
@@ -238,7 +234,6 @@ USER root
 		t,
 		scan.Rule{
 			ID:             "DS006",
-			AVDID:          "AVD-DS-0006",
 			Aliases:        []string{"DS006"},
 			ShortCode:      "no-self-referencing-copy-from",
 			Summary:        "COPY '--from' referring to the current image",
@@ -588,7 +583,6 @@ COPY --from=dep /binary /`
 					t,
 					scan.Rule{
 						ID:             "DS006",
-						AVDID:          "AVD-DS-0006",
 						Aliases:        []string{"DS006"},
 						ShortCode:      "no-self-referencing-copy-from",
 						Summary:        "COPY '--from' referring to the current image",
@@ -660,7 +654,7 @@ MAINTAINER moby@example.com`,
 # schemas:
 # - input: schema["dockerfile"]
 # custom:
-#   avd_id: USER-TEST-0001
+#   id: USER-TEST-0001
 #   short_code: maintainer-deprecated
 #   input:
 #     selector:

--- a/pkg/iac/scanners/generic/scanner_test.go
+++ b/pkg/iac/scanners/generic/scanner_test.go
@@ -20,7 +20,6 @@ func TestJsonScanner(t *testing.T) {
 
 __rego_metadata__ := {
 	"id": "ABC123",
-	"avd_id": "AVD-AB-0123",
 	"title": "title",
 	"short_code": "short",
 	"severity": "CRITICAL",
@@ -56,7 +55,6 @@ deny[res] {
 
 	assert.Equal(t, scan.Rule{
 		ID:             "ABC123",
-		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",
 		Summary:        "title",
@@ -90,7 +88,6 @@ x:
 
 __rego_metadata__ := {
 	"id": "ABC123",
-	"avd_id": "AVD-AB-0123",
 	"title": "title",
 	"short_code": "short",
 	"severity": "CRITICAL",
@@ -126,7 +123,6 @@ deny[res] {
 
 	assert.Equal(t, scan.Rule{
 		ID:             "ABC123",
-		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",
 		Summary:        "title",
@@ -159,7 +155,6 @@ z = ["a", "b", "c"]
 
 __rego_metadata__ := {
 	"id": "ABC123",
-	"avd_id": "AVD-AB-0123",
 	"title": "title",
 	"short_code": "short",
 	"severity": "CRITICAL",
@@ -195,7 +190,6 @@ deny[res] {
 
 	assert.Equal(t, scan.Rule{
 		ID:             "ABC123",
-		AVDID:          "AVD-AB-0123",
 		Aliases:        []string{"ABC123"},
 		ShortCode:      "short",
 		Summary:        "title",

--- a/pkg/iac/scanners/helm/test/scanner_test.go
+++ b/pkg/iac/scanners/helm/test/scanner_test.go
@@ -28,12 +28,12 @@ func TestScanner_ScanFS(t *testing.T) {
 			name:   "archived chart",
 			target: filepath.Join("testdata", "mysql-8.8.26.tar"),
 			assert: assertIds([]string{
-				"AVD-KSV-0001", "AVD-KSV-0003",
-				"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
-				"AVD-KSV-0015", "AVD-KSV-0016", "AVD-KSV-0018",
-				"AVD-KSV-0020", "AVD-KSV-0021", "AVD-KSV-0030",
-				"AVD-KSV-0104", "AVD-KSV-0106", "AVD-KSV-0125",
-				"AVD-KSV-0004",
+				"KSV001", "KSV003",
+				"KSV011", "KSV012", "KSV014",
+				"KSV015", "KSV016", "KSV018",
+				"KSV020", "KSV021", "KSV030",
+				"KSV104", "KSV106", "KSV0125",
+				"KSV004",
 			}),
 		},
 		{
@@ -41,19 +41,19 @@ func TestScanner_ScanFS(t *testing.T) {
 			target: filepath.Join("testdata", "testchart"),
 			assert: func(t *testing.T, results scan.Results) {
 				assertIds([]string{
-					"AVD-KSV-0001", "AVD-KSV-0003",
-					"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
-					"AVD-KSV-0015", "AVD-KSV-0016",
-					"AVD-KSV-0020", "AVD-KSV-0021", "AVD-KSV-0030",
-					"AVD-KSV-0104", "AVD-KSV-0106",
-					"AVD-KSV-0117", "AVD-KSV-0110", "AVD-KSV-0118",
-					"AVD-KSV-0004",
+					"KSV001", "KSV003",
+					"KSV011", "KSV012", "KSV014",
+					"KSV015", "KSV016",
+					"KSV020", "KSV021", "KSV030",
+					"KSV104", "KSV106",
+					"KSV117", "KSV110", "KSV118",
+					"KSV004",
 				})(t, results)
 
 				ignored := results.GetIgnored()
 				assert.Len(t, ignored, 1)
 
-				assert.Equal(t, "AVD-KSV-0018", ignored[0].Rule().AVDID)
+				assert.Equal(t, "KSV018", ignored[0].Rule().ID)
 				assert.Equal(t, "testchart/templates/deployment.yaml", ignored[0].Metadata().Range().GetFilename())
 			},
 		},
@@ -62,12 +62,12 @@ func TestScanner_ScanFS(t *testing.T) {
 			name:   "scanner with missing chart name can recover",
 			target: filepath.Join("testdata", "aws-cluster-autoscaler-bad.tar.gz"),
 			assert: assertIds([]string{
-				"AVD-KSV-0014", "AVD-KSV-0023", "AVD-KSV-0030",
-				"AVD-KSV-0104", "AVD-KSV-0003", "AVD-KSV-0018",
-				"AVD-KSV-0118", "AVD-KSV-0012", "AVD-KSV-0106",
-				"AVD-KSV-0016", "AVD-KSV-0001", "AVD-KSV-0011",
-				"AVD-KSV-0015", "AVD-KSV-0021", "AVD-KSV-0110", "AVD-KSV-0020",
-				"AVD-KSV-0004",
+				"KSV014", "KSV023", "KSV030",
+				"KSV104", "KSV003", "KSV018",
+				"KSV118", "KSV012", "KSV106",
+				"KSV016", "KSV001", "KSV011",
+				"KSV015", "KSV021", "KSV110", "KSV020",
+				"KSV004",
 			}),
 		},
 		{
@@ -77,8 +77,7 @@ func TestScanner_ScanFS(t *testing.T) {
 				rego.WithPolicyNamespaces("user"),
 				rego.WithPolicyReader(strings.NewReader(`package user.kubernetes.ID001
 __rego_metadata__ := {
-    "id": "ID001",
-	"avd_id": "AVD-USR-ID001",
+    "id": "USR-ID001",
     "title": "Services not allowed",
     "severity": "LOW",
     "description": "Services are not allowed because of some reasons.",
@@ -97,12 +96,12 @@ deny[res] {
 }`)),
 			},
 			assert: assertIds([]string{
-				"AVD-KSV-0001", "AVD-KSV-0003",
-				"AVD-KSV-0011", "AVD-KSV-0012", "AVD-KSV-0014",
-				"AVD-KSV-0015", "AVD-KSV-0016", "AVD-KSV-0018",
-				"AVD-KSV-0020", "AVD-KSV-0021", "AVD-KSV-0030",
-				"AVD-KSV-0104", "AVD-KSV-0106", "AVD-USR-ID001",
-				"AVD-KSV-0004", "AVD-KSV-0125",
+				"KSV001", "KSV003",
+				"KSV011", "KSV012", "KSV014",
+				"KSV015", "KSV016", "KSV018",
+				"KSV020", "KSV021", "KSV030",
+				"KSV104", "KSV106", "USR-ID001",
+				"KSV004", "KSV0125",
 			}),
 		},
 		{
@@ -125,7 +124,7 @@ deny[res] {
 # schemas:
 # - input: schema["kubernetes"]
 # custom:
-#   avd_id: AVD-USR-ID001
+#   id: USR-ID001
 #   severity: LOW
 #   input:
 #     selector:
@@ -157,7 +156,7 @@ deny[res] {
 # schemas:
 # - input: schema["kubernetes"]
 # custom:
-#   avd_id: AVD-USR-ID001
+#   id: USR-ID001
 #   severity: LOW
 #   input:
 #     selector:
@@ -202,7 +201,7 @@ func assertIds(expected []string) func(t *testing.T, results scan.Results) {
 
 		errorCodes := set.New[string]()
 		for _, result := range results.GetFailed() {
-			errorCodes.Append(result.Rule().AVDID)
+			errorCodes.Append(result.Rule().ID)
 		}
 		assert.ElementsMatch(t, expected, errorCodes.Items())
 	}

--- a/pkg/iac/scanners/kubernetes/scanner_test.go
+++ b/pkg/iac/scanners/kubernetes/scanner_test.go
@@ -33,7 +33,6 @@ spec:
 # title: test check
 # custom:
 #   id: KSV011
-#   avd_id: AVD-KSV-0011
 #   severity: LOW
 #   input:
 #     selector:
@@ -61,7 +60,7 @@ deny[res] {
 	failed := results.GetFailed()
 	require.Len(t, failed, 1)
 
-	assert.Equal(t, "AVD-KSV-0011", failed[0].Rule().AVDID)
+	assert.Equal(t, "KSV011", failed[0].Rule().ID)
 	assertLines(t, file, failed)
 }
 
@@ -96,7 +95,6 @@ func Test_ScanJSON(t *testing.T) {
 # title: test check
 # custom:
 #   id: KSV011
-#   avd_id: AVD-KSV-0011
 #   severity: LOW
 #   input:
 #     selector:
@@ -126,7 +124,7 @@ deny[res] {
 	failed := results.GetFailed()
 	require.Len(t, failed, 1)
 
-	assert.Equal(t, "AVD-KSV-0011", failed[0].Rule().AVDID)
+	assert.Equal(t, "KSV011", failed[0].Rule().ID)
 	assertLines(t, file, failed)
 }
 
@@ -226,7 +224,6 @@ func Test_CheckWithSubtype(t *testing.T) {
 # - input: schema["kubernetes"]
 # custom:
 #   id: KSV001
-#   avd_id: AVD-KSV-0001
 #   severity: MEDIUM
 #   input:
 #     selector:
@@ -248,7 +245,6 @@ deny[res] {
 # - input: schema["kubernetes"]
 # custom:
 #   id: KSV002
-#   avd_id: AVD-KSV-0002
 #   severity: LOW
 #   input:
 #     selector:
@@ -290,7 +286,7 @@ spec:
 
 	failure := results.GetFailed()[0]
 
-	assert.Equal(t, "AVD-KSV-0001", failure.Rule().AVDID)
+	assert.Equal(t, "KSV001", failure.Rule().ID)
 }
 
 func assertLines(t *testing.T, content string, results scan.Results) {

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -32,7 +32,7 @@ func Test_OptionWithPolicyDirs(t *testing.T) {
 	require.Len(t, results.GetFailed(), 1)
 
 	failure := results.GetFailed()[0]
-	assert.Equal(t, "USER-TEST-0123", failure.Rule().AVDID)
+	assert.Equal(t, "USER-TEST-0123", failure.Rule().ID)
 
 	actualCode, err := failure.GetCode()
 	require.NoError(t, err)
@@ -189,7 +189,6 @@ resource "aws_sqs_queue_policy" "bad_example" {
 # - https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-using-identity-based-policies.html
 # custom:
 #   id: TEST123
-#   avd_id: AVD-TEST-0123
 #   short_code: no-wildcard-actions
 #   severity: CRITICAL
 #   recommended_action: Avoid using "*" for actions in SQS policies and specify only required actions.
@@ -223,9 +222,8 @@ deny[res] {
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
-	assert.Equal(t, "AVD-TEST-0123", results[0].Rule().AVDID)
+	assert.Equal(t, "TEST123", results[0].Rule().ID)
 	assert.NotNil(t, results[0].Metadata().Range().GetFS())
-
 }
 
 func Test_ContainerDefinitionRego(t *testing.T) {
@@ -273,8 +271,7 @@ package defsec.abcdefg
 
 
 __rego_metadata__ := {
-	"id": "TEST123",
-	"avd_id": "AVD-TEST-0123",
+	"id": "TEST-0123",
 	"title": "Buckets should not be evil",
 	"short_code": "no-evil-buckets",
 	"severity": "CRITICAL",
@@ -306,7 +303,7 @@ deny[res] {
 	require.NoError(t, err)
 
 	require.Len(t, results.GetFailed(), 1)
-	assert.Equal(t, "AVD-TEST-0123", results[0].Rule().AVDID)
+	assert.Equal(t, "TEST-0123", results[0].Rule().ID)
 	assert.NotNil(t, results[0].Metadata().Range().GetFS())
 
 }
@@ -361,13 +358,13 @@ resource "aws_s3_bucket_public_access_block" "foo" {
 	failed := results.GetFailed()
 	for _, result := range failed {
 		// public access block
-		assert.NotEqual(t, "AVD-AWS-0094", result.Rule().AVDID, "AVD-AWS-0094 should not be reported - was found at "+result.Metadata().Range().String())
+		assert.NotEqual(t, "AVD-AWS-0094", result.Rule().ID, "AVD-AWS-0094 should not be reported - was found at "+result.Metadata().Range().String())
 		// encryption
-		assert.NotEqual(t, "AVD-AWS-0088", result.Rule().AVDID)
+		assert.NotEqual(t, "AVD-AWS-0088", result.Rule().ID)
 		// logging
-		assert.NotEqual(t, "AVD-AWS-0089", result.Rule().AVDID)
+		assert.NotEqual(t, "AVD-AWS-0089", result.Rule().ID)
 		// versioning
-		assert.NotEqual(t, "AVD-AWS-0090", result.Rule().AVDID)
+		assert.NotEqual(t, "AVD-AWS-0090", result.Rule().ID)
 	}
 }
 
@@ -423,7 +420,7 @@ resource "aws_s3_bucket_public_access_block" "testB" {
 
 	for _, result := range results.GetFailed() {
 		// public access block
-		assert.NotEqual(t, "AVD-AWS-0094", result.Rule().AVDID)
+		assert.NotEqual(t, "AVD-AWS-0094", result.Rule().ID)
 	}
 
 }
@@ -442,7 +439,7 @@ resource "aws_apigatewayv2_stage" "bad_example" {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0001
+#   id: AWS-0001
 #   input:
 #     selector:
 #     - type: cloud
@@ -481,7 +478,7 @@ deny[res] {
 
 	failure := results.GetFailed()[0]
 
-	assert.Equal(t, "AVD-AWS-0001", failure.Rule().AVDID)
+	assert.Equal(t, "AWS-0001", failure.Rule().ID)
 
 	actualCode, err := failure.GetCode()
 	require.NoError(t, err)
@@ -636,7 +633,7 @@ resource "aws_security_group" "main" {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0002
+#   id: AWS-0002
 #   input:
 #     selector:
 #     - type: cloud
@@ -666,7 +663,7 @@ deny[res] {
 
 	assert.Len(t, results.GetPassed(), 2)
 	require.Len(t, results.GetFailed(), 1)
-	assert.Equal(t, "AVD-AWS-0002", results.GetFailed()[0].Rule().AVDID)
+	assert.Equal(t, "AWS-0002", results.GetFailed()[0].Rule().ID)
 }
 
 func Test_RoleRefToOutput(t *testing.T) {
@@ -706,7 +703,7 @@ output "role_name" {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0001
+#   id: AWS-0001
 #   input:
 #     selector:
 #     - type: cloud
@@ -755,7 +752,7 @@ provider "aws" {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0001
+#   id: AWS-0001
 #   input:
 #     selector:
 #     - type: cloud
@@ -774,7 +771,7 @@ deny[res] {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0002
+#   id: AWS-0002
 #   input:
 #     selector:
 #     - type: cloud
@@ -804,10 +801,10 @@ deny[res] {
 	require.Len(t, results, 2)
 
 	require.Len(t, results.GetFailed(), 1)
-	assert.Equal(t, "AVD-AWS-0001", results.GetFailed()[0].Rule().AVDID)
+	assert.Equal(t, "AWS-0001", results.GetFailed()[0].Rule().ID)
 
 	require.Len(t, results.GetPassed(), 1)
-	assert.Equal(t, "AVD-AWS-0002", results.GetPassed()[0].Rule().AVDID)
+	assert.Equal(t, "AWS-0002", results.GetPassed()[0].Rule().ID)
 }
 
 func TestScanModuleWithCount(t *testing.T) {
@@ -837,7 +834,7 @@ module "this" {
 # schemas:
 # - input: schema.input
 # custom:
-#   avd_id: AVD-AWS-0001
+#   id: AWS-0001
 #   input:
 #     selector:
 #     - type: cloud
@@ -979,8 +976,7 @@ resource "aws_s3_bucket_versioning" "test" {
 # schemas:
 #   - input: schema["input"]
 # custom:
-#   id: AVD-BAR-0001
-#   avd_id: AVD-BAR-0001
+#   id: BAR-0001
 #   provider: custom
 #   service: custom
 #   severity: LOW
@@ -1014,8 +1010,7 @@ func TestRenderedCause(t *testing.T) {
 	s3check := `# METADATA
 # title: S3 Data should be versioned
 # custom:
-#   id: AVD-AWS-0090
-#   avd_id: AVD-AWS-0090
+#   id: AWS-0090
 package user.aws.s3.aws0090
 
 import rego.v1
@@ -1032,8 +1027,7 @@ deny contains res if {
 	iamcheck := `# METADATA
 # title: Service accounts should not have roles assigned with excessive privileges
 # custom:
-#   id: AVD-GCP-0007
-#   avd_id: AVD-GCP-0007
+#   id: GCP-0007
 package user.google.iam.google0007
 
 import rego.v1

--- a/pkg/iac/scanners/terraform/setup_test.go
+++ b/pkg/iac/scanners/terraform/setup_test.go
@@ -19,7 +19,7 @@ var emptyBucketCheck = `# METADATA
 # schemas:
 # - input: schema.cloud
 # custom:
-#   avd_id: USER-TEST-0123
+#   id: USER-TEST-0123
 #   short_code: non-empty-bucket
 #   provider: aws
 #   service: s3

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
@@ -64,7 +64,7 @@ func Test_ScanFS(t *testing.T) {
 			assert.Len(t, failed, len(tc.expectedIDs))
 
 			ids := lo.Map(failed, func(res scan.Result, _ int) string {
-				return res.Rule().AVDID
+				return res.Rule().ID
 			})
 			sort.Strings(ids)
 

--- a/pkg/iac/scanners/terraformplan/snapshot/testdata/just-resource/checks/s3-bucket-name.rego
+++ b/pkg/iac/scanners/terraformplan/snapshot/testdata/just-resource/checks/s3-bucket-name.rego
@@ -4,7 +4,7 @@
 # schemas:
 #   - input: schema["cloud"]
 # custom:
-#   avd_id: ID001
+#   id: ID001
 #   severity: LOW
 #   input:
 #     selector: 

--- a/pkg/iac/scanners/terraformplan/snapshot/testdata/with-local-module/checks/ec2-userdata.rego
+++ b/pkg/iac/scanners/terraformplan/snapshot/testdata/with-local-module/checks/ec2-userdata.rego
@@ -4,7 +4,7 @@
 # schemas:
 #   - input: schema["cloud"]
 # custom:
-#   avd_id: ID001
+#   id: ID001
 #   severity: MEDIUM
 #   input:
 #     selector: 

--- a/pkg/iac/scanners/terraformplan/snapshot/testdata/with-remote-module/checks/s3-bucket-name.rego
+++ b/pkg/iac/scanners/terraformplan/snapshot/testdata/with-remote-module/checks/s3-bucket-name.rego
@@ -4,7 +4,7 @@
 # schemas:
 #   - input: schema["cloud"]
 # custom:
-#   avd_id: ID001
+#   id: ID001
 #   severity: LOW
 #   input:
 #     selector: 

--- a/pkg/iac/scanners/terraformplan/snapshot/testdata/with-var/checks/s3-bucket-name.rego
+++ b/pkg/iac/scanners/terraformplan/snapshot/testdata/with-var/checks/s3-bucket-name.rego
@@ -4,7 +4,7 @@
 # schemas:
 #   - input: schema["cloud"]
 # custom:
-#   avd_id: ID001
+#   id: ID001
 #   severity: LOW
 #   input:
 #     selector: 

--- a/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/scanner_test.go
@@ -15,8 +15,7 @@ import (
 const defaultCheck = `package defsec.abcdefg
 
 __rego_metadata__ := {
-	"id": "TEST123",
-	"avd_id": "AVD-TEST-0123",
+	"id": "TEST-0123",
 	"title": "Buckets should not be evil",
 	"short_code": "no-evil-buckets",
 	"severity": "CRITICAL",
@@ -74,7 +73,7 @@ func Test_TerraformScanner(t *testing.T) {
 # schemas:
 #   - input: schema["cloud"]
 # custom:
-#   avd_id: AVD-TEST-0123
+#   id: TEST-0123
 #   severity: CRITICAL
 #   short_code: very-bad-misconfig
 #   recommended_action: "Fix the s3 bucket"
@@ -121,7 +120,7 @@ deny[cause] {
 
 			failure := results.GetFailed()[0]
 
-			assert.Equal(t, "AVD-TEST-0123", failure.Rule().AVDID)
+			assert.Equal(t, "TEST-0123", failure.Rule().ID)
 		})
 	}
 }

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -478,6 +478,7 @@ func ResultsToMisconf(configType types.ConfigType, scannerName string, results s
 
 		query := fmt.Sprintf("data.%s.%s", result.RegoNamespace(), result.RegoRule())
 
+		// TODO: use the ID field
 		ruleID := result.Rule().AVDID
 		if result.RegoNamespace() != "" && len(result.Rule().Aliases) > 0 {
 			ruleID = result.Rule().Aliases[0]

--- a/pkg/types/misconfiguration.go
+++ b/pkg/types/misconfiguration.go
@@ -4,8 +4,9 @@ import ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 
 // DetectedMisconfiguration holds detected misconfigurations
 type DetectedMisconfiguration struct {
-	Type          string               `json:",omitempty"`
-	ID            string               `json:",omitempty"`
+	Type string `json:",omitempty"`
+	ID   string `json:",omitempty"`
+	// Deprecated: Use the ID field instead.
 	AVDID         string               `json:",omitempty"`
 	Title         string               `json:",omitempty"`
 	Description   string               `json:",omitempty"`


### PR DESCRIPTION
This PR is the first step in migrating from AVDID to ID.

- Marks AVDID fields as deprecated in the structures.
- Updates internal code to reference ID instead of AVDID in tests only.
- Allows using ID in ignore rules alongside AVDID.
- No external API changes are introduced; all existing clients continue to work.

This approach enables a smooth transition from AVDID to ID without breaking external consumers.

## Related issues
- https://github.com/aquasecurity/trivy/discussions/8969

## Related PRs
- [ ] https://github.com/aquasecurity/trivy/pull/9573
- [ ] https://github.com/aquasecurity/trivy/pull/9062

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
