### PR TITLE
docs: bump pygments from 2.18.0 to 2.19.2

### DIFF
--- a/docs/build/requirements.txt
+++ b/docs/build/requirements.txt
@@ -72,7 +72,7 @@ pathspec==0.12.1
     #   mkdocs-macros-plugin
 platformdirs==4.3.6
     # via mkdocs-get-deps
-pygments==2.18.0
+pygments==2.19.2
     # via mkdocs-material
 pymdown-extensions==10.12
     # via mkdocs-material


### PR DESCRIPTION
## Description

This PR upgrades `pygments` using the command:
`pip-compile --upgrade-package pygments --output-file=docs/build/requirements.txt docs/build/requirements.in`

Pygments versions starting from [2.19.0](https://github.com/pygments/pygments/blob/0328cfaf1d953b3a0c7eb0ec0efd363deb2f9d51/CHANGES#L29-L45) add support for Rego syntax highlighting.


### Before:
<img width="686" height="150" alt="image" src="https://github.com/user-attachments/assets/2b00b898-f470-4158-a127-8ae6fcdd1479" />


### After:
<img width="690" height="153" alt="image" src="https://github.com/user-attachments/assets/98c953a1-5dd2-4fad-b044-7b1245b63325" />


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
