### PR TITLE
feat(java): do not use the java-db in offline mode

### DIFF
--- a/pkg/fanal/analyzer/language/java/jar/jar_test.go
+++ b/pkg/fanal/analyzer/language/java/jar/jar_test.go
@@ -151,6 +151,138 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 	}
 }
 
+func Test_javaLibraryAnalyzer_Analyze_Offline(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputFile       string
+		includeChecksum bool
+		want            *analyzer.AnalysisResult
+	}{
+		{
+			name:      "happy path (WAR file)",
+			inputFile: "testdata/test.war",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Jar,
+						FilePath: "testdata/test.war",
+						Packages: types.Packages{
+							{
+								Name:     "org.glassfish:javax.el",
+								FilePath: "testdata/test.war/WEB-INF/lib/javax.el-3.0.0.jar",
+								Version:  "3.0.0",
+							},
+							{
+								Name:     "com.fasterxml.jackson.core:jackson-databind",
+								FilePath: "testdata/test.war/WEB-INF/lib/jackson-databind-2.9.10.6.jar",
+								Version:  "2.9.10.6",
+							},
+							{
+								Name:     "com.fasterxml.jackson.core:jackson-annotations",
+								FilePath: "testdata/test.war/WEB-INF/lib/jackson-annotations-2.9.10.jar",
+								Version:  "2.9.10",
+							},
+							{
+								Name:     "com.fasterxml.jackson.core:jackson-core",
+								FilePath: "testdata/test.war/WEB-INF/lib/jackson-core-2.9.10.jar",
+								Version:  "2.9.10",
+							},
+							{
+								Name:     "org.slf4j:slf4j-api",
+								FilePath: "testdata/test.war/WEB-INF/lib/slf4j-api-1.7.30.jar",
+								Version:  "1.7.30",
+							},
+							{
+								Name:     "com.cronutils:cron-utils",
+								FilePath: "testdata/test.war/WEB-INF/lib/cron-utils-9.1.2.jar",
+								Version:  "9.1.2",
+							},
+							{
+								Name:     "org.apache.commons:commons-lang3",
+								FilePath: "testdata/test.war/WEB-INF/lib/commons-lang3-3.11.jar",
+								Version:  "3.11",
+							},
+							{
+								Name:     "com.example:web-app",
+								FilePath: "testdata/test.war",
+								Version:  "1.0-SNAPSHOT",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:            "happy path (PAR file)",
+			inputFile:       "testdata/test.par",
+			includeChecksum: true,
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Jar,
+						FilePath: "testdata/test.par",
+						Packages: types.Packages{
+							{
+								Name:     "com.fasterxml.jackson.core:jackson-core",
+								FilePath: "testdata/test.par/lib/jackson-core-2.9.10.jar",
+								Version:  "2.9.10",
+								Digest:   "sha1:d40913470259cfba6dcc90f96bcaa9bcff1b72e0",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "happy path (JAR file)",
+			inputFile: "testdata/test.jar",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Jar,
+						FilePath: "testdata/test.jar",
+						Packages: types.Packages{
+							{
+								Name:     "org.apache:javax.websocket",
+								FilePath: "testdata/test.jar",
+								Version:  "1.1.FR",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "sad path",
+			inputFile: "testdata/test.txt",
+			want:      &analyzer.AnalysisResult{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := javaLibraryAnalyzer{}
+			ctx := t.Context()
+
+			mfs := mapfs.New()
+			err := mfs.MkdirAll(filepath.Dir(tt.inputFile), os.ModePerm)
+			require.NoError(t, err)
+			err = mfs.WriteFile(tt.inputFile, tt.inputFile)
+			require.NoError(t, err)
+
+			got, err := a.PostAnalyze(ctx, analyzer.PostAnalysisInput{
+				FS: mfs,
+				Options: analyzer.AnalysisOptions{
+					Offline:      true,
+					FileChecksum: tt.includeChecksum,
+				},
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_javaLibraryAnalyzer_Required(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Description

The jar parser does not use the java db when offline mode is set: 

https://github.com/aquasecurity/trivy/blob/05375d17f712aeab5ff2eff33081d2e1712a7e70/pkg/dependency/parser/java/jar/parse.go#L105-L112

However the jar analyzer does not support offline mode, it always tries to initialize the java db. Skip java db initialization when offline mode is set.

## Related issues
- https://github.com/aquasecurity/trivy/issues/3421

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
