### PR TITLE
fix(license): don't normalize `unlicensed` licenses into `unlicense`

### DIFF
--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -244,7 +244,6 @@ var mapping = map[string]expr.SimpleExpr{
 	"UNICODE-DFS-2016":     licence(expr.UnicodeDFS2016, false),
 	"UNICODE-TOU":          licence(expr.UnicodeTOU, false),
 	"UNLICENSE":            licence(expr.Unlicense, false),
-	"UNLICENSED":           licence(expr.Unlicense, false),
 	"UPL-1":                licence(expr.UPL10, false),
 	"UPL-1.0":              licence(expr.UPL10, false),
 	"W3C":                  licence(expr.W3C, false),

--- a/pkg/licensing/normalize_test.go
+++ b/pkg/licensing/normalize_test.go
@@ -188,9 +188,7 @@ func TestNormalize(t *testing.T) {
 			licenses: []expression.Expression{
 				expression.SimpleExpr{License: "The Unlicense"},
 				expression.SimpleExpr{License: "Unlicense"},
-				expression.SimpleExpr{License: "Unlicensed"},
 				expression.SimpleExpr{License: "UNLICENSE"},
-				expression.SimpleExpr{License: "UNLICENSED"},
 			},
 			want:        "Unlicense",
 			wantLicense: expression.SimpleExpr{License: "Unlicense"},

--- a/pkg/licensing/scanner_test.go
+++ b/pkg/licensing/scanner_test.go
@@ -143,6 +143,19 @@ func TestScanner_Scan(t *testing.T) {
 			wantCategory: types.CategoryUnknown,
 			wantSeverity: "UNKNOWN",
 		},
+		{
+			// `Unlicensed` is a special license name in npm.
+			// It means the developer does not grant anyone the right to use the private or unpublished package under any circumstances.
+			name: "'unlicensed' npm license as unknown",
+			categories: map[types.LicenseCategory][]string{
+				types.CategoryUnencumbered: {
+					expression.Unlicense,
+				},
+			},
+			licenseName:  "UNLICENSED",
+			wantCategory: types.CategoryUnknown,
+			wantSeverity: "UNKNOWN",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

  This PR fixes a bug in license normalization where "unlicensed" licenses were incorrectly being mapped to "Unlicense".

  The issue was that both "UNLICENSE" and "UNLICENSED" were being normalized to the same "Unlicense" license expression. However, these represent fundamentally different licensing concepts:

  - "Unlicense" (or "The Unlicense") is a public domain dedication license that grants maximum freedom
  - "unlicensed" in npm specifically means the package is private/unpublished and the developer grants no rights to use it

  The fix removes the mapping of "UNLICENSED" → "Unlicense" from the normalization table, allowing "unlicensed" licenses to be properly categorized as unknown/restricted rather than being incorrectly treated as permissive public domain
  licenses.

## Example
Before:
```bash
➜ trivy -q rootfs --scanners license /Users/dmitriy/work/tmp/9500/package.json --table-mode detailed

Node.js (license)

Total: 1 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────┬────────────────┬──────────┐
│          Package          │  License  │ Classification │ Severity │
├───────────────────────────┼───────────┼────────────────┼──────────┤
│ @nxtvid/component-library │ Unlicense │ Unencumbered   │ LOW      │
└───────────────────────────┴───────────┴────────────────┴──────────┘
```
After:
```bash
➜  ./trivy -q rootfs --scanners license /Users/dmitriy/work/tmp/9500/package.json --table-mode detailed

Node.js (license)

Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬────────────┬────────────────┬──────────┐
│          Package          │  License   │ Classification │ Severity │
├───────────────────────────┼────────────┼────────────────┼──────────┤
│ @nxtvid/component-library │ UNLICENSED │ Non Standard   │ UNKNOWN  │
└───────────────────────────┴────────────┴────────────────┴──────────┘
```

## Related issues
- Close #9581


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
