### PR TITLE
feat(fs): change artifact type to repository when git info is detected

### DIFF
--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -82,6 +82,8 @@ func NewArtifact(rootPath string, c cache.ArtifactCache, w Walker, opt artifact.
 
 	// Check if the directory is a git repository and extract metadata
 	if art.isClean, art.repoMetadata, err = extractGitInfo(art.rootPath); err == nil {
+		// If git info is detected, change artifact type to repository
+		art.artifactOption.Type = types.TypeRepository
 		if art.isClean {
 			art.logger.Debug("Using the latest commit hash for calculating cache key",
 				log.String("commit_hash", art.repoMetadata.Commit))

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -218,6 +218,38 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "git repository: artifact type is changed to repository",
+			fields: fields{
+				dir: "../../../../internal/gittest/testdata/test-repo",
+			},
+			wantBlobs: []cachetest.WantBlob{
+				{
+					// Cache key is based on commit hash (8a19b492a589955c3e70c6ad8efd1e4ec6ae0d35)
+					ID: "sha256:c7173e152a268c038257b877794285986c52ac569de7e516b2963f557f4e26ee",
+					BlobInfo: types.BlobInfo{
+						SchemaVersion: types.BlobJSONSchemaVersion,
+					},
+				},
+			},
+			want: artifact.Reference{
+				Name: "../../../../internal/gittest/testdata/test-repo",
+				Type: types.TypeRepository,
+				ID:   "sha256:c7173e152a268c038257b877794285986c52ac569de7e516b2963f557f4e26ee",
+				BlobIDs: []string{
+					"sha256:c7173e152a268c038257b877794285986c52ac569de7e516b2963f557f4e26ee",
+				},
+				RepoMetadata: artifact.RepoMetadata{
+					RepoURL:   "https://github.com/aquasecurity/trivy-test-repo/",
+					Branch:    "main",
+					Tags:      []string{"v0.0.1"},
+					Commit:    "8a19b492a589955c3e70c6ad8efd1e4ec6ae0d35",
+					CommitMsg: "Update README.md",
+					Author:    "Teppei Fukuda <knqyf263@gmail.com>",
+					Committer: "GitHub <noreply@github.com>",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
When scanning a filesystem with `trivy fs` command that is actually a git repository, automatically change the artifact type from `filesystem` to `repository`. This ensures proper classification where code repositories and filesystem scans are handled differently.

The change applies whenever git repository information (commit, branch, etc.) is successfully extracted from the target directory.

## Before and After

### Before
When scanning a git repository with `trivy fs`:
```json
{
  "ArtifactType": "filesystem",
  "Metadata": {
    "RepoURL": "https://github.com/aquasecurity/trivy-test-repo/",
    "Branch": "main",
    "Tags": ["v0.0.1"],
    "Commit": "8a19b492a589955c3e70c6ad8efd1e4ec6ae0d35",
    "CommitMsg": "Update README.md",
    "Author": "Teppei Fukuda <knqyf263@gmail.com>",
    "Committer": "GitHub <noreply@github.com>"
  }
}
```

### After
When scanning a git repository with `trivy fs`:
```json
{
  "ArtifactType": "repository",
  "Metadata": {
    "RepoURL": "https://github.com/aquasecurity/trivy-test-repo/",
    "Branch": "main",
    "Tags": ["v0.0.1"],
    "Commit": "8a19b492a589955c3e70c6ad8efd1e4ec6ae0d35",
    "CommitMsg": "Update README.md",
    "Author": "Teppei Fukuda <knqyf263@gmail.com>",
    "Committer": "GitHub <noreply@github.com>"
  }
}
```

Non-git directories remain as `filesystem` type.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).