### PR TITLE
fix: Trim the end-of-range suffix when using the --detection-priority…

### DIFF
--- a/pkg/dependency/parser/python/pip/parse.go
+++ b/pkg/dependency/parser/python/pip/parse.go
@@ -43,7 +43,9 @@ func (p *Parser) splitLine(line string) []string {
 	}
 	for _, sep := range separators {
 		if result := strings.Split(line, sep); len(result) == 2 {
-			return result
+			// Trim the end-of-range suffix. ">=2.31.0,<3" becomes ">=2.31.0"
+			version := strings.Split(result[1], ",")[0]
+			return []string{result[0], version}
 		}
 	}
 	return nil

--- a/pkg/dependency/parser/python/pip/parse_test.go
+++ b/pkg/dependency/parser/python/pip/parse_test.go
@@ -73,6 +73,11 @@ func TestParse(t *testing.T) {
 			useMinVersion: true,
 			want:          requirementsCompatibleVersions,
 		},
+		{
+			name:     "comma-separated version ranges",
+			filePath: "testdata/requirements_comma_ranges.txt",
+			want:     requirementsCommaRanges,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/python/pip/parse_testcase.go
+++ b/pkg/dependency/parser/python/pip/parse_testcase.go
@@ -301,4 +301,17 @@ var (
 			},
 		},
 	}
+
+	requirementsCommaRanges = []ftypes.Package{
+		{
+			Name:    "requests",
+			Version: "2.31.0",
+			Locations: []ftypes.Location{
+				{
+					StartLine: 1,
+					EndLine:   1,
+				},
+			},
+		},
+	}
 )


### PR DESCRIPTION
… comprehensive flag

## When the --detection-priority comprehensive flag is used, Trivy takes the minimum version for a package (see [docs](https://trivy.dev/latest/docs/coverage/language/python/#dependency-detection)).

However, if the package version is specified as a range, Trivy doesn’t trim the end-of-range suffix.
e.g for requests>=2.31.0,<3:

now: requests + 2.31.0,<3
correct: requests + 2.31.0

## Related issues
- Close #9609 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
