### PR TITLE
ci: use merge commit for apidiff to avoid false positives

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -24,7 +24,7 @@ jobs:
       # frozen at an old state and apidiff cannot run correctly.
       - name: Check for merge conflicts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         # pull_request_target and mergeability are processed asynchronously.
         # As a result, it’s possible that we start the check before GitHub has finished calculating the mergeability.


### PR DESCRIPTION
## Description

This PR fixes false positive breaking change detection in the apidiff workflow when PRs are created from an old base branch.

### Problem

When a PR is created from an old base and the main branch has new commits with API additions, the current workflow compares:
- `base.sha` (latest main with new features)  
- `head.sha` (PR branch without those features)

This causes features added to main after PR creation to appear as "removed" in the PR, resulting in false breaking change detection.

### Solution

1. **Use merge commit**: Changed from `head.sha` to `refs/pull/{number}/merge` to compare the actual post-merge state
2. **Detect conflicts**: Added check for merge conflicts, as merge commits become frozen when conflicts exist

### Reference

- Related PR with false positive: https://github.com/aquasecurity/trivy/pull/9613
- GitHub merge branch behavior: https://fluffyandflakey.blog/2022/12/21/what-is-a-github-pull-request-merge-branch/

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).