### PR TITLE
test(k8s): use a specific bundle for k8s misconfig scan

### DIFF
--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -28,12 +28,14 @@ func TestK8s(t *testing.T) {
 		// Set up the output file
 		outputFile := filepath.Join(t.TempDir(), "output.json")
 
+		// it uses a fixed version of trivy-checks bundle - v1.11.2
+		// its hash is sha256:f3ea8227f838a985f0c884909e9d226362f5fc5ab6021310a179fbb24c5b57fd
 		osArgs := []string{
 			"--cache-dir", cacheDir,
 			"k8s",
 			"kind-kind-test",
 			"--report", "summary",
-			"--checks-bundle-repository", "mirror.gcr.io/aquasec/trivy-checks:1.11.2",
+			"--checks-bundle-repository", "mirror.gcr.io/aquasec/trivy-checks:1.11.2@sha256:f3ea8227f838a985f0c884909e9d226362f5fc5ab6021310a179fbb24c5b57fd",
 			"-q",
 			"--timeout", "5m0s",
 			"--format", "json",


### PR DESCRIPTION
## Description

This PR sets up a specific trivy-check bundle for integration tests of k8s subcommand.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
