### PR TITLE
fix: Use `fetch-level: 1` to check out trivy-repo in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,6 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/trivy-repo
           path: trivy-repo
-          fetch-depth: 0
           token: ${{ secrets.ORG_REPO_TOKEN }}
 
       - name: Setup git settings


### PR DESCRIPTION
## Description
We got `No space left on device` error when checking out trivy-repo — https://github.com/aquasecurity/trivy/actions/runs/18374488962.

Currently, the workflow fetches all commits for this repo:
https://github.com/aquasecurity/trivy/blob/2f695b9bd477d02efdcd876ceb18c95494974657/.github/workflows/release.yaml#L37-L42

We can fetch only the latest commit and save ~15 GB.
```
➜ du -shm ./trivy-repo     
15456	./trivy-repo
➜ du -shm ./trivy-repo/.git
15117	./trivy-repo/.git
```

Test:
- https://github.com/DmitriyLewen/trivy/actions/runs/18398657919/job/52424913210
- https://github.com/DmitriyLewen/trivy-repo/tree/main/deb/pool/main/t/trivy


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
