### PR TITLE
fix: Use `fetch-level: 1` to check out trivy-repo in the release workflow [backport: release/v0.67]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,6 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/trivy-repo
           path: trivy-repo
-          fetch-depth: 0
           token: ${{ secrets.ORG_REPO_TOKEN }}
 
       - name: Setup git settings


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.67`:
 - https://github.com/aquasecurity/trivy/pull/9636
 
# Why we don't use backport action:

The default `GITHUB_TOKEN` does not have permission to modify files under .github/workflows/ (see https://github.com/aquasecurity/trivy/actions/runs/18404387268/job/52440814372?pr=9636#step:5:28).
So I created the backport PR manually by reproducing the steps from `misc/backport/backport.sh`.
Therefore, [Backport PR check error](https://github.com/aquasecurity/trivy/actions/runs/18406056474/job/52446135357?pr=9638) for this PR can safely be ignored.

