### PR TITLE
fix(k8s): override --report=all to summary when using --compliance

### DIFF
--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -23,9 +23,8 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 	}
 	// Override report=all to summary if compliance flag is specified
 	if opts.Compliance.Spec.ID != "" && opts.ReportFormat == "all" {
-	log.WarnContext(ctx, `Compliance based results only have summary styled output. 
-	Example of correct usage: trivy k8s --report summary --compliance k8s-cis-1.23 --format table`)
-	opts.ReportFormat = "summary"
+		log.WarnContext(ctx, "Compliance based results only have summary styled output. Example of correct usage: trivy k8s --report summary --compliance k8s-cis-1.23 --format table")
+		opts.ReportFormat = "summary"
 	}
 	var artifacts []*k8sArtifacts.Artifact
 	var err error


### PR DESCRIPTION
## Description

Fixes the bug where running:

```bash
trivy k8s --report all --compliance k8s-cis-1.23 --format table
```

produces **no output**, even though valid scan data exists.

This happens because **compliance-based reports only support summary-style output**, and the CLI didn't previously handle this incompatible flag combination.

---
## Related Issues

* Fixes and closes: [#9386](https://github.com/aquasecurity/trivy/issues/9386)
* Discussed in: [#9365](https://github.com/aquasecurity/trivy/discussions/9365)

---
## Fix

* Automatically **override** `--report=all` to `--report=summary` when a `--compliance` spec is provided.
* Emit a **warning log** to inform the user and guide them toward the correct usage.

### Example Warning:

```
WARN	Compliance based results only have summary styled output. Example of correct usage: trivy k8s --report summary --compliance k8s-cis-1.23 --format table
```

---

## Results

### Before fix

```bash
$ trivy k8s --report all --compliance k8s-cis-1.23 --format table

2025-10-10T15:44:59Z    INFO    Node scanning is enabled
2025-10-10T15:44:59Z    INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-10-10T15:44:59Z    INFO    Scanning K8s... K8s="kind-kind"
```

###  After fix

```bash
$ trivy k8s --report all --compliance k8s-cis-1.23 --format table

2025-10-10T15:46:09Z    WARN    Compliance based results only have summary styled output. 
        Example of correct usage: trivy k8s --report summary --compliance k8s-cis-1.23 --format table
2025-10-10T15:46:38Z    INFO    Node scanning is enabled
2025-10-10T15:46:38Z    INFO    If you want to disable Node scanning via an in-cluster Job, please try '--disable-node-collector' to disable the Node-Collector job.
2025-10-10T15:46:38Z    INFO    Scanning K8s... K8s="kind-kind"

Summary Report for compliance: CIS Kubernetes Benchmarks v1.23
┌────────┬──────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────┬────────┐
│   ID   │ Severity │                                                  Control Name                                                   │ Status │ Issues │
├────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼────────┤
│ 1.1.1  │   HIGH   │ Ensure that the API server pod specification file permissions are set to 600 or more restrictive                │  PASS  │   0    │
│ 1.1.2  │   HIGH   │ Ensure that the API server pod specification file ownership is set to root:root                                 │  PASS  │   0    │
│ 1.1.3  │   HIGH   │ Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive        │  PASS  │   0    │
│ 1.1.4  │   HIGH   │ Ensure that the controller manager pod specification file ownership is set to root:root                         │  PASS  │   0    │
│ 1.1.5  │   HIGH   │ Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive                 │  PASS  │   0    │
│ 1.1.6  │   HIGH   │ Ensure that the scheduler pod specification file ownership is set to root:root                                  │  PASS  │   0    │
│ 1.1.7  │   HIGH   │ Ensure that the etcd pod specification file permissions are set to 600 or more restrictive                      │  PASS  │   0    │
│ 1.1.8  │   HIGH   │ Ensure that the etcd pod specification file ownership is set to root:root                                       │  PASS  │   0    │
│ 1.1.9  │   HIGH   │ Ensure that the Container Network Interface file permissions are set to 600 or more restrictive                 │  PASS  │   0    │
│ 1.1.10 │   HIGH   │ Ensure that the Container Network Interface file ownership is set to root:root                                  │  PASS  │   0    │
│ 1.1.11 │   HIGH   │ Ensure that the etcd data directory permissions are set to 700 or more restrictive                              │  PASS  │   0    │
│ 1.1.12 │   LOW    │ Ensure that the etcd data directory ownership is set to etcd:etcd                                               │  FAIL  │   1    │
│ 1.1.13 │ CRITICAL │ Ensure that the admin.conf file permissions are set to 600                                                      │  PASS  │   0    │
│ 1.1.14 │ CRITICAL │ Ensure that the admin.conf file ownership is set to root:root                                                   │  PASS  │   0    │
│ 1.1.15 │   HIGH   │ Ensure that the scheduler.conf file permissions are set to 600 or more restrictive                              │  PASS  │   0    │
│ 1.1.16 │   HIGH   │ Ensure that the scheduler.conf file ownership is set to root:root                                               │  PASS  │   0    │
│ 1.1.17 │   HIGH   │ Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive                     │  PASS  │   0    │
│ 1.1.18 │   HIGH   │ Ensure that the controller-manager.conf file ownership is set to root:root                                      │  PASS  │   0    │
│ 1.1.19 │ CRITICAL │ Ensure that the Kubernetes PKI directory and file ownership is set to root:root                                 │  PASS  │   0    │
│ 1.1.20 │ CRITICAL │ Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive                  │  PASS  │   0    │
│ 1.1.21 │ CRITICAL │ Ensure that the Kubernetes PKI key file permissions are set to 600                                              │  PASS  │   0    │
│ 1.2.1  │  MEDIUM  │ Ensure that the --anonymous-auth argument is set to false                                                       │  FAIL  │   1    │
│ 1.2.2  │   LOW    │ Ensure that the --token-auth-file parameter is not set                                                          │  PASS  │   0    │
│ 1.2.3  │   LOW    │ Ensure that the --DenyServiceExternalIPs is not set                                                             │  PASS  │   0    │
│ 1.2.4  │   LOW    │ Ensure that the --kubelet-https argument is set to true                                                         │  PASS  │   0    │
│ 1.2.5  │   HIGH   │ Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate          │  PASS  │   0    │
│ 1.2.6  │   HIGH   │ Ensure that the --kubelet-certificate-authority argument is set as appropriate                                  │  FAIL  │   1    │
│ 1.2.7  │   LOW    │ Ensure that the --authorization-mode argument is not set to AlwaysAllow                                         │  PASS  │   0    │
│ 1.2.8  │   HIGH   │ Ensure that the --authorization-mode argument includes Node                                                     │  PASS  │   0    │
│ 1.2.9  │   HIGH   │ Ensure that the --authorization-mode argument includes RBAC                                                     │  PASS  │   0    │
│ 1.2.10 │   HIGH   │ Ensure that the admission control plugin EventRateLimit is set                                                  │  FAIL  │   1    │
│ 1.2.11 │   LOW    │ Ensure that the admission control plugin AlwaysAdmit is not set                                                 │  PASS  │   0    │
│ 1.2.12 │  MEDIUM  │ Ensure that the admission control plugin AlwaysPullImages is set                                                │  FAIL  │   1    │
│ 1.2.13 │  MEDIUM  │ Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used            │  PASS  │   0    │
│ 1.2.14 │   LOW    │ Ensure that the admission control plugin ServiceAccount is set                                                  │  PASS  │   0    │
│ 1.2.15 │   LOW    │ Ensure that the admission control plugin NamespaceLifecycle is set                                              │  PASS  │   0    │
│ 1.2.16 │   LOW    │ Ensure that the admission control plugin NodeRestriction is set                                                 │  PASS  │   0    │
│ 1.2.17 │   HIGH   │ Ensure that the --secure-port argument is not set to 0                                                          │  PASS  │   0    │
│ 1.2.18 │   LOW    │ Ensure that the --profiling argument is set to false                                                            │  FAIL  │   1    │
│ 1.2.19 │   LOW    │ Ensure that the --audit-log-path argument is set                                                                │  FAIL  │   1    │
│ 1.2.20 │   LOW    │ Ensure that the --audit-log-maxage argument is set to 30 or as appropriate                                      │  FAIL  │   1    │
│ 1.2.21 │   LOW    │ Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate                                   │  FAIL  │   1    │
│ 1.2.22 │   LOW    │ Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate                                    │  FAIL  │   1    │
│ 1.2.24 │   LOW    │ Ensure that the --service-account-lookup argument is set to true                                                │  PASS  │   0    │
│ 1.2.25 │   LOW    │ Ensure that the --service-account-key-file argument is set as appropriate                                       │  PASS  │   0    │
│ 1.2.26 │   LOW    │ Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate                             │  PASS  │   0    │
│ 1.2.27 │  MEDIUM  │ Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate                     │  PASS  │   0    │
│ 1.2.28 │   LOW    │ Ensure that the --client-ca-file argument is set appropriate                                                    │  PASS  │   0    │
│ 1.2.29 │   LOW    │ Ensure that the --etcd-cafile argument is set as appropriate                                                    │  PASS  │   0    │
│ 1.2.30 │   LOW    │ Ensure that the --encryption-provider-config argument is set as appropriate                                     │  FAIL  │   1    │
│ 1.3.1  │  MEDIUM  │ Ensure that the --terminated-pod-gc-threshold argument is set as appropriate                                    │  FAIL  │   1    │
│ 1.3.3  │  MEDIUM  │ Ensure that the --use-service-account-credentials argument is set to true                                       │  PASS  │   0    │
│ 1.3.4  │  MEDIUM  │ Ensure that the --service-account-private-key-file argument is set as appropriate                               │  PASS  │   0    │
│ 1.3.5  │  MEDIUM  │ Ensure that the --root-ca-file argument is set as appropriate                                                   │  PASS  │   0    │
│ 1.3.6  │  MEDIUM  │ Ensure that the RotateKubeletServerCertificate argument is set to true                                          │  FAIL  │   1    │
│ 1.3.7  │   LOW    │ Ensure that the --bind-address argument is set to 127.0.0.1                                                     │  PASS  │   0    │
│ 1.4.1  │  MEDIUM  │ Ensure that the --profiling argument is set to false                                                            │  PASS  │   0    │
│ 1.4.2  │ CRITICAL │ Ensure that the --bind-address argument is set to 127.0.0.1                                                     │  PASS  │   0    │
│ 2.1    │  MEDIUM  │ Ensure that the --cert-file and --key-file arguments are set as appropriate                                     │  PASS  │   0    │
│ 2.2    │ CRITICAL │ Ensure that the --client-cert-auth argument is set to true                                                      │  PASS  │   0    │
│ 2.3    │ CRITICAL │ Ensure that the --auto-tls argument is not set to true                                                          │  PASS  │   0    │
│ 2.4    │ CRITICAL │ Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate                           │  PASS  │   0    │
│ 2.5    │ CRITICAL │ Ensure that the --peer-client-cert-auth argument is set to true                                                 │  PASS  │   0    │
│ 2.6    │   HIGH   │ Ensure that the --peer-auto-tls argument is not set to true                                                     │  PASS  │   0    │
│ 3.1.1  │   HIGH   │ Client certificate authentication should not be used for users (Manual)                                         │   -    │   -    │
│ 3.2.1  │   HIGH   │ Ensure that a minimal audit policy is created (Manual)                                                          │   -    │   -    │
│ 3.2.2  │   HIGH   │ Ensure that the audit policy covers key security concerns (Manual)                                              │   -    │   -    │
│ 4.1.1  │   HIGH   │ Ensure that the kubelet service file permissions are set to 600 or more restrictive                             │  FAIL  │   1    │
│ 4.1.2  │   HIGH   │ Ensure that the kubelet service file ownership is set to root:root                                              │  PASS  │   0    │
│ 4.1.3  │   HIGH   │ If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive                           │  PASS  │   0    │
│ 4.1.4  │   HIGH   │ If proxy kubeconfig file exists ensure ownership is set to root:root                                            │  PASS  │   0    │
│ 4.1.5  │   HIGH   │ Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive                   │  PASS  │   0    │
│ 4.1.6  │   HIGH   │ Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root                                    │  PASS  │   0    │
│ 4.1.7  │ CRITICAL │ Ensure that the certificate authorities file permissions are set to 600 or more restrictive                     │  FAIL  │   1    │
│ 4.1.8  │ CRITICAL │ Ensure that the client certificate authorities file ownership is set to root:root                               │  PASS  │   0    │
│ 4.1.9  │   HIGH   │ If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive │  FAIL  │   1    │
│ 4.1.10 │   HIGH   │ If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root         │  PASS  │   0    │
│ 4.2.1  │ CRITICAL │ Ensure that the --anonymous-auth argument is set to false                                                       │  PASS  │   0    │
│ 4.2.2  │ CRITICAL │ Ensure that the --authorization-mode argument is not set to AlwaysAllow                                         │  PASS  │   0    │
│ 4.2.3  │ CRITICAL │ Ensure that the --client-ca-file argument is set as appropriate                                                 │  PASS  │   0    │
│ 4.2.4  │   HIGH   │ Verify that the --read-only-port argument is set to 0                                                           │  PASS  │   0    │
│ 4.2.5  │   HIGH   │ Ensure that the --streaming-connection-idle-timeout argument is not set to 0                                    │  PASS  │   0    │
│ 4.2.6  │   HIGH   │ Ensure that the --protect-kernel-defaults argument is set to true                                               │  PASS  │   0    │
│ 4.2.7  │   HIGH   │ Ensure that the --make-iptables-util-chains argument is set to true                                             │  PASS  │   0    │
│ 4.2.8  │   HIGH   │ Ensure that the --hostname-override argument is not set                                                         │  PASS  │   0    │
│ 4.2.9  │   HIGH   │ Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture             │  PASS  │   0    │
│ 4.2.10 │ CRITICAL │ Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate                     │  PASS  │   0    │
│ 4.2.11 │ CRITICAL │ Ensure that the --rotate-certificates argument is not set to false                                              │  PASS  │   0    │
│ 4.2.12 │ CRITICAL │ Verify that the RotateKubeletServerCertificate argument is set to true                                          │  PASS  │   0    │
│ 4.2.13 │ CRITICAL │ Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers                                          │  PASS  │   0    │
│ 5.1.1  │   HIGH   │ Ensure that the cluster-admin role is only used where required                                                  │  FAIL  │   2    │
│ 5.1.2  │   HIGH   │ Minimize access to secrets                                                                                      │  FAIL  │   12   │
│ 5.1.3  │   HIGH   │ Minimize wildcard use in Roles and ClusterRoles                                                                 │  FAIL  │   8    │
│ 5.1.6  │   HIGH   │ Ensure that Service Account Tokens are only mounted where necessary                                             │  PASS  │   0    │
│ 5.1.8  │   HIGH   │ Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster                           │  PASS  │   0    │
│ 5.2.2  │   HIGH   │ Minimize the admission of privileged containers                                                                 │  FAIL  │   1    │
│ 5.2.3  │   HIGH   │ Minimize the admission of containers wishing to share the host process ID namespace                             │  PASS  │   0    │
│ 5.2.4  │   HIGH   │ Minimize the admission of containers wishing to share the host IPC namespace                                    │  PASS  │   0    │
│ 5.2.5  │   HIGH   │ Minimize the admission of containers wishing to share the host network namespace                                │  FAIL  │   6    │
│ 5.2.6  │   HIGH   │ Minimize the admission of containers with allowPrivilegeEscalation                                              │  FAIL  │   7    │
│ 5.2.7  │  MEDIUM  │ Minimize the admission of root containers                                                                       │  FAIL  │   8    │
│ 5.2.8  │  MEDIUM  │ Minimize the admission of containers with the NET_RAW capability                                                │  FAIL  │   2    │
│ 5.2.9  │   LOW    │ Minimize the admission of containers with added capabilities                                                    │  FAIL  │   7    │
│ 5.2.10 │   LOW    │ Minimize the admission of containers with capabilities assigned                                                 │  FAIL  │   7    │
│ 5.2.11 │  MEDIUM  │ Minimize the admission of containers with capabilities assigned                                                 │  PASS  │   0    │
│ 5.2.12 │  MEDIUM  │ Minimize the admission of HostPath volumes                                                                      │  FAIL  │   6    │
│ 5.2.13 │  MEDIUM  │ Minimize the admission of containers which use HostPorts                                                        │  FAIL  │   4    │
│ 5.3.1  │  MEDIUM  │ Ensure that the CNI in use supports Network Policies (Manual)                                                   │   -    │   -    │
│ 5.3.2  │  MEDIUM  │ Ensure that all Namespaces have Network Policies defined                                                        │  PASS  │   0    │
│ 5.4.1  │  MEDIUM  │ Prefer using secrets as files over secrets as environment variables (Manual)                                    │   -    │   -    │
│ 5.4.2  │  MEDIUM  │ Consider external secret storage (Manual)                                                                       │   -    │   -    │
│ 5.5.1  │  MEDIUM  │ Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)                               │   -    │   -    │
│ 5.7.1  │  MEDIUM  │ Create administrative boundaries between resources using namespaces (Manual)                                    │   -    │   -    │
│ 5.7.2  │  MEDIUM  │ Ensure that the seccomp profile is set to docker/default in your pod definitions                                │  FAIL  │   4    │
│ 5.7.3  │   HIGH   │ Apply Security Context to Your Pods and Containers                                                              │  FAIL  │   24   │
│ 5.7.4  │  MEDIUM  │ The default namespace should not be used                                                                        │  PASS  │   0    │
└────────┴──────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────┴────────┘
```

---

## Checklist

* [x] I've read the [contribution guidelines](https://trivy.dev/latest/community/contribute/pr/)
* [x] I've followed the [PR title convention](https://trivy.dev/latest/community/contribute/pr/#title)
* [x] The flag conflict is now auto-handled at runtime
* [x] A WARN log has been added for better UX
* [x] Manual tests verify the fix
* [x] No breaking changes were introduced

---

## How to Test

Run the following commands and check behavior:

### Case 1: Compliance + `--report=all` (should auto-correct and warn)

```bash
trivy k8s --report all --compliance k8s-cis-1.23 --format table
```

Expected:

* A warning message is logged.
* A summary-style compliance report is shown.

---

### Case 2: Compliance + `--report=summary` (correct usage)

```bash
trivy k8s --report summary --compliance k8s-cis-1.23 --format table
```

Expected:

* No warning.
* Summary-style report is shown as expected.

---

### Case 3: No compliance + `--report=all` (default behavior unchanged)

```bash
trivy k8s --report all --format table
```

Expected:

* Full results are displayed as before.

---