### PR TITLE
test(helm): bump up Yamale dependency for Helm chart-testing-action

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -41,6 +41,7 @@ jobs:
         id: lint
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
         with:
+          # v6.0.0 resolved the compatibility issue with Python > 3.13. may be removed after the action itself is updated
           yamale_version: "6.0.0"
       - name: Setup Kubernetes cluster (KIND)
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0


### PR DESCRIPTION
## Description
This PR updates the Yamale dependency used by the helm/chart-testing-action to version 6.0.0.

The current version (4.0.4) bundled with the chart-testing-action is incompatible with Python 3.14, causing CI pipeline failures. https://github.com/aquasecurity/trivy/actions/runs/18408728573/job/52455059977?pr=9641
It's a known issue in the action, but there was no fix for a while: https://github.com/helm/chart-testing-action/issues/177.

The compatibility issue has been addressed and resolved in Yamale v6.0.0.

It was tested here: https://github.com/aquasecurity/trivy/actions/runs/18457644453/job/52581909999?pr=9641

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
