### PR TITLE
fix(nodejs): use the default ID format to match licenses in pnpm packages.

### DIFF
--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/dependency"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/packagejson"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/nodejs/pnpm"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
@@ -65,8 +66,11 @@ func (a pnpmAnalyzer) PostAnalyze(ctx context.Context, input analyzer.PostAnalys
 		}
 
 		// Fill licenses
-		for i, lib := range app.Packages {
-			if l, ok := licenses[lib.ID]; ok {
+		for i, pkg := range app.Packages {
+			// We use snapshots for pnpm package IDs.
+			// But to match licenses, we need to use the ID-building logic as for `package.json` files.
+			id := dependency.ID(types.NodePkg, pkg.Name, pkg.Version)
+			if l, ok := licenses[id]; ok {
 				app.Packages[i].Licenses = l
 			}
 		}

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/pnpm_test.go
@@ -40,6 +40,27 @@ func Test_pnpmPkgLibraryAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name: "V9 with node_modules",
+			dir:  "testdata/happy-v9",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Pnpm,
+						FilePath: "pnpm-lock.yaml",
+						Packages: types.Packages{
+							{
+								ID:           "vue-router@4.5.1(vue@3.5.22)",
+								Name:         "vue-router",
+								Version:      "4.5.1",
+								Licenses:     []string{"MIT"},
+								Relationship: types.RelationshipDirect,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "without node_modules",
 			dir:  "testdata/no-node_modules",
 			want: &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/testdata/happy-v9/node_modules/vue-router/package.json
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/testdata/happy-v9/node_modules/vue-router/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "vue-router",
+  "version": "4.5.1",
+  "main": "index.js",
+  "unpkg": "dist/vue-router.global.js",
+  "jsdelivr": "dist/vue-router.global.js",
+  "module": "dist/vue-router.mjs",
+  "types": "dist/vue-router.d.ts",
+  "sideEffects": false,
+  "author": {
+    "name": "Eduardo San Martin Morote",
+    "email": "posva13@gmail.com"
+  },
+  "funding": "https://github.com/sponsors/posva",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuejs/router.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vuejs/router/issues"
+  },
+  "homepage": "https://github.com/vuejs/router#readme"
+}

--- a/pkg/fanal/analyzer/language/nodejs/pnpm/testdata/happy-v9/pnpm-lock.yaml
+++ b/pkg/fanal/analyzer/language/nodejs/pnpm/testdata/happy-v9/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      vue-router:
+        specifier: ^4.5.1
+        version: 4.5.1(vue@3.5.22)
+
+packages:
+
+  vue-router@4.5.1:
+    resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
+    peerDependencies:
+      vue: ^3.2.0
+
+snapshots:
+
+  vue-router@4.5.1(vue@3.5.22): {}


### PR DESCRIPTION
## Description

Fix `pnpm` license matching by using the correct dependency ID format. 
Previously, `pnpm` packages were not getting their license information populated because the license matching logic was using snapshot-based IDs instead of the standard dependency ID format used by `package.json` analyzers.

## Changes:
  - Modified pkg/fanal/analyzer/language/nodejs/pnpm/pnpm.go to use dependency.ID() function to generate consistent IDs for license matching
  - Added test case with PNPM v9 lockfile that includes license information to verify the fix
  - License information now correctly populates for `pnpm` dependencies (e.g., vue-router shows "MIT" license)


## Related issues
- Close #9660

## Related PRs
- [x] #9330

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
