### PR TITLE
refactor(misconf): type-safe parser results in generic scanner

### DIFF
--- a/pkg/iac/scanners/dockerfile/parser/parser.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/providers/dockerfile"
 )
 
-func Parse(_ context.Context, r io.Reader, path string) (any, error) {
+func Parse(_ context.Context, r io.Reader, path string) ([]*dockerfile.Dockerfile, error) {
 	parsed, err := parser.Parse(r)
 	if err != nil {
 		return nil, fmt.Errorf("dockerfile parse error: %w", err)
@@ -86,7 +86,7 @@ func Parse(_ context.Context, r io.Reader, path string) (any, error) {
 		parsedFile.Stages = append(parsedFile.Stages, stage)
 	}
 
-	return &parsedFile, nil
+	return []*dockerfile.Dockerfile{&parsedFile}, nil
 }
 
 func originalFromHeredoc(node *parser.Node) string {

--- a/pkg/iac/scanners/dockerfile/parser/parser_test.go
+++ b/pkg/iac/scanners/dockerfile/parser/parser_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/aquasecurity/trivy/pkg/iac/providers/dockerfile"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/dockerfile/parser"
 )
 
@@ -18,12 +17,11 @@ RUN make /app
 CMD python /app/app.py
 `
 
-	res, err := parser.Parse(t.Context(), strings.NewReader(input), "Dockerfile")
+	dfs, err := parser.Parse(t.Context(), strings.NewReader(input), "Dockerfile")
 	require.NoError(t, err)
+	require.Len(t, dfs, 1)
 
-	df, ok := res.(*dockerfile.Dockerfile)
-	require.True(t, ok)
-
+	df := dfs[0]
 	assert.Len(t, df.Stages, 1)
 
 	assert.Equal(t, "ubuntu:18.04", df.Stages[0].Name)
@@ -102,11 +100,12 @@ EOF`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := parser.Parse(t.Context(), strings.NewReader(tt.src), "Dockerfile")
+			dfs, err := parser.Parse(t.Context(), strings.NewReader(tt.src), "Dockerfile")
 			require.NoError(t, err)
+			require.Len(t, dfs, 1)
 
-			df, ok := res.(*dockerfile.Dockerfile)
-			require.True(t, ok)
+			df := dfs[0]
+			require.Len(t, df.Stages, 1)
 
 			cmd := df.Stages[0].Commands[0]
 

--- a/pkg/iac/scanners/dockerfile/scanner.go
+++ b/pkg/iac/scanners/dockerfile/scanner.go
@@ -1,12 +1,18 @@
 package dockerfile
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/dockerfile"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/dockerfile/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/generic"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/options"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
-func NewScanner(opts ...options.ScannerOption) *generic.GenericScanner {
-	return generic.NewScanner("Dockerfile", types.SourceDockerfile, generic.ParseFunc(parser.Parse), opts...)
+func NewScanner(opts ...options.ScannerOption) *generic.GenericScanner[*dockerfile.Dockerfile] {
+	defaultOpts := []options.ScannerOption{
+		generic.WithSupportsInlineIgnore[*dockerfile.Dockerfile](true),
+	}
+	p := generic.ParseFunc[*dockerfile.Dockerfile](parser.Parse)
+	return generic.NewScanner("Dockerfile", types.SourceDockerfile, p, append(defaultOpts, opts...)...,
+	)
 }

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -140,7 +140,7 @@ func (s *Scanner) getScanResults(ctx context.Context, path string, target fs.FS)
 		for _, manifest := range manifests {
 			fileResults, err := rs.ScanInput(ctx, types.SourceKubernetes, rego.Input{
 				Path:     file.TemplateFilePath,
-				Contents: manifest,
+				Contents: manifest.ToRego(),
 				FS:       manifestFS,
 			})
 			if err != nil {

--- a/pkg/iac/scanners/kubernetes/parser/parser.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func Parse(_ context.Context, r io.Reader, path string) ([]any, error) {
+func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -23,10 +23,10 @@ func Parse(_ context.Context, r io.Reader, path string) ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return []any{manifest.ToRego()}, nil
+		return []*Manifest{manifest}, nil
 	}
 
-	var manifests []any
+	var manifests []*Manifest
 
 	re := regexp.MustCompile(`(?m:^---\r?\n)`)
 	offset := 0
@@ -35,10 +35,9 @@ func Parse(_ context.Context, r io.Reader, path string) ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		if manifest.Content != nil {
 			manifest.Content.Offset = offset
-			manifests = append(manifests, manifest.ToRego())
+			manifests = append(manifests, manifest)
 		}
 
 		offset += countLines(partial)

--- a/pkg/iac/scanners/kubernetes/parser/parser_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser_test.go
@@ -65,13 +65,9 @@ kind: Pod
 			require.NoError(t, err)
 			require.Len(t, manifests, len(tt.expectedOffsets))
 
-			for i, m := range manifests {
-				manifest := m.(map[string]any)
-				metadata, ok := manifest["__defsec_metadata"].(map[string]any)
-				require.True(t, ok)
-				offset, ok := metadata["offset"].(int)
-				require.True(t, ok)
-				require.Equal(t, tt.expectedOffsets[i], offset)
+			for i, manifest := range manifests {
+				require.NotNil(t, manifest.Content)
+				require.Equal(t, tt.expectedOffsets[i], manifest.Content.Offset)
 			}
 		})
 	}

--- a/pkg/iac/scanners/kubernetes/scanner.go
+++ b/pkg/iac/scanners/kubernetes/scanner.go
@@ -10,10 +10,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
-func NewScanner(opts ...options.ScannerOption) *generic.GenericScanner {
-	return generic.NewScanner("Kubernetes", types.SourceKubernetes, generic.ParseFunc(parse), opts...)
+func NewScanner(opts ...options.ScannerOption) *generic.GenericScanner[*parser.Manifest] {
+	p := generic.ParseFunc[*parser.Manifest](parse)
+	return generic.NewScanner("Kubernetes", types.SourceKubernetes, p, opts...)
 }
 
-func parse(ctx context.Context, r io.Reader, path string) (any, error) {
+func parse(ctx context.Context, r io.Reader, path string) ([]*parser.Manifest, error) {
 	return parser.Parse(ctx, r, path)
 }


### PR DESCRIPTION
## Description

Previously, the generic scanner relied on `any` for parser outputs. When building Rego scanner inputs, a `switch` over `any` was needed to determine the actual type and handle multiple parser implementations correctly. Understanding what each parser returned required reading their code, and parsers could return arbitrary data.

This PR makes parsers type-safe by returning slices of a `RegoMarshaler`. As a result, constructing Rego inputs no longer requires type switches, making the scanner more predictable, maintainable, and easier to reason about.

Additionally, support for inline ignore rules (e.g., `# trivy:ignore`) is now controlled via a scanner option instead of being hardcoded in `GenericScanner`.

Benefits of this change:

- Parsers are type-safe, eliminating the need for type assertions or switches over any.
- Scanner input construction is simpler and more predictable.
- Inline-ignore support is configurable per scanner, increasing flexibility.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
