### PR TITLE
refactor: change UUID package to context-based implementation

### DIFF
--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -628,7 +628,7 @@ func setup(t *testing.T, options setupOptions) (string, string) {
 		osArgs := setupServer(addr, options.token, options.tokenHeader, options.pathPrefix, cacheDir, options.cacheBackend)
 
 		// Run Trivy server
-		assert.NoError(t, execute(osArgs))
+		assert.NoError(t, execute(t.Context(), osArgs))
 	}()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -43,7 +43,7 @@ func TestK8s(t *testing.T) {
 		}
 
 		// Run Trivy
-		err := execute(osArgs)
+		err := execute(t.Context(), osArgs)
 		require.NoError(t, err)
 
 		var got report.ConsolidatedReport
@@ -115,7 +115,7 @@ func TestK8s(t *testing.T) {
 		}
 
 		// Run Trivy
-		err := execute(osArgs)
+		err := execute(t.Context(), osArgs)
 		require.NoError(t, err)
 
 		var got *cdx.BOM
@@ -160,7 +160,7 @@ func TestK8s(t *testing.T) {
 		}
 
 		// Run Trivy
-		err := execute(osArgs)
+		err := execute(t.Context(), osArgs)
 		require.NoError(t, err)
 
 		var got report.ConsolidatedReport

--- a/integration/plugin_test.go
+++ b/integration/plugin_test.go
@@ -46,7 +46,7 @@ func TestPlugin(t *testing.T) {
 			t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 			// Install plugin
-			err := execute([]string{
+			err := execute(t.Context(), []string{
 				"plugin",
 				"install",
 				tt.plugin,
@@ -54,7 +54,7 @@ func TestPlugin(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get list of plugins
-			err = execute([]string{
+			err = execute(t.Context(), []string{
 				"plugin",
 				"list",
 			})
@@ -76,7 +76,7 @@ func TestPlugin(t *testing.T) {
 				args = append(args, "--output-plugin-arg", tt.pluginArgs)
 			}
 
-			err = execute(args)
+			err = execute(t.Context(), args)
 			require.NoError(t, err)
 
 			if *update {

--- a/integration/registry_test.go
+++ b/integration/registry_test.go
@@ -296,7 +296,7 @@ func setupEnv(t *testing.T, imageRef name.Reference, baseDir string, opt registr
 			t.Setenv("TRIVY_REGISTRY_TOKEN", token)
 		case opt.AuthLogin:
 			t.Setenv("DOCKER_CONFIG", t.TempDir())
-			err := execute([]string{
+			err := execute(t.Context(), []string{
 				"registry",
 				"login",
 				"--username",

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -168,7 +168,7 @@ func extractGitInfo(dir string) (bool, artifact.RepoMetadata, error) {
 
 func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	// Calculate cache key
-	cacheKey, err := a.calcCacheKey()
+	cacheKey, err := a.calcCacheKey(ctx)
 	if err != nil {
 		return artifact.Reference{}, xerrors.Errorf("failed to calculate a cache key: %w", err)
 	}
@@ -343,7 +343,7 @@ func (a Artifact) Clean(reference artifact.Reference) error {
 	return a.cache.DeleteBlobs(context.TODO(), reference.BlobIDs)
 }
 
-func (a Artifact) calcCacheKey() (string, error) {
+func (a Artifact) calcCacheKey(ctx context.Context) (string, error) {
 	// If this is a clean git repository, use the commit hash as cache key
 	if a.isClean && a.repoMetadata.Commit != "" {
 		return cache.CalcKey(a.repoMetadata.Commit, artifactVersion, a.analyzer.AnalyzerVersions(), a.handlerManager.Versions(), a.artifactOption)
@@ -351,7 +351,7 @@ func (a Artifact) calcCacheKey() (string, error) {
 
 	// For non-git repositories or dirty git repositories, use UUID as cache key
 	h := sha256.New()
-	if _, err := h.Write([]byte(uuid.New().String())); err != nil {
+	if _, err := h.Write([]byte(uuid.New(ctx).String())); err != nil {
 		return "", xerrors.Errorf("sha256 calculation error: %w", err)
 	}
 

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -254,14 +254,14 @@ func TestArtifact_Inspect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, tt.setupCache)
 
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -726,7 +726,7 @@ func TestTerraformMisconfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -738,7 +738,7 @@ func TestTerraformMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -962,7 +962,7 @@ func TestTerraformPlanSnapshotMisconfScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			tmpDir := t.TempDir()
 			f, err := os.Create(filepath.Join(tmpDir, "policy.rego"))
@@ -991,7 +991,7 @@ func TestTerraformPlanSnapshotMisconfScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), opt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1293,7 +1293,7 @@ func TestCloudFormationMisconfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -1303,7 +1303,7 @@ func TestCloudFormationMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1521,7 +1521,7 @@ func TestDockerfileMisconfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -1531,7 +1531,7 @@ func TestDockerfileMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -1782,7 +1782,7 @@ func TestKubernetesMisconfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -1792,7 +1792,7 @@ func TestKubernetesMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -2035,7 +2035,7 @@ func TestAzureARMMisconfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -2045,7 +2045,7 @@ func TestAzureARMMisconfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			cachetest.AssertBlobs(t, c, tt.wantBlobs)
@@ -2152,7 +2152,7 @@ func TestMixedConfigurationScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 			tt.artifactOpt.DisabledHandlers = []types.HandlerType{
@@ -2162,7 +2162,7 @@ func TestMixedConfigurationScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
@@ -2310,7 +2310,7 @@ func TestJSONConfigScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 
@@ -2324,7 +2324,7 @@ func TestJSONConfigScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
@@ -2472,7 +2472,7 @@ func TestYAMLConfigScan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistent test results
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			c := cachetest.NewCache(t, nil)
 
@@ -2486,7 +2486,7 @@ func TestYAMLConfigScan(t *testing.T) {
 			a, err := NewArtifact(tt.fields.dir, c, walker.NewFS(), tt.artifactOpt)
 			require.NoError(t, err)
 
-			got, err := a.Inspect(t.Context())
+			got, err := a.Inspect(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -301,7 +301,7 @@ func TestArtifact_Inspect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set fake UUID for consistency
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
 
 			// Create memory cache
 			c := cache.NewMemoryCache()
@@ -315,7 +315,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			require.NoError(t, err)
 			defer cleanup()
 
-			ref, err := art.Inspect(t.Context())
+			ref, err := art.Inspect(ctx)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/k8s/scanner/scanner_test.go
+++ b/pkg/k8s/scanner/scanner_test.go
@@ -274,7 +274,7 @@ func TestScanner_Scan(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx = uuid.With(ctx, "3ff14136-e09f-4df9-80ea-%012d")
 
 			runner, err := cmd.NewRunner(ctx, flagOpts, cmd.TargetK8s)
 			require.NoError(t, err)

--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"slices"
 	"sort"
 
@@ -249,9 +250,9 @@ func NewBOM(opts Options) *BOM {
 	}
 }
 
-func (b *BOM) setupComponent(c *Component) {
+func (b *BOM) setupComponent(ctx context.Context, c *Component) {
 	if c.id == uuid.Nil {
-		c.id = uuid.New()
+		c.id = uuid.New(ctx)
 	}
 	if c.PkgIdentifier.PURL != nil {
 		p := c.PkgIdentifier.PURL.String()
@@ -260,21 +261,21 @@ func (b *BOM) setupComponent(c *Component) {
 	sort.Sort(c.Properties)
 }
 
-func (b *BOM) AddComponent(c *Component) {
-	b.setupComponent(c)
+func (b *BOM) AddComponent(ctx context.Context, c *Component) {
+	b.setupComponent(ctx, c)
 	if c.Root {
 		b.rootID = c.id
 	}
 	b.components[c.id] = c
 }
 
-func (b *BOM) AddRelationship(parent, child *Component, relationshipType RelationshipType) {
+func (b *BOM) AddRelationship(ctx context.Context, parent, child *Component, relationshipType RelationshipType) {
 	// Check the wrong parent to avoid `panic`
 	if parent == nil {
 		return
 	}
 	if parent.id == uuid.Nil {
-		b.AddComponent(parent)
+		b.AddComponent(ctx, parent)
 	}
 
 	if child == nil {
@@ -287,7 +288,7 @@ func (b *BOM) AddRelationship(parent, child *Component, relationshipType Relatio
 	}
 
 	if child.id == uuid.Nil {
-		b.AddComponent(child)
+		b.AddComponent(ctx, child)
 	}
 
 	b.relationships[parent.id] = append(b.relationships[parent.id], Relationship{
@@ -300,9 +301,9 @@ func (b *BOM) AddRelationship(parent, child *Component, relationshipType Relatio
 	}
 }
 
-func (b *BOM) AddVulnerabilities(c *Component, vulns []Vulnerability) {
+func (b *BOM) AddVulnerabilities(ctx context.Context, c *Component, vulns []Vulnerability) {
 	if c.id == uuid.Nil {
-		b.AddComponent(c)
+		b.AddComponent(ctx, c)
 	}
 	if _, ok := b.vulnerabilities[c.id]; ok {
 		return

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -56,7 +56,7 @@ func NewMarshaler(version string) Marshaler {
 // MarshalReport converts the Trivy report to the CycloneDX format
 func (m *Marshaler) MarshalReport(ctx context.Context, report types.Report) (*cdx.BOM, error) {
 	// Convert into an intermediate representation
-	bom, err := sbomio.NewEncoder(sbomio.WithBOMRef()).Encode(report)
+	bom, err := sbomio.NewEncoder(sbomio.WithBOMRef()).Encode(ctx, report)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to marshal report: %w", err)
 	}
@@ -70,7 +70,7 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*cdx.BOM, error
 	m.componentIDs = make(map[uuid.UUID]string, len(m.bom.Components()))
 
 	cdxBOM := cdx.NewBOM()
-	cdxBOM.SerialNumber = uuid.New().URN()
+	cdxBOM.SerialNumber = uuid.New(ctx).URN()
 	cdxBOM.Metadata = m.Metadata(ctx)
 
 	var err error

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -63,6 +63,7 @@ var (
 )
 
 func TestMarshaler_MarshalReport(t *testing.T) {
+	ctx := t.Context()
 	testSBOM := core.NewBOM(core.Options{GenerateBOMRef: true})
 
 	// Add root component
@@ -80,7 +81,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 			},
 		},
 	}
-	testSBOM.AddComponent(rootComponent)
+	testSBOM.AddComponent(ctx, rootComponent)
 
 	// Add the jackson-databind component that matches scan results
 	jacksonComponent := &core.Component{
@@ -108,11 +109,11 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 			},
 		},
 	}
-	testSBOM.AddComponent(jacksonComponent)
+	testSBOM.AddComponent(ctx, jacksonComponent)
 
 	// Establish relationships
-	testSBOM.AddRelationship(rootComponent, jacksonComponent, core.RelationshipContains)
-	testSBOM.AddRelationship(jacksonComponent, nil, core.RelationshipDependsOn)
+	testSBOM.AddRelationship(ctx, rootComponent, jacksonComponent, core.RelationshipContains)
+	testSBOM.AddRelationship(ctx, jacksonComponent, nil, core.RelationshipDependsOn)
 
 	tests := []struct {
 		name        string
@@ -2152,7 +2153,7 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx = uuid.With(ctx, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := cyclonedx.NewMarshaler("dev")
 			got, err := marshaler.MarshalReport(ctx, tt.inputReport)

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -2,6 +2,7 @@ package cyclonedx
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -84,7 +85,7 @@ func (b *BOM) parseBOM(bom *cdx.BOM) error {
 		dependencies := lo.FromPtr(dep.Dependencies)
 		if len(dependencies) == 0 {
 			// Empty dependsOn array - create empty relationship to preserve this information
-			b.BOM.AddRelationship(ref, nil, core.RelationshipDependsOn)
+			b.BOM.AddRelationship(context.Background(), ref, nil, core.RelationshipDependsOn)
 		} else {
 			// Process actual dependencies
 			for _, depRef := range dependencies {
@@ -92,7 +93,7 @@ func (b *BOM) parseBOM(bom *cdx.BOM) error {
 				if !ok {
 					continue
 				}
-				b.BOM.AddRelationship(ref, dependency, core.RelationshipDependsOn)
+				b.BOM.AddRelationship(context.Background(), ref, dependency, core.RelationshipDependsOn)
 			}
 		}
 	}
@@ -113,7 +114,7 @@ func (b *BOM) parseMetadataComponent(bom *cdx.BOM) (*core.Component, error) {
 		return nil, xerrors.Errorf("failed to parse metadata component: %w", err)
 	}
 	root.Root = true
-	b.BOM.AddComponent(root)
+	b.BOM.AddComponent(context.Background(), root)
 	return root, nil
 }
 
@@ -163,7 +164,7 @@ func (b *BOM) parseComponents(cdxComponents *[]cdx.Component) map[string]*core.C
 			continue
 		}
 
-		b.BOM.AddComponent(c)
+		b.BOM.AddComponent(context.Background(), c)
 		components[component.BOMRef] = c
 	}
 	return components

--- a/pkg/sbom/io/encode_test.go
+++ b/pkg/sbom/io/encode_test.go
@@ -1,6 +1,7 @@
 package io_test
 
 import (
+	"context"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -1464,9 +1465,8 @@ func TestEncoder_Encode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
-
-			got, err := sbomio.NewEncoder(sbomio.WithBOMRef()).Encode(tt.report)
+			ctx := uuid.With(t.Context(), "3ff14136-e09f-4df9-80ea-%012d")
+			got, err := sbomio.NewEncoder(sbomio.WithBOMRef()).Encode(ctx, tt.report)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
@@ -1541,33 +1541,33 @@ var (
 	}
 )
 
-func newTestBOM(t *testing.T) *core.BOM {
-	uuid.SetFakeUUID(t, "2ff14136-e09f-4df9-80ea-%012d")
+func newTestBOM(_ *testing.T) *core.BOM {
+	ctx := uuid.With(context.Background(), "2ff14136-e09f-4df9-80ea-%012d")
 	bom := core.NewBOM(core.Options{})
 
 	// Copy components to avoid UUID conflicts between tests
 	appComp := appComponent.Clone()
 	libComp := libComponent.Clone()
 
-	bom.AddComponent(appComp)
-	bom.AddComponent(libComp)
+	bom.AddComponent(ctx, appComp)
+	bom.AddComponent(ctx, libComp)
 	// Add Contains relationship between appComponent and libComponent
-	bom.AddRelationship(appComp, libComp, core.RelationshipContains)
+	bom.AddRelationship(ctx, appComp, libComp, core.RelationshipContains)
 	// Add empty relationship for libComponent to preserve structure for SBOM rescanning
-	bom.AddRelationship(libComp, nil, core.RelationshipDependsOn)
+	bom.AddRelationship(ctx, libComp, nil, core.RelationshipDependsOn)
 	return bom
 }
 
 // BOM without root component
-func newTestBOM2(t *testing.T) *core.BOM {
-	uuid.SetFakeUUID(t, "2ff14136-e09f-4df9-80ea-%012d")
+func newTestBOM2(_ *testing.T) *core.BOM {
+	ctx := uuid.With(context.Background(), "2ff14136-e09f-4df9-80ea-%012d")
 	bom := core.NewBOM(core.Options{})
 
 	// Copy component to avoid UUID conflicts between tests
 	libComp := libComponent.Clone()
 
-	bom.AddComponent(libComp)
+	bom.AddComponent(ctx, libComp)
 	// Add empty relationship for libComponent to preserve structure for SBOM rescanning
-	bom.AddRelationship(libComp, nil, core.RelationshipDependsOn)
+	bom.AddRelationship(ctx, libComp, nil, core.RelationshipDependsOn)
 	return bom
 }

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -115,7 +115,7 @@ func NewMarshaler(version string, opts ...marshalOption) *Marshaler {
 
 func (m *Marshaler) MarshalReport(ctx context.Context, report types.Report) (*spdx.Document, error) {
 	// Convert into an intermediate representation
-	bom, err := sbomio.NewEncoder().Encode(report)
+	bom, err := sbomio.NewEncoder().Encode(ctx, report)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to marshal report: %w", err)
 	}
@@ -224,7 +224,7 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*spdx.Document,
 		DataLicense:       spdx.DataLicense,
 		SPDXIdentifier:    DocumentSPDXIdentifier,
 		DocumentName:      root.Name,
-		DocumentNamespace: getDocumentNamespace(root),
+		DocumentNamespace: getDocumentNamespace(ctx, root),
 		CreationInfo: &spdx.CreationInfo{
 			Creators: []common.Creator{
 				{
@@ -621,12 +621,12 @@ func elementID(elementType, pkgID string) spdx.ElementID {
 	return spdx.ElementID(fmt.Sprintf("%s-%s", elementType, pkgID))
 }
 
-func getDocumentNamespace(root *core.Component) string {
+func getDocumentNamespace(ctx context.Context, root *core.Component) string {
 	return fmt.Sprintf("%s/%s/%s-%s",
 		DocumentNamespace,
 		string(root.Type),
 		strings.ReplaceAll(strings.ReplaceAll(root.Name, "https://", ""), "http://", ""), // remove http(s):// prefix when scanning repos
-		uuid.New().String(),
+		uuid.New(ctx).String(),
 	)
 }
 

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1480,7 +1480,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 			}
 
 			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			ctx = uuid.With(ctx, "3ff14136-e09f-4df9-80ea-%012d")
 
 			marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))
 			spdxDoc, err := marshaler.MarshalReport(ctx, tc.inputReport)

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -2,6 +2,7 @@ package spdx
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -98,7 +99,7 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 			continue
 		}
 
-		s.BOM.AddRelationship(compA, compB, s.parseRelationshipType(rel.Relationship))
+		s.BOM.AddRelationship(context.Background(), compA, compB, s.parseRelationshipType(rel.Relationship))
 	}
 
 	return nil
@@ -154,7 +155,7 @@ func (s *SPDX) parsePackages(spdxDocument *spdx.Document) (map[common.ElementID]
 		if pkg.PackageSPDXIdentifier == rootID {
 			component.Root = true
 		}
-		s.BOM.AddComponent(component)
+		s.BOM.AddComponent(context.Background(), component)
 	}
 	return components, nil
 }

--- a/pkg/scan/service.go
+++ b/pkg/scan/service.go
@@ -79,7 +79,7 @@ func (s Service) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 
 	return types.Report{
 		SchemaVersion: report.SchemaVersion,
-		ReportID:      uuid.New().String(),
+		ReportID:      uuid.New(ctx).String(),
 		CreatedAt:     clock.Now(ctx),
 		ArtifactID:    s.generateArtifactID(artifactInfo),
 		ArtifactName:  artifactInfo.Name,

--- a/pkg/scan/service_test.go
+++ b/pkg/scan/service_test.go
@@ -211,9 +211,6 @@ func TestScanner_ScanArtifact(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set fake UUID for testing
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
-
 			// Initialize DB
 			_ = dbtest.InitDB(t, tt.fixtures)
 			defer db.Close()
@@ -232,7 +229,9 @@ func TestScanner_ScanArtifact(t *testing.T) {
 			scanner := local.NewService(applier, ospkg.NewScanner(), langpkg.NewScanner(), vulnerability.NewClient(db.Config{}))
 			s := NewService(scanner, artifact)
 
-			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx := t.Context()
+			ctx = clock.With(ctx, time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+			ctx = uuid.With(ctx, "3ff14136-e09f-4df9-80ea-%012d")
 			got, err := s.ScanArtifact(ctx, tt.args.options)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,8 +1,9 @@
 package uuid
 
 import (
+	"context"
 	"fmt"
-	"testing"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -10,25 +11,61 @@ import (
 type UUID = uuid.UUID
 
 var (
-	newUUID   func() uuid.UUID = uuid.New
-	Nil                        = uuid.Nil
-	MustParse                  = uuid.MustParse
+	Nil       = uuid.Nil
+	MustParse = uuid.MustParse
 )
 
-// SetFakeUUID sets a fake UUID for testing.
-// The 'format' is used to generate a fake UUID and
-// must contain a single '%d' which will be replaced with a counter.
-func SetFakeUUID(t *testing.T, format string) {
-	var count int
-	newUUID = func() uuid.UUID {
-		count++
-		return uuid.Must(uuid.Parse(fmt.Sprintf(format, count)))
-	}
-	t.Cleanup(func() {
-		newUUID = uuid.New
-	})
+// uuidKey is the context key for UUID generator. It is unexported to prevent collisions with context keys defined in
+// other packages.
+type uuidKey struct{}
+
+// generator is an unexported interface for UUID generation.
+type generator interface {
+	new() UUID
 }
 
-func New() UUID {
-	return newUUID()
+// realGenerator generates real UUIDs using the standard library.
+type realGenerator struct{}
+
+func (realGenerator) new() UUID {
+	return uuid.New()
+}
+
+// fakeGenerator generates predictable UUIDs for testing.
+type fakeGenerator struct {
+	format string
+	mu     sync.Mutex
+	count  int
+}
+
+func (g *fakeGenerator) new() UUID {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.count++
+	return uuid.Must(uuid.Parse(fmt.Sprintf(g.format, g.count)))
+}
+
+// With returns a new context with a fake UUID generator for testing.
+// The 'format' is used to generate a fake UUID and must contain a single '%d' which will be replaced with a counter.
+func With(ctx context.Context, format string) context.Context {
+	gen := &fakeGenerator{
+		format: format,
+	}
+	return context.WithValue(ctx, uuidKey{}, gen)
+}
+
+// New generates a new UUID using the generator from context.
+// If no generator is found in the context, a real UUID is generated.
+func New(ctx context.Context) UUID {
+	return generatorFromContext(ctx).new()
+}
+
+// generatorFromContext returns the UUID generator from context.
+// If no generator is found, returns a real generator.
+func generatorFromContext(ctx context.Context) generator {
+	g, ok := ctx.Value(uuidKey{}).(generator)
+	if !ok {
+		return realGenerator{}
+	}
+	return g
 }

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -75,7 +75,7 @@ func Filter(ctx context.Context, report *types.Report, opts Options) error {
 	}
 
 	// NOTE: This method call has a side effect on the report
-	bom, err := sbomio.NewEncoder(sbomio.WithParents(), sbomio.ForceRegenerate()).Encode(*report)
+	bom, err := sbomio.NewEncoder(sbomio.WithParents(), sbomio.ForceRegenerate()).Encode(ctx, *report)
 	if err != nil {
 		return xerrors.Errorf("unable to encode the SBOM: %w", err)
 	}

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -1,6 +1,7 @@
 package vex_test
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -171,8 +172,8 @@ func TestFilter(t *testing.T) {
 	// Set up the OCI registry
 	tr, d := setUpRegistry(t)
 
-	uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
-	testCycloneDXSBOM := createCycloneDXBOMWithSpringComponent()
+	ctx := uuid.With(context.Background(), "3ff14136-e09f-4df9-80ea-%012d")
+	testCycloneDXSBOM := createCycloneDXBOMWithSpringComponent(ctx)
 
 	type args struct {
 		report *types.Report
@@ -661,7 +662,7 @@ func ociPURLString(ts *httptest.Server, d v1.Hash) string {
 	return p.String()
 }
 
-func createCycloneDXBOMWithSpringComponent() *core.BOM {
+func createCycloneDXBOMWithSpringComponent(ctx context.Context) *core.BOM {
 	bom := core.NewBOM(core.Options{})
 	bom.SerialNumber = "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
 	bom.Version = 1
@@ -678,7 +679,7 @@ func createCycloneDXBOMWithSpringComponent() *core.BOM {
 		Version:       springPackage.Version,
 		PkgIdentifier: pkgIdentifier,
 	}
-	bom.AddComponent(springComponent)
+	bom.AddComponent(ctx, springComponent)
 	return bom
 }
 


### PR DESCRIPTION
## Description
Refactored UUID generation to use context-based approach, similar to the `clock` package implementation. The previous implementation was not thread-safe, so this change passes `context.Context` to UUID generation functions to enable deterministic UUID generation in tests while maintaining thread safety.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).