### PR TITLE
ci: get base_sha using base.ref

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -81,12 +81,11 @@ jobs:
           fi
       
           git fetch --depth=1 origin "$BASE_REF"
-      
-          BASE_SHA="$(git rev-parse "origin/$BASE_REF")"
+          
+          BASE_SHA="$(git rev-parse "origin/$BASE_REF")" 
           if [ -z "${BASE_SHA:-}" ]; then
             echo "::error::BASE_SHA is empty (failed to resolve origin/$BASE_REF)"; exit 1
           fi
-      
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
       # NOTE: go-apidiff is not managed in go.mod because installing it via `go get -tool`


### PR DESCRIPTION
## Description

  Fixes the API diff workflow by switching from base.sha to base.ref for proper commit reference resolution.

  Problem: The GitHub API diff workflow was using github.event.pull_request.base.sha, which becomes outdated when new commits are pushed to the base branch after a PR is created. This caused the go-apidiff tool to fail when comparing
  against stale commit references.

See https://github.com/orgs/community/discussions/59677 for more details.

## Technical Details:
  - The workflow now fetches origin/$BASE_REF and resolves it to get the current commit SHA
  - Added GitHub Actions output to pass the resolved SHA between workflow steps
  - Improved error messages for debugging when base reference resolution fails

  This ensures the API diff check always compares against the latest commit on the target branch, preventing failures due to outdated commit references.

## Tests:
current logic - we take old commit:
- we check `fa6f77902234f5bee70287a841e8cfa42ca4a505`
- latest commit from main branch - 74ba025a4618ca24d3761f9f96b1f031f88e45bc
- test run - https://github.com/DmitriyLewen/trivy/actions/runs/18742914970/job/53468803994

new logic:
- go-apidiff uses correct commit - https://github.com/DmitriyLewen/trivy/actions/runs/18744267056/job/53467694185?pr=197#step:6:79

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
