### PR TITLE
docs: add info about `java-db` subdir

### DIFF
--- a/docs/docs/advanced/self-hosting.md
+++ b/docs/docs/advanced/self-hosting.md
@@ -104,7 +104,8 @@ For Java DB the process is the same, except for the following:
 
 1. Image location is `ghcr.io/aquasecurity/trivy-java-db:1`
 2. Archive file name is `javadb.tar.gz`
-3. DB file name is `trivy-java.db`
+3. Java DB files names are `trivy-java.db` and `metadata.json`
+4. The cache subdirectory is `java-db`.
 
 ## VEX Hub
 


### PR DESCRIPTION
## Description
 Updates the Java DB self-hosting documentation to provide more accurate and complete information about the Java database structure. The changes clarify that the Java DB consists of multiple files and specify the correct cache subdirectory location.


## Related Discussions
- https://github.com/aquasecurity/trivy/discussions/9705

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
