### PR TITLE
fix(report): correct field order in SARIF license results

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -248,7 +248,7 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 				helpMarkdown: fmt.Sprintf("**License %s**\n| PkgName | Classification | Path |\n| --- | --- | --- |\n|%s|%s|%s|",
 					license.Name, license.PkgName, license.Category, license.FilePath),
 				message: fmt.Sprintf("Artifact: %s\nLicense %s\nPkgName: %s\n Classification: %s\n Path: %s",
-					res.Target, license.Name, license.Category, license.PkgName, license.FilePath),
+					res.Target, license.Name, license.PkgName, license.Category, license.FilePath),
 			})
 		}
 

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -489,7 +489,7 @@ func TestReportWriter_Sarif(t *testing.T) {
 								RuleID:    lo.ToPtr("alpine-base:GPL-3.0"),
 								RuleIndex: lo.ToPtr(uint(0)),
 								Level:     lo.ToPtr("error"),
-								Message:   sarif.Message{Text: lo.ToPtr("Artifact: OS Packages\nLicense GPL-3.0\nPkgName: restricted\n Classification: alpine-base\n Path: ")},
+								Message:   sarif.Message{Text: lo.ToPtr("Artifact: OS Packages\nLicense GPL-3.0\nPkgName: alpine-base\n Classification: restricted\n Path: ")},
 								Locations: []*sarif.Location{
 									{
 										Message: sarif.NewTextMessage(""),


### PR DESCRIPTION
## Description

This PR fixes the field order of `pkgName` and `classification` in SARIF results for licenses.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9711

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
