### PR TITLE
chore: trigger the trivy-www workflow

### DIFF
--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -55,4 +55,4 @@ jobs:
           gh workflow run build-docs.yml \
             --repo ${{ github.repository_owner }}/trivy-www \
             --ref main \
-            --field version=${{ github.ref_name }}
+            --field from_version=${{ github.ref_name }}


### PR DESCRIPTION
## Description

preparing for the move over to the split of docs from trivy website,
when there is a new release, the workflow in trivy-www should be
triggered to deploy the docs to R2 for validation.

This won't interfere with the existing docs in gh-pages, its a parallel
hosting for now.

## Related issues

- Close #9736

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
