### PR TITLE
feat(report): switch ReportID from UUIDv4 to UUIDv7

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -364,6 +364,8 @@ func runTest(t *testing.T, osArgs []string, wantFile string, format types.Format
 	if opts.fakeUUID != "" {
 		uuid.SetFakeUUID(t, opts.fakeUUID)
 	}
+	// Set fake UUID v7 for ReportID generation. Format is not configurable.
+	uuid.SetFakeUUIDV7(t, "017b7d41-e09f-7000-80ea-%012d")
 
 	// Set up the output file
 	outputFile := filepath.Join(t.TempDir(), "output.json")

--- a/integration/sbom_test.go
+++ b/integration/sbom_test.go
@@ -154,8 +154,8 @@ func TestSBOMEquivalence(t *testing.T) {
 				want.Results[0].Vulnerabilities[1].PkgIdentifier.BOMRef = "pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&distro=centos-7.6.1810"
 				want.Results[0].Vulnerabilities[2].PkgIdentifier.BOMRef = "pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&distro=centos-7.6.1810"
 
-				// SBOM parsing consumes UUIDs #1-#4 for components, so ReportID becomes #5
-				want.ReportID = "3ff14136-e09f-4df9-80ea-000000000005"
+				// ReportID uses v7 UUID with independent counter from v4 UUIDs used for SBOM components
+				want.ReportID = "017b7d41-e09f-7000-80ea-000000000001"
 			},
 		},
 		{
@@ -173,8 +173,8 @@ func TestSBOMEquivalence(t *testing.T) {
 				require.Len(t, got.Results, 1)
 				want.Results[0].Target = "testdata/fixtures/sbom/centos-7-spdx.txt (centos 7.6.1810)"
 
-				// SBOM parsing consumes UUIDs #1-#4 for components, so ReportID becomes #5
-				want.ReportID = "3ff14136-e09f-4df9-80ea-000000000005"
+				// ReportID uses v7 UUID with independent counter from v4 UUIDs used for SBOM components
+				want.ReportID = "017b7d41-e09f-7000-80ea-000000000001"
 			},
 		},
 		{
@@ -192,8 +192,8 @@ func TestSBOMEquivalence(t *testing.T) {
 				require.Len(t, got.Results, 1)
 				want.Results[0].Target = "testdata/fixtures/sbom/centos-7-spdx.json (centos 7.6.1810)"
 
-				// SBOM parsing consumes UUIDs #1-#4 for components, so ReportID becomes #5
-				want.ReportID = "3ff14136-e09f-4df9-80ea-000000000005"
+				// ReportID uses v7 UUID with independent counter from v4 UUIDs used for SBOM components
+				want.ReportID = "017b7d41-e09f-7000-80ea-000000000001"
 			},
 		},
 		{
@@ -216,8 +216,8 @@ func TestSBOMEquivalence(t *testing.T) {
 				want.Results[0].Vulnerabilities[1].PkgIdentifier.BOMRef = "pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&distro=centos-7.6.1810"
 				want.Results[0].Vulnerabilities[2].PkgIdentifier.BOMRef = "pkg:rpm/centos/openssl-libs@1.0.2k-16.el7?arch=x86_64&epoch=1&distro=centos-7.6.1810"
 
-				// SBOM parsing consumes UUIDs #1-#4 for components, so ReportID becomes #5
-				want.ReportID = "3ff14136-e09f-4df9-80ea-000000000005"
+				// ReportID uses v7 UUID with independent counter from v4 UUIDs used for SBOM components
+				want.ReportID = "017b7d41-e09f-7000-80ea-000000000001"
 			},
 		},
 	}

--- a/integration/testdata/almalinux-8.json.golden
+++ b/integration/testdata/almalinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:fb75459277a4cbcf98182b48c789cfbd4b34414e05898e1231ae8b2ca099f4e7",
   "ArtifactName": "testdata/fixtures/images/almalinux-8.tar.gz",

--- a/integration/testdata/alpine-310.json.golden
+++ b/integration/testdata/alpine-310.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:39549bf49d696f172a6513103cdc8f53717024ad1fbce62d680a8e7ddde1a612",
   "ArtifactName": "testdata/fixtures/images/alpine-310.tar.gz",

--- a/integration/testdata/alpine-39-high-critical.json.golden
+++ b/integration/testdata/alpine-39-high-critical.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:988a8e3eb049d90c20fafb183d0e792c99b8ba28433be1d1e4447a8b5a1adbdf",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",

--- a/integration/testdata/alpine-39-ignore-cveids.json.golden
+++ b/integration/testdata/alpine-39-ignore-cveids.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:988a8e3eb049d90c20fafb183d0e792c99b8ba28433be1d1e4447a8b5a1adbdf",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",

--- a/integration/testdata/alpine-39-skip.json.golden
+++ b/integration/testdata/alpine-39-skip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:988a8e3eb049d90c20fafb183d0e792c99b8ba28433be1d1e4447a8b5a1adbdf",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",

--- a/integration/testdata/alpine-39.json.golden
+++ b/integration/testdata/alpine-39.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:988a8e3eb049d90c20fafb183d0e792c99b8ba28433be1d1e4447a8b5a1adbdf",
   "ArtifactName": "testdata/fixtures/images/alpine-39.tar.gz",

--- a/integration/testdata/alpine-distroless.json.golden
+++ b/integration/testdata/alpine-distroless.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:0edd1906378dca3abc435f47f2e4b91059e9950e55cd82c76089d60b9ca68f90",
   "ArtifactName": "testdata/fixtures/images/alpine-distroless.tar.gz",

--- a/integration/testdata/amazon-1.json.golden
+++ b/integration/testdata/amazon-1.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:5a0fd7bb415c9b52d1bb909e40b9f498a89a5572724bd107d26ead4a25f203e1",
   "ArtifactName": "testdata/fixtures/images/amazon-1.tar.gz",

--- a/integration/testdata/amazon-2.json.golden
+++ b/integration/testdata/amazon-2.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:87e7ebcf8b5c0a26985fd80875e09e11850fa4828e1156da190f85b17dcecb71",
   "ArtifactName": "testdata/fixtures/images/amazon-2.tar.gz",

--- a/integration/testdata/amazonlinux2-gp2-x86-vm.json.golden
+++ b/integration/testdata/amazonlinux2-gp2-x86-vm.json.golden
@@ -3,7 +3,7 @@
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "disk.img",
   "ArtifactType": "vm",
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "Metadata": {
     "OS": {
       "Family": "amazon",

--- a/integration/testdata/bun.json.golden
+++ b/integration/testdata/bun.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/bun",
   "ArtifactType": "repository",

--- a/integration/testdata/busybox-with-lockfile.json.golden
+++ b/integration/testdata/busybox-with-lockfile.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:4f807ebe9dfe3b25af3d4354d6cff8288e9a8c63477dabcde5e63998f0e68188",
   "ArtifactName": "testdata/fixtures/images/busybox-with-lockfile.tar.gz",

--- a/integration/testdata/cargo.lock.json.golden
+++ b/integration/testdata/cargo.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/cargo",
   "ArtifactType": "repository",

--- a/integration/testdata/centos-6.json.golden
+++ b/integration/testdata/centos-6.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:6fd360ff01eb63800aaafdb5e58af85fab9d7849344b577f5f6077cceb0399bb",
   "ArtifactName": "testdata/fixtures/images/centos-6.tar.gz",

--- a/integration/testdata/centos-7-ignore-unfixed.json.golden
+++ b/integration/testdata/centos-7-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:8af996fb4a61e515887a173fdea3d5111c90c76e9f8247b3f668b17ab8215946",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",

--- a/integration/testdata/centos-7-medium.json.golden
+++ b/integration/testdata/centos-7-medium.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:8af996fb4a61e515887a173fdea3d5111c90c76e9f8247b3f668b17ab8215946",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",

--- a/integration/testdata/centos-7.json.golden
+++ b/integration/testdata/centos-7.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:8af996fb4a61e515887a173fdea3d5111c90c76e9f8247b3f668b17ab8215946",
   "ArtifactName": "testdata/fixtures/images/centos-7.tar.gz",

--- a/integration/testdata/cocoapods.json.golden
+++ b/integration/testdata/cocoapods.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/cocoapods",
   "ArtifactType": "repository",

--- a/integration/testdata/composer.lock.json.golden
+++ b/integration/testdata/composer.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/composer",
   "ArtifactType": "repository",

--- a/integration/testdata/composer.vendor.json.golden
+++ b/integration/testdata/composer.vendor.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/composer-vendor",
   "ArtifactType": "filesystem",

--- a/integration/testdata/conan.json.golden
+++ b/integration/testdata/conan.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/conan",
   "ArtifactType": "repository",

--- a/integration/testdata/conda-cyclonedx.json.golden
+++ b/integration/testdata/conda-cyclonedx.json.golden
@@ -2,7 +2,7 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000006",
+  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000005",
   "version": 1,
   "metadata": {
     "timestamp": "2021-08-25T12:20:30+00:00",
@@ -20,7 +20,7 @@
       ]
     },
     "component": {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "type": "application",
       "name": "testdata/fixtures/repo/conda",
       "properties": [
@@ -95,7 +95,7 @@
   ],
   "dependencies": [
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "dependsOn": [
         "pkg:conda/openssl@1.1.1q",
         "pkg:conda/pip@22.2.2"

--- a/integration/testdata/conda-environment-cyclonedx.json.golden
+++ b/integration/testdata/conda-environment-cyclonedx.json.golden
@@ -2,7 +2,7 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000006",
+  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000005",
   "version": 1,
   "metadata": {
     "timestamp": "2021-08-25T12:20:30+00:00",
@@ -20,7 +20,7 @@
       ]
     },
     "component": {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "type": "application",
       "name": "testdata/fixtures/repo/conda-environment",
       "properties": [
@@ -33,7 +33,7 @@
   },
   "components": [
     {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000004",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
       "type": "application",
       "name": "environment.yaml",
       "properties": [
@@ -63,13 +63,13 @@
   ],
   "dependencies": [
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "dependsOn": [
-        "3ff14136-e09f-4df9-80ea-000000000004"
+        "3ff14136-e09f-4df9-80ea-000000000003"
       ]
     },
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000004",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
       "dependsOn": [
         "pkg:conda/bzip2@1.0.8"
       ]

--- a/integration/testdata/conda-spdx.json.golden
+++ b/integration/testdata/conda-spdx.json.golden
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "testdata/fixtures/repo/conda",
-  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/conda-3ff14136-e09f-4df9-80ea-000000000006",
+  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/conda-3ff14136-e09f-4df9-80ea-000000000005",
   "creationInfo": {
     "creators": [
       "Organization: aquasecurity",

--- a/integration/testdata/debian-buster-ignore-unfixed.json.golden
+++ b/integration/testdata/debian-buster-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b75d2c78a42eae6eaa44e99638ba5fa36900538fa0b7a4feba19d18dd588552d",
   "ArtifactName": "testdata/fixtures/images/debian-buster.tar.gz",

--- a/integration/testdata/debian-buster.json.golden
+++ b/integration/testdata/debian-buster.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b75d2c78a42eae6eaa44e99638ba5fa36900538fa0b7a4feba19d18dd588552d",
   "ArtifactName": "testdata/fixtures/images/debian-buster.tar.gz",

--- a/integration/testdata/debian-stretch.json.golden
+++ b/integration/testdata/debian-stretch.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:e7f0b65012f754f3e69bfa9e94999ba080f12cd7e6ac2742d5cb908252f9609f",
   "ArtifactName": "testdata/fixtures/images/debian-stretch.tar.gz",

--- a/integration/testdata/distroless-base.json.golden
+++ b/integration/testdata/distroless-base.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:6c3688715cb42ea1466b96eb45b39d8afc9f8cdcf723df8464fb26391711a7db",
   "ArtifactName": "testdata/fixtures/images/distroless-base.tar.gz",

--- a/integration/testdata/distroless-python27.json.golden
+++ b/integration/testdata/distroless-python27.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b9ec0b7f93064fddace988e9a901386ccd55a6c16a34c00d5c45b06f62ec20ca",
   "ArtifactName": "testdata/fixtures/images/distroless-python27.tar.gz",

--- a/integration/testdata/dockerfile-custom-policies.json.golden
+++ b/integration/testdata/dockerfile-custom-policies.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/custom-policy",
   "ArtifactType": "repository",

--- a/integration/testdata/dockerfile.json.golden
+++ b/integration/testdata/dockerfile.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dockerfile",
   "ArtifactType": "repository",

--- a/integration/testdata/dockerfile_file_pattern.json.golden
+++ b/integration/testdata/dockerfile_file_pattern.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dockerfile_file_pattern",
   "ArtifactType": "repository",

--- a/integration/testdata/dotnet.json.golden
+++ b/integration/testdata/dotnet.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/dotnet",
   "ArtifactType": "repository",

--- a/integration/testdata/fluentd-gems.json.golden
+++ b/integration/testdata/fluentd-gems.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:7a550fb73ac2bf3e1fe50c96a8a5ba699be62cbb09ba9bd982557e574c904b3d",
   "ArtifactName": "testdata/fixtures/images/fluentd-multiple-lockfiles.tar.gz",

--- a/integration/testdata/fluentd-multiple-lockfiles-short.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles-short.cdx.json.golden
@@ -2,7 +2,7 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000007",
+  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000006",
   "version": 1,
   "metadata": {
     "timestamp": "2021-08-25T12:20:30+00:00",

--- a/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.cdx.json.golden
@@ -2,7 +2,7 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000164",
+  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000163",
   "version": 1,
   "metadata": {
     "timestamp": "2021-08-25T12:20:30+00:00",
@@ -20,7 +20,7 @@
       ]
     },
     "component": {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000001",
       "type": "container",
       "name": "testdata/fixtures/images/fluentd-multiple-lockfiles.tar.gz",
       "properties": [
@@ -73,7 +73,7 @@
   },
   "components": [
     {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "type": "operating-system",
       "name": "debian",
       "version": "10.2",
@@ -8583,9 +8583,9 @@
   ],
   "dependencies": [
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000002",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000001",
       "dependsOn": [
-        "3ff14136-e09f-4df9-80ea-000000000003",
+        "3ff14136-e09f-4df9-80ea-000000000002",
         "pkg:gem/activesupport@6.0.2.1",
         "pkg:gem/addressable@2.7.0",
         "pkg:gem/concurrent-ruby@1.1.6",
@@ -8644,7 +8644,7 @@
       ]
     },
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "dependsOn": [
         "pkg:deb/debian/apt@1.8.2?arch=amd64&distro=debian-10.2",
         "pkg:deb/debian/base-passwd@3.5.46?arch=amd64&distro=debian-10.2",

--- a/integration/testdata/fluentd-multiple-lockfiles.json.golden
+++ b/integration/testdata/fluentd-multiple-lockfiles.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000006",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/sbom/fluentd-multiple-lockfiles-cyclonedx.json",
   "ArtifactType": "cyclonedx",

--- a/integration/testdata/gomod-skip.json.golden
+++ b/integration/testdata/gomod-skip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gomod",
   "ArtifactType": "repository",

--- a/integration/testdata/gomod-vex.json.golden
+++ b/integration/testdata/gomod-vex.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gomod",
   "ArtifactType": "repository",

--- a/integration/testdata/gomod.json.golden
+++ b/integration/testdata/gomod.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gomod",
   "ArtifactType": "repository",

--- a/integration/testdata/gradle.json.golden
+++ b/integration/testdata/gradle.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/gradle",
   "ArtifactType": "repository",

--- a/integration/testdata/helm.json.golden
+++ b/integration/testdata/helm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm",
   "ArtifactType": "repository",

--- a/integration/testdata/helm_badname.json.golden
+++ b/integration/testdata/helm_badname.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_badname",
   "ArtifactType": "repository"

--- a/integration/testdata/helm_testchart.json.golden
+++ b/integration/testdata/helm_testchart.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_testchart",
   "ArtifactType": "repository",

--- a/integration/testdata/helm_testchart.overridden.json.golden
+++ b/integration/testdata/helm_testchart.overridden.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/helm_testchart",
   "ArtifactType": "repository",

--- a/integration/testdata/julia-spdx.json.golden
+++ b/integration/testdata/julia-spdx.json.golden
@@ -3,7 +3,7 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "testdata/fixtures/repo/julia",
-  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/julia-3ff14136-e09f-4df9-80ea-000000000008",
+  "documentNamespace": "http://trivy.dev/filesystem/testdata/fixtures/repo/julia-3ff14136-e09f-4df9-80ea-000000000007",
   "creationInfo": {
     "creators": [
       "Organization: aquasecurity",

--- a/integration/testdata/license-cyclonedx.json.golden
+++ b/integration/testdata/license-cyclonedx.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000006",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/sbom/license-cyclonedx.json",
   "ArtifactType": "cyclonedx",

--- a/integration/testdata/mariner-1.0.json.golden
+++ b/integration/testdata/mariner-1.0.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:357e30db7fb673e279ababa1128b33c8acc2fce50826727ec57ef24f5213fe0d",
   "ArtifactName": "testdata/fixtures/images/mariner-1.0.tar.gz",

--- a/integration/testdata/minikube-kbom.json.golden
+++ b/integration/testdata/minikube-kbom.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000020",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/sbom/minikube-kbom.json",
   "ArtifactType": "cyclonedx",

--- a/integration/testdata/mix.lock.json.golden
+++ b/integration/testdata/mix.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/mixlock",
   "ArtifactType": "repository",

--- a/integration/testdata/npm-ubuntu-severity.json.golden
+++ b/integration/testdata/npm-ubuntu-severity.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/npm",
   "ArtifactType": "repository",

--- a/integration/testdata/npm-with-dev.json.golden
+++ b/integration/testdata/npm-with-dev.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/npm",
   "ArtifactType": "repository",

--- a/integration/testdata/npm.json.golden
+++ b/integration/testdata/npm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/npm",
   "ArtifactType": "repository",

--- a/integration/testdata/nuget.json.golden
+++ b/integration/testdata/nuget.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/nuget",
   "ArtifactType": "repository",

--- a/integration/testdata/opensuse-leap-151.json.golden
+++ b/integration/testdata/opensuse-leap-151.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b9f31768f6c3908af7de80cff1a9e53c62f46d1bc54aaf3b97b2c922ed9cf1fd",
   "ArtifactName": "testdata/fixtures/images/opensuse-leap-151.tar.gz",

--- a/integration/testdata/opensuse-tumbleweed.json.golden
+++ b/integration/testdata/opensuse-tumbleweed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:1ab435ff0da0a8c95292bfd8a3b270b457cfca575a4a68731dd2fc142e2c13ef",
   "ArtifactName": "testdata/fixtures/images/opensuse-tumbleweed.tar.gz",

--- a/integration/testdata/oraclelinux-8.json.golden
+++ b/integration/testdata/oraclelinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:2982b2b5fd16f59d6b9ccdef6292e710791eb7fa12895a593959c5bceb7780e6",
   "ArtifactName": "testdata/fixtures/images/oraclelinux-8.tar.gz",

--- a/integration/testdata/packagesprops.json.golden
+++ b/integration/testdata/packagesprops.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/packagesprops",
   "ArtifactType": "repository",

--- a/integration/testdata/photon-30.json.golden
+++ b/integration/testdata/photon-30.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:1d4bc53b38b27a97aca270bea3abf3e9ea14964d02c71d2c93cd7bc53b74d660",
   "ArtifactName": "testdata/fixtures/images/photon-30.tar.gz",

--- a/integration/testdata/pip.json.golden
+++ b/integration/testdata/pip.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pip",
   "ArtifactType": "repository",

--- a/integration/testdata/pipenv.json.golden
+++ b/integration/testdata/pipenv.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pipenv",
   "ArtifactType": "repository",

--- a/integration/testdata/pnpm.json.golden
+++ b/integration/testdata/pnpm.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pnpm",
   "ArtifactType": "repository",

--- a/integration/testdata/poetry.json.golden
+++ b/integration/testdata/poetry.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/poetry",
   "ArtifactType": "repository",

--- a/integration/testdata/pom-cyclonedx.json.golden
+++ b/integration/testdata/pom-cyclonedx.json.golden
@@ -2,7 +2,7 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000007",
+  "serialNumber": "urn:uuid:3ff14136-e09f-4df9-80ea-000000000006",
   "version": 1,
   "metadata": {
     "timestamp": "2021-08-25T12:20:30+00:00",
@@ -20,7 +20,7 @@
       ]
     },
     "component": {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "type": "application",
       "name": "testdata/fixtures/repo/pom",
       "properties": [
@@ -33,7 +33,7 @@
   },
   "components": [
     {
-      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000004",
+      "bom-ref": "3ff14136-e09f-4df9-80ea-000000000003",
       "type": "application",
       "name": "pom.xml",
       "properties": [
@@ -86,13 +86,13 @@
   ],
   "dependencies": [
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000002",
       "dependsOn": [
-        "3ff14136-e09f-4df9-80ea-000000000004"
+        "3ff14136-e09f-4df9-80ea-000000000003"
       ]
     },
     {
-      "ref": "3ff14136-e09f-4df9-80ea-000000000004",
+      "ref": "3ff14136-e09f-4df9-80ea-000000000003",
       "dependsOn": [
         "pkg:maven/com.example/log4shell@1.0-SNAPSHOT"
       ]

--- a/integration/testdata/pom.json.golden
+++ b/integration/testdata/pom.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pom",
   "ArtifactType": "repository",

--- a/integration/testdata/pubspec.lock.json.golden
+++ b/integration/testdata/pubspec.lock.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/pubspec",
   "ArtifactType": "repository",

--- a/integration/testdata/rockylinux-8.json.golden
+++ b/integration/testdata/rockylinux-8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:ed11998b28b0bcd0488c4d2fda300f80d71ac058ce7eb12a43a4deb312ce429c",
   "ArtifactName": "testdata/fixtures/images/rockylinux-8.tar.gz",

--- a/integration/testdata/sbt.json.golden
+++ b/integration/testdata/sbt.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/sbt",
   "ArtifactType": "repository",

--- a/integration/testdata/secrets.json.golden
+++ b/integration/testdata/secrets.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/secrets",
   "ArtifactType": "repository",

--- a/integration/testdata/sl-micro-rancher5.4.json.golden
+++ b/integration/testdata/sl-micro-rancher5.4.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:f3d716e4652bf4a60bf4289eace7bb2b46878fa9461c86b12b4c059126563aee",
   "ArtifactName": "testdata/fixtures/images/sle-micro-rancher-5.4_ndb.tar.gz",

--- a/integration/testdata/spring4shell-jre11.json.golden
+++ b/integration/testdata/spring4shell-jre11.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:d5fbfb11da0ffb72f8bdeae29420a8101a04534c281854fe5ace22ec13d133bb",
   "ArtifactName": "testdata/fixtures/images/spring4shell-jre11.tar.gz",

--- a/integration/testdata/spring4shell-jre8.json.golden
+++ b/integration/testdata/spring4shell-jre8.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:8ac64b751688d0e2577befd47be60baea54f7294bee6deeb0288b580daf6ca52",
   "ArtifactName": "testdata/fixtures/images/spring4shell-jre8.tar.gz",
@@ -310,15 +310,6 @@
       "Class": "custom",
       "CustomResources": [
         {
-          "Type": "spring4shell/java-major-version",
-          "FilePath": "/usr/local/openjdk-8/release",
-          "Layer": {
-            "Digest": "sha256:d7b564a873af313eb2dbcb1ed0d393c57543e3666bdedcbe5d75841d72b1f791",
-            "DiffID": "sha256:ba40706eccba610401e4942e29f50bdf36807f8638942ce20805b359ae3ac1c1"
-          },
-          "Data": "1.8.0_322"
-        },
-        {
           "Type": "spring4shell/tomcat-version",
           "FilePath": "/usr/local/tomcat/RELEASE-NOTES",
           "Layer": {
@@ -326,6 +317,15 @@
             "DiffID": "sha256:85595543df2b1115a18284a8ef62d0b235c4bc29e3d33b55f89b54ee1eadf4c6"
           },
           "Data": "8.5.77"
+        },
+        {
+          "Type": "spring4shell/java-major-version",
+          "FilePath": "/usr/local/openjdk-8/release",
+          "Layer": {
+            "Digest": "sha256:d7b564a873af313eb2dbcb1ed0d393c57543e3666bdedcbe5d75841d72b1f791",
+            "DiffID": "sha256:ba40706eccba610401e4942e29f50bdf36807f8638942ce20805b359ae3ac1c1"
+          },
+          "Data": "1.8.0_322"
         }
       ]
     }

--- a/integration/testdata/swift.json.golden
+++ b/integration/testdata/swift.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/swift",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-exclude-misconfs-remote-module.json.golden
+++ b/integration/testdata/terraform-exclude-misconfs-remote-module.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/remote-module",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-opentofu-registry.json.golden
+++ b/integration/testdata/terraform-opentofu-registry.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/opentofu-registry",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-remote-module-in-child.json.golden
+++ b/integration/testdata/terraform-remote-module-in-child.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/remote-module-in-child",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-remote-module.json.golden
+++ b/integration/testdata/terraform-remote-module.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/remote-module",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-remote-submodule.json.golden
+++ b/integration/testdata/terraform-remote-submodule.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/remote-submodule",
   "ArtifactType": "repository",

--- a/integration/testdata/terraform-terraform-registry.json.golden
+++ b/integration/testdata/terraform-terraform-registry.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/terraform/opentofu-registry",
   "ArtifactType": "repository",

--- a/integration/testdata/test-repo.json.golden
+++ b/integration/testdata/test-repo.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:4f8b4cb139bdac63ad60b7382a80cd0414c55018e2f80d4163f59e40f71766cc",
   "ArtifactName": "https://github.com/knqyf263/trivy-ci-test",

--- a/integration/testdata/ubi-7-comprehensive.json.golden
+++ b/integration/testdata/ubi-7-comprehensive.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b4b4762f4769903a61d4605927079c4e60d007d9b12f65c39714e5311fa3d0ca",
   "ArtifactName": "testdata/fixtures/images/ubi-7.tar.gz",

--- a/integration/testdata/ubi-7.json.golden
+++ b/integration/testdata/ubi-7.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:b4b4762f4769903a61d4605927079c4e60d007d9b12f65c39714e5311fa3d0ca",
   "ArtifactName": "testdata/fixtures/images/ubi-7.tar.gz",

--- a/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
+++ b/integration/testdata/ubuntu-1804-ignore-unfixed.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:61d0ff5073e754270b3b59487ac8049c50e12bca1cf792d84ec9a62dad36a8a1",
   "ArtifactName": "testdata/fixtures/images/ubuntu-1804.tar.gz",

--- a/integration/testdata/ubuntu-1804.json.golden
+++ b/integration/testdata/ubuntu-1804.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactID": "sha256:61d0ff5073e754270b3b59487ac8049c50e12bca1cf792d84ec9a62dad36a8a1",
   "ArtifactName": "testdata/fixtures/images/ubuntu-1804.tar.gz",

--- a/integration/testdata/ubuntu-gp2-x86-vm.json.golden
+++ b/integration/testdata/ubuntu-gp2-x86-vm.json.golden
@@ -3,7 +3,7 @@
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "disk.img",
   "ArtifactType": "vm",
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000001",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "Metadata": {
     "OS": {
       "Family": "ubuntu",

--- a/integration/testdata/uv.json.golden
+++ b/integration/testdata/uv.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/uv",
   "ArtifactType": "repository",

--- a/integration/testdata/yarn.json.golden
+++ b/integration/testdata/yarn.json.golden
@@ -1,6 +1,6 @@
 {
   "SchemaVersion": 2,
-  "ReportID": "3ff14136-e09f-4df9-80ea-000000000002",
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
   "CreatedAt": "2021-08-25T12:20:30.000000005Z",
   "ArtifactName": "testdata/fixtures/repo/yarn",
   "ArtifactType": "repository",

--- a/pkg/scan/service.go
+++ b/pkg/scan/service.go
@@ -77,9 +77,14 @@ func (s Service) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 		scanResponse.Layers[i].CreatedBy = ""
 	}
 
+	reportID, err := uuid.NewV7()
+	if err != nil {
+		return types.Report{}, xerrors.Errorf("failed to generate ReportID: %w", err)
+	}
+
 	return types.Report{
 		SchemaVersion: report.SchemaVersion,
-		ReportID:      uuid.New().String(),
+		ReportID:      reportID.String(),
 		CreatedAt:     clock.Now(ctx),
 		ArtifactID:    s.generateArtifactID(artifactInfo),
 		ArtifactName:  artifactInfo.Name,

--- a/pkg/scan/service_test.go
+++ b/pkg/scan/service_test.go
@@ -58,7 +58,7 @@ func TestScanner_ScanArtifact(t *testing.T) {
 				ArtifactID:    "sha256:574abdaf07824449b1277ec1e7e67659cc869bbf97fd95447812b55644350a21", // hash(ImageID:index.docker.io/library/alpine) from RepoTag alpine:3.11
 				ArtifactName:  "../fanal/test/testdata/alpine-311.tar.gz",
 				ArtifactType:  ftypes.TypeContainerImage,
-				ReportID:      "3ff14136-e09f-4df9-80ea-000000000001",
+				ReportID:      "017b7d41-e09f-7000-80ea-000000000001",
 				Metadata: tTypes.Metadata{
 					Size: 5861888,
 					OS: &ftypes.OS{
@@ -214,8 +214,8 @@ func TestScanner_ScanArtifact(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set fake UUID for testing
-			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
+			// Set fake UUID v7 for testing
+			uuid.SetFakeUUIDV7(t, "017b7d41-e09f-7000-80ea-%012d")
 
 			// Initialize DB
 			_ = dbtest.InitDB(t, tt.fixtures)

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -10,9 +10,10 @@ import (
 type UUID = uuid.UUID
 
 var (
-	newUUID   func() uuid.UUID = uuid.New
-	Nil                        = uuid.Nil
-	MustParse                  = uuid.MustParse
+	newUUID   func() uuid.UUID          = uuid.New
+	newUUIDV7 func() (uuid.UUID, error) = uuid.NewV7
+	Nil                                 = uuid.Nil
+	MustParse                           = uuid.MustParse
 )
 
 // SetFakeUUID sets a fake UUID for testing.
@@ -29,6 +30,27 @@ func SetFakeUUID(t *testing.T, format string) {
 	})
 }
 
+// SetFakeUUIDV7 sets a fake UUID v7 for testing.
+// The 'format' is used to generate a fake UUID and
+// must contain a single '%d' which will be replaced with a counter.
+func SetFakeUUIDV7(t *testing.T, format string) {
+	var count int
+	newUUIDV7 = func() (uuid.UUID, error) {
+		count++
+		return uuid.Must(uuid.Parse(fmt.Sprintf(format, count))), nil
+	}
+	t.Cleanup(func() {
+		newUUIDV7 = uuid.NewV7
+	})
+}
+
 func New() UUID {
 	return newUUID()
+}
+
+// NewV7 generates a new UUID version 7.
+// UUIDv7 is time-ordered, combining a timestamp with random bits.
+// This makes it suitable for use cases where ordering and database performance are important.
+func NewV7() (UUID, error) {
+	return newUUIDV7()
 }


### PR DESCRIPTION
## Description
UUIDv7 provides time-ordered UUIDs, which are beneficial for database indexing and chronological sorting. This change improves the performance and usability of ReportID while maintaining UUIDv4 for other use cases like SBOM components.

- Add NewV7() function to pkg/uuid/uuid.go
- Add SetFakeUUIDV7() for testing support
- Update ReportID generation in pkg/scan/service.go to use UUIDv7
- Update tests and golden files to reflect UUIDv7 format for ReportID

## Related PRs
- https://github.com/aquasecurity/trivy/pull/9670

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
