### PR TITLE
refactor(misconf)!: use ID instead of AVDID for providers mapping

### DIFF
--- a/pkg/iac/rules/providers.go
+++ b/pkg/iac/rules/providers.go
@@ -31,7 +31,7 @@ func GetProvidersHierarchy() (providers map[string]map[string][]string) {
 		cNames := make(map[string]bool)
 		pName := strings.ToLower(rule.GetRule().Provider.DisplayName())
 		sName := strings.ToLower(rule.GetRule().Service)
-		cName := rule.GetRule().AVDID
+		cName := rule.GetRule().ID
 
 		if _, ok := provs[pName]; !ok {
 			provs[pName] = make(map[string][]string)
@@ -60,7 +60,7 @@ func GetProviders() (providers []Provider) {
 
 		pName := strings.ToLower(rule.GetRule().Provider.DisplayName())
 		sName := strings.ToLower(rule.GetRule().Service)
-		cName := rule.GetRule().AVDID
+		cName := rule.GetRule().ID
 		desc := rule.GetRule().Summary
 
 		if _, ok := provs[pName]; !ok {
@@ -163,7 +163,7 @@ func GetProviderServiceCheckNames(providerName, serviceName string) []string {
 			continue
 		}
 
-		checks = append(checks, rule.GetRule().AVDID)
+		checks = append(checks, rule.GetRule().ID)
 	}
 	return checks
 }


### PR DESCRIPTION
## Description

This PR continues the migration from `AVDID` to `ID` and standardizes check identifiers used in IaC provider mappings. It is a small change, affecting only provider-related functions to minimize impact.

Changes include:
- This change aligns provider mapping with the new check identifiers.
- Breaking change: any external code relying on `AVDID` for provider mappings will need to switch to `ID`.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/9576

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
