### PR TITLE
docs: change SecObserve URLs in documentatio

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -82,8 +82,8 @@ It has capabilities to fail the pipeline, create issues, alert communication cha
 
 
 ## SecObserve GitHub actions and GitLab templates (Community)
-[SecObserve GitHub actions and GitLab templates](https://github.com/MaibornWolff/secobserve_actions_templates) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
+[SecObserve GitHub actions and GitLab templates](https://github.com/SecObserve/secobserve_actions_templates) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
 
 The Trivy integration supports scanning Docker images and local filesystems for vulnerabilities as well as scanning IaC files for misconfigurations.
 
-👉 Get it at: <https://github.com/MaibornWolff/secobserve_actions_templates>
+👉 Get it at: <https://github.com/SecObserve/secobserve_actions_templates>

--- a/docs/ecosystem/reporting.md
+++ b/docs/ecosystem/reporting.md
@@ -8,7 +8,7 @@ DefectDojo can parse Trivy JSON reports. The parser supports deduplication and a
 ## SecObserve (Community)
 SecObserve can parse Trivy results as CycloneDX reports and provides an unified overview of vulnerabilities from different sources. Vulnerabilities can be evaluated with manual and rule based assessments.
 
-👉 Get it at: <https://github.com/MaibornWolff/SecObserve>
+👉 Get it at: <https://github.com/SecObserve/SecObserve>
 
 ## Scan2html (Community)
 A Trivy plugin that scans and outputs the results to an interactive html file.


### PR DESCRIPTION
## Description

SecObserve has been moved to another GitHub organisation and the new URLs shall be reflected in the documentation.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
