### PR TITLE
docs: add info that `SSL_CERT_FILE` works on `Unix systems other than macOS` only

### DIFF
--- a/docs/docs/references/troubleshooting.md
+++ b/docs/docs/references/troubleshooting.md
@@ -78,7 +78,7 @@ Common mistakes include the following, depending on where you are pulling images
 $ TRIVY_INSECURE=true trivy image [YOUR_IMAGE]
 ```
 
-Alternatively, you can specify the location of your certificate using `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variables.
+On Unix systems other than macOS, you can specify the location of your certificate using `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variables.
 
 ```
 $ SSL_CERT_FILE=/path/to/cert trivy image [YOUR_IMAGE]


### PR DESCRIPTION
## Description
https://pkg.go.dev/crypto/x509 docs say:
- [On macOS and Windows, certificate verification is handled by system APIs](https://pkg.go.dev/crypto/x509#pkg-overview)
- [On Unix systems other than macOS the environment variables SSL_CERT_FILE and SSL_CERT_DIR can be used to override the system default locations for the SSL certificate file and SSL certificate files directory, respectively.](https://pkg.go.dev/crypto/x509#SystemCertPool)

So `SSL_CERT_FILE` or `SSL_CERT_DIR` envs don't work on macOS and Windows.

## Example:
macOS:
```bash
➜ export HTTPS_PROXY=https://localhost:8443
➜ export SSL_CERT_FILE=./proxy_cert.pem  
➜ trivy image alpine 
2025-11-10T14:25:26+06:00	INFO	[vulndb] Need to update DB
2025-11-10T14:25:26+06:00	INFO	[vulndb] Downloading vulnerability DB...
2025-11-10T14:25:26+06:00	INFO	[vulndb] Downloading artifact...	repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-11-10T14:25:27+06:00	FATAL	Fatal error	run error: init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2: OCI repository error: 1 error occurred:
	* Get "https://mirror.gcr.io/v2/": proxyconnect tcp: tls: failed to verify certificate: x509: certificate signed by unknown authority
```
linux:
```bash
➜ docker run --rm \
  -e HTTPS_PROXY=https://host.docker.internal:8443 \
  aquasec/trivy:latest image alpine 
2025-11-10T08:36:08Z	INFO	[vulndb] Need to update DB
2025-11-10T08:36:08Z	INFO	[vulndb] Downloading vulnerability DB...
2025-11-10T08:36:08Z	INFO	[vulndb] Downloading artifact...	repo="mirror.gcr.io/aquasec/trivy-db:2"
2025-11-10T08:36:08Z	FATAL	Fatal error	run error: init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2: OCI repository error: 1 error occurred:
	* Get "https://mirror.gcr.io/v2/": proxyconnect tcp: tls: failed to verify certificate: x509: certificate signed by unknown authority


➜ docker run --rm \
  -e HTTPS_PROXY=https://host.docker.internal:8443 \
  -v "$PWD/proxy_cert.pem:/proxy_cert.pem" \
  -e SSL_CERT_FILE=/proxy_cert.pem \
  aquasec/trivy:latest image alpine
2025-11-10T08:36:21Z	INFO	[vulndb] Need to update DB
2025-11-10T08:36:21Z	INFO	[vulndb] Downloading vulnerability DB...
2025-11-10T08:36:21Z	INFO	[vulndb] Downloading artifact...	repo="mirror.gcr.io/aquasec/trivy-db:2"
111.25 KiB / 74.29 MiB [>____________________________________________________________]
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
