### PR TITLE
fix: update all documentation links

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bugs.yml
+++ b/.github/DISCUSSION_TEMPLATE/bugs.yml
@@ -10,7 +10,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/docs/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description
@@ -117,7 +117,7 @@ body:
       description: Have you tried the following?
       options:
         - label: Run `trivy clean --all`
-        - label: Read [the troubleshooting](https://trivy.dev/latest/docs/references/troubleshooting/)
+        - label: Read [the troubleshooting](https://trivy.dev/docs/latest/references/troubleshooting/)
   - type: markdown
     attributes:
       value: |

--- a/.github/DISCUSSION_TEMPLATE/documentation.yml
+++ b/.github/DISCUSSION_TEMPLATE/documentation.yml
@@ -7,7 +7,7 @@ body:
         Feel free to create a docs report if something doesn't work as expected or is unclear in the documentation.
         Please ensure that you're not creating a duplicate report by searching the [issues](https://github.com/aquasecurity/trivy/issues)/[discussions](https://github.com/aquasecurity/trivy/discussions) beforehand.
         
-        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/docs/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description

--- a/.github/DISCUSSION_TEMPLATE/false-detection.yml
+++ b/.github/DISCUSSION_TEMPLATE/false-detection.yml
@@ -8,7 +8,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/docs/latest/community/contribute/discussion/).
   - type: input
     attributes:
       label: IDs

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -9,7 +9,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/docs/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Description

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -9,7 +9,7 @@ body:
         
         **Do not open a GitHub issue, please.** Maintainers triage discussions and then create issues.
         
-        Please also check [our contribution guidelines](https://trivy.dev/latest/community/contribute/discussion/).
+        Please also check [our contribution guidelines](https://trivy.dev/docs/latest/community/contribute/discussion/).
   - type: textarea
     attributes:
       label: Question

--- a/.github/ISSUE_TEMPLATE/maintainer.md
+++ b/.github/ISSUE_TEMPLATE/maintainer.md
@@ -8,4 +8,4 @@ assignees: ''
 ---
 
 ## Are you a maintainer of the Trivy project?
-If not, please open [a discussion](https://github.com/aquasecurity/trivy/discussions); if you are, please review [the guideline](https://trivy.dev/latest/community/contribute/discussion/).
+If not, please open [a discussion](https://github.com/aquasecurity/trivy/discussions); if you are, please review [the guideline](https://trivy.dev/docs/latest/community/contribute/discussion/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,8 @@
 Remove this section if you don't have related PRs.
 
 ## Checklist
-- [ ] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
-- [ ] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
+- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
+- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
 - [ ] I've added tests that prove my fix is effective or that my feature works.
 - [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
 - [ ] I've added usage information (if the PR introduces new options)

--- a/.github/workflows/auto-close-issue.yaml
+++ b/.github/workflows/auto-close-issue.yaml
@@ -26,7 +26,7 @@ jobs:
             
             // If the user does not have write or admin permissions, leave a comment and close the issue
             if (permission !== 'write' && permission !== 'admin') {
-              const commentBody = "Please see https://trivy.dev/latest/community/contribute/issue/";
+              const commentBody = "Please see https://trivy.dev/docs/latest/community/contribute/issue/";
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/release-pr-check.yaml
+++ b/.github/workflows/release-pr-check.yaml
@@ -16,6 +16,6 @@ jobs:
         run: |
           if [ "$PR_AUTHOR" != "aqua-bot" ]; then
             echo "::error::This branch is intended for automated backporting by bot. Please refer to the documentation:"
-            echo "::error::https://trivy.dev/latest/community/maintainer/backporting/"
+            echo "::error::https://trivy.dev/docs/latest/community/maintainer/backporting/"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See [Issues](https://trivy.dev/latest/community/contribute/issue/) and [Pull Requests](https://trivy.dev/latest/community/contribute/pr/)
+See [Issues](https://trivy.dev/docs/latest/community/contribute/issue/) and [Pull Requests](https://trivy.dev/docs/latest/community/contribute/pr/)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ trivy k8s --report summary cluster
 ## Want more? Check out Aqua
 
 If you liked Trivy, you will love Aqua which builds on top of Trivy to provide even more enhanced capabilities for a complete security management offering.  
-You can find a high level comparison table specific to Trivy users [here](https://trivy.dev/latest/commercial/compare/).
+You can find a high level comparison table specific to Trivy users [here](https://trivy.dev/docs/latest/commercial/compare/).
 In addition check out the <https://aquasec.com> website for more information about our products and services.
 If you'd like to contact Aqua or request a demo, please use this form: <https://www.aquasec.com/demo>
 
@@ -130,13 +130,13 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [license]: https://github.com/aquasecurity/trivy/blob/main/LICENSE
 [license-img]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [homepage]: https://trivy.dev
-[docs]: https://trivy.dev/latest/docs/
+[docs]: https://trivy.dev/docs/latest/
 [pronunciation]: #how-to-pronounce-the-name-trivy
 [code-of-conduct]: https://github.com/aquasecurity/community/blob/main/CODE_OF_CONDUCT.md
 
-[Installation]:https://trivy.dev/latest/getting-started/installation/
-[Ecosystem]: https://trivy.dev/latest/ecosystem/
-[Scanning Coverage]: https://trivy.dev/latest/docs/coverage/
+[Installation]:https://trivy.dev/docs/latest/getting-started/installation/
+[Ecosystem]: https://trivy.dev/docs/latest/ecosystem/
+[Scanning Coverage]: https://trivy.dev/docs/latest/coverage/
 
 [alpine]: https://ariadne.space/2021/06/08/the-vulnerability-remediation-lifecycle-of-alpine-containers/
 [rego]: https://www.openpolicyagent.org/docs/latest/#rego

--- a/docs/commercial/compare.md
+++ b/docs/commercial/compare.md
@@ -66,7 +66,7 @@ If you'd like to learn more or request a demo, [click here to contact us](./cont
 
 | Feature | Trivy OSS | Aqua |
 | --- | --- | --- |
-| Infrastructure as Code (IaC) | Many popular languages as detailed [here](https://trivy.dev/latest/docs/scanner/misconfiguration/check/builtin/) | In addition, Build Pipeline configuration scanning |
+| Infrastructure as Code (IaC) | Many popular languages as detailed [here](https://trivy.dev/docs/latest/scanner/misconfiguration/check/builtin/) | In addition, Build Pipeline configuration scanning |
 | Checks customization | Create custom checks with Rego | Create custom checks in no-code interface <br> Customize existing checks with organizational preferences |
 | Cloud scanning | AWS (subset of services) | AWS, Azure, GCP, Alibaba Cloud, Oracle Cloud |
 | Compliance frameworks | CIS, NSA, vendor guides | More than 25 compliance programs |

--- a/docs/community/contribute/discussion.md
+++ b/docs/community/contribute/discussion.md
@@ -24,7 +24,7 @@ There are 4 categories:
     If you find any false positives or false negatives, please make sure to report them under the "False Detection" category, not "Bugs".
 
 ## False detection
-Trivy depends on [multiple data sources](https://trivy.dev/latest/docs/scanner/vulnerability/#data-sources).
+Trivy depends on [multiple data sources](https://trivy.dev/docs/latest/scanner/vulnerability/#data-sources).
 Sometime these databases contain mistakes.
 
 If Trivy can't detect any CVE-IDs or shows false positive result, at first please follow the next steps:

--- a/docs/tutorials/misconfiguration/custom-checks.md
+++ b/docs/tutorials/misconfiguration/custom-checks.md
@@ -1,6 +1,6 @@
 # Custom Checks with Rego
 
-Trivy can scan configuration files for common security issues (a.k.a IaC misconfiguration scanning). In addition to a comprehensive built in database of checks, you can add your own custom checks. Checks are written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) language and the full documentation for checks and customizing them is available [here](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/). 
+Trivy can scan configuration files for common security issues (a.k.a IaC misconfiguration scanning). In addition to a comprehensive built in database of checks, you can add your own custom checks. Checks are written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) language and the full documentation for checks and customizing them is available [here](https://trivy.dev/docs/latest/scanner/misconfiguration/custom/). 
 
 This tutorial will walk you through writing a custom check in Rego that checks for an issue in a Dockerfile.
 
@@ -38,7 +38,7 @@ Next, we need to specify metadata about the check. This is information that help
 
 Important: The `METADATA` has to be defined on top of the file.
 
-More information on the different fields in the metadata can be found in the [Trivy documentation.](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/)
+More information on the different fields in the metadata can be found in the [Trivy documentation.](https://trivy.dev/docs/latest/scanner/misconfiguration/custom/)
 
 ## Package and imports
 

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -9,7 +9,7 @@ We have been consolidating all of our scanning-related efforts in one place, and
 
 ## Trivy Config Command 
 
-Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://trivy.dev/latest/docs/scanner/misconfiguration/) 
+Terraform configuration scanning is available as part of the `trivy config` command. This command scans all configuration files for misconfiguration issues. You can find the details within [misconfiguration scans in the Trivy documentation.](https://trivy.dev/docs/latest/scanner/misconfiguration/) 
 
 Command structure: 
 ``` 
@@ -23,7 +23,7 @@ The `trivy config` command can scan Terraform configuration, CloudFormation, Doc
 - If the configuration that has been defined does not follow best practices, the check will fail.  
 
 ### Prerequisites 
-Install Trivy on your local machines. The documentation provides several [different installation options.](https://trivy.dev/latest/getting-started/installation/) 
+Install Trivy on your local machines. The documentation provides several [different installation options.](https://trivy.dev/docs/latest/getting-started/installation/) 
 This tutorial will use this example [Terraform tutorial](https://github.com/Cloud-Native-Security/trivy-demo/tree/main/bad_iac/terraform) for terraform misconfiguration scanning with Trivy. 
 
 Git clone the tutorial and cd into the directory: 
@@ -83,14 +83,14 @@ trivy config --severity CRITICAL, MEDIUM terraform-infra
 
 ### Passing tf.tfvars files into `trivy config` scans 
 
-You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://trivy.dev/latest/docs/coverage/iac/terraform/#value-overrides) 
+You can pass terraform values to Trivy to override default values found in the Terraform HCL code. More information are provided [in the documentation.](https://trivy.dev/docs/latest/coverage/iac/terraform/#value-overrides) 
 
 ``` 
 trivy config --tf-vars terraform.tfvars ./
 ``` 
 ### Custom Checks 
 
-We have lots of examples in the [documentation](https://trivy.dev/latest/docs/scanner/misconfiguration/custom/) on how you can write and pass custom Rego checks into terraform misconfiguration scans.
+We have lots of examples in the [documentation](https://trivy.dev/docs/latest/scanner/misconfiguration/custom/) on how you can write and pass custom Rego checks into terraform misconfiguration scans.
 
 ## Secret and vulnerability scans
 
@@ -100,15 +100,15 @@ The `trivy config` command does not perform secret and vulnerability checks out 
 trivy fs --scanners secret,misconfig ./
 ```
 
-The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://trivy.dev/latest/docs/target/filesystem/) 
+The `trivy config` command is a sub-command of the `trivy fs` command. You can learn more about this command in the [documentation.](https://trivy.dev/docs/latest/target/filesystem/) 
 
 ## Scanning Terraform Plan files
 
-Instead of scanning your different Terraform resources individually, you could also scan your Terraform Plan file before it is deployed for misconfiguration. This will give you insights into any misconfiguration of your resources as they would become deployed. [Here](https://trivy.dev/latest/docs/coverage/iac/terraform/#terraform) is the link to the documentation.
+Instead of scanning your different Terraform resources individually, you could also scan your Terraform Plan file before it is deployed for misconfiguration. This will give you insights into any misconfiguration of your resources as they would become deployed. [Here](https://trivy.dev/docs/latest/coverage/iac/terraform/#terraform) is the link to the documentation.
 
 Note that you need to be able to create a terraform init and plan without any errors. 
 
 ## Using Trivy in your CI/CD pipeline 
-Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://trivy.dev/latest/tutorials/integrations/](https://trivy.dev/latest/tutorials/integrations/) 
+Similar to tfsec, Trivy can be used either on local developer machines or integrated into your CI/CD pipeline. There are several steps available for different pipelines, including GitHub Actions, Circle CI, GitLab, Travis and more in the tutorials section of the documentation: [https://trivy.dev/docs/latest/tutorials/integrations/](https://trivy.dev/docs/latest/tutorials/integrations/) 
 
  

--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -63,9 +63,9 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry  | |
 | `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
 | `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                          | `false` |
-| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://trivy.dev/latest/docs/references/troubleshooting/#github-rate-limiting                          |      |
-| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://trivy.dev/latest/docs/advanced/private-registries/docker-hub/ |      |
-| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://trivy.dev/latest/docs/advanced/private-registries/docker-hub/ |      |
+| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://trivy.dev/docs/latest/references/troubleshooting/#github-rate-limiting                          |      |
+| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/ |      |
+| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/ |      |
 | `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
 | `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
 | `trivy.skipDBUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `tolerations`                         | Tolerations for pod assignment                                              |     |
 | `podAnnotations`                      | Annotations for pods created by statefulset                             | `{}` |
 
-The above parameters map to the env variables defined in [trivy](https://trivy.dev/latest/docs/configuration/#configuration).
+The above parameters map to the env variables defined in [trivy](https://trivy.dev/docs/latest/configuration/#configuration).
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -108,4 +108,4 @@ This chart uses a PersistentVolumeClaim to reduce the number of database downloa
 ## Caching
 
 You can specify a Redis server as cache backend. This Redis server has to be already present. You can use the [bitnami chart](https://bitnami.com/stack/redis/helm).
-More Information about the caching backends can be found [here](https://trivy.dev/latest/docs/configuration/cache/#scan-cache-backend).
+More Information about the caching backends can be found [here](https://trivy.dev/docs/latest/configuration/cache/#scan-cache-backend).

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -601,7 +601,7 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 				"If your scanning is slow, please try '--scanners %s' to disable secret scanning",
 				strings.Join(xstrings.ToStringSlice(nonSecrets), ",")))
 		}
-		// e.g. https://trivy.dev/latest/docs/scanner/secret/#recommendation
+		// e.g. https://trivy.dev/docs/latest/scanner/secret/#recommendation
 		logger.Info(fmt.Sprintf("Please see %s for faster secret detection", doc.URL("/docs/scanner/secret/", "recommendation")))
 	} else {
 		opts.SecretConfigPath = ""

--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -16,7 +16,7 @@ import (
 var (
 	emptyVersionWarn = sync.OnceFunc(func() {
 		log.WithPrefix("pom").Warn("Dependency version cannot be determined. Child dependencies will not be found.",
-			// e.g. https://trivy.dev/latest/docs/coverage/language/java/#empty-dependency-version
+			// e.g. https://trivy.dev/docs/latest/coverage/language/java/#empty-dependency-version
 			log.String("details", doc.URL("/docs/coverage/language/java/", "empty-dependency-version")))
 	})
 )

--- a/pkg/fanal/analyzer/language/conda/environment/environment.go
+++ b/pkg/fanal/analyzer/language/conda/environment/environment.go
@@ -43,7 +43,7 @@ func (*parser) Parse(ctx context.Context, r xio.ReadSeekerAt) ([]types.Package, 
 			if err != nil {
 				// Show log once per file
 				once.Do(func() {
-					// e.g. https://trivy.dev/latest/docs/coverage/os/conda/#license_1
+					// e.g. https://trivy.dev/docs/latest/coverage/os/conda/#license_1
 					log.WithPrefix("conda").Debug(fmt.Sprintf("License not found. See %s for details.", doc.URL("docs/coverage/os/conda/", "license_1")),
 						log.String("pkg", pkg.Name), log.Err(err))
 				})

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -258,7 +258,7 @@ func shouldTryOtherRepo(err error) bool {
 	for _, diagnostic := range terr.Errors {
 		// For better user experience
 		if diagnostic.Code == transport.DeniedErrorCode || diagnostic.Code == transport.UnauthorizedErrorCode {
-			// e.g. https://trivy.dev/latest/docs/references/troubleshooting/#db
+			// e.g. https://trivy.dev/docs/latest/references/troubleshooting/#db
 			log.Warnf("See %s", doc.URL("/docs/references/troubleshooting/", "db"))
 			break
 		}

--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -46,7 +46,7 @@ var (
 // Show warning if we use severity from another vendor
 // cf. https://github.com/aquasecurity/trivy/issues/6714
 var onceWarn = sync.OnceFunc(func() {
-	// e.g. https://trivy.dev/latest/docs/scanner/vulnerability/#severity-selection
+	// e.g. https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection
 	log.Warnf("Using severities from other vendors for some vulnerabilities. Read %s for details.", doc.URL("/docs/scanner/vulnerability/", "severity-selection"))
 })
 


### PR DESCRIPTION
## Description
The routing of pages at trivy.dev has changed and therefore the previous links were sending back error code 404.

## Related issues
- N/A (at least as far as I'm aware)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
