### PR TITLE
feat(misconf): support https_traffic_only_enabled in Az storage account

### DIFF
--- a/pkg/iac/adapters/terraform/azure/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/storage/adapt.go
@@ -176,8 +176,10 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 		account.NetworkRules = append(account.NetworkRules, adaptNetworkRule(networkBlock))
 	}
 
-	httpsOnlyAttr := resource.GetAttribute("enable_https_traffic_only")
-	account.EnforceHTTPS = httpsOnlyAttr.AsBoolValueOrDefault(true, resource)
+	account.EnforceHTTPS = resource.GetFirstAttributeOf(
+		"enable_https_traffic_only",
+		"https_traffic_only_enabled", // provider above version 4
+	).AsBoolValueOrDefault(true, resource)
 
 	// Adapt blob properties
 	blobPropertiesBlock := resource.GetBlock("blob_properties")

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/iac/terraform/context"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
+	"github.com/aquasecurity/trivy/pkg/set"
 )
 
 type Block struct {
@@ -303,11 +304,18 @@ func (b *Block) GetAttributes() []*Attribute {
 }
 
 func (b *Block) GetAttribute(name string) *Attribute {
-	if b == nil || b.hclBlock == nil {
+	return b.GetFirstAttributeOf(name)
+}
+
+func (b *Block) GetFirstAttributeOf(names ...string) *Attribute {
+	if b == nil || b.hclBlock == nil || len(names) == 0 {
 		return nil
 	}
+
+	nameSet := set.New(names...)
+
 	for _, attr := range b.attributes {
-		if attr.Name() == name {
+		if ok := nameSet.Contains(attr.Name()); ok {
 			return attr
 		}
 	}


### PR DESCRIPTION
## Description

This PR adds support for the `https_traffic_only_enabled` attribute in Azure Storage Accounts, which replaces the older `enable_https_traffic_only`.

A small improvement is also included: a new `Block.GetFirstAttributeOf` method that returns the first existing attribute from the provided list. This helps eliminate boilerplate such as:
```go
if attr := resource.GetAttribute("https_traffic_only_enabled"); attr.IsNotNil() { 
  account.EnforceHTTPS = attr.AsBoolValueOrDefault(true, resource) 
} else if attr := resource.GetAttribute("enable_https_traffic_only"); attr.IsNotNil() { 
  account.EnforceHTTPS = attr.AsBoolValueOrDefault(true, resource) 
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
