### PR TITLE
test(go): set `GOPATH` for tests

### DIFF
--- a/pkg/fanal/analyzer/language/golang/mod/mod_test.go
+++ b/pkg/fanal/analyzer/language/golang/mod/mod_test.go
@@ -3,6 +3,7 @@ package mod
 import (
 	"sort"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -335,11 +336,6 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 	// Load GOPATH fixture once as fs.FS (represents $GOPATH/pkg/mod)
 	gopathFS := testutil.TxtarToFS(t, gopathFixture)
 
-	// We will use GOPATH dir as fs got from txtar in test case if needed.
-	// So, unset GOPATH env to avoid interference.
-	// e.g. when PC contains actual GOPATH modules
-	t.Setenv("GOPATH", "non-existent-path")
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Load test case txtar as fs.FS
@@ -350,6 +346,8 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 
 			// Set GOPATH fs.FS for testing
 			ma := a.(*gomodAnalyzer)
+			// Use empty fs.FS to simulate no GOPATH scenario
+			ma.gopathFS = fstest.MapFS{}
 			if tt.gopath {
 				ma.gopathFS = gopathFS
 			}


### PR DESCRIPTION
## Description

  Fix test environment isolation in Go mod analyzer tests by unsetting the GOPATH environment variable to prevent interference from the host system's actual GOPATH modules.

## Reasons

  This change addresses a potential source of test instability where the presence of actual Go modules in a developer's GOPATH could interfere with the controlled test environment. By explicitly setting GOPATH to a non-existent path, we
  ensure that tests use only the carefully crafted txtar fixtures, making the test suite more reliable and predictable across different development environments.

## Example of broken test
before:
```bash
=== RUN   Test_gomodAnalyzer_Analyze/no_pkg_dir_found
    mod_test.go:362: 
        	Error Trace:	/Users/dmitriy/work/aquasecurity/trivy/pkg/fanal/analyzer/language/golang/mod/mod_test.go:362
        	Error:      	Not equal: 
        	            	expected: &analyzer.AnalysisResult{m:sync.Mutex{_:sync.noCopy{}, mu:sync.Mutex{state:0, sema:0x0}}, OS:types.OS{Family:"", Name:"", Eosl:false, Extended:false}, Repository:(*types.Repository)(nil), PackageInfos:[]types.PackageInfo(nil), Applications:[]types.Application{types.Application{Type:"gomod", FilePath:"go.mod", Packages:types.Packages{types.Package{ID:"github.com/org/repo", Name:"github.com/org/repo", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/org/repo"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:1, DependsOn:[]string{"github.com/aquasecurity/go-dep-parser@v1.0.0", "github.com/aquasecurity/go-version@v1.0.1", "golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"}, Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"github.com/aquasecurity/go-dep-parser@v1.0.0", Name:"github.com/aquasecurity/go-dep-parser", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v1.0.0", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/aquasecurity/go-dep-parser"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:3, DependsOn:[]string(nil), Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"github.com/aquasecurity/go-version@v1.0.1", Name:"github.com/aquasecurity/go-version", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v1.0.1", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/aquasecurity/go-version"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:3, DependsOn:[]string(nil), Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", Name:"golang.org/x/xerrors", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v0.0.0-20200804184101-5ec99f83aff1", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef(nil), Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:true, Relationship:4, DependsOn:[]string(nil), Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}}}}, Misconfigurations:[]types.Misconfiguration(nil), Secrets:[]types.Secret(nil), Licenses:[]types.LicenseFile(nil), SystemInstalledFiles:[]string(nil), Digests:map[string]string(nil), BuildInfo:(*types.BuildInfo)(nil), CustomResources:[]types.CustomResource(nil)}
        	            	actual  : &analyzer.AnalysisResult{m:sync.Mutex{_:sync.noCopy{}, mu:sync.Mutex{state:0, sema:0x0}}, OS:types.OS{Family:"", Name:"", Eosl:false, Extended:false}, Repository:(*types.Repository)(nil), PackageInfos:[]types.PackageInfo(nil), Applications:[]types.Application{types.Application{Type:"gomod", FilePath:"go.mod", Packages:types.Packages{types.Package{ID:"github.com/org/repo", Name:"github.com/org/repo", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/org/repo"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:1, DependsOn:[]string{"github.com/aquasecurity/go-dep-parser@v1.0.0", "github.com/aquasecurity/go-version@v1.0.1", "golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"}, Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"github.com/aquasecurity/go-dep-parser@v1.0.0", Name:"github.com/aquasecurity/go-dep-parser", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v1.0.0", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/aquasecurity/go-dep-parser"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:3, DependsOn:[]string(nil), Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"github.com/aquasecurity/go-version@v1.0.1", Name:"github.com/aquasecurity/go-version", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v1.0.1", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string(nil), Maintainer:"", ExternalReferences:[]types.ExternalRef{types.ExternalRef{Type:"vcs", URL:"https://github.com/aquasecurity/go-version"}}, Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:false, Relationship:3, DependsOn:[]string(nil), Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}, types.Package{ID:"golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1", Name:"golang.org/x/xerrors", Identifier:types.PkgIdentifier{UID:"", PURL:(*packageurl.PackageURL)(nil), BOMRef:""}, Version:"v0.0.0-20200804184101-5ec99f83aff1", Release:"", Epoch:0, Arch:"", Dev:false, SrcName:"", SrcVersion:"", SrcRelease:"", SrcEpoch:0, Licenses:[]string{"BSD-3-Clause"}, Maintainer:"", ExternalReferences:[]types.ExternalRef(nil), Modularitylabel:"", BuildInfo:(*types.BuildInfo)(nil), Indirect:true, Relationship:4, DependsOn:[]string{}, Layer:types.Layer{Size:0, Digest:"", DiffID:"", CreatedBy:""}, FilePath:"", Digest:"", Locations:types.Locations(nil), InstalledFiles:[]string(nil)}}}}, Misconfigurations:[]types.Misconfiguration(nil), Secrets:[]types.Secret(nil), Licenses:[]types.LicenseFile(nil), SystemInstalledFiles:[]string(nil), Digests:map[string]string(nil), BuildInfo:(*types.BuildInfo)(nil), CustomResources:[]types.CustomResource(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -166,3 +166,5 @@
        	            	      SrcEpoch: (int) 0,
        	            	-     Licenses: ([]string) <nil>,
        	            	+     Licenses: ([]string) (len=1) {
        	            	+      (string) (len=12) "BSD-3-Clause"
        	            	+     },
        	            	      Maintainer: (string) "",
        	            	@@ -173,3 +175,4 @@
        	            	      Relationship: (types.Relationship) 4,
        	            	-     DependsOn: ([]string) <nil>,
        	            	+     DependsOn: ([]string) {
        	            	+     },
        	            	      Layer: (types.Layer) {
        	Test:       	Test_gomodAnalyzer_Analyze/no_pkg_dir_found
--- FAIL: Test_gomodAnalyzer_Analyze/no_pkg_dir_found (0.25s)
```
after:
```
=== RUN   Test_gomodAnalyzer_Analyze
=== RUN   Test_gomodAnalyzer_Analyze/no_pkg_dir_found
--- PASS: Test_gomodAnalyzer_Analyze/no_pkg_dir_found (0.00s)
--- PASS: Test_gomodAnalyzer_Analyze (0.00s)
PASS
```

## Related PRs
- [x] #9775


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
