### PR TITLE
feat(suse): Add new openSUSE, Micro and SLES releases end of life dates

### DIFF
--- a/pkg/detector/ospkg/suse/suse.go
+++ b/pkg/detector/ospkg/suse/suse.go
@@ -41,9 +41,10 @@ var (
 		"15.3": time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.4": time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.5": time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC),
-		"15.6": time.Date(2031, 7, 31, 23, 59, 59, 0, time.UTC),
-		// 6 months after SLES 15 SP7 release
-		// "15.7": time.Date(2031, 7, 31, 23, 59, 59, 0, time.UTC),
+		"15.6": time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
+		"15.7": time.Date(2031, 7, 31, 23, 59, 59, 0, time.UTC),
+		"16.0": time.Date(2027, 11, 30, 23, 59, 59, 0, time.UTC),
+		"16.1": time.Date(2028, 11, 30, 23, 59, 59, 0, time.UTC),
 	}
 	slemicroEolDates = map[string]time.Time{
 		// Source: https://www.suse.com/lifecycle/
@@ -54,8 +55,9 @@ var (
 		"5.4": time.Date(2027, 4, 30, 23, 59, 59, 0, time.UTC),
 		"5.5": time.Date(2027, 10, 31, 23, 59, 59, 0, time.UTC),
 		"6.0": time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC),
-		// 6.1 will be released late 2024
-		// "6.1": time.Date(2028, 11, 30, 23, 59, 59, 0, time.UTC),
+		"6.1": time.Date(2028, 11, 30, 23, 59, 59, 0, time.UTC),
+		// 6.2 will be released late 2025
+		// "6.2": time.Date(2029, 11, 30, 23, 59, 59, 0, time.UTC),
 	}
 
 	opensuseEolDates = map[string]time.Time{
@@ -70,6 +72,7 @@ var (
 		"15.4": time.Date(2023, 11, 30, 23, 59, 59, 0, time.UTC),
 		"15.5": time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC),
 		"15.6": time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
+		"16.0": time.Date(2027, 10, 31, 23, 59, 59, 0, time.UTC),
 	}
 )
 


### PR DESCRIPTION
## Description

openSUSE Leap 16 and SLES 15.7 and 16.0 were released. also add 16.1 eol dates

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
