### PR TITLE
ci: remove unused preinstalled software/images for build tests to free up disk space.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -247,7 +247,7 @@ jobs:
           echo "id=--id build-macos --id build-bsd" >> $GITHUB_OUTPUT
         else
           echo "id=--id build-linux" >> $GITHUB_OUTPUT
-        fi 
+        fi
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
## Description
GitHub has reduced the available disk space on its Ubuntu 24.04 runners to 19 GB.
```bash
 Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   53G   19G  74% /
```

For the build tests we need approximately:
1.	1 GB for the dist directory
3. 2.5 GB for the pkg directory (with Go modules)
4. 13 GB for the go-build directory (see `GOCACHE` env)

To make this work, we need to remove unused files for Android and .NET from the runner.
This frees up about 18 GB of space.
Before:
```bash
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   54G   19G  75% /
```
After:
```bash
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   36G   37G  50% /
```

test run with info about disk space - https://github.com/DmitriyLewen/trivy/actions/runs/19455913593/job/55669659130

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
