### PR TITLE
fix(misconf): ensure value used as ignore marker is non-null and known

### DIFF
--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -204,6 +204,9 @@ func ignoreByParams(params map[string]string, modules terraform.Modules, m *type
 	}
 	for key, param := range params {
 		val := block.GetValueByPath(key)
+		if val.IsNull() || !val.IsKnown() {
+			return false
+		}
 		switch val.Type() {
 		case cty.String:
 			if val.AsString() != param {

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -390,6 +390,14 @@ data "aws_iam_policy_document" "this" {
 }`,
 			assertLength: 0,
 		},
+		{
+			name: "ignore marker value is unknown",
+			source: `#trivy:ignore:*[bucket=mybucket-bucket1]
+resource "aws_s3_bucket" "test" {
+  bucket = "mybucket-${each.key}"
+}`,
+			assertLength: 1,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

This PR prevents Trivy from panicking when a value used as an ignore marker is null or unknown.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9834

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
