### PR TITLE
refactor(misconf): parse azure_policy_enabled to addonprofile.azurepolicy.enabled

### DIFF
--- a/pkg/iac/adapters/terraform/azure/container/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/container/adapt_test.go
@@ -48,31 +48,20 @@ func Test_adaptCluster(t *testing.T) {
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
 				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("calico", iacTypes.NewTestMetadata()),
+					NetworkPolicy: iacTypes.StringTest("calico"),
 				},
-				EnablePrivateCluster: iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+				EnablePrivateCluster: iacTypes.BoolTest(true),
 				APIServerAuthorizedIPRanges: []iacTypes.StringValue{
-					iacTypes.String("1.2.3.4/32", iacTypes.NewTestMetadata()),
+					iacTypes.StringTest("1.2.3.4/32"),
 				},
-				AzurePolicyEnabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID: iacTypes.String("", iacTypes.NewTestMetadata()),
 				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
 					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+						Enabled: iacTypes.BoolTest(true),
 					},
 				},
 				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+					Enabled: iacTypes.BoolTest(true),
 				},
 			},
 		},
@@ -84,28 +73,9 @@ func Test_adaptCluster(t *testing.T) {
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
-				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-				},
+				AddonProfile: container.AddonProfile{},
 				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+					Enabled: iacTypes.BoolTest(true),
 				},
 			},
 		},
@@ -115,31 +85,7 @@ func Test_adaptCluster(t *testing.T) {
 			resource "azurerm_kubernetes_cluster" "example" {
 			}
 `,
-			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
-				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-				},
-				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				},
-			},
+			expected: container.KubernetesCluster{},
 		},
 		{
 			name: "rbac off with k8s rbac on",
@@ -153,28 +99,8 @@ resource "azurerm_kubernetes_cluster" "misreporting_example" {
  }
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
-				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-				},
 				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+					Enabled: iacTypes.BoolTest(true),
 				},
 			},
 		},
@@ -186,28 +112,10 @@ resource "azurerm_kubernetes_cluster" "misreporting_example" {
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(true, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
 				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
 					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
+						Enabled: iacTypes.BoolTest(true),
 					},
-				},
-				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 				},
 			},
 		},
@@ -223,28 +131,10 @@ resource "azurerm_kubernetes_cluster" "misreporting_example" {
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
 				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
 					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(true, iacTypes.NewTestMetadata()),
+						Enabled: iacTypes.BoolTest(true),
 					},
-				},
-				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 				},
 			},
 		},
@@ -252,33 +142,11 @@ resource "azurerm_kubernetes_cluster" "misreporting_example" {
 			name: "disk encryption set defined",
 			terraform: `
 			resource "azurerm_kubernetes_cluster" "example" {
-				disk_encryption_set_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Compute/diskEncryptionSets/example-des"
+				disk_encryption_set_id = "test-id"
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Compute/diskEncryptionSets/example-des", iacTypes.NewTestMetadata()),
-				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-				},
-				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				},
+				DiskEncryptionSetID: iacTypes.StringTest("test-id"),
 			},
 		},
 		{
@@ -290,40 +158,16 @@ resource "azurerm_kubernetes_cluster" "misreporting_example" {
 					node_count = 1
 					vm_size = "Standard_DS2_v2"
 					type = "VirtualMachineScaleSets"
-					disk_encryption_set_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Compute/diskEncryptionSets/node-pool-des"
+					disk_encryption_set_id = "test-id"
 				}
 			}
 `,
 			expected: container.KubernetesCluster{
-				Metadata: iacTypes.NewTestMetadata(),
-				NetworkProfile: container.NetworkProfile{
-					Metadata:      iacTypes.NewTestMetadata(),
-					NetworkPolicy: iacTypes.String("", iacTypes.NewTestMetadata()),
-				},
-				EnablePrivateCluster: iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				AzurePolicyEnabled:   iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-				DiskEncryptionSetID:  iacTypes.String("", iacTypes.NewTestMetadata()),
 				AgentPools: []container.AgentPool{
 					{
-						Metadata:            iacTypes.NewTestMetadata(),
-						DiskEncryptionSetID: iacTypes.String("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Compute/diskEncryptionSets/node-pool-des", iacTypes.NewTestMetadata()),
-						NodeType:            iacTypes.String("VirtualMachineScaleSets", iacTypes.NewTestMetadata()),
+						DiskEncryptionSetID: iacTypes.StringTest("test-id"),
+						NodeType:            iacTypes.StringTest("VirtualMachineScaleSets"),
 					},
-				},
-				AddonProfile: container.AddonProfile{
-					Metadata: iacTypes.NewTestMetadata(),
-					OMSAgent: container.OMSAgent{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-					AzurePolicy: container.AzurePolicy{
-						Metadata: iacTypes.NewTestMetadata(),
-						Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
-					},
-				},
-				RoleBasedAccessControl: container.RoleBasedAccessControl{
-					Metadata: iacTypes.NewTestMetadata(),
-					Enabled:  iacTypes.Bool(false, iacTypes.NewTestMetadata()),
 				},
 			},
 		},

--- a/pkg/iac/providers/azure/container/container.go
+++ b/pkg/iac/providers/azure/container/container.go
@@ -15,7 +15,6 @@ type KubernetesCluster struct {
 	APIServerAuthorizedIPRanges []iacTypes.StringValue
 	AddonProfile                AddonProfile
 	RoleBasedAccessControl      RoleBasedAccessControl
-	AzurePolicyEnabled          iacTypes.BoolValue
 	DiskEncryptionSetID         iacTypes.StringValue
 	AgentPools                  []AgentPool
 }

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -4500,6 +4500,19 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Authentication": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "enabled": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.FunctionApp": {
       "type": "object",
       "properties": {
@@ -4513,6 +4526,19 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Identity": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "type": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Service": {
       "type": "object",
       "properties": {
@@ -4522,7 +4548,7 @@
         },
         "authentication": {
           "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Service.Authentication"
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Authentication"
         },
         "enableclientcert": {
           "type": "object",
@@ -4534,7 +4560,7 @@
         },
         "identity": {
           "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Service.Identity"
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Identity"
         },
         "site": {
           "type": "object",
@@ -4542,27 +4568,13 @@
         }
       }
     },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Service.Authentication": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
-        }
-      }
-    },
-    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Service.Identity": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
-        }
-      }
-    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Site": {
       "type": "object",
       "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
         "enablehttp2": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
@@ -4866,10 +4878,6 @@
             "type": "object",
             "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
           }
-        },
-        "azurepolicyenabled": {
-          "type": "object",
-          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
         },
         "diskencryptionsetid": {
           "type": "object",
@@ -5333,6 +5341,31 @@
         }
       }
     },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.IPConfiguration": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "haspublicip": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "primary": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "publicipaddress": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "subnetid": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        }
+      }
+    },
     "github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.Network": {
       "type": "object",
       "properties": {
@@ -5373,6 +5406,13 @@
         "haspublicip": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
+        },
+        "ipconfigurations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.network.IPConfiguration"
+          }
         },
         "publicipaddress": {
           "type": "object",


### PR DESCRIPTION
## Description

A recent PR added parsing of the new `azure_policy_enabled` attribute—which replaces `addonprofile.azurepolicy.enabled`—into a new field. This PR switches the parsing to the old field to avoid burdening the rules with additional checks for the new attribute, which is outside the scope of this change, and to keep the existing rule behavior unchanged. 

Tests and adapters have also been cleaned for better readability.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/9673

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
