### PR TITLE
feat(aws): Add support for dualstack ECR endpoints

### DIFF
--- a/pkg/fanal/image/registry/ecr/ecr.go
+++ b/pkg/fanal/image/registry/ecr/ecr.go
@@ -79,11 +79,13 @@ func (e *ECR) CheckOptions(domain string, option types.RegistryOptions) (intf.Re
 // <registry-id>.dkr.ecr.<region>.amazonaws.com.cn
 // <registry-id>.dkr.ecr.<region>.sc2s.sgov.gov
 // <registry-id>.dkr.ecr.<region>.c2s.ic.gov
+// <registry-id>.dkr-ecr.<region>.on.aws
 // see
 // - https://docs.aws.amazon.com/general/latest/gr/ecr.html
 // - https://docs.amazonaws.cn/en_us/aws/latest/userguide/endpoints-arns.html
+// - https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr-requests.html
 // - https://github.com/boto/botocore/blob/1.34.51/botocore/data/endpoints.json
-var ecrEndpointMatch = regexp.MustCompile(`^[^.]+\.dkr\.ecr(?:-fips)?\.([^.]+)\.(?:amazonaws\.com(?:\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$`)
+var ecrEndpointMatch = regexp.MustCompile(`^[^.]+\.dkr[.-]ecr(?:-fips)?\.([^.]+)\.(?:amazonaws\.com(?:\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov|on\.aws)$`)
 
 func determineRegion(domain string) string {
 	matches := ecrEndpointMatch.FindStringSubmatch(domain)

--- a/pkg/fanal/image/registry/ecr/ecr_test.go
+++ b/pkg/fanal/image/registry/ecr/ecr_test.go
@@ -51,6 +51,10 @@ func TestCheckOptions(t *testing.T) {
 			domain:         "xxx.dkr.ecr-fips.fips-region.amazonaws.com",
 			expectedRegion: "fips-region",
 		},
+		"dualstack-region-1": {
+			domain:         "xxx.dkr-ecr.region-1.on.aws",
+			expectedRegion: "region-1",
+		},
 		"cn-region-1": {
 			domain:         "xxx.dkr.ecr.region-1.amazonaws.com.cn",
 			expectedRegion: "region-1",


### PR DESCRIPTION
## Description

Update the regular expression detecting a ECR image to include the dualstack pattern so ensure that AWS/ECR authentication continues to work on the new images.

## Related issues

- Close #9861

## Related PRs
- [x] #6217

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## before

can be found in the comment https://github.com/aquasecurity/trivy/discussions/9861#discussioncomment-15128995 which uses the main/latest official version

## after 

Local build:
```
➜  trivy git:(main) ✗ ./trivy version  
Version: cae72026
Vulnerability DB:
  Version: 2
  UpdatedAt: 2025-12-01 18:28:50.844697798 +0000 UTC
  NextUpdate: 2025-12-02 18:28:50.844697527 +0000 UTC
  DownloadedAt: 2025-12-01 21:48:57.872102 +0000 UTC
Java DB:
  Version: 1
  UpdatedAt: 2025-07-21 00:57:21.959910533 +0000 UTC
  NextUpdate: 2025-07-24 00:57:21.959910282 +0000 UTC
  DownloadedAt: 2025-07-22 00:03:12.262323 +0000 UTC
➜  trivy git:(main) ✗ 
➜  trivy git:(main) ✗ 
➜  trivy git:(main) ✗ ./trivy image 000000000000.dkr-ecr.ap-southeast-2.on.aws/private-image-tag:latest
2025-12-02T09:05:53+11:00       INFO    [vuln] Vulnerability scanning is enabled
2025-12-02T09:05:53+11:00       INFO    [secret] Secret scanning is enabled
2025-12-02T09:05:53+11:00       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-12-02T09:05:53+11:00       INFO    [secret] Please see https://trivy.dev/docs/dev/guide/scanner/secret#recommendation for faster secret detection
2025-12-02T09:05:54+11:00       INFO    Detected OS     family="alpine" version="3.22.1"
2025-12-02T09:05:54+11:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.22" repository="3.22" pkg_num=29
2025-12-02T09:05:54+11:00       INFO    Number of language-specific files       num=1
2025-12-02T09:05:54+11:00       INFO    [python-pkg] Detecting vulnerabilities...
2025-12-02T09:05:54+11:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/docs/dev/guide/scanner/vulnerability#severity-selection for details.
2025-12-02T09:05:54+11:00       INFO    Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┬─────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┼─────────┤
```
