### PR TITLE
fix: update cosing settings for GoReleaser after bumping cosing to v3

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -296,10 +296,6 @@ signs:
   signature: "${artifact}.sigstore.json"
   args:
     - "sign-blob"
-    # `use-signing-config` is enabled by default since Cosign v2.6.0, and we can't use the --oidc-issue flag with it.
-    # Therefore, we need to explicitly disable it.
-    - "--use-signing-config=false"
-    - "--oidc-issuer=https://token.actions.githubusercontent.com"
     - "--bundle=${signature}"
     - "${artifact}"
     - "--yes"


### PR DESCRIPTION
## Description
We got error when trying to release v0.68.0 - https://github.com/aquasecurity/trivy/actions/runs/19850246115/job/56875421993#step:14:77
Cosign now doesn't allow using  SigningConfig + `--oidc-issuer` flag - https://github.com/sigstore/cosign/blob/38bf9e6a9965554b10211b144a9432972d108881/cmd/cosign/cli/signcommon/common.go#L652-L657
Similar issue - https://github.com/sigstore/cosign/issues/4469

## Possible changes:
1. Simple solution:
	Use `--use-signing-config=false` (this flag is [enabled by default](https://github.com/sigstore/cosign/blob/38bf9e6a9965554b10211b144a9432972d108881/cmd/cosign/cli/options/signblob.go#L94-L95)).
	commit with changes - https://github.com/DmitriyLewen/trivy/commit/eaed91dc300b95ad1900177f522b391739b08edf
	test run (i created special small repo to test this) - https://github.com/DmitriyLewen/cosign-test/actions/runs/19853773009
2. Migrate to the `--bundle` flag, recommended by GoReleaser - https://goreleaser.com/blog/cosign-v3/
	This doesn’t fix the issue by itself,, but i think we should migrate anyway.  
	commit with 1 + 2 solution: https://github.com/DmitriyLewen/trivy/commit/1527e46d689f0fc6e21452783fc829e2d83fca06
	test run - https://github.com/DmitriyLewen/cosign-test/actions/runs/19854337808
3. Use the default Sigstore config. This solution doesn't work without p.2. We should use `--bundle` flag with Sigstore config (see https://github.com/DmitriyLewen/cosign-test/actions/runs/19854136000/job/56887685014#step:5:54).
	commit with 2 + 3 solutions - https://github.com/DmitriyLewen/trivy/commit/2ad98222674a4f21dac316dfbfa65cd325c4d444
	test run - https://github.com/DmitriyLewen/cosign-test/actions/runs/19854224614
	I also rechecked that default sigstore bundle uses same issuer url (we should check [1.3.6.1.4.1.57264.1.8](https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md#1361415726418--issuer-v2):
	```bash
	➜ wget -q https://github.com/DmitriyLewen/cosign-test/releases/download/v0.2.1/cosign-test_0.2.1_darwin_amd64.tar.gz.sigstore.json
	➜  jq -r '.verificationMaterial.certificate.rawBytes' cosign-test_0.2.1_darwin_amd64.tar.gz.sigstore.json | base64 -d > cert.der   
	➜  openssl x509 -in cert.der -inform DER -text -noout | grep 1.3.6.1.4.1.57264.1.8 -A 1
	            1.3.6.1.4.1.57264.1.8: 
	                .+https://token.actions.githubusercontent.com
	```

## Summary
I think we should use the combined solution of steps 2 and 3.


## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
