### PR TITLE
chore: update the install script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -273,7 +273,7 @@ http_download_wget() {
   fi
 }
 http_download() {
-  log_debug`` "http_download $2"
+  log_debug "http_download $2"
   if is_command curl; then
     http_download_curl "$@"
     return


### PR DESCRIPTION
## Description

The install script pulls the binary from the github releases; this change updates that to used the detected OS and Arch to pull the release from the get.trivy.dev endpoint so it can be included in the download stats

### MacOS (arm64)
```bash
./contrib/install.sh -d v0.67.2
aquasecurity/trivy info checking GitHub for tag 'v0.67.2'
aquasecurity/trivy info found version: 0.67.2 for v0.67.2/macOS/ARM64
aquasecurity/trivy debug downloading files into /var/folders/3h/yms3js091w5gk1hq7s8n02k40000gn/T/tmp.uVyIonsXr8
aquasecurity/trivy debug http_download https://get.trivy.dev/trivy?os=macOS&arch=ARM64&version=0.67.2&type=tar.gz&client=install-script
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.67.2/trivy_0.67.2_checksums.txt
aquasecurity/trivy info installed ./bin/trivy

./bin/trivy --version                                                               
Version: 0.67.2
```

### Linux (amd64)
```bash 
./contrib/install.sh -d v0.68.1 
aquasecurity/trivy info checking GitHub for tag 'v0.68.1'
aquasecurity/trivy info found version: 0.68.1 for v0.68.1/Linux/64bit
aquasecurity/trivy debug downloading files into /tmp/tmp.T3nR13LPgR
aquasecurity/trivy debug http_download https://get.trivy.dev/trivy?os=Linux&arch=64bit&version=0.68.1&type=tar.gz&client=install-script
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_checksums.txt
aquasecurity/trivy info installed ./bin/trivy

./bin/trivy --version                                                                
Version: 0.68.1
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
