### PR TITLE
feat(secret): add detection for Symfony default secret key

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -853,6 +853,6 @@ var builtinRules = []Rule{
 		Title:    "Symfony Default Secret",
 		Severity: "HIGH",
 		Regex:    MustCompile(`ThisTokenIsNotSoSecretChangeIt|ThisEzPlatformTokenIsNotSoSecret_PleaseChangeIt`),
-		Keywords: []string{"ThisTokenIsNotSoSecretChangeIt", "ThisEzPlatformTokenIsNotSoSecret_PleaseChangeIt"},
+		Keywords: []string{"TokenIsNotSoSecret"},
 	},
 }

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -976,22 +976,30 @@ func TestSecretScanner(t *testing.T) {
 		Category:  secret.CategorySymfony,
 		Title:     "Symfony Default Secret",
 		Severity:  "HIGH",
-		StartLine: 1,
-		EndLine:   1,
-		Match:     "APP_SECRET=********************************",
+		StartLine: 2,
+		EndLine:   2,
+		Match:     "  secret: ******************************",
 		Code: types.Code{
 			Lines: []types.Line{
 				{
 					Number:      1,
-					Content:     "APP_SECRET=********************************",
-					Highlighted: "APP_SECRET=********************************",
+					Content:     "parameters:",
+					Highlighted: "parameters:",
+					IsCause:     false,
+					FirstCause:  false,
+					LastCause:   false,
+				},
+				{
+					Number:      2,
+					Content:     "  secret: ******************************",
+					Highlighted: "  secret: ******************************",
 					IsCause:     true,
 					FirstCause:  true,
 					LastCause:   true,
 				},
 			},
 		},
-		Offset: 11,
+		Offset: 22,
 	}
 	wantMultiLine := types.SecretFinding{
 		RuleID:    "multi-line-secret",
@@ -1282,9 +1290,9 @@ func TestSecretScanner(t *testing.T) {
 		{
 			name:          "find Symfony default secret",
 			configPath:    filepath.Join("testdata", "config.yaml"),
-			inputFilePath: filepath.Join("testdata", "symfony-secret.txt"),
+			inputFilePath: filepath.Join("testdata", "symfony-secret.yaml"),
 			want: types.Secret{
-				FilePath: filepath.Join("testdata", "symfony-secret.txt"),
+				FilePath: filepath.Join("testdata", "symfony-secret.yaml"),
 				Findings: []types.SecretFinding{wantFindingSymfonySecret},
 			},
 		},

--- a/pkg/fanal/secret/testdata/symfony-secret.txt
+++ b/pkg/fanal/secret/testdata/symfony-secret.txt
@@ -1,1 +1,0 @@
-APP_SECRET=ThisTokenIsNotSoSecretChangeIt

--- a/pkg/fanal/secret/testdata/symfony-secret.yaml
+++ b/pkg/fanal/secret/testdata/symfony-secret.yaml
@@ -1,0 +1,2 @@
+parameters:
+  secret: ThisTokenIsNotSoSecretChangeIt


### PR DESCRIPTION
## Summary
Add a new secret detection rule for the old default Symfony secret key `ThisTokenIsNotSoSecretChangeIt`.

## Details
When projects were bootstrapped with older versions of Symfony (< 4.0), the configuration was generated with a default secret key. This key can be exploited for **Remote Code Execution (RCE)**.

### Changes
- Added `CategorySymfony` to secret categories
- Added `symfony-secret` rule to detect `ThisTokenIsNotSoSecretChangeIt`
- Severity: **HIGH** (due to RCE risk)

### Detection examples
```yaml
# parameters.yml
parameters:
    secret: ThisTokenIsNotSoSecretChangeIt
```

```env
# .env
APP_SECRET=ThisTokenIsNotSoSecretChangeIt
```

## References
- Fixes #3910
- [Symfony Secret Fragment RCE](https://www.ambionics.io/blog/symfony-secret-fragment)
- [symfony-standard parameters.yml.dist](https://github.com/symfony/symfony-standard/blob/3.4/app/config/parameters.yml.dist#L19)