### PR TITLE
fix(vex): add CVE-2025-66564 as not_affected into Trivy VEX file

### DIFF
--- a/.vex/trivy.openvex.json
+++ b/.vex/trivy.openvex.json
@@ -599,6 +599,36 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2025-4192",
+        "name": "GO-2025-4192",
+        "description": "Sigstore Timestamp Authority allocates excessive memory during request parsing in github.com/sigstore/timestamp-authority",
+        "aliases": [
+          "CVE-2025-66564",
+          "GHSA-4qg8-fj49-pxjh"
+        ]
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aquasecurity/trivy",
+          "identifiers": {
+            "purl": "pkg:golang/github.com/aquasecurity/trivy"
+          },
+          "subcomponents": [
+            {
+              "@id": "pkg:golang/github.com/sigstore/timestamp-authority@v1.2.2",
+              "identifiers": {
+                "purl": "pkg:golang/github.com/sigstore/timestamp-authority@v1.2.2"
+              }
+            }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
     }
   ]
 }


### PR DESCRIPTION
## Description
Trivy contains vulnerable `github.com/sigstore/timestamp-authority` indirect package:
```bash
┌─────────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│                 Library                 │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/sigstore/timestamp-authority │ CVE-2025-66564 │ HIGH     │ fixed  │ v1.2.2            │ 2.0.3           │ Sigstore Timestamp Authority is a service for issuing RFC    │
│                                         │                │          │        │                   │                 │ 3161 timesta ......                                          │
│                                         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-66564                   │
├─────────────────────────────────────────┼────────────────┤          │        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
```

There is fix only for `v2` version - https://pkg.go.dev/vuln/GO-2025-4192
So we can't simlply bump version for this repository.

## Solution
I checked this using `govulncheck`:
```
➜  govulncheck -mode binary -format openvex ./trivy jq ' .statements[13] '
{
  "vulnerability": {
    "@id": "https://pkg.go.dev/vuln/GO-2025-4192",
    "name": "GO-2025-4192",
    "description": "Sigstore Timestamp Authority allocates excessive memory during request parsing in github.com/sigstore/timestamp-authority",
    "aliases": [
      "CVE-2025-66564",
      "GHSA-4qg8-fj49-pxjh"
    ]
  },
  "products": [
    {
      "@id": "Unknown Product",
      "subcomponents": [
        {
          "@id": "pkg:golang/github.com%2Fsigstore%2Ftimestamp-authority@v1.2.2"
        }
      ]
    }
  ],
  "status": "not_affected",
  "justification": "vulnerable_code_not_present",
  "impact_statement": "Govulncheck determined that the vulnerable code isn't called"
}

```
Trivy doesn't use vulnerable package, so we can add this package to our VEX file.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
