### PR TITLE
ci: enable `check-latest` for `setup-go`

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
+          check-latest: true # Ensure we use the latest Go patch version
           cache: false
 
       # Ensure the base commit exists locally for go-apidiff to compare against.

--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -55,6 +56,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -88,6 +90,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Run golangci-lint for caching
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
+          check-latest: true # Ensure we use the latest Go patch version
           cache: false
 
       - name: Install Go tools

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0

--- a/.github/workflows/spdx-cron.yaml
+++ b/.github/workflows/spdx-cron.yaml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod
+          cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: go mod tidy
         run: |
@@ -80,6 +81,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -113,6 +115,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -132,6 +135,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -167,6 +171,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -201,6 +206,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+          check-latest: true # Ensure we use the latest Go patch version
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -236,6 +242,7 @@ jobs:
       with:
         go-version-file: go.mod
         cache: false
+        check-latest: true # Ensure we use the latest Go patch version
 
     - name: Determine GoReleaser ID
       id: goreleaser_id


### PR DESCRIPTION
## Description
For the last release (v0.68.1) `setup-go` installed `v1.25.4` instead of the latest patch version `v1.25.5`.
This happened due to a bug in `setup-go`: https://github.com/actions/setup-go/issues/688

To ensure we always use the latest patch version, we will enable `check-latest`.
This flag checks for the latest available Go patch version and installs it.

Here is a test run demonstrating that this flag works correctly with `go-version-file: go.mod`:
https://github.com/DmitriyLewen/test-setup-go-flags/actions/runs/20123622090


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
