### PR TITLE
chore(alpine): add EOL date for alpine 3.23

### DIFF
--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -50,6 +50,7 @@ var eolDates = map[string]time.Time{
 	"3.20": time.Date(2026, 4, 1, 23, 59, 59, 0, time.UTC),
 	"3.21": time.Date(2026, 12, 5, 23, 59, 59, 0, time.UTC),
 	"3.22": time.Date(2027, 4, 30, 23, 59, 59, 0, time.UTC),
+	"3.23": time.Date(2027, 11, 1, 23, 59, 59, 0, time.UTC),
 	"edge": time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
 }
 


### PR DESCRIPTION
## Description
Alpine released 3.23 one week ago - https://alpinelinux.org/releases/
Trivy-db already contains advisories for 3.23:
<img width="346" height="96" alt="изображение" src="https://github.com/user-attachments/assets/b813c076-b1ec-4b82-ad49-de72346ae091" />


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
