### PR TITLE
chore(deps): bump alpine from `3.22.1` to `3.23.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1
+FROM alpine:3.23.0
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1
+FROM alpine:3.23.0
 RUN apk --no-cache add ca-certificates git
 
 # binaries were created with GoReleaser


### PR DESCRIPTION
## Description
Bump alpine images from `3.22.1` to `3.23.0`.

## Test build
```bash
➜ docker build -t trivy:test-alpine-3.23.0 .                                          
[+] Building 0.1s (9/9) FINISHED                                                                                                                                                                                             docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 182B                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:3.23.0                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                            0.0s
 => => transferring context: 87B                                                                                                                                                                                                             0.0s
 => [1/4] FROM docker.io/library/alpine:3.23.0                                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                            0.1s
 => => transferring context: 253B                                                                                                                                                                                                            0.0s
 => CACHED [2/4] RUN apk --no-cache add ca-certificates git                                                                                                                                                                                  0.0s
 => CACHED [3/4] COPY trivy /usr/local/bin/trivy                                                                                                                                                                                             0.0s
 => CACHED [4/4] COPY contrib/*.tpl contrib/                                                                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                                                                                      0.0s
 => => writing image sha256:66c59541590343ef2c33956505eaf4cbb15b30e1c90bfe5feb1647bab27c3435                                                                                                                                                 0.0s
 => => naming to docker.io/library/trivy:test-alpine-3.23.0                                                                                                                                                                                  0.0s
➜ docker run -it --rm trivy:test-alpine-3.23.0 -q image alpine:3.21.0 --table-mode summary

Report Summary

┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ alpine:3.21.0 (alpine 3.21.0) │ alpine │       18        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


```

## Vulnerabilities
alpine 3.22.2 still contains vulnerable packages:
```bash
➜ trivy -q image alpine:3.22.2 --table-mode summary             

Report Summary

┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ alpine:3.22.2 (alpine 3.22.2) │ alpine │        6        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘
```
But alpine already updated vulnerable packages in `3.23.0`:
```bash
➜  ./trivy  image alpine:3.23.0 --table-mode summary 
2025-12-12T12:11:54+06:00       INFO    Detected OS     family="alpine" version="3.23.0"
2025-12-12T12:11:54+06:00       INFO    [alpine] Detecting vulnerabilities...   os_version="3.23" repository="3.23" pkg_num=16
2025-12-12T12:11:54+06:00       INFO    Number of language-specific files       num=0

Report Summary

┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ alpine:3.23.0 (alpine 3.23.0) │ alpine │        0        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘

```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
