### PR TITLE
feat(misconf): support for ARM resources defined as an object

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -145,7 +145,7 @@ func init() {
 			Schema     string         `json:"$schema"`
 			Handler    string         `json:"handler"`
 			Parameters map[string]any `json:"parameters"`
-			Resources  []any          `json:"resources"`
+			Resources  any            `json:"resources"`
 		}{}
 
 		data, err := io.ReadAll(r)
@@ -168,7 +168,17 @@ func init() {
 			return false
 		}
 
-		return len(sniff.Parameters) > 0 || len(sniff.Resources) > 0
+		hasResources := false
+		if sniff.Resources != nil {
+			switch resources := sniff.Resources.(type) {
+			case []any:
+				hasResources = len(resources) > 0
+			case map[string]any:
+				hasResources = len(resources) > 0
+			}
+		}
+
+		return len(sniff.Parameters) > 0 || hasResources
 	}
 
 	matchers[FileTypeDockerfile] = func(name string, _ io.ReadSeeker) bool {

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -453,6 +453,30 @@ rules:
 			},
 		},
 		{
+			name: "Azure ARM resources defined as an object",
+			path: "test.json",
+			r: strings.NewReader(`{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "resources": {
+    "myacc": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2025-06-01",
+      "name": "my-acc-test",
+      "location": "location",
+			"kind": "Storage"
+    }
+  }
+}`),
+			expected: []FileType{
+				FileTypeJSON,
+				FileTypeCloudFormation,
+				FileTypeAzureARM,
+				FileTypeAnsible,
+			},
+		},
+		{
 			name: "Azure ARM template with parameters",
 			path: "test.json",
 			r: strings.NewReader(`


### PR DESCRIPTION
## Description

This PR adds support for templates where resources are declared as an object rather than a list. This syntax was added in the language v2. More details: https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/resource-declaration#use-symbolic-name

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9467

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
