### PR TITLE
docs: add info that `--file-pattern` flag doesn't disable default behaviuor

### DIFF
--- a/docs/guide/configuration/skipping.md
+++ b/docs/guide/configuration/skipping.md
@@ -68,6 +68,9 @@ image:
 You can customize which files Trivy scans and how it interprets them with the `--file-patterns` flag.
 A file pattern configuration takes the following form: `<analyzer>:<path>`, such that files matching the `<path>` will be processed with the respective `<analyzer>`.
 
+!!! Note
+    `--file-patterns` flag doesn't disable the default file detection behavior of Trivy. It only adds the file detection based on the specified patterns.
+
 For example:
 
 ```bash


### PR DESCRIPTION
## Description

  This PR improves the documentation for the `--file-patterns` flag in Trivy's configuration guide. It clarifies an important behavioral detail and fixes syntax errors in example commands.

## Changes

  - Added important note explaining that --file-patterns doesn't disable default file detection behavior - it only adds additional patterns on top of the defaults (docs/guide/configuration/skipping.md:71-72)
  - Fixed command-line syntax in all example commands by properly separating the --file-patterns flag value from the directory argument with quotes (docs/guide/configuration/skipping.md:77, 97, 103)


## Related discussions 
- Close #9945

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
