### PR TITLE
chore: add client option to install script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -10,7 +10,7 @@ $this: download go binaries for aquasecurity/trivy
 
 Usage: $this [-b] bindir [-c] client [-d] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
-  -c sets client identifier for download tracking, Defaults to install-script
+  -c sets client identifier for download tracking (letters, digits, and '-' characters are allowed), Defaults to install-script
   -d turns on debug logging
   -x turns on verbose logging
    [tag] is a tag from


### PR DESCRIPTION
## Description

Add the option to use `-c` in the install script to specify the client that is doing the installation. This is defaulted to install-script, but allows for the setup-trivy github action to specify -c gh-action or something similar when installing to help differentiate in the logs

An allow list of acceptable clients will be added to trivy-downloads to filter spurious entries

### Examples

Without client specified (defaults to install-script):

```sh
./contrib/install.sh -d
aquasecurity/trivy info checking GitHub for latest tag
aquasecurity/trivy info found version: 0.68.2 for v0.68.2/macOS/ARM64
aquasecurity/trivy debug downloading files into /var/folders/3h/yms3js091w5gk1hq7s8n02k40000gn/T/tmp.GMEimKtBf7
aquasecurity/trivy debug http_download https://get.trivy.dev/trivy?os=macOS&arch=ARM64&version=0.68.2&type=tar.gz&client=install-script
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.68.2/trivy_0.68.2_checksums.txt
aquasecurity/trivy info installed ./bin/trivy
```

With the client specified as gh-action:

```sh
./contrib/install.sh -d -c gh-action
aquasecurity/trivy info checking GitHub for latest tag
aquasecurity/trivy info found version: 0.68.2 for v0.68.2/macOS/ARM64
aquasecurity/trivy debug downloading files into /var/folders/3h/yms3js091w5gk1hq7s8n02k40000gn/T/tmp.dR1Z9kLrOO
aquasecurity/trivy debug http_download https://get.trivy.dev/trivy?os=macOS&arch=ARM64&version=0.68.2&type=tar.gz&client=gh-action
aquasecurity/trivy debug http_download https://github.com/aquasecurity/trivy/releases/download/v0.68.2/trivy_0.68.2_checksums.txt
aquasecurity/trivy info installed ./bin/trivy
```

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
