### PR TITLE
fix(image): race condition in image artifact inspection

### DIFF
--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -392,9 +392,7 @@ func (a Artifact) saveLayer(diffID string) (int64, error) {
 func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys, baseDiffIDs []string,
 	layerKeyMap map[string]types.Layer, configFile *v1.ConfigFile) error {
 
-	// Merge OS info from layers in order
 	var osFound types.OS
-
 	p := parallel.NewPipeline(a.artifactOption.Parallel, false, layerKeys, func(ctx context.Context,
 		layerKey string) (any, error) {
 		layer := layerKeyMap[layerKey]


### PR DESCRIPTION
## Description

This PR fixes a concurrent access to a stack variable `osFound` during parallel inspection of image layers.

This concurrent access being UB, it could result in crashes.

## Related issues

No related issue. I can open one if needed.

Adding a specific test to reproduce would probably need to introduce tests with the `-race` flags. Not done as part of this PR.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
