### PR TITLE
perf(misconf): optimize string concatenation in azure scanner

### DIFF
--- a/pkg/iac/scanners/azure/functions/concat.go
+++ b/pkg/iac/scanners/azure/functions/concat.go
@@ -2,17 +2,18 @@ package functions
 
 import (
 	"fmt"
+	"strings"
 )
 
 func Concat(args ...any) any {
 
 	switch args[0].(type) {
 	case string:
-		var result string
+		var sb strings.Builder
 		for _, arg := range args {
-			result += fmt.Sprintf("%v", arg)
+			sb.WriteString(fmt.Sprintf("%v", arg))
 		}
-		return result
+		return sb.String()
 	case any:
 		var result []any
 		for _, arg := range args {


### PR DESCRIPTION
## Description
Optimize string concatenation in `pkg/iac/scanners/azure/functions/concat.go` by replacing `+=` in a loop with `strings.Builder`. This improves performance from O(n^2) to O(n) by minimizing memory allocations during iteration.

## Related issues
- Close N/A

## Related PRs
<!-- Remove this section if you don't have related PRs. -->

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
