### PR TITLE
fix(misconf): safely parse rotation_period in google_kms_crypto_key

### DIFF
--- a/pkg/iac/adapters/terraform/google/kms/adapt.go
+++ b/pkg/iac/adapters/terraform/google/kms/adapt.go
@@ -2,6 +2,7 @@ package kms
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/iac/providers/google/kms"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
@@ -45,10 +46,12 @@ func adaptKey(resource *terraform.Block) kms.Key {
 		return key
 	}
 	rotationStr := rotationPeriodAttr.Value().AsString()
-	if rotationStr[len(rotationStr)-1:] != "s" {
+	secondsStr, ok := strings.CutSuffix(rotationStr, "s")
+	if !ok {
 		return key
 	}
-	seconds, err := strconv.Atoi(rotationStr[:len(rotationStr)-1])
+
+	seconds, err := strconv.Atoi(secondsStr)
 	if err != nil {
 		return key
 	}

--- a/pkg/iac/adapters/terraform/google/kms/adapt_test.go
+++ b/pkg/iac/adapters/terraform/google/kms/adapt_test.go
@@ -81,6 +81,29 @@ func Test_adaptKeyRings(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "invalid rotation period",
+			terraform: `
+			resource "google_kms_key_ring" "keyring" {
+  name = "keyring-example"
+}
+			  
+resource "google_kms_crypto_key" "example-key" {
+  name     = "crypto-key-example"
+  key_ring = google_kms_key_ring.keyring.id
+	rotation_period = ""
+}
+`,
+			expected: []kms.KeyRing{
+				{
+					Keys: []kms.Key{
+						{
+							RotationPeriodSeconds: iacTypes.IntTest(-1),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Use `strings.Cut` for more idiomatic and safer parsing

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/9979