### PR TITLE
chore: update reference links to Go Wiki

### DIFF
--- a/docs/guide/scanner/misconfiguration/custom/testing.md
+++ b/docs/guide/scanner/misconfiguration/custom/testing.md
@@ -86,5 +86,5 @@ The following example stores allowed and denied configuration files in a directo
 
 [opa-testing]: https://www.openpolicyagent.org/docs/latest/policy-testing/
 [defsec]: https://github.com/aquasecurity/trivy-checks/tree/main
-[table]: https://github.com/golang/go/wiki/TableDrivenTests
+[table]: https://go.dev/wiki/TableDrivenTests
 [fanal]: https://github.com/aquasecurity/fanal

--- a/misc/lint/rules.go
+++ b/misc/lint/rules.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// cf. https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices
+// cf. https://go.dev/wiki/CodeReviewComments#declaring-empty-slices
 func declareEmptySlices(m dsl.Matcher) {
 	m.Match(
 		`$name := []$t{}`,


### PR DESCRIPTION
## Description

Updates the reference links to the Go Wiki, as it has moved to go.dev.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
