### PR TITLE
fix(misconf): correct typos in block and attribute names

### DIFF
--- a/pkg/iac/adapters/terraform/aws/s3/bucket.go
+++ b/pkg/iac/adapters/terraform/aws/s3/bucket.go
@@ -160,7 +160,7 @@ func getLogging(block *terraform.Block, a *adapter) s3.Logging {
 	}
 
 	if val, ok := applyForBucketRelatedResource(a, block, "aws_s3_bucket_logging", func(resource *terraform.Block) s3.Logging {
-		targetBucket := resource.GetAttribute("target-bucket").AsStringValueOrDefault("", resource)
+		targetBucket := resource.GetAttribute("target_bucket").AsStringValueOrDefault("", resource)
 		if referencedBlock, err := a.modules.GetReferencedBlock(resource.GetAttribute("target_bucket"), resource); err == nil {
 			targetBucket = iacTypes.String(referencedBlock.FullName(), resource.GetAttribute("target_bucket").GetMetadata())
 		}
@@ -310,7 +310,7 @@ func getObject(b *terraform.Block, a *adapter) []s3.Contents {
 
 func getAccelerateStatus(b *terraform.Block, a *adapter) iacTypes.StringValue {
 	var status iacTypes.StringValue
-	for _, r := range a.modules.GetReferencingResources(b, " aws_s3_bucket_accelerate_configuration", "bucket") {
+	for _, r := range a.modules.GetReferencingResources(b, "aws_s3_bucket_accelerate_configuration", "bucket") {
 		status = r.GetAttribute("status").AsStringValueOrDefault("Enabled", r)
 	}
 	return status


### PR DESCRIPTION
## Description

This PR fixes typos in the resource name and attribute.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
