### PR TITLE
test: fix assertion after 2026 roll over

### DIFF
--- a/pkg/iac/ignore/rule_test.go
+++ b/pkg/iac/ignore/rule_test.go
@@ -1,7 +1,9 @@
 package ignore_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -157,7 +159,7 @@ func TestRules_Ignore(t *testing.T) {
 		},
 		{
 			name: "ignore rule with expiry date not passed",
-			src:  `#trivy:ignore:rule-1:exp:2026-01-01`,
+			src:  fmt.Sprintf(`#trivy:ignore:rule-1:exp:%d-01-01`, time.Now().Year()+1),
 			args: args{
 				metadata: metadataWithLine(filename, 2),
 				ids:      []string{"rule-1"},


### PR DESCRIPTION
## Description

This PR fixes an assertion in `rule_test.go` that was based on 2026 being in the future. 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
