### PR TITLE
feat(sbom): exclude PEP 770 SBOMs in .dist-info/sboms/

### DIFF
--- a/pkg/fanal/analyzer/sbom/sbom.go
+++ b/pkg/fanal/analyzer/sbom/sbom.go
@@ -76,6 +76,13 @@ func (a sbomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput)
 }
 
 func (a sbomAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	// Exclude PEP 770 SBOMs in .dist-info/sboms/ directories.
+	// These are handled by the Python packaging analyzer instead.
+	// cf. https://peps.python.org/pep-0770/
+	if strings.Contains(filePath, ".dist-info/sboms/") {
+		return false
+	}
+
 	for _, suffix := range requiredSuffixes {
 		if strings.HasSuffix(filePath, suffix) {
 			return true

--- a/pkg/fanal/analyzer/sbom/sbom_test.go
+++ b/pkg/fanal/analyzer/sbom/sbom_test.go
@@ -384,6 +384,26 @@ func Test_packagingAnalyzer_Required(t *testing.T) {
 			filePath: "/test/result.json",
 			want:     false,
 		},
+		{
+			name:     "pep770 cdx.json in dist-info/sboms",
+			filePath: "python3.8/site-packages/xgboost-3.1.2.dist-info/sboms/auditwheel.cdx.json",
+			want:     false,
+		},
+		{
+			name:     "pep770 spdx.json in dist-info/sboms",
+			filePath: "python3.8/site-packages/xgboost-3.1.2.dist-info/sboms/auditwheel.spdx.json",
+			want:     false,
+		},
+		{
+			name:     "pep770 cdx in dist-info/sboms",
+			filePath: "python3.8/site-packages/xgboost-3.1.2.dist-info/sboms/auditwheel.cdx",
+			want:     false,
+		},
+		{
+			name:     "pep770 spdx in dist-info/sboms",
+			filePath: "python3.8/site-packages/xgboost-3.1.2.dist-info/sboms/auditwheel.spdx",
+			want:     false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Exclude Python package SBOM files from the SBOM analyzer to prevent duplicate package detection.

[PEP 770](https://peps.python.org/pep-0770/) defines a standard location for SBOMs in Python packages (`.dist-info/sboms/`). Tools like `auditwheel` (v6.5.0+) generate CycloneDX SBOMs documenting bundled shared libraries in this directory.

This PR excludes these paths from the SBOM analyzer to avoid duplicate detection. Full support for parsing bundled native libraries will require architectural changes and will be addressed separately.

## Related issues
- #10021 (wil not be closed)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).