### PR TITLE
feat(rocky): enable modular package vulnerability detection

### DIFF
--- a/pkg/detector/ospkg/rocky/rocky.go
+++ b/pkg/detector/ospkg/rocky/rocky.go
@@ -44,12 +44,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 		log.Int("pkg_num", len(pkgs)))
 
 	var vulns []types.DetectedVulnerability
-	var skipPkgs []string
 	for _, pkg := range pkgs {
-		if pkg.Modularitylabel != "" {
-			skipPkgs = append(skipPkgs, pkg.Name)
-			continue
-		}
 		pkgName := addModularNamespace(pkg.Name, pkg.Modularitylabel)
 		advisories, err := s.vs.Get(db.GetParams{
 			Release: osVer,
@@ -80,10 +75,6 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 				vulns = append(vulns, vuln)
 			}
 		}
-	}
-	if len(skipPkgs) > 0 {
-		log.InfoContext(ctx, "Skipped detection of the packages because modular packages cannot be detected correctly due to a bug in Rocky Linux Errata. See also: https://forums.rockylinux.org/t/some-errata-missing-in-comparison-with-rhel-and-almalinux/3843",
-			log.Any("packages", skipPkgs))
 	}
 
 	return vulns, nil

--- a/pkg/detector/ospkg/rocky/rocky_test.go
+++ b/pkg/detector/ospkg/rocky/rocky_test.go
@@ -70,7 +70,7 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
-			name: "skip modular package",
+			name: "modular package",
 			fixtures: []string{
 				"testdata/fixtures/modular.yaml",
 				"testdata/fixtures/data-source.yaml",
@@ -94,7 +94,20 @@ func TestScanner_Detect(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "nginx",
+					VulnerabilityID:  "CVE-2021-23017",
+					InstalledVersion: "1:1.16.1-2.module+el8.4.0+543+efbf198b.0",
+					FixedVersion:     "1:1.16.1-2.module+el8.4.0+543+efbf198b.1",
+					Layer:            ftypes.Layer{},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Rocky,
+						Name: "Rocky Linux updateinfo",
+						URL:  "https://download.rockylinux.org/pub/rocky/",
+					},
+				},
+			},
 		},
 		{
 			name: "Get returns an error",

--- a/pkg/detector/ospkg/rocky/testdata/fixtures/modular.yaml
+++ b/pkg/detector/ospkg/rocky/testdata/fixtures/modular.yaml
@@ -1,7 +1,13 @@
 - bucket: rocky 8
   pairs:
-    - bucket: nginx:1.16::nginx # actual: bucket of modular package is not created. ref: https://github.com/aquasecurity/trivy-db/pull/154
+    - bucket: "nginx:1.16::nginx"
       pairs:
         - key: CVE-2021-23017
           value:
             FixedVersion: "1:1.16.1-2.module+el8.4.0+543+efbf198b.1"
+            Entries:
+              - FixedVersion: "1:1.16.1-2.module+el8.4.0+543+efbf198b.1"
+                Arches:
+                  - "x86_64"
+                VendorIDs:
+                  - "RLSA-2021:2258"


### PR DESCRIPTION
## Description
Remove the skip logic for modular packages in Rocky Linux scanner.

Previously, modular packages (e.g., `nginx:1.16`) were skipped due to a bug in Rocky Linux Errata where module information was missing. This has now been fixed upstream, and trivy-db supports the modular package format (`module:stream::pkgName`).

## Related PRs
- https://github.com/aquasecurity/trivy-db/pull/613
- https://github.com/aquasecurity/vuln-list-update/pull/398

**Note:** This PR should be merged after the above PRs are merged.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).