### PR TITLE
docs: fix mistake in config file example for skip-dirs/skip-files flag

### DIFF
--- a/docs/guide/configuration/skipping.md
+++ b/docs/guide/configuration/skipping.md
@@ -54,7 +54,7 @@ Like any other flag, this is available as Trivy YAML configuration.
 For example:
 
 ```yaml
-image:
+scan:
   skip-files:
     - foo
     - "testdata/*/bar"


### PR DESCRIPTION
## Description
Example for config file contains incorrect struct (image.skip-files instead of scan.skip-files) 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
