### PR TITLE
fix(nodejs): correctly parse npm: protocol aliases in yarn.lock

### DIFF
--- a/pkg/dependency/parser/nodejs/yarn/parse.go
+++ b/pkg/dependency/parser/nodejs/yarn/parse.go
@@ -19,6 +19,8 @@ import (
 	xslices "github.com/aquasecurity/trivy/pkg/x/slices"
 )
 
+const npmProtocol = "npm"
+
 var (
 	// yarnPatternRegexp parses the top-level package pattern in yarn.lock
 	// e.g., "lodash@^4.17.0" or "my-alias@npm:lodash@^4.17.0"
@@ -95,7 +97,7 @@ func parsePattern(target string) (pkgName, protocol, version string, err error) 
 	// Based on yarn's alias detection:
 	// https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/LegacyMigrationResolver.ts
 	// "If the range is a valid descriptor we're dealing with an alias"
-	if protocol == "npm" {
+	if protocol == npmProtocol {
 		if realPkg, realVersion, ok := tryParseDescriptor(rng); ok {
 			return realPkg, protocol, realVersion, nil
 		}
@@ -144,7 +146,7 @@ func tryParseDescriptor(descriptor string) (string, string, bool) {
 // rather than a valid npm package name.
 // npm package names: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#name
 func looksLikeVersionConstraint(s string) bool {
-	if len(s) == 0 {
+	if s == "" {
 		return true
 	}
 	// Version constraints start with: digits, ^, ~, >, <, =, *
@@ -181,7 +183,7 @@ func parsePackagePatterns(target string) (pkgName, protocol string, patterns []s
 		// Example: "ip@^2.0.0", "ip@npm:@rootio/ip@2.0.0-root.io.1"
 		// Here "ip" is the alias, "@rootio/ip" is the real package.
 		// parsePattern returns the real name for npm: protocol aliases.
-		if proto == "npm" {
+		if proto == npmProtocol {
 			pkgName = name
 			protocol = proto
 			break
@@ -222,7 +224,7 @@ func getDependency(target string) (name, version string, err error) {
 func validProtocol(protocol string) bool {
 	switch protocol {
 	// only scan npm packages
-	case "npm", "":
+	case npmProtocol, "":
 		return true
 	}
 	return false

--- a/pkg/dependency/parser/nodejs/yarn/parse.go
+++ b/pkg/dependency/parser/nodejs/yarn/parse.go
@@ -161,25 +161,27 @@ func looksLikeVersionConstraint(s string) bool {
 	return false
 }
 
-func parsePackagePatterns(target string) (packagename, protocol string, patterns []string, err error) {
+func parsePackagePatterns(target string) (pkgName, protocol string, patterns []string, err error) {
 	patternsSplit := strings.Split(target, ", ")
 
-	var pkgName string
 	// Step 1: detect correct package name and protocol from multiple patterns
 	for _, pattern := range patternsSplit {
 		name, proto, _, parseErr := parsePattern(pattern)
 		if parseErr != nil {
 			continue
 		}
+
+		// Save the first valid package name and protocol
 		if pkgName == "" {
 			pkgName = name
 			protocol = proto
 		}
+
+		// Alias pattern has priority — use the real package name.
+		// Example: "ip@^2.0.0", "ip@npm:@rootio/ip@2.0.0-root.io.1"
+		// Here "ip" is the alias, "@rootio/ip" is the real package.
+		// parsePattern returns the real name for npm: protocol aliases.
 		if proto == "npm" {
-			// npm alias has priority — use the real package name.
-			// Example: "ip@^2.0.0", "ip@npm:@rootio/ip@2.0.0-root.io.1"
-			// Here "ip" is the alias, "@rootio/ip" is the real package.
-			// parsePattern returns the real name for npm: protocol aliases.
 			pkgName = name
 			protocol = proto
 			break

--- a/pkg/dependency/parser/nodejs/yarn/parse_test.go
+++ b/pkg/dependency/parser/nodejs/yarn/parse_test.go
@@ -217,9 +217,9 @@ func TestParsePackagePatterns(t *testing.T) {
 			expectName:     "@rootio/braces",
 			expectProtocol: "npm",
 			expactPatterns: []string{
-				"@rootio/braces@^2.3.1",
-				"@rootio/braces@3.0.2-root.io.1",
-				"@rootio/braces@~3.0.2",
+				"braces@^2.3.1",                     // Keep original name
+				"@rootio/braces@3.0.2-root.io.1",   // Real name from npm: alias
+				"braces@~3.0.2",                     // Keep original name
 			},
 		},
 		{

--- a/pkg/dependency/parser/nodejs/yarn/parse_test.go
+++ b/pkg/dependency/parser/nodejs/yarn/parse_test.go
@@ -217,9 +217,9 @@ func TestParsePackagePatterns(t *testing.T) {
 			expectName:     "@rootio/braces",
 			expectProtocol: "npm",
 			expactPatterns: []string{
-				"braces@^2.3.1",                     // Keep original name
-				"@rootio/braces@3.0.2-root.io.1",   // Real name from npm: alias
-				"braces@~3.0.2",                     // Keep original name
+				"braces@^2.3.1",                  // Keep original name
+				"@rootio/braces@3.0.2-root.io.1", // Real name from npm: alias
+				"braces@~3.0.2",                  // Keep original name
 			},
 		},
 		{

--- a/pkg/dependency/parser/nodejs/yarn/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/yarn/parse_testcase.go
@@ -157,4 +157,18 @@ var (
 			DependsOn: []string{"ms@2.1.2"},
 		},
 	}
+
+	yarnWithAliases = []ftypes.Package{
+		{ID: "@rootio/braces@3.0.2-root.io.1", Name: "@rootio/braces", Version: "3.0.2-root.io.1", Locations: []ftypes.Location{{StartLine: 3, EndLine: 8}}},
+		{ID: "@rootio/ip@2.0.0-root.io.1", Name: "@rootio/ip", Version: "2.0.0-root.io.1", Locations: []ftypes.Location{{StartLine: 15, EndLine: 18}}},
+		{ID: "fill-range@7.0.1", Name: "fill-range", Version: "7.0.1", Locations: []ftypes.Location{{StartLine: 10, EndLine: 13}}},
+		{ID: "lodash-es@4.17.21", Name: "lodash-es", Version: "4.17.21", Locations: []ftypes.Location{{StartLine: 20, EndLine: 23}}},
+	}
+
+	yarnWithAliasesDeps = []ftypes.Dependency{
+		{
+			ID:        "@rootio/braces@3.0.2-root.io.1",
+			DependsOn: []string{"fill-range@7.0.1"},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/yarn/testdata/yarn_with_aliases.lock
+++ b/pkg/dependency/parser/nodejs/yarn/testdata/yarn_with_aliases.lock
@@ -1,0 +1,23 @@
+# yarn lockfile v1
+
+"braces@^2.3.1", "braces@npm:@rootio/braces@3.0.2-root.io.1", "braces@~3.0.2":
+  version "3.0.2-root.io.1"
+  resolved "https://pkg.root.io/npm/@rootio/braces/-/braces-3.0.2-root.io.1.tgz#a74cd5712414f374d0bde3eba741a8e98063aea6"
+  integrity sha512-WnnAm4Y1VcaZdioQuQCruhvn6kd52e2pntzi1b+nUHTqntS4W73oWrwZ+8HtM7MerqR5S/ZZ5r8tDbY3r53shA==
+  dependencies:
+    fill-range "^7.0.1"
+
+"fill-range@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+
+"ip@^2.0.0", "ip@npm:@rootio/ip@2.0.0-root.io.1":
+  version "2.0.0-root.io.1"
+  resolved "https://pkg.root.io/npm/@rootio/ip/-/ip-2.0.0-root.io.1.tgz#35b32364c597337787065a05c43a8f9d3335f334"
+  integrity sha512-WwztdZazH2t+ptepLOSudgFqmFmQ0b+Xa2SQ1eR8yuMTFFoPOwSnD5VvSVH1DKpxhtnmgzuEEGiOxUi92ojh2Q==
+
+"lodash@npm:lodash-es@^4.17.21":
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==

--- a/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
+++ b/pkg/fanal/analyzer/language/nodejs/yarn/yarn.go
@@ -288,11 +288,12 @@ func (a yarnAnalyzer) walkDependencies(parent *types.Package, pkgs map[string]ty
 			continue
 		}
 
-		// Handle aliases
+		// Extract version constraint from npm: protocol if present
+		// Since the parser now resolves aliases, pkg.Name is already correct.
+		// We just need to extract the version constraint from patterns like "npm:package@version".
 		// cf. https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias
 		if m := fragmentRegexp.FindStringSubmatch(constraint); len(m) == 5 {
-			pkg.Name = m[2] // original name
-			constraint = m[4]
+			constraint = m[4] // Extract just the version constraint
 		}
 
 		// Try to find an exact match to the pattern.


### PR DESCRIPTION
## Description
  When Yarn package aliases/overrides use the npm: protocol (e.g.,
  "braces@npm:@rootio/braces@3.0.2"), Trivy was incorrectly parsing
  the alias name instead of the real package name, causing false
  positive vulnerability reports.

  Problem:
  - Pattern "braces@npm:@rootio/braces@3.0.2-root.io.1" was parsed as
    package="braces" instead of package="@rootio/braces"
  - Vulnerability scanner queried the public "braces" package instead
    of the custom "@rootio/braces" package
  - Users with aliased/overridden packages received incorrect CVE reports

  Solution:
  - Added parseNpmAliasTarget() to detect and extract real package names
    from npm: protocol targets
  - Modified parsePackagePatterns() to check all patterns for aliases and
    use the real package name when found
  - Handles edge cases:
    - Scoped packages: "@scope/package@version"
    - Unscoped packages: "package@version"
    - Version tags: "latest", "next" (not treated as aliases)
    - Version ranges: "^1.0.0", "~2.3.4" (not treated as aliases)

  Testing:
  - Added comprehensive unit tests for alias parsing logic
  - Added integration test with real alias examples
  - All existing tests continue to pass
  - Verified with real-world yarn.lock containing @rootio/* aliases

  Impact:
  Reduces false positive vulnerability reports for projects using Yarn
  package aliases/overrides. A project with 16 aliased packages saw
  vulnerability count drop from 34 to 17 (removed 17 false positives).

  Related: https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias
