### PR TITLE
feat(report): include local DB version info in JSON output

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -532,3 +532,15 @@ func overrideDockerRemovedFields(_ *testing.T, want, got *types.Report) {
 	got.Metadata.ImageConfig.Config.Hostname = ""
 	want.Metadata.ImageConfig.Config.Hostname = ""
 }
+
+// overrideDBMetadata clears database metadata fields from TrivyInfo.
+// Database metadata (VulnerabilityDB, JavaDB, CheckBundle) varies based on the
+// local cache state and test environment, so we clear these fields for comparison.
+func overrideDBMetadata(_ *testing.T, want, got *types.Report) {
+	got.Trivy.VulnerabilityDB = nil
+	got.Trivy.JavaDB = nil
+	got.Trivy.CheckBundle = nil
+	want.Trivy.VulnerabilityDB = nil
+	want.Trivy.JavaDB = nil
+	want.Trivy.CheckBundle = nil
+}

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -514,6 +514,8 @@ func (o *Options) ScanOpts() types.ScanOptions {
 		IncludeDevDeps:      o.IncludeDevDeps,
 		Distro:              o.Distro,
 		VulnSeveritySources: o.VulnSeveritySources,
+		CacheDir:            o.CacheDir,
+		IsRemote:            o.ServerAddr != "",
 	}
 }
 

--- a/pkg/scan/export_test.go
+++ b/pkg/scan/export_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // Bridge to expose scan internals to tests in the scan_test package.
@@ -9,4 +10,9 @@ import (
 // GenerateArtifactID exports generateArtifactID for testing.
 func (s Service) GenerateArtifactID(artifactInfo artifact.Reference) string {
 	return s.generateArtifactID(artifactInfo)
+}
+
+// BuildTrivyInfo exports buildTrivyInfo for testing.
+func BuildTrivyInfo(options types.ScanOptions) types.TrivyInfo {
+	return buildTrivyInfo(options)
 }

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -10,9 +10,12 @@ import (
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
 
-// TrivyInfo contains Trivy-specific information
+// TrivyInfo contains Trivy version and database metadata.
 type TrivyInfo struct {
-	Version string `json:",omitempty"` // Trivy version
+	Version         string          `json:",omitempty"`
+	VulnerabilityDB *DBMetadata     `json:",omitempty"`
+	JavaDB          *DBMetadata     `json:",omitempty"`
+	CheckBundle     *BundleMetadata `json:",omitempty"`
 }
 
 // Report represents a scan result

--- a/pkg/types/scan.go
+++ b/pkg/types/scan.go
@@ -120,6 +120,9 @@ type ScanOptions struct {
 	IncludeDevDeps      bool
 	Distro              types.OS // Forced OS
 	VulnSeveritySources []dbTypes.SourceID
+
+	CacheDir string // directory for cached databases
+	IsRemote bool   // true when running in client/server mode
 }
 
 // ScanResponse represents the response from the scan service

--- a/pkg/types/version.go
+++ b/pkg/types/version.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// DBMetadata holds database metadata for vulnerability or Java DB.
+// This is a lightweight struct defined in pkg/types to avoid WASM compatibility
+// issues that would arise from importing pkg/db or pkg/policy.
+type DBMetadata struct {
+	Version      int       `json:",omitempty"`
+	UpdatedAt    time.Time `json:",omitempty"`
+	NextUpdate   time.Time `json:",omitempty"`
+	DownloadedAt time.Time `json:",omitempty"`
+}
+
+func (m DBMetadata) String() string {
+	return fmt.Sprintf(`  Version: %d
+  UpdatedAt: %s
+  NextUpdate: %s
+  DownloadedAt: %s
+`, m.Version, m.UpdatedAt.UTC(), m.NextUpdate.UTC(), m.DownloadedAt.UTC())
+}
+
+// BundleMetadata holds policy/check bundle metadata.
+// This is a lightweight alternative to policy.Metadata to avoid importing
+// pkg/policy which has dependencies incompatible with wasip1/wasm.
+type BundleMetadata struct {
+	Digest       string    `json:",omitempty"`
+	DownloadedAt time.Time `json:",omitempty"`
+}
+
+func (m BundleMetadata) String() string {
+	return fmt.Sprintf(`Check Bundle:
+  Digest: %s
+  DownloadedAt: %s
+`, m.Digest, m.DownloadedAt.UTC())
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -20,6 +20,11 @@ type VersionInfo struct {
 	CheckBundle     *policy.Metadata   `json:",omitempty"`
 }
 
+// AppVersion returns the application version string.
+func AppVersion() string {
+	return app.Version()
+}
+
 func formatDBMetadata(title string, meta metadata.Metadata) string {
 	return fmt.Sprintf(`%s:
   Version: %d


### PR DESCRIPTION
Include local database version information (vulnerability DB, Java DB, check bundle metadata) in JSON output for standalone mode.

This helps assessment teams verify scans are performed with current vulnerability databases, addressing compliance requirements for organizations with monthly scan requirements.

In client/server mode, local DB metadata is not included since databases reside on the server.

Closes #10076
