### PR TITLE
fix(repo): return a nil interface for gitAuth if missing

### DIFF
--- a/pkg/fanal/artifact/repo/git.go
+++ b/pkg/fanal/artifact/repo/git.go
@@ -154,30 +154,26 @@ func newURL(rawurl string) (*url.URL, error) {
 
 // Helper function to check for a GitHub/GitLab token from env vars in order to
 // make authenticated requests to access private repos
-func gitAuth() *http.BasicAuth {
-	var auth *http.BasicAuth
-
+func gitAuth() http.AuthMethod {
 	// The username can be anything for HTTPS Git operations
 	gitUsername := "fanal-aquasecurity-scan"
 
 	// We first check if a GitHub token was provided
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken != "" {
-		auth = &http.BasicAuth{
+		return &http.BasicAuth{
 			Username: gitUsername,
 			Password: githubToken,
 		}
-		return auth
 	}
 
 	// Otherwise we check if a GitLab token was provided
 	gitlabToken := os.Getenv("GITLAB_TOKEN")
 	if gitlabToken != "" {
-		auth = &http.BasicAuth{
+		return &http.BasicAuth{
 			Username: gitUsername,
 			Password: gitlabToken,
 		}
-		return auth
 	}
 
 	// If no token was provided, we simply return a nil,


### PR DESCRIPTION
In our gitAuth function, we return a nil http.BasicAuth pointer when there is no GITLAB_TOKEN or GITHUB_TOKEN present. However, this results in an http.AuthMethod with a non-nil type, but a nil value, which results in go-git assuming that there is an actual AuthMethod present.

Why does this matter? Because for URLs with username:password strings, go-git extracts the username and password into an http.BasicAuth struct, and uses that as the AuthMethod, but when we pass the nil pointer, it overwrites this http.BasicAuth that was extracted.

The reason this is mostly not an issue is that `net/http` will automatically add the correct headers when it notices that the URL has username:password. However, if the remote server redirects for any reason, go-git will not have any authentication for the subsequent request, and it will fail.

Thus, the following fails:

```
trivy repo https://u:$GITLAB_TOKEN@gitlab.com/namespace/project
```

Because we pass a nil pointer to go-git, who overwrites the AuthMethod it had extracted from the URL. net/http adds the headers anyway, but receives a redirect response, so go-git makes an unauthenticated request, which fails.

On GitHub, getting the same behaviour is trickier because it doesn't redirect to `.git` URLs, but it's certainly still possible.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
