### PR TITLE
fix(server): exclude JavaDB and CheckBundle from /version endpoint

### DIFF
--- a/pkg/rpc/server/listen.go
+++ b/pkg/rpc/server/listen.go
@@ -146,7 +146,7 @@ func (s Server) NewServeMux(ctx context.Context, serverCache cache.Cache, dbUpda
 	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 
-		if err := json.NewEncoder(w).Encode(version.NewVersionInfo(s.cacheDir)); err != nil {
+		if err := json.NewEncoder(w).Encode(version.NewVersionInfo(s.cacheDir, version.Server())); err != nil {
 			log.Error("Version error", log.Err(err))
 		}
 	})

--- a/pkg/rpc/server/listen_test.go
+++ b/pkg/rpc/server/listen_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aquasecurity/trivy/pkg/clock"
 	"github.com/aquasecurity/trivy/pkg/db"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/policy"
 	"github.com/aquasecurity/trivy/pkg/version"
 	rpcCache "github.com/aquasecurity/trivy/rpc/cache"
 )
@@ -218,7 +217,8 @@ func Test_VersionEndpoint(t *testing.T) {
 	var versionInfo version.VersionInfo
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&versionInfo))
 
-	expected := version.VersionInfo{
+	// Server mode excludes JavaDB and CheckBundle as they are managed on the client side
+	want := version.VersionInfo{
 		Version: "dev",
 		VulnerabilityDB: &metadata.Metadata{
 			Version:      2,
@@ -226,10 +226,6 @@ func Test_VersionEndpoint(t *testing.T) {
 			UpdatedAt:    time.Date(2023, 7, 20, 12, 11, 37, 696263932, time.UTC),
 			DownloadedAt: time.Date(2023, 7, 25, 7, 1, 41, 239158000, time.UTC),
 		},
-		CheckBundle: &policy.Metadata{
-			Digest:       "sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43",
-			DownloadedAt: time.Date(2023, 7, 23, 16, 40, 33, 122462000, time.UTC),
-		},
 	}
-	assert.Equal(t, expected, versionInfo)
+	assert.Equal(t, want, versionInfo)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -10,32 +10,62 @@ import (
 	"github.com/aquasecurity/trivy/pkg/policy"
 )
 
-func Test_BuildVersionInfo(t *testing.T) {
-
-	expected := VersionInfo{
-		Version: "dev",
-		VulnerabilityDB: &metadata.Metadata{
-			Version:      2,
-			NextUpdate:   time.Date(2023, 7, 20, 18, 11, 37, 696263532, time.UTC),
-			UpdatedAt:    time.Date(2023, 7, 20, 12, 11, 37, 696263932, time.UTC),
-			DownloadedAt: time.Date(2023, 7, 25, 7, 1, 41, 239158000, time.UTC),
+func TestNewVersionInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []VersionOption
+		want VersionInfo
+	}{
+		{
+			name: "default",
+			opts: nil,
+			want: VersionInfo{
+				Version: "dev",
+				VulnerabilityDB: &metadata.Metadata{
+					Version:      2,
+					NextUpdate:   time.Date(2023, 7, 20, 18, 11, 37, 696263532, time.UTC),
+					UpdatedAt:    time.Date(2023, 7, 20, 12, 11, 37, 696263932, time.UTC),
+					DownloadedAt: time.Date(2023, 7, 25, 7, 1, 41, 239158000, time.UTC),
+				},
+				JavaDB: &metadata.Metadata{
+					Version:      1,
+					NextUpdate:   time.Date(2023, 7, 28, 1, 3, 52, 169192565, time.UTC),
+					UpdatedAt:    time.Date(2023, 7, 25, 1, 3, 52, 169192765, time.UTC),
+					DownloadedAt: time.Date(2023, 7, 25, 9, 37, 48, 906152000, time.UTC),
+				},
+				CheckBundle: &policy.Metadata{
+					Digest:       "sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43",
+					DownloadedAt: time.Date(2023, 7, 23, 16, 40, 33, 122462000, time.UTC),
+				},
+			},
 		},
-		JavaDB: &metadata.Metadata{
-			Version:      1,
-			NextUpdate:   time.Date(2023, 7, 28, 1, 3, 52, 169192565, time.UTC),
-			UpdatedAt:    time.Date(2023, 7, 25, 1, 3, 52, 169192765, time.UTC),
-			DownloadedAt: time.Date(2023, 7, 25, 9, 37, 48, 906152000, time.UTC),
-		},
-		CheckBundle: &policy.Metadata{
-			Digest:       "sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43",
-			DownloadedAt: time.Date(2023, 7, 23, 16, 40, 33, 122462000, time.UTC),
+		{
+			name: "server mode excludes JavaDB and CheckBundle",
+			opts: []VersionOption{Server()},
+			want: VersionInfo{
+				Version: "dev",
+				VulnerabilityDB: &metadata.Metadata{
+					Version:      2,
+					NextUpdate:   time.Date(2023, 7, 20, 18, 11, 37, 696263532, time.UTC),
+					UpdatedAt:    time.Date(2023, 7, 20, 12, 11, 37, 696263932, time.UTC),
+					DownloadedAt: time.Date(2023, 7, 25, 7, 1, 41, 239158000, time.UTC),
+				},
+				JavaDB:      nil,
+				CheckBundle: nil,
+			},
 		},
 	}
-	assert.Equal(t, expected, NewVersionInfo("testdata/testcache"))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewVersionInfo("testdata/testcache", tt.opts...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
-func Test_VersionInfoString(t *testing.T) {
-	expected := `Version: dev
+func TestVersionInfo_String(t *testing.T) {
+	want := `Version: dev
 Vulnerability DB:
   Version: 2
   UpdatedAt: 2023-07-20 12:11:37.696263932 +0000 UTC
@@ -50,6 +80,6 @@ Check Bundle:
   Digest: sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43
   DownloadedAt: 2023-07-23 16:40:33.122462 +0000 UTC
 `
-	versionInfo := NewVersionInfo("testdata/testcache")
-	assert.Equal(t, expected, versionInfo.String())
+	got := NewVersionInfo("testdata/testcache")
+	assert.Equal(t, want, got.String())
 }


### PR DESCRIPTION
## Description

JavaDB and CheckBundle are managed on the client side in client/server mode, so returning them from the server `/version` endpoint is incorrect.

This PR adds a functional option to `NewVersionInfo()` to exclude these fields when called from the server.

### Before
```bash
$ curl -s http://localhost:4954/version | jq .
{
  "Version": "0.68.1",
  "VulnerabilityDB": {
    "Version": 2,
    "NextUpdate": "2026-01-31T06:34:45Z",
    "UpdatedAt": "2026-01-30T06:34:45Z",
    "DownloadedAt": "2026-01-30T07:42:22Z"
  },
  "JavaDB": {
    "Version": 1,
    "NextUpdate": "2025-12-15T01:12:39Z",
    "UpdatedAt": "2025-12-12T01:12:39Z",
    "DownloadedAt": "2025-12-12T17:10:03Z"
  },
  "CheckBundle": {
    "Digest": "sha256:0491169789b867ae5a7353381220c1d4d97b3a0d6d9dfd84a25d06f0ba68aa93",
    "DownloadedAt": "2025-12-23T17:02:42Z"
  }
}
```

### After
```bash
$ curl -s http://localhost:4954/version | jq .
{
  "Version": "0.68.1",
  "VulnerabilityDB": {
    "Version": 2,
    "NextUpdate": "2026-01-31T06:34:45Z",
    "UpdatedAt": "2026-01-30T06:34:45Z",
    "DownloadedAt": "2026-01-30T07:42:22Z"
  }
}
```

## Related issues
- Close #10099

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).