### PR TITLE
refactor: unify scanner error limit and compiler limit

### DIFF
--- a/pkg/flag/rego_flags.go
+++ b/pkg/flag/rego_flags.go
@@ -83,7 +83,7 @@ var (
 		ConfigName:    "rego.error-limit",
 		Usage:         "maximum number of compile errors allowed during Rego policy evaluation",
 		TelemetrySafe: true,
-		Default:       rego.CompileErrorLimit,
+		Default:       rego.DefaultAllowedRegoErrors,
 	}
 )
 

--- a/pkg/iac/rego/embed.go
+++ b/pkg/iac/rego/embed.go
@@ -41,7 +41,7 @@ func RegisterRegoRules(modules map[string]*ast.Module) {
 		WithCapabilities(nil).
 		WithUseTypeCheckAnnotations(true)
 
-	compiler.SetErrorLimit(CompileErrorLimit)
+	compiler.SetErrorLimit(DefaultAllowedRegoErrors)
 	compiler.Compile(modules)
 	if compiler.Failed() {
 		// we should panic as the embedded rego policies are syntactically incorrect...

--- a/pkg/iac/rego/load_test.go
+++ b/pkg/iac/rego/load_test.go
@@ -29,7 +29,7 @@ func Test_RegoScanning_WithSomeInvalidPolicies(t *testing.T) {
 		var debugBuf bytes.Buffer
 		slog.SetDefault(log.New(log.NewHandler(&debugBuf, nil)))
 		scanner := rego.NewScanner(
-			rego.WithRegoErrorLimits(0),
+			rego.WithMaxAllowedErrors(0),
 			rego.WithPolicyDirs("."),
 		)
 
@@ -42,7 +42,7 @@ func Test_RegoScanning_WithSomeInvalidPolicies(t *testing.T) {
 		var debugBuf bytes.Buffer
 		slog.SetDefault(log.New(log.NewHandler(&debugBuf, nil)))
 		scanner := rego.NewScanner(
-			rego.WithRegoErrorLimits(1),
+			rego.WithMaxAllowedErrors(1),
 			rego.WithPolicyDirs("."),
 		)
 
@@ -206,7 +206,7 @@ deny {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner := rego.NewScanner(
-				rego.WithRegoErrorLimits(0),
+				rego.WithMaxAllowedErrors(0),
 				rego.WithEmbeddedPolicies(false),
 				rego.WithPolicyDirs("."),
 			)
@@ -254,7 +254,7 @@ func Test_FallbackErrorWithoutLocation(t *testing.T) {
 		},
 	}
 
-	for i := range rego.CompileErrorLimit + 1 {
+	for i := range rego.DefaultAllowedRegoErrors + 1 {
 		src := `# METADATA
 # schemas:
 # - input: schema["fooschema"]

--- a/pkg/iac/rego/options.go
+++ b/pkg/iac/rego/options.go
@@ -90,10 +90,10 @@ func WithDataFilesystem(fsys fs.FS) options.ScannerOption {
 	}
 }
 
-func WithRegoErrorLimits(limit int) options.ScannerOption {
+func WithMaxAllowedErrors(limit int) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if ss, ok := s.(*Scanner); ok {
-			ss.regoErrorLimit = limit
+			ss.maxAllowedErrors = limit
 		}
 	}
 }

--- a/pkg/iac/rego/scanner_test.go
+++ b/pkg/iac/rego/scanner_test.go
@@ -806,7 +806,7 @@ deny {
 	})
 
 	scanner := rego.NewScanner(
-		rego.WithRegoErrorLimits(0),
+		rego.WithMaxAllowedErrors(0),
 		rego.WithPolicyDirs("policies"),
 	)
 

--- a/pkg/iac/scanners/dockerfile/scanner_test.go
+++ b/pkg/iac/scanners/dockerfile/scanner_test.go
@@ -563,7 +563,7 @@ COPY --from=dep /binary /`
 				rego.WithPolicyDirs("rules"),
 				rego.WithEmbeddedLibraries(true),
 				rego.WithTrace(&traceBuf),
-				rego.WithRegoErrorLimits(0),
+				rego.WithMaxAllowedErrors(0),
 			)
 
 			results, err := scanner.ScanFS(t.Context(), fsys, "code")
@@ -685,7 +685,7 @@ deny contains res if {
 				rego.WithPolicyReader(strings.NewReader(check)),
 				rego.WithPolicyNamespaces("user"),
 				rego.WithEmbeddedLibraries(true),
-				rego.WithRegoErrorLimits(0),
+				rego.WithMaxAllowedErrors(0),
 			)
 			results, err := scanner.ScanFS(t.Context(), fsys, ".")
 			require.NoError(t, err)

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -856,7 +856,7 @@ deny[res] {
 		rego.WithPolicyNamespaces("user"),
 		rego.WithEmbeddedLibraries(false),
 		rego.WithEmbeddedPolicies(false),
-		rego.WithRegoErrorLimits(0),
+		rego.WithMaxAllowedErrors(0),
 		ScannerWithAllDirectories(true),
 	)
 

--- a/pkg/iac/scanners/terraform/setup_test.go
+++ b/pkg/iac/scanners/terraform/setup_test.go
@@ -93,7 +93,7 @@ func scanFS(fsys fs.FS, target string, opts ...options.ScannerOption) (scan.Resu
 	s := New(append(
 		[]options.ScannerOption{
 			rego.WithEmbeddedLibraries(true),
-			rego.WithRegoErrorLimits(0),
+			rego.WithMaxAllowedErrors(0),
 			ScannerWithAllDirectories(true),
 			ScannerWithSkipCachedModules(true),
 			ScannerWithStopOnHCLError(true),

--- a/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
+++ b/pkg/iac/scanners/terraformplan/snapshot/scanner_test.go
@@ -51,7 +51,7 @@ func Test_ScanFS(t *testing.T) {
 				rego.WithPolicyNamespaces("user"),
 				rego.WithEmbeddedLibraries(false),
 				rego.WithEmbeddedPolicies(false),
-				rego.WithRegoErrorLimits(0),
+				rego.WithMaxAllowedErrors(0),
 				tfscanner.ScannerWithSkipCachedModules(true),
 			)
 

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -247,7 +247,7 @@ func initRegoOptions(opt ScannerOption) ([]options.ScannerOption, error) {
 	}
 
 	if opt.RegoErrorLimit >= 0 {
-		opts = append(opts, rego.WithRegoErrorLimits(opt.RegoErrorLimit))
+		opts = append(opts, rego.WithMaxAllowedErrors(opt.RegoErrorLimit))
 	}
 
 	policyFS, policyPaths, err := CreatePolicyFS(opt.PolicyPaths)


### PR DESCRIPTION
## Description

This PR refactors the scanner to unify and clarify error handling. Rename `regoErrorLimit` field and option to `maxAllowedErrors` to remove misleading naming. Adjust internal compiler error limit to match the scanner's allowed errors and ignore compiler-internal "error limit reached" markers.

Fixes: https://github.com/aquasecurity/trivy/actions/runs/21514223176/job/61988481770?pr=10090

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
