### PR TITLE
fix: update PhotonOS feed URL

### DIFF
--- a/docs/guide/coverage/os/photon.md
+++ b/docs/guide/coverage/os/photon.md
@@ -50,6 +50,6 @@ Trivy identifies licenses by examining the metadata of RPM packages.
 
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
 
-[metadata]: https://packages.vmware.com/photon/photon_cve_metadata/
+[metadata]: https://packages.broadcom.com/photon/photon_cve_metadata/
 
 [vulnerability statuses]: ../../configuration/filtering.md#by-status

--- a/docs/guide/scanner/vulnerability.md
+++ b/docs/guide/scanner/vulnerability.md
@@ -403,7 +403,7 @@ Example logic for the following vendor severity levels when scanning an Alpine i
 [rocky]: https://download.rockylinux.org/pub/rocky/
 [oracle]: https://linux.oracle.com/security/oval/
 [suse]: http://ftp.suse.com/pub/projects/security/cvrf/
-[photon]: https://packages.vmware.com/photon/photon_cve_metadata/
+[photon]: https://packages.broadcom.com/photon/photon_cve_metadata/
 [azure]: https://github.com/microsoft/AzureLinuxVulnerabilityData/
 [rootio]: https://api.root.io/external/patch_feed
 [seal]: http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip

--- a/integration/testdata/fixtures/db/data-source.yaml
+++ b/integration/testdata/fixtures/db/data-source.yaml
@@ -54,7 +54,7 @@
       value:
         ID: "photon"
         Name: "Photon OS CVE metadata"
-        URL: "https://packages.vmware.com/photon/photon_cve_metadata/"
+        URL: "https://packages.broadcom.com/photon/photon_cve_metadata/"
     - key: alma 8
       value:
         ID: "alma"

--- a/integration/testdata/photon-30.json.golden
+++ b/integration/testdata/photon-30.json.golden
@@ -100,7 +100,7 @@
           "DataSource": {
             "ID": "photon",
             "Name": "Photon OS CVE metadata",
-            "URL": "https://packages.vmware.com/photon/photon_cve_metadata/"
+            "URL": "https://packages.broadcom.com/photon/photon_cve_metadata/"
           },
           "Fingerprint": "sha256:4e81b35fc699744ea7b1f01c4d40f4be024599b0b89bc703b5d96118537d214b",
           "Title": "bash: when effective UID is not equal to its real UID the saved UID is not dropped",
@@ -165,7 +165,7 @@
           "DataSource": {
             "ID": "photon",
             "Name": "Photon OS CVE metadata",
-            "URL": "https://packages.vmware.com/photon/photon_cve_metadata/"
+            "URL": "https://packages.broadcom.com/photon/photon_cve_metadata/"
           },
           "Fingerprint": "sha256:12a8a4ae7fd278f8aeb8001707801d38ca7ccea68430208692a2b7d40860f590",
           "Title": "curl: double free due to subsequent call of realloc()",
@@ -238,7 +238,7 @@
           "DataSource": {
             "ID": "photon",
             "Name": "Photon OS CVE metadata",
-            "URL": "https://packages.vmware.com/photon/photon_cve_metadata/"
+            "URL": "https://packages.broadcom.com/photon/photon_cve_metadata/"
           },
           "Fingerprint": "sha256:8625bdfcbb7eeaffcef1af0571c227ca2c742411ee81cb598749dbfdc4a40d8c",
           "Title": "curl: double free due to subsequent call of realloc()",

--- a/pkg/detector/ospkg/photon/photon_test.go
+++ b/pkg/detector/ospkg/photon/photon_test.go
@@ -63,7 +63,7 @@ func TestScanner_Detect(t *testing.T) {
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Photon,
 						Name: "Photon OS CVE metadata",
-						URL:  "https://packages.vmware.com/photon/photon_cve_metadata/",
+						URL:  "https://packages.broadcom.com/photon/photon_cve_metadata/",
 					},
 				},
 			},

--- a/pkg/detector/ospkg/photon/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/photon/testdata/fixtures/data-source.yaml
@@ -4,4 +4,4 @@
       value:
         ID: "photon"
         Name: "Photon OS CVE metadata"
-        URL: "https://packages.vmware.com/photon/photon_cve_metadata/"
+        URL: "https://packages.broadcom.com/photon/photon_cve_metadata/"


### PR DESCRIPTION
There was a change in the Photon OS CVE feed. It is now served at https://packages.broadcom.com/photon/photon_cve_metadata.

The previous feed (https://packages.vmware.com/photon/photon_cve_metadata/) was last updated in December 2025 and is no longer maintained in favor of the new feed, which was recently updated.

Related PRs:
- https://github.com/aquasecurity/trivy-db/pull/625
- https://github.com/aquasecurity/vuln-list-update/pull/402