### PR TITLE
fix(misconf): initialize custom annotation field if empty

### DIFF
--- a/pkg/iac/rego/metadata.go
+++ b/pkg/iac/rego/metadata.go
@@ -200,11 +200,15 @@ func (sm *StaticMetadata) FromAnnotations(annotations *ast.Annotations) error {
 		}
 		sm.References = append(sm.References, resource.Ref.String())
 	}
-	if custom := annotations.Custom; custom != nil {
-		if err := sm.populate(custom); err != nil {
-			return err
-		}
+
+	if annotations.Custom == nil {
+		annotations.Custom = make(map[string]any)
 	}
+
+	if err := sm.populate(annotations.Custom); err != nil {
+		return err
+	}
+
 	if len(annotations.RelatedResources) > 0 {
 		sm.PrimaryURL = annotations.RelatedResources[0].Ref.String()
 	}


### PR DESCRIPTION
## Description

This PR fixes an issue caused by recent changes in OPA's [annotation parsing](https://github.com/open-policy-agent/opa/pull/8210), where the `Custom` field is no longer initialized if it is missing from the annotations. It ensures that `Custom` is properly initialized when empty, so that metadata is correctly populated.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/10116

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
