### PR TITLE
feat(misconf): adapt ARM k8s clusters (#9696)

### DIFF
--- a/pkg/iac/adapters/arm/container/adapt.go
+++ b/pkg/iac/adapters/arm/container/adapt.go
@@ -11,7 +11,60 @@ func Adapt(deployment azure.Deployment) container.Container {
 	}
 }
 
-func adaptKubernetesClusters(_ azure.Deployment) []container.KubernetesCluster {
+func adaptKubernetesClusters(deployment azure.Deployment) []container.KubernetesCluster {
+	var clusters []container.KubernetesCluster
+	for _, resource := range deployment.GetResourcesByType("Microsoft.ContainerService/managedClusters") {
+		props := resource.Properties
 
-	return nil
+		cluster := container.KubernetesCluster{
+			Metadata: resource.Metadata,
+			NetworkProfile: container.NetworkProfile{
+				Metadata:      props.GetMapValue("networkProfile").GetMetadata(),
+				NetworkPolicy: props.GetMapValue("networkProfile").GetMapValue("networkPolicy").AsStringValue("", props.GetMapValue("networkProfile").GetMetadata()),
+			},
+			EnablePrivateCluster:        props.GetMapValue("apiServerAccessProfile").GetMapValue("enablePrivateCluster").AsBoolValue(false, props.GetMapValue("apiServerAccessProfile").GetMetadata()),
+			APIServerAuthorizedIPRanges: nil, // Extracted below
+			RoleBasedAccessControl: container.RoleBasedAccessControl{
+				Metadata: props.GetMetadata(),
+				Enabled:  props.GetMapValue("enableRBAC").AsBoolValue(false, props.GetMetadata()),
+			},
+			AddonProfile: container.AddonProfile{
+				Metadata: props.GetMapValue("addonProfiles").GetMetadata(),
+				OMSAgent: container.OMSAgent{
+					Metadata: props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMetadata(),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMapValue("enabled").AsBoolValue(false, props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMetadata()),
+				},
+				AzurePolicy: container.AzurePolicy{
+					Metadata: props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMetadata(),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMapValue("enabled").AsBoolValue(false, props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMetadata()),
+				},
+			},
+			DiskEncryptionSetID: props.GetMapValue("diskEncryptionSetID").AsStringValue("", props.GetMetadata()),
+			AgentPools:          adaptAgentPools(resource),
+		}
+
+		// API Server Authorized IP Ranges
+		if ranges := props.GetMapValue("apiServerAccessProfile").GetMapValue("authorizedIPRanges"); !ranges.IsNull() {
+			cluster.APIServerAuthorizedIPRanges = ranges.AsStringValuesList("")
+		}
+
+		clusters = append(clusters, cluster)
+	}
+	return clusters
+}
+
+func adaptAgentPools(resource azure.Resource) []container.AgentPool {
+	var pools []container.AgentPool
+	// agentPoolProfiles is an array of objects
+	profiles := resource.Properties.GetMapValue("agentPoolProfiles")
+	if profiles.Kind == azure.KindArray {
+		for _, profile := range profiles.AsList() {
+			pools = append(pools, container.AgentPool{
+				Metadata:            profile.GetMetadata(),
+				DiskEncryptionSetID: profile.GetMapValue("diskEncryptionSetID").AsStringValue("", profile.GetMetadata()),
+				NodeType:            profile.GetMapValue("type").AsStringValue("VirtualMachineScaleSets", profile.GetMetadata()),
+			})
+		}
+	}
+	return pools
 }

--- a/pkg/iac/adapters/arm/container/adapt_test.go
+++ b/pkg/iac/adapters/arm/container/adapt_test.go
@@ -1,0 +1,121 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/trivy/pkg/iac/adapters/arm/adaptertest"
+	"github.com/aquasecurity/trivy/pkg/iac/providers/azure/container"
+	"github.com/aquasecurity/trivy/pkg/iac/types"
+)
+
+func TestAdapt(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		expected container.Container
+	}{
+		{
+			name: "complete",
+			source: `{
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "properties": {
+        "networkProfile": {
+          "networkPolicy": "calico"
+        },
+        "apiServerAccessProfile": {
+          "enablePrivateCluster": true,
+          "authorizedIPRanges": ["1.2.3.4/32"]
+        },
+        "enableRBAC": true,
+        "addonProfiles": {
+          "omsagent": { "enabled": true },
+          "azurepolicy": { "enabled": true }
+        },
+        "diskEncryptionSetID": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/des",
+        "agentPoolProfiles": [
+          {
+            "name": "nodepool1",
+            "type": "VirtualMachineScaleSets",
+            "diskEncryptionSetID": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/des-pool"
+          }
+        ]
+      }
+    }
+  ]
+}`,
+			expected: container.Container{
+				KubernetesClusters: []container.KubernetesCluster{
+					{
+						NetworkProfile: container.NetworkProfile{
+							NetworkPolicy: types.StringTest("calico"),
+						},
+						EnablePrivateCluster:        types.BoolTest(true),
+						APIServerAuthorizedIPRanges: []types.StringValue{types.StringTest("1.2.3.4/32")},
+						RoleBasedAccessControl: container.RoleBasedAccessControl{
+							Enabled: types.BoolTest(true),
+						},
+						AddonProfile: container.AddonProfile{
+							OMSAgent: container.OMSAgent{
+								Enabled: types.BoolTest(true),
+							},
+							AzurePolicy: container.AzurePolicy{
+								Enabled: types.BoolTest(true),
+							},
+						},
+						DiskEncryptionSetID: types.StringTest("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/des"),
+						AgentPools: []container.AgentPool{
+							{
+								DiskEncryptionSetID: types.StringTest("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/diskEncryptionSets/des-pool"),
+								NodeType:            types.StringTest("VirtualMachineScaleSets"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "defaults",
+			source: `{
+  "resources": [
+    {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "properties": {
+      }
+    }
+  ]
+}`,
+			expected: container.Container{
+				KubernetesClusters: []container.KubernetesCluster{
+					{
+						NetworkProfile: container.NetworkProfile{
+							NetworkPolicy: types.StringTest(""),
+						},
+						EnablePrivateCluster:        types.BoolTest(false),
+						APIServerAuthorizedIPRanges: nil,
+						RoleBasedAccessControl: container.RoleBasedAccessControl{
+							Enabled: types.BoolTest(false),
+						},
+						AddonProfile: container.AddonProfile{
+							OMSAgent: container.OMSAgent{
+								Enabled: types.BoolTest(false),
+							},
+							AzurePolicy: container.AzurePolicy{
+								Enabled: types.BoolTest(false),
+							},
+						},
+						DiskEncryptionSetID: types.StringTest(""),
+						AgentPools:          nil,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adaptertest.AdaptAndCompare(t, tt.source, tt.expected, Adapt)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Implement the ARM adapter for `Microsoft.ContainerService/managedClusters`.
Previously, this was a placeholder. This PR adds the logic to map ARM properties (Network Profile, RBAC, Addons like OMSAgent and AzurePolicy, Private Cluster settings, etc.) to the Trivy `container.KubernetesCluster` struct.

## Related issues
- Close #9696

## Related PRs
- #6005 (Introduction of the placeholder)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).