### PR TITLE
feat(plugin): implement WASM module instance pooling

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -484,10 +484,11 @@ func (m *wasmModule) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 	log.Debug("Module analyzing...", log.String("module", m.name), log.FilePath(filePath))
 
 	// Get an instance from the pool
-	inst, _ := m.pool.Get().(*wasmInstance)
-	if inst == nil {
+	val := m.pool.Get()
+	if val == nil {
 		return nil, xerrors.New("failed to instantiate WASM module")
 	}
+	inst := val.(*wasmInstance)
 	defer m.pool.Put(inst)
 
 	if err := inst.memFS.initialize(filePath, input.Content); err != nil {
@@ -545,10 +546,11 @@ func (m *wasmModule) PostScan(ctx context.Context, results types.Results) (types
 	}
 
 	// Get an instance from the pool
-	inst, _ := m.pool.Get().(*wasmInstance)
-	if inst == nil {
+	val := m.pool.Get()
+	if val == nil {
 		return nil, xerrors.New("failed to instantiate WASM module")
 	}
+	inst := val.(*wasmInstance)
 	defer m.pool.Put(inst)
 
 	// Marshal the argument into WASM memory so that the WASM module can read it.

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -3,6 +3,7 @@ package module
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -176,11 +177,11 @@ func (m *Manager) Close(ctx context.Context) error {
 	var errs error
 	for _, mod := range m.modules {
 		if err := mod.Close(ctx); err != nil {
-			errs = error.Join(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 	if err := m.cache.Close(ctx); err != nil {
-		errs = error.Join(errs, err)
+		errs = errors.Join(errs, err)
 	}
 	return errs
 }

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -422,7 +422,7 @@ func newWASMPlugin(ctx context.Context, ccache wazero.CompilationCache, code []b
 			// Panic on error as `New` cannot return error
 			inst, err := instantiate()
 			if err != nil {
-				panic(err) //nolint:gocritic
+				return nil
 			}
 			return inst
 		},
@@ -484,7 +484,10 @@ func (m *wasmModule) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 	log.Debug("Module analyzing...", log.String("module", m.name), log.FilePath(filePath))
 
 	// Get an instance from the pool
-	inst := m.pool.Get().(*wasmInstance)
+	inst, _ := m.pool.Get().(*wasmInstance)
+	if inst == nil {
+		return nil, xerrors.New("failed to instantiate WASM module")
+	}
 	defer m.pool.Put(inst)
 
 	if err := inst.memFS.initialize(filePath, input.Content); err != nil {
@@ -542,7 +545,10 @@ func (m *wasmModule) PostScan(ctx context.Context, results types.Results) (types
 	}
 
 	// Get an instance from the pool
-	inst := m.pool.Get().(*wasmInstance)
+	inst, _ := m.pool.Get().(*wasmInstance)
+	if inst == nil {
+		return nil, xerrors.New("failed to instantiate WASM module")
+	}
 	defer m.pool.Put(inst)
 
 	// Marshal the argument into WASM memory so that the WASM module can read it.

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -422,7 +422,7 @@ func newWASMPlugin(ctx context.Context, ccache wazero.CompilationCache, code []b
 			// Panic on error as `New` cannot return error
 			inst, err := instantiate()
 			if err != nil {
-				panic(err)
+				panic(err) //nolint:gocritic
 			}
 			return inst
 		},


### PR DESCRIPTION
## Description
This PR implements module instance pooling for WASM modules. Previously, WASM module analysis was serialized using a mutex because `wazero` module instances are not thread-safe. This change introduces a `sync.Pool` to manage a pool of `wasmInstance`s, allowing concurrent execution of `Analyze` and `PostScan` methods. This directly addresses the TODO comment in `pkg/module/module.go` regarding performance improvements to "improve the Analyze performance by having module instance pool".

Key changes:
- Refactored `wasmModule` to be a manager that holds a `sync.Pool` of instances.
- Introduced `wasmInstance` struct to hold stateful module data (`api.Module`, `memFS`, exported functions).
- Updated `Analyze` and `PostScan` to lease instances from the pool for the effective duration of the call.
- Updated `Close` to properly close the `wazero.Runtime` and cleanup resources.

## Related issues
- Addresses "TODO: This is temporary solution and we could improve the Analyze performance by having module instance pool."

## Related PRs
<!-- Remove this section if you don't have related PRs. -->

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works. (Verified that existing tests pass with the refactoring).
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
