### PR TITLE
ci: use 1.25 version for setup-go instead of version from go.mod

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           check-latest: true # Ensure we use the latest Go patch version
           cache: false
 

--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 

--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  GO_VERSION: '1.25'
+
 jobs:
   test-images:
     name: Cache test images
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -54,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -88,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           check-latest: true # Ensure we use the latest Go patch version
           cache: false
 

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
           check-latest: true # Ensure we use the latest Go patch version
 

--- a/.github/workflows/spdx-cron.yaml
+++ b/.github/workflows/spdx-cron.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+env:
+  GO_VERSION: '1.25'
+
 jobs:
   test:
     name: Test
@@ -24,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -79,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -113,7 +116,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -133,7 +136,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -169,7 +172,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -204,7 +207,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true # Ensure we use the latest Go patch version
 
@@ -240,7 +243,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version-file: go.mod
+        go-version: ${{ env.GO_VERSION }}
         cache: false
         check-latest: true # Ensure we use the latest Go patch version
 


### PR DESCRIPTION
## Description

Since the `check-latest` flag does not work for `major.minor.patch` versions (the exact specified version is always used), we can no longer use the version from the `go.mod` file.

  To avoid the need to update `go.mod` for every patch release, we now specify the `major.minor` version directly in the workflow files.

  Future changes will only be required when upgrading to Go 1.26.

  See: https://github.com/actions/setup-go/issues/713#issuecomment-3851031540

  ## Changes

  - `.github/workflows/test.yaml`
  - `.github/workflows/cache-test-assets.yaml`
  - `.github/workflows/release.yaml`
  - `.github/workflows/reusable-release.yaml`
  - `.github/workflows/spdx-cron.yaml`
  - `.github/workflows/auto-update-labels.yaml`
  - `.github/workflows/apidiff.yaml`

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
