### PR TITLE
ci: add composite action for Go setup

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,31 @@
+name: Setup Go
+description: >
+  Set up Go with the major.minor version extracted from go.mod.
+  This ensures check-latest works correctly even when go.mod contains a patch version.
+  cf. https://github.com/actions/setup-go/issues/713
+
+inputs:
+  go-version-file:
+    description: Path to the go.mod file
+    required: false
+    default: go.mod
+
+runs:
+  using: composite
+  steps:
+    - name: Extract Go version from go.mod
+      id: go-version
+      shell: bash
+      run: |
+        # Extract the major.minor version from the go directive in go.mod
+        # e.g. 1.25.5 → 1.25
+        go_version=$(grep -m1 '^go ' "${{ inputs.go-version-file }}" | awk '{print $2}')
+        major_minor=$(echo "$go_version" | cut -d. -f1,2)
+        echo "version=$major_minor" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Go
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+        cache: false
+        check-latest: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: monthly
     groups:

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -62,11 +62,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          check-latest: true # Ensure we use the latest Go patch version
-          cache: false
+        uses: ./.github/actions/setup-go
 
       # Ensure the base commit exists locally for go-apidiff to compare against.
       # Even though we checkout the merge commit, go-apidiff needs the base ref to exist.

--- a/.github/workflows/auto-update-labels.yaml
+++ b/.github/workflows/auto-update-labels.yaml
@@ -14,11 +14,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -18,11 +18,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -52,11 +48,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -86,11 +78,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Run golangci-lint for caching
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,11 +71,7 @@ jobs:
           git config --global user.name "GitHub Actions"
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          check-latest: true # Ensure we use the latest Go patch version
-          cache: false
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -65,11 +65,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false # Disable cache to avoid free space issues during `Post Setup Go` step.
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0

--- a/.github/workflows/spdx-cron.yaml
+++ b/.github/workflows/spdx-cron.yaml
@@ -13,11 +13,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: go mod tidy
         run: |
@@ -77,11 +73,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -111,11 +103,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -131,11 +119,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -167,11 +151,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -202,11 +182,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-        with:
-          go-version-file: go.mod
-          cache: false
-          check-latest: true # Ensure we use the latest Go patch version
+        uses: ./.github/actions/setup-go
 
       - name: Install Go tools
         run: go install tool # GOBIN is added to the PATH by the setup-go action
@@ -238,11 +214,7 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
-      with:
-        go-version-file: go.mod
-        cache: false
-        check-latest: true # Ensure we use the latest Go patch version
+      uses: ./.github/actions/setup-go
 
     - name: Determine GoReleaser ID
       id: goreleaser_id


### PR DESCRIPTION
## Description

When `go.mod` contains a patch version (e.g. `go 1.25.5`), `setup-go` treats it as a pinned version and `check-latest` does not resolve the latest patch release. This adds a composite action that extracts only `major.minor` from `go.mod` so that `check-latest` works correctly.

All 13 usages of `actions/setup-go` across 7 workflow files are replaced with the composite action, centralizing the configuration.

cf. https://github.com/actions/setup-go/issues/713

## Related PRs
- #10144

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).