### PR TITLE
docs: update version endpoint example in client/server documentation

### DIFF
--- a/docs/guide/references/modes/client-server.md
+++ b/docs/guide/references/modes/client-server.md
@@ -319,7 +319,7 @@ ok
 Returns the `200 OK` status if the request was successful.
 ### Version
 
-Returns the version of the Trivy and all components (db, policy). Authentication is not required.
+Returns the version of the Trivy server and the vulnerability database metadata. Authentication is not required.
 
 Example request:
 ```bash
@@ -331,16 +331,6 @@ curl -s 0.0.0.0:8080/version | jq
     "NextUpdate": "2023-07-25T14:15:29.876639806Z",
     "UpdatedAt": "2023-07-25T08:15:29.876640206Z",
     "DownloadedAt": "2023-07-25T09:36:25.599004Z"
-  },
-  "JavaDB": {
-    "Version": 1,
-    "NextUpdate": "2023-07-28T01:03:52.169192565Z",
-    "UpdatedAt": "2023-07-25T01:03:52.169192765Z",
-    "DownloadedAt": "2023-07-25T09:37:48.906152Z"
-  },
-  "PolicyBundle": {
-    "Digest": "sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43",
-    "DownloadedAt": "2023-07-23T11:40:33.122462Z"
   }
 }
 ```


### PR DESCRIPTION
## Description

Updates the  endpoint documentation in the client/server mode guide to reflect the current server behavior after #10075.

## Changes

- Removed  and  from the example response
- Updated description text from "Returns the version of the Trivy and all components (db, policy)" to "Returns the version of the Trivy server and the vulnerability database metadata"

## Reason

Since #10075, the Trivy server only returns  information because Java DB and check bundles are now downloaded on the client side, not served by the Trivy server.

## Related Issue

Fixes #10142