### PR TITLE
refactor: reduce complexity of init in detect.go

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,8 +45,9 @@ linters:
       settings:
         ruleguard:
           failOn: all
-          rules: '${base-path}/misc/lint/rules.go'
+          rules: "${base-path}/misc/lint/rules.go"
     gocyclo:
+      # Next highest complexity candidate: ApplyLayers in pkg/fanal/applier/docker.go (score: 28)
       min-complexity: 20
     gomodguard:
       blocked:
@@ -187,7 +188,7 @@ linters:
         text: "importShadow:"
       - linters:
           - goconst
-        text: "string `each` has 3 occurrences, make it a constant"  # FIXME
+        text: "string `each` has 3 occurrences, make it a constant" # FIXME
     presets:
       - comments
       - common-false-positives
@@ -196,7 +197,7 @@ linters:
     warn-unused: true
 
 run:
-  go: '1.25'
+  go: "1.25"
   timeout: 30m
 
 formatters:

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -423,6 +423,24 @@ rules:
 			},
 		},
 		{
+			name: "kubernetes, multi-doc with non-map doc first",
+			path: "k8s.yaml",
+			r: strings.NewReader(`---
+- this is a list, not a map
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valid-service
+`),
+			expected: []FileType{
+				FileTypeKubernetes,
+				FileTypeYAML,
+				FileTypeHelm,
+				FileTypeAnsible,
+			},
+		},
+		{
 			name: "Azure ARM template with resources",
 			path: "test.json",
 			r: strings.NewReader(`


### PR DESCRIPTION
## Description

This PR refactors the init function in pkg/iac/detection/detect.go to significantly reduce its cyclomatic complexity.

Previously, init had a complexity score of 50 (well above the linter limit of 20) because it initialized the matchers map using multiple large anonymous functions. This required a `// nolint` directive to bypass the check.
 

Changes made:

* Extracted each anonymous matching function into a named private function (e.g., detectJSON, detectYAML, detectHelm, etc.) to improve readability and maintainability.
* Simplified init to be a clear list of function assignments.
* Removed the // nolint directive as the complexity is now trivial.
* Added a comment in .golangci.yaml identifying the next highest complexity function (ApplyLayers in pkg/fanal/applier/docker.go) for future refactoring efforts.

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
