### PR TITLE
refactor(rpc): remove unused Insecure field from ServiceOption

### DIFF
--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -570,7 +570,6 @@ func (o *Options) ClientScannerOpts() client.ServiceOption {
 	return client.ServiceOption{
 		RemoteURL:     o.ServerAddr,
 		CustomHeaders: o.CustomHeaders,
-		Insecure:      o.Insecure,
 		PathPrefix:    o.PathPrefix,
 	}
 }

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -25,7 +25,6 @@ import (
 // ServiceOption holds options for RPC client
 type ServiceOption struct {
 	RemoteURL     string
-	Insecure      bool
 	CustomHeaders http.Header
 	PathPrefix    string
 }


### PR DESCRIPTION
## Description

The `Insecure` field in `ServiceOption` struct is defined but never used. This field is redundant because the insecure option is already configured at the transport level via `xhttp.SetDefaultTransport()`.

## Changes

- Removed `Insecure` field from `ServiceOption` struct in `pkg/rpc/client/client.go`
- Removed `Insecure` field assignment in `pkg/flag/options.go`

Fixes #10098