### PR TITLE
docs: fix incorrect count of Python package managers

### DIFF
--- a/docs/guide/coverage/language/python.md
+++ b/docs/guide/coverage/language/python.md
@@ -1,6 +1,6 @@
 # Python
 
-Trivy supports three types of Python package managers: `pip`, `Pipenv` and `Poetry`.
+Trivy supports the following Python package managers: `pip`, `Pipenv`, `Poetry` and `uv`.
 The following scanners are supported for package managers.
 
 | Package manager | SBOM | Vulnerability | License |
@@ -10,7 +10,7 @@ The following scanners are supported for package managers.
 | Poetry          |  ✓   |       ✓       |    -    |
 | uv              |  ✓   |       ✓       |    -    |
 
-In addition, Trivy supports three formats of Python packages: `egg`, `wheel` and `conda`.
+In addition, Trivy supports these formats of Python packages: `egg`, `wheel` and `conda`.
 The following scanners are supported for Python packages.
 
 | Packaging | SBOM | Vulnerability | License |


### PR DESCRIPTION
## Description

Fix count error in `python.md`/Package managers. This is a minor change.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
