### PR TITLE
feat(alinux): add support for Alibaba Cloud Linux

### DIFF
--- a/docs/guide/coverage/os/alinux.md
+++ b/docs/guide/coverage/os/alinux.md
@@ -1,0 +1,73 @@
+# Alibaba Cloud Linux
+Trivy supports the following scanners for OS packages.
+
+|    Scanner    | Supported |
+| :-----------: | :-------: |
+|     SBOM      |     ✓     |
+| Vulnerability |     ✓     |
+|    License    |     ✓     |
+
+Please see [here](index.md#supported-os) for supported versions.
+
+The table below outlines the features offered by Trivy.
+
+|               Feature                | Supported |
+|:------------------------------------:|:---------:|
+|       Unfixed vulnerabilities        |     -     |
+| [Dependency graph][dependency-graph] |     ✓     |
+|        End of life awareness         |     ✓     |
+
+## SBOM
+Trivy detects packages that have been installed through package managers such as `dnf` and `yum`.
+
+## Vulnerability
+Alibaba Cloud Linux offers its own security advisories, and these are utilized when scanning Alibaba Cloud Linux for vulnerabilities.
+
+### Data Source
+See [here](../../scanner/vulnerability.md#data-sources).
+
+### Fixed Version
+When looking at fixed versions, it's crucial to consider the patches supplied by Alibaba Cloud.
+For example, for CVE-2020-25694, the fixed version for Alibaba Cloud Linux 3 is listed as `12.5-1.1.al8` in [ALINUX3-SA-2021:0002].
+Note that this is different from the upstream fixed version.
+Typically, only the upstream information gets listed on [NVD], so it's important not to get confused.
+
+### Severity
+Trivy calculates the severity of an issue based on the severity provided by Alibaba Cloud Linux.
+If the severity is not provided or defined yet by Alibaba Cloud Linux, the severity from the NVD is taken into account.
+
+Using CVE-2020-10543 as an example, while it is rated as "High" in NVD, Alibaba Cloud Linux has marked it as ["Moderate"][ALINUX3-SA-2021:0012].
+As a result, Trivy will display it as "Medium".
+
+The table below is the mapping of Alibaba Cloud Linux's severity to Trivy's severity levels.
+
+| Alibaba Cloud Linux |  Trivy   |
+| :-----------------: | :------: |
+|         Low         |   Low    |
+|      Moderate       |  Medium  |
+|      Important      |   High   |
+|      Critical       | Critical |
+
+### Status
+Trivy supports the following [vulnerability statuses] for Alibaba Cloud Linux.
+
+|       Status        | Supported |
+| :-----------------: | :-------: |
+|        Fixed        |     ✓     |
+|      Affected       |     ✓     |
+| Under Investigation |           |
+|    Will Not Fix     |           |
+|    Fix Deferred     |           |
+|     End of Life     |           |
+
+
+## License
+Trivy identifies licenses by examining the metadata of RPM packages.
+
+[dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
+
+[ALINUX3-SA-2021:0002]: https://alas.aliyuncs.com/alinux3/ALINUX3-SA-2021-0002
+[ALINUX3-SA-2021:0012]: https://alas.aliyuncs.com/alinux3/ALINUX3-SA-2021-0012
+[NVD]: https://nvd.nist.gov/vuln/detail/CVE-2020-25694
+
+[vulnerability statuses]: ../../configuration/filtering.md#by-status

--- a/docs/guide/coverage/os/index.md
+++ b/docs/guide/coverage/os/index.md
@@ -22,6 +22,7 @@ Trivy supports operating systems for
 | [Rocky Linux](rocky.md)                        | 8, 9                                | dnf/yum/rpm      |
 | [Oracle Linux](oracle.md)                      | 5, 6, 7, 8                          | dnf/yum/rpm      |
 | [Azure Linux (CBL-Mariner)](azure.md)          | 1.0, 2.0, 3.0                       | tdnf/dnf/yum/rpm |
+| [Alibaba Cloud Linux](alinux.md)               | 2, 3, 4                             | dnf/yum/rpm      |
 | [Amazon Linux](amazon.md)                      | 1, 2, 2023                          | dnf/yum/rpm      |
 | [openSUSE Leap](suse.md)                       | 42, 15                              | zypper/rpm       |
 | [openSUSE Tumbleweed](suse.md)                 | (n/a)                               | zypper/rpm       |

--- a/docs/guide/scanner/vulnerability.md
+++ b/docs/guide/scanner/vulnerability.md
@@ -26,6 +26,7 @@ See [here](../coverage/os/index.md#supported-os) for the supported OSes.
 | Wolfi Linux               | [secdb][wolfi]                                               |
 | Chainguard                | [secdb][chainguard]                                          |
 | MinimOS                   | [secdb][minimos]                                             |
+| Alibaba Cloud Linux       | [Alinux Security Center][alinux]                             |
 | Amazon Linux              | [Amazon Linux Security Center][amazon]                       |
 | Echo                      | [Echo][echo]                                                 |
 | Debian                    | [Security Bug Tracker][debian-tracker] / [OVAL][debian-oval] |
@@ -403,6 +404,7 @@ Example logic for the following vendor severity levels when scanning an Alpine i
 [wolfi]: https://packages.wolfi.dev/os/security.json
 [chainguard]: https://packages.cgr.dev/chainguard/security.json
 [minimos]: https://packages.mini.dev/advisories/secdb/security.json
+[alinux]: https://alas.aliyuncs.com/
 [amazon]: https://alas.aws.amazon.com/
 [echo]: https://advisory.echohq.com/data.json
 [debian-tracker]: https://security-tracker.debian.org/tracker/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
           - Overview: guide/coverage/index.md
           - OS:
               - Overview: guide/coverage/os/index.md
+              - Alibaba Cloud Linux: guide/coverage/os/alinux.md
               - AlmaLinux: guide/coverage/os/alma.md
               - Alpine Linux: guide/coverage/os/alpine.md
               - Amazon Linux: guide/coverage/os/amazon.md

--- a/pkg/detector/ospkg/alinux/alinux.go
+++ b/pkg/detector/ospkg/alinux/alinux.go
@@ -1,0 +1,83 @@
+package alinux
+
+import (
+	"context"
+	"time"
+
+	version "github.com/knqyf263/go-rpm-version"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbAlinux "github.com/aquasecurity/trivy-db/pkg/vulnsrc/alinux"
+	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+var (
+	eolDates = map[string]time.Time{
+		// https://www.alibabacloud.com/help/en/alinux/product-overview/alibaba-cloud-linux-overview
+		"2": time.Date(2024, 3, 31, 23, 59, 59, 0, time.UTC),
+		"3": time.Date(2031, 4, 30, 23, 59, 59, 0, time.UTC),
+		"4": time.Date(2038, 6, 30, 23, 59, 59, 0, time.UTC),
+	}
+)
+
+// Scanner implements the Alibaba Cloud Linux scanner
+type Scanner struct {
+	vs dbAlinux.VulnSrc
+}
+
+// NewScanner is the factory method for Scanner
+func NewScanner() *Scanner {
+	return &Scanner{
+		vs: dbAlinux.NewVulnSrc(),
+	}
+}
+
+// Detect vulnerabilities in packages using the Alinux scanner
+func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	osVer = osver.Major(osVer)
+	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
+		log.Int("pkg_num", len(pkgs)))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		advisories, err := s.vs.Get(db.GetParams{
+			Release: osVer,
+			PkgName: pkg.Name,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get Alinux advisories: %w", err)
+		}
+
+		installed := utils.FormatVersion(pkg)
+		installedVersion := version.NewVersion(installed)
+		for _, adv := range advisories {
+			fixedVersion := version.NewVersion(adv.FixedVersion)
+			if installedVersion.LessThan(fixedVersion) {
+				vuln := types.DetectedVulnerability{
+					VulnerabilityID:  adv.VulnerabilityID,
+					PkgID:            pkg.ID,
+					PkgName:          pkg.Name,
+					InstalledVersion: installed,
+					FixedVersion:     fixedVersion.String(),
+					PkgIdentifier:    pkg.Identifier,
+					Layer:            pkg.Layer,
+					DataSource:       adv.DataSource,
+					Custom:           adv.Custom,
+				}
+				vulns = append(vulns, vuln)
+			}
+		}
+	}
+
+	return vulns, nil
+}
+
+// IsSupportedVersion checks if the version is supported.
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	return osver.Supported(ctx, eolDates, osFamily, osver.Major(osVer))
+}

--- a/pkg/detector/ospkg/alinux/alinux_test.go
+++ b/pkg/detector/ospkg/alinux/alinux_test.go
@@ -1,0 +1,255 @@
+package alinux_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy/internal/dbtest"
+	"github.com/aquasecurity/trivy/pkg/clock"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alinux"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestScanner_Detect(t *testing.T) {
+	type args struct {
+		osVer string
+		pkgs  []ftypes.Package
+	}
+	tests := []struct {
+		name     string
+		args     args
+		fixtures []string
+		want     []types.DetectedVulnerability
+		wantErr  string
+	}{
+		{
+			// ALINUX2-SA-2025:0006: postgresql security update (Important)
+			// CVE-2024-10979: Incorrect control of environment variables in PostgreSQL PL/Perl
+			name: "alinux 2",
+			fixtures: []string{
+				"testdata/fixtures/alinux.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "2.1903",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "postgresql",
+						Version: "9.2.24",
+						Release: "9.0.al7.2",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "postgresql",
+					VulnerabilityID:  "CVE-2024-10979",
+					InstalledVersion: "9.2.24-9.0.al7.2",
+					FixedVersion:     "9.2.24-9.1.al7.2",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Alinux,
+						Name: "Alibaba Cloud Linux Security Center",
+						URL:  "https://alas.aliyuncs.com/",
+					},
+				},
+			},
+		},
+		{
+			// ALINUX3-SA-2026:0021: glib2 security update (Moderate)
+			// CVE-2025-13601: heap-based buffer overflow in g_escape_uri_string()
+			name: "alinux 3",
+			fixtures: []string{
+				"testdata/fixtures/alinux.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "3",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "glib2",
+						Version: "2.68.4",
+						Release: "14.al8",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "glib2",
+					VulnerabilityID:  "CVE-2025-13601",
+					InstalledVersion: "2.68.4-14.al8",
+					FixedVersion:     "2.68.4-18.0.1.al8.1",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Alinux,
+						Name: "Alibaba Cloud Linux Security Center",
+						URL:  "https://alas.aliyuncs.com/",
+					},
+				},
+			},
+		},
+		{
+			// ALINUX4-SA-2026:0034: python-urllib3 security update (Important)
+			// CVE-2026-21441: urllib3 decompression bomb via HTTP redirect
+			name: "alinux 4",
+			fixtures: []string{
+				"testdata/fixtures/alinux.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "4.0",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "python-urllib3",
+						Version: "1.26.19",
+						Release: "3.alnx4",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "python-urllib3",
+					VulnerabilityID:  "CVE-2026-21441",
+					InstalledVersion: "1.26.19-3.alnx4",
+					FixedVersion:     "1.26.19-4.alnx4",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Alinux,
+						Name: "Alibaba Cloud Linux Security Center",
+						URL:  "https://alas.aliyuncs.com/",
+					},
+				},
+			},
+		},
+		{
+			name: "no matching advisory",
+			fixtures: []string{
+				"testdata/fixtures/alinux.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "3",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "bash",
+						Version: "5.0.17",
+						Release: "2.al8",
+					},
+				},
+			},
+		},
+		{
+			name: "Get returns an error",
+			fixtures: []string{
+				"testdata/fixtures/invalid.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "2",
+				pkgs: []ftypes.Package{
+					{
+						Name:    "postgresql",
+						Version: "9.2.24",
+						Release: "9.0.al7.2",
+					},
+				},
+			},
+			wantErr: "failed to get Alinux advisories",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = dbtest.InitDB(t, tt.fixtures)
+			defer db.Close()
+
+			s := alinux.NewScanner()
+			got, err := s.Detect(t.Context(), tt.args.osVer, nil, tt.args.pkgs)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestScanner_IsSupportedVersion(t *testing.T) {
+	type args struct {
+		osFamily ftypes.OSType
+		osVer    string
+	}
+	tests := []struct {
+		name string
+		now  time.Time
+		args args
+		want bool
+	}{
+		{
+			name: "alinux 2 before EOL",
+			now:  time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "alinux",
+				osVer:    "2.1903",
+			},
+			want: true,
+		},
+		{
+			name: "alinux 2 after EOL",
+			now:  time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "alinux",
+				osVer:    "2",
+			},
+			want: false,
+		},
+		{
+			name: "alinux 3 active",
+			now:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "alinux",
+				osVer:    "3",
+			},
+			want: true,
+		},
+		{
+			name: "alinux 4 active",
+			now:  time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "alinux",
+				osVer:    "4.0",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := clock.With(t.Context(), tt.now)
+			s := alinux.NewScanner()
+			got := s.IsSupportedVersion(ctx, tt.args.osFamily, tt.args.osVer)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/ospkg/alinux/testdata/fixtures/alinux.yaml
+++ b/pkg/detector/ospkg/alinux/testdata/fixtures/alinux.yaml
@@ -1,0 +1,21 @@
+- bucket: alinux 2
+  pairs:
+    - bucket: postgresql
+      pairs:
+        - key: CVE-2024-10979
+          value:
+            FixedVersion: "9.2.24-9.1.al7.2"
+- bucket: alinux 3
+  pairs:
+    - bucket: glib2
+      pairs:
+        - key: CVE-2025-13601
+          value:
+            FixedVersion: "2.68.4-18.0.1.al8.1"
+- bucket: alinux 4
+  pairs:
+    - bucket: python-urllib3
+      pairs:
+        - key: CVE-2026-21441
+          value:
+            FixedVersion: "1.26.19-4.alnx4"

--- a/pkg/detector/ospkg/alinux/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/alinux/testdata/fixtures/data-source.yaml
@@ -1,0 +1,17 @@
+- bucket: data-source
+  pairs:
+    - key: alinux 2
+      value:
+        ID: "alinux"
+        Name: "Alibaba Cloud Linux Security Center"
+        URL: "https://alas.aliyuncs.com/"
+    - key: alinux 3
+      value:
+        ID: "alinux"
+        Name: "Alibaba Cloud Linux Security Center"
+        URL: "https://alas.aliyuncs.com/"
+    - key: alinux 4
+      value:
+        ID: "alinux"
+        Name: "Alibaba Cloud Linux Security Center"
+        URL: "https://alas.aliyuncs.com/"

--- a/pkg/detector/ospkg/alinux/testdata/fixtures/invalid.yaml
+++ b/pkg/detector/ospkg/alinux/testdata/fixtures/invalid.yaml
@@ -1,0 +1,9 @@
+- bucket: alinux 2
+  pairs:
+    - bucket: postgresql
+      pairs:
+        - key: CVE-2024-10979
+          value:
+            FixedVersion:
+              - foo
+              - bar

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alinux"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alma"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/alpine"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/amazon"
@@ -42,6 +43,7 @@ var (
 	ErrUnsupportedOS = xerrors.New("unsupported os")
 
 	drivers = map[ftypes.OSType]driver.Driver{
+		ftypes.Alinux:             alinux.NewScanner(),
 		ftypes.Alpine:             alpine.NewScanner(),
 		ftypes.Alma:               alma.NewScanner(),
 		ftypes.Amazon:             amazon.NewScanner(),

--- a/pkg/fanal/analyzer/all/import.go
+++ b/pkg/fanal/analyzer/all/import.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/swift/cocoapods"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/swift/swift"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/licensing"
+	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/alinux"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/alpine"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/amazonlinux"
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/debian"

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -13,6 +13,7 @@ const (
 	//   OS
 	// ======
 	TypeOSRelease  Type = "os-release"
+	TypeAlinux     Type = "alinux"
 	TypeAlpine     Type = "alpine"
 	TypeAmazon     Type = "amazon"
 	TypeAzure      Type = "azurelinux"
@@ -157,6 +158,7 @@ var (
 	// TypeOSes has all OS-related analyzers
 	TypeOSes = []Type{
 		TypeOSRelease,
+		TypeAlinux,
 		TypeAlpine,
 		TypeAmazon,
 		TypeCBLMariner,

--- a/pkg/fanal/analyzer/os/alinux/alinux.go
+++ b/pkg/fanal/analyzer/os/alinux/alinux.go
@@ -1,0 +1,74 @@
+package alinux
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func init() {
+	analyzer.RegisterAnalyzer(&alinuxOSAnalyzer{})
+}
+
+const version = 1
+
+var (
+	requiredFiles = []string{
+		"etc/alinux-release",
+		"etc/system-release",
+	}
+	alinuxRe = regexp.MustCompile(`Alibaba Cloud Linux.*release (\d[\d.]*)`)
+)
+
+type alinuxOSAnalyzer struct{}
+
+func (a alinuxOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	foundOS, err := a.parseRelease(input.Content)
+	if err != nil {
+		return nil, err
+	}
+	return &analyzer.AnalysisResult{
+		OS: foundOS,
+	}, nil
+}
+
+func (a alinuxOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		result := alinuxRe.FindStringSubmatch(line)
+		if len(result) == 2 {
+			return types.OS{
+				Family: types.Alinux,
+				Name:   result[1],
+			}, nil
+		}
+	}
+	return types.OS{}, xerrors.Errorf("alinux: %w", fos.AnalyzeOSError)
+}
+
+func (a alinuxOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	return slices.Contains(requiredFiles, filePath)
+}
+
+func (a alinuxOSAnalyzer) Type() analyzer.Type {
+	return analyzer.TypeAlinux
+}
+
+func (a alinuxOSAnalyzer) Version() int {
+	return version
+}
+
+// StaticPaths returns the static paths of the alinux analyzer
+func (a alinuxOSAnalyzer) StaticPaths() []string {
+	return requiredFiles
+}

--- a/pkg/fanal/analyzer/os/alinux/alinux_test.go
+++ b/pkg/fanal/analyzer/os/alinux/alinux_test.go
@@ -1,0 +1,91 @@
+package alinux
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func Test_alinuxOSAnalyzer_Analyze(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   analyzer.AnalysisInput
+		want    *analyzer.AnalysisResult
+		wantErr string
+	}{
+		{
+			name: "happy path alinux 2",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/alinux-release",
+				Content:  strings.NewReader("Alibaba Cloud Linux release 2.1903 LTS (Hunting Beagle)"),
+			},
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.Alinux,
+					Name:   "2.1903",
+				},
+			},
+		},
+		{
+			name: "happy path alinux 3",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/alinux-release",
+				Content:  strings.NewReader("Alibaba Cloud Linux release 3 (Soaring Falcon)"),
+			},
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.Alinux,
+					Name:   "3",
+				},
+			},
+		},
+		{
+			name: "happy path alinux 4",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/system-release",
+				Content:  strings.NewReader("Alibaba Cloud Linux release 4.0"),
+			},
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.Alinux,
+					Name:   "4.0",
+				},
+			},
+		},
+		{
+			name: "sad path",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/alinux-release",
+				Content:  strings.NewReader("foo bar"),
+			},
+			wantErr: fos.AnalyzeOSError.Error(),
+		},
+		{
+			name: "sad path empty",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/alinux-release",
+				Content:  strings.NewReader(""),
+			},
+			wantErr: fos.AnalyzeOSError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := alinuxOSAnalyzer{}
+			ctx := t.Context()
+			got, err := a.Analyze(ctx, tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -71,6 +71,8 @@ func idToOSFamily(id string) types.OSType {
 	switch id {
 	case "activestate":
 		return types.ActiveState
+	case "alinux":
+		return types.Alinux
 	case "rhel":
 		return types.RedHat
 	case "centos":

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -49,6 +49,7 @@ var (
 )
 
 var osVendors = []string{
+	"Alibaba Cloud",         // Alibaba Cloud Linux (Alinux)
 	"Amazon Linux",          // Amazon Linux 1
 	"Amazon.com",            // Amazon Linux 2
 	"CentOS",                // CentOS
@@ -257,7 +258,11 @@ func packageProvidedByVendor(pkg *rpmdb.PackageInfo) bool {
 	if pkg.Vendor == "" {
 		// Official Amazon packages may not contain `Vendor` field:
 		// https://github.com/aquasecurity/trivy/issues/5887
-		return strings.Contains(pkg.Release, "amzn")
+		// Alibaba Cloud Linux packages use "al7", "al8", "alnx4" suffixes
+		return strings.Contains(pkg.Release, "amzn") ||
+			strings.Contains(pkg.Release, ".al7") ||
+			strings.Contains(pkg.Release, ".al8") ||
+			strings.Contains(pkg.Release, ".alnx4")
 	}
 
 	for _, vendor := range osVendors {

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -22,6 +22,7 @@ const (
 // Operating systems
 const (
 	ActiveState        OSType = "activestate"
+	Alinux             OSType = "alinux"
 	Alma               OSType = "alma"
 	Alpine             OSType = "alpine"
 	Amazon             OSType = "amazon"
@@ -138,6 +139,7 @@ const (
 var (
 	OSTypes = []OSType{
 		ActiveState,
+		Alinux,
 		Alma,
 		Alpine,
 		Amazon,


### PR DESCRIPTION
## Description
It would be interesting to add support for the [Alibaba Cloud Linux](https://www.alibabacloud.com/help/en/alinux/product-overview/alibaba-cloud-linux-overview) Linux distribution.

Alibaba Cloud Linux (short for Alinux) is a next-generation Linux distribution released by [Alibaba Cloud](https://www.alibabacloud.com/en). It includes advanced features developed by the Linux community, and provides a stable and reliable environment for applications running on the cloud.

The Alinux Security Team provides a publicly available [Alinux Security Center](https://alas.aliyuncs.com/errata), which serves as the official channel for publishing product vulnerability databases and security advisories. We request community support to enable vulnerability scanning for Alinux and facilitate the provision of machine-readable security data in [OVAL](https://mirrors.aliyun.com/alinux/cve/data/OVAL/) and [CSAF_VEX](https://mirrors.aliyun.com/alinux/cve/data/CSAF/) standard formats.

Trivy is widely used by customers on Alibaba Cloud for Linux container image scanning, but currently does not support Alinux vulnerability scanning. Hope this support can be added soon.

## Related issues
- Close #10182

## Related PRs
- [x] [#630](https://github.com/aquasecurity/trivy-db/pull/630)
- [x] [#405](https://github.com/aquasecurity/vuln-list-update/pull/405)

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
