### PR TITLE
feat(vex): add support for OWASP Risk Ratings in VEX documents

### DIFF
--- a/pkg/types/vex_rating.go
+++ b/pkg/types/vex_rating.go
@@ -1,0 +1,19 @@
+package types
+
+// OWASPRating represents an OWASP Risk Rating from a VEX document.
+// This provides a contextual risk score that considers the specific deployment environment,
+// calculated using the OWASP Risk Rating methodology.
+// See: https://owasp.org/www-community/OWASP_Risk_Rating_Methodology
+type OWASPRating struct {
+	// Score is the numerical risk score (0-81 scale)
+	// Calculated as: Likelihood × Impact
+	Score float64 `json:"score,omitempty"`
+
+	// Severity is the severity level based on the score
+	// Thresholds: 0-9 (low), 10-39 (medium), 40-59 (high), 60-81 (critical)
+	Severity string `json:"severity,omitempty"`
+
+	// Vector is the OWASP Risk Rating vector string that produced this rating
+	// Format: "SL:7/M:7/O:7/S:7/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7"
+	Vector string `json:"vector,omitempty"`
+}

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -30,6 +30,11 @@ type DetectedVulnerability struct {
 	// Custom is for extensibility and not supposed to be used in OSS
 	Custom any `json:",omitempty"`
 
+	// OWASPRating holds the OWASP Risk Rating from VEX documents
+	// This provides a contextual risk assessment based on the specific deployment environment
+	// and is calculated using the OWASP Risk Rating methodology
+	OWASPRating *OWASPRating `json:",omitempty"`
+
 	// Embed vulnerability details
 	types.Vulnerability
 }

--- a/pkg/vex/csaf.go
+++ b/pkg/vex/csaf.go
@@ -175,3 +175,9 @@ func (v *CSAF) statement(vuln *csaf.Vulnerability) string {
 	}
 	return lo.FromPtr(threat.Details)
 }
+
+// EnrichWithRatings is a no-op for CSAF as it doesn't currently support ratings
+func (v *CSAF) EnrichWithRatings(vuln *types.DetectedVulnerability, product *core.Component) {
+	// CSAF spec doesn't include rating information yet
+	// This is a no-op to satisfy the VEX interface
+}

--- a/pkg/vex/cyclonedx.go
+++ b/pkg/vex/cyclonedx.go
@@ -20,6 +20,7 @@ type Statement struct {
 	Affects       []string
 	Status        types.FindingStatus
 	Justification string
+	OWASPRating   *types.OWASPRating
 }
 
 func newCycloneDX(sbom *core.BOM, vex *cdx.BOM) *CycloneDX {
@@ -30,10 +31,14 @@ func newCycloneDX(sbom *core.BOM, vex *cdx.BOM) *CycloneDX {
 		})
 
 		analysis := lo.FromPtr(vuln.Analysis)
+
+		owaspRating := parseOWASPRating(vuln.Ratings)
+
 		statements[vuln.ID] = Statement{
 			Affects:       affects,
 			Status:        cdxStatus(analysis.State),
 			Justification: string(analysis.Justification),
+			OWASPRating:   owaspRating,
 		}
 	}
 	return &CycloneDX{
@@ -41,6 +46,34 @@ func newCycloneDX(sbom *core.BOM, vex *cdx.BOM) *CycloneDX {
 		statements: statements,
 		logger:     log.WithPrefix("vex").With(log.String("format", "CycloneDX")),
 	}
+}
+
+// parseOWASPRating extracts the OWASP Risk Rating from CycloneDX VulnerabilityRatings
+func parseOWASPRating(cdxRatings *[]cdx.VulnerabilityRating) *types.OWASPRating {
+	if cdxRatings == nil || len(*cdxRatings) == 0 {
+		return nil
+	}
+
+	// Look for OWASP rating specifically
+	for _, r := range *cdxRatings {
+		method := string(r.Method)
+		if method != "OWASP" {
+			continue
+		}
+
+		rating := &types.OWASPRating{
+			Vector:   r.Vector,
+			Severity: string(r.Severity),
+		}
+
+		if r.Score != nil {
+			rating.Score = *r.Score
+		}
+
+		return rating
+	}
+
+	return nil
 }
 
 func (v *CycloneDX) NotAffected(vuln types.DetectedVulnerability, product, _ *core.Component) (types.ModifiedFinding, bool) {
@@ -71,6 +104,30 @@ func (v *CycloneDX) NotAffected(vuln types.DetectedVulnerability, product, _ *co
 		}
 	}
 	return types.ModifiedFinding{}, false
+}
+
+// EnrichWithRatings enriches the vulnerability with OWASP Risk Rating from VEX if available
+func (v *CycloneDX) EnrichWithRatings(vuln *types.DetectedVulnerability, product *core.Component) {
+	stmt, ok := v.statements[vuln.VulnerabilityID]
+	if !ok || stmt.OWASPRating == nil {
+		return
+	}
+
+	// Check if this vulnerability affects the product
+	for _, affect := range stmt.Affects {
+		link, err := cdx.ParseBOMLink(affect)
+		if err != nil {
+			continue
+		}
+		if v.sbom.SerialNumber != link.SerialNumber() || v.sbom.Version != link.Version() {
+			continue
+		}
+		if product.PkgIdentifier.Match(link.Reference()) {
+			// Apply OWASP rating from VEX to this vulnerability
+			vuln.OWASPRating = stmt.OWASPRating
+			return
+		}
+	}
 }
 
 func cdxStatus(s cdx.ImpactAnalysisState) types.FindingStatus {

--- a/pkg/vex/cyclonedx.go
+++ b/pkg/vex/cyclonedx.go
@@ -113,7 +113,13 @@ func (v *CycloneDX) EnrichWithRatings(vuln *types.DetectedVulnerability, product
 		return
 	}
 
-	// Check if this vulnerability affects the product
+	// If no affects are specified, apply the rating globally to all instances of this vulnerability
+	if len(stmt.Affects) == 0 {
+		vuln.OWASPRating = stmt.OWASPRating
+		return
+	}
+
+	// Check if this vulnerability affects the product via BOM-Link
 	for _, affect := range stmt.Affects {
 		link, err := cdx.ParseBOMLink(affect)
 		if err != nil {

--- a/pkg/vex/cyclonedx_ratings_test.go
+++ b/pkg/vex/cyclonedx_ratings_test.go
@@ -1,0 +1,113 @@
+package vex
+
+import (
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestParseOWASPRating(t *testing.T) {
+	tests := []struct {
+		name     string
+		ratings  *[]cdx.VulnerabilityRating
+		expected *types.OWASPRating
+	}{
+		{
+			name:     "nil ratings",
+			ratings:  nil,
+			expected: nil,
+		},
+		{
+			name:     "empty ratings",
+			ratings:  &[]cdx.VulnerabilityRating{},
+			expected: nil,
+		},
+		{
+			name: "OWASP rating from vens",
+			ratings: &[]cdx.VulnerabilityRating{
+				{
+					Method:   "OWASP",
+					Score:    ptrFloat64(27.5),
+					Severity: "medium",
+					Vector:   "SL:7/M:7/O:7/S:7/ED:4/EE:4/A:4/ID:5/LC:5/LI:5/LAV:5/LAC:5/FD:5/RD:5/NC:5/PV:5",
+				},
+			},
+			expected: &types.OWASPRating{
+				Score:    27.5,
+				Severity: "medium",
+				Vector:   "SL:7/M:7/O:7/S:7/ED:4/EE:4/A:4/ID:5/LC:5/LI:5/LAV:5/LAC:5/FD:5/RD:5/NC:5/PV:5",
+			},
+		},
+		{
+			name: "multiple ratings - only OWASP extracted",
+			ratings: &[]cdx.VulnerabilityRating{
+				{
+					Method:   "CVSSv3",
+					Score:    ptrFloat64(7.5),
+					Severity: "high",
+				},
+				{
+					Method:   "OWASP",
+					Score:    ptrFloat64(42.5),
+					Severity: "high",
+					Vector:   "SL:5/M:5/O:5/S:5/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7",
+				},
+				{
+					Method:   "OTHER",
+					Score:    ptrFloat64(10.0),
+					Severity: "low",
+				},
+			},
+			expected: &types.OWASPRating{
+				Score:    42.5,
+				Severity: "high",
+				Vector:   "SL:5/M:5/O:5/S:5/ED:6/EE:6/A:6/ID:3/LC:7/LI:7/LAV:7/LAC:7/FD:7/RD:7/NC:7/PV:7",
+			},
+		},
+		{
+			name: "OWASP rating without score",
+			ratings: &[]cdx.VulnerabilityRating{
+				{
+					Method:   "OWASP",
+					Severity: "medium",
+					Vector:   "SL:5/M:5/O:5/S:5/ED:5/EE:5/A:5/ID:5/LC:5/LI:5/LAV:5/LAC:5/FD:5/RD:5/NC:5/PV:5",
+				},
+			},
+			expected: &types.OWASPRating{
+				Score:    0,
+				Severity: "medium",
+				Vector:   "SL:5/M:5/O:5/S:5/ED:5/EE:5/A:5/ID:5/LC:5/LI:5/LAV:5/LAC:5/FD:5/RD:5/NC:5/PV:5",
+			},
+		},
+		{
+			name: "non-OWASP ratings only - returns nil",
+			ratings: &[]cdx.VulnerabilityRating{
+				{
+					Method:   "CVSSv3",
+					Score:    ptrFloat64(7.5),
+					Severity: "high",
+				},
+				{
+					Method:   "OTHER",
+					Score:    ptrFloat64(10.0),
+					Severity: "low",
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseOWASPRating(tt.ratings)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func ptrFloat64(f float64) *float64 {
+	return &f
+}

--- a/pkg/vex/openvex.go
+++ b/pkg/vex/openvex.go
@@ -52,6 +52,12 @@ func (v *OpenVEX) Matches(vuln types.DetectedVulnerability, product, subComponen
 	return v.vex.Matches(vuln.VulnerabilityID, product.PkgIdentifier.PURL.String(), []string{subComponentPURL})
 }
 
+// EnrichWithRatings is a no-op for OpenVEX as it doesn't currently support ratings
+func (v *OpenVEX) EnrichWithRatings(vuln *types.DetectedVulnerability, product *core.Component) {
+	// OpenVEX spec doesn't include rating information yet
+	// This is a no-op to satisfy the VEX interface
+}
+
 func findingStatus(status openvex.Status) types.FindingStatus {
 	switch status {
 	case openvex.StatusNotAffected:

--- a/pkg/vex/sbomref.go
+++ b/pkg/vex/sbomref.go
@@ -107,3 +107,10 @@ func (set *SBOMReferenceSet) NotAffected(vuln types.DetectedVulnerability, produ
 	}
 	return types.ModifiedFinding{}, false
 }
+
+// EnrichWithRatings enriches the vulnerability with ratings from all VEX documents in the set
+func (set *SBOMReferenceSet) EnrichWithRatings(vuln *types.DetectedVulnerability, product *core.Component) {
+	for _, vex := range set.VEXes {
+		vex.EnrichWithRatings(vuln, product)
+	}
+}


### PR DESCRIPTION
## Why this change?

The CycloneDX spec now recommends that tools consider ratings when prioritizing vulnerabilities ([spec PR #722](https://github.com/CycloneDX/specification/pull/722)):

> _"Consumers SHOULD consider ratings in prioritization decisions"_

This PR lets Trivy use **context-aware OWASP Risk Ratings** from CycloneDX VEX documents. These ratings are generated by tools like [vens](https://github.com/venslabs/vens) (available in the [Trivy plugin index](https://aquasecurity.github.io/trivy-plugin-index/)) and provide context-specific risk scores based on factors like network exposure, data sensitivity, etc.

## What's changed

- Added an `OWASPRating` field to `DetectedVulnerability` (optional with `omitempty`)
- VEX processing now enriches vulnerabilities with OWASP ratings from CycloneDX VEX `ratings` blocks

## Example output

```json
{
  "VulnerabilityID": "CVE-2011-3374",
  "Severity": "LOW",
  "OWASPRating": {
    "score": 27.5,
    "severity": "medium",
    "vector": "SL:7/M:7/O:7/S:7/ED:4/EE:4/A:4/ID:5/LC:5/LI:5/LAV:5/LAC:5/FD:5/RD:5/NC:5/PV:5"
  }
}
```

## Why this matters

This brings context-aware vulnerability prioritization to Trivy. The same CVE can have different risk scores depending on how and where it's deployed. For example, a vulnerability in an internet-facing service is way more critical than the same one buried in an isolated internal component.

This complements the generic CVSS approach with environment-specific assessment, which aligns with what the CycloneDX spec now recommends. And it's fully backward compatible, so existing workflows won't be affected.


Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
