### PR TITLE
build: add linux/riscv64 builds

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -101,6 +101,7 @@ adjust_os() {
     arm64) OS=ARM64 ;;
     ppc64le) OS=Linux ;;
     s390x) OS=Linux ;;
+    riscv64) OS=Linux ;;
     darwin) OS=macOS ;;
     dragonfly) OS=DragonFlyBSD ;;
     freebsd) OS=FreeBSD ;;
@@ -120,6 +121,7 @@ adjust_arch() {
     arm64) ARCH=ARM64 ;;
     ppc64le) ARCH=PPC64LE ;;
     s390x) ARCH=s390x ;;
+    riscv64) ARCH=riscv64 ;;
   esac
   true
 }
@@ -203,6 +205,7 @@ uname_arch() {
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
     s390*) arch="s390x" ;;
+    riscv64*) arch="riscv64" ;;
   esac
   echo ${arch}
 }
@@ -240,6 +243,7 @@ uname_arch_check() {
     mips64) return 0 ;;
     mips64le) return 0 ;;
     s390x) return 0 ;;
+    riscv64) return 0 ;;
     amd64p32) return 0 ;;
   esac
   log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -21,6 +21,7 @@ builds:
       - arm64
       - s390x
       - ppc64le
+      - riscv64
     goarm:
       - 7
   - id: build-bsd
@@ -250,6 +251,31 @@ dockers:
       - "--platform=linux/ppc64le"
     extra_files:
     - contrib/
+  - image_templates:
+      - "docker.io/aquasec/trivy:{{ .Version }}-riscv64"
+      - "docker.io/aquasec/trivy:latest-riscv64"
+      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64"
+      - "ghcr.io/aquasecurity/trivy:latest-riscv64"
+      - "public.ecr.aws/aquasecurity/trivy:latest-riscv64"
+      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64"
+    use: buildx
+    goos: linux
+    goarch: riscv64
+    ids:
+      - build-linux
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
+      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
+      - "--platform=linux/riscv64"
+    extra_files:
+      - contrib/
 
 docker_manifests:
   - name_template: 'aquasec/trivy:{{ .Version }}'
@@ -258,36 +284,42 @@ docker_manifests:
     - 'aquasec/trivy:{{ .Version }}-arm64'
     - 'aquasec/trivy:{{ .Version }}-s390x'
     - 'aquasec/trivy:{{ .Version }}-ppc64le'
+    - 'aquasec/trivy:{{ .Version }}-riscv64'
   - name_template: 'ghcr.io/aquasecurity/trivy:{{ .Version }}'
     image_templates:
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}'
     image_templates:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'aquasec/trivy:latest'
     image_templates:
     - 'aquasec/trivy:{{ .Version }}-amd64'
     - 'aquasec/trivy:{{ .Version }}-arm64'
     - 'aquasec/trivy:{{ .Version }}-s390x'
     - 'aquasec/trivy:{{ .Version }}-ppc64le'
+    - 'aquasec/trivy:{{ .Version }}-riscv64'
   - name_template: 'ghcr.io/aquasecurity/trivy:latest'
     image_templates:
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-riscv64'
   - name_template: 'public.ecr.aws/aquasecurity/trivy:latest'
     image_templates:
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
     - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
+    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-riscv64'
 
 signs:
 - cmd: cosign


### PR DESCRIPTION
## Description

I'd like to include trivy also on RISC-V in the k3s build I'm working on.

Not directly related: If diskspace on build time is still a relevant problem, I think limiting the parallelism of goreleaser could help.

## Related PRs
- [x] #4992

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
