### PR TITLE
ci: run Trivy version bump in trivy-action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,7 +36,7 @@ jobs:
           release-please release-pr --repo-url=${{ github.server_url }}/${{ github.repository }} \
             --token=${{ secrets.ORG_REPO_TOKEN }} \
             --release-as=${{ github.event.inputs.version }} \
-            --target-branch=${{ github.ref_name }}
+            --target-branch="$GITHUB_REF_NAME"
 
   release-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
           gh workflow run update_version.yml \
             --repo ${{ github.repository_owner }}/trivy-telemetry \
             --ref main \
-            --field version=${{ github.ref_name }}
+            --field version="$GITHUB_REF_NAME"
 
       - name: Trigger update_version workflow in trivy-downloads
         if: always()
@@ -110,7 +110,7 @@ jobs:
           gh workflow run update_version.yml \
             --repo ${{ github.repository_owner }}/trivy-downloads \
             --ref main \
-            --field version=${{ github.ref_name }} \
+            --field version="$GITHUB_REF_NAME" \
             --field artifact=trivy
 
       - name: Trigger version update and release workflow in trivy-chocolatey
@@ -123,7 +123,7 @@ jobs:
           gh workflow run release.yml \
             --repo ${{ github.repository_owner }}/trivy-chocolatey \
             --ref main \
-            --field version=${{ github.ref_name }}
+            --field version="$GITHUB_REF_NAME"
 
       - name: Run version bump in trivy-action
         if: always()
@@ -132,8 +132,7 @@ jobs:
           # This allows triggering workflows in other repositories
           GH_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
         run: |
-          version="${{ github.ref_name }}"
           gh workflow run bump-trivy.yaml \
             --repo ${{ github.repository_owner }}/trivy-action \
             --ref master \
-            --field trivy-version=${version#v}
+            --field trivy-version="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Description

Added a step with a workflow call to bump the Trivy version in `trivy-action`. `always` conditions have been added for all steps in the `trigger-version-update` job, since they are independent of each other and failure in one step should not affect the others.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
