### PR TITLE
feat(bottlerocket): add vulnerability matching for Bottlerocket OS

### DIFF
--- a/docs/guide/coverage/os/bottlerocket.md
+++ b/docs/guide/coverage/os/bottlerocket.md
@@ -4,7 +4,7 @@ Trivy supports the following scanners for OS packages.
 |    Scanner    | Supported |
 | :-----------: | :-------: |
 |     SBOM      |     ✓     |
-| Vulnerability |     -     |
+| Vulnerability |     ✓     |
 |    License    |     -     |
 
 Please see [here](index.md#supported-os) for supported versions.
@@ -18,4 +18,11 @@ The table below outlines the features offered by Trivy.
 ## SBOM
 Trivy detects packages that are listed in the [software inventory].
 
+## Vulnerability
+Trivy checks for vulnerabilities using the [Bottlerocket security advisories][advisories],
+comparing installed package versions from the software inventory against known fixed versions.
+
+Data source: [Bottlerocket Security Advisories][advisories]
+
 [software inventory]: https://bottlerocket.dev/en/os/1.37.x/concepts/variants/#software-inventory
+[advisories]: https://advisories.bottlerocket.aws/

--- a/pkg/detector/ospkg/bottlerocket/bottlerocket.go
+++ b/pkg/detector/ospkg/bottlerocket/bottlerocket.go
@@ -3,24 +3,67 @@ package bottlerocket
 import (
 	"context"
 
+	version "github.com/knqyf263/go-rpm-version"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/bottlerocket"
 	osver "github.com/aquasecurity/trivy/pkg/detector/ospkg/version"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // Scanner implements the Bottlerocket scanner
 type Scanner struct {
+	vs bottlerocket.VulnSrc
 }
 
 // NewScanner is the factory method for Scanner
 func NewScanner() *Scanner {
-	return &Scanner{}
+	return &Scanner{
+		vs: bottlerocket.NewVulnSrc(),
+	}
 }
 
-func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, _ []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	log.InfoContext(ctx, "Vulnerability detection of Bottlerocket packages is currently not supported.")
-	return nil, nil
+func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	log.InfoContext(ctx, "Detecting vulnerabilities...", log.Int("pkg_num", len(pkgs)))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		advisories, err := s.vs.Get(db.GetParams{
+			PkgName: pkg.Name,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get Bottlerocket advisories: %w", err)
+		}
+
+		installed := utils.FormatVersion(pkg)
+		if installed == "" {
+			continue
+		}
+
+		installedVersion := version.NewVersion(installed)
+
+		for _, adv := range advisories {
+			fixedVersion := version.NewVersion(adv.FixedVersion)
+			if installedVersion.LessThan(fixedVersion) {
+				vulns = append(vulns, types.DetectedVulnerability{
+					VulnerabilityID:  adv.VulnerabilityID,
+					PkgID:            pkg.ID,
+					PkgName:          pkg.Name,
+					InstalledVersion: installed,
+					FixedVersion:     adv.FixedVersion,
+					PkgIdentifier:    pkg.Identifier,
+					Layer:            pkg.Layer,
+					DataSource:       adv.DataSource,
+					Custom:           adv.Custom,
+				})
+			}
+		}
+	}
+	return vulns, nil
 }
 
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {

--- a/pkg/detector/ospkg/bottlerocket/bottlerocket_test.go
+++ b/pkg/detector/ospkg/bottlerocket/bottlerocket_test.go
@@ -1,0 +1,155 @@
+package bottlerocket_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy/internal/dbtest"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/bottlerocket"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestScanner_Detect(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixtures []string
+		pkgs     []ftypes.Package
+		want     []types.DetectedVulnerability
+		wantErr  string
+	}{
+		{
+			name: "vulnerable kernel",
+			fixtures: []string{
+				"testdata/fixtures/bottlerocket.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			pkgs: []ftypes.Package{
+				{
+					Name:    "kernel-6.1",
+					Version: "6.1.50",
+					Release: "1.1690000000.br1",
+					Epoch:   0,
+					Layer: ftypes.Layer{
+						DiffID: "sha256:aaa",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "kernel-6.1",
+					VulnerabilityID:  "CVE-2023-5345",
+					InstalledVersion: "6.1.50-1.1690000000.br1",
+					FixedVersion:     "6.1.61-1.1700513487.br1",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:aaa",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Bottlerocket,
+						Name: "Bottlerocket Security Advisories",
+						URL:  "https://advisories.bottlerocket.aws/",
+					},
+				},
+			},
+		},
+		{
+			name: "not vulnerable - installed version is newer",
+			fixtures: []string{
+				"testdata/fixtures/bottlerocket.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			pkgs: []ftypes.Package{
+				{
+					Name:    "kernel-6.1",
+					Version: "6.1.70",
+					Release: "1.1710000000.br1",
+					Epoch:   0,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "vulnerable package with epoch",
+			fixtures: []string{
+				"testdata/fixtures/bottlerocket.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			pkgs: []ftypes.Package{
+				{
+					Name:    "glibc",
+					Version: "2.40",
+					Release: "1.1740525475.e3a5862c.br1",
+					Epoch:   1,
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "glibc",
+					VulnerabilityID:  "CVE-2024-99999",
+					InstalledVersion: "1:2.40-1.1740525475.e3a5862c.br1",
+					FixedVersion:     "1:2.41-1.1760000000.aaaaaaaa.br1",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Bottlerocket,
+						Name: "Bottlerocket Security Advisories",
+						URL:  "https://advisories.bottlerocket.aws/",
+					},
+				},
+			},
+		},
+		{
+			name: "no packages",
+			fixtures: []string{
+				"testdata/fixtures/bottlerocket.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			pkgs: nil,
+			want: nil,
+		},
+		{
+			name: "Get returns an error",
+			fixtures: []string{
+				"testdata/fixtures/invalid.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			pkgs: []ftypes.Package{
+				{
+					Name:    "kernel-6.1",
+					Version: "6.1.50",
+					Release: "1.1690000000.br1",
+				},
+			},
+			wantErr: "failed to get Bottlerocket advisories",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = dbtest.InitDB(t, tt.fixtures)
+			defer db.Close()
+
+			s := bottlerocket.NewScanner()
+			got, err := s.Detect(t.Context(), "", nil, tt.pkgs)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].VulnerabilityID < got[j].VulnerabilityID
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestScanner_IsSupportedVersion(t *testing.T) {
+	s := bottlerocket.NewScanner()
+	assert.True(t, s.IsSupportedVersion(t.Context(), ftypes.Bottlerocket, "1.19.0"))
+}

--- a/pkg/detector/ospkg/bottlerocket/testdata/fixtures/bottlerocket.yaml
+++ b/pkg/detector/ospkg/bottlerocket/testdata/fixtures/bottlerocket.yaml
@@ -1,0 +1,17 @@
+- bucket: bottlerocket
+  pairs:
+    - bucket: kernel-6.1
+      pairs:
+        - key: CVE-2023-5345
+          value:
+            FixedVersion: "6.1.61-1.1700513487.br1"
+    - bucket: amazon-ssm-agent
+      pairs:
+        - key: CVE-2025-22870
+          value:
+            FixedVersion: "3.3.2746.0-1.1754950980.06e00082.br1"
+    - bucket: glibc
+      pairs:
+        - key: CVE-2024-99999
+          value:
+            FixedVersion: "1:2.41-1.1760000000.aaaaaaaa.br1"

--- a/pkg/detector/ospkg/bottlerocket/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/bottlerocket/testdata/fixtures/data-source.yaml
@@ -1,0 +1,7 @@
+- bucket: data-source
+  pairs:
+    - key: bottlerocket
+      value:
+        ID: "bottlerocket"
+        Name: "Bottlerocket Security Advisories"
+        URL: "https://advisories.bottlerocket.aws/"

--- a/pkg/detector/ospkg/bottlerocket/testdata/fixtures/invalid.yaml
+++ b/pkg/detector/ospkg/bottlerocket/testdata/fixtures/invalid.yaml
@@ -1,0 +1,6 @@
+- bucket: bottlerocket
+  pairs:
+    - bucket: kernel-6.1
+      pairs:
+        - key: CVE-2023-5345
+          value: "invalid"

--- a/pkg/fanal/analyzer/pkg/bottlerocket_inventory/bottlerocket_inventory.go
+++ b/pkg/fanal/analyzer/pkg/bottlerocket_inventory/bottlerocket_inventory.go
@@ -80,10 +80,18 @@ func (a bottlerocketInventoryAnalyzer) parseApplicationInventory(_ context.Conte
 			Epoch:   epoch,
 			Name:    app.Name,
 			Version: app.Version,
+			Release: app.Release,
 		}
 
 		if pkg.Name != "" && pkg.Version != "" {
-			pkg.ID = fmt.Sprintf("%s@%s", pkg.Name, pkg.Version)
+			ver := pkg.Version
+			if pkg.Release != "" {
+				ver = fmt.Sprintf("%s-%s", ver, pkg.Release)
+			}
+			if pkg.Epoch != 0 {
+				ver = fmt.Sprintf("%d:%s", pkg.Epoch, ver)
+			}
+			pkg.ID = fmt.Sprintf("%s@%s", pkg.Name, ver)
 		}
 
 		pkgs = append(pkgs, pkg)

--- a/pkg/fanal/analyzer/pkg/bottlerocket_inventory/bottlerocket_inventory_test.go
+++ b/pkg/fanal/analyzer/pkg/bottlerocket_inventory/bottlerocket_inventory_test.go
@@ -12,23 +12,26 @@ import (
 
 var pkgs = []types.Package{
 	{
-		ID:      "glibc@2.40",
+		ID:      "glibc@1:2.40-1.1740525475.e3a5862c.br1",
 		Name:    "glibc",
 		Version: "2.40",
+		Release: "1.1740525475.e3a5862c.br1",
 		Epoch:   1,
 		Arch:    "x86_64",
 	},
 	{
-		ID:      "kernel-6.1@6.1.128",
+		ID:      "kernel-6.1@6.1.128-1.1740603423.4d405dc9.br1",
 		Name:    "kernel-6.1",
 		Version: "6.1.128",
+		Release: "1.1740603423.4d405dc9.br1",
 		Epoch:   0,
 		Arch:    "x86_64",
 	},
 	{
-		ID:      "systemd@252.22",
+		ID:      "systemd@252.22-1.1740525475.e3a5862c.br1",
 		Name:    "systemd",
 		Version: "252.22",
+		Release: "1.1740525475.e3a5862c.br1",
 		Epoch:   0,
 		Arch:    "x86_64",
 	},

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -142,6 +142,7 @@ var (
 		Alpine,
 		Amazon,
 		Azure,
+		Bottlerocket,
 		CBLMariner,
 		CentOS,
 		CentOSStream,


### PR DESCRIPTION
## Description

Enable vulnerability detection by matching installed package versions from the Bottlerocket software inventory against security advisories stored in trivy-db, using RPM version comparison.

- Add Release field in the inventory analyzer output
- Implement the scanner using go-rpm-version for epoch:version-release comparison against advisory fixed versions
- Add Bottlerocket to the OSTypes validation list
- Update coverage documentation

## Related PRs
- [ ] https://github.com/aquasecurity/vuln-list-update/pull/406
- [ ] https://github.com/aquasecurity/trivy-db/pull/636
- [x] https://github.com/aquasecurity/trivy/pull/8653 (merged)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
