### PR TITLE
chore: bump golangci-lint to v2.10.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         id: lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.4
+          version: v2.10
           args: --verbose
           skip-save-cache: true  # Restore cache from main branch but don't save new cache
         env:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,9 +68,13 @@ linters:
         - G101
         - G114
         - G115
+        - G117 # Potential exposure of secrets in values marshaled by JSON/YAML/XML/TOML
         - G204
         - G304
         - G402
+        - G703 # Path traversal via taint analysis
+        - G704 # SSRF via taint analysis
+        - G705 # XSS via taint analysis
     govet:
       disable:
         - shadow
@@ -92,6 +96,8 @@ linters:
       sprintf1: false
       # Optimizes into strings concatenation.
       strconcat: false
+      # Optimizes string concatenation in a loop.
+      concat-loop: false
     revive:
       max-open-files: 2048
       # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
@@ -159,6 +165,7 @@ linters:
     - unused
     - usestdlibvars
     - usetesting
+    - modernize
 
   exclusions:
     generated: lax

--- a/go.mod
+++ b/go.mod
@@ -478,7 +478,6 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	golang.org/x/tools/gopls v0.21.0 // indirect
 	google.golang.org/api v0.260.0 // indirect
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
@@ -519,6 +518,5 @@ tool (
 	github.com/magefile/mage
 	github.com/twitchtv/twirp/protoc-gen-twirp
 	golang.org/x/tools/cmd/goyacc
-	golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize
 	sigs.k8s.io/kind
 )

--- a/go.sum
+++ b/go.sum
@@ -1404,8 +1404,6 @@ golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnps
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
-golang.org/x/tools/gopls v0.21.0 h1:k8RlBm3ES+GVe+fbTSkzwKgarmNwN+6aDalb0T0xfag=
-golang.org/x/tools/gopls v0.21.0/go.mod h1:x/34IonzHuKpDDlMUjYezcjbwNOJ32FtrYOLqAuOmNo=
 golang.org/x/vuln v1.1.4 h1:Ju8QsuyhX3Hk8ma3CesTbO8vfJD9EvUBgHvkxHBzj0I=
 golang.org/x/vuln v1.1.4/go.mod h1:F+45wmU18ym/ca5PLTPLsSzr2KppzswxPP603ldA67s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -75,7 +75,7 @@ func (Tool) PipTools() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v2.4.0"
+	const version = "v2.10.0"
 	bin := filepath.Join(GOBIN, "golangci-lint")
 	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
 		return nil
@@ -348,19 +348,13 @@ type Lint mg.Namespace
 // Run runs linters
 func (l Lint) Run() error {
 	mg.Deps(Tool{}.GolangciLint, Tool{}.Install)
-	if err := sh.RunWithV(ENV, "golangci-lint", "run", "--build-tags=integration"); err != nil {
-		return err
-	}
-	return sh.RunWithV(ENV, "modernize", "./...")
+	return sh.RunWithV(ENV, "golangci-lint", "run", "--build-tags=integration")
 }
 
 // Fix auto fixes linters
 func (l Lint) Fix() error {
 	mg.Deps(Tool{}.GolangciLint, Tool{}.Install)
-	if err := sh.RunWithV(ENV, "golangci-lint", "run", "--fix", "--build-tags=integration"); err != nil {
-		return err
-	}
-	return sh.RunWithV(ENV, "modernize", "-fix", "./...")
+	return sh.RunWithV(ENV, "golangci-lint", "run", "--fix", "--build-tags=integration")
 }
 
 // Fmt formats Go code

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -990,11 +991,11 @@ func NewKubernetesCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 	reportFlagGroup.ExitOnEOL = nil // disable '--exit-on-eol'
 	reportFlagGroup.TableMode = nil // disable '--table-mode's
 	compliance := flag.ComplianceFlag.Clone()
-	var compliances string
+	var compliances strings.Builder
 	for _, val := range types.BuiltInK8sCompliances {
-		compliances += fmt.Sprintf("\n  - %s", val)
+		fmt.Fprintf(&compliances, "\n  - %s", val)
 	}
-	compliance.Usage = fmt.Sprintf("%s\nBuilt-in compliance's:%s", compliance.Usage, compliances)
+	compliance.Usage = fmt.Sprintf("%s\nBuilt-in compliance's:%s", compliance.Usage, compliances.String())
 	reportFlagGroup.Compliance = compliance // override usage as the accepted values differ for each subcommand.
 
 	formatFlag := flag.FormatFlag.Clone()

--- a/pkg/dependency/parser/java/pom/var.go
+++ b/pkg/dependency/parser/java/pom/var.go
@@ -53,9 +53,9 @@ func evaluateVariable(s string, props map[string]string, seenProps []string) str
 }
 
 func printLoopedPropertiesStack(env string, usedProps []string) {
-	var s string
+	var sb strings.Builder
 	for _, prop := range usedProps {
-		s += fmt.Sprintf("%s -> ", prop)
+		fmt.Fprintf(&sb, "%s -> ", prop)
 	}
-	log.Warn("Lopped properties were detected", log.String("prop", s+env))
+	log.Warn("Lopped properties were detected", log.String("prop", sb.String()+env))
 }

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -126,8 +126,8 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 func (a alpineCmdAnalyzer) parseConfig(apkIndexArchive *apkIndex, config *v1.ConfigFile) (packages []types.Package) {
 	envs := make(map[string]string)
 	for _, env := range config.Config.Env {
-		index := strings.Index(env, "=")
-		envs["$"+env[:index]] = env[index+1:]
+		before, after, _ := strings.Cut(env, "=")
+		envs["$"+before] = after
 	}
 
 	uniqPkgs := make(map[string]types.Package)

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -139,11 +139,11 @@ func stripBuildMetadata(line string) string {
 }
 
 func buildRunInstruction(s string) string {
-	pos := strings.Index(s, "/bin/sh -c")
-	if pos == -1 {
+	_, after, ok := strings.Cut(s, "/bin/sh -c")
+	if !ok {
 		return s
 	}
-	return "RUN" + s[pos+len("/bin/sh -c"):]
+	return "RUN" + after
 }
 
 func buildHealthcheckInstruction(health *v1.HealthConfig) string {

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -278,41 +278,43 @@ func (f *Flag[T]) Add(cmd *cobra.Command) {
 	case int:
 		flags.IntP(f.Name, f.Shorthand, v, f.Usage)
 	case string:
-		usage := f.Usage
+		var usage strings.Builder
+		usage.WriteString(f.Usage)
 		if len(f.Values) > 0 {
 			if len(f.Values) <= 4 {
 				// Display inline for a small number of choices
-				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
+				fmt.Fprintf(&usage, " (allowed values: %s)", strings.Join(f.Values, ","))
 			} else {
 				// Display as a bullet list for many choices
-				usage += "\nAllowed values:"
+				usage.WriteString("\nAllowed values:")
 				for _, val := range f.Values {
-					usage += fmt.Sprintf("\n  - %s", val)
+					fmt.Fprintf(&usage, "\n  - %s", val)
 				}
 				if v != "" {
-					usage += "\n"
+					usage.WriteString("\n")
 				}
 			}
 		}
-		flags.StringP(f.Name, f.Shorthand, v, usage)
+		flags.StringP(f.Name, f.Shorthand, v, usage.String())
 	case []string:
-		usage := f.Usage
+		var usage strings.Builder
+		usage.WriteString(f.Usage)
 		if len(f.Values) > 0 {
 			if len(f.Values) <= 4 {
 				// Display inline for a small number of choices
-				usage += fmt.Sprintf(" (allowed values: %s)", strings.Join(f.Values, ","))
+				fmt.Fprintf(&usage, " (allowed values: %s)", strings.Join(f.Values, ","))
 			} else {
 				// Display as a bullet list for many choices
-				usage += "\nAllowed values:"
+				usage.WriteString("\nAllowed values:")
 				for _, val := range f.Values {
-					usage += fmt.Sprintf("\n  - %s", val)
+					fmt.Fprintf(&usage, "\n  - %s", val)
 				}
 				if len(v) != 0 {
-					usage += "\n"
+					usage.WriteString("\n")
 				}
 			}
 		}
-		flags.StringSliceP(f.Name, f.Shorthand, v, usage)
+		flags.StringSliceP(f.Name, f.Shorthand, v, usage.String())
 	case bool:
 		flags.BoolP(f.Name, f.Shorthand, v, f.Usage)
 	case time.Duration:
@@ -667,7 +669,7 @@ func (f *Flags) AddFlags(cmd *cobra.Command) {
 }
 
 func (f *Flags) Usages(cmd *cobra.Command) string {
-	var usages string
+	var usages strings.Builder
 	for _, group := range f.groups() {
 		flags := pflag.NewFlagSet(cmd.Name(), pflag.ContinueOnError)
 		lflags := cmd.LocalFlags()
@@ -681,10 +683,10 @@ func (f *Flags) Usages(cmd *cobra.Command) string {
 			continue
 		}
 
-		usages += fmt.Sprintf("%s Flags\n", group.Name())
-		usages += flags.FlagUsages() + "\n"
+		fmt.Fprintf(&usages, "%s Flags\n", group.Name())
+		usages.WriteString(flags.FlagUsages() + "\n")
 	}
-	return strings.TrimSpace(usages)
+	return strings.TrimSpace(usages.String())
 }
 
 func (f *Flags) Bind(cmd *cobra.Command) error {

--- a/pkg/iac/rego/convert/anonymous.go
+++ b/pkg/iac/rego/convert/anonymous.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-var converterInterface = reflect.TypeOf((*Converter)(nil)).Elem()
+var converterInterface = reflect.TypeFor[Converter]()
 
 func anonymousToRego(inputValue reflect.Value) any {
 

--- a/pkg/iac/rego/convert/struct.go
+++ b/pkg/iac/rego/convert/struct.go
@@ -11,7 +11,7 @@ type metadataProvider interface {
 	GetMetadata() types.Metadata
 }
 
-var metadataInterface = reflect.TypeOf((*metadataProvider)(nil)).Elem()
+var metadataInterface = reflect.TypeFor[metadataProvider]()
 
 func StructToRego(inputValue reflect.Value) map[string]any {
 

--- a/pkg/iac/rego/schemas/builder.go
+++ b/pkg/iac/rego/schemas/builder.go
@@ -164,7 +164,7 @@ func (b *builder) readProperty(name string, parent, inputType reflect.Type, inde
 	return nil, nil
 }
 
-var converterInterface = reflect.TypeOf((*convert.Converter)(nil)).Elem()
+var converterInterface = reflect.TypeFor[convert.Converter]()
 
 func (b *builder) readStruct(name string, parent, inputType reflect.Type, indent int) (*Property, error) {
 
@@ -257,7 +257,7 @@ func (b *builder) readRego(def *Property, name string, parent, typ reflect.Type,
 			child := &Property{
 				Properties: make(map[string]Property),
 			}
-			if err := b.readRego(child, k, reflect.TypeOf(raw), reflect.TypeOf(v), v, indent+1); err != nil {
+			if err := b.readRego(child, k, reflect.TypeOf(raw), reflect.TypeFor[string](), v, indent+1); err != nil {
 				return err
 			}
 			def.Properties[k] = *child

--- a/pkg/iac/scanners/azure/functions/concat.go
+++ b/pkg/iac/scanners/azure/functions/concat.go
@@ -11,7 +11,7 @@ func Concat(args ...any) any {
 	case string:
 		var sb strings.Builder
 		for _, arg := range args {
-			sb.WriteString(fmt.Sprintf("%v", arg))
+			fmt.Fprintf(&sb, "%v", arg)
 		}
 		return sb.String()
 	case any:

--- a/pkg/iac/scanners/azure/functions/resource.go
+++ b/pkg/iac/scanners/azure/functions/resource.go
@@ -2,34 +2,29 @@ package functions
 
 import (
 	"fmt"
+	"strings"
 )
 
 func ResourceID(args ...any) any {
-	if len(args) < 2 {
-		return nil
-	}
-
-	var resourceID string
-
-	for _, arg := range args {
-		resourceID += "/" + fmt.Sprintf("%v", arg)
-	}
-
-	return resourceID
+	return buildResourceID(2, args...)
 }
 
 func ExtensionResourceID(args ...any) any {
-	if len(args) < 3 {
+	return buildResourceID(3, args...)
+}
+
+func buildResourceID(minArgs int, args ...any) any {
+	if len(args) < minArgs {
 		return nil
 	}
 
-	var resourceID string
+	var resourceID strings.Builder
 
 	for _, arg := range args {
-		resourceID += "/" + fmt.Sprintf("%v", arg)
+		fmt.Fprintf(&resourceID, "/%v", arg)
 	}
 
-	return resourceID
+	return resourceID.String()
 }
 
 func ResourceGroup(_ ...any) any {

--- a/pkg/iac/scanners/terraform/parser/resolvers/writable.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/writable.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package resolvers
 

--- a/pkg/licensing/normalize.go
+++ b/pkg/licensing/normalize.go
@@ -542,8 +542,8 @@ func standardizeKeyAndSuffix(name string) expr.SimpleExpr {
 	}
 	hasPlus := false
 	for _, s := range plusSuffixes {
-		if strings.HasSuffix(name, s) {
-			name = strings.TrimSuffix(name, s)
+		if before, ok := strings.CutSuffix(name, s); ok {
+			name = before
 			hasPlus = true
 		}
 	}

--- a/pkg/plugin/index.go
+++ b/pkg/plugin/index.go
@@ -65,7 +65,7 @@ func (m *Manager) Search(ctx context.Context, keyword string) error {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%-20s %-60s %-20s %s\n", "NAME", "DESCRIPTION", "MAINTAINER", "OUTPUT"))
+	fmt.Fprintf(&buf, "%-20s %-60s %-20s %s\n", "NAME", "DESCRIPTION", "MAINTAINER", "OUTPUT")
 	for _, p := range index.Plugins {
 		if keyword == "" || strings.Contains(p.Name, keyword) || strings.Contains(p.Summary, keyword) {
 			s := fmt.Sprintf("%-20s %-60s %-20s %s\n", truncateString(p.Name, 20),

--- a/pkg/vex/repo/manager.go
+++ b/pkg/vex/repo/manager.go
@@ -163,7 +163,7 @@ func (m *Manager) List(ctx context.Context) error {
 
 	var output strings.Builder
 
-	output.WriteString(fmt.Sprintf("VEX Repositories (config: %s)\n\n", m.configFile))
+	fmt.Fprintf(&output, "VEX Repositories (config: %s)\n\n", m.configFile)
 
 	if len(conf.Repositories) == 0 {
 		output.WriteString("No repositories configured.\n")
@@ -177,7 +177,7 @@ func (m *Manager) List(ctx context.Context) error {
 			if repo.Insecure {
 				tlsVerify = "\n  TLS Verify: No"
 			}
-			output.WriteString(fmt.Sprintf("- Name: %s\n  URL: %s\n  Status: %s%s\n\n", repo.Name, repo.URL, status, tlsVerify))
+			fmt.Fprintf(&output, "- Name: %s\n  URL: %s\n  Status: %s%s\n\n", repo.Name, repo.URL, status, tlsVerify)
 		}
 	}
 


### PR DESCRIPTION
## Description

Upgraded `golangci-lint` to v2.10.0, which resolves an issue that occurred when go1.26 was installed locally.

Some linters have been temporarily disabled due to a large number of newly reported issues. In particular, several `gosec` rules were turned off, as addressing them would require significant effort and is better handled in separate, dedicated changes.

The `modernize` linter has also been enabled, as it has been available in golangci-lint since [v2.6.0](https://ville.dev/blog/posts/go-modernize/).

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
