### PR TITLE
Fix/skip absolute dirs

### DIFF
--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -44,6 +44,17 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 			return err
 		}
 
+		// Skip absolute system directories (/dev, /proc, /sys) but not relative project directories
+		if filepath.IsAbs(filePath) {
+			relToRoot, err := filepath.Rel("/", filePath)
+			if err == nil && isSystemDir(relToRoot) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
 		// For exported rootfs (e.g. images/alpine/etc/alpine-release)
 		relPath, err := filepath.Rel(root, filePath)
 		if err != nil {
@@ -151,6 +162,17 @@ func (w *FS) BuildSkipPaths(base string, paths []string) []string {
 
 	relativePaths = utils.CleanSkipPaths(relativePaths)
 	return relativePaths
+}
+
+var systemDirs = map[string]bool{
+	"dev":  true,
+	"proc": true,
+	"sys":  true,
+}
+
+func isSystemDir(path string) bool {
+	dir := strings.Split(path, "/")[0]
+	return systemDirs[dir]
 }
 
 // fileOpener returns a function opening a file.

--- a/pkg/fanal/walker/vm.go
+++ b/pkg/fanal/walker/vm.go
@@ -58,6 +58,7 @@ func NewVM() *VM {
 func (w *VM) Walk(vreader *io.SectionReader, root string, opt Option, fn WalkFunc) error {
 	w.skipFiles = opt.SkipFiles
 	w.skipDirs = append(opt.SkipDirs, defaultSkipDirs...)
+	w.skipDirs = append(w.skipDirs, "dev", "proc", "sys")
 
 	// This function will be called on each file.
 	w.analyzeFn = fn

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -10,9 +10,6 @@ const defaultSizeThreshold = int64(100) << 20 // 200MB
 
 var defaultSkipDirs = []string{
 	"**/.git",
-	"proc",
-	"sys",
-	"dev",
 }
 
 type Option struct {

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -504,6 +504,8 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA512:
+			alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:


### PR DESCRIPTION
## Description

Fixes the issue where Trivy skips `dev` subdirectory in projects even when it's a regular project directory (relative path), not the Linux system /dev directory (absolute path).

### Changes
- Only skip /dev, /proc, /sys when they are absolute system paths
- Don't skip relative project directories like ./dev
- VM/disk image scanning still skips dev/proc/sys (as they are absolute within the image)

### Before
Trivy incorrectly skipped project directories named `dev`.

### After
Trivy only skips system directories like `/dev`, `/proc`, `/sys` when scanning.

## Related issues
- Close #6651

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
