### PR TITLE
ci: pin Docker Engine to v29 for integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,8 @@ jobs:
       # GitHub runners were rolled back to Docker Engine v28, while tests rely on Docker Engine v29.
       # This version mismatch leads to differences in image IDs and causes integration tests to fail.
       # We explicitly install Docker Engine v29 to ensure consistent behavior.
+      # Remove this temporary solution when the issue is resolved.
+      # https://github.com/actions/runner-images/issues/13474
       - name: Set up Docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
         with:


### PR DESCRIPTION
## Description

The upgrade of Docker Engine to v29 in GitHub runners caused multiple issues for users, and the `runner-images` team decided to roll back the major version. As a result, runners are now using Docker Engine v28 again, which caused integration tests to fail on our side. We already rely on Docker Engine v29, and the version mismatch leads to differences in generated image IDs.

This PR pins Docker Engine to v29 in CI to align with Trivy and prevent integration test failures.


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
