### PR TITLE
feat: add --no-color flag and NO_COLOR env var support

### DIFF
--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
@@ -86,6 +87,14 @@ var (
 		TelemetrySafe: true,
 		Internal:      true, // Hidden from help output, intended for maintainer debugging only
 	}
+	NoColorFlag = Flag[bool]{
+		Name:          "no-color",
+		ConfigName:    "no-color",
+		Usage:         "disable colorized output",
+		Persistent:    true,
+		TelemetrySafe: true,
+		EnvName:       "NO_COLOR", // https://no-color.org/
+	}
 )
 
 // GlobalFlagGroup composes global flags
@@ -100,6 +109,7 @@ type GlobalFlagGroup struct {
 	CacheDir              *Flag[string]
 	GenerateDefaultConfig *Flag[bool]
 	TraceHTTP             *Flag[bool]
+	NoColor               *Flag[bool]
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -114,6 +124,7 @@ type GlobalOptions struct {
 	CacheDir              string
 	GenerateDefaultConfig bool
 	TraceHTTP             bool
+	NoColor               bool
 }
 
 func NewGlobalFlagGroup() *GlobalFlagGroup {
@@ -128,6 +139,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		CacheDir:              CacheDirFlag.Clone(),
 		GenerateDefaultConfig: GenerateDefaultConfigFlag.Clone(),
 		TraceHTTP:             TraceHTTPFlag.Clone(),
+		NoColor:               NoColorFlag.Clone(),
 	}
 }
 
@@ -147,6 +159,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.CacheDir,
 		f.GenerateDefaultConfig,
 		f.TraceHTTP,
+		f.NoColor,
 	}
 }
 
@@ -175,6 +188,12 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 
 	log.Debug("Cache dir", log.String("dir", f.CacheDir.Value()))
 
+	// Respect the NO_COLOR env var (https://no-color.org/) as well as --no-color flag.
+	noColor := f.NoColor.Value() || os.Getenv("NO_COLOR") != ""
+	if noColor {
+		color.NoColor = true
+	}
+
 	opts.GlobalOptions = GlobalOptions{
 		ConfigFile:            f.ConfigFile.Value(),
 		ShowVersion:           f.ShowVersion.Value(),
@@ -186,6 +205,7 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 		CacheDir:              f.CacheDir.Value(),
 		GenerateDefaultConfig: f.GenerateDefaultConfig.Value(),
 		TraceHTTP:             f.TraceHTTP.Value(),
+		NoColor:               noColor,
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #1091

## Problem

Trivy's output contains ANSI escape codes for color. When output is redirected to files or viewed in CI logs, these codes appear as garbled characters like `?[31m` instead of readable text.

## Solution

Add a `--no-color` CLI flag (persistent, applies to all subcommands) and respect the standard `NO_COLOR` environment variable from https://no-color.org/.

When either is set, `color.NoColor = true` is applied globally, which disables all color output from the `fatih/color` package used throughout Trivy.

## Usage

```bash
# Via flag
trivy image --no-color alpine:latest

# Via env var (no-color.org standard)
NO_COLOR=1 trivy image alpine:latest
```

## Changes

- **`pkg/flag/global_flags.go`**
  - New `NoColorFlag` with `EnvName: "NO_COLOR"`
  - Added `NoColor *Flag[bool]` to `GlobalFlagGroup`
  - Added `NoColor bool` to `GlobalOptions`
  - Wired through `NewGlobalFlagGroup()`, `Flags()`, and `ToOptions()`
  - `ToOptions()` checks both `--no-color` flag and `NO_COLOR` env and sets `color.NoColor = true`

## Backward compatibility

Default is `false`; existing behaviour is unchanged.

Made with [Cursor](https://cursor.com)