### PR TITLE
ci: bump golangci-lint to v2.10 in cache-test-assets

### DIFF
--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Run golangci-lint for caching
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.4
+          version: v2.10
           args: --verbose
         env:
           GOEXPERIMENT: jsonv2


### PR DESCRIPTION
## Description
Fixes https://github.com/aquasecurity/trivy/actions/runs/22430788375/job/64949043780

In this PR https://github.com/aquasecurity/trivy/pull/10223, I forgot to update golangci-lint in the asset caching workflow. This PR fixes that.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/10223

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
