### PR TITLE
fix(module): pass both ptr and size to WASM free() to prevent memory leak

### DIFF
--- a/pkg/module/free_test.go
+++ b/pkg/module/free_test.go
@@ -1,0 +1,67 @@
+package module
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero"
+)
+
+// TestFreeCallSignature is a regression test for a bug where free() was called
+// with only one argument (ptr) instead of two (ptr, size).
+//
+// The WASM SDK exports: free(ptr uint32, size uint32)
+// wazero enforces strict parameter counts, so calling free with a wrong number
+// of arguments returns an error. Previously this error was silently ignored
+// (via errcheck nolint), causing a memory leak that eventually crashed the WASM
+// module with errors like:
+//   - "malloc error: module closed with exit_code(4)"
+//   - "malloc error: wasm error: out of bounds memory access"
+//   - "malloc error: runtime error: invalid memory address or nil pointer dereference"
+func TestFreeCallSignature(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Test satisfied adequately by Linux tests")
+	}
+
+	ctx := t.Context()
+
+	wasmCode, err := os.ReadFile("testdata/scanner/scanner.wasm")
+	require.NoError(t, err, "scanner.wasm not found; run 'mage test:generateModules' first")
+
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	mod, err := newWASMPlugin(ctx, cache, wasmCode)
+	require.NoError(t, err)
+	defer mod.Close(ctx)
+
+	const allocSize = 64
+
+	t.Run("free with correct args (ptr, size) succeeds", func(t *testing.T) {
+		// Allocate a small buffer via malloc — this is exactly what marshal() and
+		// stringToPtrSize() do before returning ptr+size to the caller.
+		results, err := mod.malloc.Call(ctx, allocSize)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		ptr := results[0]
+		_, err = mod.free.Call(ctx, ptr, allocSize)
+		assert.NoError(t, err,
+			"free(ptr, size) must succeed — the WASM SDK expects two parameters")
+	})
+
+	t.Run("free with wrong args (ptr only) fails", func(t *testing.T) {
+		// Re-allocate since the previous buffer was freed
+		results, err := mod.malloc.Call(ctx, allocSize)
+		require.NoError(t, err)
+		ptr := results[0]
+
+		_, err = mod.free.Call(ctx, ptr) // only one arg — this is the old buggy call
+		assert.ErrorContainsf(t, err,
+			"expected 2 params, but passed 1",
+			"free(ptr) with missing size argument must fail — "+
+				"this was the root cause of the WASM memory leak")
+	})
+}

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -461,7 +461,7 @@ func (m *wasmModule) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 	if err != nil {
 		return nil, xerrors.Errorf("failed to write string to memory: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) // nolint: errcheck
+	defer m.free.Call(ctx, inputPtr, inputSize) // nolint: errcheck
 
 	// 2. Call analyze
 	analyzeRes, err := m.analyze.Call(ctx, inputPtr, inputSize)
@@ -511,7 +511,7 @@ func (m *wasmModule) PostScan(ctx context.Context, results types.Results) (types
 	if err != nil {
 		return nil, xerrors.Errorf("post scan marshal error: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) //nolint: errcheck
+	defer m.free.Call(ctx, inputPtr, inputSize) //nolint: errcheck
 
 	analyzeRes, err := m.postScan.Call(ctx, inputPtr, inputSize)
 	if err != nil {


### PR DESCRIPTION
## Description
Fix a WASM memory leak in wasmModule.Analyze() and wasmModule.PostScan() where free() was called with an incorrect number of arguments.

The WASM SDK exports free(ptr uint32, size uint32) — two parameters. However, two call sites in module.go only passed one argument:

```
// Before (broken — free silently fails, memory is never reclaimed)
defer m.free.Call(ctx, inputPtr)

// After (correct — matches SDK signature)
defer m.free.Call(ctx, inputPtr, inputSize)
```

wazero validates parameter counts at runtime, so the single-argument call always returned an error. Because both call sites used // nolint: errcheck, the failure was silently ignored, and free() never executed. This caused a memory leak that eventually exhausted WASM linear memory, crashing the module with errors such as:

```
malloc error: module closed with exit_code(4)
malloc error: wasm error: out of bounds memory access
malloc error: runtime error: invalid memory address or nil pointer dereference
```

## Related issues
- Close #10255

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
