### PR TITLE
ci: run Trivy version bump in trivy-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,4 +150,4 @@ jobs:
           gh workflow run bump-trivy.yaml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-action" \
             --ref master \
-            --field "trivy-version=$VERSION"
+            --field "trivy_version=$VERSION"


### PR DESCRIPTION
## Description

Added a step with a workflow call to bump the Trivy version in `trivy-action`. `always` conditions have been added for all steps in the `trigger-version-update` job, since they are independent of each other and failure in one step should not affect the others.

This PR is opened from a correct fork and replaces  https://github.com/aquasecurity/trivy/pull/10201

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
