### PR TITLE
fix(misconf): reject nil plays during playbook parsing

### DIFF
--- a/pkg/iac/scanners/ansible/parser/discovery.go
+++ b/pkg/iac/scanners/ansible/parser/discovery.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 
 	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/aquasecurity/trivy/pkg/iac/scanners/ansible/fsutils"
 )
 
 // FindProjects locates Ansible project roots within fsys starting from root.
@@ -68,13 +70,9 @@ func isAnsibleProject(fsys fs.FS, dir string) bool {
 }
 
 func isPlaybookFile(fsys fs.FS, filePath string) bool {
-	data, err := fs.ReadFile(fsys, filePath)
+	f := fsutils.NewFileSource(fsys, filePath)
+	plays, err := parsePlays(f)
 	if err != nil {
-		return false
-	}
-
-	var plays []*Play
-	if err := decodeYAML(data, &plays); err != nil {
 		return false
 	}
 

--- a/pkg/iac/scanners/ansible/parser/discovery_test.go
+++ b/pkg/iac/scanners/ansible/parser/discovery_test.go
@@ -59,6 +59,14 @@ func TestFindProjects(t *testing.T) {
 			dir:      ".",
 			expected: []string{"proj1", "proj2"},
 		},
+		{
+			name: "playbook with invalid play",
+			fsys: fstest.MapFS{
+				"play.yml": &fstest.MapFile{Data: []byte(`-`)},
+			},
+			dir:      ".",
+			expected: []string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/ansible/parser/parser_test.go
+++ b/pkg/iac/scanners/ansible/parser/parser_test.go
@@ -551,6 +551,20 @@ name: mycol
 			},
 			expectedTasks: []string{"Test task"},
 		},
+		{
+			name: "with invalid play",
+			files: map[string]string{
+				"playbook.yaml": `---
+-
+- hosts: localhost
+  tasks:
+    - name: Test task
+      debug:
+        msg: Test task
+`,
+			},
+			expectedTasks: []string{"Test task"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/ansible/parser/play.go
+++ b/pkg/iac/scanners/ansible/parser/play.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"path/filepath"
 
+	"github.com/samber/lo"
+	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/ansible/fsutils"
@@ -36,6 +38,17 @@ type Playbook struct {
 
 func (pb *Playbook) resolveIncludedSrc(incPath string) fsutils.FileSource {
 	return pb.Src.Dir().Join(incPath)
+}
+
+func parsePlays(f fsutils.FileSource) ([]*Play, error) {
+	var plays []*Play
+	if err := decodeYAMLFile(f, &plays); err != nil {
+		return nil, xerrors.Errorf("decode YAML file: %w", err)
+	}
+
+	return lo.Filter(plays, func(p *Play, _ int) bool {
+		return p != nil
+	}), nil
 }
 
 // Play represents a single play in an Ansible playbook.

--- a/pkg/iac/scanners/ansible/parser/play.go
+++ b/pkg/iac/scanners/ansible/parser/play.go
@@ -46,9 +46,7 @@ func parsePlays(f fsutils.FileSource) ([]*Play, error) {
 		return nil, xerrors.Errorf("decode YAML file: %w", err)
 	}
 
-	return lo.Filter(plays, func(p *Play, _ int) bool {
-		return p != nil
-	}), nil
+	return lo.Compact(plays), nil
 }
 
 // Play represents a single play in an Ansible playbook.


### PR DESCRIPTION
## Description

Prevent panic when accessing nil plays by filtering them out during parsing.

This PR is opened from a correct fork and replaces https://github.com/aquasecurity/trivy/pull/10132

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/10131

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
