### PR TITLE
fix: detected vulnerability fields in azure and mariner detector

### DIFF
--- a/pkg/detector/ospkg/azure/azure.go
+++ b/pkg/detector/ospkg/azure/azure.go
@@ -64,6 +64,7 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 				PkgIdentifier:    pkg.Identifier,
 				Layer:            pkg.Layer,
 				DataSource:       adv.DataSource,
+				Custom:           adv.Custom,
 			}
 
 			// Unpatched vulnerabilities


### PR DESCRIPTION
## Description
In azure and mariner detector we are missing Custom Field in Detected vuln in final result
start passing the adv.Custom field in DetectedVulnerability

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
