### PR TITLE
refactor: log statuses as strings

### DIFF
--- a/pkg/flag/vulnerability_flags.go
+++ b/pkg/flag/vulnerability_flags.go
@@ -107,10 +107,7 @@ func (f *VulnerabilityFlagGroup) ToOptions(opts *Options) error {
 	case len(ignoreStatuses) == 0:
 		ignoreStatuses = nil
 	}
-	log.Debug("Ignore statuses",
-		log.Any("statuses", xslices.Map(ignoreStatuses,
-			func(s dbTypes.Status) string { return s.String() })),
-	)
+	log.Debug("Ignore statuses", log.Any("statuses", xstrings.ToStringSlice(ignoreStatuses)))
 
 	opts.VulnerabilityOptions = VulnerabilityOptions{
 		IgnoreStatuses:      ignoreStatuses,

--- a/pkg/x/strings/strings.go
+++ b/pkg/x/strings/strings.go
@@ -21,6 +21,9 @@ func ToStringSlice[T any](ss []T) []string {
 		case fmt.Stringer:
 			return v.String()
 		default:
+			if stringer, ok := any(&s).(fmt.Stringer); ok {
+				return stringer.String()
+			}
 			return fmt.Sprint(v)
 		}
 	})


### PR DESCRIPTION
## Description

Statuses are logged in a human-readable format.

Before:
```
2026-03-02T20:15:55+06:00       DEBUG   Ignore statuses statuses=[0 1 2 4 5 6 7]
```

After:
```
2026-03-02T20:18:34+06:00       DEBUG   Ignore statuses statuses=[unknown not_affected affected under_investigation will_not_fix fix_deferred end_of_life]
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
