### PR TITLE
chore: replace smithy epoch parsing with stdlib time.Unix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.290.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
-	github.com/aws/smithy-go v1.24.1
 	github.com/bitnami/go-version v0.0.0-20231130084017-bb00604d650c
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -205,6 +204,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
+	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect

--- a/pkg/iac/scanners/azure/functions/date_time_epoch.go
+++ b/pkg/iac/scanners/azure/functions/date_time_epoch.go
@@ -2,8 +2,6 @@ package functions
 
 import (
 	"time"
-
-	smithyTime "github.com/aws/smithy-go/time"
 )
 
 func DateTimeFromEpoch(args ...any) any {
@@ -16,7 +14,7 @@ func DateTimeFromEpoch(args ...any) any {
 		return nil
 	}
 
-	return smithyTime.ParseEpochSeconds(float64(epoch)).Format(time.RFC3339)
+	return time.Unix(int64(epoch), 0).UTC().Format(time.RFC3339)
 }
 
 func DateTimeToEpoch(args ...any) any {


### PR DESCRIPTION
## Description

Use the Go standard library `time` package instead of `github.com/aws/smithy-go/time` for epoch seconds parsing, keeping the function behavior unchanged since the input is integer epoch seconds.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
