### PR TITLE
fix(vex): handle 304 status code

### DIFF
--- a/pkg/downloader/backup.go
+++ b/pkg/downloader/backup.go
@@ -10,21 +10,27 @@ import (
 )
 
 // backupDst renames dst aside so that go-getter can create it fresh.
-// It returns a restore function that moves the backup back into place.
-func backupDst(dst string) (restore func(), err error) {
+// It returns a cleanup function: call it with restore=true to move the backup
+// back into place (e.g. on a 304), or restore=false to drop it.
+func backupDst(dst string) (cleanup func(restore bool), err error) {
 	backup := dst + ".backup"
 	_ = os.RemoveAll(backup)
 
 	if err := os.Rename(dst, backup); errors.Is(err, os.ErrNotExist) {
-		return func() {}, nil
+		return func(bool) {}, nil
 	} else if err != nil {
 		return nil, xerrors.Errorf("failed to rename dst: %w", err)
 	}
 
-	return func() {
-		_ = os.RemoveAll(dst)
-		if err := os.Rename(backup, dst); err != nil {
-			log.Warn("Failed to restore backup", log.FilePath(backup), log.Err(err))
+	return func(restore bool) {
+		if restore {
+			_ = os.RemoveAll(dst)
+			if err := os.Rename(backup, dst); err != nil {
+				log.Warn("Failed to restore backup", log.FilePath(backup), log.Err(err))
+			}
 		}
+		// After a successful restore the rename already consumed the backup,
+		// so this is a no-op; otherwise it drops the unused backup.
+		_ = os.RemoveAll(backup)
 	}, nil
 }

--- a/pkg/downloader/backup.go
+++ b/pkg/downloader/backup.go
@@ -12,17 +12,19 @@ import (
 // backupDst renames dst aside so that go-getter can create it fresh.
 // It returns a cleanup function: call it with restore=true to move the backup
 // back into place (e.g. on a 304), or restore=false to drop it.
-func backupDst(dst string) (cleanup func(restore bool), err error) {
+func backupDst(dst string) (func(restore bool), error) {
+	cleanup := func(bool) {}
+
 	backup := dst + ".backup"
 	_ = os.RemoveAll(backup)
 
 	if err := os.Rename(dst, backup); errors.Is(err, os.ErrNotExist) {
-		return func(bool) {}, nil
+		return cleanup, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("failed to rename dst: %w", err)
+		return cleanup, xerrors.Errorf("failed to rename dst: %w", err)
 	}
 
-	return func(restore bool) {
+	cleanup = func(restore bool) {
 		if restore {
 			_ = os.RemoveAll(dst)
 			if err := os.Rename(backup, dst); err != nil {
@@ -32,5 +34,6 @@ func backupDst(dst string) (cleanup func(restore bool), err error) {
 		// After a successful restore the rename already consumed the backup,
 		// so this is a no-op; otherwise it drops the unused backup.
 		_ = os.RemoveAll(backup)
-	}, nil
+	}
+	return cleanup, nil
 }

--- a/pkg/downloader/backup.go
+++ b/pkg/downloader/backup.go
@@ -1,0 +1,30 @@
+package downloader
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+// backupDst renames dst aside so that go-getter can create it fresh.
+// It returns a restore function that moves the backup back into place.
+func backupDst(dst string) (restore func(), err error) {
+	backup := dst + ".backup"
+	_ = os.RemoveAll(backup)
+
+	if err := os.Rename(dst, backup); errors.Is(err, os.ErrNotExist) {
+		return func() {}, nil
+	} else if err != nil {
+		return nil, xerrors.Errorf("failed to rename dst: %w", err)
+	}
+
+	return func() {
+		_ = os.RemoveAll(dst)
+		if err := os.Rename(backup, dst); err != nil {
+			log.Warn("Failed to restore backup", log.FilePath(backup), log.Err(err))
+		}
+	}, nil
+}

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -56,23 +56,25 @@ func DownloadToTempDir(ctx context.Context, src string, opts Options) (string, e
 }
 
 // Download downloads the configured source to the destination.
-func Download(ctx context.Context, src, dst, pwd string, opts Options) (string, error) {
+func Download(ctx context.Context, src, dst, pwd string, opts Options) (_ string, err error) {
 	dst = filepath.Clean(dst)
 
 	// go-getter won't create dst if it already exists, so we always rename it aside.
 	// We restore it only on a 304 (ErrSkipDownload).
 	// On any other outcome the backup is dropped,
 	// so a genuine failure never resurrects stale files.
-	restore := func() {}
+	cleanup := func(bool) {}
 	if opts.ETag != "" {
-		var err error
-		restore, err = backupDst(dst)
-		if err != nil {
+		if cleanup, err = backupDst(dst); err != nil {
 			return "", xerrors.Errorf("failed to back up dst: %w", err)
 		}
 	} else {
 		_ = os.RemoveAll(dst)
 	}
+	// err is a named result, so every return below sets it before this runs.
+	defer func() {
+		cleanup(errors.Is(err, ErrSkipDownload))
+	}()
 
 	var clientOpts []getter.ClientOption
 	if opts.Insecure {
@@ -112,16 +114,10 @@ func Download(ctx context.Context, src, dst, pwd string, opts Options) (string, 
 		Options: clientOpts,
 	}
 
-	if err := client.Get(); err != nil {
-		if errors.Is(err, ErrSkipDownload) {
-			restore()
-		} else {
-			_ = os.RemoveAll(dst + ".backup")
-		}
+	if err = client.Get(); err != nil {
 		return "", xerrors.Errorf("failed to download %s: %w", src, err)
 	}
 
-	_ = os.RemoveAll(dst + ".backup")
 	return transport.newETag, nil
 }
 

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -63,9 +63,15 @@ func Download(ctx context.Context, src, dst, pwd string, opts Options) (string, 
 	// We restore it only on a 304 (ErrSkipDownload).
 	// On any other outcome the backup is dropped,
 	// so a genuine failure never resurrects stale files.
-	restore, err := backupDst(dst)
-	if err != nil {
-		return "", xerrors.Errorf("failed to back up dst: %w", err)
+	restore := func() {}
+	if opts.ETag != "" {
+		var err error
+		restore, err = backupDst(dst)
+		if err != nil {
+			return "", xerrors.Errorf("failed to back up dst: %w", err)
+		}
+	} else {
+		_ = os.RemoveAll(dst)
 	}
 
 	var clientOpts []getter.ClientOption

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -56,8 +57,16 @@ func DownloadToTempDir(ctx context.Context, src string, opts Options) (string, e
 
 // Download downloads the configured source to the destination.
 func Download(ctx context.Context, src, dst, pwd string, opts Options) (string, error) {
-	// go-getter doesn't allow the dst directory already exists if the src is directory.
-	_ = os.RemoveAll(dst)
+	dst = filepath.Clean(dst)
+
+	// go-getter won't create dst if it already exists, so we always rename it aside.
+	// We restore it only on a 304 (ErrSkipDownload).
+	// On any other outcome the backup is dropped,
+	// so a genuine failure never resurrects stale files.
+	restore, err := backupDst(dst)
+	if err != nil {
+		return "", xerrors.Errorf("failed to back up dst: %w", err)
+	}
 
 	var clientOpts []getter.ClientOption
 	if opts.Insecure {
@@ -98,9 +107,15 @@ func Download(ctx context.Context, src, dst, pwd string, opts Options) (string, 
 	}
 
 	if err := client.Get(); err != nil {
+		if errors.Is(err, ErrSkipDownload) {
+			restore()
+		} else {
+			_ = os.RemoveAll(dst + ".backup")
+		}
 		return "", xerrors.Errorf("failed to download %s: %w", src, err)
 	}
 
+	_ = os.RemoveAll(dst + ".backup")
 	return transport.newETag, nil
 }
 

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -117,11 +117,8 @@ func TestDownloadWithETag(t *testing.T) {
 			dst := filepath.Join(t.TempDir(), "vex.json")
 			require.NoError(t, os.WriteFile(dst, []byte("cached content"), 0o600))
 
-			_ = xhttp.WithTransport(t.Context(), xhttp.NewTransport(xhttp.Options{Insecure: true}))
-
 			newETag, err := downloader.Download(t.Context(), server.URL, dst, "", downloader.Options{
-				Insecure: true,
-				ETag:     tt.cachedETag,
+				ETag: tt.cachedETag,
 			})
 
 			if tt.wantErr != nil {

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,79 @@ func TestDownload(t *testing.T) {
 			content, err := os.ReadFile(dst)
 			require.NoError(t, err)
 			assert.Equal(t, "test content", string(content))
+		})
+	}
+}
+
+func TestDownloadWithETag(t *testing.T) {
+	const (
+		etag       = "test-etag"
+		newContent = "new content"
+	)
+
+	// Test server that supports conditional requests:
+	// - If-None-Match matches the current ETag -> 304 Not Modified
+	// - otherwise -> 200 with fresh content and the current ETag
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		_, err := w.Write([]byte(newContent))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name        string
+		cachedETag  string // ETag sent in the request (simulates the cached vexhub ETag)
+		wantErr     error  // expected error (ErrSkipDownload on 304, nil otherwise)
+		wantETag    string
+		wantContent string
+	}{
+		{
+			name:        "304 restores the cached files",
+			cachedETag:  etag, // matches -> server replies 304
+			wantErr:     downloader.ErrSkipDownload,
+			wantETag:    "",               // no new ETag on skip
+			wantContent: "cached content", // existing file is restored untouched
+		},
+		{
+			name:        "stale ETag downloads new content and drops the backup",
+			cachedETag:  "stale-etag", // no match -> server replies 200
+			wantErr:     nil,
+			wantETag:    etag,       // fresh ETag is returned
+			wantContent: newContent, // file now holds the new content
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate an already-cached vexhub file
+			dst := filepath.Join(t.TempDir(), "vex.json")
+			require.NoError(t, os.WriteFile(dst, []byte("cached content"), 0o600))
+
+			ctx := xhttp.WithTransport(t.Context(), xhttp.NewTransport(xhttp.Options{Insecure: true}))
+
+			newETag, err := downloader.Download(ctx, server.URL, dst, "", downloader.Options{
+				Insecure: true,
+				ETag:     tt.cachedETag,
+			})
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantETag, newETag)
+
+			// The file holds the expected content (restored on 304, replaced on 200)
+			content, err := os.ReadFile(dst)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantContent, string(content))
+
+			assert.NoFileExists(t, dst+".backup")
 		})
 	}
 }

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -77,7 +77,7 @@ func TestDownloadWithETag(t *testing.T) {
 	// Test server that supports conditional requests:
 	// - If-None-Match matches the current ETag -> 304 Not Modified
 	// - otherwise -> 200 with fresh content and the current ETag
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("If-None-Match") == etag {
 			w.WriteHeader(http.StatusNotModified)
 			return
@@ -117,9 +117,9 @@ func TestDownloadWithETag(t *testing.T) {
 			dst := filepath.Join(t.TempDir(), "vex.json")
 			require.NoError(t, os.WriteFile(dst, []byte("cached content"), 0o600))
 
-			ctx := xhttp.WithTransport(t.Context(), xhttp.NewTransport(xhttp.Options{Insecure: true}))
+			_ = xhttp.WithTransport(t.Context(), xhttp.NewTransport(xhttp.Options{Insecure: true}))
 
-			newETag, err := downloader.Download(ctx, server.URL, dst, "", downloader.Options{
+			newETag, err := downloader.Download(t.Context(), server.URL, dst, "", downloader.Options{
 				Insecure: true,
 				ETag:     tt.cachedETag,
 			})


### PR DESCRIPTION
## Description
Currently, trivy deletes the content of the vex cache every time a new download happens.
This action is not always needed, since when an ETag is provided, the server may respond with `304 Not Modified`, meaning the existing content at `dst` is still valid.
In that case, trivy should not destroy `dst`. Instead, we can move it aside as a backup and restore it on 304.
This particular case happens when a Vexhub repository has a small ' update_interval '.
Here's the original PR where we noticed the bug: https://github.com/kubewarden/sbomscanner/issues/867
cc @fabriziosestito 

## Related issues
There's no open issue for it.

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
