### PR TITLE
perf(plugin): optimize directory traversal by replacing filepath.Walk with filepath.WalkDir

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -117,10 +117,10 @@ func (m *Manager) loadModules(ctx context.Context) error {
 	}
 	log.Debug("Module dir", log.String("dir", m.dir))
 
-	err = filepath.Walk(m.dir, func(path string, info fs.FileInfo, err error) error {
+	err = filepath.WalkDir(m.dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
-		} else if info.IsDir() || filepath.Ext(info.Name()) != ".wasm" {
+		} else if d.IsDir() || filepath.Ext(d.Name()) != ".wasm" {
 			return nil
 		}
 


### PR DESCRIPTION
## Description
**perf(plugin): optimize directory traversal with filepath.WalkDir**

Prior to Go 1.16, `filepath.Walk` invoked `os.Lstat` on every visited file or directory to retrieve a heavy `fs.FileInfo` object, causing a significant performance bottleneck due to excessive system calls.

This commit replaces `filepath.Walk` with the more performant `filepath.WalkDir` API in the `pkg/module` package. The newer API passes an `fs.DirEntry` instead, which utilizes cached directory entry information provided by modern operating systems during the initial directory read.

This optimization minimizes unnecessary `lstat` syscalls over large directory structures when loading WebAssembly modules, significantly improving filesystem traversal speed and reducing CPU overhead.


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
