### PR TITLE
fix(cyclonedx): add CVSS v4 ratings to vulnerability output

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -488,6 +488,9 @@ func (m *Marshaler) ratings(vuln core.Vulnerability) *[]cdx.VulnerabilityRating 
 			if cvss.V3Score != 0 || cvss.V3Vector != "" {
 				rates = append(rates, m.ratingV3(sourceID, severity, cvss))
 			}
+			if cvss.V40Score != 0 || cvss.V40Vector != "" {
+				rates = append(rates, m.ratingV4(sourceID, severity, cvss))
+			}
 		} else { // When the vendor provides only severity
 			rate := cdx.VulnerabilityRating{
 				Source: &cdx.Source{
@@ -548,6 +551,18 @@ func (m *Marshaler) ratingV3(sourceID dtypes.SourceID, severity dtypes.Severity,
 		rate.Method = cdx.ScoringMethodCVSSv31
 	}
 	return rate
+}
+
+func (m *Marshaler) ratingV4(sourceID dtypes.SourceID, severity dtypes.Severity, cvss dtypes.CVSS) cdx.VulnerabilityRating {
+	return cdx.VulnerabilityRating{
+		Source: &cdx.Source{
+			Name: string(sourceID),
+		},
+		Score:    &cvss.V40Score,
+		Method:   cdx.ScoringMethodCVSSv4,
+		Severity: m.severity(severity),
+		Vector:   cvss.V40Vector,
+	}
 }
 
 // severity converts the Trivy severity to the CycloneDX severity


### PR DESCRIPTION
## Description

The `ratings()` method in the CycloneDX marshaler handles CVSS v2 and v3 scores but not v4. When a vulnerability has only `V40Score`/`V40Vector` (and no v2/v3 data), the resulting `ratings` array is empty in CycloneDX output.

## Changes

- Added `ratingV4()` method mirroring the existing `ratingV2`/`ratingV3` pattern
- Added `V40Score`/`V40Vector` check in the `ratings()` loop alongside the v2/v3 checks

Both prerequisites were already in place:
- `trivy-db` `CVSS` struct has `V40Score` and `V40Vector` fields
- `cyclonedx-go v0.10.0` defines `ScoringMethodCVSSv4`

Fixes #10292