### PR TITLE
feat(sarif): add invocation startTimeUtc and endTimeUtc

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -257,6 +257,15 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 	sw.run.OriginalUriBaseIDs = map[string]*sarif.ArtifactLocation{
 		"ROOTPATH": {URI: &rootPath},
 	}
+
+	// Add invocation with timestamps so consumers can monitor report freshness.
+	// cf. https://github.com/aquasecurity/trivy/issues/3226
+	if !report.CreatedAt.IsZero() {
+		sw.run.AddInvocation(true).
+			WithStartTimeUTC(report.CreatedAt).
+			WithEndTimeUTC(report.CreatedAt)
+	}
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/samber/lo"
@@ -533,6 +534,44 @@ func TestReportWriter_Sarif(t *testing.T) {
 								Version:        lo.ToPtr(""),
 								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
 								Rules:          []*sarif.ReportingDescriptor{},
+							},
+						},
+						Results:    []*sarif.Result{},
+						ColumnKind: "utf16CodeUnits",
+						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
+							"ROOTPATH": {
+								URI: lo.ToPtr("file:///"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "report with invocation timestamps",
+			input: types.Report{
+				CreatedAt: time.Date(2021, 8, 25, 12, 20, 30, 0, time.UTC),
+				Results:   types.Results{},
+			},
+			want: &sarif.Report{
+				Version: "2.1.0",
+				Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				Runs: []*sarif.Run{
+					{
+						Tool: sarif.Tool{
+							Driver: &sarif.ToolComponent{
+								FullName:       lo.ToPtr("Trivy Vulnerability Scanner"),
+								Name:           "Trivy",
+								Version:        lo.ToPtr(""),
+								InformationURI: lo.ToPtr("https://github.com/aquasecurity/trivy"),
+								Rules:          []*sarif.ReportingDescriptor{},
+							},
+						},
+						Invocations: []*sarif.Invocation{
+							{
+								ExecutionSuccessful: lo.ToPtr(true),
+								StartTimeUTC:        lo.ToPtr(time.Date(2021, 8, 25, 12, 20, 30, 0, time.UTC)),
+								EndTimeUTC:          lo.ToPtr(time.Date(2021, 8, 25, 12, 20, 30, 0, time.UTC)),
 							},
 						},
 						Results:    []*sarif.Result{},


### PR DESCRIPTION
## Summary
- Adds `startTimeUtc` and `endTimeUtc` properties to the SARIF `invocation` object, allowing consumers to monitor report freshness
- Uses `report.CreatedAt` (scan completion timestamp) for both fields
- Only adds the invocation when `CreatedAt` is set, preserving backward compatibility for existing consumers

## Motivation
Resolves #3226 — users want to verify that SARIF reports are current. The [SARIF v2.1.0 spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317574) defines `startTimeUtc` and `endTimeUtc` on the `invocation` object for exactly this purpose.

## Changes
- `pkg/report/sarif.go`: Add an `Invocation` with timestamps to the SARIF run
- `pkg/report/sarif_test.go`: Add test case verifying invocation timestamps are included when `CreatedAt` is set

## Example SARIF output (new)
```json
"invocations": [
  {
    "executionSuccessful": true,
    "startTimeUtc": "2024-01-15T10:30:00Z",
    "endTimeUtc": "2024-01-15T10:30:00Z"
  }
]
```

## Test plan
- [x] Added unit test `"report with invocation timestamps"` with a fixed `CreatedAt` value
- [x] Existing tests pass unchanged (no invocation added when `CreatedAt` is zero)