### PR TITLE
fix(cyclonedx): add CVSS v4 ratings to vulnerability output

### DIFF
--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -488,6 +488,9 @@ func (m *Marshaler) ratings(vuln core.Vulnerability) *[]cdx.VulnerabilityRating 
 			if cvss.V3Score != 0 || cvss.V3Vector != "" {
 				rates = append(rates, m.ratingV3(sourceID, severity, cvss))
 			}
+			if cvss.V40Score != 0 || cvss.V40Vector != "" {
+				rates = append(rates, m.ratingV4(sourceID, severity, cvss))
+			}
 		} else { // When the vendor provides only severity
 			rate := cdx.VulnerabilityRating{
 				Source: &cdx.Source{
@@ -548,6 +551,18 @@ func (m *Marshaler) ratingV3(sourceID dtypes.SourceID, severity dtypes.Severity,
 		rate.Method = cdx.ScoringMethodCVSSv31
 	}
 	return rate
+}
+
+func (m *Marshaler) ratingV4(sourceID dtypes.SourceID, severity dtypes.Severity, cvss dtypes.CVSS) cdx.VulnerabilityRating {
+	return cdx.VulnerabilityRating{
+		Source: &cdx.Source{
+			Name: string(sourceID),
+		},
+		Score:    &cvss.V40Score,
+		Method:   cdx.ScoringMethodCVSSv4,
+		Severity: m.severity(severity),
+		Vector:   cvss.V40Vector,
+	}
 }
 
 // severity converts the Trivy severity to the CycloneDX severity

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -217,10 +217,12 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 									CweIDs: []string{"CWE-416"},
 									CVSS: dtypes.VendorCVSS{
 										vulnerability.NVD: dtypes.CVSS{
-											V2Vector: "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-											V3Vector: "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-											V2Score:  4.3,
-											V3Score:  5.5,
+											V2Vector:  "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+											V3Vector:  "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+											V40Vector: "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+											V2Score:   4.3,
+											V3Score:   5.5,
+											V40Score:  8.7,
 										},
 										vulnerability.RedHatOVAL: dtypes.CVSS{
 											V3Vector: "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
@@ -705,6 +707,16 @@ func TestMarshaler_MarshalReport(t *testing.T) {
 								Severity: cdx.SeverityMedium,
 								Method:   cdx.ScoringMethodCVSSv3,
 								Vector:   "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+							},
+							{
+								Source: &cdx.Source{
+									Name: string(vulnerability.NVD),
+									URL:  "",
+								},
+								Score:    lo.ToPtr(8.7),
+								Severity: cdx.SeverityMedium,
+								Method:   cdx.ScoringMethodCVSSv4,
+								Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
 							},
 							{
 								Source: &cdx.Source{


### PR DESCRIPTION
## Summary

When a vulnerability has only CVSS v4 scores (V40Score/V40Vector), the CycloneDX output returns empty `ratings: []`. This happens because `ratings()` in `marshal.go` checks for v2 and v3 but never checks V40 fields.

The CVSS entry exists in the map so the `else` branch (severity-only fallback) is skipped, and neither v2 nor v3 conditions match, resulting in no ratings at all.

## Changes

- `marshal.go`: add V40Score/V40Vector check in `ratings()`, add `ratingV4()` method using `cdx.ScoringMethodCVSSv4`
- `marshal_test.go`: add V40 data to existing test case and expected output

Both prerequisites were already in place:
- `trivy-db` CVSS struct has `V40Score` and `V40Vector` fields
- `cyclonedx-go v0.10.0` defines `ScoringMethodCVSSv4` (supported in CycloneDX spec 1.5+)

## Testing

```
GOEXPERIMENT=jsonv2 go test ./pkg/sbom/cyclonedx/ -run TestMarshaler_MarshalReport -v
```

All subtests pass, including the updated case with v4 rating data.

Fixes #10292