### PR TITLE
feat(ci): add build provenance attestations to release workflow

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -25,6 +25,7 @@ jobs:
       id-token: write # For cosign
       packages: write # For GHCR
       contents: read  # Not required for public repositories, but for clarity
+      attestations: write # For build provenance attestations
     steps:
       - name: Cosign install
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -95,6 +96,17 @@ jobs:
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FILE: "gpg.key"
           TMPDIR: "tmp"
+
+      - name: Generate build provenance attestations
+        if: ${{ inputs.goreleaser_config != 'goreleaser-canary.yml' }}
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*_checksums.txt
 
       - name: "remove gpg key"
         run: |


### PR DESCRIPTION
## Summary

Adds SLSA build provenance attestations to the release workflow so users can verify the origin of release artifacts.

## Changes

In `reusable-release.yaml`:
- Added `attestations: write` permission
- Added `actions/attest-build-provenance@v2.1.0` step after GoReleaser
- Only runs for non-canary builds
- Covers: `.tar.gz`, `.zip`, `.deb`, `.rpm`, and checksum files

After this, users can verify release artifacts:
```bash
gh attestation verify trivy_0.69.3_Linux-64bit.tar.gz --repo aquasecurity/trivy
```

## Testing

This is a CI-only change. The attestation step uses GitHub's built-in OIDC and Sigstore integration, no secrets needed beyond the existing `id-token: write` permission.

Fixes #10315