### PR TITLE
fix: handle Go 1.26 GOEXPERIMENT version format change

### DIFF
--- a/pkg/dependency/parser/golang/binary/export_test.go
+++ b/pkg/dependency/parser/golang/binary/export_test.go
@@ -13,3 +13,5 @@ func (p *Parser) ChooseMainVersion(version, ldflagsVersion, elfVersion string) s
 func (p *Parser) ELFSymbolVersion(r io.ReaderAt, name string) string {
 	return p.elfSymbolVersion(r, name)
 }
+
+var ParseStdlibVersion = parseStdlibVersion

--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -60,6 +60,7 @@ func parseStdlibVersion(goVersion string) string {
 	// Ex: "go1.22.3 X:boringcrypto" (Go <=1.25) or "go1.26.0-X:nodwarf5" (Go >=1.26)
 	stdlibVersion := strings.TrimPrefix(goVersion, "go")
 	// Strip GOEXPERIMENT suffix: " X:foo" (Go <=1.25) or "-X:foo" (Go >=1.26)
+	// cf. https://github.com/golang/go/blob/9daaab305c4d1dede9e4f6efdc5e1268a69327e6/src/cmd/go/internal/cache/hash.go#L48-L58
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " X:")
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, "-X:")
 	// Add the `v` prefix to be consistent with module and dependency versions.

--- a/pkg/dependency/parser/golang/binary/parse_internal_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_internal_test.go
@@ -1,9 +1,11 @@
-package binary
+package binary_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/dependency/parser/golang/binary"
 )
 
 func TestParseStdlibVersion(t *testing.T) {
@@ -40,7 +42,7 @@ func TestParseStdlibVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseStdlibVersion(tt.goVersion)
+			got := binary.ParseStdlibVersion(tt.goVersion)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Description
Go 1.26 changed the format used to embed GOEXPERIMENT flags in the binary's build info from \ X:\ separator (Go <=1.25) to \-X:\ separator (Go >=1.26). Trivy was failing to correctly parse the stdlib version from binaries built with Go 1.26 when GOEXPERIMENT flags are present.

## Changes
- Strip both GOEXPERIMENT separator formats when parsing stdlib version: \ X:foo\ (Go <=1.25) and \-X:foo\ (Go >=1.26)
- Extract version parsing logic to \parseStdlibVersion\ for testability
- Add unit tests for both format variants

## Testing
- Added \TestParseStdlibVersion\ with test cases for plain version, Go <=1.25 format (\go1.25.3 X:nodwarf5\), and Go >=1.26 format (\go1.26.0-X:nodwarf5\)
- Existing \goexperiment\ integration test continues to pass

Fixes #10350