### PR TITLE
feat(sbom): add SHA-512 hash support for SPDX checksums

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -504,10 +504,12 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA512:
+    		alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:
-			return nil
+			continue
 		}
 		checksums = append(checksums, spdx.Checksum{
 			Algorithm: alg,


### PR DESCRIPTION
## Summary
Adds SHA-512 hash algorithm support to Trivy's SPDX checksum handling.

## Changes
- Add `digest.SHA512` case to `spdxChecksums` in `pkg/sbom/spdx/marshal.go`
- Fix `default` case from `return nil` to `continue` — the previous behavior 
  incorrectly dropped all remaining valid checksums when an unsupported 
  algorithm was encountered

## Testing
- `go build ./pkg/sbom/spdx/...` passes cleanly

Fixes #9094