### PR TITLE
feat(spdx): add SHA-512 checksum support to SPDX unmarshaler

### DIFF
--- a/pkg/sbom/spdx/testdata/happy/package-hashes.json
+++ b/pkg/sbom/spdx/testdata/happy/package-hashes.json
@@ -1,0 +1,29 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2022-09-12T17:02:46.826609Z",
+    "creators": [
+      "Tool: trivy-dev",
+      "Organization: aquasecurity"
+    ]
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "http://trivy.dev/container/maven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
+  "name": "maven-test-project",
+  "packages": [
+    {
+      "name": "lodash",
+      "SPDXID": "SPDXRef-Package-lodash-4.17.21",
+      "versionInfo": "4.17.21",
+      "downloadLocation": "NONE",
+      "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a"
+        }
+      ]
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spdx/tools-golang/tagvalue"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/digest"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
 
@@ -184,14 +186,25 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 	}
 
 	// Files
-	// TODO: handle checksums as well
 	if path, ok := s.pkgFilePaths[spdxPkg.PackageSPDXIdentifier]; ok {
 		component.Files = []core.File{
 			{Path: path},
 		}
 	} else if len(spdxPkg.Files) > 0 {
+		file := spdxPkg.Files[0]
 		component.Files = []core.File{
-			{Path: spdxPkg.Files[0].FileName}, // Take the first file name
+			{
+				Path:    file.FileName,
+				Digests: s.unmarshalChecksums(file.Checksums),
+			},
+		}
+	}
+
+	if len(component.Files) == 0 && len(spdxPkg.PackageChecksums) > 0 {
+		component.Files = []core.File{
+			{
+				Digests: s.unmarshalChecksums(spdxPkg.PackageChecksums),
+			},
 		}
 	}
 
@@ -273,6 +286,28 @@ func (s *SPDX) parseExternalReferences(refs []*spdx.PackageExternalReference) (*
 		return &packageURL, nil
 	}
 	return nil, nil
+}
+
+func (s *SPDX) unmarshalChecksums(checksums []spdx.Checksum) []digest.Digest {
+	var digests []digest.Digest
+	for _, h := range checksums {
+		var alg digest.Algorithm
+		switch h.Algorithm {
+		case common.SHA1:
+			alg = digest.SHA1
+		case common.SHA256:
+			alg = digest.SHA256
+		case common.SHA512:
+			alg = digest.SHA512
+		case common.MD5:
+			alg = digest.MD5
+		default:
+			log.Warn("Unsupported hash algorithm", log.String("algorithm", string(h.Algorithm)))
+			continue
+		}
+		digests = append(digests, digest.NewDigestFromString(alg, h.Value))
+	}
+	return digests
 }
 
 func (s *SPDX) isTrivySBOM(spdxDocument *spdx.Document) bool {

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/pkg/digest"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/sbom/core"
 	sbomio "github.com/aquasecurity/trivy/pkg/sbom/io"
 	"github.com/aquasecurity/trivy/pkg/sbom/spdx"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -266,6 +268,26 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 										Name:      "pear_exception",
 										Version:   "v1.0.0",
 									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "happy path package with SHA512 checksum",
+			inputFile: "testdata/happy/package-hashes.json",
+			want: types.SBOM{
+				Components: []core.Component{
+					{
+						Type:    core.TypeLibrary,
+						Name:    "lodash",
+						Version: "4.17.21",
+						Files: []core.File{
+							{
+								Digests: []digest.Digest{
+									digest.NewDigestFromString(digest.SHA512, "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a"),
 								},
 							},
 						},


### PR DESCRIPTION
## Summary
Adds SHA-512 checksum support to the SPDX unmarshaler, completing the 
full round-trip support (marshal + unmarshal) for SHA-512 in SPDX.

## Changes
- Add `unmarshalChecksums()` to convert `[]spdx.Checksum` to `[]digest.Digest`
- Update file parsing block to include checksums from `spdx.Files`
- Add fallback: if no files exist but `PackageChecksums` is non-empty, 
  store digests as a digest-only `core.File` entry
- Add test data (`testdata/happy/package-hashes.json`) and unmarshal test case

## Note
`go test ./pkg/sbom/spdx/...` fails with a pre-existing Go 1.26 
`encoding/json/jsontext` build constraint issue unrelated to these changes.
`go build ./pkg/sbom/spdx/...` passes cleanly.

Closes #9094
Ref #9130