### PR TITLE
ci: replace personal email with github-actions[bot] in workflows

### DIFF
--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Configure the git user
         run: |
-          git config user.name "knqyf263"
-          git config user.email "knqyf263@gmail.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Deploy the dev documents
         run: mike deploy --push dev

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -30,8 +30,8 @@ jobs:
           GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Configure the git user
         run: |
-          git config user.name "knqyf263"
-          git config user.email "knqyf263@gmail.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Deploy the latest documents from new tag push
         if: ${{ github.event.inputs.version == '' }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Setup git settings
         run: |
-          git config --global user.email "knqyf263@gmail.com"
-          git config --global user.name "Teppei Fukuda"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Create rpm repository
         run: ci/deploy-rpm.sh

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -23,7 +23,7 @@ jobs:
         pip install -r docs/build/requirements.txt
     - name: Configure the git user
       run: |
-        git config user.name "knqyf263"
-        git config user.email "knqyf263@gmail.com"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Deploy the dev documents
       run: mike deploy test

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -87,7 +87,7 @@ nfpms:
       - rpm
     vendor: "aquasecurity"
     homepage: "https://github.com/aquasecurity"
-    maintainer: "Teppei Fukuda <knqyf263@gmail.com>"
+    maintainer: "Aqua Security <oss@aquasec.com>"
     description: "A Fast Vulnerability Scanner for Containers"
     license: "Apache-2.0"
     file_name_template: >-


### PR DESCRIPTION
## Description
Replace hardcoded personal email address with the GitHub Actions bot noreply address in workflow git configurations and update the goreleaser maintainer to use the organization contact.

### Changes
- `.github/workflows/test-docs.yaml` - Use `github-actions[bot]` for git config
- `.github/workflows/mkdocs-dev.yaml` - Use `github-actions[bot]` for git config
- `.github/workflows/mkdocs-latest.yaml` - Use `github-actions[bot]` for git config
- `.github/workflows/release.yaml` - Use `github-actions[bot]` for git config
- `goreleaser.yml` - Update maintainer to `Aqua Security <oss@aquasec.com>`

## Related issues
- Close #10324

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).