### PR TITLE
fix(misconf): make identifiers in ignore rules case-insensitive

### DIFF
--- a/docs/guide/scanner/misconfiguration/config/config.md
+++ b/docs/guide/scanner/misconfiguration/config/config.md
@@ -159,7 +159,7 @@ In cases where Trivy can detect comments of a specific format immediately adjace
     Use a [.trivyignore.yaml](../../../configuration/filtering.md#trivyignoreyaml) file to ignore such checks.
 
 
-The ignore rule must contain one of the possible check IDs that can be found in its metadata: ID, short code or alias. The `id` from the metadata is not case-sensitive, so you can specify, for example, `AVD-AWS-0089` or `avd-aws-0089`.
+The ignore rule must contain one of the possible check identifiers that can be found in its metadata: ID, long id, or aliases. All of these identifiers are case-insensitive, so you can specify, for example, `AWS-0089`, `aws-0089`, or any combination of upper/lowercase letters.
 
 For example, to ignore a misconfiguration ID `AVD-GCP-0051` in a Terraform HCL file:
 

--- a/pkg/iac/ignore/rule.go
+++ b/pkg/iac/ignore/rule.go
@@ -114,10 +114,24 @@ func defaultIgnorers(ids []string) map[string]Ignorer {
 	}
 }
 
-// MatchPattern checks if the pattern string matches the input pattern.
+// MatchPattern checks if the pattern matches the input (case-insensitive).
 // The wildcard '*' in the pattern matches any sequence of characters.
 func MatchPattern(input, pattern string) bool {
-	re := "(?i)^" + strings.ReplaceAll(regexp.QuoteMeta(pattern), "\\*", ".*") + "$"
+	return doMatchPattern(input, pattern, true)
+}
+
+// MatchPatternCaseSensitive is like MatchPattern but performs a case-sensitive match.
+func MatchPatternCaseSensitive(input, pattern string) bool {
+	return doMatchPattern(input, pattern, false)
+}
+
+func doMatchPattern(input, pattern string, caseInsensitive bool) bool {
+	prefix := ""
+	if caseInsensitive {
+		prefix = "(?i)"
+	}
+	// TODO: compile and cache the regex for better performance
+	re := prefix + "^" + strings.ReplaceAll(regexp.QuoteMeta(pattern), "\\*", ".*") + "$"
 	matched, err := regexp.MatchString(re, input)
 	return err == nil && matched
 }

--- a/pkg/iac/ignore/rule.go
+++ b/pkg/iac/ignore/rule.go
@@ -117,21 +117,7 @@ func defaultIgnorers(ids []string) map[string]Ignorer {
 // MatchPattern checks if the pattern string matches the input pattern.
 // The wildcard '*' in the pattern matches any sequence of characters.
 func MatchPattern(input, pattern string) bool {
-	matched, err := regexp.MatchString(regexpFromPattern(pattern), input)
+	re := "(?i)^" + strings.ReplaceAll(regexp.QuoteMeta(pattern), "\\*", ".*") + "$"
+	matched, err := regexp.MatchString(re, input)
 	return err == nil && matched
-}
-
-func regexpFromPattern(pattern string) string {
-	parts := strings.Split(pattern, "*")
-	if len(parts) == 1 {
-		return "^" + pattern + "$"
-	}
-	var sb strings.Builder
-	for i, literal := range parts {
-		if i > 0 {
-			sb.WriteString(".*")
-		}
-		sb.WriteString(regexp.QuoteMeta(literal))
-	}
-	return "^" + sb.String() + "$"
 }

--- a/pkg/iac/ignore/rule_test.go
+++ b/pkg/iac/ignore/rule_test.go
@@ -350,6 +350,24 @@ func TestMatchPattern(t *testing.T) {
 		{"example", "test", false},
 		{"example-test", "*-test*", true},
 		{"example-test", "*example-*", true},
+
+		{"HelloWorld", "hello*", true},
+		{"HELLOworld", "hello*", true},
+		{"HELLOworld", "HELLO*", true},
+		{"helloworld", "HELLO*", true},
+
+		{"abc", "abc", true},
+		{"AbC", "abc", true},
+		{"abc", "def", false},
+
+		{"foobar", "*bar", true},
+		{"foobar", "foo*", true},
+		{"foobar", "*oo*", true},
+		{"foobar", "*baz*", false},
+
+		{"", "*", true},
+		{"", "", true},
+		{"nonempty", "", false},
 	}
 
 	for _, tc := range tests {

--- a/pkg/iac/ignore/rule_test.go
+++ b/pkg/iac/ignore/rule_test.go
@@ -300,7 +300,7 @@ func TestRules_IgnoreWithCustomIgnorer(t *testing.T) {
 						if !ok {
 							return false
 						}
-						return ignore.MatchPattern("dev-stage1", ws)
+						return ignore.MatchPatternCaseSensitive("dev-stage1", ws)
 					},
 				},
 			},
@@ -373,6 +373,28 @@ func TestMatchPattern(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input+":"+tc.pattern, func(t *testing.T) {
 			got := ignore.MatchPattern(tc.input, tc.pattern)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestMatchPatternCaseSensitive(t *testing.T) {
+	tests := []struct {
+		input    string
+		pattern  string
+		expected bool
+	}{
+		{"dev-stage1", "dev-*", true},
+		{"dev-stage1", "DEV-*", false},
+		{"production", "production", true},
+		{"Production", "production", false},
+		{"prod", "prod*", true},
+		{"Prod", "prod*", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input+":"+tc.pattern, func(t *testing.T) {
+			got := ignore.MatchPatternCaseSensitive(tc.input, tc.pattern)
 			assert.Equal(t, tc.expected, got)
 		})
 	}

--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -267,19 +267,19 @@ func (r *Results) AddIgnored(source any, descriptions ...string) {
 }
 
 func (r *Results) Ignore(ignoreRules ignore.Rules, ignores map[string]ignore.Ignorer) {
-	for i, result := range *r {
+	for i := range *r {
+		result := &(*r)[i]
+		rule := result.Rule()
 		allIDs := []string{
-			result.Rule().ID,
-			strings.ToLower(result.Rule().ID),
-			result.Rule().CanonicalID(),
-			result.Rule().AVDID,
-			strings.ToLower(result.Rule().AVDID),
-			result.Rule().ShortCode,
+			rule.ID,
+			rule.CanonicalID(),
+			rule.AVDID,
+			rule.ShortCode,
 		}
-		allIDs = append(allIDs, result.Rule().Aliases...)
+		allIDs = append(allIDs, rule.Aliases...)
 
 		if ignoreRules.Ignore(result.Metadata(), allIDs, ignores) {
-			(*r)[i].OverrideStatus(StatusIgnored)
+			result.OverrideStatus(StatusIgnored)
 		}
 	}
 }

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -237,7 +237,7 @@ func workspaceIgnorer(ws string) ignore.Ignorer {
 		if !ok {
 			return false
 		}
-		return ignore.MatchPattern(ws, ignoredWorkspace)
+		return ignore.MatchPatternCaseSensitive(ws, ignoredWorkspace)
 	}
 }
 


### PR DESCRIPTION
## Description

Make identifiers used in ignore rules case-insensitive.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/10374

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
