### PR TITLE
fix(go): handle Go 1.26 GOEXPERIMENT version format in binary parser

### DIFF
--- a/pkg/dependency/parser/golang/binary/export_test.go
+++ b/pkg/dependency/parser/golang/binary/export_test.go
@@ -13,3 +13,8 @@ func (p *Parser) ChooseMainVersion(version, ldflagsVersion, elfVersion string) s
 func (p *Parser) ELFSymbolVersion(r io.ReaderAt, name string) string {
 	return p.elfSymbolVersion(r, name)
 }
+
+// ParseStdlibVersion exports parseStdlibVersion for testing.
+func ParseStdlibVersion(goVersion string) string {
+	return parseStdlibVersion(goVersion)
+}

--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -61,11 +61,7 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		return nil, nil, convertError(err)
 	}
 
-	// Ex: "go1.22.3 X:boringcrypto"
-	stdlibVersion := strings.TrimPrefix(info.GoVersion, "go")
-	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " ")
-	// Add the `v` prefix to be consistent with module and dependency versions.
-	stdlibVersion = fmt.Sprintf("v%s", stdlibVersion)
+	stdlibVersion := parseStdlibVersion(info.GoVersion)
 
 	ldflags := p.ldFlags(info.Settings)
 	pkgs := make(ftypes.Packages, 0, len(info.Deps)+2)
@@ -290,6 +286,23 @@ func classifyVersion(foundVersions [][]string, key, moduleName, val string) {
 	default:
 		foundVersions[2] = append(foundVersions[2], val)
 	}
+}
+
+// parseStdlibVersion extracts the Go stdlib version from the GoVersion string
+// embedded in a Go binary's build info.
+// It strips the "go" prefix and any GOEXPERIMENT suffix, then prepends "v"
+// to be consistent with module and dependency versions.
+//
+// Format examples:
+//
+//	"go1.22.3"                => "v1.22.3"    (no experiment)
+//	"go1.22.3 X:boringcrypto" => "v1.22.3"   (Go <=1.25 format)
+//	"go1.26.0-X:nodwarf5"     => "v1.26.0"   (Go >=1.26 format)
+func parseStdlibVersion(goVersion string) string {
+	v := strings.TrimPrefix(goVersion, "go")
+	v, _, _ = strings.Cut(v, " X:")
+	v, _, _ = strings.Cut(v, "-X:")
+	return fmt.Sprintf("v%s", v)
 }
 
 // versionPrefix returns version prefix from `-ldflags` flag key

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -235,6 +235,61 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseStdlibVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		goVersion string
+		want      string
+	}{
+		{
+			name:      "plain version",
+			goVersion: "go1.22.3",
+			want:      "v1.22.3",
+		},
+		{
+			name:      "GOEXPERIMENT with space separator (Go <=1.25)",
+			goVersion: "go1.22.3 X:boringcrypto",
+			want:      "v1.22.3",
+		},
+		{
+			name:      "GOEXPERIMENT with dash separator (Go >=1.26)",
+			goVersion: "go1.26.0-X:nodwarf5",
+			want:      "v1.26.0",
+		},
+		{
+			name:      "multiple GOEXPERIMENT flags with space separator",
+			goVersion: "go1.24.0 X:boringcrypto,nodwarf5",
+			want:      "v1.24.0",
+		},
+		{
+			name:      "multiple GOEXPERIMENT flags with dash separator",
+			goVersion: "go1.26.0-X:boringcrypto,nodwarf5",
+			want:      "v1.26.0",
+		},
+		{
+			name:      "release candidate version",
+			goVersion: "go1.26rc1",
+			want:      "v1.26rc1",
+		},
+		{
+			name:      "version without patch",
+			goVersion: "go1.26",
+			want:      "v1.26",
+		},
+		{
+			name:      "plain version with patch",
+			goVersion: "go1.26.0",
+			want:      "v1.26.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := binary.ParseStdlibVersion(tt.goVersion)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParser_ChooseMainVersion(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Description

Go 1.26 changed the GOEXPERIMENT separator in binary build info from a space to a dash (`go1.26.0-X:nodwarf5` instead of `go1.22.3 X:boringcrypto`). The existing space-based `strings.Cut` missed the new format, leaving the suffix in the version string and breaking downstream semver validation.

Extracts the inline version-stripping logic into `parseStdlibVersion()` that handles both formats by cutting on `" X:"` (Go <=1.25) and `"-X:"` (Go >=1.26).

## Related issues
- Close #10350

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).