### PR TITLE
feat(os): add CleanStart OS support

### DIFF
--- a/docs/guide/coverage/os/cleanstart.md
+++ b/docs/guide/coverage/os/cleanstart.md
@@ -1,0 +1,32 @@
+# CleanStart OS
+Trivy supports these scanners for OS packages.
+
+|    Scanner    | Supported |
+| :-----------: | :-------: |
+|     SBOM      |     ✓     |
+| Vulnerability |     ✓     |
+|    License    |     ✓     |
+
+The table below outlines the features offered by Trivy.
+
+|               Feature                | Supported |
+|:------------------------------------:|:---------:|
+|    Detect unfixed vulnerabilities    |     -     |
+| [Dependency graph][dependency-graph] |     ✓     |
+|        End of life awareness         |     -     |
+
+## SBOM
+Same as [Alpine Linux](alpine.md#sbom).
+
+## Vulnerability
+CleanStart OS offers its own security advisories, and these are utilized when scanning CleanStart for vulnerabilities.
+Everything else is the same as [Alpine Linux](alpine.md#vulnerability).
+
+### Data Source
+See [here](../../scanner/vulnerability.md#data-sources).
+
+## License
+Same as [Alpine Linux](alpine.md#license).
+
+[dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
+[advisories]: https://github.com/cleanstart-dev/cleanstart-security-advisories

--- a/docs/guide/coverage/os/index.md
+++ b/docs/guide/coverage/os/index.md
@@ -14,6 +14,7 @@ Trivy supports operating systems for
 | [Alpine Linux](alpine.md)                      | 2.2 - 2.7, 3.0 - 3.22, edge         | apk              |
 | [Wolfi Linux](wolfi.md)                        | (n/a)                               | apk              |
 | [Chainguard](chainguard.md)                    | (n/a)                               | apk              |
+| [CleanStart](cleanstart.md)                    | (n/a)                               | apk              |
 | [MinimOS](minimos.md)                          | (n/a)                               | apk              |
 | [Red Hat Enterprise Linux](rhel.md)            | 6, 7, 8, 9                          | dnf/yum/rpm      |
 | [Red Hat Enterprise Linux](rhel.md)            | 10 (SBOM only)                      | dnf/yum/rpm      |

--- a/docs/guide/scanner/vulnerability.md
+++ b/docs/guide/scanner/vulnerability.md
@@ -26,6 +26,7 @@ See [here](../coverage/os/index.md#supported-os) for the supported OSes.
 | Wolfi Linux               | [secdb][wolfi]                                               |
 | Chainguard                | [secdb][chainguard]                                          |
 | MinimOS                   | [secdb][minimos]                                             |
+| CleanStart                | [CleanStart Security Advisories][cleanstart]                                             |
 | Amazon Linux              | [Amazon Linux Security Center][amazon]                       |
 | Echo                      | [Echo][echo]                                                 |
 | Debian                    | [Security Bug Tracker][debian-tracker] / [OVAL][debian-oval] |
@@ -402,6 +403,7 @@ Example logic for the following vendor severity levels when scanning an Alpine i
 [alpine]: https://secdb.alpinelinux.org/
 [wolfi]: https://packages.wolfi.dev/os/security.json
 [chainguard]: https://packages.cgr.dev/chainguard/security.json
+[cleanstart]: https://github.com/cleanstart-dev/cleanstart-security-advisories
 [minimos]: https://packages.mini.dev/advisories/secdb/security.json
 [amazon]: https://alas.aws.amazon.com/
 [echo]: https://advisory.echohq.com/data.json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
               - Bottlerocket: guide/coverage/os/bottlerocket.md
               - CentOS: guide/coverage/os/centos.md
               - Chainguard: guide/coverage/os/chainguard.md
+              - CleanStart: guide/coverage/os/cleanstart.md
               - CoreOS: guide/coverage/os/coreos.md
               - Debian: guide/coverage/os/debian.md
               - Echo: guide/coverage/os/echo.md

--- a/pkg/detector/ospkg/cleanstart/cleanstart.go
+++ b/pkg/detector/ospkg/cleanstart/cleanstart.go
@@ -1,0 +1,89 @@
+package cleanstart
+
+import (
+	"context"
+
+	version "github.com/knqyf263/go-apk-version"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/cleanstart"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+// Scanner implements the CleanStart scanner
+type Scanner struct {
+	vs cleanstart.VulnSrc
+}
+
+// NewScanner is the factory method for Scanner
+func NewScanner() *Scanner {
+	return &Scanner{
+		vs: cleanstart.NewVulnSrc(),
+	}
+}
+
+// Detect vulnerabilities in package using CleanStart scanner
+func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	log.InfoContext(ctx, "Detecting vulnerabilities...", log.Int("pkg_num", len(pkgs)))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		srcName := pkg.SrcName
+		if srcName == "" {
+			srcName = pkg.Name
+		}
+		advisories, err := s.vs.Get(db.GetParams{
+			PkgName: srcName,
+		})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get CleanStart advisories: %w", err)
+		}
+
+		installed := utils.FormatVersion(pkg)
+		installedVersion, err := version.NewVersion(installed)
+		if err != nil {
+			log.DebugContext(ctx, "Failed to parse the installed package version",
+				log.String("version", installed), log.Err(err))
+			continue
+		}
+
+		for _, adv := range advisories {
+			if !s.isVulnerable(ctx, installedVersion, adv) {
+				continue
+			}
+			vulns = append(vulns, types.DetectedVulnerability{
+				VulnerabilityID:  adv.VulnerabilityID,
+				PkgID:            pkg.ID,
+				PkgName:          pkg.Name,
+				InstalledVersion: installed,
+				FixedVersion:     adv.FixedVersion,
+				Layer:            pkg.Layer,
+				PkgIdentifier:    pkg.Identifier,
+				Custom:           adv.Custom,
+				DataSource:       adv.DataSource,
+			})
+		}
+	}
+	return vulns, nil
+}
+
+func (s *Scanner) isVulnerable(ctx context.Context, installedVersion version.Version, adv dbTypes.Advisory) bool {
+	fixedVersion, err := version.NewVersion(adv.FixedVersion)
+	if err != nil {
+		log.DebugContext(ctx, "Failed to parse the fixed version",
+			log.String("version", adv.FixedVersion), log.Err(err))
+		return false
+	}
+	return installedVersion.LessThan(fixedVersion)
+}
+
+// IsSupportedVersion checks if the version is supported.
+// CleanStart is a rolling release so all versions are always supported.
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
+	return true
+}

--- a/pkg/detector/ospkg/cleanstart/cleanstart_test.go
+++ b/pkg/detector/ospkg/cleanstart/cleanstart_test.go
@@ -1,0 +1,165 @@
+package cleanstart_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	"github.com/aquasecurity/trivy/internal/dbtest"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/cleanstart"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestScanner_Detect(t *testing.T) {
+	type args struct {
+		repo *ftypes.Repository
+		pkgs []ftypes.Package
+	}
+	tests := []struct {
+		name     string
+		args     args
+		fixtures []string
+		want     []types.DetectedVulnerability
+		wantErr  string
+	}{
+		{
+			name: "happy path",
+			fixtures: []string{
+				"testdata/fixtures/cleanstart.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "redis",
+						Version:    "7.4.5-r0",
+						SrcName:    "redis",
+						SrcVersion: "7.4.5-r0",
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+					},
+					{
+						Name:       "invalid",
+						Version:    "invalid",
+						SrcName:    "invalid",
+						SrcVersion: "invalid",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "redis",
+					VulnerabilityID:  "CLEANSTART-2026-MZ27698",
+					InstalledVersion: "7.4.5-r0",
+					FixedVersion:     "7.4.6-r0",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.CleanStart,
+						Name: "CleanStart Security Advisories",
+						URL:  "https://github.com/cleanstart-dev/cleanstart-security-advisories",
+					},
+				},
+				{
+					PkgName:          "redis",
+					VulnerabilityID:  "CVE-2025-12345",
+					InstalledVersion: "7.4.5-r0",
+					FixedVersion:     "7.4.6-r0",
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.CleanStart,
+						Name: "CleanStart Security Advisories",
+						URL:  "https://github.com/cleanstart-dev/cleanstart-security-advisories",
+					},
+				},
+			},
+		},
+		{
+			name: "no src name",
+			fixtures: []string{
+				"testdata/fixtures/cleanstart.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "redis",
+						Version:    "7.4.5-r0",
+						SrcVersion: "7.4.5-r0",
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					PkgName:          "redis",
+					VulnerabilityID:  "CLEANSTART-2026-MZ27698",
+					InstalledVersion: "7.4.5-r0",
+					FixedVersion:     "7.4.6-r0",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.CleanStart,
+						Name: "CleanStart Security Advisories",
+						URL:  "https://github.com/cleanstart-dev/cleanstart-security-advisories",
+					},
+				},
+				{
+					PkgName:          "redis",
+					VulnerabilityID:  "CVE-2025-12345",
+					InstalledVersion: "7.4.5-r0",
+					FixedVersion:     "7.4.6-r0",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.CleanStart,
+						Name: "CleanStart Security Advisories",
+						URL:  "https://github.com/cleanstart-dev/cleanstart-security-advisories",
+					},
+				},
+			},
+		},
+		{
+			name: "Get returns an error",
+			fixtures: []string{
+				"testdata/fixtures/invalid.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				pkgs: []ftypes.Package{
+					{
+						Name:       "redis",
+						Version:    "7.4.5-r0",
+						SrcName:    "redis",
+						SrcVersion: "7.4.5-r0",
+					},
+				},
+			},
+			wantErr: "failed to get CleanStart advisories",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = dbtest.InitDB(t, tt.fixtures)
+			defer db.Close()
+
+			s := cleanstart.NewScanner()
+			got, err := s.Detect(t.Context(), "", tt.args.repo, tt.args.pkgs)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].VulnerabilityID < got[j].VulnerabilityID
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/ospkg/cleanstart/testdata/fixtures/cleanstart.yaml
+++ b/pkg/detector/ospkg/cleanstart/testdata/fixtures/cleanstart.yaml
@@ -1,0 +1,15 @@
+- bucket: cleanstart
+  pairs:
+    - bucket: redis
+      pairs:
+        - key: CVE-2025-12345
+          value:
+            FixedVersion: "7.4.6-r0"
+        - key: CLEANSTART-2026-MZ27698
+          value:
+            FixedVersion: "7.4.6-r0"
+    - bucket: invalid-src
+      pairs:
+        - key: CVE-2025-00001
+          value:
+            FixedVersion: "invalid"

--- a/pkg/detector/ospkg/cleanstart/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/cleanstart/testdata/fixtures/data-source.yaml
@@ -1,0 +1,7 @@
+- bucket: data-source
+  pairs:
+    - key: cleanstart
+      value:
+        ID: "cleanstart"
+        Name: "CleanStart Security Advisories"
+        URL: "https://github.com/cleanstart-dev/cleanstart-security-advisories"

--- a/pkg/detector/ospkg/cleanstart/testdata/fixtures/invalid.yaml
+++ b/pkg/detector/ospkg/cleanstart/testdata/fixtures/invalid.yaml
@@ -1,0 +1,9 @@
+- bucket: cleanstart
+  pairs:
+    - bucket: redis
+      pairs:
+        - key: CVE-2025-12345
+          value:
+            FixedVersion:
+              - foo
+              - bar

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/suse"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/ubuntu"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/wolfi"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/cleanstart"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -61,6 +62,7 @@ var (
 		ftypes.Photon:             photon.NewScanner(),
 		ftypes.Wolfi:              wolfi.NewScanner(),
 		ftypes.Chainguard:         chainguard.NewScanner(),
+		ftypes.CleanStart:         cleanstart.NewScanner(),
 		ftypes.Echo:               echo.NewScanner(),
 		ftypes.MinimOS:            minimos.NewScanner(),
 		ftypes.CoreOS:             coreos.NewScanner(),

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -112,6 +112,8 @@ func idToOSFamily(id string) types.OSType {
 		return types.Echo
 	case "minimos":
 		return types.MinimOS
+	case "clnstrt", "cleanstart":
+    	return types.CleanStart
 	case "coreos":
 		return types.CoreOS
 	}

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -47,6 +47,7 @@ const (
 	SLES               OSType = "sles"
 	Ubuntu             OSType = "ubuntu"
 	Wolfi              OSType = "wolfi"
+	CleanStart         OSType = "cleanstart"
 )
 
 // HasOSPackages returns true if the OS type has OS-level packages managed by a package manager.
@@ -163,6 +164,7 @@ var (
 		SLES,
 		Ubuntu,
 		Wolfi,
+		CleanStart,
 	}
 	AggregatingTypes = []LangType{
 		PythonPkg,


### PR DESCRIPTION
## Description
Adds CleanStart OS as a supported distribution in the Trivy scanner.

CleanStart is a container-optimized Linux distribution using APK package management. It uses `ID=clnstrt` in `/etc/os-release` today, with `ID=cleanstart` planned — both identifiers are handled. The OS family is reported as `cleanstart` in scan output regardless of which identifier is present.

**Changes:**
- `pkg/fanal/types/const.go` — added `CleanStart OSType = "cleanstart"` constant, appended to `OSTypes` slice
- `pkg/fanal/analyzer/os/release/release.go` — added `"clnstrt", "cleanstart"` cases to `idToOSFamily()` to handle both identifiers during ongoing transition
- `pkg/detector/ospkg/detect.go` — registered `ftypes.CleanStart: cleanstart.NewScanner()` in the drivers map
- `pkg/detector/ospkg/cleanstart/cleanstart.go` (new) — APK-based vulnerability scanner; `IsSupportedVersion` always returns `true` as CleanStart is a rolling release
- `docs/guide/coverage/os/cleanstart.md` (new) — OS coverage documentation
- `docs/guide/coverage/os/index.md` — added CleanStart to supported OS table
- `docs/guide/scanner/vulnerability.md` — added CleanStart data source
- `mkdocs.yml` — added CleanStart to navigation

**Before:**
<img width="800" height="108" alt="image" src="https://github.com/user-attachments/assets/b20a09d6-7a3c-4a39-a1c7-3cc4143522dc" />

**After:**
<img width="1425" height="150" alt="image" src="https://github.com/user-attachments/assets/d6b5c132-0e46-4ba7-a954-2ce41c944db7" />


## Related PRs
- [ ] [vuln-list-update PR](https://github.com/aquasecurity/vuln-list-update/pull/410)
- [ ] [trivy-db PR](https://github.com/aquasecurity/trivy-db/pull/647)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
