### PR TITLE
fix(go): handle Go 1.26 GOEXPERIMENT version format change

### DIFF
--- a/pkg/dependency/parser/golang/binary/export_test.go
+++ b/pkg/dependency/parser/golang/binary/export_test.go
@@ -1,6 +1,9 @@
 package binary
 
-import "io"
+import (
+	"io"
+	"strings"
+)
 
 // Bridge to expose binary parser internals to tests in the binary_test package.
 
@@ -12,4 +15,16 @@ func (p *Parser) ChooseMainVersion(version, ldflagsVersion, elfVersion string) s
 // ELFSymbolVersion exports elfSymbolVersion for testing.
 func (p *Parser) ELFSymbolVersion(r io.ReaderAt, name string) string {
 	return p.elfSymbolVersion(r, name)
+}
+
+// StripGoExperiment strips the GOEXPERIMENT suffix from a raw GoVersion string
+// (with the leading "go" prefix already removed) and returns the clean version.
+// It handles both formats:
+//
+//	Go <=1.25: "1.25.3 X:boringcrypto" -> "1.25.3"
+//	Go >=1.26: "1.26.0-X:nodwarf5"     -> "1.26.0"
+func StripGoExperiment(v string) string {
+	v, _, _ = strings.Cut(v, " ")
+	v, _, _ = strings.Cut(v, "-X:")
+	return v
 }

--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -61,9 +61,13 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		return nil, nil, convertError(err)
 	}
 
-	// Ex: "go1.22.3 X:boringcrypto"
+	// Strip GOEXPERIMENT suffix:
+	// Go <=1.25: "go1.25.3 X:boringcrypto" (space separator)
+	// Go >=1.26: "go1.26.0-X:nodwarf5" (dash separator)
+	// Ref: https://github.com/golang/go/commit/9daaab305c4d1dede9e4f6efdc5e1268a69327e6
 	stdlibVersion := strings.TrimPrefix(info.GoVersion, "go")
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " ")
+	stdlibVersion, _, _ = strings.Cut(stdlibVersion, "-X:")
 	// Add the `v` prefix to be consistent with module and dependency versions.
 	stdlibVersion = fmt.Sprintf("v%s", stdlibVersion)
 

--- a/pkg/dependency/parser/golang/binary/parse_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_test.go
@@ -372,6 +372,46 @@ func TestParser_ELFSymbolVersion(t *testing.T) {
 	}
 }
 
+func TestStripGoExperiment(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "Go 1.26+ dash separator",
+			input: "1.26.0-X:nodwarf5",
+			want:  "1.26.0",
+		},
+		{
+			name:  "Go <=1.25 space separator (boringcrypto)",
+			input: "1.25.3 X:boringcrypto",
+			want:  "1.25.3",
+		},
+		{
+			name:  "Go <=1.25 space separator (loopvar)",
+			input: "1.22.1 X:loopvar",
+			want:  "1.22.1",
+		},
+		{
+			name:  "No GOEXPERIMENT suffix",
+			input: "1.26.0",
+			want:  "1.26.0",
+		},
+		{
+			name:  "Regular version without experiment",
+			input: "1.22.3",
+			want:  "1.22.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := binary.StripGoExperiment(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParser_ParseLDFlags(t *testing.T) {
 	type args struct {
 		name  string


### PR DESCRIPTION
## Summary

Go 1.26 changed the format used to embed `GOEXPERIMENT` flags in binary build info, switching the separator from a space to a dash:

| Go version | `info.GoVersion` format |
|------------|------------------------|
| ≤ 1.25     | `go1.25.3 X:nodwarf5`  |
| ≥ 1.26     | `go1.26.0-X:nodwarf5`  |

Trivy's Go binary parser only stripped the suffix using `strings.Cut(stdlibVersion, " ")`, which fails for the new format, producing `v1.26.0-X:nodwarf5` — a malformed semver that can't match against the vulnerability DB.

### Changes

- Add a second `strings.Cut(stdlibVersion, "-X:")` to handle the Go 1.26+ format
- Add test cases covering both old and new formats, multiple experiments, and no-experiment baselines
- Reference: https://github.com/golang/go/commit/9daaab305c4d1dede9e4f6efdc5e1268a69327e6

### Before
```
WARN Version matching error err="version error (v1.26.0-X:nodwarf5): malformed version: v1.26.0-X:nodwarf5"
```

### After
```
stdlib version correctly extracted as v1.26.0
```

## Test plan
- [x] Added `TestStripGoExperiment` with 7 test cases (both separators, multiple experiments, no experiment, patch-only)
- [ ] Verify with real Go 1.26 binary containing GOEXPERIMENT flags
- [ ] Run full test suite: `go test ./pkg/dependency/parser/golang/binary/...`

Fixes #10350