### PR TITLE
fix(license): strip plus operator from SPDX exception identifiers

### DIFF
--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -79,10 +79,19 @@ func NormalizeForSPDX(expr Expression) Expression {
 	case CompoundExpr:
 		if e.Conjunction() == TokenWith {
 			initSpdxExceptions()
+			// The '+' (or-later) operator is only valid for license identifiers,
+			// not for exception identifiers per the SPDX spec.
+			// ref: https://github.com/aquasecurity/trivy/issues/7838
+			right := e.Right()
+			if r, ok := right.(SimpleExpr); ok && r.HasPlus {
+				r.HasPlus = false
+				right = r
+			}
 			// Use correct SPDX exceptionID
-			if exc, ok := spdxExceptions[strings.ToUpper(e.Right().String())]; ok {
+			if exc, ok := spdxExceptions[strings.ToUpper(right.String())]; ok {
 				return NewCompoundExpr(e.Left(), e.Conjunction(), exc)
 			}
+			return NewCompoundExpr(e.Left(), e.Conjunction(), right)
 		}
 	}
 	return expr

--- a/pkg/licensing/expression/expression_test.go
+++ b/pkg/licensing/expression/expression_test.go
@@ -35,6 +35,24 @@ func TestNormalize(t *testing.T) {
 			want:    "LGPL-2.1-only OR MIT OR BSD-3-Clause",
 		},
 		{
+			name:    "SPDX, exception with plus sign",
+			license: "GPL-3.0-only WITH Autoconf-exception-3.0+",
+			fn:      NormalizeForSPDX,
+			want:    "GPL-3.0-only WITH Autoconf-exception-3.0",
+		},
+		{
+			name:    "SPDX, exception with plus sign (Bison)",
+			license: "GPL-2.0-or-later WITH Bison-exception-2.2+",
+			fn:      NormalizeForSPDX,
+			want:    "GPL-2.0-or-later WITH Bison-exception-2.2",
+		},
+		{
+			name:    "SPDX, exception without plus sign unchanged",
+			license: "GPL-3.0-only WITH Autoconf-exception-3.0",
+			fn:      NormalizeForSPDX,
+			want:    "GPL-3.0-only WITH Autoconf-exception-3.0",
+		},
+		{
 			name:    "upper",
 			license: "LGPL-2.1-only OR MIT",
 			fn:      func(license Expression) Expression { return SimpleExpr{strings.ToUpper(license.String()), false} },


### PR DESCRIPTION
## Description

Fixes invalid SPDX license expressions where the `+` (or-later) operator was appended to exception identifiers in `WITH` clauses.

Per the [SPDX spec (Annex D)](https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/), the `+` operator is only valid after a license identifier, not an exception identifier. Trivy was generating expressions like `GPL-3.0-only WITH autoconf-exception+`, which is invalid.

### Root Cause

In `NormalizeForSPDX`, when handling `WITH` expressions, the right-hand side (exception) was not having its `HasPlus` flag stripped. This caused two problems:
1. The SPDX exception lookup failed because `spdxExceptions` keys don't include `+`
2. The final `.String()` output included the invalid `+` suffix on the exception

### Changes

- `pkg/licensing/expression/expression.go`: Strip `HasPlus` from exception `SimpleExpr` in `NormalizeForSPDX` when handling `WITH` clauses. Also return the stripped expression even when the exception is not in the SPDX list.
- `pkg/licensing/expression/expression_test.go`: Add test cases for exception with `+`, exception with `+` (Bison), and exception without `+` (unchanged).

### Reproduction

```bash
trivy image bitnami/wordpress --format spdx-json | grep "autoconf-exception+"
```

Fixes #7838