### PR TITLE
ci: merge a new rpm repo with existing data

### DIFF
--- a/ci/deploy-rpm.sh
+++ b/ci/deploy-rpm.sh
@@ -31,8 +31,6 @@ function merge_repo_with_new_packages () {
                 mergerepo_c -v --all -r "$rpm_old" -r "$rpm_tmp" -o "$rpm_path"
         else
                 # No existing repo: initialize from the new metadata
-                rm -rf "$rpm_path/repodata"
-                mkdir -p "$rpm_path"
                 cp -r "$rpm_tmp/repodata" "$rpm_path"/
         fi
 


### PR DESCRIPTION
## Description

Notes:
* we don't need to install `mergerepo_c` separately, it's a part of `createrepo_c` package:
```sh
# dpkg -L createrepo-c | grep mergerepo_c
/usr/bin/mergerepo_c
/usr/share/man/man8/mergerepo_c.8.gz
/usr/share/bash-completion/completions/mergerepo_c
```

## Related issues
- Close https://github.com/aquasecurity/trivy-repo/issues/44

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
