### PR TITLE
refactor: promote analyzer errors from debug to warn log level

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -510,7 +510,7 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, eg *errgroup.Group, lim
 				case errors.Is(analyzeErr, context.DeadlineExceeded):
 					return xerrors.Errorf("analyzer timed out: %w", analyzeErr)
 				default:
-					ag.logger.Debug("Analysis error", log.Err(err))
+					ag.logger.Warn("Analysis error", log.Err(analyzeErr))
 					return nil
 				}
 			}

--- a/pkg/fanal/analyzer/config_analyzer.go
+++ b/pkg/fanal/analyzer/config_analyzer.go
@@ -114,7 +114,7 @@ func (ag *ConfigAnalyzerGroup) AnalyzeImageConfig(ctx context.Context, targetOS 
 
 		r, err := a.Analyze(ctx, input)
 		if err != nil {
-			log.Debug("Image config analysis error", log.Err(err))
+			log.Warn("Image config analysis error", log.Err(err))
 			continue
 		}
 

--- a/pkg/fanal/analyzer/language/analyze.go
+++ b/pkg/fanal/analyzer/language/analyze.go
@@ -18,11 +18,19 @@ type Parser interface {
 	Parse(_ context.Context, r xio.ReadSeekerAt) ([]types.Package, []types.Dependency, error)
 }
 
+// parseError represents a file parsing failure.
+// It implements fsutils.WarnError so that WalkDir logs it at Warn level
+// instead of the default Debug level.
+type parseError struct{ error }
+
+func (parseError) WarnError()      {}
+func (e parseError) Unwrap() error { return e.error }
+
 // Analyze returns an analysis result of the lock file
 func Analyze(ctx context.Context, fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser) (*analyzer.AnalysisResult, error) {
 	app, err := Parse(ctx, fileType, filePath, r, parser)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, err
 	}
 
 	if app == nil {
@@ -36,7 +44,7 @@ func Analyze(ctx context.Context, fileType types.LangType, filePath string, r xi
 func AnalyzePackage(ctx context.Context, fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser, checksum bool) (*analyzer.AnalysisResult, error) {
 	app, err := ParsePackage(ctx, fileType, filePath, r, parser, checksum)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, err
 	}
 
 	if app == nil {
@@ -54,7 +62,7 @@ func Parse(ctx context.Context, fileType types.LangType, filePath string, r io.R
 	}
 	parsedPkgs, parsedDependencies, err := parser.Parse(ctx, rr)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, parseError{xerrors.Errorf("failed to parse %s: %w", filePath, err)}
 	}
 
 	// The file path of each library should be empty in case of dependency list such as lock file
@@ -66,7 +74,7 @@ func Parse(ctx context.Context, fileType types.LangType, filePath string, r io.R
 func ParsePackage(ctx context.Context, fileType types.LangType, filePath string, r xio.ReadSeekerAt, parser Parser, checksum bool) (*types.Application, error) {
 	parsedPkgs, parsedDependencies, err := parser.Parse(ctx, r)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", filePath, err)
+		return nil, parseError{xerrors.Errorf("failed to parse %s: %w", filePath, err)}
 	}
 
 	// The reader is not passed if the checksum is not necessarily calculated.

--- a/pkg/utils/fsutils/fs.go
+++ b/pkg/utils/fsutils/fs.go
@@ -1,6 +1,7 @@
 package fsutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -12,6 +13,12 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/log"
 )
+
+// WarnError is implemented by errors that should be logged at Warn level
+// in WalkDir instead of the default Debug level.
+type WarnError interface {
+	WarnError()
+}
 
 const (
 	xdgDataHome = "XDG_DATA_HOME"
@@ -86,7 +93,12 @@ func WalkDir(fsys fs.FS, root string, required WalkDirRequiredFunc, fn WalkDirFu
 		defer f.Close()
 
 		if err = fn(path, d, f); err != nil {
-			log.Debug("Walk error", log.FilePath(path), log.Err(err))
+			var we WarnError
+			if errors.As(err, &we) {
+				log.Warn("Walk error", log.FilePath(path), log.Err(err))
+			} else {
+				log.Debug("Walk error", log.FilePath(path), log.Err(err))
+			}
 		}
 		return nil
 	})

--- a/pkg/utils/fsutils/fs_test.go
+++ b/pkg/utils/fsutils/fs_test.go
@@ -1,13 +1,66 @@
 package fsutils
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/log"
 )
+
+type warnError struct{ error }
+
+func (warnError) WarnError() {}
+
+func TestWalkDir_LogLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel string
+	}{
+		{
+			name:      "regular error is logged as debug",
+			err:       errors.New("some error"),
+			wantLevel: "DEBUG",
+		},
+		{
+			name:      "WarnError is logged as warn",
+			err:       warnError{errors.New("parse error")},
+			wantLevel: "WARN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			original := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(original) })
+			log.SetDefault(slog.New(log.NewHandler(&buf, &log.Options{Level: slog.LevelDebug})))
+
+			fsys := fstest.MapFS{
+				"test.txt": &fstest.MapFile{Data: []byte("content")},
+			}
+
+			err := WalkDir(fsys, ".", func(_ string, d fs.DirEntry) bool {
+				return d.Type().IsRegular()
+			}, func(_ string, _ fs.DirEntry, _ io.Reader) error {
+				return tt.err
+			})
+			require.NoError(t, err)
+
+			assert.Contains(t, buf.String(), tt.wantLevel)
+		})
+	}
+}
 
 func TestCopyFile(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Description

Analyzer and post-analyzer errors were silently swallowed at `DEBUG` level,
making them invisible to users running Trivy without the `--debug` flag.

This PR introduces a lightweight mechanism to distinguish meaningful parse failures from expected walk errors:

- Add `WarnError` interface in `fsutils` — `WalkDir` logs callback errors at `WARN` if the error implements it, `DEBUG` otherwise
- Add `parseError` type in the `language` package implementing `WarnError`, so all language parser failures (e.g. malformed `package-lock.json`) are visible as warnings
- Fix `log.Debug` → `log.Warn` for unhandled errors in `AnalyzeFile` and `AnalyzeImageConfig`
- Fix a bug in `AnalyzeFile` where `err` (outer scope) was passed to `log.Err` instead of `analyzeErr`

**Before:**
```bash
$ trivy -d fs /Users/dmitriy/work/tmp/10119/package-lock.json
...
2026-03-18T16:27:06+06:00	DEBUG	Walk error	file_path="package-lock.json" err="parse error: failed to parse package-lock.json: decode error: json: cannot unmarshal JSON array into Go string within \"/packages/node_modules~1tv4/license\""
```

**After:**
```bash
$ ./trivy fs /Users/dmitriy/work/tmp/10119/package-lock.json
...
2026-03-18T16:27:13+06:00	WARN	Walk error	file_path="package-lock.json" err="parse error: failed to parse package-lock.json: decode error: json: cannot unmarshal JSON array into Go string within \"/packages/node_modules~1tv4/license\""
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).