### PR TITLE
fix: remove os.Stdout from wazero module config

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -282,7 +282,7 @@ type wasmModule struct {
 
 func newWASMPlugin(ctx context.Context, ccache wazero.CompilationCache, code []byte) (*wasmModule, error) {
 	mf := &memFS{}
-	config := wazero.NewModuleConfig().WithStdout(os.Stdout).WithFS(mf).WithStartFunctions("_initialize")
+	config := wazero.NewModuleConfig().WithFS(mf).WithStartFunctions("_initialize")
 
 	// Create an empty namespace so that multiple modules will not conflict
 	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(ccache))


### PR DESCRIPTION
## Description

When a WASM module is loaded, `os.Stdout` is passed directly to wazero via `WithStdout(os.Stdout)`. This causes wazero to set the stdout file descriptor to non-blocking mode during WASI initialization, which affects the entire process. As a result, subsequent writes to stdout may fail with `resource temporarily unavailable (EAGAIN)`.

WASM modules in Trivy log via the `env` host functions (`debug`, `info`, `warn`, `error`) which write through Trivy's logger. They do not write directly to stdout.

Additionally, the wazero documentation explicitly warns against passing `os.Stdout`:
> This does not default to os.Stdout as that both violates sandboxing
> and prevents concurrent modules.

The default wazero behavior (`io.Discard`) is the correct choice here.

## Setup

```bash
echo 'from scratch' > testdata/Dockerfile
mkdir -p ~/.trivy/modules
cp ./pkg/module/testdata/scanner/scanner.wasm ~/.trivy/modules/scanner.wasm 
```

## Before

```bash
❯ trivy conf ./testdata/Dockerfile -f json -q
{
  "SchemaVersion": 2,
  "Trivy": {
    "Version": "0.69.1"
  },
  "ReportID": "019d00b6-e276-70a7-a216-93c971297c86",
  "CreatedAt": "2026-03-18T17:31:18.774044+06:00",
  "ArtifactName": "testdata/Dockerfile",
  "ArtifactType": "filesystem",
  "Results": [
    {
      "Target": "Dockerfile",
      "Class": "config",
      "Type": "dockerfile",
      "MisconfSummary": {
        "Successes": 25,
        "Failures": 2
      },
      "Misconfigurations": [
        {
          "Type": "Dockerfile Security Check",
          "ID": "DS-0002",
          "Title": "Image user should not be 'root'",
          "Description": "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
          "Message": "Specify at least 1 USER command in Dockerfile with non-root user as argument",
          "Namespace": "builtin.dockerfile.DS002",
          "Query":2026-03-18T17:31:18+06:00     FATAL   Fatal error     run error: report error: unable to write results: failed to write results: failed to write json: write /dev/stdout: resource temporarily unavailable
```

## After

```bash
❯ ./trivy conf ./testdata/Dockerfile -f json -q
{
  "SchemaVersion": 2,
  "Trivy": {
    "Version": "0.69.0-62-g51c1599208"
  },
  "ReportID": "019d00b7-0126-7900-8030-c2ceccec822d",
  "CreatedAt": "2026-03-18T17:31:26.630591+06:00",
  "ArtifactName": "testdata/Dockerfile",
  "ArtifactType": "filesystem",
  "Results": [
    {
      "Target": "Dockerfile",
      "Class": "config",
      "Type": "dockerfile",
      "MisconfSummary": {
        "Successes": 25,
        "Failures": 2
      },
      "Misconfigurations": [
        {
          "Type": "Dockerfile Security Check",
          "ID": "DS-0002",
          "Title": "Image user should not be 'root'",
          "Description": "Running containers with 'root' user can lead to a container escape situation. It is a best practice to run containers as non-root users, which can be done by adding a 'USER' statement to the Dockerfile.",
          "Message": "Specify at least 1 USER command in Dockerfile with non-root user as argument",
          "Namespace": "builtin.dockerfile.DS002",
          "Query": "data.builtin.dockerfile.DS002.deny",
          "Resolution": "Add 'USER \u003cnon root user name\u003e' line to the Dockerfile",
          "Severity": "HIGH",
          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds-0002",
          "References": [
            "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
            "https://avd.aquasec.com/misconfig/ds-0002"
          ],
          "Status": "FAIL",
          "CauseMetadata": {
            "Provider": "Dockerfile",
            "Service": "general"
          }
        },
        {
          "Type": "Dockerfile Security Check",
          "ID": "DS-0026",
          "Title": "No HEALTHCHECK defined",
          "Description": "You should add HEALTHCHECK instruction in your docker container images to perform the health check on running containers.",
          "Message": "Add HEALTHCHECK instruction in your Dockerfile",
          "Namespace": "builtin.dockerfile.DS026",
          "Query": "data.builtin.dockerfile.DS026.deny",
          "Resolution": "Add HEALTHCHECK instruction in Dockerfile",
          "Severity": "LOW",
          "PrimaryURL": "https://avd.aquasec.com/misconfig/ds-0026",
          "References": [
            "https://blog.aquasec.com/docker-security-best-practices",
            "https://avd.aquasec.com/misconfig/ds-0026"
          ],
          "Status": "FAIL",
          "CauseMetadata": {
            "Provider": "Dockerfile",
            "Service": "general"
          }
        }
      ]
    }
  ]
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
