### PR TITLE
fix(report): handle `git@` SSH URIs for non-GitHub hosts in `sarif` report

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -362,6 +362,29 @@ func clearURI(s string) string {
 		s = strings.ReplaceAll(s, "git@github.com:", "github.com/")
 		s = strings.ReplaceAll(s, ".git", "")
 		s = strings.ReplaceAll(s, "?ref=", "/tree/")
+	case strings.HasPrefix(s, "git@bitbucket.org:"):
+		// build Bitbucket url format
+		// e.g. `git@bitbucket.org:org/repo.git?ref=1.8.4/file.tf` -> `bitbucket.org/org/repo/src/1.8.4/file.tf`
+		// cf. https://github.com/aquasecurity/trivy/issues/8154
+		s = strings.ReplaceAll(s, "git@bitbucket.org:", "bitbucket.org/")
+		s = strings.ReplaceAll(s, ".git", "")
+		s = strings.ReplaceAll(s, "?ref=", "/src/")
+	case strings.HasPrefix(s, "git@"):
+		// generic git SSH format for other hosts (GitLab, Gitea, etc.)
+		// e.g. `git@gitlab.com:org/repo.git?ref=v1.0.0/main.tf` -> `gitlab.com/org/repo/main.tf`
+		s = strings.TrimPrefix(s, "git@")
+		s = strings.Replace(s, ":", "/", 1)
+		s = strings.ReplaceAll(s, ".git", "")
+		// Strip `?ref=<tag>` for generic hosts since the path format varies
+		if idx := strings.Index(s, "?ref="); idx != -1 {
+			rest := s[idx+5:] // content after `?ref=`
+			// If the ref contains a path separator, keep the file path after the ref
+			if slashIdx := strings.Index(rest, "/"); slashIdx != -1 {
+				s = s[:idx] + rest[slashIdx:]
+			} else {
+				s = s[:idx]
+			}
+		}
 	case strings.HasPrefix(s, "git::https:/") && !strings.HasPrefix(s, "git::https://"):
 		s = strings.TrimPrefix(s, "git::https:/")
 		s = strings.ReplaceAll(s, ".git", "")
@@ -395,6 +418,7 @@ func toUri(str string) *url.URL {
 	if err != nil {
 		logger := log.WithPrefix("sarif")
 		logger.Error("Unable to parse URI", log.String("URI", str), log.Err(err))
+		return &url.URL{}
 	}
 	return uri
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -853,6 +853,31 @@ func Test_clearURI(t *testing.T) {
 			uri:  "gcs::https://www.googleapis.com/storage/v1/modules/foomodule.zip",
 			want: "https://www.googleapis.com/storage/v1/modules/foomodule.zip",
 		},
+		{
+			name: "bitbucket ssh",
+			uri:  "git@bitbucket.org:org/repo.git/terraform?ref=1.8.4/terraform/.terraform/modules/aws_ecs_app/terraform/sg.tf",
+			want: "bitbucket.org/org/repo/terraform/src/1.8.4/terraform/.terraform/modules/aws_ecs_app/terraform/sg.tf",
+		},
+		{
+			name: "bitbucket ssh without ref",
+			uri:  "git@bitbucket.org:myteam/myrepo.git/main.tf",
+			want: "bitbucket.org/myteam/myrepo/main.tf",
+		},
+		{
+			name: "generic git ssh",
+			uri:  "git@gitlab.com:org/repo.git?ref=v1.0.0/main.tf",
+			want: "gitlab.com/org/repo/main.tf",
+		},
+		{
+			name: "generic git ssh with ref only",
+			uri:  "git@gitlab.com:org/repo.git?ref=v1.0.0",
+			want: "gitlab.com/org/repo",
+		},
+		{
+			name: "generic git ssh without ref",
+			uri:  "git@gitlab.com:org/repo.git",
+			want: "gitlab.com/org/repo",
+		},
 	}
 
 	for _, tt := range test {
@@ -862,6 +887,12 @@ func Test_clearURI(t *testing.T) {
 			require.NotNil(t, report.ToUri(got))
 		})
 	}
+}
+
+func Test_toUri_unparseable(t *testing.T) {
+	got := report.ToUri("://")
+	require.NotNil(t, got)
+	assert.Equal(t, "", got.String())
 }
 
 func TestMakePropertiesMarshal(t *testing.T) {


### PR DESCRIPTION
## Description

`clearURI()` only handled `git@github.com:` SSH URIs (fixed in #7898). When a Terraform module source uses `git@bitbucket.org:` or any other SSH host, `url.Parse` rejects the colon in the first path segment and `toUri()` returns nil. `addSarifResult` then panics on nil pointer dereference when calling `artifactLocation.String()`.

The fix adds two new cases to `clearURI()`:
- `git@bitbucket.org:` -- converts to Bitbucket web URL format (`/src/` for refs)
- `git@` generic fallback -- converts any other SSH host (GitLab, Gitea, etc.) to a parseable URL

`toUri()` now returns `&url.URL{}` instead of nil on parse error to prevent panics from any future unhandled URI format.

## Related issues
- Close #8154

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).