### PR TITLE
docs: convert README demonstration videos to mp4

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ trivy image python:3.4-alpine
 <details>
 <summary>Result</summary>
 
-https://user-images.githubusercontent.com/1161307/171013513-95f18734-233d-45d3-aaf5-d6aec687db0e.mov
+https://github.com/user-attachments/assets/8eea74bd-5c51-429e-a3bc-3ae33a9441e9
 
 </details>
 
@@ -83,7 +83,7 @@ trivy fs --scanners vuln,secret,misconfig myproject/
 <details>
 <summary>Result</summary>
 
-https://user-images.githubusercontent.com/1161307/171013917-b1f37810-f434-465c-b01a-22de036bd9b3.mov
+https://github.com/user-attachments/assets/6190a66a-ec5c-47e2-82f7-f365fb1ff2ce
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ trivy image python:3.4-alpine
 <details>
 <summary>Result</summary>
 
-https://github.com/user-attachments/assets/8eea74bd-5c51-429e-a3bc-3ae33a9441e9
+https://github.com/user-attachments/assets/af1c11e7-d9c5-48af-8e05-cb34dfd6352a
 
 </details>
 
@@ -83,7 +83,7 @@ trivy fs --scanners vuln,secret,misconfig myproject/
 <details>
 <summary>Result</summary>
 
-https://github.com/user-attachments/assets/6190a66a-ec5c-47e2-82f7-f365fb1ff2ce
+https://github.com/user-attachments/assets/6b3894b7-77c5-4ffc-ac94-ffe6648a30dc
 
 </details>
 


### PR DESCRIPTION
## Description

The demonstration videos in the README don't play on Chrome or Edge. 

## Related issues
- Close #10418

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
