### PR TITLE
feat(cli): add support for json logging

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -34,7 +34,7 @@ func main() {
 func run() error {
 	// Trivy behaves as the specified plugin.
 	if runAsPlugin := os.Getenv("TRIVY_RUN_AS_PLUGIN"); runAsPlugin != "" {
-		log.InitLogger(false, false)
+		log.InitLogger(false, false, "")
 		if err := plugin.Run(context.Background(), runAsPlugin, plugin.Options{Args: os.Args[1:]}); err != nil {
 			return xerrors.Errorf("plugin error: %w", err)
 		}

--- a/pkg/attestation/sbom/rekor_test.go
+++ b/pkg/attestation/sbom/rekor_test.go
@@ -30,7 +30,7 @@ func TestRekor_RetrieveSBOM(t *testing.T) {
 		},
 	}
 
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := rekortest.NewServer(t)

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -208,7 +208,7 @@ func NewRootCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 				return err
 			}
 			// Initialize logger
-			log.InitLogger(opts.Debug, opts.Quiet)
+			log.InitLogger(opts.Debug, opts.Quiet, opts.LogFormat)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -17,7 +17,7 @@ import (
 
 // Run runs the scan
 func Run(ctx context.Context, opts flag.Options) (err error) {
-	log.InitLogger(opts.Debug, opts.Quiet)
+	log.InitLogger(opts.Debug, opts.Quiet, opts.LogFormat)
 
 	// Set the default HTTP transport
 	xhttp.SetDefaultTransport(xhttp.NewTransport(xhttp.Options{

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, false)
+	log.InitLogger(false, false, "")
 	os.Exit(m.Run())
 }
 

--- a/pkg/fanal/analyzer/language/nodejs/bun/bun_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/bun/bun_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	os.Exit(m.Run())
 }
 

--- a/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
+++ b/pkg/fanal/analyzer/language/nodejs/npm/npm_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	os.Exit(m.Run())
 }
 

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	os.Exit(m.Run())
 }
 

--- a/pkg/fanal/handler/unpackaged/unpackaged_test.go
+++ b/pkg/fanal/handler/unpackaged/unpackaged_test.go
@@ -73,7 +73,7 @@ func Test_unpackagedHook_Handle(t *testing.T) {
 		},
 	}
 
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := rekortest.NewServer(t)

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	os.Exit(m.Run())
 }
 

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -36,6 +36,15 @@ var (
 		Persistent:    true,
 		TelemetrySafe: true,
 	}
+	LogFormatFlag = Flag[string]{
+		Name:          "log-format",
+		ConfigName:    "log.format",
+		Default:       "text",
+		Values:        []string{"text", "json"},
+		Usage:         "log format (text, json)",
+		Persistent:    true,
+		TelemetrySafe: true,
+	}
 	DebugFlag = Flag[bool]{
 		Name:          "debug",
 		ConfigName:    "debug",
@@ -93,6 +102,7 @@ type GlobalFlagGroup struct {
 	ConfigFile            *Flag[string]
 	ShowVersion           *Flag[bool] // spf13/cobra can't override the logic of version printing like VersionPrinter in urfave/cli. -v needs to be defined ourselves.
 	Quiet                 *Flag[bool]
+	LogFormat             *Flag[string]
 	Debug                 *Flag[bool]
 	Insecure              *Flag[bool]
 	CACert                *Flag[string]
@@ -107,6 +117,7 @@ type GlobalOptions struct {
 	ConfigFile            string
 	ShowVersion           bool
 	Quiet                 bool
+	LogFormat             string
 	Debug                 bool
 	Insecure              bool
 	CACerts               *x509.CertPool
@@ -121,6 +132,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		ConfigFile:            ConfigFileFlag.Clone(),
 		ShowVersion:           ShowVersionFlag.Clone(),
 		Quiet:                 QuietFlag.Clone(),
+		LogFormat:             LogFormatFlag.Clone(),
 		Debug:                 DebugFlag.Clone(),
 		Insecure:              InsecureFlag.Clone(),
 		CACert:                CACertFlag.Clone(),
@@ -140,6 +152,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.ConfigFile,
 		f.ShowVersion,
 		f.Quiet,
+		f.LogFormat,
 		f.Debug,
 		f.Insecure,
 		f.CACert,
@@ -179,6 +192,7 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 		ConfigFile:            f.ConfigFile.Value(),
 		ShowVersion:           f.ShowVersion.Value(),
 		Quiet:                 f.Quiet.Value(),
+		LogFormat:             f.LogFormat.Value(),
 		Debug:                 f.Debug.Value(),
 		Insecure:              insecure,
 		CACerts:               caCerts,

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -54,12 +54,12 @@ func NewScanner(cluster string, runner cmd.Runner, opts flag.Options) *Scanner {
 
 func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact) (report.Report, error) {
 	// disable logs before scanning
-	log.InitLogger(s.opts.Debug, true)
+	log.InitLogger(s.opts.Debug, true, "")
 
 	// enable log, this is done in a defer function,
 	// to enable logs even when the function returns earlier
 	// due to an error
-	defer log.InitLogger(s.opts.Debug, false)
+	defer log.InitLogger(s.opts.Debug, false, "")
 
 	if s.opts.Format == types.FormatCycloneDX {
 		kbom, err := s.clusterInfoToReportResources(artifactsData)

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -38,10 +38,16 @@ func New(h slog.Handler) *Logger {
 }
 
 // InitLogger initializes the logger variable and flushes the buffered logs if needed.
-func InitLogger(debug, disable bool) {
+func InitLogger(debug, disable bool, logFormat string) {
 	level := lo.Ternary(debug, slog.LevelDebug, slog.LevelInfo)
 	out := lo.Ternary(disable, io.Discard, io.Writer(os.Stderr))
-	h := NewHandler(out, &Options{Level: level})
+
+	var h slog.Handler
+	if logFormat == "json" {
+		h = slog.NewJSONHandler(out, &slog.HandlerOptions{Level: level})
+	} else {
+		h = NewHandler(out, &Options{Level: level})
+	}
 
 	// Flush the buffered logs if needed.
 	if d, ok := slog.Default().Handler().(*DeferredHandler); ok {

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -177,7 +177,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger(false, true)
+	log.InitLogger(false, true, "")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Description
This PR adds a new optional global flag `--log-format` which supports either `text` or `json`, with the default being `text`.

## Related issues
- Close #3300 


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
