### PR TITLE
feat: add SHA-512 hash support for SPDX SBOM format

### DIFF
--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -3,6 +3,7 @@ package digest
 import (
 	"crypto/sha1" // nolint
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -87,4 +88,22 @@ func CalcSHA256FromReader(r io.ReadSeeker) (Digest, error) {
 	}
 
 	return NewDigest(SHA256, h), nil
+}
+
+// CalcSHA512 calculates the SHA512 hash of the given data
+func CalcSHA512(data []byte) Digest {
+	h := sha512.Sum512(data)
+	return NewDigestFromString(SHA512, hex.EncodeToString(h[:]))
+}
+
+// CalcSHA512FromReader calculates the SHA512 hash from a reader
+func CalcSHA512FromReader(r io.ReadSeeker) (Digest, error) {
+	defer r.Seek(0, io.SeekStart)
+
+	h := sha512.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", xerrors.Errorf("unable to calculate sha512 digest: %w", err)
+	}
+
+	return NewDigest(SHA512, h), nil
 }

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -507,6 +507,8 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA512:
+			alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:


### PR DESCRIPTION
## Summary
- Addresses #9094 — adds SHA-512 hash algorithm support to the SPDX SBOM marshaler
- CycloneDX marshal/unmarshal already supported SHA-512; this PR adds the missing SPDX piece
- Adds `CalcSHA512` and `CalcSHA512FromReader` helper functions to the digest package

## Changes
- `pkg/sbom/spdx/marshal.go`: Added `digest.SHA512 → spdx.SHA512` case to `spdxChecksums()`, which was the only location still missing SHA-512 support
- `pkg/digest/digest.go`: Added `crypto/sha512` import and `CalcSHA512`/`CalcSHA512FromReader` functions following the existing SHA-256 pattern

## Test plan
- [ ] Existing tests pass (no behavioral change for SHA-1, SHA-256, MD5)
- [ ] SPDX output now includes SHA-512 checksums instead of returning nil
- [ ] CycloneDX SHA-512 support unchanged (already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)