### PR TITLE
feat(java): support Maven 4 project-specific settings.xml

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -88,7 +88,7 @@ func NewParser(filePath string, opts ...option) *Parser {
 		defaultRepo: mavenCentralRepo,
 	}
 
-	s := readSettings()
+	s := readSettings(filepath.Dir(filePath))
 	o.settingsRepos = s.effectiveRepositories()
 	localRepository := s.LocalRepository
 	if localRepository == "" {

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -88,7 +88,7 @@ func NewParser(filePath string, opts ...option) *Parser {
 		defaultRepo: mavenCentralRepo,
 	}
 
-	s := readSettings(filepath.Dir(filePath))
+	s := readSettings(findMvnProjectRoot(filepath.Dir(filePath)))
 	o.settingsRepos = s.effectiveRepositories()
 	localRepository := s.LocalRepository
 	if localRepository == "" {

--- a/pkg/dependency/parser/java/pom/settings.go
+++ b/pkg/dependency/parser/java/pom/settings.go
@@ -39,11 +39,12 @@ type Proxy struct {
 }
 
 type settings struct {
-	LocalRepository string    `xml:"localRepository"`
-	Servers         []Server  `xml:"servers>server"`
-	Profiles        []Profile `xml:"profiles>profile"`
-	ActiveProfiles  []string  `xml:"activeProfiles>activeProfile"`
-	Proxies         []Proxy   `xml:"proxies>proxy"`
+	LocalRepository string          `xml:"localRepository"`
+	Servers         []Server        `xml:"servers>server"`
+	Profiles        []Profile       `xml:"profiles>profile"`
+	ActiveProfiles  []string        `xml:"activeProfiles>activeProfile"`
+	Proxies         []Proxy         `xml:"proxies>proxy"`
+	Repositories    []pomRepository `xml:"repositories>repository"` // Maven 4
 }
 
 func (s settings) effectiveRepositories() []repository {
@@ -53,6 +54,11 @@ func (s settings) effectiveRepositories() []repository {
 			pomRepos = append(pomRepos, profile.Repositories...)
 		}
 	}
+
+	// Root-level repositories (Maven 4)
+	// Profile repos take precedence, so they come first for dedup.
+	pomRepos = append(pomRepos, s.Repositories...)
+
 	pomRepos = lo.UniqBy(pomRepos, func(r pomRepository) string {
 		return r.ID
 	})
@@ -102,13 +108,24 @@ func (p Proxy) isNonProxyHost(host string) bool {
 	return false
 }
 
-func readSettings() settings {
+func readSettings(rootDir string) settings {
 	s := settings{}
 
 	userSettingsPath := filepath.Join(os.Getenv("HOME"), ".m2", "settings.xml")
 	userSettings, err := openSettings(userSettingsPath)
 	if err == nil {
 		s = userSettings
+	}
+
+	// Maven 4: project-specific settings (.mvn/settings.xml)
+	// User settings take precedence over project settings.
+	// https://maven.apache.org/ref/4-LATEST/api/maven-api-settings/settings.html
+	if rootDir != "" {
+		projectSettingsPath := filepath.Join(rootDir, ".mvn", "settings.xml")
+		projectSettings, pErr := openSettings(projectSettingsPath)
+		if pErr == nil {
+			mergeInto(&s, projectSettings)
+		}
 	}
 
 	// Some package managers use this path by default
@@ -119,31 +136,34 @@ func readSettings() settings {
 	globalSettingsPath := filepath.Join(mavenHome, "conf", "settings.xml")
 	globalSettings, err := openSettings(globalSettingsPath)
 	if err == nil {
-		// We need to merge global and user settings. User settings being dominant.
+		// We need to merge global, project, and user settings.
+		// Precedence: user > project > global
 		// https://maven.apache.org/settings.html#quick-overview
-		if s.LocalRepository == "" {
-			s.LocalRepository = globalSettings.LocalRepository
-		}
-
-		// Maven servers
-		s.Servers = lo.UniqBy(append(s.Servers, globalSettings.Servers...), func(server Server) string {
-			return server.ID
-		})
-
-		// Merge profiles
-		s.Profiles = lo.UniqBy(append(s.Profiles, globalSettings.Profiles...), func(p Profile) string {
-			return p.ID
-		})
-		// Merge active profiles
-		s.ActiveProfiles = lo.Uniq(append(s.ActiveProfiles, globalSettings.ActiveProfiles...))
-
-		// Merge proxies
-		s.Proxies = lo.UniqBy(append(s.Proxies, globalSettings.Proxies...), func(p Proxy) string {
-			return p.ID
-		})
+		mergeInto(&s, globalSettings)
 	}
 
 	return s
+}
+
+// mergeInto merges lower-priority settings into s. s keeps its values on conflict.
+func mergeInto(s *settings, lower settings) {
+	if s.LocalRepository == "" {
+		s.LocalRepository = lower.LocalRepository
+	}
+
+	s.Servers = lo.UniqBy(append(s.Servers, lower.Servers...), func(server Server) string {
+		return server.ID
+	})
+	s.Profiles = lo.UniqBy(append(s.Profiles, lower.Profiles...), func(p Profile) string {
+		return p.ID
+	})
+	s.ActiveProfiles = lo.Uniq(append(s.ActiveProfiles, lower.ActiveProfiles...))
+	s.Proxies = lo.UniqBy(append(s.Proxies, lower.Proxies...), func(p Proxy) string {
+		return p.ID
+	})
+	s.Repositories = lo.UniqBy(append(s.Repositories, lower.Repositories...), func(r pomRepository) string {
+		return r.ID
+	})
 }
 
 func openSettings(filePath string) (settings, error) {
@@ -194,5 +214,12 @@ func expandAllEnvPlaceholders(s *settings) {
 		s.Proxies[i].Username = evaluateVariable(proxy.Username, nil, nil)
 		s.Proxies[i].Password = evaluateVariable(proxy.Password, nil, nil)
 		s.Proxies[i].NonProxyHosts = evaluateVariable(proxy.NonProxyHosts, nil, nil)
+	}
+
+	// Root-level repositories (Maven 4)
+	for i, repo := range s.Repositories {
+		s.Repositories[i].ID = evaluateVariable(repo.ID, nil, nil)
+		s.Repositories[i].Name = evaluateVariable(repo.Name, nil, nil)
+		s.Repositories[i].URL = evaluateVariable(repo.URL, nil, nil)
 	}
 }

--- a/pkg/dependency/parser/java/pom/settings.go
+++ b/pkg/dependency/parser/java/pom/settings.go
@@ -108,6 +108,22 @@ func (p Proxy) isNonProxyHost(host string) bool {
 	return false
 }
 
+// findMvnProjectRoot walks up from startDir looking for a .mvn/settings.xml file.
+// Returns the directory containing .mvn/settings.xml, or empty string if not found.
+func findMvnProjectRoot(startDir string) string {
+	dir := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".mvn", "settings.xml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
 func readSettings(rootDir string) settings {
 	s := settings{}
 

--- a/pkg/dependency/parser/java/pom/settings_test.go
+++ b/pkg/dependency/parser/java/pom/settings_test.go
@@ -11,6 +11,7 @@ import (
 func Test_ReadSettings(t *testing.T) {
 	tests := []struct {
 		name         string
+		rootDir      string
 		envs         map[string]string
 		wantSettings settings
 	}{
@@ -70,6 +71,7 @@ func Test_ReadSettings(t *testing.T) {
 				},
 				ActiveProfiles: []string{},
 				Proxies:        []Proxy{},
+				Repositories:   []pomRepository{},
 			},
 		},
 		{
@@ -251,7 +253,126 @@ func Test_ReadSettings(t *testing.T) {
 				ActiveProfiles: []string{
 					"mycompany-global",
 				},
-				Proxies: []Proxy{},
+				Proxies:      []Proxy{},
+				Repositories: []pomRepository{},
+			},
+		},
+		{
+			name:    "happy path with only project settings",
+			rootDir: filepath.Join("testdata", "settings", "project"),
+			envs: map[string]string{
+				"HOME":       "",
+				"MAVEN_HOME": "NOT_EXISTING_PATH",
+			},
+			wantSettings: settings{
+				LocalRepository: "testdata/project/repository",
+				Servers: []Server{
+					{
+						ID: "project-server",
+					},
+					{
+						ID:       "server-with-credentials",
+						Username: "test-user",
+						Password: "test-password-from-project",
+					},
+				},
+				Profiles: []Profile{
+					{
+						ID: "mycompany-project",
+						Repositories: []pomRepository{
+							{
+								ID:               "mycompany-project-releases",
+								URL:              "https://mycompany.example.com/repository/project-releases",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "false",
+							},
+						},
+						ActiveByDefault: true,
+					},
+				},
+				ActiveProfiles: []string{},
+				Proxies:        []Proxy{},
+				Repositories:   []pomRepository{},
+			},
+		},
+		{
+			name:    "global < project < user merge precedence",
+			rootDir: filepath.Join("testdata", "settings", "project"),
+			envs: map[string]string{
+				"HOME":       filepath.Join("testdata", "settings", "user"),
+				"MAVEN_HOME": filepath.Join("testdata", "settings", "global"),
+			},
+			wantSettings: settings{
+				LocalRepository: "testdata/user/repository",
+				Servers: []Server{
+					{
+						ID: "user-server",
+					},
+					{
+						ID:       "server-with-credentials",
+						Username: "test-user",
+						Password: "test-password",
+					},
+					{
+						ID:       "server-with-name-only",
+						Username: "test-user-only",
+					},
+					{
+						ID: "project-server",
+					},
+					{
+						ID: "global-server",
+					},
+				},
+				Profiles: []Profile{
+					{
+						ID: "mycompany-global",
+						Repositories: []pomRepository{
+							{
+								ID:               "mycompany-releases",
+								URL:              "https://mycompany.example.com/repository/user-releases",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "false",
+							},
+							{
+								ID:               "mycompany-user-snapshots",
+								URL:              "https://mycompany.example.com/repository/user-snapshots",
+								ReleasesEnabled:  "false",
+								SnapshotsEnabled: "true",
+							},
+						},
+						ActiveByDefault: true,
+					},
+					{
+						ID: "mycompany-project",
+						Repositories: []pomRepository{
+							{
+								ID:               "mycompany-project-releases",
+								URL:              "https://mycompany.example.com/repository/project-releases",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "false",
+							},
+						},
+						ActiveByDefault: true,
+					},
+					{
+						ID: "default",
+						Repositories: []pomRepository{
+							{
+								ID:               "mycompany-default-releases",
+								URL:              "https://mycompany.example.com/repository/default-releases",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "false",
+							},
+						},
+						ActiveByDefault: true,
+					},
+				},
+				ActiveProfiles: []string{
+					"mycompany-global",
+				},
+				Proxies:      []Proxy{},
+				Repositories: []pomRepository{},
 			},
 		},
 		{
@@ -352,6 +473,7 @@ func Test_ReadSettings(t *testing.T) {
 						Port:     "8080",
 					},
 				},
+				Repositories: []pomRepository{},
 			},
 		},
 		{
@@ -377,6 +499,7 @@ func Test_ReadSettings(t *testing.T) {
 						NonProxyHosts: "localhost|*.internal.com",
 					},
 				},
+				Repositories: []pomRepository{},
 			},
 		},
 	}
@@ -386,7 +509,7 @@ func Test_ReadSettings(t *testing.T) {
 				t.Setenv(env, settingsDir)
 			}
 
-			gotSettings := readSettings()
+			gotSettings := readSettings(tt.rootDir)
 			require.Equal(t, tt.wantSettings, gotSettings)
 		})
 	}
@@ -492,6 +615,73 @@ func Test_effectiveRepositories(t *testing.T) {
 					url:             mustParseURL(t, "https://p1.example.com/dup"),
 					releaseEnabled:  true,
 					snapshotEnabled: false,
+				},
+			},
+		},
+		{
+			name: "root-level repositories (Maven 4)",
+			s: settings{
+				Repositories: []pomRepository{
+					{
+						ID:               "root-repo",
+						URL:              "https://example.com/root",
+						ReleasesEnabled:  "true",
+						SnapshotsEnabled: "false",
+					},
+				},
+			},
+			want: []repository{
+				{
+					url:             mustParseURL(t, "https://example.com/root"),
+					releaseEnabled:  true,
+					snapshotEnabled: false,
+				},
+			},
+		},
+		{
+			name: "root-level repos + profile repos combined, profiles take precedence",
+			s: settings{
+				Repositories: []pomRepository{
+					{
+						ID:               "dup",
+						URL:              "https://example.com/root-dup",
+						ReleasesEnabled:  "true",
+						SnapshotsEnabled: "false",
+					},
+					{
+						ID:               "root-only",
+						URL:              "https://example.com/root-only",
+						ReleasesEnabled:  "true",
+						SnapshotsEnabled: "false",
+					},
+				},
+				Profiles: []Profile{
+					{
+						ID:              "p1",
+						ActiveByDefault: true,
+						Repositories: []pomRepository{
+							{
+								ID:               "dup",
+								URL:              "https://example.com/profile-dup",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "true",
+							},
+						},
+					},
+				},
+			},
+			// Profile repo "dup" wins over root-level "dup".
+			// After reverse: [root-only, dup(from profile)]
+			want: []repository{
+				{
+					url:             mustParseURL(t, "https://example.com/root-only"),
+					releaseEnabled:  true,
+					snapshotEnabled: false,
+				},
+				{
+					url:             mustParseURL(t, "https://example.com/profile-dup"),
+					releaseEnabled:  true,
+					snapshotEnabled: true,
 				},
 			},
 		},

--- a/pkg/dependency/parser/java/pom/settings_test.go
+++ b/pkg/dependency/parser/java/pom/settings_test.go
@@ -296,6 +296,46 @@ func Test_ReadSettings(t *testing.T) {
 			},
 		},
 		{
+			name:    "project settings with root-level repositories (Maven 4)",
+			rootDir: filepath.Join("testdata", "settings", "project-with-repos"),
+			envs: map[string]string{
+				"HOME":       "",
+				"MAVEN_HOME": "NOT_EXISTING_PATH",
+			},
+			wantSettings: settings{
+				Servers: []Server{
+					{
+						ID:       "root-repo",
+						Username: "root-user",
+						Password: "root-pass",
+					},
+				},
+				Profiles: []Profile{
+					{
+						ID: "profile-with-repo",
+						Repositories: []pomRepository{
+							{
+								ID:               "profile-repo",
+								URL:              "https://mycompany.example.com/repository/profile-releases",
+								ReleasesEnabled:  "true",
+								SnapshotsEnabled: "false",
+							},
+						},
+					},
+				},
+				ActiveProfiles: []string{"profile-with-repo"},
+				Proxies:        []Proxy{},
+				Repositories: []pomRepository{
+					{
+						ID:               "root-repo",
+						URL:              "https://mycompany.example.com/repository/root-releases",
+						ReleasesEnabled:  "true",
+						SnapshotsEnabled: "false",
+					},
+				},
+			},
+		},
+		{
 			name:    "global < project < user merge precedence",
 			rootDir: filepath.Join("testdata", "settings", "project"),
 			envs: map[string]string{
@@ -733,6 +773,36 @@ func mustParseURL(t *testing.T, s string) url.URL {
 	u, err := url.Parse(s)
 	require.NoError(t, err)
 	return *u
+}
+
+func Test_findMvnProjectRoot(t *testing.T) {
+	tests := []struct {
+		name     string
+		startDir string
+		want     string
+	}{
+		{
+			name:     "finds .mvn/settings.xml in same directory",
+			startDir: filepath.Join("testdata", "settings", "project"),
+			want:     filepath.Join("testdata", "settings", "project"),
+		},
+		{
+			name:     "walks up to find .mvn/settings.xml from subdirectory",
+			startDir: filepath.Join("testdata", "settings", "project", "submodule"),
+			want:     filepath.Join("testdata", "settings", "project"),
+		},
+		{
+			name:     "returns empty when .mvn/settings.xml not found",
+			startDir: filepath.Join("testdata", "settings", "user"),
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findMvnProjectRoot(tt.startDir)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func Test_effectiveProxies(t *testing.T) {

--- a/pkg/dependency/parser/java/pom/testdata/settings/project-with-repos/.mvn/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/project-with-repos/.mvn/settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/2.0.0 https://maven.apache.org/xsd/settings-2.0.0.xsd">
+    <servers>
+        <server>
+            <id>root-repo</id>
+            <username>root-user</username>
+            <password>root-pass</password>
+        </server>
+    </servers>
+    <repositories>
+        <repository>
+            <id>root-repo</id>
+            <url>https://mycompany.example.com/repository/root-releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <profiles>
+        <profile>
+            <id>profile-with-repo</id>
+            <repositories>
+                <repository>
+                    <id>profile-repo</id>
+                    <url>https://mycompany.example.com/repository/profile-releases</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>profile-with-repo</activeProfile>
+    </activeProfiles>
+</settings>

--- a/pkg/dependency/parser/java/pom/testdata/settings/project/.mvn/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/project/.mvn/settings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/2.0.0 https://maven.apache.org/xsd/settings-2.0.0.xsd">
+    <localRepository>testdata/project/repository</localRepository>
+
+    <servers>
+        <server>
+            <id>project-server</id>
+        </server>
+        <server>
+            <id>server-with-credentials</id>
+            <username>test-user</username>
+            <password>test-password-from-project</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>mycompany-project</id>
+            <repositories>
+                <repository>
+                    <id>mycompany-project-releases</id>
+                    <url>https://mycompany.example.com/repository/project-releases</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
## Description

Add support for Maven 4 project-specific `settings.xml` (`.mvn/settings.xml`) with 3-tier merge precedence: global < project < user.

Maven 4 introduces two new capabilities reflected here:
1. **Project-level settings** via `.mvn/settings.xml` in the project root (walked up from pom.xml location)
2. **Root-level `<repositories>`** directly under `<settings>`, not only inside `<profiles>`

### Changes

- **settings.go**: Added `Repositories` field to the `settings` struct for Maven 4 root-level repositories. Refactored `readSettings()` to accept a `rootDir` parameter and implement 3-tier merge (global → project → user). Extracted `mergeSettings()` helper. Updated `effectiveRepositories()` to include root-level repos. Added `findMvnProjectRoot()` to walk up directories looking for `.mvn/settings.xml`.
- **parse.go**: Pass project directory to `readSettings()`.
- **settings_test.go**: Added tests for project settings loading, 3-tier merge precedence, root-level repositories, and combined repo sources.

## Related issues
- Close #9908

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).