### PR TITLE
fix: extract 3 secret references from run blocks to env vars

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -81,7 +81,9 @@ jobs:
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
         continue-on-error: true
         run: |
-          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }} -p .cr-release-packages
+          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${ORG_REPO_TOKEN} -p .cr-release-packages
+        env:
+          ORG_REPO_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
       - name: Index helm chart
         run: |
           ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -34,9 +34,10 @@ jobs:
       - name: Release Please
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
+          ORG_REPO_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}
         run: |
           release-please release-pr --repo-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-            --token="${{ secrets.ORG_REPO_TOKEN }}" \
+            --token="${ORG_REPO_TOKEN}" \
             --release-as="$RELEASE_VERSION" \
             --target-branch="$GITHUB_REF_NAME"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,9 @@ jobs:
         run: ci/deploy-rpm.sh
 
       - name: Import GPG key
-        run: echo -e "${{ secrets.GPG_KEY }}" | gpg --import
+        run: echo -e "${GPG_KEY}" | gpg --import
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
 
       - name: Create deb repository
         run: ci/deploy-deb.sh


### PR DESCRIPTION
## Fix: CI/CD Hardening for GitHub Actions Workflows

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified a few workflow hardening opportunities in this repository.

This PR applies automated fixes and is intended to be helpful — if it's not
welcome, just close it.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-008 | high | `.github/workflows/publish-chart.yaml` | Extracted `ORG_REPO_TOKEN` from run block to env var |
| RGS-008 | high | `.github/workflows/release-please.yaml` | Extracted `ORG_REPO_TOKEN` from run block to env var |
| RGS-008 | high | `.github/workflows/release.yaml` | Extracted `GPG_KEY` from run block to env var |

### What changed

Each fix moves a `${{ secrets.* }}` reference from a `run:` block into an `env:`
mapping. This prevents the secret value from being interpolated directly into
the shell command string, reducing exposure surface. Workflow behavior is
unchanged.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior.

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install
from the [repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)