### PR TITLE
feat(ci): Install trivy with expected checksum

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -8,10 +8,11 @@ usage() {
   cat <<EOF
 $this: download go binaries for aquasecurity/trivy
 
-Usage: $this [-b] bindir [-c] client [-d] [tag]
+Usage: $this [-b] bindir [-c] client [-d] [-s] checksum [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -c sets client identifier for download tracking (letters, digits, and '-' characters are allowed), Defaults to install-script
   -d turns on debug logging
+  -s sets expected sha256 checksum of the tarball, skips downloading checksum from GitHub
   -x turns on verbose logging
    [tag] is a tag from
    https://github.com/aquasecurity/trivy/releases
@@ -30,7 +31,8 @@ parse_args() {
 
   BINDIR=${BINDIR:-./bin}
   CLIENT=${CLIENT:-install-script}
-  while getopts "b:c:dh?x" arg; do
+  EXPECTED_CHECKSUM=${EXPECTED_CHECKSUM:-}
+  while getopts "b:c:dh?s:x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       c)
@@ -43,6 +45,14 @@ parse_args() {
         ;;
       d) log_set_priority 10 ;;
       h | \?) usage "$0" ;;
+      s)
+        if printf '%s' "$OPTARG" | grep -Eq '^[A-Fa-f0-9]{64}$'; then
+          EXPECTED_CHECKSUM="$OPTARG"
+        else
+          log_crit "invalid checksum '${OPTARG}'; expected 64 character hex string (sha256)"
+          exit 1
+        fi
+        ;;
       x) set -x ;;
     esac
   done
@@ -57,8 +67,18 @@ execute() {
   tmpdir=$(mktemp -d)
   log_debug "downloading files into ${tmpdir}"
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
-  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
-  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  if [ -n "${EXPECTED_CHECKSUM}" ]; then
+    log_info "verifying tarball checksum against user-provided checksum"
+    got=$(hash_sha256 "${tmpdir}/${TARBALL}")
+    if [ "${EXPECTED_CHECKSUM}" != "${got}" ]; then
+      log_err "checksum for '${TARBALL}' did not verify ${EXPECTED_CHECKSUM} vs ${got}"
+      rm -rf "${tmpdir}"
+      exit 1
+    fi
+  else
+    http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+    hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  fi
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
   test ! -d "${BINDIR}" && install -d "${BINDIR}"


### PR DESCRIPTION
## Description

This adds a way to pass a SHA256 checksum directly to `contrib/install.sh`.

Right now the script always downloads the checksum file from the GitHub release and verifies the archive against that. I wanted to make it possible to verify against a user provided checksum, so this pr adds `-s` and `EXPECTED_CHECKSUM` for that case.

If one of those is set, the script skips downloading the checksum file from github release assets and compares the downloaded file's hash against the expected checksum.

## Related issues
- Discussion: https://github.com/aquasecurity/trivy/discussions/10453

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Verification script

I checked this manually on macos arm64 with trivy v0.69.3.

```bash
VERSION=v0.69.3
CORRECT_SHA=a2f2179afd4f8bb265ca3c7aefb56a666bc4a9a411663bc0f22c3549fbc643a5
WRONG_SHA=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef

rm -rf /tmp/trivy-test1 /tmp/trivy-test2 /tmp/trivy-test3 /tmp/trivy-test4
trap 'rm -rf /tmp/trivy-test1 /tmp/trivy-test2 /tmp/trivy-test3 /tmp/trivy-test4' EXIT

./contrib/install.sh -b /tmp/trivy-test1 "$VERSION"
./contrib/install.sh -b /tmp/trivy-test2 -s "$CORRECT_SHA" "$VERSION"
EXPECTED_CHECKSUM="$CORRECT_SHA" ./contrib/install.sh -b /tmp/trivy-test4 "$VERSION"

if ./contrib/install.sh -b /tmp/trivy-test3 -s "$WRONG_SHA" "$VERSION"; then
  echo "wrong checksum test unexpectedly succeeded"
  exit 1
fi

if ./contrib/install.sh -s tooshort "$VERSION"; then
  echo "invalid checksum format test unexpectedly succeeded"
  exit 1
fi
```
