### PR TITLE
feat(redhat): Add Red Hat Hummingbird support

### DIFF
--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/driver"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/echo"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/hummingbird"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/minimos"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/oracle"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/photon"
@@ -64,6 +65,7 @@ var (
 		ftypes.Wolfi:              wolfi.NewScanner(),
 		ftypes.Chainguard:         chainguard.NewScanner(),
 		ftypes.Echo:               echo.NewScanner(),
+		ftypes.Hummingbird:        hummingbird.NewScanner(),
 		ftypes.MinimOS:            minimos.NewScanner(),
 		ftypes.CoreOS:             coreos.NewScanner(),
 	}

--- a/pkg/detector/ospkg/hummingbird/hummingbird.go
+++ b/pkg/detector/ospkg/hummingbird/hummingbird.go
@@ -1,0 +1,126 @@
+package hummingbird
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+
+	version "github.com/knqyf263/go-rpm-version"
+	"golang.org/x/xerrors"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	redhat "github.com/aquasecurity/trivy-db/pkg/vulnsrc/redhat-oval"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+var defaultContentSets = []string{
+	"public-hummingbird-x86_64-rpms",
+	"public-hummingbird-aarch64-rpms",
+	"public-hummingbird-source-rpms",
+}
+
+type Scanner struct {
+	vs redhat.VulnSrc
+}
+
+func NewScanner() *Scanner {
+	return &Scanner{
+		vs: redhat.NewVulnSrc(),
+	}
+}
+
+func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	log.InfoContext(ctx, "Detecting Hummingbird vulnerabilities...",
+		log.String("os_version", osVer), log.Int("pkg_num", len(pkgs)))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		detectedVulns, err := s.detect(pkg)
+		if err != nil {
+			return nil, xerrors.Errorf("hummingbird vulnerability detection error: %w", err)
+		}
+		vulns = append(vulns, detectedVulns...)
+	}
+	return vulns, nil
+}
+
+func (s *Scanner) detect(pkg ftypes.Package) ([]types.DetectedVulnerability, error) {
+	var contentSets []string
+	var nvr string
+	if pkg.BuildInfo == nil {
+		contentSets = defaultContentSets
+	} else {
+		contentSets = pkg.BuildInfo.ContentSets
+		nvr = fmt.Sprintf("%s-%s", pkg.BuildInfo.Nvr, pkg.BuildInfo.Arch)
+	}
+
+	advisories, err := s.vs.Get(pkg.Name, contentSets, []string{nvr})
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get Hummingbird advisories: %w", err)
+	}
+
+	// Fall back to source RPM name if no advisories found by binary name.
+	// The VEX feed may reference source RPM names instead of binary RPM names.
+	if len(advisories) == 0 && pkg.SrcName != "" && pkg.SrcName != pkg.Name {
+		advisories, err = s.vs.Get(pkg.SrcName, contentSets, []string{nvr})
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get Hummingbird advisories by source name: %w", err)
+		}
+	}
+
+	uniqAdvisories := make(map[string]dbTypes.Advisory)
+	for _, adv := range advisories {
+		if len(adv.Arches) != 0 && pkg.Arch != "noarch" {
+			if !slices.Contains(adv.Arches, pkg.Arch) {
+				continue
+			}
+		}
+
+		if a, ok := uniqAdvisories[adv.VulnerabilityID]; ok {
+			if version.NewVersion(a.FixedVersion).LessThan(version.NewVersion(adv.FixedVersion)) {
+				uniqAdvisories[adv.VulnerabilityID] = adv
+			}
+		} else {
+			uniqAdvisories[adv.VulnerabilityID] = adv
+		}
+	}
+
+	var vulns []types.DetectedVulnerability
+	for _, adv := range uniqAdvisories {
+		vuln := types.DetectedVulnerability{
+			VulnerabilityID:  adv.VulnerabilityID,
+			VendorIDs:        adv.VendorIDs,
+			PkgID:            pkg.ID,
+			PkgName:          pkg.Name,
+			InstalledVersion: utils.FormatVersion(pkg),
+			FixedVersion:     version.NewVersion(adv.FixedVersion).String(),
+			PkgIdentifier:    pkg.Identifier,
+			Status:           adv.Status,
+			Layer:            pkg.Layer,
+			SeveritySource:   vulnerability.RedHat,
+			Vulnerability: dbTypes.Vulnerability{
+				Severity: adv.Severity.String(),
+			},
+			Custom: adv.Custom,
+		}
+
+		if adv.FixedVersion == "" || version.NewVersion(vuln.InstalledVersion).LessThan(version.NewVersion(adv.FixedVersion)) {
+			vulns = append(vulns, vuln)
+		}
+	}
+
+	sort.Slice(vulns, func(i, j int) bool {
+		return vulns[i].VulnerabilityID < vulns[j].VulnerabilityID
+	})
+	return vulns, nil
+}
+
+// Hummingbird uses date-based versioning and has no EOL dates.
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
+	return true
+}

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -110,6 +110,8 @@ func idToOSFamily(id string) types.OSType {
 		return types.CBLMariner
 	case "echo":
 		return types.Echo
+	case "hummingbird":
+		return types.Hummingbird
 	case "minimos":
 		return types.MinimOS
 	case "coreos":

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -53,6 +53,7 @@ var osVendors = []string{
 	"Amazon.com",            // Amazon Linux 2
 	"CentOS",                // CentOS
 	"Fedora Project",        // Fedora
+	"Hummingbird",           // Hummingbird OS
 	"Oracle America",        // Oracle Linux
 	"Red Hat",               // Red Hat
 	"AlmaLinux",             // AlmaLinux
@@ -257,7 +258,14 @@ func packageProvidedByVendor(pkg *rpmdb.PackageInfo) bool {
 	if pkg.Vendor == "" {
 		// Official Amazon packages may not contain `Vendor` field:
 		// https://github.com/aquasecurity/trivy/issues/5887
-		return strings.Contains(pkg.Release, "amzn")
+		if strings.Contains(pkg.Release, "amzn") {
+			return true
+		}
+		// Hummingbird packages may not contain the `Vendor` field
+		if strings.Contains(pkg.Release, ".hum") {
+			return true
+		}
+		return false
 	}
 
 	for _, vendor := range osVendors {

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -35,6 +35,7 @@ const (
 	Debian             OSType = "debian"
 	Echo               OSType = "echo"
 	Fedora             OSType = "fedora"
+	Hummingbird        OSType = "hummingbird"
 	MinimOS            OSType = "minimos"
 	OpenSUSE           OSType = "opensuse"
 	OpenSUSELeap       OSType = "opensuse-leap"
@@ -152,6 +153,7 @@ var (
 		Debian,
 		Echo,
 		Fedora,
+		Hummingbird,
 		MinimOS,
 		OpenSUSE,
 		OpenSUSELeap,

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -485,7 +485,7 @@ func purlType(t ftypes.TargetType) string {
 	case ftypes.Debian, ftypes.Ubuntu, ftypes.Echo:
 		return packageurl.TypeDebian
 	case ftypes.RedHat, ftypes.CentOS, ftypes.Rocky, ftypes.Alma,
-		ftypes.Amazon, ftypes.Fedora, ftypes.Oracle, ftypes.OpenSUSE,
+		ftypes.Amazon, ftypes.Fedora, ftypes.Hummingbird, ftypes.Oracle, ftypes.OpenSUSE,
 		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.SLEMicro, ftypes.Photon,
 		ftypes.Azure, ftypes.CBLMariner, ftypes.CoreOS:
 		return packageurl.TypeRPM


### PR DESCRIPTION
OS detection is handled through the existing os-release analyzer by adding "hummingbird" to the ID-to-OS-family mapping. No dedicated analyzer type is needed since Hummingbird uses a standard /etc/os-release file, following the same pattern as other projects.

The vulnerability driver reuses the Red Hat advisory database query mechanism since Hummingbird advisories share the same CSAF VEX database structure. It differs from the RHEL driver in three ways: it uses Hummingbird-specific default content sets (ie, public-hummingbird-*-rpms), it passes the full date-based version rather than extracting a major version number, and it has no end-of-life date restrictions.

Add support for Red Hat Hummingbird images.

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
