### PR TITLE
feat(sarif): add invocation timestamps to SARIF output

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -3,6 +3,7 @@ package report
 import (
 	"context"
 	"fmt"
+	"time"
 	"io"
 	"net/url"
 	"path/filepath"
@@ -126,6 +127,7 @@ func pathToFileURI(path string) string {
 }
 
 func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
+	startTime := time.Now().UTC()
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return xerrors.Errorf("error creating a new sarif template: %w", err)
@@ -268,6 +270,17 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			},
 		}
 	}
+
+	endTime := time.Now().UTC()
+	success := true
+	sw.run.Invocations = []*sarif.Invocation{
+		{
+			ExecutionSuccessful: &success,
+			StartTimeUTC:        &startTime,
+			EndTimeUTC:          &endTime,
+		},
+	}
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -178,6 +178,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 						PropertyBag: sarif.PropertyBag{
 							Properties: map[string]any{
 								"imageName":   "debian:9",
@@ -331,6 +336,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
 							"ROOTPATH": {
 								URI: lo.ToPtr(tmpScanURI),
@@ -426,6 +436,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
 							"ROOTPATH": {
 								URI: lo.ToPtr(tmpScanURI),
@@ -516,6 +531,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
 							"ROOTPATH": {
 								URI: lo.ToPtr(tmpScanURI),
@@ -544,6 +564,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 						},
 						Results:    []*sarif.Result{},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 						OriginalUriBaseIDs: map[string]*sarif.ArtifactLocation{
 							"ROOTPATH": {
 								URI: lo.ToPtr(tmpScanURI),
@@ -728,6 +753,11 @@ func TestReportWriter_Sarif(t *testing.T) {
 							},
 						},
 						ColumnKind: "utf16CodeUnits",
+						Invocations: []*sarif.Invocation{
+						    {
+						        ExecutionSuccessful: lo.ToPtr(true),
+						    },
+						},
 					},
 				},
 			},
@@ -747,6 +777,19 @@ func TestReportWriter_Sarif(t *testing.T) {
 			result := &sarif.Report{}
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
 			require.NoError(t, err)
+			for i := range result.Runs {
+			    if len(result.Runs[i].Invocations) > 0 {
+			        result.Runs[i].Invocations[0].StartTimeUTC = nil
+			        result.Runs[i].Invocations[0].EndTimeUTC = nil
+			    }
+			}
+			
+			for i := range tt.want.Runs {
+			    if len(tt.want.Runs[i].Invocations) > 0 {
+			        tt.want.Runs[i].Invocations[0].StartTimeUTC = nil
+			        tt.want.Runs[i].Invocations[0].EndTimeUTC = nil
+			    }
+			}
 			assert.Equal(t, tt.want, result)
 		})
 	}


### PR DESCRIPTION
## Summary

This PR adds SARIF invocation metadata to Trivy reports by populating the `invocations` field with:

* `startTimeUtc`
* `endTimeUtc`
* `executionSuccessful`

---

## Motivation

Currently, SARIF output generated by Trivy does not include the `invocations` field, which makes it difficult to determine when a scan was executed or whether it completed successfully.

Adding this metadata aligns Trivy’s SARIF output with the SARIF specification and enables downstream tools to:

* Track scan execution time
* Verify report freshness
* Improve auditability of security scans

---

## Changes

* Updated `pkg/report/sarif.go` to include invocation metadata:

  * Capture start and end timestamps
  * Set `executionSuccessful` to `true`
* Updated SARIF tests in `pkg/report/sarif_test.go`:

  * Added `Invocations` to expected output
  * Normalized dynamic timestamp fields in test comparisons

---

## Example

Before:

```json
"invocations": null
```

After:

```json
"invocations": [
  {
    "executionSuccessful": true,
    "startTimeUtc": "...",
    "endTimeUtc": "..."
  }
]
```

---

## Notes

* `executionSuccessful` is currently always `true`, as SARIF output is only generated for successful scans.
* Handling failure scenarios (e.g., emitting SARIF on scan errors) could be explored separately.

---

## Validation

* Reproduced issue using:

  ```
  trivy image -f sarif -o before.sarif python:3.9-slim
  ```
* Verified fix:

  ```
  trivy image -f sarif -o after.sarif python:3.9-slim
  ```
* Confirmed `.runs[0].invocations` is populated
* All existing tests pass locally (`go test ./...`)

---

## Related Issue

Closes #3226