### PR TITLE
feat(report): include local DB version info in JSON output

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -549,3 +549,15 @@ func overrideServerInfo(t *testing.T, want, got *types.Report) {
 	got.Trivy.Server = types.VersionInfo{}
 	want.Trivy.Server = types.VersionInfo{}
 }
+
+// overrideDBMetadata clears database metadata fields from TrivyInfo.
+// Database metadata (VulnerabilityDB, JavaDB, CheckBundle) varies based on the
+// local cache state and test environment, so we clear these fields for comparison.
+func overrideDBMetadata(_ *testing.T, want, got *types.Report) {
+	got.Trivy.VulnerabilityDB = nil
+	got.Trivy.JavaDB = nil
+	got.Trivy.CheckBundle = nil
+	want.Trivy.VulnerabilityDB = nil
+	want.Trivy.JavaDB = nil
+	want.Trivy.CheckBundle = nil
+}

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -516,6 +516,8 @@ func (o *Options) ScanOpts() types.ScanOptions {
 		IncludeDevDeps:      o.IncludeDevDeps,
 		Distro:              o.Distro,
 		VulnSeveritySources: o.VulnSeveritySources,
+		CacheDir:            o.CacheDir,
+		IsRemote:            o.ServerAddr != "",
 	}
 }
 

--- a/pkg/scan/export_test.go
+++ b/pkg/scan/export_test.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // Bridge to expose scan internals to tests in the scan_test package.
@@ -9,4 +10,9 @@ import (
 // GenerateArtifactID exports generateArtifactID for testing.
 func (s Service) GenerateArtifactID(artifactInfo artifact.Reference) string {
 	return s.generateArtifactID(artifactInfo)
+}
+
+// BuildTrivyInfo exports buildTrivyInfo for testing.
+func BuildTrivyInfo(options types.ScanOptions, serverInfo types.VersionInfo) types.TrivyInfo {
+	return buildTrivyInfo(options, serverInfo)
 }

--- a/pkg/scan/service.go
+++ b/pkg/scan/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/uuid"
-	"github.com/aquasecurity/trivy/pkg/version/app"
+	"github.com/aquasecurity/trivy/pkg/version"
 )
 
 // Service is the main service that coordinates security scanning operations.
@@ -86,15 +86,12 @@ func (s Service) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 
 	r := types.Report{
 		SchemaVersion: report.SchemaVersion,
-		Trivy: types.TrivyInfo{
-			Version: app.Version(),
-			Server:  scanResponse.ServerInfo,
-		},
-		ReportID:     reportID.String(),
-		CreatedAt:    clock.Now(ctx),
-		ArtifactID:   s.generateArtifactID(artifactInfo),
-		ArtifactName: artifactInfo.Name,
-		ArtifactType: artifactInfo.Type,
+		Trivy:         buildTrivyInfo(options, scanResponse.ServerInfo),
+		ReportID:      reportID.String(),
+		CreatedAt:     clock.Now(ctx),
+		ArtifactID:    s.generateArtifactID(artifactInfo),
+		ArtifactName:  artifactInfo.Name,
+		ArtifactType:  artifactInfo.Type,
 		Metadata: types.Metadata{
 			OS: ptros,
 
@@ -182,5 +179,21 @@ func (s Service) generateArtifactID(artifactInfo artifact.Reference) string {
 	default:
 		// Empty string for other types
 		return ""
+	}
+}
+
+// buildTrivyInfo constructs TrivyInfo with local DB metadata and server info.
+// In standalone mode, all local DB metadata is included.
+// In client/server mode, VulnerabilityDB is excluded from the client-side output
+// (it is server-managed and available via Server.VulnerabilityDB), while
+// JavaDB and CheckBundle are included as they are managed on the client side.
+func buildTrivyInfo(options types.ScanOptions, serverInfo types.VersionInfo) types.TrivyInfo {
+	opts := []version.VersionOption{}
+	if options.IsRemote {
+		opts = append(opts, version.Client())
+	}
+	return types.TrivyInfo{
+		VersionInfo: version.NewVersionInfo(options.CacheDir, opts...),
+		Server:      serverInfo,
 	}
 }

--- a/pkg/scan/service_test.go
+++ b/pkg/scan/service_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy-db/pkg/db"
+	"github.com/aquasecurity/trivy-db/pkg/metadata"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/internal/dbtest"
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/clock"
+	trivydb "github.com/aquasecurity/trivy/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
 	image2 "github.com/aquasecurity/trivy/pkg/fanal/artifact/image"
@@ -463,4 +465,63 @@ func TestService_generateArtifactID(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestBuildTrivyInfo(t *testing.T) {
+	t.Run("standalone mode with empty cache dir", func(t *testing.T) {
+		info := scan.BuildTrivyInfo(tTypes.ScanOptions{
+			CacheDir: "",
+			IsRemote: false,
+		}, tTypes.VersionInfo{})
+		assert.NotEmpty(t, info.Version)
+	})
+
+	t.Run("client/server mode excludes VulnerabilityDB and populates Server field", func(t *testing.T) {
+		serverInfo := tTypes.VersionInfo{
+			Version: "0.50.0",
+		}
+		info := scan.BuildTrivyInfo(tTypes.ScanOptions{
+			CacheDir: "/non/existent/path",
+			IsRemote: true,
+		}, serverInfo)
+		assert.NotEmpty(t, info.Version)
+		assert.Nil(t, info.VulnerabilityDB)
+		assert.Equal(t, serverInfo, info.Server)
+	})
+
+	t.Run("standalone mode with non-existent cache dir", func(t *testing.T) {
+		info := scan.BuildTrivyInfo(tTypes.ScanOptions{
+			CacheDir: "/non/existent/path",
+			IsRemote: false,
+		}, tTypes.VersionInfo{})
+		assert.NotEmpty(t, info.Version)
+		assert.Nil(t, info.VulnerabilityDB)
+		assert.Nil(t, info.JavaDB)
+		assert.Nil(t, info.CheckBundle)
+	})
+
+	t.Run("standalone mode with valid vulnerability DB metadata", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		dbDir := trivydb.Dir(cacheDir)
+		testMeta := metadata.Metadata{
+			Version:      2,
+			NextUpdate:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			DownloadedAt: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		}
+		metaClient := metadata.NewClient(dbDir)
+		require.NoError(t, metaClient.Update(testMeta))
+
+		info := scan.BuildTrivyInfo(tTypes.ScanOptions{
+			CacheDir: cacheDir,
+			IsRemote: false,
+		}, tTypes.VersionInfo{})
+
+		assert.NotEmpty(t, info.Version)
+		require.NotNil(t, info.VulnerabilityDB)
+		assert.Equal(t, 2, info.VulnerabilityDB.Version)
+		assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), info.VulnerabilityDB.UpdatedAt)
+		assert.Equal(t, time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), info.VulnerabilityDB.NextUpdate)
+		assert.Equal(t, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), info.VulnerabilityDB.DownloadedAt)
+	})
 }

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -10,10 +10,10 @@ import (
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
 
-// TrivyInfo contains Trivy-specific information
+// TrivyInfo contains Trivy version and database metadata.
 type TrivyInfo struct {
-	Version string      `json:",omitempty"` // Client version
-	Server  VersionInfo `json:",omitzero"`  // Server info (client/server mode only)
+	VersionInfo              // Client version + local DB metadata (VulnerabilityDB, JavaDB, CheckBundle)
+	Server      VersionInfo `json:",omitzero"` // Server info (client/server mode only)
 }
 
 // Report represents a scan result

--- a/pkg/types/scan.go
+++ b/pkg/types/scan.go
@@ -120,6 +120,9 @@ type ScanOptions struct {
 	IncludeDevDeps      bool
 	Distro              types.OS // Forced OS
 	VulnSeveritySources []dbTypes.SourceID
+
+	CacheDir string // directory for cached databases
+	IsRemote bool   // true when running in client/server mode
 }
 
 // ScanResponse represents the response from the scan service

--- a/pkg/types/version.go
+++ b/pkg/types/version.go
@@ -11,8 +11,8 @@ import (
 // This is a lightweight alternative to policy.Metadata to avoid importing
 // pkg/policy which has dependencies incompatible with wasip1/wasm.
 type BundleMetadata struct {
-	Digest       string
-	DownloadedAt time.Time
+	Digest       string    `json:",omitempty"`
+	DownloadedAt time.Time `json:",omitempty"`
 }
 
 func (m BundleMetadata) String() string {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,6 +18,7 @@ type VersionOption func(*versionOptions)
 
 type versionOptions struct {
 	forServer bool
+	forClient bool
 }
 
 // Server returns a VersionOption that excludes JavaDB and CheckBundle
@@ -25,6 +26,14 @@ type versionOptions struct {
 func Server() VersionOption {
 	return func(o *versionOptions) {
 		o.forServer = true
+	}
+}
+
+// Client returns a VersionOption that excludes VulnerabilityDB
+// from version info, as it is managed on the server side in client/server mode.
+func Client() VersionOption {
+	return func(o *versionOptions) {
+		o.forClient = true
 	}
 }
 
@@ -38,17 +47,20 @@ func NewVersionInfo(cacheDir string, opts ...VersionOption) types.VersionInfo {
 	var javadbMeta *metadata.Metadata
 	var pbMeta *types.BundleMetadata
 
-	mc := metadata.NewClient(db.Dir(cacheDir))
-	meta, err := mc.Get()
-	if err != nil {
-		log.Debug("Failed to get DB metadata", log.Err(err))
-	}
-	if !meta.UpdatedAt.IsZero() && !meta.NextUpdate.IsZero() && meta.Version != 0 {
-		dbMeta = &metadata.Metadata{
-			Version:      meta.Version,
-			NextUpdate:   meta.NextUpdate.UTC(),
-			UpdatedAt:    meta.UpdatedAt.UTC(),
-			DownloadedAt: meta.DownloadedAt.UTC(),
+	// Skip VulnerabilityDB for client mode as it is managed on the server side
+	if !options.forClient {
+		mc := metadata.NewClient(db.Dir(cacheDir))
+		meta, err := mc.Get()
+		if err != nil {
+			log.Debug("Failed to get DB metadata", log.Err(err))
+		}
+		if !meta.UpdatedAt.IsZero() && !meta.NextUpdate.IsZero() && meta.Version != 0 {
+			dbMeta = &metadata.Metadata{
+				Version:      meta.Version,
+				NextUpdate:   meta.NextUpdate.UTC(),
+				UpdatedAt:    meta.UpdatedAt.UTC(),
+				DownloadedAt: meta.DownloadedAt.UTC(),
+			}
 		}
 	}
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -54,6 +54,24 @@ func TestNewVersionInfo(t *testing.T) {
 				CheckBundle: nil,
 			},
 		},
+		{
+			name: "client mode excludes VulnerabilityDB",
+			opts: []VersionOption{Client()},
+			want: types.VersionInfo{
+				Version:         "dev",
+				VulnerabilityDB: nil,
+				JavaDB: &metadata.Metadata{
+					Version:      1,
+					NextUpdate:   time.Date(2023, 7, 28, 1, 3, 52, 169192565, time.UTC),
+					UpdatedAt:    time.Date(2023, 7, 25, 1, 3, 52, 169192765, time.UTC),
+					DownloadedAt: time.Date(2023, 7, 25, 9, 37, 48, 906152000, time.UTC),
+				},
+				CheckBundle: &types.BundleMetadata{
+					Digest:       "sha256:829832357626da2677955e3b427191212978ba20012b6eaa03229ca28569ae43",
+					DownloadedAt: time.Date(2023, 7, 23, 16, 40, 33, 122462000, time.UTC),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem
JSON scan output does not include local database version information, making it impossible for assessment teams to verify that scans were performed with current vulnerability databases.

## Root cause
`TrivyInfo` in the JSON report only contained the Trivy version string. No mechanism existed to surface local DB metadata (VulnerabilityDB, JavaDB, CheckBundle) in the output.

## Fix
- Embed `VersionInfo` in `TrivyInfo` so all local DB metadata fields are promoted to the top level of the `Trivy` JSON object
- Add a `Client()` option to `version.NewVersionInfo()`, symmetric with the existing `Server()` option:
  - `Server()` — excludes JavaDB and CheckBundle (client-managed)
  - `Client()` — excludes VulnerabilityDB (server-managed)
- In client/server mode, `buildTrivyInfo` uses `Client()` so the local `VersionInfo` shows JavaDB and CheckBundle while VulnerabilityDB comes from `Server.VulnerabilityDB`
- `buildTrivyInfo` now accepts `scanResponse.ServerInfo` so the `Server` field is populated in client/server mode

## Verification
```bash
trivy image alpine:3.18 --format json | jq '.Trivy'
# Standalone output:
# {
#   "Version": "0.x.x",
#   "VulnerabilityDB": { "Version": 2, "UpdatedAt": "...", ... },
#   "JavaDB": { ... },
#   "CheckBundle": { ... }
# }
```

Closes #10076

---
*Note: This replaces #10092, which was closed due to a fork configuration issue. All review feedback from @DmitriyLewen has been incorporated.*