### PR TITLE
test: Add test cases for `SeparateMisconfigReports` with partial scanner configurations

### DIFF
--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -822,8 +822,44 @@ func Test_separateMisconfigReports(t *testing.T) {
 			},
 		},
 
-		// TODO: add vuln only
-		// TODO: add secret only
+		{
+			name: "Vulnerability Report Only",
+			k8sReport: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+				},
+			},
+			scanners: types.Scanners{types.VulnerabilityScanner},
+			expectedReports: []Report{
+				{
+					Resources: []Resource{
+						{Kind: "Deploy"},
+					},
+				},
+				{
+					Resources: []Resource{},
+				},
+			},
+		},
+		{
+			name: "Secret Report Only",
+			k8sReport: Report{
+				Resources: []Resource{
+					deployLuaWithSecrets,
+				},
+			},
+			scanners: types.Scanners{types.SecretScanner},
+			expectedReports: []Report{
+				{
+					Resources: []Resource{
+						{Kind: "Deploy"},
+					},
+				},
+				{
+					Resources: []Resource{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:**

Add test cases to `SeparateMisconfigReports` in `pkg/k8s/report/report_test.go` to verify report separation logic when only vulnerability scanning or only secret scanning is enabled. These tests address existing TODOs and ensure the function correctly produces the expected number of assessment reports (Workload and Infra) under partial scanner configurations.

**Changes:**

- Added test case for vulnerability-only scanner configuration.
- Added test case for secret-only scanner configuration.
- Verified that the correct number of Workload and Infra reports are generated in each scenario.


## Checklist

- [x]  I've read the [[guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/)](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x]  I've followed the [[conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title)](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x]  I've added tests that prove my fix is effective or that my feature works.
- [ ]  I've updated the [[documentation](https://github.com/aquasecurity/trivy/blob/main/docs)](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ]  I've added usage information (if the PR introduces new options)
- [ ]  I've included a "before" and "after" example to the description (if the PR is a user interface change).