### PR TITLE
ci: trigger helm chart publishing via helm-charts workflow

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -69,5 +69,6 @@ jobs:
           gh workflow run publish-chart.yaml \
             --repo "$GITHUB_REPOSITORY_OWNER/helm-charts" \
             --ref main \
+            --field "repository=$GITHUB_REPOSITORY" \
             --field "ref=$REF" \
             --field "chart_dir=helm/trivy"


### PR DESCRIPTION
## Description

Update `publish-chart` workflow to trigger helm-charts publication instead of publishing directly.

Test run: https://github.com/nikpivkin/trivy/actions/runs/23945238903/job/69840270638

### TODO
- [x] Replace ORG_REPO_TOKEN with a new one 
- [x] Use a self-hosted runner

Zizmor did not detect any issues:
```bash
❯ zizmor .github/workflows/publish-chart.yaml
🌈 zizmor v1.22.0
 INFO audit: zizmor: 🌈 completed .github/workflows/publish-chart.yaml
No findings to report. Good job! (4 suppressed)
```

## Related PRs
- [ ] https://github.com/aquasecurity/helm-charts/pull/10 - It must be merged first.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
