### PR TITLE
ci: trigger rpm/deb deployment via trivy-repo workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
   deploy-packages:
     name: Deploy rpm/deb packages
     needs: release # run this job after 'release' job completes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     steps:
       - name: Trigger deploy-packages workflow in trivy-repo
         env:


### PR DESCRIPTION
## Description

Replaces the self-contained `deploy-packages` job with a lightweight trigger that dispatches the `deploy-packages` workflow in `aquasecurity/trivy-repo`.
The deployment logic now lives in trivy-repo — see blocking PR below.

## Related issues

## Related PRs
- [x] aquasecurity/trivy-repo#47 ⚠️ **must be merged first**

## Security (zizmor)

Audited with [zizmor](https://github.com/woodruff/zizmor) v1.22.0 — no new findings.

```
zizmor .github/workflows/release.yaml
No findings to report. (6 suppressed)
```

The 6 suppressed findings are pre-existing in the file and unrelated to this PR.

## Test run
- https://github.com/DmitriyLewen/trivy/actions/runs/23939343876/job/69823079993

## TODO
- [x] Replace ORG_REPO_TOKEN with a new one 
- [x] Use a self-hosted runner

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).