### PR TITLE
feat(purl): generate OCI PURLs for local images without registry digests

### DIFF
--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -299,36 +299,71 @@ func (p *PackageURL) String() string {
 
 // ref. https://github.com/package-url/purl-spec/blob/a748c36ad415c8aeffe2b8a4a5d8a50d16d6d85f/PURL-TYPES.rst#oci
 func parseOCI(metadata types.Metadata) (*packageurl.PackageURL, error) {
-	if len(metadata.RepoDigests) == 0 {
-		return nil, nil
+	if len(metadata.RepoDigests) > 0 {
+		digest, err := cn.NewDigest(metadata.RepoDigests[0])
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse digest: %w", err)
+		}
+
+		name := strings.ToLower(digest.RepositoryStr())
+		index := strings.LastIndex(name, "/")
+		if index != -1 {
+			name = name[index+1:]
+		}
+
+		var qualifiers packageurl.Qualifiers
+		if repoURL := digest.Repository.Name(); repoURL != "" {
+			qualifiers = append(qualifiers, packageurl.Qualifier{
+				Key:   "repository_url",
+				Value: repoURL,
+			})
+		}
+		if arch := metadata.ImageConfig.Architecture; arch != "" {
+			qualifiers = append(qualifiers, packageurl.Qualifier{
+				Key:   "arch",
+				Value: arch,
+			})
+		}
+
+		return packageurl.NewPackageURL(packageurl.TypeOCI, "", name, digest.DigestStr(), qualifiers, ""), nil
 	}
 
-	digest, err := cn.NewDigest(metadata.RepoDigests[0])
-	if err != nil {
-		return nil, xerrors.Errorf("failed to parse digest: %w", err)
+	if len(metadata.RepoTags) > 0 {
+		tag, err := cn.NewTag(metadata.RepoTags[0])
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse tag: %w", err)
+		}
+
+		name := strings.ToLower(tag.RepositoryStr())
+		index := strings.LastIndex(name, "/")
+		if index != -1 {
+			name = name[index+1:]
+		}
+
+		var qualifiers packageurl.Qualifiers
+		if repoURL := tag.Repository.Name(); repoURL != "" {
+			qualifiers = append(qualifiers, packageurl.Qualifier{
+				Key:   "repository_url",
+				Value: repoURL,
+			})
+		}
+		if t := tag.TagStr(); t != "" && t != "latest" {
+			qualifiers = append(qualifiers, packageurl.Qualifier{
+				Key:   "tag",
+				Value: t,
+			})
+		}
+		if arch := metadata.ImageConfig.Architecture; arch != "" {
+			qualifiers = append(qualifiers, packageurl.Qualifier{
+				Key:   "arch",
+				Value: arch,
+			})
+		}
+
+		return packageurl.NewPackageURL(packageurl.TypeOCI, "", name, "", qualifiers, ""), nil
 	}
 
-	name := strings.ToLower(digest.RepositoryStr())
-	index := strings.LastIndex(name, "/")
-	if index != -1 {
-		name = name[index+1:]
-	}
-
-	var qualifiers packageurl.Qualifiers
-	if repoURL := digest.Repository.Name(); repoURL != "" {
-		qualifiers = append(qualifiers, packageurl.Qualifier{
-			Key:   "repository_url",
-			Value: repoURL,
-		})
-	}
-	if arch := metadata.ImageConfig.Architecture; arch != "" {
-		qualifiers = append(qualifiers, packageurl.Qualifier{
-			Key:   "arch",
-			Value: metadata.ImageConfig.Architecture,
-		})
-	}
-
-	return packageurl.NewPackageURL(packageurl.TypeOCI, "", name, digest.DigestStr(), qualifiers, ""), nil
+	return nil, nil
 }
 
 // ref. https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#apk

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -375,7 +375,52 @@ func TestNewPackageURL(t *testing.T) {
 			},
 		},
 		{
-			name: "container local",
+			name: "container local with latest tag",
+			typ:  purl.TypeOCI,
+			metadata: types.Metadata{
+				RepoTags:    []string{"test:latest"},
+				RepoDigests: []string{},
+				ImageConfig: v1.ConfigFile{
+					Architecture: "amd64",
+				},
+				ImageID: "sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+			want: &purl.PackageURL{
+				Type:      packageurl.TypeOCI,
+				Namespace: "",
+				Name:      "test",
+				Version:   "",
+				Qualifiers: packageurl.Qualifiers{
+					{Key: "repository_url", Value: "index.docker.io/library/test"},
+					{Key: "arch", Value: "amd64"},
+				},
+			},
+		},
+		{
+			name: "container local with specific tag",
+			typ:  purl.TypeOCI,
+			metadata: types.Metadata{
+				RepoTags:    []string{"test:v1.0"},
+				RepoDigests: []string{},
+				ImageConfig: v1.ConfigFile{
+					Architecture: "amd64",
+				},
+				ImageID: "sha256:8fe1727132b2506c17ba0e1f6a6ed8a016bb1f5735e43b2738cd3fd1979b6260",
+			},
+			want: &purl.PackageURL{
+				Type:      packageurl.TypeOCI,
+				Namespace: "",
+				Name:      "test",
+				Version:   "",
+				Qualifiers: packageurl.Qualifiers{
+					{Key: "repository_url", Value: "index.docker.io/library/test"},
+					{Key: "tag", Value: "v1.0"},
+					{Key: "arch", Value: "amd64"},
+				},
+			},
+		},
+		{
+			name: "container local no tags no digests",
 			typ:  purl.TypeOCI,
 			metadata: types.Metadata{
 				RepoTags:    []string{},


### PR DESCRIPTION
Closes #9399
Fixes #9381

## Problem

When scanning locally built container images that have no `RepoDigests`
(i.e. not yet pushed to a registry), `parseOCI` returned `nil` immediately,
resulting in a `null` purl in CycloneDX output. This broke VEX matching
and SBOM identification for local development workflows.

## Solution

Extended `parseOCI` in `pkg/purl/purl.go` to fall back to `RepoTags` when
`RepoDigests` is empty. The PURL is constructed using the image name from
the tag as the identity, with `repository_url`, optional `tag` (omitted for
`latest`), and `arch` qualifiers.

This aligns with the PURL spec discussion in #9381 — OCI PURLs can be used
for identity without requiring location (digest).

## Behavior

Local image with `latest` tag:
pkg:oci/test?repository_url=index.docker.io%2Flibrary%2Ftest&arch=amd64

Local image with specific tag:
pkg:oci/test?repository_url=index.docker.io%2Flibrary%2Ftest&tag=v1.0&arch=amd64

Images with no tags and no digests still return nil (unchanged).
VEX OCI attestation retrieval (`--vex oci`) is unaffected — it still
requires a registry digest.

## Changes

- `pkg/purl/purl.go` — fallback path in `parseOCI` using `cn.NewTag`
- `pkg/purl/purl_test.go` — updated and expanded test cases
