### PR TITLE
refactor(deps): replace archived go-homedir with os.UserHomeDir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/masahiro331/go-vmdk-parser v0.0.0-20221225061455-612096e4bbbd
 	github.com/masahiro331/go-xfs-filesystem v0.0.0-20231205045356-1b22259a6c44
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/moby/buildkit v0.27.1
 	github.com/moby/docker-image-spec v1.3.1

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
+	"golang.org/x/xerrors"
 )
 
 // MakeFileFunc constructs a function that takes a file path and returns the
@@ -415,7 +416,7 @@ func expandHome(path string) (string, error) {
 		return path, nil
 	}
 	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
-		return "", errors.New("cannot expand user-specific home dir")
+		return "", xerrors.New("cannot expand user-specific home dir")
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -9,12 +9,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/mitchellh/go-homedir"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -196,7 +196,7 @@ func MakeFileExistsFunc(target fs.FS, baseDir string) function.Function {
 		Type: function.StaticReturnType(cty.Bool),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			path := args[0].AsString()
-			path, err := homedir.Expand(path)
+			path, err := expandHome(path)
 			if err != nil {
 				return cty.UnknownVal(cty.Bool), fmt.Errorf("failed to expand ~: %s", err)
 			}
@@ -350,13 +350,13 @@ var PathExpandFunc = function.New(&function.Spec{
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 
-		homePath, err := homedir.Expand(args[0].AsString())
+		homePath, err := expandHome(args[0].AsString())
 		return cty.StringVal(homePath), err
 	},
 })
 
 func openFile(target fs.FS, baseDir, path string) (fs.File, error) {
-	path, err := homedir.Expand(path)
+	path, err := expandHome(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand ~: %s", err)
 	}
@@ -403,4 +403,19 @@ func readFileBytes(target fs.FS, baseDir, path string) ([]byte, error) {
 func File(target fs.FS, baseDir string, path cty.Value) (cty.Value, error) {
 	fn := MakeFileFunc(target, baseDir, false)
 	return fn.Call([]cty.Value{path})
+}
+
+// expandHome expands a leading ~ in the path to the current user's home directory.
+func expandHome(path string) (string, error) {
+	if path == "~" {
+		return os.UserHomeDir()
+	}
+	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[2:]), nil
+	}
+	return path, nil
 }

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -406,16 +405,21 @@ func File(target fs.FS, baseDir string, path cty.Value) (cty.Value, error) {
 }
 
 // expandHome expands a leading ~ in the path to the current user's home directory.
+// User-specific forms like ~user/foo are not supported and return an error,
+// matching the behavior of the archived github.com/mitchellh/go-homedir Expand.
 func expandHome(path string) (string, error) {
-	if path == "~" {
-		return os.UserHomeDir()
+	if len(path) == 0 {
+		return path, nil
 	}
-	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, path[2:]), nil
+	if path[0] != '~' {
+		return path, nil
 	}
-	return path, nil
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, path[1:]), nil
 }

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -4,13 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExpandHome(t *testing.T) {
 	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("os.UserHomeDir() failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	tests := []struct {
 		name    string
@@ -68,13 +69,12 @@ func TestExpandHome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := expandHome(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("expandHome(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("expandHome(%q) = %q, want %q", tt.input, got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -1,0 +1,75 @@
+package funcs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir() failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "tilde only",
+			input: "~",
+			want:  home,
+		},
+		{
+			name:  "tilde with forward slash path",
+			input: "~/Documents/test.tf",
+			want:  filepath.Join(home, "Documents/test.tf"),
+		},
+		{
+			name:  "tilde with nested path",
+			input: "~/a/b/c",
+			want:  filepath.Join(home, "a/b/c"),
+		},
+		{
+			name:  "absolute path unchanged",
+			input: "/etc/passwd",
+			want:  "/etc/passwd",
+		},
+		{
+			name:  "relative path unchanged",
+			input: "relative/path",
+			want:  "relative/path",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "tilde in middle unchanged",
+			input: "/foo/~/bar",
+			want:  "/foo/~/bar",
+		},
+		{
+			name:  "tilde prefix without slash unchanged",
+			input: "~username",
+			want:  "~username",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandHome(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("expandHome(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("expandHome(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
+++ b/pkg/iac/scanners/terraform/parser/funcs/filesystem_test.go
@@ -54,9 +54,14 @@ func TestExpandHome(t *testing.T) {
 			want:  "/foo/~/bar",
 		},
 		{
-			name:  "tilde prefix without slash unchanged",
-			input: "~username",
-			want:  "~username",
+			name:    "user-specific home dir is not supported",
+			input:   "~username",
+			wantErr: true,
+		},
+		{
+			name:    "user-specific home dir with path is not supported",
+			input:   "~foo/foo",
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Replace `mitchellh/go-homedir` (archived since 2019) with `os.UserHomeDir()` (stdlib, Go 1.12+)
- 3 calls to `homedir.Expand()` in `pkg/iac/scanners/terraform/parser/funcs/filesystem.go` replaced with a local `expandHome()` helper
- Cross-platform: `os.UserHomeDir()` supports Linux, macOS, and Windows

## Why

`mitchellh/go-homedir` has been archived since January 2019. Its author archived it because `os.UserHomeDir()` was added to the Go standard library in Go 1.12, making the package unnecessary.

This was detected by [uzomuzo](https://github.com/future-architect/uzomuzo-oss), an open-source dependency lifecycle scanner that classifies the package as **EOL-Confirmed**.

## Notes

- The package remains as an **indirect** dependency via `google/go-containerregistry` — this PR removes only the direct import
- `expandHome()` handles `~`, `~/path`, and `~\path` (Windows) — matching the behavior of the original `homedir.Expand()`

## Test plan

- [x] `go vet ./pkg/iac/scanners/terraform/parser/funcs/` — clean
- [x] `go test ./pkg/iac/scanners/terraform/parser/...` — all pass
- [x] `go mod tidy` — clean
- [x] `TestExpandHome` — 8 table-driven cases covering tilde expansion, absolute/relative paths, empty string, and edge cases