### PR TITLE
fix(misconf): handle nil ResourceChange in Terraform plan JSON parser

### DIFF
--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
@@ -65,7 +65,11 @@ func buildPlanBlocks(module Module, resourceChanges []ResourceChange, configurat
 		resourceExprs := getConfiguration(r.Address, module.Address, configuration)
 		schema := schemaForBlock(r, resourceExprs)
 		changes := getValues(r.Address, resourceChanges)
-		resource := decodeBlock(schema, changes.After)
+		var after map[string]any
+		if changes != nil {
+			after = changes.After
+		}
+		resource := decodeBlock(schema, after)
 		// fill top-level block fields
 		resource.BlockType = r.BlockType()
 		resource.Type = r.Type

--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
@@ -81,6 +81,13 @@ resource "aws_security_group" "sg" {
 }
 `,
 		},
+		{
+			name: "resource with no matching resource_change",
+			path: "../testdata/plan_missing_changes.json",
+			expected: `resource "null_resource" "example" {
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/terraformplan/tfjson/testdata/plan_missing_changes.json
+++ b/pkg/iac/scanners/terraformplan/tfjson/testdata/plan_missing_changes.json
@@ -1,0 +1,34 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.11.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "null_resource.example",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "example",
+          "provider_name": "registry.opentofu.org/hashicorp/null",
+          "schema_version": 0,
+          "values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "null_resource.example",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "example",
+          "provider_config_key": "null",
+          "expressions": {}
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

`buildPlanBlocks` in `pkg/iac/scanners/terraformplan/tfjson/parser/parser.go` panics with a nil pointer dereference when a resource exists in `planned_values` but has no matching entry in `resource_changes`. `getValues()` returns nil, and `changes.After` dereferences it.

## Changes

- Added nil check on the return value of `getValues()` before accessing `.After`
- `decodeBlock` already handles a nil map correctly (range over nil is a no-op in Go), so the resource gets an empty block with schema references populated
- Added test case with a plan JSON where `resource_changes` is empty but `planned_values` contains a resource

## Test results

```
=== RUN   TestParser_Parse
=== RUN   TestParser_Parse/simple_case
=== RUN   TestParser_Parse/with_module_call
=== RUN   TestParser_Parse/resource_with_no_matching_resource_change
--- PASS: TestParser_Parse (0.00s)
    --- PASS: TestParser_Parse/simple_case (0.00s)
    --- PASS: TestParser_Parse/with_module_call (0.00s)
    --- PASS: TestParser_Parse/resource_with_no_matching_resource_change (0.00s)
PASS
```

Closes #10399
Related discussion: #10346