### PR TITLE
feat(sbom): add SHA-384 and SHA-512 hash support for SPDX

### DIFF
--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -22,8 +22,9 @@ func (a Algorithm) String() string {
 const (
 	SHA1   Algorithm = "sha1"   // sha1 with hex encoding (lower case only)
 	SHA256 Algorithm = "sha256" // sha256 with hex encoding (lower case only)
-	SHA512 Algorithm = "sha512"
-	MD5    Algorithm = "md5" // md5 with hex encoding (lower case only)
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding (lower case only)
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding (lower case only)
+	MD5    Algorithm = "md5"    // md5 with hex encoding (lower case only)
 )
 
 // Digest allows simple protection of hex formatted digest strings, prefixed by their algorithm.

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -280,6 +280,8 @@ func (m *Marshaler) Hashes(files []core.File) *[]cdx.Hash {
 			alg = cdx.HashAlgoSHA1
 		case digest.SHA256:
 			alg = cdx.HashAlgoSHA256
+		case digest.SHA384:
+			alg = cdx.HashAlgoSHA384
 		case digest.SHA512:
 			alg = cdx.HashAlgoSHA512
 		case digest.MD5:

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -267,6 +267,8 @@ func (b *BOM) unmarshalHashes(hashes *[]cdx.Hash) []digest.Digest {
 			alg = digest.SHA1
 		case cdx.HashAlgoSHA256:
 			alg = digest.SHA256
+		case cdx.HashAlgoSHA384:
+			alg = digest.SHA384
 		case cdx.HashAlgoSHA512:
 			alg = digest.SHA512
 		case cdx.HashAlgoMD5:

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -507,10 +507,15 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA384:
+			alg = spdx.SHA384
+		case digest.SHA512:
+			alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:
-			return nil
+			m.logger.Warn("Unsupported hash algorithm", log.String("algorithm", d.Algorithm().String()))
+			continue
 		}
 		checksums = append(checksums, spdx.Checksum{
 			Algorithm: alg,

--- a/pkg/sbom/spdx/testdata/happy/package-hashes.json
+++ b/pkg/sbom/spdx/testdata/happy/package-hashes.json
@@ -1,0 +1,54 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2022-09-12T17:02:46.826609Z",
+    "creators": [
+      "Tool: trivy-dev",
+      "Organization: aquasecurity"
+    ]
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "http://trivy.dev/container/maven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
+  "name": "maven-test-project",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-ContainerImage-fbbee9b988766322",
+      "filesAnalyzed": false,
+      "name": "maven-test-project"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-lodash-4.17.21",
+      "name": "lodash",
+      "versionInfo": "4.17.21",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NONE",
+      "licenseDeclared": "NONE",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:npm/lodash@4.17.21",
+          "referenceType": "purl"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "relatedSpdxElement": "SPDXRef-ContainerImage-fbbee9b988766322",
+      "relationshipType": "DESCRIBES",
+      "spdxElementId": "SPDXRef-DOCUMENT"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-lodash-4.17.21",
+      "relationshipType": "CONTAINS",
+      "spdxElementId": "SPDXRef-ContainerImage-fbbee9b988766322"
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spdx/tools-golang/tagvalue"
 	"golang.org/x/xerrors"
 
+	"github.com/aquasecurity/trivy/pkg/digest"
+	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
 
@@ -184,14 +186,26 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 	}
 
 	// Files
-	// TODO: handle checksums as well
 	if path, ok := s.pkgFilePaths[spdxPkg.PackageSPDXIdentifier]; ok {
 		component.Files = []core.File{
 			{Path: path},
 		}
 	} else if len(spdxPkg.Files) > 0 {
+		file := spdxPkg.Files[0]
 		component.Files = []core.File{
-			{Path: spdxPkg.Files[0].FileName}, // Take the first file name
+			{
+				Path:    file.FileName, // Take the first file name
+				Digests: s.unmarshalChecksums(file.Checksums),
+			},
+		}
+	}
+
+	if len(component.Files) == 0 && len(spdxPkg.PackageChecksums) > 0 {
+		// If no files are specified, use the package checksums
+		component.Files = []core.File{
+			{
+				Digests: s.unmarshalChecksums(spdxPkg.PackageChecksums),
+			},
 		}
 	}
 
@@ -273,6 +287,30 @@ func (s *SPDX) parseExternalReferences(refs []*spdx.PackageExternalReference) (*
 		return &packageURL, nil
 	}
 	return nil, nil
+}
+
+func (s *SPDX) unmarshalChecksums(checksums []spdx.Checksum) []digest.Digest {
+	var digests []digest.Digest
+	for _, h := range checksums {
+		var alg digest.Algorithm
+		switch h.Algorithm {
+		case common.SHA1:
+			alg = digest.SHA1
+		case common.SHA256:
+			alg = digest.SHA256
+		case common.SHA384:
+			alg = digest.SHA384
+		case common.SHA512:
+			alg = digest.SHA512
+		case common.MD5:
+			alg = digest.MD5
+		default:
+			log.Warn("Unsupported hash algorithm", log.String("algorithm", string(h.Algorithm)))
+			continue
+		}
+		digests = append(digests, digest.NewDigestFromString(alg, h.Value))
+	}
+	return digests
 }
 
 func (s *SPDX) isTrivySBOM(spdxDocument *spdx.Document) bool {

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -332,6 +332,32 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy path package with hash",
+			inputFile: "testdata/happy/package-hashes.json",
+			want: types.SBOM{
+				Applications: []ftypes.Application{
+					{
+						Type: "node-pkg",
+						Packages: ftypes.Packages{
+							{
+								ID:      "lodash@4.17.21",
+								Name:    "lodash",
+								Version: "4.17.21",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypeNPM,
+										Name:    "lodash",
+										Version: "4.17.21",
+									},
+								},
+								Digest: "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:      "happy path empty component",
 			inputFile: "testdata/happy/empty-bom.json",
 			want:      types.SBOM{},


### PR DESCRIPTION
## Summary

Adds SHA-384 and SHA-512 algorithm support to the SPDX SBOM marshaler and unmarshaler, completing the work started in #9126 (CycloneDX).

## Motivation

npm uses SHA-512 for package integrity verification (`integrity` field in `package-lock.json`). The CycloneDX side was addressed in #9126, but the SPDX marshaler still had two problems:

1. The `spdxChecksums()` switch statement did not handle SHA-384 or SHA-512, and its `default` branch returned `nil` — meaning a single unsupported algorithm caused **all** checksums on that component to be dropped silently.
2. The SPDX unmarshaler did not parse checksums from packages or files at all (there was a `TODO` comment for this).

## Changes

- **`pkg/digest/digest.go`** — Add `SHA384` algorithm constant
- **`pkg/sbom/spdx/marshal.go`** — Add SHA-384 and SHA-512 cases to `spdxChecksums()`; change `default` from `return nil` to `continue` with a warning log so other valid checksums are preserved
- **`pkg/sbom/spdx/unmarshal.go`** — Add `unmarshalChecksums()` helper to convert SPDX checksums to digest types; update `parsePackage()` to parse both package-level and file-level checksums into `core.File.Digests`; remove the `TODO` comment
- **`pkg/sbom/spdx/unmarshal_test.go`** — Add test case for unmarshaling a package with SHA-512 checksum
- **`pkg/sbom/cyclonedx/{marshal,unmarshal}.go`** — Add SHA-384 support for consistency with the digest package

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).

## Related

- Fixes #9094
- Continues #9126 (merged — CycloneDX SHA-512 support)
- Supersedes #9130 (stale since Oct 2025)
