### PR TITLE
chore: remove aquasecurity/homebrew-trivy tap from GoReleaser

### DIFF
--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -303,46 +303,6 @@ or
 unset GITHUB_TOKEN
 ```
 
-## Homebrew
-### Scope error
-!!! error
-    Error: Your macOS keychain GitHub credentials do not have sufficient scope!
-
-```
-$ brew tap aquasecurity/trivy
-Error: Your macOS keychain GitHub credentials do not have sufficient scope!
-Scopes they need: none
-Scopes they have:
-Create a personal access token:
-https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
-echo 'export HOMEBREW_GITHUB_API_TOKEN=your_token_here' >> ~/.zshrc
-```
-
-Try:
-
-```
-$ printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase
-```
-
-### Already installed
-!!! error
-    Error: aquasecurity/trivy/trivy 64 already installed
-
-```
-$ brew upgrade
-...
-Error: aquasecurity/trivy/trivy 64 already installed
-```
-
-Try:
-
-```
-$ brew unlink trivy && brew uninstall trivy
-($ rm -rf /usr/local/Cellar/trivy/64)
-$ brew install aquasecurity/trivy/trivy
-```
-
-
 ## Debugging
 ### HTTP Request/Response Tracing
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -138,17 +138,6 @@ archives:
         format: zip
 
 
-brews:
-  -
-    repository:
-      owner: aquasecurity
-      name: homebrew-trivy
-    homepage: "https://github.com/aquasecurity/trivy"
-    description: "Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues"
-    url_template: "https://get.trivy.dev/trivy?version={{ .Version }}&os={{ tolower .Os }}&arch={{ tolower .Arch }}"
-    test: |
-      system "#{bin}/trivy", "--version"
-
 dockers:
   - image_templates:
       - "docker.io/aquasec/trivy:{{ .Version }}-amd64"


### PR DESCRIPTION
## Description

Remove the custom Homebrew tap (`aquasecurity/homebrew-trivy`) from GoReleaser configuration. Trivy is available in the official Homebrew formula (`brew install trivy`) via https://formulae.brew.sh/formula/trivy, so maintaining a separate tap is unnecessary.

- Remove `brews` section from `goreleaser.yml`
- Remove related troubleshooting entries from documentation

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).