### PR TITLE
ci: migrate from mkdocs-material-insiders to mkdocs-material

### DIFF
--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -22,10 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.44-insiders-4.53.14
           pip install -r docs/build/requirements.txt
-        env:
-          GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Configure the git user
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -24,10 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.44-insiders-4.53.14
           pip install -r docs/build/requirements.txt
-        env:
-          GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Configure the git user
         run: |
           git config user.name "github-actions[bot]"

--- a/docs/build/requirements.in
+++ b/docs/build/requirements.in
@@ -1,3 +1,3 @@
-mkdocs-material==9.5.44
+mkdocs-material==9.7.0
 mkdocs-macros-plugin
 mike

--- a/docs/build/requirements.txt
+++ b/docs/build/requirements.txt
@@ -6,6 +6,8 @@
 #
 babel==2.16.0
     # via mkdocs-material
+backrefs==6.2
+    # via mkdocs-material
 certifi==2024.8.30
     # via requests
 charset-normalizer==3.4.0
@@ -56,7 +58,7 @@ mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-macros-plugin==1.3.7
     # via -r docs/build/requirements.in
-mkdocs-material==9.5.44
+mkdocs-material==9.7.0
     # via -r docs/build/requirements.in
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
@@ -94,8 +96,6 @@ pyyaml-env-tag==0.1
     # via
     #   mike
     #   mkdocs
-regex==2024.11.6
-    # via mkdocs-material
 requests==2.32.3
     # via mkdocs-material
 six==1.16.0


### PR DESCRIPTION
## Description

Material for MkDocs Insiders [is now free for everyone](https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/): starting with `mkdocs-material` 9.7.0, all previously sponsor-only features have been merged into the public package, and bug fixes will only land in the community edition going forward.

This PR migrates the docs tooling off the private `mkdocs-material-insiders` fork and onto the public `mkdocs-material` package:

- **Workflows** (`.github/workflows/mkdocs-dev.yaml`, `.github/workflows/mkdocs-latest.yaml`): removed the `pip install git+https://.../mkdocs-material-insiders.git@9.5.44-insiders-4.53.14` step and the associated `MKDOCS_AQUA_BOT` token. The workflows now install docs dependencies solely from `docs/build/requirements.txt`.
- **Requirements** (`docs/build/requirements.in`, `docs/build/requirements.txt`): bumped `mkdocs-material` from `9.5.44` to `9.7.0` and regenerated the lockfile with `pip-compile`. This picks up all formerly-insiders features and the latest community fixes.

After this PR, the `MKDOCS_AQUA_BOT` secret is no longer used and can be removed from repo settings separately.

## Test
- https://github.com/DmitriyLewen/trivy/actions/runs/24242520742/job/70780357209 (mkdocs-latest.yaml run)
- new commit(in my fork) - https://github.com/DmitriyLewen/trivy/commit/c059c2a8c2a6942d07dbda6080ce120850d91e14

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).