### PR TITLE
feat(report): add startTimeUtc and endTimeUtc to SARIF invocation

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	containerName "github.com/google/go-containerregistry/pkg/name"
 	"github.com/owenrumney/go-sarif/v2/sarif"
@@ -126,6 +127,8 @@ func pathToFileURI(path string) string {
 }
 
 func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
+	startTime := time.Now().UTC()
+
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return xerrors.Errorf("error creating a new sarif template: %w", err)
@@ -268,6 +271,12 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			},
 		}
 	}
+
+	endTime := time.Now().UTC()
+	sw.run.AddInvocation(true).
+		WithStartTimeUTC(startTime).
+		WithEndTimeUTC(endTime)
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }


### PR DESCRIPTION
## Summary

Adds `startTimeUtc` and `endTimeUtc` properties to the SARIF output's invocation object, as requested in #3226.

## Details

Per the [SARIF v2.1.0 specification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317574), the invocation object supports `startTimeUtc` and `endTimeUtc` timestamps to indicate when a tool's invocation started and ended.

This allows consumers of Trivy's SARIF reports to:
- Monitor that reports are current/fresh
- Track scan duration
- Correlate reports with CI/CD pipeline events

## Changes

- **`pkg/report/sarif.go`**:
  - Added `"time"` import
  - Record `time.Now().UTC()` at the start of the `Write` method
  - Record `time.Now().UTC()` at the end of report generation
  - Add an invocation entry to the SARIF run with both timestamps and `executionSuccessful: true`

## Example SARIF output

Before:
```json
{
  "runs": [{
    "tool": { ... },
    "results": [ ... ]
  }]
}
```

After:
```json
{
  "runs": [{
    "tool": { ... },
    "invocations": [{
      "startTimeUtc": "2024-01-15T10:30:00.000Z",
      "endTimeUtc": "2024-01-15T10:30:05.000Z",
      "executionSuccessful": true
    }],
    "results": [ ... ]
  }]
}
```

Fixes #3226