### PR TITLE
fix(misconf): guard against nil resource change in tfjson parser

### DIFF
--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser.go
@@ -65,7 +65,11 @@ func buildPlanBlocks(module Module, resourceChanges []ResourceChange, configurat
 		resourceExprs := getConfiguration(r.Address, module.Address, configuration)
 		schema := schemaForBlock(r, resourceExprs)
 		changes := getValues(r.Address, resourceChanges)
-		resource := decodeBlock(schema, changes.After)
+		var afterValues map[string]any
+		if changes != nil {
+			afterValues = changes.After
+		}
+		resource := decodeBlock(schema, afterValues)
 		// fill top-level block fields
 		resource.BlockType = r.BlockType()
 		resource.Type = r.Type

--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
@@ -81,6 +81,17 @@ resource "aws_security_group" "sg" {
 }
 `,
 		},
+		{
+			// Regression test: resource present in planned_values but absent from
+			// resource_changes must not cause a nil-pointer panic. The block is
+			// emitted with no attributes because there is no "after" state to
+			// decode values from.
+			name: "resource present in planned_values but missing from resource_changes",
+			path: "../testdata/missing_resource_changes.json",
+			expected: `resource "aws_s3_bucket" "example" {
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/terraformplan/tfjson/testdata/missing_resource_changes.json
+++ b/pkg/iac/scanners/terraformplan/tfjson/testdata/missing_resource_changes.json
@@ -1,0 +1,46 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.3.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "example",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "my-test-bucket",
+            "force_destroy": false
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.example",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "example",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "my-test-bucket"
+            },
+            "force_destroy": {
+              "constant_value": false
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a nil-pointer panic in the Terraform Plan JSON scanner when a resource appears in `planned_values` but has no corresponding entry in `resource_changes`.

**Root cause:** `buildPlanBlocks` in `pkg/iac/scanners/terraformplan/tfjson/parser/parser.go` calls `getValues(r.Address, resourceChanges)` and immediately dereferences the result via `changes.After`. `getValues` returns `nil` when no matching `ResourceChange` is found (e.g. data sources or certain no-op resources), which causes the panic.

**Fix:** Introduce a nil guard — if `getValues` returns nil, `afterValues` is left as a nil map. Ranging over a nil map in `decodeBlock` is safe in Go and produces an empty but valid block that can still be scanned for misconfigurations.

## Changes
- `parser.go`: add nil check before accessing `changes.After`
- `parser_test.go`: add regression test case
- `testdata/missing_resource_changes.json`: fixture with a resource in `planned_values` but absent from `resource_changes`

## Test

```
go test ./pkg/iac/scanners/terraformplan/tfjson/parser/...
```

All existing tests continue to pass; the new test exercises the previously panicking code path.

Fixes #10399