### PR TITLE
fix: correct Redis SCAN cursor propagation and guard empty Unlink in Clear()

### DIFF
--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -214,13 +214,18 @@ func (c RedisCache) Close() error {
 }
 
 func (c RedisCache) Clear(ctx context.Context) error {
+	var cursor uint64
 	for {
-		keys, cursor, err := c.client.Scan(ctx, 0, redisPrefix+"::*", 100).Result()
+		var keys []string
+		var err error
+		keys, cursor, err = c.client.Scan(ctx, cursor, redisPrefix+"::*", 100).Result()
 		if err != nil {
 			return xerrors.Errorf("failed to perform prefix scanning: %w", err)
 		}
-		if err = c.client.Unlink(ctx, keys...).Err(); err != nil {
-			return xerrors.Errorf("failed to unlink redis keys: %w", err)
+		if len(keys) > 0 {
+			if err = c.client.Unlink(ctx, keys...).Err(); err != nil {
+				return xerrors.Errorf("failed to unlink redis keys: %w", err)
+			}
 		}
 		if cursor == 0 { // We cleared all keys
 			break


### PR DESCRIPTION
## Summary

Fixes two bugs in `RedisCache.Clear()` (`pkg/cache/redis.go`):

### Bug 1: Redis SCAN cursor was never advanced

The `SCAN` command is a cursor-based iterator. Each call returns a new cursor value that must be passed to the next call. When the returned cursor is `0`, the full iteration is complete.

The previous code always passed `cursor=0`, which means it always restarted the scan from the beginning of the keyspace on every loop iteration. With more than 100 matching `fanal::*` keys, the loop would never advance through the full keyspace, potentially leaving keys undeleted.

### Bug 2: `Unlink` called with empty key slice

When `Scan` returns an empty `keys` slice (e.g., on an already-empty cache), calling `Unlink(ctx, keys...)` with no keys causes Redis to return `ERR wrong number of arguments for 'unlink' command`, making `Clear()` fail even when there's nothing to delete.

### Fix

- Use a `var cursor uint64` initialized to `0` and update it with the value returned from each `Scan` call.
- Guard `Unlink` with `if len(keys) > 0`.

Closes #10520

---
Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>