### PR TITLE
feat(helm): Add parameter to customize container args

### DIFF
--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -54,42 +54,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Trivy chart and their default values.
 
-|                 Parameter             |                                Description                              |    Default     |
-|---------------------------------------|-------------------------------------------------------------------------|----------------|
-| `image.registry`                      | Image registry                                                          | `docker.io`    |
-| `image.repository`                    | Image name                                                              | `aquasec/trivy` |
-| `image.tag`                           | Image tag                                                               | `{TAG_NAME}`   |
-| `image.pullPolicy`                    | Image pull policy                                                       | `IfNotPresent` |
-| `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry  | |
-| `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
-| `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                          | `false` |
-| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://trivy.dev/docs/latest/references/troubleshooting/#github-rate-limiting                          |      |
-| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/ |      |
-| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/ |      |
-| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
-| `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
-| `trivy.skipDBUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
-| `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from        | `ghcr.io/aquasecurity/trivy-db`        |
-| `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
-| `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
-| `trivy.cache.redis.ttl`               | Specify redis TTL, e.g. 3600s or 24h                                    | `` |
-| `trivy.cache.redis.tls`               | Enable Redis TLS with public certificates                               | `` |
-| `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
-| `trivy.existingSecret`                | existingSecret if an existing secret has been created outside the chart. Overrides gitHubToken, registryUsername, registryPassword, serverToken | `` |
-| `trivy.podAnnotations`                | Annotations for pods created by statefulset                             | `{}` |
-| `trivy.extraEnvVars`                  | extraEnvVars to be set on the container                                 | `{}` |
-| `trivy.sslCertDir`                    | Can be used to override the system default locations for SSL certificate files directory, example: `/ssl/certs` | `` |
-| `service.name`                        | If specified, the name used for the Trivy service                       |     |
-| `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
-| `service.port`                        | Kubernetes service port                                                 | `4954`      |
-| `service.sessionAffinity`             | Kubernetes service session affinity                                     | `ClientIP`  |
-| `httpProxy`                           | The URL of the HTTP proxy server                                        |     |
-| `httpsProxy`                          | The URL of the HTTPS proxy server                                       |     |
-| `noProxy`                             | The URLs that the proxy settings do not apply to                        |     |
-| `nodeSelector`                        | Node labels for pod assignment                                              |     |
-| `affinity`                            | Affinity settings for pod assignment                                              |     |
-| `tolerations`                         | Tolerations for pod assignment                                              |     |
-| `podAnnotations`                      | Annotations for pods created by statefulset                             | `{}` |
+|                 Parameter                 |                                Description                                                                                                      |            Default              |
+|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| `image.registry`                          | Image registry                                                                                                                                  | `docker.io`                     |
+| `image.repository`                        | Image name                                                                                                                                      | `aquasec/trivy`                 |
+| `image.tag`                               | Image tag                                                                                                                                       | `{TAG_NAME}`                    |
+| `image.pullPolicy`                        | Image pull policy                                                                                                                               | `IfNotPresent`                  |
+| `image.pullSecret`                        | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry                                              | ``                              |
+| `replicaCount`                            | Number of Trivy Pods to run                                                                                                                     | `1`                             |
+| `trivy.customContainerArgs`               | The custom container args in case of using an image with a different entrypoint                                                                 | `[]`                            |
+| `trivy.debugMode`                         | The flag to enable or disable Trivy debug mode                                                                                                  | `false`                         |
+| `trivy.gitHubToken`                       | The GitHub access token to download Trivy DB. More info: https://trivy.dev/docs/latest/references/troubleshooting/#github-rate-limiting         | ``                              |
+| `trivy.registryUsername`                  | The username used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/                      | ``                              |
+| `trivy.registryPassword`                  | The password used to log in at dockerhub. More info: https://trivy.dev/docs/latest/advanced/private-registries/docker-hub/                      | ``                              |
+| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                                  | ``                              |
+| `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource                                                                        | ``                              |
+| `trivy.skipDBUpdate`                      | The flag to enable or disable Trivy DB downloads from GitHub                                                                                    | `false`                         |
+| `trivy.dbRepository`                      | OCI repository to retrieve the trivy vulnerability database from                                                                                | `ghcr.io/aquasecurity/trivy-db` |
+| `trivy.cache.redis.enabled`               | Enable Redis as caching backend                                                                                                                 | `false`                         |
+| `trivy.cache.redis.url`                   | Specify redis connection url, e.g. redis://redis.redis.svc:6379                                                                                 | ``                              |
+| `trivy.cache.redis.ttl`                   | Specify redis TTL, e.g. 3600s or 24h                                                                                                            | ``                              |
+| `trivy.cache.redis.tls`                   | Enable Redis TLS with public certificates                                                                                                       | ``                              |
+| `trivy.serverToken`                       | The token to authenticate Trivy client with Trivy server                                                                                        | ``                              |
+| `trivy.existingSecret`                    | existingSecret if an existing secret has been created outside the chart. Overrides gitHubToken, registryUsername, registryPassword, serverToken | ``                              |
+| `trivy.podAnnotations`                    | Annotations for pods created by statefulset                                                                                                     | `{}`                            |
+| `trivy.extraEnvVars`                      | extraEnvVars to be set on the container                                                                                                         | `{}`                            |
+| `trivy.sslCertDir`                        | Can be used to override the system default locations for SSL certificate files directory, example: `/ssl/certs`                                 | ``                              |
+| `service.name`                            | If specified, the name used for the Trivy service                                                                                               | ``                              |
+| `service.type`                            | Kubernetes service type                                                                                                                         | `ClusterIP`                     |
+| `service.port`                            | Kubernetes service port                                                                                                                         | `4954`                          |
+| `service.sessionAffinity`                 | Kubernetes service session affinity                                                                                                             | `ClientIP`                      |
+| `httpProxy`                               | The URL of the HTTP proxy server                                                                                                                | ``                              |
+| `httpsProxy`                              | The URL of the HTTPS proxy server                                                                                                               | ``                              |
+| `noProxy`                                 | The URLs that the proxy settings do not apply to                                                                                                | ``                              |
+| `nodeSelector`                            | Node labels for pod assignment                                                                                                                  | `{}`                            |
+| `affinity`                                | Affinity settings for pod assignment                                                                                                            | `{}`                            |
+| `tolerations`                             | Tolerations for pod assignment                                                                                                                  | `[]`                            |
+| `podAnnotations`                          | Annotations for pods created by statefulset                                                                                                     | `{}`                            |
 
 The above parameters map to the env variables defined in [trivy](https://trivy.dev/docs/latest/configuration/#configuration).
 

--- a/helm/trivy/templates/_helpers.tpl
+++ b/helm/trivy/templates/_helpers.tpl
@@ -53,3 +53,14 @@ Return the proper imageRef as used by the container template spec.
 {{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
+
+{{/*
+Return the proper customContainerArgs as used by the container template spec.
+*/}}
+{{- define "trivy.containerArgs" -}}
+{{- if .Values.trivy.customContainerArgs -}}
+{{- toYaml .Values.trivy.customContainerArgs -}}
+{{- else -}}
+- server
+{{- end -}}
+{{- end -}}

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{ toYaml .Values.securityContext | indent 12 }}
           {{- end }}
           args:
-            - server
+            {{- include "trivy.containerArgs" . | nindent 12 }}
           {{- if .Values.trivy.registryCredentialsExistingSecret }}
           env:
             - name: TRIVY_USERNAME

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -57,6 +57,8 @@ tolerations: []
 podAnnotations: {}
 
 trivy:
+  # Define custom container args in case of using an image with a different entrypoint.
+  customContainerArgs: []
   # debugMode the flag to enable Trivy debug mode
   debugMode: false
   # gitHubToken the GitHub access token to download Trivy DB
@@ -133,7 +135,7 @@ trivy:
 
 service:
   # If specified, the name used for the Trivy service.
-  name:
+  name: ""
   # type Kubernetes service type
   type: ClusterIP
   # port Kubernetes service port
@@ -144,7 +146,7 @@ service:
 ingress:
   enabled: false
   # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
-  ingressClassName:
+  ingressClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
   hosts:
@@ -158,8 +160,8 @@ ingress:
   #      - trivy.example.com
 
 # httpProxy the URL of the HTTP proxy server
-httpProxy:
+httpProxy: ""
 # httpsProxy the URL of the HTTPS proxy server
-httpsProxy:
+httpsProxy: ""
 # noProxy the URLs that the proxy settings do not apply to
-noProxy:
+noProxy: ""


### PR DESCRIPTION
## Description

The organisation I work for uses customised Docker images and official Helm charts. The challenge with trivy was that we were unable to adjust the container arguments to use our customised image with the official Helm chart. This feature adds a new parameter, `trivy.customContainerArgs`, which allows the default value, `server`, to be overridden.

In addition to updating the documentation for the new parameter, the table in the README has been updated to include missing default values for other parameters, as well as the values.yaml file, to ensure consistency.

Simple tests:
* before
```
$ helm template my-trivy .

# Source: trivy/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: my-trivy
  labels:
    app.kubernetes.io/name: trivy
    helm.sh/chart: trivy-0.21.3
    app.kubernetes.io/instance: my-trivy
    app.kubernetes.io/version: "0.69.3"
    app.kubernetes.io/managed-by: Helm
spec:
  podManagementPolicy: "Parallel"
  serviceName: my-trivy
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: trivy
      app.kubernetes.io/instance: my-trivy
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
      spec:
        resources:
          requests:
            storage: 5Gi
        accessModes:
          - ReadWriteOnce
        storageClassName: 
  template:
    metadata:
      annotations:
        checksum/config: e9c603f8c1a7b460736add81d62a8b20e83d6c01c2799b7d458068a959d9757a
      labels:
        app.kubernetes.io/name: trivy
        app.kubernetes.io/instance: my-trivy
    spec:
      serviceAccountName: my-trivy
      automountServiceAccountToken: false
      securityContext:
        fsGroup: 65534
        runAsNonRoot: true
        runAsUser: 65534
      containers:
        - name: main
          image: docker.io/aquasec/trivy:0.69.3
          imagePullPolicy: "IfNotPresent"
          securityContext:
            privileged: false
            readOnlyRootFilesystem: true
          args:
            - server
          envFrom:
            - configMapRef:
                name: my-trivy
            - secretRef:
                name: my-trivy
          ports:
            - name: trivy-http
              containerPort: 4954
          livenessProbe:
            httpGet:
              scheme: HTTP
              path: /healthz
              port: trivy-http
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            failureThreshold: 10
          readinessProbe:
            httpGet:
              scheme: HTTP
              path: /healthz
              port: trivy-http
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            failureThreshold: 3
          volumeMounts:
            - mountPath: /tmp
              name: tmp-data
              readOnly: false
            - mountPath: /home/scanner/.cache
              name: data
              readOnly: false
          resources:
            limits:
              cpu: 1
              memory: 1Gi
            requests:
              cpu: 200m
              memory: 512Mi
      volumes:
        - name: tmp-data
          emptyDir: {}
```
* after
```
$ helm template my-trivy . --set "trivy.customContainerArgs={arg1,arg2}"

# Source: trivy/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: my-trivy
  labels:
    app.kubernetes.io/name: trivy
    helm.sh/chart: trivy-0.21.3
    app.kubernetes.io/instance: my-trivy
    app.kubernetes.io/version: "0.69.3"
    app.kubernetes.io/managed-by: Helm
spec:
  podManagementPolicy: "Parallel"
  serviceName: my-trivy
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: trivy
      app.kubernetes.io/instance: my-trivy
  volumeClaimTemplates:
    - apiVersion: v1
      kind: PersistentVolumeClaim
      metadata:
        name: data
      spec:
        resources:
          requests:
            storage: 5Gi
        accessModes:
          - ReadWriteOnce
        storageClassName: 
  template:
    metadata:
      annotations:
        checksum/config: e9c603f8c1a7b460736add81d62a8b20e83d6c01c2799b7d458068a959d9757a
      labels:
        app.kubernetes.io/name: trivy
        app.kubernetes.io/instance: my-trivy
    spec:
      serviceAccountName: my-trivy
      automountServiceAccountToken: false
      securityContext:
        fsGroup: 65534
        runAsNonRoot: true
        runAsUser: 65534
      containers:
        - name: main
          image: docker.io/aquasec/trivy:0.69.3
          imagePullPolicy: "IfNotPresent"
          securityContext:
            privileged: false
            readOnlyRootFilesystem: true
          args:
            - arg1
            - arg2
          envFrom:
            - configMapRef:
                name: my-trivy
            - secretRef:
                name: my-trivy
          ports:
            - name: trivy-http
              containerPort: 4954
          livenessProbe:
            httpGet:
              scheme: HTTP
              path: /healthz
              port: trivy-http
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            failureThreshold: 10
          readinessProbe:
            httpGet:
              scheme: HTTP
              path: /healthz
              port: trivy-http
            initialDelaySeconds: 5
            periodSeconds: 10
            successThreshold: 1
            failureThreshold: 3
          volumeMounts:
            - mountPath: /tmp
              name: tmp-data
              readOnly: false
            - mountPath: /home/scanner/.cache
              name: data
              readOnly: false
          resources:
            limits:
              cpu: 1
              memory: 1Gi
            requests:
              cpu: 200m
              memory: 512Mi
      volumes:
        - name: tmp-data
          emptyDir: {}
```

## Related issues
- There is no issue created for such feature.

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
