### PR TITLE
docs: add community resource on securing GitHub Actions after CVE-2026-33634

### DIFF
--- a/docs/tutorials/additional-resources/community.md
+++ b/docs/tutorials/additional-resources/community.md
@@ -12,6 +12,7 @@ Below is a list of additional resources from the community.
 - [Continuous Container Vulnerability Testing with Trivy](https://semaphoreci.com/blog/continuous-container-vulnerability-testing-with-trivy)
 - [Getting Started With Trivy and Jenkins](https://youtu.be/MWe01VdwuMA)
 - [How to use Tekton to set up a CI pipeline with OpenShift Pipelines](https://www.redhat.com/architect/cicd-pipeline-openshift-tekton)
+- [12 Steps to Secure GitHub Actions After the Trivy Attack](https://haitmg.pl/blog/github-actions-security-after-trivy-attack/)
 
 ## Misconfiguration Scanning
 


### PR DESCRIPTION
## Summary

Adds a link to the community resources page for the article **"12 Steps to Secure GitHub Actions After the Trivy Attack"** ([haitmg.pl/blog/github-actions-security-after-trivy-attack/](https://haitmg.pl/blog/github-actions-security-after-trivy-attack/)).

The article covers:
- The CVE-2026-33634 supply chain attack timeline and how it affected Trivy's GitHub Actions workflow
- A practical 12-step hardening guide for GitHub Actions pipelines to prevent similar attacks
- Actionable mitigation steps including pin-by-SHA, OIDC authentication, least-privilege tokens, and workflow isolation

Added to the **CI/CD Pipelines** section as it is directly relevant to securing CI/CD workflows that use Trivy.

## Notes

This is a documentation-only change - a single line added to `docs/tutorials/additional-resources/community.md`.