### PR TITLE
fix: incorrect log message when analyzer encounters an error, causing confusing messages, like "Analyzer error=nil"

### DIFF
--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -510,7 +510,7 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, eg *errgroup.Group, lim
 				case errors.Is(analyzeErr, context.DeadlineExceeded):
 					return xerrors.Errorf("analyzer timed out: %w", analyzeErr)
 				default:
-					ag.logger.Debug("Analysis error", log.Err(err))
+					ag.logger.Debug("Analysis error", log.Err(analyzeErr))
 					return nil
 				}
 			}


### PR DESCRIPTION
## Description

While trying to investigate, why my cdx.json isn't being processed i've got a not very helpful error message "Analyzer error=nil", by carefully looking at the code it's pretty clear, that the incorrect variable is being printed out.

This PR addresses the issue.