### PR TITLE
fix(secret): prevent data race on builtinRules in scanner

### DIFF
--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -28,6 +28,10 @@ var (
 	})
 )
 
+func init() {
+	precomputeLowercaseKeywords(builtinRules)
+}
+
 const (
 	// DefaultBufferSize is the default chunk size for streaming secret scanning
 	// 64KB provides a good balance between memory usage and I/O efficiency
@@ -394,9 +398,6 @@ func NewScanner(config *Config, opts ...Option) Scanner {
 
 	// Use the default rules
 	if config == nil {
-		// Pre-compute lowercase keywords for builtin rules
-		precomputeLowercaseKeywords(builtinRules)
-
 		scanner.Global = &Global{
 			Rules:      builtinRules,
 			AllowRules: builtinAllowRules,

--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -28,9 +28,9 @@ var (
 	})
 )
 
-func init() {
+var initBuiltinRules = sync.OnceFunc(func() {
 	precomputeLowercaseKeywords(builtinRules)
-}
+})
 
 const (
 	// DefaultBufferSize is the default chunk size for streaming secret scanning
@@ -377,6 +377,8 @@ func precomputeLowercaseKeywords(rules []Rule) {
 }
 
 func NewScanner(config *Config, opts ...Option) Scanner {
+	initBuiltinRules()
+
 	scanner := Scanner{
 		logger:      log.WithPrefix(log.PrefixSecret),
 		bufferSize:  DefaultBufferSize,
@@ -413,6 +415,9 @@ func NewScanner(config *Config, opts ...Option) Scanner {
 		})
 	}
 
+	// Pre-compute lowercase keywords before copying into enabledRules.
+	precomputeLowercaseKeywords(config.CustomRules)
+
 	// Custom rules are enabled regardless of "enable-builtin-rules".
 	enabledRules = append(enabledRules, config.CustomRules...)
 
@@ -426,9 +431,6 @@ func NewScanner(config *Config, opts ...Option) Scanner {
 	allowRules = lo.Filter(allowRules, func(v AllowRule, _ int) bool {
 		return !slices.Contains(config.DisableAllowRuleIDs, v.ID)
 	})
-
-	// Pre-compute lowercase keywords for all rules
-	precomputeLowercaseKeywords(rules)
 
 	scanner.Global = &Global{
 		Rules:        rules,

--- a/pkg/fanal/secret/scanner_test.go
+++ b/pkg/fanal/secret/scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1973,4 +1974,23 @@ func TestSecretScannerWithStreaming(t *testing.T) {
 			assert.Equal(t, tt.want.Findings, got.Findings, "unexpected findings")
 		})
 	}
+}
+
+func TestScanConcurrent(_ *testing.T) {
+	// Regression test for a data race on builtinRules.keywordsLower when
+	// multiple goroutines call NewScanner(nil) and Scan concurrently.
+	const workers = 20
+	content := strings.Repeat("aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n", 50)
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			scanner := secret.NewScanner(nil)
+			scanner.Scan(secret.ScanArgs{
+				FilePath: "test.env",
+				Content:  strings.NewReader(content),
+			})
+		})
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Description

`NewScanner(nil)` called `precomputeLowercaseKeywords(builtinRules)` on every invocation, which always rewrites `keywordsLower` on the global `builtinRules` slice. When multiple goroutines create scanners and scan concurrently, a
write/read race on the slice header produces a nil data pointer with non-zero length, causing a nil pointer dereference inside `bytes.Contains`.

Detected in https://github.com/aquasecurity/trivy/actions/runs/24496672965/job/71593153810 .

Test result before fixing:
```bash
❯ go test -race -run TestNewScannerConcurrent ./pkg/fanal/secret/
==================
WARNING: DATA RACE
Write at 0x000103b996d8 by goroutine 19:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:368 +0x94
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Previous write at 0x000103b996d8 by goroutine 33:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:368 +0x94
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Goroutine 19 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 33 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x000103b996d8 by goroutine 19:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:370 +0x15c
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Previous write at 0x000103b996d8 by goroutine 32:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:368 +0x94
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Goroutine 19 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 32 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Write at 0x00c0004ee000 by goroutine 35:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:370 +0x18c
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Previous write at 0x00c0004ee000 by goroutine 30:
  github.com/aquasecurity/trivy/pkg/fanal/secret.precomputeLowercaseKeywords()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:370 +0x18c
  github.com/aquasecurity/trivy/pkg/fanal/secret.NewScanner()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner.go:398 +0x3c8
  github.com/aquasecurity/trivy/pkg/fanal/secret_test.TestNewScannerConcurrent.func1()
      /Users/nikita/projects/trivy/pkg/fanal/secret/scanner_test.go:1988 +0x40

Goroutine 35 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34

Goroutine 30 (running) created at:
  sync.(*WaitGroup).Go()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:238 +0x6c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestNewScannerConcurrent (0.01s)
    testing.go:1712: race detected during execution of test
FAIL
FAIL    github.com/aquasecurity/trivy/pkg/fanal/secret  1.144s
```

And after:
```
❯ go test -race -run TestNewScannerConcurrent ./pkg/fanal/secret/
ok      github.com/aquasecurity/trivy/pkg/fanal/secret  2.245s
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
