### PR TITLE
ci(helm): bump Trivy version to 0.70.0 for Trivy Helm Chart 0.22.0

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.21.3
-appVersion: 0.69.3
+version: 0.22.0
+appVersion: 0.70.0
 description: Trivy helm chart
 keywords:
   - scanner


### PR DESCRIPTION
This PR bumps Trivy up to the 0.70.0 version for the Trivy Helm chart 0.22.0.