### PR TITLE
fix: add SHA-512 support in SPDX checksum serialization

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -507,10 +507,12 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA512:
+			alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:
-			return nil
+			continue
 		}
 		checksums = append(checksums, spdx.Checksum{
 			Algorithm: alg,


### PR DESCRIPTION
## Description

The `spdxChecksums` function in `pkg/sbom/spdx/marshal.go` was missing SHA-512 digest algorithm support, causing SHA-512 checksums to be dropped from SPDX SBOM output.

Additionally, the `default` case in the switch statement returned `nil`, which discarded **all** checksums if any single digest used an unsupported algorithm. This was overly aggressive — it should only skip the unsupported algorithm while preserving the rest.

## Changes

1. Added `digest.SHA512` case mapping to `spdx.SHA512`
2. Changed `default: return nil` to `default: continue` so unsupported algorithms don't invalidate the entire checksum set

## Related

Note: CycloneDX SHA-512 support was already implemented in `pkg/sbom/cyclonedx/unmarshal.go` (line 270-271). This PR brings parity to the SPDX output path.

Closes #9094