### PR TITLE
feat(vuln): include package locations (line numbers) in JSON output

### DIFF
--- a/pkg/detector/library/detect.go
+++ b/pkg/detector/library/detect.go
@@ -42,6 +42,7 @@ func detect(ctx context.Context, driver Driver, pkgs []ftypes.Package) ([]types.
 			vulns[i].Layer = pkg.Layer
 			vulns[i].PkgPath = pkg.FilePath
 			vulns[i].PkgIdentifier = pkg.Identifier
+			vulns[i].Locations = pkg.Locations
 		}
 		vulnerabilities = append(vulnerabilities, vulns...)
 	}

--- a/pkg/report/json_test.go
+++ b/pkg/report/json_test.go
@@ -10,6 +10,7 @@ import (
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/report"
 	"github.com/aquasecurity/trivy/pkg/types"
 )
@@ -58,6 +59,56 @@ func TestReportWriter_JSON(t *testing.T) {
 									Severity:    "HIGH",
 									VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
 										vulnerability.NVD: dbTypes.SeverityHigh,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "vulnerability with locations",
+			detectedVulns: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2021-9999",
+					PkgName:          "bar",
+					InstalledVersion: "2.0.0",
+					FixedVersion:     "2.0.1",
+					PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2021-9999",
+					Locations: ftypes.Locations{
+						{StartLine: 12, EndLine: 14},
+					},
+					Vulnerability: dbTypes.Vulnerability{
+						Title:    "barbaz",
+						Severity: "MEDIUM",
+						VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+							vulnerability.NVD: dbTypes.SeverityMedium,
+						},
+					},
+				},
+			},
+			want: types.Report{
+				SchemaVersion: 2,
+				ArtifactName:  "alpine:3.14",
+				Results: types.Results{
+					types.Result{
+						Target: "foojson",
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2021-9999",
+								PkgName:          "bar",
+								InstalledVersion: "2.0.0",
+								FixedVersion:     "2.0.1",
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2021-9999",
+								Locations: ftypes.Locations{
+									{StartLine: 12, EndLine: 14},
+								},
+								Vulnerability: dbTypes.Vulnerability{
+									Title:    "barbaz",
+									Severity: "MEDIUM",
+									VendorSeverity: map[dbTypes.SourceID]dbTypes.Severity{
+										vulnerability.NVD: dbTypes.SeverityMedium,
 									},
 								},
 							},

--- a/pkg/types/vulnerability.go
+++ b/pkg/types/vulnerability.go
@@ -23,6 +23,10 @@ type DetectedVulnerability struct {
 	// DataSource holds where the advisory comes from
 	DataSource *types.DataSource `json:",omitempty"`
 
+	// Locations holds the source file positions where the vulnerable package was detected.
+	// For language-specific packages this corresponds to the line(s) in the manifest file.
+	Locations ftypes.Locations `json:",omitempty"`
+
 	// Fingerprint is a unique identifier for the vulnerability based on
 	// ArtifactID, Target, PkgID, and VulnerabilityID
 	Fingerprint string `json:",omitempty"`


### PR DESCRIPTION
## Summary

Closes #4418

Line numbers are already present in SARIF output (via `Package.Locations`) but were missing from the JSON report. This PR makes them available in JSON as well.

### Changes

- **`pkg/types/vulnerability.go`** – adds a `Locations []ftypes.Location` field to `DetectedVulnerability`. The field carries `StartLine`/`EndLine` pairs identifying where the vulnerable package was declared in the manifest file.
- **`pkg/detector/library/detect.go`** – copies `pkg.Locations` onto every `DetectedVulnerability` produced by the library detector (same place where `Layer`, `PkgPath`, and `PkgIdentifier` are already propagated from the package).
- **`pkg/report/json_test.go`** – adds a test case with `Locations` set, verifying the values survive the JSON marshal/unmarshal round-trip.

### Example JSON output (after)

```json
{
  "VulnerabilityID": "CVE-2021-9999",
  "PkgName": "bar",
  "InstalledVersion": "2.0.0",
  "Locations": [
    { "StartLine": 12, "EndLine": 14 }
  ],
  ...
}
```

## Test plan

- [x] `pkg/report/json_test.go` – new `"vulnerability with locations"` case
- [ ] Run `go test ./pkg/report/...` locally once the Go toolchain issue in the dev environment is resolved

