### PR TITLE
fix(walker): scan .git metadata for secrets, skipping only heavy binary subdirs

### DIFF
--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -90,31 +90,51 @@ func TestFS_Walk(t *testing.T) {
 }
 
 func TestFS_Walk_GitConfig(t *testing.T) {
-	// .git/config may contain credentials embedded in remote URLs and must be
-	// scanned. Heavy binary subdirectories (.git/objects, .git/lfs,
-	// .git/modules) must remain skipped for performance reasons.
-	// We create a temporary tree because git itself does not track nested .git
-	// directories inside a repository.
+	// .git/config and .git/credentials may contain embedded secrets and must
+	// be scanned. Subdirectories that are either binary-heavy or high-volume
+	// with no secret value must remain skipped:
+	//   objects – packed git object store
+	//   lfs     – Git LFS binary data
+	//   modules – submodule checkouts
+	//   logs    – reflog entries (plaintext but high-volume, low-signal)
+	//
+	// We use t.TempDir() instead of static testdata because git itself ignores
+	// nested .git directories inside a repository.
 	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git", "objects"), 0o755))
+
+	// Files that MUST be scanned
 	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "config"),
 		[]byte("[remote \"origin\"]\n\turl = https://user:token@github.com/org/repo.git\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "objects", "abc123"),
-		[]byte("binary content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "credentials"),
+		[]byte("https://user:ghp_secret@github.com\n"), 0o644))
 
-	var visitedConfig bool
+	// Directories that MUST be skipped
+	skippedDirs := []string{"objects", "lfs", "modules", "logs"}
+	for _, d := range skippedDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".git", d), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, ".git", d, "file"),
+			[]byte("content"), 0o644))
+	}
+
+	var visitedConfig, visitedCredentials bool
 	w := walker.NewFS()
 	err := w.Walk(root, walker.Option{}, func(filePath string, _ os.FileInfo, _ analyzer.Opener) error {
-		if strings.HasSuffix(filePath, ".git/objects/abc123") {
-			assert.Fail(t, ".git/objects must be skipped", "got %s", filePath)
+		for _, d := range skippedDirs {
+			if strings.Contains(filePath, filepath.Join(".git", d)) {
+				assert.Failf(t, "skipped dir was walked", ".git/%s must be skipped, got: %s", d, filePath)
+			}
 		}
-		if strings.HasSuffix(filePath, ".git/config") {
+		if strings.HasSuffix(filePath, filepath.Join(".git", "config")) {
 			visitedConfig = true
+		}
+		if strings.HasSuffix(filePath, filepath.Join(".git", "credentials")) {
+			visitedCredentials = true
 		}
 		return nil
 	})
 	require.NoError(t, err)
 	assert.True(t, visitedConfig, ".git/config should be scanned")
+	assert.True(t, visitedCredentials, ".git/credentials should be scanned")
 }
 
 func TestFS_BuildSkipPaths(t *testing.T) {

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -89,6 +89,34 @@ func TestFS_Walk(t *testing.T) {
 	}
 }
 
+func TestFS_Walk_GitConfig(t *testing.T) {
+	// .git/config may contain credentials embedded in remote URLs and must be
+	// scanned. Heavy binary subdirectories (.git/objects, .git/lfs,
+	// .git/modules) must remain skipped for performance reasons.
+	// We create a temporary tree because git itself does not track nested .git
+	// directories inside a repository.
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git", "objects"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://user:token@github.com/org/repo.git\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "objects", "abc123"),
+		[]byte("binary content"), 0o644))
+
+	var visitedConfig bool
+	w := walker.NewFS()
+	err := w.Walk(root, walker.Option{}, func(filePath string, _ os.FileInfo, _ analyzer.Opener) error {
+		if strings.HasSuffix(filePath, ".git/objects/abc123") {
+			assert.Fail(t, ".git/objects must be skipped", "got %s", filePath)
+		}
+		if strings.HasSuffix(filePath, ".git/config") {
+			visitedConfig = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, visitedConfig, ".git/config should be scanned")
+}
+
 func TestFS_BuildSkipPaths(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -9,11 +9,17 @@ import (
 const defaultSizeThreshold = int64(100) << 20 // 200MB
 
 var defaultSkipDirs = []string{
-	// Skip heavy binary subdirectories of .git/ for performance, but allow
-	// .git/config to be scanned since it may contain credentials in remote URLs.
+	// Scan .git/ metadata (e.g. .git/config, .git/credentials) for secrets, but
+	// skip subdirectories that are either binary-heavy or high-volume with no
+	// secret value:
+	//   objects  – packed git object store; binary, can be very large
+	//   lfs      – Git LFS binary data
+	//   modules  – submodule checkouts
+	//   logs     – reflog entries; plaintext but high-volume and low-signal
 	"**/.git/objects",
 	"**/.git/lfs",
 	"**/.git/modules",
+	"**/.git/logs",
 	"proc",
 	"sys",
 	"dev",

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -9,7 +9,11 @@ import (
 const defaultSizeThreshold = int64(100) << 20 // 200MB
 
 var defaultSkipDirs = []string{
-	"**/.git",
+	// Skip heavy binary subdirectories of .git/ for performance, but allow
+	// .git/config to be scanned since it may contain credentials in remote URLs.
+	"**/.git/objects",
+	"**/.git/lfs",
+	"**/.git/modules",
 	"proc",
 	"sys",
 	"dev",


### PR DESCRIPTION
## Summary

Closes #6699

Trivy currently skips the entire `.git/` directory for performance reasons (`**/.git` in `defaultSkipDirs`). This also prevents the secret scanner from checking `.git/config`, which can contain credentials embedded in remote URLs, e.g.:

```
[remote "origin"]
    url = https://user:ghp_mytoken@github.com/org/repo.git
```

### Changes

- **`pkg/fanal/walker/walk.go`** – replaces the blanket `**/.git` skip with targeted skips for the three heavy/binary subdirectories that cause the performance concern:
  - `**/.git/objects` – packed git object store (binary, can be very large)
  - `**/.git/lfs` – Git LFS binary objects
  - `**/.git/modules` – submodule data

  Small text files such as `.git/config`, `.git/HEAD`, `.git/FETCH_HEAD`, etc. are now walked and passed to the analyzers/scanners.

- **`pkg/fanal/walker/fs_test.go`** – adds `TestFS_Walk_GitConfig` which builds a temporary directory tree containing `.git/config` and `.git/objects/abc123`, then asserts that `config` is visited and `objects/` is skipped.

> **Note:** the test uses `t.TempDir()` rather than static testdata because git itself ignores nested `.git` directories inside a repository.

## Test plan

- [x] `TestFS_Walk_GitConfig` – verifies `.git/config` is visited and `.git/objects` is skipped
- [ ] Run `go test ./pkg/fanal/walker/...` once local toolchain issues are resolved
