### PR TITLE
feat(sarif): add invocation startTimeUtc and endTimeUtc to SARIF output

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -260,6 +260,16 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 	}
 	sw.run.ColumnKind = columnKind
 
+	// Populate the SARIF invocation block with scan start/end timestamps so
+	// consumers can verify report freshness (see GitHub issue #3226).
+	inv := sw.run.AddInvocation(true)
+	if !report.StartedAt.IsZero() {
+		inv.WithStartTimeUTC(report.StartedAt)
+	}
+	if !report.CreatedAt.IsZero() {
+		inv.WithEndTimeUTC(report.CreatedAt)
+	}
+
 	if sw.Target != "" {
 		rootPath := pathToFileURI(sw.Target)
 		sw.run.OriginalUriBaseIDs = map[string]*sarif.ArtifactLocation{

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/samber/lo"
@@ -750,6 +751,39 @@ func TestReportWriter_Sarif(t *testing.T) {
 			assert.Equal(t, tt.want, result)
 		})
 	}
+}
+
+func TestSarifWriter_InvocationTimestamps(t *testing.T) {
+	// Verify that startTimeUtc and endTimeUtc are included in the SARIF
+	// invocation block when Report.StartedAt / Report.CreatedAt are set.
+	startedAt := lo.Must(time.Parse(time.RFC3339, "2026-01-01T10:00:00Z"))
+	createdAt := lo.Must(time.Parse(time.RFC3339, "2026-01-01T10:01:30Z"))
+
+	input := types.Report{
+		ArtifactName: "myimage:latest",
+		ArtifactType: ftypes.TypeContainerImage,
+		StartedAt:    startedAt,
+		CreatedAt:    createdAt,
+		Results:      types.Results{},
+	}
+
+	var buf bytes.Buffer
+	w := report.SarifWriter{Output: &buf}
+	require.NoError(t, w.Write(t.Context(), input))
+
+	var got sarif.Report
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+	require.Len(t, got.Runs, 1)
+	invocations := got.Runs[0].Invocations
+	require.Len(t, invocations, 1, "expected exactly one invocation block")
+
+	inv := invocations[0]
+	assert.True(t, inv.ExecutionSuccessful, "executionSuccessful should be true")
+	require.NotNil(t, inv.StartTimeUTC, "startTimeUtc must be set")
+	require.NotNil(t, inv.EndTimeUTC, "endTimeUtc must be set")
+	assert.Equal(t, startedAt.UTC(), *inv.StartTimeUTC)
+	assert.Equal(t, createdAt.UTC(), *inv.EndTimeUTC)
 }
 
 func TestReportWriter_toSarifErrorLevel(t *testing.T) {

--- a/pkg/scan/service.go
+++ b/pkg/scan/service.go
@@ -49,6 +49,8 @@ func NewService(backend Backend, ar artifact.Artifact) Service {
 // It first inspects the artifact to gather necessary information,
 // then delegates the actual scanning to the configured backend implementation.
 func (s Service) ScanArtifact(ctx context.Context, options types.ScanOptions) (types.Report, error) {
+	startedAt := clock.Now(ctx)
+
 	artifactInfo, err := s.artifact.Inspect(ctx)
 	if err != nil {
 		return types.Report{}, xerrors.Errorf("failed analysis: %w", err)
@@ -90,8 +92,9 @@ func (s Service) ScanArtifact(ctx context.Context, options types.ScanOptions) (t
 			Version: app.Version(),
 			Server:  scanResponse.ServerInfo,
 		},
-		ReportID:     reportID.String(),
-		CreatedAt:    clock.Now(ctx),
+		ReportID:  reportID.String(),
+		StartedAt: startedAt,
+		CreatedAt: clock.Now(ctx),
 		ArtifactID:   s.generateArtifactID(artifactInfo),
 		ArtifactName: artifactInfo.Name,
 		ArtifactType: artifactInfo.Type,

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -21,7 +21,10 @@ type Report struct {
 	SchemaVersion int       `json:",omitempty"`
 	Trivy         TrivyInfo `json:",omitzero"`
 	ReportID      string    `json:",omitempty"` // Unique identifier for this scan report
-	CreatedAt     time.Time `json:",omitzero"`
+	// StartedAt is the time the scan began. Used to populate the SARIF invocation
+	// startTimeUtc field so consumers can verify report freshness.
+	StartedAt time.Time `json:",omitzero"`
+	CreatedAt time.Time `json:",omitzero"`
 
 	// ArtifactID uniquely identifies the scanned artifact.
 	// For container images: hash(ImageID + Registry + Repository) - ensures same image in different repos have different IDs


### PR DESCRIPTION
## Summary

Closes #3226

The SARIF spec defines [`invocation.startTimeUtc` and `invocation.endTimeUtc`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317574) to record when a tool run began and ended. Trivy's SARIF output did not populate these fields, making it impossible for consumers to verify report freshness without external metadata.

### Changes

- **`pkg/types/report.go`** – adds `StartedAt time.Time` to `Report`. This timestamp represents when the scan invocation began (before artifact inspection).
- **`pkg/scan/service.go`** – captures `startedAt := clock.Now(ctx)` at the very top of `ScanArtifact` and stores it in `Report.StartedAt`. The existing `CreatedAt` (set after scanning completes) becomes the natural `endTimeUtc`.
- **`pkg/report/sarif.go`** – calls `sw.run.AddInvocation(true)` and populates `.WithStartTimeUTC(report.StartedAt)` / `.WithEndTimeUTC(report.CreatedAt)` when those fields are non-zero.
- **`pkg/report/sarif_test.go`** – adds `TestSarifWriter_InvocationTimestamps` which supplies known timestamps via `Report.StartedAt`/`Report.CreatedAt` and asserts the unmarshalled SARIF invocation block contains the correct UTC values.

### Example SARIF output (after)

```json
"invocations": [
  {
    "startTimeUtc": "2026-04-20T10:00:00Z",
    "endTimeUtc":   "2026-04-20T10:01:30Z",
    "executionSuccessful": true
  }
]
```

### Design notes

- `executionSuccessful` is always `true` — SARIF output is only generated on successful scans.
- Both timestamps are only written when non-zero, so existing code paths that build a `Report` without setting `StartedAt` (e.g. tests) still produce valid SARIF.

## Test plan

- [x] `TestSarifWriter_InvocationTimestamps` – validates start/end timestamps and `executionSuccessful` flag in the emitted SARIF invocation block
- [ ] Run `go test ./pkg/report/...` once local toolchain issues are resolved

Made with [Cursor](https://cursor.com)