### PR TITLE
module: pass size when freeing input buffer so WASM module frees the full allocation

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -461,7 +461,10 @@ func (m *wasmModule) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 	if err != nil {
 		return nil, xerrors.Errorf("failed to write string to memory: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) // nolint: errcheck
+	// free takes (ptr, size); passing only ptr leaks the buffer on the
+	// WASM side because the allocator can't match the free to the
+	// originating malloc (#10392).
+	defer m.free.Call(ctx, uint64(inputPtr), uint64(inputSize)) // nolint: errcheck
 
 	// 2. Call analyze
 	analyzeRes, err := m.analyze.Call(ctx, inputPtr, inputSize)
@@ -511,7 +514,10 @@ func (m *wasmModule) PostScan(ctx context.Context, results types.Results) (types
 	if err != nil {
 		return nil, xerrors.Errorf("post scan marshal error: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) //nolint: errcheck
+	// free takes (ptr, size); passing only ptr leaks the buffer on the
+	// WASM side because the allocator can't match the free to the
+	// originating malloc (#10392).
+	defer m.free.Call(ctx, uint64(inputPtr), uint64(inputSize)) //nolint: errcheck
 
 	analyzeRes, err := m.postScan.Call(ctx, inputPtr, inputSize)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #10392.

The WASM SDK's `free(ptr, size)` takes two arguments; passing only `ptr` leaves the allocator unable to match the free to the originating malloc, so the trailing bytes stay pinned and the WASM instance's memory pages accumulate across every `analyze` / `post_scan` call.

Every other call site routes through `freePtr`, which splits `ptrSize` and calls `free.Call(ctx, ptr, size)`. The two stragglers in `wasmModule.Analyze` (around line 464) and `wasmModule.PostScan` (around line 514) were the only spots still calling `free.Call(ctx, inputPtr)` with just the pointer.

## Fix

Pass `uint64(inputSize)` alongside `uint64(inputPtr)` on both defers. Matches the signature already used by `freePtr` and the `wasm-sdk` `free` export, so the WASM module now actually releases each analyze / post-scan input buffer.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go build ./pkg/module/...` clean
- [x] `GOEXPERIMENT=jsonv2 go vet ./pkg/module/...` clean
- The module unit tests require pre-built WASM modules (`mage test:generateModules` / `mage test:unit`); unaffected by this change and not runnable in a bare clone. Confirmed my diff does not touch any test assertion.
- [ ] Manual: run trivy against a workload exercising a WASM module analyzer/post-scan over many iterations; RSS should plateau instead of trending upward.
