### PR TITLE
chore(deps): bump masahiro331/go-vmdk-parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/masahiro331/go-ebs-file v0.0.0-20240917043618-e6d2bea5c32e
 	github.com/masahiro331/go-ext4-filesystem v0.0.0-20240620024024-ca14e6327bbd
 	github.com/masahiro331/go-mvn-version v0.0.0-20250131095131-f4974fa13b8a
-	github.com/masahiro331/go-vmdk-parser v0.0.0-20221225061455-612096e4bbbd
+	github.com/masahiro331/go-vmdk-parser v0.0.0-20260422020701-a12df6824e31
 	github.com/masahiro331/go-xfs-filesystem v0.0.0-20231205045356-1b22259a6c44
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/masahiro331/go-ext4-filesystem v0.0.0-20240620024024-ca14e6327bbd h1:
 github.com/masahiro331/go-ext4-filesystem v0.0.0-20240620024024-ca14e6327bbd/go.mod h1:3XMMY1M486mWGTD13WPItg6FsgflQR72ZMAkd+gsyoQ=
 github.com/masahiro331/go-mvn-version v0.0.0-20250131095131-f4974fa13b8a h1:eLvAzVoRfHEOl64OxFhepPf3vj7SKvXY/tFc3BS0b7s=
 github.com/masahiro331/go-mvn-version v0.0.0-20250131095131-f4974fa13b8a/go.mod h1:jZ3F25l7DbD7l7DcA8aj7eo1EZ84nbzcQHBB4lCSrI8=
-github.com/masahiro331/go-vmdk-parser v0.0.0-20221225061455-612096e4bbbd h1:Y30EzvuoVp97b0unb/GOFXzBUKRXZXUN2e0wYmvC+ic=
-github.com/masahiro331/go-vmdk-parser v0.0.0-20221225061455-612096e4bbbd/go.mod h1:5f7mCJGW9cJb8SDn3z8qodGxpMCOo8d/2nls/tiwRrw=
+github.com/masahiro331/go-vmdk-parser v0.0.0-20260422020701-a12df6824e31 h1:Bicc7368sOIu9Rx4QmnuxwfwbIaIU68RNJnAxhoILA0=
+github.com/masahiro331/go-vmdk-parser v0.0.0-20260422020701-a12df6824e31/go.mod h1:5f7mCJGW9cJb8SDn3z8qodGxpMCOo8d/2nls/tiwRrw=
 github.com/masahiro331/go-xfs-filesystem v0.0.0-20231205045356-1b22259a6c44 h1:VmSjn0UCyfXUNdePDr7uM/uZTnGSp+mKD5+cYkEoLx4=
 github.com/masahiro331/go-xfs-filesystem v0.0.0-20231205045356-1b22259a6c44/go.mod h1:QKBZqdn6teT0LK3QhAf3K6xakItd1LonOShOEC44idQ=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/fanal/artifact/vm/vm_test.go
+++ b/pkg/fanal/artifact/vm/vm_test.go
@@ -76,11 +76,9 @@ func TestNewArtifact(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
-			name:   "sad path unsupported vm format",
-			target: "testdata/monolithicSparse.vmdk",
-			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
-				return assert.ErrorContains(t, err, "unsupported type error")
-			},
+			name:    "happy path for monolithic-sparse",
+			target:  "testdata/monolithicSparse.vmdk",
+			wantErr: assert.NoError,
 		},
 		{
 			name:   "sad path file not found",


### PR DESCRIPTION
## Description

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/10323

Changes: https://github.com/masahiro331/go-vmdk-parser/compare/612096e4bbbd...HEAD

MonolithicSparse support was added in [a12df68](https://github.com/masahiro331/go-vmdk-parser/commit/a12df6824e31e824cbbefd7647fa8178d2dae953) and should be mentioned in the release notes."

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
