### PR TITLE
docs(nodejs): clarify package.json behavior in image scanning

### DIFF
--- a/docs/guide/coverage/language/nodejs.md
+++ b/docs/guide/coverage/language/nodejs.md
@@ -89,7 +89,11 @@ Trivy parses the manifest files of installed packages in container image scannin
 
 ### package.json
 Trivy searches for `package.json` files under `node_modules` and identifies installed packages.
-It only extracts package names, versions and licenses for those packages.
+It only extracts package names, versions and licenses for those packages; the `dependencies` field is not analyzed.
+
+!!! note
+    To detect vulnerabilities in Node.js dependencies within a container image, ensure that `node_modules` is present in the image,
+    or use a lock file (`package-lock.json`, `yarn.lock`, etc.) with filesystem scanning.
 
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
 [pnpm-lockfile-v6]: https://github.com/pnpm/spec/blob/fd3238639af86c09b7032cc942bab3438b497036/lockfile/6.0.md


### PR DESCRIPTION
## Description

The coverage table shows `package.json` as supported for `image/rootfs `targets, which led users to expect declared `dependencies` to be scanned for vulnerabilities. Clarify that only `name/version/license` are extracted from `node_modules/*/package.json`, and that the `dependencies` field is not analyzed.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
