### PR TITLE
fix(misconf): make ignore rule ID matching case-insensitive

### DIFF
--- a/pkg/iac/ignore/rule.go
+++ b/pkg/iac/ignore/rule.go
@@ -103,8 +103,9 @@ func defaultIgnorers(ids []string) map[string]Ignorer {
 				return true
 			}
 
+			lowerID := strings.ToLower(id)
 			return slices.ContainsFunc(ids, func(s string) bool {
-				return MatchPattern(s, id)
+				return MatchPattern(strings.ToLower(s), lowerID)
 			})
 		},
 		"exp": func(_ types.Metadata, param any) bool {

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -362,6 +362,12 @@ resource "aws_s3_bucket" "test" {}`,
 			assertLength: 0,
 		},
 		{
+			name: "ignore by alias is case-insensitive",
+			source: `#%s:ignore:MY-ALIAS
+resource "aws_s3_bucket" "test" {}`,
+			assertLength: 0,
+		},
+		{
 			name: "ignore for implied IAM resource",
 			source: `# %s:ignore:aws-iam-enforce-mfa
 resource "aws_iam_group" "this" {


### PR DESCRIPTION
After AVDIDs were stored in aliases, ignore directives that referenced aliases became case-sensitive. This broke backwards compatibility:

  # trivy:ignore:AVD-AWS-0053  // succeeds
  # trivy:ignore:avd-aws-0053  // fails

Lowercase both sides of the comparison in defaultIgnorers so any identifier (ID, AVDID, alias, short code) matches regardless of case.

Closes #10374

## Description

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
