### PR TITLE
ci: remove secrets from run block

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -34,9 +34,10 @@ jobs:
       - name: Release Please
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
+          TRIVY_REPO_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
         run: |
           release-please release-pr --repo-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-            --token="${{ secrets.TRIVY_REPO_TOKEN }}" \
+            --token="$TRIVY_REPO_TOKEN" \
             --release-as="$RELEASE_VERSION" \
             --target-branch="$GITHUB_REF_NAME"
 


### PR DESCRIPTION
## Description

Move `TRIVY_REPO_TOKEN` from an inline `${{ secrets.TRIVY_REPO_TOKEN }}` expression inside the `run` block to the step-level `env` map, referencing it as `$TRIVY_REPO_TOKEN`.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
