### PR TITLE
fix(helm): skip large files in helm chart archives

### DIFF
--- a/pkg/iac/scanners/helm/parser/parser_tar.go
+++ b/pkg/iac/scanners/helm/parser/parser_tar.go
@@ -11,10 +11,11 @@ import (
 	"path"
 	"path/filepath"
 
+	"helm.sh/helm/v3/pkg/chart/loader"
+
 	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
-	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 var errSkipFS = errors.New("skip parse FS")

--- a/pkg/iac/scanners/helm/parser/parser_tar.go
+++ b/pkg/iac/scanners/helm/parser/parser_tar.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/detection"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/mapfs"
+	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 var errSkipFS = errors.New("skip parse FS")
@@ -71,7 +72,12 @@ func (p *Parser) unpackArchive(srcFS fs.FS, targetFS *mapfs.FS, archivePath stri
 				return err
 			}
 		case tar.TypeReg:
-			data, err := io.ReadAll(tr)
+			if header.Size > loader.MaxDecompressedFileSize {
+				p.logger.Warn("Skipping large file in chart archive",
+					log.FilePath(targetPath), log.Int64("size", header.Size))
+				continue
+			}
+			data, err := io.ReadAll(io.LimitReader(tr, loader.MaxDecompressedFileSize))
 			if err != nil {
 				return fmt.Errorf("read file: %w", err)
 			}


### PR DESCRIPTION
## Description
This PR adds skipping large files inside Helm archives, and logs a warning.

Before:
```sh
% docker run -it --rm -v ~/arch/:/arch aquasec/trivy:0.70.0 config /arch
2026-04-30T05:15:11Z	INFO	[misconfig] Misconfiguration scanning is enabled
2026-04-30T05:15:11Z	INFO	[checks-client] Need to update the checks bundle
2026-04-30T05:15:11Z	INFO	[checks-client] Downloading the checks bundle...
234.65 KiB / 234.65 KiB [------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 1.04 MiB p/s 400ms
%
```
After:
```sh
2026-04-30T11:17:36+06:00	INFO	[misconfig] Misconfiguration scanning is enabled
2026-04-30T11:17:36+06:00	INFO	[checks-client] Using existing checks from cache	path="~/Library/Caches/trivy/policy/content"
2026-04-30T11:17:37+06:00	WARN	[helm parser] Skipping large file in chart archive	file_path="evil-chart/templates/bigfile.yaml" size=524288206
2026-04-30T11:17:37+06:00	INFO	Detected config files	num=3
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
