### PR TITLE
ci: remove injection risk in goreleaser action

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -103,12 +103,19 @@ jobs:
         run: |
           mkdir tmp    
 
+      - name: Build GoReleaser args
+        id: goreleaser-args
+        run: echo "args=-f=${GORELEASER_CONFIG} ${GORELEASER_OPTIONS}" >> "$GITHUB_OUTPUT"
+        env:
+          GORELEASER_CONFIG: ${{ inputs.goreleaser_config }}
+          GORELEASER_OPTIONS: ${{ inputs.goreleaser_options }}
+
       - name: GoReleaser
         id: goreleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.1.0
-          args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
+          args: release ${{ steps.goreleaser-args.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Description
`goreleaser_options` was interpolated directly into the `args` string  passed to `goreleaser-action`. Since the action executes `args` in a shell, a crafted input value could inject arbitrary shell commands.

Now it doesn’t contain an issue, because all args are hard-coded in release.yaml and canary.yaml. but if we add workflow_dispatch it will bring risk.

We already use the similar way:
https://github.com/aquasecurity/trivy/blob/fb6a83a55ff2adf62aa8b7c915572596cdb54c4d/.github/workflows/test.yaml#L244-L260


## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
