### PR TITLE
fix(nodejs): silently skip package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,7 +45,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, nil
 	}
 
 	var id string


### PR DESCRIPTION
Fixes #10607

When a package.json has a name with URL-unfriendly characters (e.g., subpath files like `node_modules/rxjs/ajax/package.json`), the parser currently returns an error, causing misleading DEBUG warnings during scanning.

**Fix:** Return an empty `Package{}` instead of an error when `IsValidName()` returns false. The caller already skips packages with empty ID, so this is a clean no-op for invalid names.

**Change:** 1 line in `pkg/dependency/parser/nodejs/packagejson/parse.go`