### PR TITLE
fix(misconf): match alias-style ignore IDs case-insensitively (#10374)

### DIFF
--- a/pkg/iac/scan/result.go
+++ b/pkg/iac/scan/result.go
@@ -276,7 +276,14 @@ func (r *Results) Ignore(ignoreRules ignore.Rules, ignores map[string]ignore.Ign
 			strings.ToLower(result.Rule().AVDID),
 			result.Rule().ShortCode,
 		}
-		allIDs = append(allIDs, result.Rule().Aliases...)
+		// Aliases need a case-insensitive companion entry too — the
+		// same rule applied to ID / AVDID just above. Without this,
+		// `# trivy:ignore:avd-aws-0053` (lowercase) misses the
+		// `AVD-AWS-0053` alias that the new alias-based AVDID storage
+		// puts in the rule. See issue #10374.
+		for _, a := range result.Rule().Aliases {
+			allIDs = append(allIDs, a, strings.ToLower(a))
+		}
 
 		if ignoreRules.Ignore(result.Metadata(), allIDs, ignores) {
 			(*r)[i].OverrideStatus(StatusIgnored)

--- a/pkg/iac/scanners/terraform/ignore_test.go
+++ b/pkg/iac/scanners/terraform/ignore_test.go
@@ -590,6 +590,43 @@ resource "aws_s3_bucket" "test" {}
 	testutil.AssertRuleNotFailed(t, "aws-s3-non-empty-bucket", results, "")
 }
 
+// Regression test for issue #10374: when an alias-style identifier is the
+// only place an AVD ID lives (i.e. the rule's avd_id field stays empty and
+// the AVD identifier is exposed via the aliases list instead), the inline
+// ignore comment should still match it case-insensitively — the same way
+// `trivy:ignore:` already matches against ID / AVDID case-insensitively.
+func Test_IgnoreByLowercaseAlias(t *testing.T) {
+	check := `# METADATA
+# custom:
+#   id: TEST-0123
+#   short_code: non-empty-bucket
+#   provider: aws
+#   service: s3
+#   aliases:
+#     - AVD-TEST-0123
+package user.test123
+
+import rego.v1
+
+
+deny contains res if {
+  some bucket in input.aws.s3.buckets
+  bucket.name.value == ""
+  res := result.new("The bucket name cannot be empty.", bucket.name)
+}`
+
+	src := `
+# trivy:ignore:avd-test-0123
+resource "aws_s3_bucket" "test" {}
+`
+
+	results := scanHCL(t, src,
+		rego.WithPolicyReader(strings.NewReader(check)),
+		rego.WithPolicyNamespaces("user"),
+	)
+	testutil.AssertRuleNotFailed(t, "aws-s3-non-empty-bucket", results, "")
+}
+
 func Test_IgnoreInlineByAllIDs(t *testing.T) {
 	testCases := []struct {
 		input string


### PR DESCRIPTION
Closes #10374.

## Background

Inline check IDs in trivy are matched case-insensitively for `ID` and `AVDID`:

```
# trivy:ignore:AWS-0053   ← works
# trivy:ignore:aws-0053   ← also works
```

The recent change that exposes AVD identifiers via the rule's `Aliases` list (rather than the dedicated `AVDID` field) regressed the second form for any rule whose AVD identifier now lives in `Aliases`:

```
# trivy:ignore:AVD-AWS-0053   ← still works (verbatim alias match)
# trivy:ignore:avd-aws-0053   ← regressed (alias matched case-sensitive)
```

The regression was reported via #10246's discussion thread.

## Root cause

`pkg/iac/scan/result.go:270-279` builds the candidate identifier list passed into `ignoreRules.Ignore()`:

```go
allIDs := []string{
    result.Rule().ID,
    strings.ToLower(result.Rule().ID),    // ← lowercase variant
    result.Rule().CanonicalID(),
    result.Rule().AVDID,
    strings.ToLower(result.Rule().AVDID), // ← lowercase variant
    result.Rule().ShortCode,
}
allIDs = append(allIDs, result.Rule().Aliases...)  // ← raw, no lowercase variant
```

`ID` and `AVDID` each get a paired `strings.ToLower(...)` companion, but appended aliases are added verbatim — so a lowercased AVD ID typed by the user fails the `slices.Contains` membership check.

## Fix

Append `(alias, lowercase(alias))` for each alias instead of just `alias`. Restores the case-insensitive contract for all four identifier surfaces.

## Test

Added `Test_IgnoreByLowercaseAlias` next to the existing `Test_IgnoreByAVDID` in `pkg/iac/scanners/terraform/ignore_test.go`. Same shape, but the AVD identifier lives in the rego metadata's `aliases:` list (matching the new alias-based storage) instead of the deprecated `avd_id:` field, and the inline ignore comment is the lowercase form.

```
$ go test ./pkg/iac/scanners/terraform/ -run "Test_IgnoreByLowercaseAlias"

# without this patch:
--- FAIL: Test_IgnoreByLowercaseAlias (0.75s)
    util.go:41: Should be false
    util.go:46: Should be true

# with this patch:
--- PASS: Test_IgnoreByLowercaseAlias (0.17s)
PASS
```

The existing `Test_IgnoreByAVDID` and `Test_IgnoreInlineByAllIDs` (8 sub-cases) all continue to pass.

## Notes

- Diff is `+45 / -1` lines across two files (one-line plus comment in result.go, plus the new test).
- No public API change.
- The fix only touches the candidate-ID construction, not the matcher itself, so the case-insensitive behaviour is consistent across every code path that goes through `ignoreRules.Ignore()`.
