### PR TITLE
feat(ignore): make id optional in .trivyignore.yaml entries (#10583)

### DIFF
--- a/docs/guide/configuration/filtering.md
+++ b/docs/guide/configuration/filtering.md
@@ -343,11 +343,28 @@ Available fields:
 
 | Field      | Required | Type                | Description                                                                                                                                                             |
 |------------|:--------:|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id         |    ✓     | string              | The identifier of the vulnerability, misconfiguration, secret, or license[^1].                                                                                          |
+| id         |          | string              | The identifier of the vulnerability, misconfiguration, secret, or license[^1]. When omitted, every finding that satisfies the remaining filters is ignored. At least one of `id`, `paths` or `purls` must be set. |
 | paths[^2]  |          | string array        | The list of file paths to ignore. If `paths` is not set, the ignore finding is applied to all files.                                                                    |
 | purls      |          | string array        | The list of PURLs to ignore packages. If `purls` is not set, the ignore finding is applied to all packages. This field is currently available only for vulnerabilities. |
 | expired_at |          | date (`yyyy-mm-dd`) | The expiration date of the ignore finding. If `expired_at` is not set, the ignore finding is always valid.                                                              |
 | statement  |          | string              | The reason for ignoring the finding. (This field is not used for filtering.)                                                                                            |
+
+!!! tip "Ignore every finding for a package or path"
+    Omit `id` to ignore every finding that matches the remaining filters. This is useful for noisy dependencies that ship with hundreds of advisories (for example kernel headers like `linux-libc-dev`):
+
+    ```yaml
+    vulnerabilities:
+      - purls:
+          - "pkg:deb/ubuntu/linux-libc-dev"
+        statement: Kernel headers, not exercised at runtime
+
+    misconfigurations:
+      - paths:
+          - "test/fixtures/**"
+        statement: Test fixtures, safe to ignore
+    ```
+
+    Trivy rejects entries with `id`, `paths` and `purls` all empty so an accidental no-op cannot silently disable scanning.
 
 ```bash
 $ cat .trivyignore.yaml

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -26,7 +26,10 @@ import (
 type IgnoreFinding struct {
 	// ID is the identifier of the vulnerability, misconfiguration, secret, or license.
 	// e.g. CVE-2019-8331, AVD-AWS-0175, etc.
-	// required: true
+	// When ID is empty, the entry matches any finding that satisfies the remaining
+	// filters (paths and/or purls). At least one of id, paths or purls must be set;
+	// an entry with all three empty is rejected to avoid silently ignoring everything.
+	// required: false
 	ID string `yaml:"id"`
 
 	// Paths is the list of file paths to ignore.
@@ -80,6 +83,10 @@ func (i *IgnoreFinding) UnmarshalYAML(value *yaml.Node) error {
 		i.PURLs = append(i.PURLs, parsedPURL)
 	}
 
+	if i.ID == "" && len(i.Paths) == 0 && len(tmp.PURLs) == 0 {
+		return xerrors.New("ignore file entry must specify at least one of id, paths or purls")
+	}
+
 	return nil
 }
 
@@ -87,7 +94,9 @@ type IgnoreFindings []IgnoreFinding
 
 func (f *IgnoreFindings) Match(id, path string, pkg *packageurl.PackageURL) *IgnoreFinding {
 	for _, finding := range *f {
-		if id != finding.ID {
+		// An empty finding.ID acts as a wildcard so users can ignore every finding
+		// that matches the remaining filters (paths and/or purls).
+		if finding.ID != "" && id != finding.ID {
 			continue
 		}
 		if !matchPath(path, finding.Paths) || !matchPURL(pkg, finding.PURLs) {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/purl"
 )
 
 func TestParseIgnoreFile(t *testing.T) {
@@ -72,4 +75,107 @@ func TestParseIgnoreFile(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+	t.Run("happy path id-optional yaml", func(t *testing.T) {
+		got, err := ParseIgnoreFile(t.Context(), "testdata/.trivyignore-id-optional.yaml")
+		require.NoError(t, err)
+		assert.Len(t, got.Vulnerabilities, 3)
+		assert.Len(t, got.Misconfigurations, 1)
+		assert.Len(t, got.Secrets, 1)
+
+		// First vuln entry: id empty, purls only — matches every finding for the purl.
+		entry := got.Vulnerabilities[0]
+		assert.Empty(t, entry.ID)
+		require.Len(t, entry.PURLs, 1)
+	})
+
+	t.Run("entry with no id paths or purls is rejected", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "TestParseIgnoreFile-empty-entry-*.yaml")
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = f.WriteString("vulnerabilities:\n  - statement: matches everything\n")
+		require.NoError(t, err)
+
+		_, err = ParseIgnoreFile(t.Context(), f.Name())
+		require.ErrorContains(t, err, "must specify at least one of id, paths or purls")
+	})
+}
+
+func TestIgnoreFindings_Match_IDOptional(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings IgnoreFindings
+		id       string
+		path     string
+		pkg      *packageurl.PackageURL
+		matched  bool
+	}{
+		{
+			name: "empty id with matching purl ignores any finding for the package",
+			findings: IgnoreFindings{
+				{
+					PURLs: mustPackageURLs(t, "pkg:deb/ubuntu/linux-libc-dev"),
+				},
+			},
+			id:      "CVE-2024-1111",
+			pkg:     &packageurl.PackageURL{Type: "deb", Namespace: "ubuntu", Name: "linux-libc-dev"},
+			matched: true,
+		},
+		{
+			name: "empty id with matching purl skips findings on other packages",
+			findings: IgnoreFindings{
+				{
+					PURLs: mustPackageURLs(t, "pkg:deb/ubuntu/linux-libc-dev"),
+				},
+			},
+			id:      "CVE-2024-1111",
+			pkg:     &packageurl.PackageURL{Type: "deb", Namespace: "ubuntu", Name: "openssl"},
+			matched: false,
+		},
+		{
+			name: "empty id with matching path ignores any finding under that path",
+			findings: IgnoreFindings{
+				{
+					Paths: []string{"vendor/**"},
+				},
+			},
+			id:      "AVD-AWS-0175",
+			path:    "vendor/foo/bar.tf",
+			matched: true,
+		},
+		{
+			name: "non-empty id still requires id equality",
+			findings: IgnoreFindings{
+				{
+					ID:    "CVE-2024-1111",
+					Paths: []string{"vendor/**"},
+				},
+			},
+			id:      "CVE-2024-9999",
+			path:    "vendor/foo/bar.tf",
+			matched: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.findings.Match(tc.id, tc.path, tc.pkg)
+			if tc.matched {
+				require.NotNil(t, got)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func mustPackageURLs(t *testing.T, raws ...string) []*purl.PackageURL {
+	t.Helper()
+	out := make([]*purl.PackageURL, 0, len(raws))
+	for _, raw := range raws {
+		p, err := purl.FromString(raw)
+		require.NoError(t, err)
+		out = append(out, p)
+	}
+	return out
 }

--- a/pkg/result/testdata/.trivyignore-id-optional.yaml
+++ b/pkg/result/testdata/.trivyignore-id-optional.yaml
@@ -1,0 +1,19 @@
+vulnerabilities:
+  - purls:
+      - "pkg:deb/ubuntu/linux-libc-dev"
+    statement: Kernel headers, not exercised at runtime
+  - paths:
+      - "vendor/**"
+    statement: Vendored, not in scope
+  - id: CVE-2024-9999
+    purls:
+      - "pkg:golang/example.com/foo"
+
+misconfigurations:
+  - paths:
+      - "test/fixtures/**"
+    statement: Test fixtures, safe to ignore
+
+secrets:
+  - paths:
+      - "tests/**"


### PR DESCRIPTION
## Description

Closes #10583.

`.trivyignore.yaml` currently requires `id` and matches it strictly against `finding.ID`, which means users have to enumerate every CVE on a noisy package (the issue calls out `linux-libc-dev` with 500+ advisories). The `purls:` and `paths:` fields can only narrow the scope of an already-matched ID, never widen it.

This PR adds the workaround proposed in the issue: when `id` is empty, the entry matches any finding that satisfies the remaining filters.

```yaml
vulnerabilities:
  - purls:
      - \"pkg:deb/ubuntu/linux-libc-dev\"
    statement: Kernel headers, not exercised at runtime

misconfigurations:
  - paths:
      - \"test/fixtures/**\"
    statement: Test fixtures, safe to ignore
```

## Behavior

- `Match()` now treats an empty `finding.ID` as a wildcard, so the entry only has to satisfy `matchPath` + `matchPURL`.
- An entry where `id`, `paths` and `purls` are all empty is rejected at parse time (`UnmarshalYAML` returns an error). This avoids the worst footgun: a typo silently disabling scanning. The error message names all three fields.
- Existing entries with a non-empty `id` continue to require strict equality, so this is fully backwards-compatible.

## Tests

`pkg/result/ignore_test.go`:

- `TestParseIgnoreFile/happy_path_id-optional_yaml` — parses a fixture covering id-less vuln+misconfig+secret entries.
- `TestParseIgnoreFile/entry_with_no_id_paths_or_purls_is_rejected` — guards the new validation.
- `TestIgnoreFindings_Match_IDOptional` — 4 sub-tests for the new wildcard behavior:
  - empty id + matching purl ignores any finding for the package
  - empty id + matching purl skips findings on other packages
  - empty id + matching path ignores any finding under that path
  - non-empty id still requires id equality (regression guard)

```
=== RUN   TestParseIgnoreFile
--- PASS: TestParseIgnoreFile (0.00s)
=== RUN   TestIgnoreFindings_Match_IDOptional
--- PASS: TestIgnoreFindings_Match_IDOptional (0.00s)
ok  	github.com/aquasecurity/trivy/pkg/result	0.062s
```

`TestFilter/ignore_findings_by_type_in_policy_file` fails on this branch but the same test also fails on a clean checkout of `upstream/main` (unrelated to this PR).

## Docs

`docs/guide/configuration/filtering.md` updated:
- `id` is now marked non-required.
- New tip block shows the id-less syntax for vulnerabilities and misconfigurations.