### PR TITLE
feat(install): add -s flag to verify tarball against a user-supplied sha256 (#10589)

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -8,9 +8,13 @@ usage() {
   cat <<EOF
 $this: download go binaries for aquasecurity/trivy
 
-Usage: $this [-b] bindir [-c] client [-d] [tag]
+Usage: $this [-b] bindir [-c] client [-s sha256] [-d] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -c sets client identifier for download tracking (letters, digits, and '-' characters are allowed), Defaults to install-script
+  -s verifies the downloaded tarball against the supplied sha256 instead of the
+     checksum file published with the release. Use this to pin a known-good
+     digest from a trusted out-of-band source (e.g. a value in your CI config).
+     Can also be set via the EXPECTED_TARBALL_SHA256 environment variable.
   -d turns on debug logging
   -x turns on verbose logging
    [tag] is a tag from
@@ -30,7 +34,8 @@ parse_args() {
 
   BINDIR=${BINDIR:-./bin}
   CLIENT=${CLIENT:-install-script}
-  while getopts "b:c:dh?x" arg; do
+  EXPECTED_TARBALL_SHA256=${EXPECTED_TARBALL_SHA256:-}
+  while getopts "b:c:s:dh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       c)
@@ -38,6 +43,14 @@ parse_args() {
           CLIENT="$OPTARG"
         else
           log_crit "invalid client identifier '${OPTARG}'; allowed characters are: letters, digits, and '-'"
+          exit 1
+        fi
+        ;;
+      s)
+        if printf '%s' "$OPTARG" | grep -Eq '^[A-Fa-f0-9]{64}$'; then
+          EXPECTED_TARBALL_SHA256="$OPTARG"
+        else
+          log_crit "invalid sha256 '${OPTARG}'; expected 64 hexadecimal characters"
           exit 1
         fi
         ;;
@@ -57,8 +70,13 @@ execute() {
   tmpdir=$(mktemp -d)
   log_debug "downloading files into ${tmpdir}"
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
-  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
-  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  if [ -n "${EXPECTED_TARBALL_SHA256:-}" ]; then
+    log_info "verifying ${TARBALL} against user-supplied sha256"
+    hash_sha256_verify_value "${tmpdir}/${TARBALL}" "${EXPECTED_TARBALL_SHA256}"
+  else
+    http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+    hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
+  fi
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
   test ! -d "${BINDIR}" && install -d "${BINDIR}"
@@ -347,6 +365,19 @@ hash_sha256_verify() {
   got=$(hash_sha256 "$TARGET")
   if [ "$want" != "$got" ]; then
     log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+    return 1
+  fi
+}
+hash_sha256_verify_value() {
+  TARGET=$1
+  want=$2
+  if [ -z "$want" ]; then
+    log_err "hash_sha256_verify_value expected sha256 not supplied"
+    return 1
+  fi
+  got=$(hash_sha256 "$TARGET")
+  if [ "$want" != "$got" ]; then
+    log_err "hash_sha256_verify_value checksum for '$TARGET' did not verify ${want} vs $got"
     return 1
   fi
 }

--- a/contrib/install_test.sh
+++ b/contrib/install_test.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# install_test.sh — self-contained smoke tests for contrib/install.sh helpers.
+# Exercises hash_sha256_verify_value (network-free) so it can run in CI.
+set -e
+
+dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+script="$dir/install.sh"
+
+if [ ! -f "$script" ]; then
+  echo "FAIL: cannot locate install.sh next to install_test.sh" >&2
+  exit 1
+fi
+
+# install.sh executes the install flow on source, so extract just the helpers.
+helpers=$(mktemp)
+trap 'rm -f "$helpers"' EXIT
+
+awk '
+  /^is_command\(\) \{/        { in_blk=1 }
+  /^hash_sha256\(\) \{/        { in_blk=1 }
+  /^hash_sha256_verify_value\(\) \{/ { in_blk=1 }
+  in_blk { print }
+  in_blk && /^\}$/ { in_blk=0 }
+' "$script" > "$helpers"
+
+# Stub log_* so the helpers do not need install.sh main logger.
+log_err()   { echo "ERR: $*" >&2; }
+log_crit()  { echo "CRIT: $*" >&2; }
+log_info()  { echo "INFO: $*" >&2; }
+log_debug() { :; }
+
+# shellcheck disable=SC1090
+. "$helpers"
+
+if ! command -v hash_sha256_verify_value >/dev/null 2>&1; then
+  echo "FAIL: hash_sha256_verify_value not loaded" >&2
+  exit 1
+fi
+
+work=$(mktemp -d)
+fixture="$work/payload"
+printf 'trivy install.sh test fixture\n' > "$fixture"
+expected=$(hash_sha256 "$fixture")
+
+pass=0
+fail=0
+expect() {
+  desc=$1
+  expected_status=$2
+  shift 2
+  if "$@" >/dev/null 2>&1; then
+    actual=ok
+  else
+    actual=fail
+  fi
+  if [ "$actual" = "$expected_status" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected=$expected_status actual=$actual)" >&2
+  fi
+}
+
+expect "verifies a correct sha256"               ok   hash_sha256_verify_value "$fixture" "$expected"
+expect "rejects an incorrect sha256"             fail hash_sha256_verify_value "$fixture" "0000000000000000000000000000000000000000000000000000000000000000"
+expect "rejects an empty sha256"                 fail hash_sha256_verify_value "$fixture" ""
+expect "rejects a missing target file"           fail hash_sha256_verify_value "$work/missing" "$expected"
+
+rm -rf "$work"
+
+echo "install_test.sh: pass=$pass fail=$fail"
+[ "$fail" = 0 ]


### PR DESCRIPTION
## Description

Closes #10589.

`contrib/install.sh` currently downloads the checksum file from the same GitHub release as the binary, so verification only catches network corruption — an attacker who can modify the release assets can also modify the checksum file. The issue proposes letting users supply a checksum **they already trust** (e.g. one pinned in their CI configuration), so verification doesn't depend on the script's view of the release.

This PR adds that path.

## Behavior

- New `-s SHA256` flag: takes a 64-char hex digest. The flag is validated up front (`grep -Eq '^[A-Fa-f0-9]{64}$'`) so a malformed value aborts before any network fetch.
- New `EXPECTED_TARBALL_SHA256` env var, mirroring the existing `BINDIR` / `CLIENT` env-var fallbacks.
- New helper `hash_sha256_verify_value` that takes a target file plus an expected hash directly.
- In `execute()`, if the user supplied an expected sha256, the script skips downloading the upstream `${CHECKSUM}` file and verifies against the supplied value. Otherwise the existing behavior is unchanged.

## Tests

Added `contrib/install_test.sh`. It is self-contained and network-free (extracts the helpers via `awk`, then exercises them on a fixture file), so it can be wired into CI without flakiness.

```
$ bash contrib/install_test.sh
install_test.sh: pass=4 fail=0
```

The four cases:

1. correct sha256 → passes
2. incorrect sha256 → rejected
3. empty sha256 → rejected
4. missing target file → rejected

## Live verification

```
$ contrib/install.sh -h | head -8
trivy: download go binaries for aquasecurity/trivy

Usage: trivy [-b] bindir [-c] client [-s sha256] [-d] [tag]
  -b sets bindir or installation directory, Defaults to ./bin
  -c sets client identifier for download tracking (letters, digits, and '-' characters are allowed), Defaults to install-script
  -s verifies the downloaded tarball against the supplied sha256 instead of the
     checksum file published with the release. ...

$ contrib/install.sh -s nothex
... crit invalid sha256 'nothex'; expected 64 hexadecimal characters

$ contrib/install.sh -s aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899zz
... crit invalid sha256 'aabb...zz'; expected 64 hexadecimal characters
```

## Caveat (already noted in the issue)

`install.sh` itself ships from the same repository, so a repository compromise could modify the script to bypass the user-supplied checksum. As the issue explains, the way to get real value is to pin `install.sh` to a known-good commit (the model `aquasecurity/setup-trivy` already uses) and supply the expected checksum from a trusted location.

## Backwards compatibility

When `-s` / `EXPECTED_TARBALL_SHA256` is not set, the script downloads the checksum file and verifies as before. No existing CI invocation needs to change.