### PR TITLE
feat(secret): support new stateless format for GitHub App installation tokens (#10591)

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -137,11 +137,19 @@ var builtinRules = []Rule{
 		Keywords:        []string{"gho_"},
 	},
 	{
+		// `ghu_` user-to-server tokens stay strictly 36 characters, but
+		// starting 2026-04-27 GitHub rolled out a new stateless format for
+		// `ghs_` installation tokens shaped `ghs_<APPID>_<JWT>` (~520 chars
+		// average, with an internal `_` separator). Keep ghu_ strict and
+		// broaden ghs_ to accept the new variable-length form so we don't
+		// silently miss every installation token minted after the cutover.
+		// See https://github.com/aquasecurity/trivy/issues/10591 and
+		// https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/.
 		ID:              "github-app-token",
 		Category:        CategoryGitHub,
 		Title:           "GitHub App Token",
 		Severity:        "CRITICAL",
-		Regex:           MustCompileWithoutWordPrefix(`?P<secret>(ghu|ghs)_[0-9a-zA-Z]{36}`),
+		Regex:           MustCompileWithoutWordPrefix(`?P<secret>(?:ghu_[0-9a-zA-Z]{36}|ghs_[0-9a-zA-Z_]{36,})`),
 		SecretGroupName: "secret",
 		Keywords:        []string{"ghu_", "ghs_"},
 	},

--- a/pkg/fanal/secret/builtin_rules_test.go
+++ b/pkg/fanal/secret/builtin_rules_test.go
@@ -1,0 +1,88 @@
+package secret_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/secret"
+)
+
+// TestGitHubAppToken_BothFormats pins the regex update added in
+// https://github.com/aquasecurity/trivy/issues/10591. GitHub started rolling
+// out a new stateless `ghs_` installation token format on 2026-04-27 (~520
+// chars, internal `_` separator). The rule must match both the legacy
+// 36-char form and the new variable-length form, while keeping `ghu_` strict.
+func TestGitHubAppToken_BothFormats(t *testing.T) {
+	rule := findBuiltinRule(t, "github-app-token")
+
+	// Build a JWT-like body that satisfies the new ghs_<APPID>_<JWT> shape:
+	// `ghs_` + APPID + `_` + JWT.
+	jwt := strings.Repeat("a", 100) + "_" + strings.Repeat("b", 200) + "_" + strings.Repeat("c", 200)
+
+	cases := []struct {
+		name     string
+		input    string
+		wantHit  bool
+	}{
+		{
+			name:    "legacy ghs_ 36-char token still detected",
+			input:   "ghs_" + strings.Repeat("0", 36),
+			wantHit: true,
+		},
+		{
+			name:    "legacy ghu_ 36-char token still detected",
+			input:   "ghu_" + strings.Repeat("0", 36),
+			wantHit: true,
+		},
+		{
+			name:    "stateless ghs_<APPID>_<JWT> token detected (issue #10591)",
+			input:   "ghs_123456_" + jwt,
+			wantHit: true,
+		},
+		{
+			name:    "stateless ghs_ with realistic ~520-char body",
+			input:   "ghs_" + strings.Repeat("X", 520),
+			wantHit: true,
+		},
+		{
+			name:    "ghu_ with extra characters past 36 must NOT extend match (kept strict)",
+			input:   "ghu_" + strings.Repeat("0", 30),
+			wantHit: false, // too short; ghu_ stays at exactly 36
+		},
+		{
+			name:    "ghs_ shorter than 36 chars is rejected",
+			input:   "ghs_" + strings.Repeat("0", 20),
+			wantHit: false,
+		},
+		{
+			name:    "non-ghs/ghu prefix not matched",
+			input:   "ghp_" + strings.Repeat("0", 36),
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+func findBuiltinRule(t *testing.T, id string) secret.Rule {
+	t.Helper()
+	for _, r := range secret.GetBuiltinRules() {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("builtin rule %q not found", id)
+	return secret.Rule{}
+}


### PR DESCRIPTION
## Summary

Closes #10591.

GitHub started rolling out a new stateless format for \`ghs_\` installation tokens on 2026-04-27. The old form was a fixed 36-char alphanumeric; the new form is shaped \`ghs_<APPID>_<JWT>\` (~520 chars on average, variable length, with an internal \`_\` separator). The current rule's regex silently misses every new token because (a) the \`{36}\` length quantifier no longer matches and (b) the \`[0-9a-zA-Z]\` class rejects the internal underscore separator — exactly what the issue body describes.

## Change

Update the \`github-app-token\` rule's regex to accept both forms while keeping \`ghu_\` strict:

\`\`\`go
Regex: MustCompileWithoutWordPrefix(\`?P<secret>(?:ghu_[0-9a-zA-Z]{36}|ghs_[0-9a-zA-Z_]{36,})\`)
\`\`\`

This is **option 1** as proposed in the issue. The lower bound of \`{36,}\` on \`ghs_\` keeps the legacy ghs_ form covered (the issue's first acceptance criterion); the upper bound is left open so any future token-length change is also picked up. \`ghu_\` is unchanged.

A short comment block above the rule cross-references the issue and the GitHub changelog so the next person to touch it has context.

## Test

\`pkg/fanal/secret/builtin_rules_test.go\` (new, focused on the rule's regex):

- legacy \`ghs_\` 36-char token still matches
- legacy \`ghu_\` 36-char token still matches
- new stateless \`ghs_123456_<jwt>\` token matches (issue #10591 case)
- realistic ~520-char \`ghs_\` body matches
- \`ghu_\` with fewer than 36 chars does NOT match (strict kept)
- \`ghs_\` shorter than 36 chars does NOT match
- \`ghp_\` prefix is not picked up by the github-app-token rule (separate rule still handles it)

```
$ go test ./pkg/fanal/secret/...
ok  	github.com/aquasecurity/trivy/pkg/fanal/secret	0.070s
```

All existing scanner tests continue to pass.

## Acceptance criteria mapping

| Issue criterion | Status |
|---|---|
| New \`ghs_\` tokens (~520 chars, with internal \`_\`) detected with severity CRITICAL | ✅ rule severity unchanged at CRITICAL; new format covered |
| Existing \`ghs_[0-9a-zA-Z]{36}\` and \`ghu_[0-9a-zA-Z]{36}\` still detected | ✅ legacy 36-char tokens covered by both regex branches |

## Notes

- I went with the single-rule option (the first one in the issue body) rather than splitting into a new rule for stateless ghs_, on the grounds that they both signal the same secret class and the existing \`github-app-token\` rule ID stays stable for any consumer suppression configs. Happy to split into a dedicated \`github-app-installation-token\` rule if you'd prefer separate IDs — that's the second option you suggested.
- The `[0-9a-zA-Z_]` class follows the issue body verbatim. The new \`<APPID>\` and \`<JWT>\` parts of the token use base64url-without-padding, which is `[A-Za-z0-9_-]`, so a \`-\` could also appear in real tokens. If you want to widen the class to \`[0-9a-zA-Z_-]\` I can adjust — flagged here so the call is explicit rather than silent.