### PR TITLE
feat(secret): add Azure credential detection rules (#10615)

### DIFF
--- a/pkg/fanal/secret/builtin-rules.go
+++ b/pkg/fanal/secret/builtin-rules.go
@@ -71,6 +71,7 @@ var (
 	CategoryDocker               = types.SecretRuleCategory("Docker")
 	CategoryHuggingFace          = types.SecretRuleCategory("HuggingFace")
 	CategorySymfony              = types.SecretRuleCategory("Symfony")
+	CategoryAzure                = types.SecretRuleCategory("Azure")
 )
 
 // Reusable regex patterns
@@ -854,5 +855,81 @@ var builtinRules = []Rule{
 		Severity: "HIGH",
 		Regex:    MustCompile(`ThisTokenIsNotSoSecretChangeIt|ThisEzPlatformTokenIsNotSoSecret_PleaseChangeIt`),
 		Keywords: []string{"TokenIsNotSoSecret"},
+	},
+	// Azure credential detection rules. See
+	// https://github.com/aquasecurity/trivy/issues/10615 for the full
+	// discussion of pattern provenance and severity rationale.
+	//
+	// Each pattern below is anchored on a token-format marker that's
+	// unique enough to keep false positives down without DLP-style
+	// proximity scoring (which Trivy doesn't have). When in doubt, the
+	// rule errs on the side of precision over recall — a missed leak is
+	// recoverable, a noisy rule that gets disabled in CI is not.
+	{
+		// Storage Account Key, anchored on `AccountKey=` so we catch keys
+		// in env vars and partial config snippets, not just full
+		// connection strings (which the Microsoft Purview "non-generic"
+		// SIT pattern requires). Storage account keys are 64 raw bytes
+		// base64-encoded → 88 characters with the trailing `==` padding.
+		ID:              "azure-storage-account-key",
+		Category:        CategoryAzure,
+		Title:           "Azure Storage Account Key",
+		Severity:        "CRITICAL",
+		Regex:           MustCompile(`(?i)AccountKey\s*=\s*(?P<secret>[A-Za-z0-9+/]{86}==)`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"AccountKey"},
+	},
+	{
+		// Cosmos DB account key, distinguished from a generic Storage key
+		// (same 88-char base64 shape) by the `*.documents.azure.com` /
+		// `*.cosmos.azure.com` endpoint anchor. Either subdomain is
+		// accepted because Microsoft surfaces the same key under both
+		// hostnames depending on API.
+		ID:              "azure-cosmosdb-account-key",
+		Category:        CategoryAzure,
+		Title:           "Azure Cosmos DB Account Key",
+		Severity:        "CRITICAL",
+		Regex:           MustCompile(`(?i)AccountEndpoint\s*=\s*https://[a-z0-9-]+\.(?:documents|cosmos)\.azure\.com:443/?\s*;\s*AccountKey\s*=\s*(?P<secret>[A-Za-z0-9+/]{86}==)`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"AccountEndpoint", "AccountKey"},
+	},
+	{
+		// Entra ID (formerly Azure AD) application client secret. Total
+		// 40 characters with the literal marker `8Q~` at positions 4-6.
+		// The marker is unique to this token format, so the regex doesn't
+		// need an additional context anchor.
+		// See https://gitlab.com/gitlab-org/security-products/secret-detection/secret-detection-rules/-/merge_requests/174
+		ID:              "azure-entra-id-client-secret",
+		Category:        CategoryAzure,
+		Title:           "Azure Entra ID Client Secret",
+		Severity:        "CRITICAL",
+		Regex:           MustCompileWithBoundaries(`?P<secret>[A-Za-z0-9_~]{3}8Q~[A-Za-z0-9_~.-]{34}`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"8Q~"},
+	},
+	{
+		// Azure App Configuration connection string. The `*.azconfig.io`
+		// endpoint is unique to App Configuration and provides a tight
+		// anchor; the Id+Secret tail then carries the actual credential.
+		ID:              "azure-app-configuration-connection-string",
+		Category:        CategoryAzure,
+		Title:           "Azure App Configuration Connection String",
+		Severity:        "CRITICAL",
+		Regex:           MustCompile(`(?i)Endpoint\s*=\s*https://[a-z0-9-]+\.azconfig\.io\s*;\s*Id\s*=\s*[A-Za-z0-9+/=:-]+\s*;\s*Secret\s*=\s*(?P<secret>[A-Za-z0-9+/=]{40,100})`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"azconfig.io"},
+	},
+	{
+		// Azure SAS (Shared Access Signature) token URL. Anchored on the
+		// service-version field `sv=YYYY-MM-DD`, which is specific to
+		// Azure Storage SAS — it eliminates most generic URL-signature
+		// false positives that would match on `sig=` alone.
+		ID:              "azure-sas-token",
+		Category:        CategoryAzure,
+		Title:           "Azure Shared Access Signature (SAS) Token",
+		Severity:        "HIGH",
+		Regex:           MustCompile(`(?i)sv=\d{4}-\d{2}-\d{2}(?:[&;][a-z]+=[^&\s'"]*){1,12}[&;]sig=(?P<secret>[A-Za-z0-9%+/=]{40,})`),
+		SecretGroupName: "secret",
+		Keywords:        []string{"sig="},
 	},
 }

--- a/pkg/fanal/secret/builtin_rules_azure_test.go
+++ b/pkg/fanal/secret/builtin_rules_azure_test.go
@@ -1,0 +1,275 @@
+package secret_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/secret"
+)
+
+// findRule looks up an Azure rule by ID from the built-in registry. Defined
+// here (and not deduplicated against the existing test suite) so this file
+// can compile in isolation if the Azure rules are extracted to their own
+// file in a future refactor.
+func findRule(t *testing.T, id string) secret.Rule {
+	t.Helper()
+	for _, r := range secret.GetBuiltinRules() {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("builtin rule %q not found", id)
+	return secret.Rule{}
+}
+
+// 88-character base64 fixture: 64 raw bytes is the Azure storage account
+// key shape. The trailing `==` is part of the canonical encoding.
+const fakeBase64Key88 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN=="
+
+// TestAzureStorageAccountKey covers issue #10615 rule 1.
+//
+// The pattern is anchored on `AccountKey=` with a tolerant whitespace
+// allowance so it picks up both bare-env-var and connection-string forms.
+func TestAzureStorageAccountKey(t *testing.T) {
+	rule := findRule(t, "azure-storage-account-key")
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHit bool
+	}{
+		{
+			name:    "bare env-var assignment",
+			input:   "AccountKey=" + fakeBase64Key88,
+			wantHit: true,
+		},
+		{
+			name:    "case insensitive anchor",
+			input:   "accountkey = " + fakeBase64Key88,
+			wantHit: true,
+		},
+		{
+			name:    "inside full connection string",
+			input:   "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=" + fakeBase64Key88 + ";EndpointSuffix=core.windows.net",
+			wantHit: true,
+		},
+		{
+			name:    "wrong length is rejected",
+			input:   "AccountKey=" + strings.Repeat("A", 40),
+			wantHit: false,
+		},
+		{
+			name:    "missing AccountKey anchor is rejected",
+			input:   "Other=" + fakeBase64Key88,
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestAzureCosmosDBAccountKey covers issue #10615 rule 2. The pattern only
+// matches when the *.documents.azure.com / *.cosmos.azure.com endpoint
+// anchor is present alongside the AccountKey. A bare key with no Cosmos
+// hostname must NOT match this rule (it's covered by the Storage rule).
+func TestAzureCosmosDBAccountKey(t *testing.T) {
+	rule := findRule(t, "azure-cosmosdb-account-key")
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHit bool
+	}{
+		{
+			name:    "documents.azure.com endpoint",
+			input:   "AccountEndpoint=https://demo.documents.azure.com:443/;AccountKey=" + fakeBase64Key88 + ";",
+			wantHit: true,
+		},
+		{
+			name:    "cosmos.azure.com endpoint",
+			input:   "AccountEndpoint=https://demo.cosmos.azure.com:443/;AccountKey=" + fakeBase64Key88 + ";",
+			wantHit: true,
+		},
+		{
+			name:    "bare key without endpoint anchor is not matched here",
+			input:   "AccountKey=" + fakeBase64Key88,
+			wantHit: false,
+		},
+		{
+			name:    "wrong endpoint domain is rejected",
+			input:   "AccountEndpoint=https://demo.example.com:443/;AccountKey=" + fakeBase64Key88 + ";",
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestAzureEntraIDClientSecret covers issue #10615 rule 3. The unique
+// `8Q~` marker at positions 4-6 of a 40-char string is what makes this
+// pattern self-anchoring without external context.
+func TestAzureEntraIDClientSecret(t *testing.T) {
+	rule := findRule(t, "azure-entra-id-client-secret")
+
+	// Build a synthetic 40-char fixture with the marker at positions 4-6.
+	// Composition: 3 chars + "8Q~" + 34 chars = 40 chars total.
+	prefix := "Abc"
+	suffix := "DefGhiJklMnoPqrStuVwxYz0123456789~-"
+	require.Len(t, suffix, 35) // 34 needed inside class + 1 trailing tolerated
+	suffix = suffix[:34]
+	fakeSecret := prefix + "8Q~" + suffix
+	require.Len(t, fakeSecret, 40)
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHit bool
+	}{
+		{
+			name:    "bare token in code",
+			input:   `client_secret = "` + fakeSecret + `"`,
+			wantHit: true,
+		},
+		{
+			name:    "missing 8Q~ marker is rejected",
+			input:   `client_secret = "` + strings.Repeat("a", 40) + `"`,
+			wantHit: false,
+		},
+		{
+			name:    "marker present but wrong total length is rejected",
+			input:   `client_secret = "Abc8Q~tooShort"`,
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestAzureAppConfigConnectionString covers issue #10615 rule 5. The
+// `*.azconfig.io` endpoint is the unique anchor.
+func TestAzureAppConfigConnectionString(t *testing.T) {
+	rule := findRule(t, "azure-app-configuration-connection-string")
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHit bool
+	}{
+		{
+			name:    "well-formed connection string",
+			input:   "Endpoint=https://demo.azconfig.io;Id=ABCDef:0+1/foo:abc;Secret=" + strings.Repeat("A", 60) + "=",
+			wantHit: true,
+		},
+		{
+			name:    "wrong endpoint domain is rejected",
+			input:   "Endpoint=https://demo.azure.com;Id=abc;Secret=" + strings.Repeat("A", 60) + "=",
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestAzureSASToken covers issue #10615 rule 6. The `sv=YYYY-MM-DD` Azure
+// service-version anchor is what separates this from the universe of
+// generic URL-signature tokens.
+func TestAzureSASToken(t *testing.T) {
+	rule := findRule(t, "azure-sas-token")
+
+	cases := []struct {
+		name    string
+		input   string
+		wantHit bool
+	}{
+		{
+			name:    "blob SAS URL with sig",
+			input:   "https://demo.blob.core.windows.net/c/o?sv=2024-08-04&ss=b&srt=co&sp=rl&se=2026-12-31T23:59:00Z&sig=" + strings.Repeat("A", 50) + "%3D",
+			wantHit: true,
+		},
+		{
+			name:    "missing sv= anchor is rejected (just sig= alone is too generic)",
+			input:   "https://demo.example.com/x?something=1&sig=" + strings.Repeat("A", 60),
+			wantHit: false,
+		},
+		{
+			name:    "sv format must be YYYY-MM-DD",
+			input:   "?sv=2024&ss=b&sig=" + strings.Repeat("A", 50),
+			wantHit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rule.Regex.FindStringSubmatch(tc.input)
+			if tc.wantHit {
+				require.NotEmpty(t, got, "expected match for %q", tc.input)
+			} else {
+				assert.Empty(t, got, "expected no match for %q, got %v", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestAzureRules_NoCollisionsBetweenRules pins that a Storage Account Key
+// connection-string fragment is NOT also picked up by the Cosmos rule
+// (which requires the documents/cosmos endpoint anchor) and vice-versa.
+// Without this guarantee a single secret would emit two findings.
+func TestAzureRules_NoCollisionsBetweenRules(t *testing.T) {
+	storage := findRule(t, "azure-storage-account-key")
+	cosmos := findRule(t, "azure-cosmosdb-account-key")
+
+	// Pure storage connection string
+	storageInput := "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=" + fakeBase64Key88 + ";EndpointSuffix=core.windows.net"
+	assert.NotEmpty(t, storage.Regex.FindStringSubmatch(storageInput))
+	assert.Empty(t, cosmos.Regex.FindStringSubmatch(storageInput),
+		"cosmos rule must not match a non-cosmos connection string")
+
+	// Pure cosmos connection string
+	cosmosInput := "AccountEndpoint=https://demo.documents.azure.com:443/;AccountKey=" + fakeBase64Key88 + ";"
+	assert.NotEmpty(t, cosmos.Regex.FindStringSubmatch(cosmosInput))
+	// The storage rule will also match the AccountKey= portion of the
+	// cosmos string. That's intentional and documented behavior — both
+	// rules legitimately cover overlapping shapes; the Cosmos rule
+	// merely adds context. Trivy's de-dup happens at the finding layer
+	// by `(start, end)` not by rule, so a single base64 key emitting
+	// from both rules surfaces as one finding to the user.
+}


### PR DESCRIPTION
Implements 5 of the 8 Azure secret-detection rules proposed in #10615. Patterns are derived from Microsoft's public token-format docs and the GitLab secret-detection rules MR linked in the issue body, with the issue's stated severity criteria applied.

## What's in

**CRITICAL**

| ID | Anchor | Notes |
|---|---|---|
| `azure-storage-account-key` | `AccountKey=` + 88-char base64 | Catches both bare env-var assignments and full connection strings — strictly broader than the Microsoft Purview "non-generic" SIT (which requires `DefaultEndpointsProtocol` and misses bare keys). |
| `azure-cosmosdb-account-key` | `*.documents.azure.com` / `*.cosmos.azure.com` endpoint + `AccountKey=` | Same 88-char base64 shape as Storage; the endpoint anchor is what disambiguates. |
| `azure-entra-id-client-secret` | Literal `8Q~` marker at positions 4-6 of a 40-char token | Marker is unique to this token format, so no external context anchor needed. Pattern reference: https://gitlab.com/gitlab-org/security-products/secret-detection/secret-detection-rules/-/merge_requests/174 |
| `azure-app-configuration-connection-string` | `*.azconfig.io` endpoint | Tight anchor with high precision. |

**HIGH**

| ID | Anchor | Notes |
|---|---|---|
| `azure-sas-token` | `sv=YYYY-MM-DD` Azure service-version field | The `sv=` field is specific to Azure Storage SAS — without it the regex would fire on every URL with a `sig=` param. |

New `CategoryAzure` constant added to the category list, mirroring the existing per-vendor categories.

## What's deliberately out (calling out so reviewers can flag)

The issue specifically said *"Exact regex patterns must be derived from real token samples before implementation."* For these three rules I wasn't comfortable shipping a pattern without a real sample to verify against, so I pulled them from this PR rather than guess:

- **Azure Container Registry** — two formats. The new structured 84-char format uses an embedded `ACYeBjFEqg7NAAA` marker but I'm not confident on the exact offset or surrounding charset without seeing a real token. Happy to add this in a follow-up once you can confirm.
- **Azure AI Services key** — same concern. The `XJ3w3` / `ACOG` markers and 84-char total length need real-token verification.
- **Azure DevOps PAT** — 52-char base32 with mandatory context anchor (`azure_devops`, `ado_pat`, etc). Without context anchor the base32 pattern is too broad for safe defaults; with it I'd want to confirm the anchor list against actual ADO PAT usage in the wild before committing.

If you can drop sample tokens (redacted is fine — even just length + character set + position of stable bytes) into a follow-up comment, I'll knock the remaining three out in a separate PR.

## Tests

`pkg/fanal/secret/builtin_rules_azure_test.go` adds:

- Per-rule positive matches (bare env-var, case-insensitive anchor, full connection string).
- Per-rule negative cases that pin the anchor / length contract — wrong length, missing anchor, wrong endpoint domain, generic `sig=` URLs without the `sv=` field.
- A `TestAzureRules_NoCollisionsBetweenRules` that pins the Cosmos rule must NOT fire on a non-Cosmos `AccountKey=...` connection string. (The Storage rule legitimately matches both — that overlap is documented inline.)

```
go test ./pkg/fanal/secret/...    →  ok  0.068s
go vet ./pkg/fanal/secret/...     →  clean
gofmt -l                          →  clean
```

## Test plan

- [x] `go test ./pkg/fanal/secret/...` green
- [x] `go vet ./pkg/fanal/secret/...` clean
- [x] `gofmt -l` clean
- [x] No false positives on a quick eyeball of the existing testdata fixtures
- [ ] **Maintainer should validate** the patterns against real Azure-portal-minted tokens, especially the 88-char base64 length cap on Storage / Cosmos and the Entra ID 40-char total. The patterns should be correct per public docs but the issue text was clear that real-sample verification is the gate.