### PR TITLE
fix(misconf): handle whitespace-only files in Kubernetes parser

### DIFF
--- a/pkg/iac/scanners/kubernetes/parser/parser.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser.go
@@ -14,16 +14,7 @@ func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 		return nil, err
 	}
 
-	if len(contents) == 0 {
-		return nil, nil
-	}
-
-	contents = bytes.TrimSpace(contents)
-	if len(contents) == 0 {
-		return nil, nil
-	}
-
-	if bytes.TrimSpace(contents)[0] == '{' {
+	if bytes.HasPrefix(contents, []byte("{")) {
 		manifest, err := ManifestFromJSON(path, contents)
 		if err != nil {
 			return nil, err

--- a/pkg/iac/scanners/kubernetes/parser/parser.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser.go
@@ -18,6 +18,11 @@ func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 		return nil, nil
 	}
 
+	contents = bytes.TrimSpace(contents)
+	if len(contents) == 0 {
+		return nil, nil
+	}
+
 	if bytes.TrimSpace(contents)[0] == '{' {
 		manifest, err := ManifestFromJSON(path, contents)
 		if err != nil {

--- a/pkg/iac/scanners/kubernetes/parser/parser_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser_test.go
@@ -72,3 +72,31 @@ kind: Pod
 		})
 	}
 }
+
+func TestParse_WhitespaceOnly(t *testing.T) {
+	const filePath = "test.yaml"
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "single space", src: " "},
+		{name: "multiple spaces", src: "    "},
+		{name: "single newline", src: "\n"},
+		{name: "multiple newlines", src: "\n\n\n"},
+		{name: "tabs only", src: "\t\t"},
+		{name: "mixed whitespace", src: "  \t\n  \r\n\t "},
+		{name: "CRLF only", src: "\r\n\r\n"},
+		{name: "BOM only", src: "\xef\xbb\xbf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				manifests, err := parser.Parse(t.Context(), strings.NewReader(tt.src), filePath)
+				require.NoError(t, err)
+				require.Empty(t, manifests)
+			})
+		})
+	}
+}

--- a/pkg/iac/scanners/kubernetes/parser/parser_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser_test.go
@@ -87,16 +87,13 @@ func TestParse_WhitespaceOnly(t *testing.T) {
 		{name: "tabs only", src: "\t\t"},
 		{name: "mixed whitespace", src: "  \t\n  \r\n\t "},
 		{name: "CRLF only", src: "\r\n\r\n"},
-		{name: "BOM only", src: "\xef\xbb\xbf"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.NotPanics(t, func() {
-				manifests, err := parser.Parse(t.Context(), strings.NewReader(tt.src), filePath)
-				require.NoError(t, err)
-				require.Empty(t, manifests)
-			})
+			manifests, err := parser.Parse(t.Context(), strings.NewReader(tt.src), filePath)
+			require.NoError(t, err)
+			require.Empty(t, manifests)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The Kubernetes parser at `pkg/iac/scanners/kubernetes/parser/parser.go`
panics with `index out of range [0] with length 0` when given a non-empty file
that contains only whitespace.

Presently, only truly empty files are caught by this guard but a file containing just whitespaces bypasses this check and then `bytes.TrimSpace(contents)[0]` indexes into a zero-length slice causing panics.

Fix is - Trim once and then perform length check on trimmed content thus covering both empty and whitespace-only inputs.

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [X] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [X] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [X] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
