### PR TITLE
docs(misconf): fix typo in misconfiguration config

### DIFF
--- a/docs/guide/scanner/misconfiguration/config/config.md
+++ b/docs/guide/scanner/misconfiguration/config/config.md
@@ -195,7 +195,7 @@ As an example, consider the following check metadata:
 ```
 Long ID would look like the following: `aws-s3-enable-logging`.
 
-Example for CloudFromation:
+Example for CloudFormation:
 ```yaml
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:


### PR DESCRIPTION
## Description

Fix a typo in the [misconfiguration configuration page](https://trivy.dev/docs/latest/guide/scanner/misconfiguration/config/config/).

## Related issues

None


## Checklist

- [X] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [X] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.