### PR TITLE
docs: document how to disable check.trivy.dev connections

### DIFF
--- a/docs/guide/advanced/air-gap.md
+++ b/docs/guide/advanced/air-gap.md
@@ -80,3 +80,11 @@ There's no way to leverage Maven Central in a network-restricted environment, bu
 
 Trivy [checks for updates](../configuration/others.md#check-for-updates) and [collects usage telemetry](../advanced/telemetry.md) by connecting to the following domain: `https://check.trivy.dev`.
 Connectivity with this domain is entirely optional and is not necessary for the normal operation of Trivy.
+
+To prevent Trivy from connecting to `check.trivy.dev`, disable both the version check and telemetry collection explicitly:
+
+```bash
+trivy image --skip-version-check --disable-telemetry <image>
+```
+
+Note that these are two independent features controlled by separate flags — using only one of them is not sufficient to prevent all connections to this domain.


### PR DESCRIPTION
## Description

Both `--skip-version-check` and `--disable-telemetry` are required to prevent  any connections to check.trivy.dev. This wasn't documented in the air-gap guide.

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/10579

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
