### PR TITLE
refactor(azure): adjust an unreachable code in DateTimeAdd

### DIFF
--- a/pkg/iac/scanners/azure/functions/date_time_add.go
+++ b/pkg/iac/scanners/azure/functions/date_time_add.go
@@ -41,11 +41,7 @@ func DateTimeAdd(args ...any) any {
 	timeDuration := duration.timeDuration()
 	baseTime = baseTime.Add(timeDuration)
 
-	if ok {
-		return baseTime.Format(format)
-	}
-
-	return baseTime.Format(time.RFC3339)
+	return baseTime.Format(format)
 }
 
 type Iso8601Duration struct {


### PR DESCRIPTION
## Description
This PR is slitghly adjusting the function [DateTimeAdd](https://github.com/aquasecurity/trivy/blob/d4ac98a84951956e5813a370ab2342950e776444/pkg/iac/scanners/azure/functions/date_time_add.go#L13) by removing the following unnecessary check: https://github.com/aquasecurity/trivy/blob/d4ac98a84951956e5813a370ab2342950e776444/pkg/iac/scanners/azure/functions/date_time_add.go#L44-L46

which is redundant because the `ok` variable is checked here:
https://github.com/aquasecurity/trivy/blob/d4ac98a84951956e5813a370ab2342950e776444/pkg/iac/scanners/azure/functions/date_time_add.go#L19-L21

and it's value does not change during further execution because the `ok` variable in the following `if` block is local:
https://github.com/aquasecurity/trivy/blob/d4ac98a84951956e5813a370ab2342950e776444/pkg/iac/scanners/azure/functions/date_time_add.go#L24-L29

## Related issues
- Closes #10624 

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
