### PR TITLE
fix(misconf): handle nil plays from invalid ansible playbook YAML (#10131)

### DIFF
--- a/pkg/iac/scanners/ansible/parser/parser.go
+++ b/pkg/iac/scanners/ansible/parser/parser.go
@@ -226,6 +226,24 @@ func (p *Parser) loadPlaybook(f fsutils.FileSource) (*Playbook, error) {
 		return nil, xerrors.Errorf("decode YAML file: %w", err)
 	}
 
+	// A YAML sequence with empty/null entries (e.g. a top-level "-" with no
+	// mapping under it) decodes into a []*Play that contains nil pointers.
+	// Drop those so downstream code can dereference plays freely.
+	skipped := 0
+	filtered := plays[:0]
+	for _, play := range plays {
+		if play == nil {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, play)
+	}
+	plays = filtered
+	if skipped > 0 {
+		p.logger.Debug("Skipped empty plays in playbook",
+			log.FilePath(f.Path), log.Int("skipped", skipped))
+	}
+
 	p.logger.Debug("Loaded playbook",
 		log.FilePath(f.Path), log.Int("plays_count", len(plays)))
 	return &Playbook{

--- a/pkg/iac/scanners/ansible/parser/parser_test.go
+++ b/pkg/iac/scanners/ansible/parser/parser_test.go
@@ -56,6 +56,26 @@ func TestParser_Parse(t *testing.T) {
 			expectedTasks: []string{"Pre-task", "Task", "Post-task"},
 		},
 		{
+			name: "playbook with empty/null sequence entry",
+			files: map[string]string{
+				"playbook.yaml": `-
+- hosts: localhost
+  tasks:
+    - name: only real task
+      debug:
+        msg: test
+`,
+			},
+			expectedTasks: []string{"only real task"},
+		},
+		{
+			name: "playbook is only an empty sequence entry",
+			files: map[string]string{
+				"playbook.yaml": "-\n",
+			},
+			expectedTasks: nil,
+		},
+		{
 			name: "task name with unquoted template",
 			files: map[string]string{
 				"playbook.yaml": `---


### PR DESCRIPTION
## Description

Fixes #10131.

A playbook YAML containing an empty/null sequence entry like:

```yaml
-
```

decodes (via `gopkg.in/yaml.v3`) into a `[]*Play` whose elements are nil pointers. `findEntryPoints` and `resolvePlaybook` then dereference those entries and the scan panics:

```
SIGSEGV at (*Play).includedPlaybook (play.go:106)
  -> findEntryPoints                  (parser.go:242)
  -> (*Parser).parsePlaybooks         (parser.go:202)
  -> (*Parser).Parse                  (parser.go:147)
```

I reproduced the panic against `main` with the new test case (\`playbook is only an empty sequence entry\`) and confirmed the SIGSEGV stack matches what the issue describes.

## Fix

Filter out the nil entries inside `loadPlaybook` immediately after decoding, before they reach any consumer. A `Debug` log records how many entries were dropped so the skip is still observable.

This keeps the change in one place — every other call site (`findEntryPoints`, `resolvePlaybook`, callers of `pb.Plays`) can keep dereferencing freely. An alternative would be to add nil guards at every loop, but that fans out the fix and leaves room for the next caller to forget.

## Tests

Two new cases under `TestParser_Parse`:

- \`playbook with empty/null sequence entry\` — \`-\` at the top of an otherwise-valid playbook is silently dropped, the surrounding play and its task still parse correctly (\`expectedTasks: [\"only real task\"]\`).
- \`playbook is only an empty sequence entry\` — exact reproducer from the issue (\`-\\n\`); parser returns no tasks instead of panicking.

Both fail on \`main\` (the second one panics, taking down the whole \`TestParser_Parse\` run); both pass with this commit. Full ansible scanner suite is green.

## Checklist

- [x] I've read the [contribution guidelines](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/).
- [x] Tests added.
- [x] Issue closed in commit message.