### PR TITLE
ci: migrate PAT tokens to GitHub App

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -34,11 +34,21 @@ jobs:
       startsWith(github.event.comment.body, '@aqua-bot backport release/')
     runs-on: ubuntu-2404-2core
     steps:
+      # GITHUB_TOKEN cannot trigger workflows on PRs it creates, so the backport
+      # PR would not run CI — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true # backport.sh runs git push
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract branch name
         env:
@@ -58,8 +68,6 @@ jobs:
 
       - name: Run backport script
         env:
-          # Use TRIVY_REPO_TOKEN instead of GITHUB_TOKEN
-          # This allows the created PR to trigger tests and other workflows
-          GITHUB_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: ./misc/backport/backport.sh "$BRANCH_NAME" "$ISSUE_NUMBER"

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -51,7 +51,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.ACTIONS_MULTI_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: trivy-www

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -41,15 +41,23 @@ jobs:
         run: mike deploy --push --update-aliases "$DOCS_VERSION" latest
 
   # This workflow is used to trigger the trivy-www deployment
-  trigger-trivy-www-deploy: 
+  trigger-trivy-www-deploy:
     needs: deploy
     runs-on: ubuntu-2404-2core
     steps:
-      - name: Trigger update_version workflow in trivy-telemetry
+      # GITHUB_TOKEN is scoped to the current repository and cannot trigger
+      # workflows in other repos — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: trivy-www
+      - name: Trigger build-docs workflow in trivy-www
         env:
-          # Use TRIVY_WORKFLOW_TRIGGER_TOKEN instead of GITHUB_TOKEN
-          # This allows triggering workflows in other repositories
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run build-docs.yml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-www" \

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -67,7 +67,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.ACTIONS_MULTI_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: helm-charts

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -61,9 +61,19 @@ jobs:
       - test-chart
     runs-on: ubuntu-2404-2core
     steps:
+      # GITHUB_TOKEN is scoped to the current repository and cannot trigger
+      # workflows in other repos — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: helm-charts
       - name: Trigger publish-chart workflow in helm-charts
         env:
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REF: ${{ github.sha }}
         run: |
           gh workflow run publish-chart.yaml \

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,27 +17,45 @@ jobs:
     runs-on: ubuntu-2404-2core
     if: ${{ !startsWith(github.event.head_commit.message, 'release:') && !github.event.inputs.version }}
     steps:
+      # GITHUB_TOKEN cannot trigger workflows on PRs it creates, so the release PR
+      # would not run CI — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          token: ${{ secrets.TRIVY_REPO_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: ${{ github.ref_name }}
 
   manual-release-please:
     runs-on: ubuntu-2404-2core
     if: ${{ github.event.inputs.version }}
     steps:
+      # GITHUB_TOKEN cannot trigger workflows on PRs it creates, so the release PR
+      # would not run CI — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+
       - name: Install Release Please CLI
         run: npm install release-please -g
 
       - name: Release Please
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
-          TRIVY_REPO_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           release-please release-pr --repo-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-            --token="$TRIVY_REPO_TOKEN" \
+            --token="$APP_TOKEN" \
             --release-as="$RELEASE_VERSION" \
             --target-branch="$GITHUB_REF_NAME"
 
@@ -57,13 +75,23 @@ jobs:
           echo "pr_number=$( echo "$COMMIT_MESSAGE" | sed 's/.*(\#\([0-9]\+\)).*$/\1/' )" >> $GITHUB_OUTPUT
           echo "release_branch=release/v$( echo "$COMMIT_MESSAGE" | sed 's/^release: v\([0-9]\+\.[0-9]\+\).*$/\1/' )" >> $GITHUB_OUTPUT
 
+      # GITHUB_TOKEN cannot trigger the release workflow on the created tag —
+      # generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        if: ${{ steps.extract_info.outputs.version }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+
       - name: Tag release
         if: ${{ steps.extract_info.outputs.version }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           VERSION: ${{ steps.extract_info.outputs.version }}
         with:
-          github-token: ${{ secrets.TRIVY_REPO_TOKEN }} # To trigger another workflow
+          github-token: ${{ steps.app-token.outputs.token }} # To trigger another workflow
           script: |
             await github.rest.git.createRef({
               owner: context.repo.owner,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.ACTIONS_MULTI_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: trivy-repo
@@ -84,7 +84,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.ACTIONS_MULTI_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,19 @@ jobs:
     needs: release # run this job after 'release' job completes
     runs-on: ubuntu-2404-2core
     steps:
+      # GITHUB_TOKEN is scoped to the current repository and cannot trigger
+      # workflows in other repos — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: trivy-repo
       - name: Trigger deploy-packages workflow in trivy-repo
         env:
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run deploy-packages.yml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-repo" \
@@ -68,12 +78,24 @@ jobs:
     needs: release
     runs-on: ubuntu-2404-2core
     steps:
+      # GITHUB_TOKEN is scoped to the current repository and cannot trigger
+      # workflows in other repos — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            trivy-telemetry
+            trivy-downloads
+            trivy-chocolatey
+            trivy-action
       - name: Trigger update_version workflow in trivy-telemetry
         if: always()
         env:
-          # Use TRIVY_WORKFLOW_TRIGGER_TOKEN instead of GITHUB_TOKEN
-          # This allows triggering workflows in other repositories
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run update_version.yml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-telemetry" \
@@ -83,9 +105,7 @@ jobs:
       - name: Trigger update_version workflow in trivy-downloads
         if: always()
         env:
-          # Use TRIVY_WORKFLOW_TRIGGER_TOKEN instead of GITHUB_TOKEN
-          # This allows triggering workflows in other repositories
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run update_version.yml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-downloads" \
@@ -96,9 +116,7 @@ jobs:
       - name: Trigger version update and release workflow in trivy-chocolatey
         if: always()
         env:
-          # Use TRIVY_WORKFLOW_TRIGGER_TOKEN instead of GITHUB_TOKEN
-          # This allows triggering workflows in other repositories
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh workflow run release.yml \
             --repo "$GITHUB_REPOSITORY_OWNER/trivy-chocolatey" \
@@ -108,9 +126,7 @@ jobs:
       - name: Run version bump in trivy-action
         if: always()
         env:
-          # Use TRIVY_WORKFLOW_TRIGGER_TOKEN instead of GITHUB_TOKEN
-          # This allows triggering workflows in other repositories
-          GH_TOKEN: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           gh workflow run bump-trivy.yaml \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,11 +49,21 @@ jobs:
     needs: release
     runs-on: ubuntu-2404-2core
     steps:
+      # GITHUB_TOKEN cannot trigger workflows on PRs it creates, so the chart
+      # version PR would not run CI — generate a GitHub App installation token instead.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true # mage helm:updateVersion runs git push
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Git user
         run: |
@@ -69,9 +79,7 @@ jobs:
       - name: Create a PR with Trivy version
         run: mage helm:updateVersion
         env:
-          # Use TRIVY_REPO_TOKEN instead of GITHUB_TOKEN
-          # This allows the created PR to trigger tests and other workflows
-          GITHUB_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   # `trigger-version-update` triggers workflows in the `aqua` repositories to update the Trivy version.
   trigger-version-update:


### PR DESCRIPTION
## Description
This PR migrates two long-lived PATs to short-lived GitHub App installation tokens (via [`actions/create-github-app-token`][action], `v3.1.1`, pinned by SHA):

### `TRIVY_WORKFLOW_TRIGGER_TOKEN` → GitHub App
Used to dispatch `workflow_dispatch` events in sibling repositories. Each job now generates a token scoped only to the repositories it dispatches to.

### `TRIVY_REPO_TOKEN` → GitHub App
App token for jobs that create PRs / push (backport, release-please, release chart version bump). `GITHUB_TOKEN` cannot trigger workflows on PRs it creates, so an App token is required.

Note: the GoReleaser usage of `TRIVY_REPO_TOKEN` in `reusable-release.yaml` is migrated separately to the built-in `GITHUB_TOKEN` in #10655 — a full release can run up to 90 minutes and would exceed the 1-hour App token TTL.

[action]: https://github.com/actions/create-github-app-token

## Required admin actions

- [x] **Add secrets:** `ACTIONS_MULTI_WRITE_GH_APP_CLIENT_ID`, `TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY`, `REPO_TRIVY_WRITE_GH_APP_CLIENT_ID`, `REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY`.
- [ ] **Remove (after merge of both this PR and #10655):** `TRIVY_WORKFLOW_TRIGGER_TOKEN`, `TRIVY_REPO_TOKEN`.

## Test run

End-to-end verified on fork `DmitriyLewen/trivy` (combined with #10655 in one test branch) by pushing tag `v0.999.5` ([workflow run](https://github.com/DmitriyLewen/trivy/actions/runs/25731027349)). The test branch trims DockerHub/ECR, retargets GHCR to the fork namespace, and limits builds to linux/amd64+arm64.

1. **Chart version PR created via App token** — the `update-chart-version` job used the `REPO_TRIVY_WRITE` App token to push a branch and open a PR: https://github.com/DmitriyLewen/trivy/pull/3

2. **Cross-repo workflow dispatches via App token** — the `ACTIONS_MULTI_WRITE` App token successfully dispatched workflows in `trivy-repo` (`deploy-packages`) and `trivy-action` (`trigger-version-update`). Dispatches to `trivy-telemetry`, `trivy-downloads`, `trivy-chocolatey` returned 404 — those forks did not have the corresponding workflow files enabled at the time of the test, which is a fork-setup issue, not a token issue.