### PR TITLE
fix: pull instead of clone when test repo already exists

### DIFF
--- a/internal/gittest/testdata/fixture.go
+++ b/internal/gittest/testdata/fixture.go
@@ -28,6 +28,18 @@ func Fixtures() error {
 		return nil
 	}
 
+	if repo, err := git.PlainOpen(cloneDir); err == nil {
+		slog.Info("Pulling...", slog.String("url", repoURL))
+		w, err := repo.Worktree()
+		if err != nil {
+			return xerrors.Errorf("error getting worktree: %w", err)
+		}
+		if err = w.Pull(&git.PullOptions{}); err != nil && err != git.NoErrAlreadyUpToDate {
+			return xerrors.Errorf("error pulling repository: %w", err)
+		}
+		return nil
+	}
+
 	slog.Info("Cloning...", slog.String("url", repoURL))
 
 	// Clone the repository with all branches and tags

--- a/internal/gittest/testdata/fixture.go
+++ b/internal/gittest/testdata/fixture.go
@@ -1,6 +1,7 @@
 package gittest
 
 import (
+	"errors"
 	"log/slog"
 	"path/filepath"
 	"runtime"
@@ -28,14 +29,18 @@ func Fixtures() error {
 		return nil
 	}
 
+	// Pull the repository if it already exists
 	if repo, err := git.PlainOpen(cloneDir); err == nil {
 		slog.Info("Pulling...", slog.String("url", repoURL))
 		w, err := repo.Worktree()
 		if err != nil {
 			return xerrors.Errorf("error getting worktree: %w", err)
 		}
-		if err = w.Pull(&git.PullOptions{}); err != nil && err != git.NoErrAlreadyUpToDate {
+		if err = w.Pull(&git.PullOptions{}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 			return xerrors.Errorf("error pulling repository: %w", err)
+		}
+		if err = repo.Fetch(&git.FetchOptions{Tags: git.AllTags}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+			return xerrors.Errorf("error fetching tags: %w", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

`target.Path` returns `true` (needs update) when `fixture.go` is newer than `test-repo` — e.g. after `git pull` or switching branches. `git.PlainClone` then fails with `repository already exists` if the directory is already present.

## Steps to reproduce

1. Run `mage test:unit` — `test-repo` is cloned successfully
2. Run `touch internal/gittest/testdata/fixture.go`
3. Run `mage test:unit` again — fails with `error cloning repository: repository already exists`

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
