### PR TITLE
fix: add default control-plane tolerations for node-collector

### DIFF
--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"golang.org/x/xerrors"
+	corev1 "k8s.io/api/core/v1"
 
 	trivy_checks "github.com/aquasecurity/trivy-checks"
 	k8sArtifacts "github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
@@ -61,11 +62,17 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 }
 
 func nodeCollectorOptions(ctx context.Context, opts flag.Options) []trivyk8s.NodeCollectorOption {
+	// Add default tolerations for common control-plane taints if none are specified
+	tolerations := opts.Tolerations
+	if len(tolerations) == 0 {
+		tolerations = getDefaultTolerations()
+	}
+
 	nodeCollectorOptions := []trivyk8s.NodeCollectorOption{
 		trivyk8s.WithScanJobNamespace(opts.NodeCollectorNamespace),
 		trivyk8s.WithIgnoreLabels(opts.ExcludeNodes),
 		trivyk8s.WithScanJobImageRef(opts.NodeCollectorImageRef),
-		trivyk8s.WithTolerations(opts.Tolerations),
+		trivyk8s.WithTolerations(tolerations),
 	}
 
 	ctx = log.WithContextPrefix(ctx, log.PrefixMisconfiguration)
@@ -100,4 +107,21 @@ func getComplianceCommands(opts flag.Options) []string {
 		}
 	}
 	return commands
+}
+
+// getDefaultTolerations returns default tolerations for common control-plane taints
+// This allows the node-collector job to be scheduled on control-plane nodes by default
+func getDefaultTolerations() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
 }

--- a/pkg/k8s/commands/cluster.go
+++ b/pkg/k8s/commands/cluster.go
@@ -62,11 +62,9 @@ func clusterRun(ctx context.Context, opts flag.Options, cluster k8s.Cluster) err
 }
 
 func nodeCollectorOptions(ctx context.Context, opts flag.Options) []trivyk8s.NodeCollectorOption {
-	// Add default tolerations for common control-plane taints if none are specified
-	tolerations := opts.Tolerations
-	if len(tolerations) == 0 {
-		tolerations = getDefaultTolerations()
-	}
+	// Merge user-provided tolerations with defaults for common control-plane taints
+	// This ensures control-plane nodes are always scannable even when custom tolerations are added
+	tolerations := append(getDefaultTolerations(), opts.Tolerations...)
 
 	nodeCollectorOptions := []trivyk8s.NodeCollectorOption{
 		trivyk8s.WithScanJobNamespace(opts.NodeCollectorNamespace),

--- a/pkg/k8s/commands/cluster_test.go
+++ b/pkg/k8s/commands/cluster_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetDefaultTolerations(t *testing.T) {
+	tolerations := getDefaultTolerations()
+
+	assert.Len(t, tolerations, 2, "should return 2 default tolerations")
+
+	// Check for control-plane toleration
+	assert.Contains(t, tolerations, corev1.Toleration{
+		Key:      "node-role.kubernetes.io/control-plane",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	})
+
+	// Check for master toleration (legacy)
+	assert.Contains(t, tolerations, corev1.Toleration{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	})
+}


### PR DESCRIPTION
## Summary

Node-collector pods fail to schedule on clusters with tainted control-plane nodes, causing k8s scanning to hang until timeout.

- Adds default tolerations for `node-role.kubernetes.io/control-plane:NoSchedule` and `node-role.kubernetes.io/master:NoSchedule` when no custom tolerations are specified
- User-provided `--tolerations` flag still overrides defaults
- Zero breaking changes

## Test plan
- [x] Unit test for default tolerations
- [ ] CI passes
- [ ] Test on cluster with tainted control-plane nodes

Fixes #8087