### PR TITLE
fix(nodejs): skip package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,7 +45,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, nil
 	}
 
 	var id string

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -93,7 +93,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "invalid package name",
 			inputFile: "testdata/invalid_name.json",
-			wantErr:   "Name can only contain URL-friendly characters",
+			want:      packagejson.Package{},
 		},
 		{
 			name:      "sad path",


### PR DESCRIPTION
## Description

Closes #10607.

This changes the Node.js `package.json` parser to skip package metadata files with invalid package names instead of returning a parser error. This prevents debug walk errors for subpath `package.json` files like `rxjs/ajax`, which are module resolution hints rather than standalone npm packages.

## Related issues
- Closes #10607

## Testing

- Updated `pkg/dependency/parser/nodejs/packagejson/parse_test.go` so invalid package names return an empty package without an error.
- I could not run `go test ./pkg/dependency/parser/nodejs/packagejson` locally because this environment does not have the `go` command installed.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the documentation with the relevant information (not needed for this bug fix).
- [x] I've added usage information (not applicable; this PR introduces no new options).
- [x] I've included a "before" and "after" example to the description (not applicable; this is not a user interface change).
