### PR TITLE
fix(nodejs): silently skip package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,7 +45,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, nil
 	}
 
 	var id string

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -93,7 +93,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "invalid package name",
 			inputFile: "testdata/invalid_name.json",
-			wantErr:   "Name can only contain URL-friendly characters",
+			want:      packagejson.Package{},
 		},
 		{
 			name:      "sad path",


### PR DESCRIPTION
## Summary

Fixes #10607. Trivy was logging a spurious `DEBUG Walk error` for every `package.json` file whose `name` field contains a slash (e.g. `"name": "rxjs/ajax"`). These files are module-resolution hints used by older bundlers — they are not standalone packages, carry no `version`, and are never published to the npm registry independently. The scan result is unaffected, but the noise is misleading.

## Root Cause

`Parse` returned an error when `IsValidName` was false, which propagated up as a walk error and triggered the DEBUG log. The fix changes the invalid-name path to return an empty `Package{}` with `nil` error. Callers already guard on `pkg.ID == ""` and silently skip those entries, so no behavioral change occurs.

## Changes

- `pkg/dependency/parser/nodejs/packagejson/parse.go`: return `Package{}, nil` instead of an error when `IsValidName` returns false
- `pkg/dependency/parser/nodejs/packagejson/parse_test.go`: update `invalid package name` test case to expect an empty `Package{}` instead of an error

## Testing

```
go test ./pkg/dependency/parser/nodejs/packagejson/... -v
```

All 9 test cases pass, including `invalid_package_name` which now expects silent skip behavior.

## Related

- Fixes #10607