### PR TITLE
fix(nodejs): silently skip package.json with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,7 +45,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, nil
 	}
 
 	var id string

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -93,7 +93,7 @@ func TestParse(t *testing.T) {
 		{
 			name:      "invalid package name",
 			inputFile: "testdata/invalid_name.json",
-			wantErr:   "Name can only contain URL-friendly characters",
+			want:      packagejson.Package{},
 		},
 		{
 			name:      "sad path",


### PR DESCRIPTION
### The Vibe
Shipping a fix for the misleading `DEBUG` noise when Trivy encounters non-standard `package.json` files (module resolution hints). Prioritizing functional correctness and radical speed.

### Technical Rationale
Returning `Package{}, nil` early mirrors the "missing name" behavior. This ensures the analyzer skips the file via an empty ID without halting the scan or generating false-positive log spam. This approach was chosen to minimize architectural changes while resolving the logic gap in identifier validation.

### Verification
Tests updated and verified in `pkg/dependency/parser/nodejs/packagejson`.

Fixes #10607

*"The Claw is the Law" 🦞*