### PR TITLE
ci: migrate PAT tokens to GITHUB_TOKEN for reusable-release workflow

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -23,7 +23,6 @@ jobs:
       ECR_ACCESS_KEY_ID: ${{ secrets.ECR_ACCESS_KEY_ID }}
       ECR_SECRET_ACCESS_KEY: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
       GPG_KEY: ${{ secrets.GPG_KEY }}
-      TRIVY_REPO_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   upload-binaries:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
       ECR_SECRET_ACCESS_KEY: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
       GPG_KEY: ${{ secrets.GPG_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      TRIVY_REPO_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
 
   deploy-packages:
     name: Deploy rpm/deb packages

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -24,8 +24,6 @@ on:
         required: true
       GPG_PASSPHRASE:
         required: true
-      TRIVY_REPO_TOKEN:
-        required: true
 
 env:
   GH_USER: "aqua-bot"
@@ -39,7 +37,8 @@ jobs:
     permissions:
       id-token: write # For cosign
       packages: write # For GHCR
-      contents: read  # Not required for public repositories, but for clarity
+      contents: write # For GoReleaser to create the GitHub Release
+      discussions: write # For GoReleaser to attach the release to a Discussion (discussion_category_name)
       attestations: write # For build provenance attestations
     steps:
       - name: Cosign install
@@ -110,7 +109,7 @@ jobs:
           version: v2.1.0
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
-          GITHUB_TOKEN: ${{ secrets.TRIVY_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NFPM_DEFAULT_RPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_FILE: "gpg.key"
           TMPDIR: "tmp"


### PR DESCRIPTION
## Description
This PR switches GoReleaser in `reusable-release.yaml` from the long-lived PAT `TRIVY_REPO_TOKEN` to the built-in `GITHUB_TOKEN`. A full release runs up to 90 minutes, exceeding the 1-hour GitHub App installation token TTL, so an App token is not suitable here.

Changes:
- `reusable-release.yaml`: `permissions: contents: read → write` and add `discussions: write` (so the built-in token can create the GitHub Release and attach a Discussion). GoReleaser env switched to `secrets.GITHUB_TOKEN`. `TRIVY_REPO_TOKEN` removed from the workflow's `secrets:` block.
- `release.yaml`, `canary.yaml`: drop the `TRIVY_REPO_TOKEN` passthrough.

### Why `GITHUB_TOKEN` is safe here
- GoReleaser config has no cross-repo publishing sections (no `brews`/`scoop`/`nix`).
- DockerHub / ECR / GHCR registry pushes are authenticated by separate `docker/login-action` steps with their own secrets — independent of GoReleaser's `GITHUB_TOKEN`.
- No workflow in this repo subscribes to the `release: published` event, so a change of release author won't break downstream triggers.

## Test run

End-to-end verified on fork `DmitriyLewen/trivy` (combined with #10628 in one test branch) by pushing tag `v0.999.5` ([workflow run](https://github.com/DmitriyLewen/trivy/actions/runs/25731027349)). The test branch trims DockerHub/ECR, retargets GHCR to the fork namespace, and limits builds to linux/amd64+arm64.

**Release succeeded** — GoReleaser with the built-in `GITHUB_TOKEN` created the release, attached a Discussion in the `Development` category, pushed images to GHCR, signed with cosign, and produced build attestations: https://github.com/DmitriyLewen/trivy/releases/tag/v0.999.5

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).