### PR TITLE
feat(k8s): support caching for k8s subcommand

### DIFF
--- a/pkg/k8s/scanner/cache.go
+++ b/pkg/k8s/scanner/cache.go
@@ -1,0 +1,60 @@
+package scanner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/aquasecurity/trivy-kubernetes/pkg/artifacts"
+	"github.com/aquasecurity/trivy/pkg/k8s/report"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+type resourceCache struct {
+	dir string
+}
+
+func newResourceCache(baseDir string) (*resourceCache, error) {
+	cacheDir := filepath.Join(baseDir, "k8s-artifacts")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return nil, err
+	}
+	return &resourceCache{dir: cacheDir}, nil
+}
+
+func (c *resourceCache) key(artifact *artifacts.Artifact) string {
+	// Create a unique hash for the artifact based on its identifying fields.
+	// Since K8s resources change versions, hashing the raw resource is a safe bet.
+	h := sha256.New()
+	h.Write(artifact.RawResource)
+	return hex.EncodeToString(h.Sum(nil)) + ".json"
+}
+
+func (c *resourceCache) get(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, bool) {
+	path := filepath.Join(c.dir, c.key(artifact))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var res []report.Resource
+	if err := json.Unmarshal(data, &res); err != nil {
+		log.WarnContext(ctx, "Failed to unmarshal cached k8s artifact", log.Err(err))
+		return nil, false
+	}
+	return res, true
+}
+
+func (c *resourceCache) put(ctx context.Context, artifact *artifacts.Artifact, res []report.Resource) {
+	path := filepath.Join(c.dir, c.key(artifact))
+	data, err := json.Marshal(res)
+	if err != nil {
+		log.WarnContext(ctx, "Failed to marshal k8s artifact for cache", log.Err(err))
+		return
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		log.WarnContext(ctx, "Failed to write k8s artifact to cache", log.Err(err))
+	}
+}

--- a/pkg/k8s/scanner/cache.go
+++ b/pkg/k8s/scanner/cache.go
@@ -19,22 +19,31 @@ type resourceCache struct {
 
 func newResourceCache(baseDir string) (*resourceCache, error) {
 	cacheDir := filepath.Join(baseDir, "k8s-artifacts")
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return nil, err
 	}
 	return &resourceCache{dir: cacheDir}, nil
 }
 
-func (c *resourceCache) key(artifact *artifacts.Artifact) string {
+func (c *resourceCache) key(artifact *artifacts.Artifact) (string, error) {
 	// Create a unique hash for the artifact based on its identifying fields.
 	// Since K8s resources change versions, hashing the raw resource is a safe bet.
+	data, err := json.Marshal(artifact.RawResource)
+	if err != nil {
+		return "", err
+	}
 	h := sha256.New()
-	h.Write(artifact.RawResource)
-	return hex.EncodeToString(h.Sum(nil)) + ".json"
+	_, _ = h.Write(data)
+	return hex.EncodeToString(h.Sum(nil)) + ".json", nil
 }
 
 func (c *resourceCache) get(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, bool) {
-	path := filepath.Join(c.dir, c.key(artifact))
+	key, err := c.key(artifact)
+	if err != nil {
+		log.WarnContext(ctx, "Failed to compute cache key", log.Err(err))
+		return nil, false
+	}
+	path := filepath.Join(c.dir, key)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, false
@@ -48,13 +57,18 @@ func (c *resourceCache) get(ctx context.Context, artifact *artifacts.Artifact) (
 }
 
 func (c *resourceCache) put(ctx context.Context, artifact *artifacts.Artifact, res []report.Resource) {
-	path := filepath.Join(c.dir, c.key(artifact))
+	key, err := c.key(artifact)
+	if err != nil {
+		log.WarnContext(ctx, "Failed to compute cache key", log.Err(err))
+		return
+	}
+	path := filepath.Join(c.dir, key)
 	data, err := json.Marshal(res)
 	if err != nil {
 		log.WarnContext(ctx, "Failed to marshal k8s artifact for cache", log.Err(err))
 		return
 	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		log.WarnContext(ctx, "Failed to write k8s artifact to cache", log.Err(err))
 	}
 }

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -94,57 +94,11 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 
 	// scan images from kubernetes cluster in parallel
 	if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner, types.SecretScanner) && !s.opts.SkipImages {
-		var resCache *resourceCache
-		if s.opts.CacheDir != "" {
-			resCache, _ = newResourceCache(s.opts.CacheDir)
-		}
-
-		onItem := func(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, error) {
-			if resCache != nil {
-				if cached, ok := resCache.get(ctx, artifact); ok {
-					log.DebugContext(ctx, "Cache hit for k8s artifact", log.String("kind", artifact.Kind), log.String("name", artifact.Name))
-					return cached, nil
-				}
-			}
-
-			opts := s.opts
-			opts.Credentials = make([]ftypes.Credential, len(s.opts.Credentials))
-			copy(opts.Credentials, s.opts.Credentials)
-			// add image private registry credential auto detected from workload imagePullsecret / serviceAccount
-			if len(artifact.Credentials) > 0 {
-				for _, cred := range artifact.Credentials {
-					opts.RegistryOptions.Credentials = append(opts.RegistryOptions.Credentials,
-						ftypes.Credential{
-							Username: cred.Username,
-							Password: cred.Password,
-						},
-					)
-				}
-			}
-			vulns, err := s.scanVulns(ctx, artifact, opts)
-			if err != nil {
-				return nil, xerrors.Errorf("scanning vulnerabilities error: %w", err)
-			}
-			if resCache != nil {
-				resCache.put(ctx, artifact, vulns)
-			}
-			return vulns, nil
-		}
-
-		onResult := func(result []report.Resource) error {
-			resources = append(resources, result...)
-			return nil
-		}
-		workers := s.opts.Parallel
-		if s.opts.CacheBackend == string(cache.TypeFS) {
-			// To avoid lock contention in bbolt, we limit the number of workers to 1 when using FS cache.
-			workers = 1
-		}
-
-		p := parallel.NewPipeline(workers, !s.opts.Quiet, resourceArtifacts, onItem, onResult)
-		if err := p.Do(ctx); err != nil {
+		imageResources, err := s.scanImages(ctx, resourceArtifacts)
+		if err != nil {
 			return report.Report{}, err
 		}
+		resources = append(resources, imageResources...)
 	}
 
 	if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner) {
@@ -160,6 +114,67 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 		Resources:     resources,
 	}, nil
 
+}
+
+func (s *Scanner) scanImages(ctx context.Context, resourceArtifacts []*artifacts.Artifact) ([]report.Resource, error) {
+	var resCache *resourceCache
+	if s.opts.CacheDir != "" {
+		var cacheErr error
+		resCache, cacheErr = newResourceCache(s.opts.CacheDir)
+		if cacheErr != nil {
+			log.WarnContext(ctx, "Failed to initialize k8s artifact cache", log.Err(cacheErr))
+		}
+	}
+
+	var resources []report.Resource
+
+	onItem := func(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, error) {
+		if resCache != nil {
+			if cached, ok := resCache.get(ctx, artifact); ok {
+				log.DebugContext(ctx, "Cache hit for k8s artifact", log.String("kind", artifact.Kind), log.String("name", artifact.Name))
+				return cached, nil
+			}
+		}
+
+		opts := s.opts
+		opts.Credentials = make([]ftypes.Credential, len(s.opts.Credentials))
+		copy(opts.Credentials, s.opts.Credentials)
+		// add image private registry credential auto detected from workload imagePullsecret / serviceAccount
+		if len(artifact.Credentials) > 0 {
+			for _, cred := range artifact.Credentials {
+				opts.RegistryOptions.Credentials = append(opts.RegistryOptions.Credentials,
+					ftypes.Credential{
+						Username: cred.Username,
+						Password: cred.Password,
+					},
+				)
+			}
+		}
+		vulns, err := s.scanVulns(ctx, artifact, opts)
+		if err != nil {
+			return nil, xerrors.Errorf("scanning vulnerabilities error: %w", err)
+		}
+		if resCache != nil {
+			resCache.put(ctx, artifact, vulns)
+		}
+		return vulns, nil
+	}
+
+	onResult := func(result []report.Resource) error {
+		resources = append(resources, result...)
+		return nil
+	}
+	workers := s.opts.Parallel
+	if s.opts.CacheBackend == string(cache.TypeFS) {
+		// To avoid lock contention in bbolt, we limit the number of workers to 1 when using FS cache.
+		workers = 1
+	}
+
+	p := parallel.NewPipeline(workers, !s.opts.Quiet, resourceArtifacts, onItem, onResult)
+	if err := p.Do(ctx); err != nil {
+		return nil, err
+	}
+	return resources, nil
 }
 
 func (s *Scanner) scanVulns(ctx context.Context, artifact *artifacts.Artifact, opts flag.Options) ([]report.Resource, error) {

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -94,7 +94,19 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 
 	// scan images from kubernetes cluster in parallel
 	if s.opts.Scanners.AnyEnabled(types.VulnerabilityScanner, types.SecretScanner) && !s.opts.SkipImages {
+		var resCache *resourceCache
+		if s.opts.CacheDir != "" {
+			resCache, _ = newResourceCache(s.opts.CacheDir)
+		}
+
 		onItem := func(ctx context.Context, artifact *artifacts.Artifact) ([]report.Resource, error) {
+			if resCache != nil {
+				if cached, ok := resCache.get(ctx, artifact); ok {
+					log.DebugContext(ctx, "Cache hit for k8s artifact", log.String("kind", artifact.Kind), log.String("name", artifact.Name))
+					return cached, nil
+				}
+			}
+
 			opts := s.opts
 			opts.Credentials = make([]ftypes.Credential, len(s.opts.Credentials))
 			copy(opts.Credentials, s.opts.Credentials)
@@ -112,6 +124,9 @@ func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact)
 			vulns, err := s.scanVulns(ctx, artifact, opts)
 			if err != nil {
 				return nil, xerrors.Errorf("scanning vulnerabilities error: %w", err)
+			}
+			if resCache != nil {
+				resCache.put(ctx, artifact, vulns)
 			}
 			return vulns, nil
 		}


### PR DESCRIPTION
## Description

This PR introduces an artifact-level caching mechanism for the `trivy k8s` subcommand. 

When scanning massive Kubernetes clusters, the operation can take a significant amount of time. If the context is cancelled due to a CI timeout or network failure, Trivy previously lost all progress because results were held in memory until the pipeline completed. 

To solve this, I've added a `resourceCache` in `pkg/k8s/scanner/cache.go` that serializes and checkpoints successful `[]report.Resource` results to the local filesystem (`--cache-dir`). The cache key is generated by computing a SHA256 hash of the artifact's `RawResource`, naturally busting the cache whenever a K8s resource is mutated or its `ResourceVersion` bumps. The parallel execution pipeline (`onItem`) has been updated to immediately return cached reports upon a hit, completely bypassing the redundant image downloads and scanning.

## Related issues
- Close #3698

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
