### PR TITLE
fix(nodejs): silently skip subdirectory package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,6 +45,14 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
+		// Subdirectory package.json files (e.g. rxjs/ajax/package.json)
+		// are module resolution hints, not real packages.
+		// They are never published independently and may have slashes
+		// in the name field. Silently skip them.
+		// https://github.com/aquasecurity/trivy/issues/10607
+		if pkgJSON.Version == "" {
+			return Package{}, nil
+		}
 		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
 	}
 


### PR DESCRIPTION
## Summary
Fixes #10607 - Subdirectory `package.json` files (e.g. `rxjs/ajax/package.json`) with slashes in the `name` field no longer produce misleading WARNING logs.

These files are module resolution hints used by bundlers, not real packages:
- They have no `version` field
- They are never published independently  
- npm docs state name format rules only apply when publishing

## Changes
- `pkg/dependency/parser/nodejs/packagejson/parse.go`: Skip invalid name check when `version` is empty (indicates a non-package hint file)

## Test plan
- [x] All existing tests pass including `invalid_package_name` (still errors when version is present)
- [x] Build succeeds