### PR TITLE
fix(misconf): prevent path traversal in Terraform filesystem functions

### DIFF
--- a/docs/guide/coverage/iac/terraform.md
+++ b/docs/guide/coverage/iac/terraform.md
@@ -53,6 +53,29 @@ The secret scan is performed on plain text files, with no special treatment for 
 
 ### Terraform configurations
 
+#### Filesystem functions
+
+Trivy treats the scan root as a trust boundary: only files within it are considered trusted input.
+Functions such as `file()`, `filebase64()`, and related file-reading functions cannot access paths outside the scanned directory.
+
+```hcl
+# Works: path is within the scan root
+user_data = file("scripts/bootstrap.sh")
+
+# Fails: path escapes the scan root
+user_data = file("../shared/bootstrap.sh")
+```
+
+This can affect configurations that reference shared files from a parent directory, for example when scanning a subdirectory such as `envs/production/` while shared files live at the repository root.
+
+**Workaround:** scan from the repository root so all referenced files fall within the scan boundary:
+
+```bash
+trivy config --skip-dirs envs/staging ./
+```
+
+If certain checks produce false positives due to unresolved `file()` calls, they can be suppressed using `--ignore-policy` or inline `# trivy:ignore` comments.
+
 #### Data sources and computed attributes
 
 Trivy relies on static analysis of Terraform configurations. As a result, data sources and

--- a/docs/guide/coverage/iac/terraform.md
+++ b/docs/guide/coverage/iac/terraform.md
@@ -66,7 +66,7 @@ user_data = file("scripts/bootstrap.sh")
 user_data = file("../shared/bootstrap.sh")
 ```
 
-This can affect configurations that reference shared files from a parent directory, for example when scanning a subdirectory such as `envs/production/` while shared files live at the repository root.
+This can affect configurations that reference shared files from a parent directory, for example, when scanning a subdirectory such as `envs/production/`, while shared files live at the repository root.
 
 **Workaround:** scan from the repository root so all referenced files fall within the scan boundary:
 

--- a/pkg/iac/scanners/terraform/parser/functions.go
+++ b/pkg/iac/scanners/terraform/parser/functions.go
@@ -10,11 +10,19 @@ import (
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser/funcs"
+	"github.com/aquasecurity/trivy/pkg/mapfs"
 )
 
 // Functions returns the set of functions that should be used to when evaluating
 // expressions in the receiving scope.
 func Functions(target fs.FS, baseDir string) map[string]function.Function {
+	// Use a sandboxed FS without underlyingRoot for file functions to prevent
+	// path traversal above the scan root via mapfs's underlying OS fallback.
+	if mfs, ok := target.(*mapfs.FS); ok {
+		target = mfs.Sandboxed()
+	} else {
+		target = mapfs.New()
+	}
 	return map[string]function.Function{
 		"abs":              stdlib.AbsoluteFunc,
 		"abspath":          funcs.AbsPathFunc,

--- a/pkg/iac/scanners/terraform/parser/functions_test.go
+++ b/pkg/iac/scanners/terraform/parser/functions_test.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/aquasecurity/trivy/pkg/mapfs"
+)
+
+// newTestFS creates a temp layout simulating a real scan:
+//
+//	tmpDir/
+//	  secret.txt              ← sensitive file OUTSIDE scan root
+//	  scanroot/               ← underlyingRoot, actual scan directory
+//	    userdata.sh           ← virtual file in scan root
+//	    modules/vpc/
+//	      userdata.sh         ← virtual file in child module
+func newTestFS(t *testing.T) *mapfs.FS {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "secret.txt"), []byte("sensitive-data"), 0o600))
+
+	scanRoot := filepath.Join(tmpDir, "scanroot")
+	require.NoError(t, os.MkdirAll(scanRoot, 0o755))
+
+	mfs := mapfs.New(mapfs.WithUnderlyingRoot(scanRoot))
+	require.NoError(t, mfs.WriteVirtualFile("userdata.sh", []byte("#!/bin/bash"), 0o644))
+	require.NoError(t, mfs.MkdirAll("modules/vpc", 0o755))
+	require.NoError(t, mfs.WriteVirtualFile("modules/vpc/userdata.sh", []byte("#!/bin/bash"), 0o644))
+	return mfs
+}
+
+func TestFunctions_File(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseDir string
+		path    string
+		want    string
+		wantErr string
+	}{
+		{name: "file in scan root", baseDir: ".", path: "userdata.sh", want: "#!/bin/bash"},
+		{name: "file read from child module", baseDir: "modules/vpc", path: "userdata.sh", want: "#!/bin/bash"},
+		{name: "traversal one level up", baseDir: ".", path: "../secret.txt", wantErr: "no file exists at"},
+		{name: "traversal parent dir only", baseDir: ".", path: "..", wantErr: "no file exists at"},
+	}
+
+	for _, tt := range tests {
+		fns := Functions(newTestFS(t), tt.baseDir)
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := fns["file"].Call([]cty.Value{cty.StringVal(tt.path)})
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, val.AsString())
+		})
+	}
+}
+
+// wrappedFS wraps fs.FS so that the *mapfs.FS type assertion in Functions() misses,
+// exercising the mapfs.New() fallback path.
+type wrappedFS struct{ fs.FS }
+
+func TestFunctions_File_UnknownFSType(t *testing.T) {
+	// Even though the wrapped FS contains userdata.sh, Functions() cannot
+	// unwrap it, falls back to mapfs.New(), and the call must fail — not
+	// silently read from the host filesystem.
+	fns := Functions(wrappedFS{newTestFS(t)}, ".")
+	_, err := fns["file"].Call([]cty.Value{cty.StringVal("userdata.sh")})
+	assert.ErrorContains(t, err, "no file exists at")
+}
+
+func TestFunctions_FileExists(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want cty.Value
+	}{
+		{name: "file in scan root", path: "userdata.sh", want: cty.True},
+		{name: "traversal one level up", path: "../secret.txt", want: cty.False},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fns := Functions(newTestFS(t), ".")
+			val, err := fns["fileexists"].Call([]cty.Value{cty.StringVal(tt.path)})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}

--- a/pkg/iac/scanners/terraform/parser/functions_test.go
+++ b/pkg/iac/scanners/terraform/parser/functions_test.go
@@ -52,8 +52,8 @@ func TestFunctions_File(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fns := Functions(newTestFS(t), tt.baseDir)
 		t.Run(tt.name, func(t *testing.T) {
+			fns := Functions(newTestFS(t), tt.baseDir)
 			val, err := fns["file"].Call([]cty.Value{cty.StringVal(tt.path)})
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/mapfs"
 	"github.com/aquasecurity/trivy/pkg/set"
 )
 
@@ -2177,7 +2178,17 @@ resource "test" "fileset-func" {
 		"path/b.py": ``,
 	}
 
-	resources := parse(t, files).GetResourcesByType("test")
+	fsys := mapfs.New()
+	for name, content := range files {
+		fsys.MkdirAll(filepath.Dir(name), 0o755)
+		fsys.WriteVirtualFile(name, []byte(content), 0o644)
+	}
+
+	parser := New(fsys, "", OptionStopOnHCLError(true))
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+	modules, err := parser.EvaluateAll(t.Context())
+	require.NoError(t, err)
+	resources := modules.GetResourcesByType("test")
 	require.Len(t, resources, 1)
 	attr := resources[0].GetAttribute("value")
 	require.NotNil(t, attr)

--- a/pkg/mapfs/fs.go
+++ b/pkg/mapfs/fs.go
@@ -273,6 +273,12 @@ func (m *FS) RemoveAll(path string) error {
 	return m.root.RemoveAll(cleanPath(path))
 }
 
+// Sandboxed returns a copy of the filesystem without the underlying root,
+// preventing access to the local filesystem outside of the in-memory filesystem.
+func (m *FS) Sandboxed() *FS {
+	return &FS{root: m.root}
+}
+
 func cleanPath(path string) string {
 	// Convert the volume name like 'C:' into dir like 'C\'
 	if vol := filepath.VolumeName(path); vol != "" {


### PR DESCRIPTION
## Description

Terraform's `file()` and related functions received a `mapfs.FS` with `WithUnderlyingRoot` set, which allowed `../` sequences to read arbitrary files outside the scan root.

Fixed by passing a sandboxed FS (without `underlyingRoot`) to all Terraform filesystem functions. Only the scan root is considered trusted input — access above it is intentionally blocked. Adds tests and documents the scan-root boundary as a known limitation.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
