### PR TITLE
fix(secret): correctly skip secret-scanner config file from scanning

### DIFF
--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -46,7 +46,7 @@ type SecretAnalyzer struct {
 func NewSecretAnalyzer(s secret.Scanner, configPath string) *SecretAnalyzer {
 	return &SecretAnalyzer{
 		scanner:    s,
-		configPath: configPath,
+		configPath: cleanPath(configPath),
 	}
 }
 
@@ -63,8 +63,15 @@ func (a *SecretAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
 		return xerrors.Errorf("secret config error: %w", err)
 	}
 	a.scanner = secret.NewScanner(c)
-	a.configPath = configPath
+	a.configPath = cleanPath(opt.SecretScannerOption.ConfigPath)
 	return nil
+}
+
+func cleanPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(p))
 }
 
 func (a *SecretAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
@@ -116,15 +123,15 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 	}
 
 	// Skip the secret-scanner config file itself.
-	// filePath is scan-relative and slash-normalized by the walker; configPath comes from the
-	// --secret-config flag verbatim and may carry a scan-root prefix or native separators, so
-	// normalize both and accept filePath as a path-boundary suffix of configPath. This trades
-	// off a rare over-skip (same-basename file elsewhere in the scan tree) for correctly
-	// handling the common case where the flag value is given relative to CWD, not scan root.
+	// a.configPath is already cleaned/slash-normalized in Init; filePath is scan-relative
+	// from the walker but may carry native separators on Windows, so normalize it too.
+	// We accept filePath as a path-boundary suffix of configPath to handle the common case
+	// where --secret-config is given relative to CWD (so it carries a scan-root prefix that
+	// the walker strips from filePath). This trades off a rare over-skip (same-basename
+	// file elsewhere in the scan tree) for correctness in the common case.
 	if a.configPath != "" {
-		cleanFile := filepath.ToSlash(filepath.Clean(filePath))
-		cleanConfig := filepath.ToSlash(filepath.Clean(a.configPath))
-		if cleanConfig == cleanFile || strings.HasSuffix(cleanConfig, "/"+cleanFile) {
+		cleanFile := cleanPath(filePath)
+		if a.configPath == cleanFile || strings.HasSuffix(a.configPath, "/"+cleanFile) {
 			return false
 		}
 	}

--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
@@ -116,11 +117,14 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 
 	// Skip the secret-scanner config file itself.
 	// filePath is scan-relative and slash-normalized by the walker; configPath comes from the
-	// --secret-config flag verbatim and may contain native separators, so normalize both.
+	// --secret-config flag verbatim and may carry a scan-root prefix or native separators, so
+	// normalize both and accept filePath as a path-boundary suffix of configPath. This trades
+	// off a rare over-skip (same-basename file elsewhere in the scan tree) for correctly
+	// handling the common case where the flag value is given relative to CWD, not scan root.
 	if a.configPath != "" {
 		cleanFile := filepath.ToSlash(filepath.Clean(filePath))
 		cleanConfig := filepath.ToSlash(filepath.Clean(a.configPath))
-		if cleanConfig == cleanFile {
+		if cleanConfig == cleanFile || strings.HasSuffix(cleanConfig, "/"+cleanFile) {
 			return false
 		}
 	}

--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -164,9 +164,15 @@ func (a *SecretAnalyzer) Required(filePath string, fi os.FileInfo) bool {
 		return false
 	}
 
-	// Skip the config file for secret scanning
-	if filepath.Base(a.configPath) == filePath {
-		return false
+	// Skip the secret-scanner config file itself.
+	// filePath is scan-relative and slash-normalized by the walker; configPath comes from the
+	// --secret-config flag verbatim and may contain native separators, so normalize both.
+	if a.configPath != "" {
+		cleanFile := filepath.ToSlash(filepath.Clean(filePath))
+		cleanConfig := filepath.ToSlash(filepath.Clean(a.configPath))
+		if cleanConfig == cleanFile {
+			return false
+		}
 	}
 
 	// Check if the file extension should be skipped

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -208,35 +208,73 @@ func TestSecretAnalyzer(t *testing.T) {
 }
 
 func TestSecretRequire(t *testing.T) {
+	const defaultConfig = "testdata/skip-tests-config.yaml"
+
 	tests := []struct {
-		name     string
-		filePath string
-		want     bool
+		name       string
+		configPath string
+		filePath   string
+		want       bool
 	}{
 		{
-			name:     "pass regular file",
-			filePath: "testdata/secret.txt",
-			want:     true,
+			name:       "pass regular file",
+			configPath: defaultConfig,
+			filePath:   "testdata/secret.txt",
+			want:       true,
 		},
 		{
-			name:     "skip small file",
-			filePath: "testdata/emptyfile",
-			want:     false,
+			name:       "skip small file",
+			configPath: defaultConfig,
+			filePath:   "testdata/emptyfile",
+			want:       false,
 		},
 		{
-			name:     "skip folder",
-			filePath: "testdata/node_modules/secret.txt",
-			want:     false,
+			name:       "skip folder",
+			configPath: defaultConfig,
+			filePath:   "testdata/node_modules/secret.txt",
+			want:       false,
 		},
 		{
-			name:     "skip file",
-			filePath: "testdata/package-lock.json",
-			want:     false,
+			name:       "skip file",
+			configPath: defaultConfig,
+			filePath:   "testdata/package-lock.json",
+			want:       false,
 		},
 		{
-			name:     "skip extension",
-			filePath: "testdata/secret.doc",
-			want:     false,
+			name:       "skip extension",
+			configPath: defaultConfig,
+			filePath:   "testdata/secret.doc",
+			want:       false,
+		},
+		{
+			name:       "skip config file when configPath is a relative path matching filePath",
+			configPath: "testdata/skip-tests-config.yaml",
+			filePath:   "testdata/skip-tests-config.yaml",
+			want:       false,
+		},
+		{
+			name:       "skip config file when configPath is a bare filename matching filePath",
+			configPath: "skip-tests-config.yaml",
+			filePath:   "skip-tests-config.yaml",
+			want:       false,
+		},
+		{
+			name:       "do not skip unrelated file sharing a path suffix with configPath",
+			configPath: "foo/bar/myconfig.yaml",
+			filePath:   "bar/myconfig.yaml",
+			want:       true,
+		},
+		{
+			name:       "do not skip file at scan root when configPath is in a subfolder",
+			configPath: "configs/myconfig.yaml",
+			filePath:   "myconfig.yaml",
+			want:       true,
+		},
+		{
+			name:       "do not skip file when configPath is empty",
+			configPath: "",
+			filePath:   "src/myfile.yaml",
+			want:       true,
 		},
 	}
 
@@ -245,12 +283,18 @@ func TestSecretRequire(t *testing.T) {
 			a := secret.SecretAnalyzer{}
 			err := a.Init(analyzer.AnalyzerOptions{
 				SecretScannerOption: analyzer.SecretScannerOption{
-					ConfigPath: "testdata/skip-tests-config.yaml",
+					ConfigPath: tt.configPath,
 				},
 			})
 			require.NoError(t, err)
 
-			fi, err := os.Stat(tt.filePath)
+			// Stat a real file so fi.Size() passes the small-file check; the path
+			// argument passed to Required can be a synthetic scan-relative path.
+			statPath := tt.filePath
+			if _, err := os.Stat(statPath); err != nil {
+				statPath = defaultConfig
+			}
+			fi, err := os.Stat(statPath)
 			require.NoError(t, err)
 
 			got := a.Required(tt.filePath, fi)

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -259,15 +259,15 @@ func TestSecretRequire(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "do not skip unrelated file sharing a path suffix with configPath",
-			configPath: "foo/bar/myconfig.yaml",
-			filePath:   "bar/myconfig.yaml",
-			want:       true,
+			name:       "skip config file when configPath has a scan-root prefix and filePath is the tail",
+			configPath: "testdata/fixtures/repo/secrets/trivy-secret.yaml",
+			filePath:   "trivy-secret.yaml",
+			want:       false,
 		},
 		{
-			name:       "do not skip file at scan root when configPath is in a subfolder",
-			configPath: "configs/myconfig.yaml",
-			filePath:   "myconfig.yaml",
+			name:       "do not skip file whose basename matches but path boundary does not",
+			configPath: "trivy-secret.yaml",
+			filePath:   "my-trivy-secret.yaml",
 			want:       true,
 		},
 		{

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -3,6 +3,7 @@ package secret_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,17 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/secret"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
+
+// fakeFileInfo lets Required tests use synthetic scan-relative paths without
+// needing the path to exist on disk; Required only reads Size().
+type fakeFileInfo struct{ size int64 }
+
+func (f fakeFileInfo) Name() string       { return "" }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
 
 func TestSecretAnalyzer(t *testing.T) {
 	wantFinding1 := types.SecretFinding{
@@ -214,6 +226,7 @@ func TestSecretRequire(t *testing.T) {
 		name       string
 		configPath string
 		filePath   string
+		size       int64
 		want       bool
 	}{
 		{
@@ -226,6 +239,7 @@ func TestSecretRequire(t *testing.T) {
 			name:       "skip small file",
 			configPath: defaultConfig,
 			filePath:   "testdata/emptyfile",
+			size:       5,
 			want:       false,
 		},
 		{
@@ -288,16 +302,11 @@ func TestSecretRequire(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Stat a real file so fi.Size() passes the small-file check; the path
-			// argument passed to Required can be a synthetic scan-relative path.
-			statPath := tt.filePath
-			if _, err := os.Stat(statPath); err != nil {
-				statPath = defaultConfig
+			size := tt.size
+			if size == 0 {
+				size = 1024
 			}
-			fi, err := os.Stat(statPath)
-			require.NoError(t, err)
-
-			got := a.Required(tt.filePath, fi)
+			got := a.Required(tt.filePath, fakeFileInfo{size: size})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -1,6 +1,7 @@
 package secret_test
 
 import (
+	"cmp"
 	"os"
 	"testing"
 	"time"
@@ -285,6 +286,16 @@ func TestSecretRequire(t *testing.T) {
 			want:       true,
 		},
 		{
+			// Known limitation of the path-suffix match: an unrelated file at the scan
+			// root whose name equals the configPath's tail is also skipped. This locks
+			// in the trade-off documented in Required so a refactor cannot silently
+			// change it.
+			name:       "over-skip: configPath suffix matches unrelated file at scan root",
+			configPath: "configs/myconfig.yaml",
+			filePath:   "myconfig.yaml",
+			want:       false,
+		},
+		{
 			name:       "do not skip file when configPath is empty",
 			configPath: "",
 			filePath:   "src/myfile.yaml",
@@ -302,10 +313,7 @@ func TestSecretRequire(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			size := tt.size
-			if size == 0 {
-				size = 1024
-			}
+			size := cmp.Or(tt.size, 1024)
 			got := a.Required(tt.filePath, fakeFileInfo{size: size})
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
## Description

`SecretAnalyzer.Required` only skips the `--secret-config` file when the flag value is a bare filename and the file lives in the scan root. The current check compares the base name of `a.configPath` to the scan-relative `filePath`:

```go
if filepath.Base(a.configPath) == filePath {
    return false
}
```

When the user passes a relative path with directories (e.g. `configs/trivy-secret.yaml`), the comparison never succeeds and Trivy ends up scanning its own secret-scanner config — producing false positives against the user's rules.

This PR replaces the check with a normalized path-suffix comparison:

- `a.configPath` is cleaned and slash-normalized once in `Init` (`filepath.ToSlash(filepath.Clean(...))`); the same normalization is applied to `filePath` on each call,
- the file is skipped when the cleaned `filePath` either equals the cleaned `configPath`, or is its path-boundary suffix (`HasSuffix(cleanConfig, "/"+cleanFile)`).

This covers the common shapes the flag value can take:
- bare filename (`--secret-config trivy-secret.yaml`),
- a path relative to CWD that already equals the scan-relative form (`--secret-config configs/trivy-secret.yaml`),
- a path relative to CWD that carries a scan-root prefix the walker strips off (`--secret-config testdata/.../secrets/trivy-secret.yaml` against scan root `testdata/.../secrets`),
- an absolute path whose tail matches the scan-relative `filePath`.

**Known limitation:** the suffix check can over-skip when an unrelated file in the scan tree shares the same trailing path with `--secret-config` (e.g. `--secret-config configs/myconfig.yaml` while the scan tree contains `myconfig.yaml`). The fully correct fix requires plumbing the scan root through the analyzer interface so the configPath can be resolved into a scan-relative path; that's left for a follow-up.

## Reproduction (before this PR)

```
project/
├── configs/
│   └── trivy-secret.yaml   # custom rule looking for TRIVYSELFSCANDEMOMARKER
│                           # — same marker is in the regex/keywords lines
└── src/hello.txt
```

```sh
$ trivy fs --scanners secret --secret-config configs/trivy-secret.yaml ./project
...
configs/trivy-secret.yaml (secrets)
===================================
Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 2, CRITICAL: 0)
```

## Reproduction (after this PR)

```sh
$ trivy fs --scanners secret --secret-config configs/trivy-secret.yaml ./project
...
INFO  [report] No issues detected with scanner(s).  scanners=[secret]
```

## Related issues
- Close #10665

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
