### PR TITLE
fix(nodejs): silently skip package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -45,7 +45,11 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		// Names that aren't URL-friendly aren't publishable to the registry,
+		// so these are almost always subpath package.json files that exist
+		// purely as module resolution hints (e.g. rxjs/ajax/package.json).
+		// Skip them silently — callers already ignore packages without an ID.
+		return Package{}, nil
 	}
 
 	var id string

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -91,9 +91,12 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:      "invalid package name",
+			// Subpath package.json files (e.g. rxjs/ajax/package.json) carry
+			// a non-URL-friendly name and aren't real packages. Parser
+			// returns an empty Package and no error so the caller skips it.
+			name:      "subpath package.json with non-URL-friendly name",
 			inputFile: "testdata/invalid_name.json",
-			wantErr:   "Name can only contain URL-friendly characters",
+			want:      packagejson.Package{},
 		},
 		{
 			name:      "sad path",


### PR DESCRIPTION
## Description

Closes #10607.

Subpath `package.json` files (e.g. `rxjs/ajax/package.json`) live inside published packages purely to hint bundlers at the right entry point. They:

- have no `version` field,
- are never published to the npm registry independently,
- often carry a slash in `name` (e.g. `"rxjs/ajax"`) — invalid for the registry but fine on disk per the [npm docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#name).

Right now Trivy returns an error from `packagejson.Parser.Parse` for these files, which `fsutils.WalkDir` swallows and logs at DEBUG. The scan result is unaffected, but the logs are noisy and misleading:

```
DEBUG   Walk error  file_path="node_modules/.pnpm/rxjs@6.6.7/node_modules/rxjs/ajax/package.json" err="unable to parse ...: Name can only contain URL-friendly characters"
```

This PR returns an empty `Package` and a nil error when `IsValidName` fails. Callers already skip packages without an ID (and already accept empty-name packages, since `IsValidName("")` returns true), so behavior for real packages is unchanged. Existing test renamed and updated to reflect the new expectation.

## Related issues

- Close #10607

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.