### PR TITLE
fix(misconf): support github_repository_vulnerability_alerts resource

### DIFF
--- a/pkg/iac/adapters/terraform/github/repositories/adapt.go
+++ b/pkg/iac/adapters/terraform/github/repositories/adapt.go
@@ -30,9 +30,8 @@ func adaptRepository(modules terraform.Modules, resource *terraform.Block) githu
 
 	// The standalone github_repository_vulnerability_alerts resource is the recommended
 	// approach (vulnerability_alerts on github_repository is deprecated). If present, it takes precedence.
-	for _, alertsBlock := range modules.GetReferencingResources(resource, "github_repository_vulnerability_alerts", "repository") {
-		repo.VulnerabilityAlerts = alertsBlock.GetAttribute("enabled").AsBoolValueOrDefault(true, alertsBlock)
-		break
+	if blocks := modules.GetReferencingResources(resource, "github_repository_vulnerability_alerts", "repository"); len(blocks) > 0 {
+		repo.VulnerabilityAlerts = blocks[0].GetAttribute("enabled").AsBoolValueOrDefault(true, blocks[0])
 	}
 
 	privateAttr := resource.GetAttribute("private")

--- a/pkg/iac/adapters/terraform/github/repositories/adapt.go
+++ b/pkg/iac/adapters/terraform/github/repositories/adapt.go
@@ -14,19 +14,25 @@ func adaptRepositories(modules terraform.Modules) []github.Repository {
 	var repositories []github.Repository
 	for _, module := range modules {
 		for _, resource := range module.GetResourcesByType("github_repository") {
-			repositories = append(repositories, adaptRepository(resource))
+			repositories = append(repositories, adaptRepository(modules, resource))
 		}
 	}
 	return repositories
 }
 
-func adaptRepository(resource *terraform.Block) github.Repository {
-
+func adaptRepository(modules terraform.Modules, resource *terraform.Block) github.Repository {
 	repo := github.Repository{
 		Metadata:            resource.GetMetadata(),
 		Public:              types.Bool(true, resource.GetMetadata()),
 		VulnerabilityAlerts: resource.GetAttribute("vulnerability_alerts").AsBoolValueOrDefault(false, resource),
 		Archived:            resource.GetAttribute("archived").AsBoolValueOrDefault(false, resource),
+	}
+
+	// The standalone github_repository_vulnerability_alerts resource is the recommended
+	// approach (vulnerability_alerts on github_repository is deprecated). If present, it takes precedence.
+	for _, alertsBlock := range modules.GetReferencingResources(resource, "github_repository_vulnerability_alerts", "repository") {
+		repo.VulnerabilityAlerts = alertsBlock.GetAttribute("enabled").AsBoolValueOrDefault(true, alertsBlock)
+		break
 	}
 
 	privateAttr := resource.GetAttribute("private")

--- a/pkg/iac/adapters/terraform/github/repositories/adapt_test.go
+++ b/pkg/iac/adapters/terraform/github/repositories/adapt_test.go
@@ -136,7 +136,7 @@ resource "github_repository_vulnerability_alerts" "my-repo" {
 			},
 		},
 		{
-			name: "standalone resource overrides deprecated",
+			name: "disabled standalone resource overrides enabled deprecated field",
 			src: `
 resource "github_repository" "my-repo" {
 	name                 = "my-repo"
@@ -150,6 +150,23 @@ resource "github_repository_vulnerability_alerts" "my-repo" {
 			expected: github.Repository{
 				Public:              iacTypes.BoolTest(true),
 				VulnerabilityAlerts: iacTypes.BoolTest(true),
+			},
+		},
+		{
+			name: "enabled standalone resource overrides disabled deprecated field",
+			src: `
+resource "github_repository" "my-repo" {
+	name                 = "my-repo"
+	vulnerability_alerts = true
+}
+resource "github_repository_vulnerability_alerts" "my-repo" {
+	repository = github_repository.my-repo.name
+	enabled    = false
+}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
 			},
 		},
 	}

--- a/pkg/iac/adapters/terraform/github/repositories/adapt_test.go
+++ b/pkg/iac/adapters/terraform/github/repositories/adapt_test.go
@@ -3,109 +3,163 @@ package repositories
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/internal/testutil"
 	"github.com/aquasecurity/trivy/pkg/iac/adapters/terraform/tftestutil"
+	"github.com/aquasecurity/trivy/pkg/iac/providers/github"
+	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
-func Test_AdaptDefaults(t *testing.T) {
-
-	src := `
-resource "github_repository" "my-repo" {
-	
-}
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
-
-	assert.True(t, repo.Public.IsTrue())
-}
-
-func Test_Adapt_Private(t *testing.T) {
-
-	src := `
+func Test_Adapt(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected github.Repository
+	}{
+		{
+			name: "defaults",
+			src: `
+resource "github_repository" "my-repo" {}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "private field",
+			src: `
 resource "github_repository" "my-repo" {
 	private = true
 }
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
-
-	assert.False(t, repo.Public.IsTrue())
-	assert.Equal(t, 3, repo.Public.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 3, repo.Public.GetMetadata().Range().GetEndLine())
-}
-
-func Test_Adapt_Public(t *testing.T) {
-
-	src := `
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(false),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "public field",
+			src: `
 resource "github_repository" "my-repo" {
 	private = false
 }
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
-
-	assert.True(t, repo.Public.IsTrue())
-	assert.Equal(t, 3, repo.Public.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 3, repo.Public.GetMetadata().Range().GetEndLine())
-}
-
-func Test_Adapt_VisibilityOverride(t *testing.T) {
-
-	src := `
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "visibility overrides private",
+			src: `
 resource "github_repository" "my-repo" {
-	private = true
+	private    = true
 	visibility = "public"
 }
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
-
-	assert.True(t, repo.Public.IsTrue())
-	assert.Equal(t, 4, repo.Public.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 4, repo.Public.GetMetadata().Range().GetEndLine())
-}
-
-func Test_Adapt_VulnerabilityAlertsEnabled(t *testing.T) {
-
-	src := `
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "deprecated field enabled",
+			src: `
 resource "github_repository" "my-repo" {
 	vulnerability_alerts = true
 }
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
-
-	assert.True(t, repo.VulnerabilityAlerts.IsTrue())
-	assert.Equal(t, 3, repo.VulnerabilityAlerts.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 3, repo.VulnerabilityAlerts.GetMetadata().Range().GetEndLine())
-}
-
-func Test_Adapt_VulnerabilityAlertsDisabled(t *testing.T) {
-
-	src := `
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(true),
+			},
+		},
+		{
+			name: "deprecated field disabled",
+			src: `
 resource "github_repository" "my-repo" {
 	vulnerability_alerts = false
 }
-`
-	modules := tftestutil.CreateModulesFromSource(t, src, ".tf")
-	repositories := Adapt(modules)
-	require.Len(t, repositories, 1)
-	repo := repositories[0]
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "standalone resource enabled",
+			src: `
+resource "github_repository" "my-repo" {
+	name = "my-repo"
+}
+resource "github_repository_vulnerability_alerts" "my-repo" {
+	repository = github_repository.my-repo.name
+	enabled    = true
+}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(true),
+			},
+		},
+		{
+			name: "standalone resource disabled",
+			src: `
+resource "github_repository" "my-repo" {
+	name = "my-repo"
+}
+resource "github_repository_vulnerability_alerts" "my-repo" {
+	repository = github_repository.my-repo.name
+	enabled    = false
+}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(false),
+			},
+		},
+		{
+			name: "standalone resource default enabled",
+			src: `
+resource "github_repository" "my-repo" {
+	name = "my-repo"
+}
+resource "github_repository_vulnerability_alerts" "my-repo" {
+	repository = github_repository.my-repo.name
+}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(true),
+			},
+		},
+		{
+			name: "standalone resource overrides deprecated",
+			src: `
+resource "github_repository" "my-repo" {
+	name                 = "my-repo"
+	vulnerability_alerts = false
+}
+resource "github_repository_vulnerability_alerts" "my-repo" {
+	repository = github_repository.my-repo.name
+	enabled    = true
+}
+`,
+			expected: github.Repository{
+				Public:              iacTypes.BoolTest(true),
+				VulnerabilityAlerts: iacTypes.BoolTest(true),
+			},
+		},
+	}
 
-	assert.False(t, repo.VulnerabilityAlerts.IsTrue())
-	assert.Equal(t, 3, repo.VulnerabilityAlerts.GetMetadata().Range().GetStartLine())
-	assert.Equal(t, 3, repo.VulnerabilityAlerts.GetMetadata().Range().GetEndLine())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modules := tftestutil.CreateModulesFromSource(t, tt.src, ".tf")
+			adapted := Adapt(modules)
+			require.Len(t, adapted, 1)
+			testutil.AssertDefsecEqual(t, tt.expected, adapted[0])
+		})
+	}
 }


### PR DESCRIPTION
## Description

When vulnerability alerts are managed via the standalone `github_repository_vulnerability_alerts` resource (the recommended approach per provider docs), Trivy incorrectly raised GIT-0003. Fixes the adapter to check for this resource in addition to the deprecated `vulnerability_alerts` field on `github_repository`.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/10675

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
