### PR TITLE
fix(nodejs): handle legacy license formats in npm lockfile parser

### DIFF
--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -41,7 +41,8 @@ type Dependency struct {
 type Package struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
-	// License is reused from packagejson because npm just passes this value through from package.json.
+	// License is reused from packagejson because npm copies this field from package.json.
+	// Modern npm versions normalize it, but legacy lockfiles still contain object/array shapes.
 	License              packagejson.License `json:"license"`
 	Dependencies         map[string]string   `json:"dependencies"`
 	OptionalDependencies map[string]string   `json:"optionalDependencies"`
@@ -142,8 +143,8 @@ func (p *Parser) parseV2(packages map[string]Package) ([]ftypes.Package, []ftype
 			sort.Sort(savedPkg.Locations)
 
 			// If for some reason license is missing in savedPkg, but exists in the current pkg, add it.
-			if len(savedPkg.Licenses) == 0 && len(pkg.License.Names()) > 0 {
-				savedPkg.Licenses = pkg.License.Names()
+			if licenses := pkg.License.Names(); len(savedPkg.Licenses) == 0 && len(licenses) > 0 {
+				savedPkg.Licenses = licenses
 			}
 
 			pkgs[pkgID] = savedPkg

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -39,17 +39,18 @@ type Dependency struct {
 }
 
 type Package struct {
-	Name                 string            `json:"name"`
-	Version              string            `json:"version"`
-	License              string            `json:"license"`
-	Dependencies         map[string]string `json:"dependencies"`
-	OptionalDependencies map[string]string `json:"optionalDependencies"`
-	DevDependencies      map[string]string `json:"devDependencies"`
-	PeerDependencies     map[string]string `json:"peerDependencies"`
-	Resolved             string            `json:"resolved"`
-	Dev                  bool              `json:"dev"`
-	Link                 bool              `json:"link"`
-	Workspaces           any               `json:"workspaces"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	// License is reused from packagejson because npm just passes this value through from package.json.
+	License              packagejson.License `json:"license"`
+	Dependencies         map[string]string   `json:"dependencies"`
+	OptionalDependencies map[string]string   `json:"optionalDependencies"`
+	DevDependencies      map[string]string   `json:"devDependencies"`
+	PeerDependencies     map[string]string   `json:"peerDependencies"`
+	Resolved             string              `json:"resolved"`
+	Dev                  bool                `json:"dev"`
+	Link                 bool                `json:"link"`
+	Workspaces           any                 `json:"workspaces"`
 	xjson.Location
 }
 
@@ -141,18 +142,15 @@ func (p *Parser) parseV2(packages map[string]Package) ([]ftypes.Package, []ftype
 			sort.Sort(savedPkg.Locations)
 
 			// If for some reason license is missing in savedPkg, but exists in the current pkg, add it.
-			if len(savedPkg.Licenses) == 0 && pkg.License != "" {
-				savedPkg.Licenses = []string{pkg.License}
+			if len(savedPkg.Licenses) == 0 && len(pkg.License.Names()) > 0 {
+				savedPkg.Licenses = pkg.License.Names()
 			}
 
 			pkgs[pkgID] = savedPkg
 			continue
 		}
 
-		var licenses []string
-		if pkg.License != "" {
-			licenses = []string{pkg.License}
-		}
+		licenses := pkg.License.Names()
 
 		newPkg := ftypes.Package{
 			ID:                 pkgID,

--- a/pkg/dependency/parser/nodejs/npm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_test.go
@@ -71,6 +71,12 @@ func TestParse(t *testing.T) {
 			want:     nil,
 			wantDeps: nil,
 		},
+		{
+			name:     "lock version v3 with legacy license formats",
+			file:     "testdata/package-lock_v3_with_legacy_licenses.json",
+			want:     npmV3WithLegacyLicensesPkgs,
+			wantDeps: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -1783,16 +1783,17 @@ var (
 			},
 			Locations: []ftypes.Location{
 				{
-					StartLine: 41,
-					EndLine:   46,
+					StartLine: 38,
+					EndLine:   43,
 				},
 			},
 		},
 		{
+			// Array-of-strings license shape is not supported, so no licenses are extracted.
+			// The rest of the lockfile must still be parsed successfully.
 			ID:           "pause-stream@0.0.11",
 			Name:         "pause-stream",
 			Version:      "0.0.11",
-			Licenses:     []string{"Apache-2.0"},
 			Relationship: ftypes.RelationshipDirect,
 			ExternalReferences: []ftypes.ExternalRef{
 				{
@@ -1803,7 +1804,7 @@ var (
 			Locations: []ftypes.Location{
 				{
 					StartLine: 32,
-					EndLine:   40,
+					EndLine:   37,
 				},
 			},
 		},

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -1767,4 +1767,64 @@ var (
 			DependsOn: []string{"mkdirp@0.5.1"},
 		},
 	}
+
+	npmV3WithLegacyLicensesPkgs = []ftypes.Package{
+		{
+			ID:           "mustache@2.3.2",
+			Name:         "mustache",
+			Version:      "2.3.2",
+			Licenses:     []string{"MIT"},
+			Relationship: ftypes.RelationshipDirect,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+					URL:  "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 41,
+					EndLine:   46,
+				},
+			},
+		},
+		{
+			ID:           "pause-stream@0.0.11",
+			Name:         "pause-stream",
+			Version:      "0.0.11",
+			Licenses:     []string{"Apache-2.0"},
+			Relationship: ftypes.RelationshipDirect,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+					URL:  "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 32,
+					EndLine:   40,
+				},
+			},
+		},
+		{
+			ID:           "tv4@1.3.0",
+			Name:         "tv4",
+			Version:      "1.3.0",
+			Licenses:     []string{"Public Domain", "MIT"},
+			Relationship: ftypes.RelationshipDirect,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+					URL:  "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 17,
+					EndLine:   31,
+				},
+			},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_legacy_licenses.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_legacy_licenses.json
@@ -1,0 +1,48 @@
+{
+  "name": "node_v3_legacy_licenses",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_v3_legacy_licenses",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "tv4": "^1.3.0",
+        "pause-stream": "^0.0.11",
+        "mustache": "^2.3.2"
+      }
+    },
+    "node_modules/tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
+      "license": [
+        {
+          "type": "Public Domain",
+          "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
+        },
+        {
+          "type": "MIT",
+          "url": "http://jsonary.com/LICENSE.txt"
+        }
+      ]
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": {
+        "type": "Apache-2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_legacy_licenses.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v3_with_legacy_licenses.json
@@ -33,10 +33,7 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "license": {
-        "type": "Apache-2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0"
-      }
+      "license": ["MIT", "Apache2"]
     },
     "node_modules/mustache": {
       "version": "2.3.2",

--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -14,24 +14,6 @@ import (
 
 var nameRegexp = regexp.MustCompile(`^(@[A-Za-z0-9-._]+/)?[A-Za-z0-9-._]+$`)
 
-type packageJSON struct {
-	Name                 string            `json:"name"`
-	Version              string            `json:"version"`
-	License              any               `json:"license"`
-	Dependencies         map[string]string `json:"dependencies"`
-	OptionalDependencies map[string]string `json:"optionalDependencies"`
-	DevDependencies      map[string]string `json:"devDependencies"`
-	Workspaces           any               `json:"workspaces"`
-}
-
-type Package struct {
-	ftypes.Package
-	Dependencies         map[string]string
-	OptionalDependencies map[string]string
-	DevDependencies      map[string]string
-	Workspaces           []string
-}
-
 type Parser struct{}
 
 func NewParser() *Parser {
@@ -60,30 +42,13 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 			ID:       id,
 			Name:     pkgJSON.Name,
 			Version:  pkgJSON.Version,
-			Licenses: parseLicense(pkgJSON.License),
+			Licenses: pkgJSON.License.Names(),
 		},
 		Dependencies:         pkgJSON.Dependencies,
 		OptionalDependencies: pkgJSON.OptionalDependencies,
 		DevDependencies:      pkgJSON.DevDependencies,
 		Workspaces:           ParseWorkspaces(pkgJSON.Workspaces),
 	}, nil
-}
-
-func parseLicense(val any) []string {
-	// the license isn't always a string, check for legacy struct if not string
-	switch v := val.(type) {
-	case string:
-		if v != "" {
-			return []string{v}
-		}
-	case map[string]any:
-		if license, ok := v["type"]; ok {
-			if s, ok := license.(string); ok && s != "" {
-				return []string{s}
-			}
-		}
-	}
-	return nil
 }
 
 // ParseWorkspaces returns slice of workspaces

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -67,6 +67,55 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "happy path - legacy array of objects license",
+			inputFile: "testdata/legacy_array_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:       "tv4@1.3.0",
+					Name:     "tv4",
+					Version:  "1.3.0",
+					Licenses: []string{"Public Domain", "MIT"},
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
+			name:      "invalid license value (number)",
+			inputFile: "testdata/invalid_license_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:      "weird-license@1.0.0",
+					Name:    "weird-license",
+					Version: "1.0.0",
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
+			name:      "null license value",
+			inputFile: "testdata/null_license_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:      "null-license@1.0.0",
+					Name:    "null-license",
+					Version: "1.0.0",
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
+			name:      "unknown license object",
+			inputFile: "testdata/unknown_license_object_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:      "unknown-license-object@1.0.0",
+					Name:    "unknown-license-object",
+					Version: "1.0.0",
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
 			name:      "happy path - version doesn't exist",
 			inputFile: "testdata/without_version_package.json",
 			want: packagejson.Package{

--- a/pkg/dependency/parser/nodejs/packagejson/parse_test.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse_test.go
@@ -80,6 +80,31 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "empty array license",
+			inputFile: "testdata/empty_array_license_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:      "empty-array-license@1.0.0",
+					Name:    "empty-array-license",
+					Version: "1.0.0",
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
+			name:      "mixed array of objects with empty type",
+			inputFile: "testdata/mixed_array_license_package.json",
+			want: packagejson.Package{
+				Package: ftypes.Package{
+					ID:       "mixed-array-license@1.0.0",
+					Name:     "mixed-array-license",
+					Version:  "1.0.0",
+					Licenses: []string{"MIT"},
+				},
+				Dependencies: make(map[string]string),
+			},
+		},
+		{
 			name:      "invalid license value (number)",
 			inputFile: "testdata/invalid_license_package.json",
 			want: packagejson.Package{

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/empty_array_license_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/empty_array_license_package.json
@@ -1,0 +1,6 @@
+{
+  "name": "empty-array-license",
+  "version": "1.0.0",
+  "license": [],
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/invalid_license_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/invalid_license_package.json
@@ -1,0 +1,6 @@
+{
+  "name": "weird-license",
+  "version": "1.0.0",
+  "license": 42,
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/legacy_array_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/legacy_array_package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tv4",
+  "version": "1.3.0",
+  "license": [
+    {
+      "type": "Public Domain",
+      "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    {
+      "type": "MIT",
+      "url": "http://jsonary.com/LICENSE.txt"
+    }
+  ],
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/mixed_array_license_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/mixed_array_license_package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mixed-array-license",
+  "version": "1.0.0",
+  "license": [
+    {"type": ""},
+    {"type": "MIT"}
+  ],
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/null_license_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/null_license_package.json
@@ -1,0 +1,6 @@
+{
+  "name": "null-license",
+  "version": "1.0.0",
+  "license": null,
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/testdata/unknown_license_object_package.json
+++ b/pkg/dependency/parser/nodejs/packagejson/testdata/unknown_license_object_package.json
@@ -1,0 +1,8 @@
+{
+  "name": "unknown-license-object",
+  "version": "1.0.0",
+  "license": {
+    "foo": "bar"
+  },
+  "dependencies": {}
+}

--- a/pkg/dependency/parser/nodejs/packagejson/types.go
+++ b/pkg/dependency/parser/nodejs/packagejson/types.go
@@ -1,0 +1,77 @@
+package packagejson
+
+import (
+	"encoding/json"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+type packageJSON struct {
+	Name                 string            `json:"name"`
+	Version              string            `json:"version"`
+	License              License           `json:"license"`
+	Dependencies         map[string]string `json:"dependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	Workspaces           any               `json:"workspaces"`
+}
+
+type Package struct {
+	ftypes.Package
+	Dependencies         map[string]string
+	OptionalDependencies map[string]string
+	DevDependencies      map[string]string
+	Workspaces           []string
+}
+
+// License represents the npm "license" field, which historically
+// supports several shapes:
+//   - string:                 "MIT"
+//   - object (legacy):        {"type": "MIT", "url": "..."}
+//   - array of objects (legacy): [{"type": "MIT", ...}, {"type": "Apache-2.0", ...}]
+//
+// See https://docs.npmjs.com/cli/v11/configuring-npm/package-json#license
+type License struct {
+	names []string
+}
+
+type licenseObject struct {
+	Type string `json:"type"`
+}
+
+func (l *License) UnmarshalJSON(data []byte) error {
+	// "MIT"
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s != "" {
+			l.names = []string{s}
+		}
+		return nil
+	}
+
+	// {"type": "MIT", ...}
+	var obj licenseObject
+	if err := json.Unmarshal(data, &obj); err == nil && obj.Type != "" {
+		l.names = []string{obj.Type}
+		return nil
+	}
+
+	// [{"type": "MIT", ...}, ...]
+	var arr []licenseObject
+	if err := json.Unmarshal(data, &arr); err == nil {
+		for _, o := range arr {
+			if o.Type != "" {
+				l.names = append(l.names, o.Type)
+			}
+		}
+		return nil
+	}
+
+	// Unknown shape — return empty list instead of failing the whole file.
+	return nil
+}
+
+// Names returns the list of license names extracted from the field.
+func (l License) Names() []string {
+	return l.names
+}


### PR DESCRIPTION
## Description

`package-lock.json` copies the `license` field as-is from `package.json`, which
historically supports several shapes: string, legacy object, and legacy array
of objects. The npm parser only handled the string form — encountering an
object or array caused the JSON decoder to fail and **the entire lockfile to
be skipped**. Users reported this for `tv4` (2.9M downloads/day) and
`pause-stream` (5.1M downloads/day), both of which use legacy formats and
often appear as transitive dependencies.

### Example

A `package-lock.json` containing `tv4` (legacy array of objects),
`pause-stream` (legacy array of strings), and `mustache` (modern string):

```json
"node_modules/tv4": {
  "version": "1.3.0",
  "license": [
    {"type": "Public Domain", "url": "..."},
    {"type": "MIT", "url": "..."}
  ]
},
"node_modules/pause-stream": {
  "version": "0.0.11",
  "license": ["MIT", "Apache2"]
},
"node_modules/mustache": {
  "version": "2.3.2",
  "license": "MIT"
}
```

**Before this PR** — the whole lockfile is dropped, no packages are scanned:
```
DEBUG  Walk error  file_path="package-lock.json"
  err="parse error: failed to parse package-lock.json: decode error:
  json: cannot unmarshal JSON array into Go string within
  \"/packages/node_modules~1tv4/license\""
WARN  [report] Supported files for scanner(s) not found.  scanners=[vuln]
```

**After this PR** — all packages are parsed; supported license shapes are
extracted, unsupported shapes (like array of strings) yield no licenses but
no longer break the lockfile:
```
mustache@2.3.2       licenses=[MIT]
pause-stream@0.0.11  licenses=[]
tv4@1.3.0            licenses=[Public Domain, MIT]
```

> **Note:** the array-of-strings form is intentionally not extracted in this
> PR — it can be added in a follow-up. The main fix is that the lockfile
> itself parses successfully regardless of which legacy shape a package uses.

### Changes

- Add a `License` type in `packagejson` with a custom `UnmarshalJSON` that
  accepts string, legacy object, and legacy array of objects, returning an
  empty list on unknown shapes instead of failing the whole file.
- Extract `packageJSON`/`Package` structs into a dedicated `types.go`.
- Reuse `packagejson.License` in the npm parser, since npm just passes the
  value through from `package.json`.
- Tests cover string, legacy object, legacy array of objects, empty/mixed
  arrays, and invalid values (`null`, number, unknown object).

## Related Discussion
- https://github.com/aquasecurity/trivy/discussions/10119

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).