### PR TITLE
feat(cache): make fs cache lock timeout configurable

### DIFF
--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -21,6 +21,7 @@ type Type string
 type Options struct {
 	Backend     string
 	CacheDir    string
+	LockTimeout time.Duration
 	RedisCACert string
 	RedisCert   string
 	RedisKey    string
@@ -59,7 +60,11 @@ func New(opts Options) (Cache, func(), error) {
 		cache = redisCache
 	case TypeFS:
 		// standalone mode
-		fsCache, err := NewFSCache(opts.CacheDir)
+		var fsOpts []FSCacheOption
+		if opts.LockTimeout > 0 {
+			fsOpts = append(fsOpts, WithLockTimeout(opts.LockTimeout))
+		}
+		fsCache, err := NewFSCache(opts.CacheDir, fsOpts...)
 		if err != nil {
 			return nil, cleanup, xerrors.Errorf("unable to initialize fs cache: %w", err)
 		}

--- a/pkg/cache/fs.go
+++ b/pkg/cache/fs.go
@@ -25,14 +25,38 @@ type FSCache struct {
 	directory string
 }
 
-func NewFSCache(cacheDir string) (FSCache, error) {
+type fsCacheConfig struct {
+	lockTimeout time.Duration
+}
+
+// FSCacheOption configures NewFSCache.
+type FSCacheOption func(*fsCacheConfig)
+
+// WithLockTimeout overrides the default 5-second timeout used when acquiring
+// the bolt cache file's OS-level lock. A non-positive value is ignored and
+// the default is preserved. Useful when multiple trivy processes share a
+// cache directory and serialized access is expected to exceed the default.
+func WithLockTimeout(d time.Duration) FSCacheOption {
+	return func(c *fsCacheConfig) {
+		if d > 0 {
+			c.lockTimeout = d
+		}
+	}
+}
+
+func NewFSCache(cacheDir string, opts ...FSCacheOption) (FSCache, error) {
+	cfg := fsCacheConfig{lockTimeout: defaultFSCacheTimeout}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	dir := filepath.Join(cacheDir, scanCacheDirName)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return FSCache{}, xerrors.Errorf("failed to create cache dir: %w", err)
 	}
 
 	db, err := bolt.Open(filepath.Join(dir, "fanal.db"), 0o600, &bolt.Options{
-		Timeout: defaultFSCacheTimeout,
+		Timeout: cfg.lockTimeout,
 	})
 	if err != nil {
 		// Check if the error is due to timeout (database locked by another process)

--- a/pkg/cache/fs_test.go
+++ b/pkg/cache/fs_test.go
@@ -490,3 +490,37 @@ func TestFSCache_MissingBlobs(t *testing.T) {
 		})
 	}
 }
+
+func TestNewFSCache_LockTimeoutDefault(t *testing.T) {
+	t.Parallel()
+	c, err := NewFSCache(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+}
+
+func TestNewFSCache_LockTimeoutCustom(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	c1, err := NewFSCache(dir, WithLockTimeout(200*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c1.Close() })
+
+	// A second open against the same dir must give up well before the 5s
+	// default, proving the custom timeout is applied to bolt.Open.
+	start := time.Now()
+	_, err = NewFSCache(dir, WithLockTimeout(200*time.Millisecond))
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cache may be in use by another process")
+	require.Less(t, elapsed, time.Second, "should give up well before the 5s default")
+}
+
+func TestWithLockTimeout_NonPositiveIgnored(t *testing.T) {
+	t.Parallel()
+	cfg := fsCacheConfig{lockTimeout: defaultFSCacheTimeout}
+	WithLockTimeout(0)(&cfg)
+	WithLockTimeout(-1 * time.Second)(&cfg)
+	require.Equal(t, defaultFSCacheTimeout, cfg.lockTimeout,
+		"non-positive durations should leave the default in place")
+}

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -33,6 +33,11 @@ var (
 		ConfigName: "cache.ttl",
 		Usage:      "cache TTL when using redis as cache backend",
 	}
+	CacheLockTimeoutFlag = Flag[time.Duration]{
+		Name:       "cache-lock-timeout",
+		ConfigName: "cache.lock-timeout",
+		Usage:      "fs cache backend: timeout when acquiring the cache file lock (default 5s; 0 keeps the default)",
+	}
 	RedisTLSFlag = Flag[bool]{
 		Name:          "redis-tls",
 		ConfigName:    "cache.redis.tls",
@@ -58,9 +63,10 @@ var (
 
 // CacheFlagGroup composes common printer flag structs used for commands requiring cache logic.
 type CacheFlagGroup struct {
-	ClearCache   *Flag[bool]
-	CacheBackend *Flag[string]
-	CacheTTL     *Flag[time.Duration]
+	ClearCache       *Flag[bool]
+	CacheBackend     *Flag[string]
+	CacheTTL         *Flag[time.Duration]
+	CacheLockTimeout *Flag[time.Duration]
 
 	RedisTLS    *Flag[bool]
 	RedisCACert *Flag[string]
@@ -71,24 +77,26 @@ type CacheFlagGroup struct {
 type CacheOptions struct {
 	ClearCache bool
 
-	CacheBackend string
-	CacheTTL     time.Duration
-	RedisTLS     bool
-	RedisCACert  string
-	RedisCert    string
-	RedisKey     string
+	CacheBackend     string
+	CacheTTL         time.Duration
+	CacheLockTimeout time.Duration
+	RedisTLS         bool
+	RedisCACert      string
+	RedisCert        string
+	RedisKey         string
 }
 
 // NewCacheFlagGroup returns a default CacheFlagGroup
 func NewCacheFlagGroup() *CacheFlagGroup {
 	return &CacheFlagGroup{
-		ClearCache:   ClearCacheFlag.Clone(),
-		CacheBackend: CacheBackendFlag.Clone(),
-		CacheTTL:     CacheTTLFlag.Clone(),
-		RedisTLS:     RedisTLSFlag.Clone(),
-		RedisCACert:  RedisCACertFlag.Clone(),
-		RedisCert:    RedisCertFlag.Clone(),
-		RedisKey:     RedisKeyFlag.Clone(),
+		ClearCache:       ClearCacheFlag.Clone(),
+		CacheBackend:     CacheBackendFlag.Clone(),
+		CacheTTL:         CacheTTLFlag.Clone(),
+		CacheLockTimeout: CacheLockTimeoutFlag.Clone(),
+		RedisTLS:         RedisTLSFlag.Clone(),
+		RedisCACert:      RedisCACertFlag.Clone(),
+		RedisCert:        RedisCertFlag.Clone(),
+		RedisKey:         RedisKeyFlag.Clone(),
 	}
 }
 
@@ -101,6 +109,7 @@ func (fg *CacheFlagGroup) Flags() []Flagger {
 		fg.ClearCache,
 		fg.CacheBackend,
 		fg.CacheTTL,
+		fg.CacheLockTimeout,
 		fg.RedisTLS,
 		fg.RedisCACert,
 		fg.RedisCert,
@@ -110,13 +119,14 @@ func (fg *CacheFlagGroup) Flags() []Flagger {
 
 func (fg *CacheFlagGroup) ToOptions(opts *Options) error {
 	opts.CacheOptions = CacheOptions{
-		ClearCache:   fg.ClearCache.Value(),
-		CacheBackend: fg.CacheBackend.Value(),
-		CacheTTL:     fg.CacheTTL.Value(),
-		RedisTLS:     fg.RedisTLS.Value(),
-		RedisCACert:  fg.RedisCACert.Value(),
-		RedisCert:    fg.RedisCert.Value(),
-		RedisKey:     fg.RedisKey.Value(),
+		ClearCache:       fg.ClearCache.Value(),
+		CacheBackend:     fg.CacheBackend.Value(),
+		CacheTTL:         fg.CacheTTL.Value(),
+		CacheLockTimeout: fg.CacheLockTimeout.Value(),
+		RedisTLS:         fg.RedisTLS.Value(),
+		RedisCACert:      fg.RedisCACert.Value(),
+		RedisCert:        fg.RedisCert.Value(),
+		RedisKey:         fg.RedisKey.Value(),
 	}
 	return nil
 }

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -551,6 +551,7 @@ func (o *Options) CacheOpts() cache.Options {
 	return cache.Options{
 		Backend:     o.CacheBackend,
 		CacheDir:    o.CacheDir,
+		LockTimeout: o.CacheLockTimeout,
 		RedisCACert: o.RedisCACert,
 		RedisCert:   o.RedisCert,
 		RedisKey:    o.RedisKey,


### PR DESCRIPTION
Refs https://github.com/aquasecurity/trivy/discussions/10690

## Description

Expose the bolt cache file lock timeout via a new CLI flag, env var, and config key. The default remains 5s — existing callers see no change in behavior.

| Surface | Name |
|---|---|
| CLI flag | `--cache-lock-timeout` |
| Env var | `TRIVY_CACHE_LOCK_TIMEOUT` |
| Config | `cache.lock-timeout` |
| Default | `5s` (unchanged) |

`NewFSCache` gains a variadic options pattern (`FSCacheOption` / `WithLockTimeout`) so existing call sites (test files, integration tests, RPC server tests) continue to compile and behave identically.

## Why

`trivy-operator` in Standalone scan-pod mode creates pods with **N parallel `trivy` containers** (one per workload container), all sharing a single emptyDir cache. trivy's fs cache opens the bolt DB with an OS-level flock and a [hardcoded 5s timeout](https://github.com/aquasecurity/trivy/blob/main/pkg/cache/fs.go#L19). For any workload with ≥ 2 containers (e.g. an app + a fluent-bit/istio sidecar), sibling trivy processes deterministically collide on the lock; only the first wins, and the rest exit with `unable to initialize fs cache: cache may be in use by another process: timeout`.

The current workaround is `operator.builtInTrivyServer: true` (ClientServer mode), which is appropriate at scale but forces an always-on `trivy-server` Deployment even on small clusters. Making the timeout configurable lets operators tune it up (e.g. 30s) and keep Standalone mode working for multi-container pods without the server's footprint.

A complementary issue in trivy-operator proposes restructuring Standalone scan pods to avoid the contention entirely: aquasecurity/trivy-operator#2967.

## Tests

Added three tests in `pkg/cache/fs_test.go`:

- `TestNewFSCache_LockTimeoutDefault` — no option preserves today's behavior.
- `TestNewFSCache_LockTimeoutCustom` — a custom 200ms timeout is actually applied to `bolt.Open` (second open of the same dir fails in <1s with the expected error, well before the 5s default).
- `TestWithLockTimeout_NonPositiveIgnored` — `0` and negative values leave the default in place.

```
$ GOEXPERIMENT=jsonv2 go test ./pkg/cache/ ./pkg/flag/
ok  	github.com/aquasecurity/trivy/pkg/cache	4.706s
ok  	github.com/aquasecurity/trivy/pkg/flag	1.037s
```

## CLI smoke

```
$ trivy image --help | grep -A1 cache-lock-timeout
      --cache-lock-timeout duration   fs cache backend: timeout when acquiring the cache file lock (default 5s; 0 keeps the default)
```

## Backward compatibility

- `NewFSCache(cacheDir)` — existing signature still works (variadic options).
- `cache.Options.LockTimeout` defaults to zero, treated as "use the default" in `cache.New`.
- New flag is omitted from the CLI when unset; behavior is identical to today.

Filed as a draft for sanity-check on the API shape (functional options on `NewFSCache` vs. expanding `cache.Options` only) before pushing tests for the flag layer too.

> Originally referenced #10688, which was auto-closed because non-maintainer issues aren't accepted on this repo. Discussion thread now lives at discussions/10690.