### PR TITLE
fix(java): surface 429 from a remote Maven repository as a fatal error when scanning pom.xml files

### DIFF
--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -120,6 +120,25 @@ $ GITHUB_TOKEN=XXXXXXXXXX trivy image --vex repo [YOUR_IMAGE]
     `GITHUB_TOKEN` doesn't help with the rate limit for the vulnerability database and other assets.
     See https://github.com/aquasecurity/trivy/discussions/8009
 
+### Maven Central rate limiting (HTTP 429)
+
+When scanning Java projects, Trivy resolves transitive dependencies by downloading POM files from Maven Central (or any other configured remote Maven repository) when they are missing from the local `~/.m2` cache. Remote Maven repositories typically rate-limit per IP and return `429 Too Many Requests` once the limit is exceeded; scans of large projects with an empty local cache routinely run into this.
+
+!!! error
+    ```
+    FATAL Error remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/.../<artifact>-<version>.pom. Retry-After: 1800.
+    The repository blocks all subsequent requests from this IP until the block clears.
+    To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).
+    ```
+
+The block applies to *all* subsequent requests from the affected IP for the duration indicated by `Retry-After`, regardless of whether the artifact would otherwise be served from a cache layer. The wait depends on the repository's policy — for Maven Central it is typically tens of minutes on the first violation and grows on repeat — so Trivy fails fast on the first `429` rather than retrying and risking an extended block.
+
+Recommended mitigations:
+
+- **Populate `~/.m2` before scanning.** Run `mvn dependency:resolve` (or any build step that resolves dependencies) so that every POM is cached locally. In CI, cache the `~/.m2` directory between runs (e.g. keyed on `pom.xml` checksums) so subsequent runs reuse the artifacts.
+- **Wait for the block to expire.** The `Retry-After` value in the error tells you the minimum wait. Repeated scans during the block will extend it.
+- **Use `--offline-scan`** to skip remote lookups entirely and rely only on the local `~/.m2` cache. Be careful: any transitive POM missing from the cache is silently skipped, so populate `~/.m2` first (see above) — otherwise the dependency tree will be incomplete.
+
 ### Unable to open JAR files
 
 !!! error

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -968,6 +968,10 @@ func isDirectory(path string) (bool, error) {
 	return fileInfo.IsDir(), err
 }
 
+// shouldReturnError reports whether err should abort POM resolving.
+// context.DeadlineExceeded and any *types.UserError stop the resolving to
+// avoid producing a report with incomplete information; the error is then
+// propagated up the stack.
 func shouldReturnError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -986,8 +986,8 @@ func rateLimitError(req *http.Request, resp *http.Response) *types.UserError {
 	}
 	return &types.UserError{
 		Message: fmt.Sprintf(
-			"remote Maven repository returned 429 Too Many Requests for %s.%s "+
-				"The repository blocks all subsequent requests from this IP until the block clears. "+
+			"remote Maven repository returned 429 Too Many Requests for %s.%s\n"+
+				"The repository blocks all subsequent requests from this IP until the block clears.\n"+
 				"To avoid this, populate the local Maven cache before scanning "+
 				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).",
 			req.URL.Redacted(), ra,

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/hashstructure/v2"
@@ -850,6 +851,9 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(ctx context.Context, repoURL 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", newRateLimitError(req, resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
 		return "", nil
@@ -888,6 +892,9 @@ func (p *Parser) fetchPOMFromRemoteRepository(ctx context.Context, repoURL url.U
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, newRateLimitError(req, resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
 		return nil, nil
@@ -962,5 +969,45 @@ func isDirectory(path string) (bool, error) {
 }
 
 func shouldReturnError(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var rl *RateLimitError
+	return errors.As(err, &rl)
+}
+
+// RateLimitError indicates that a remote Maven repository returned 429 Too Many Requests.
+// Maven Central rate limits are per-IP and apply to all subsequent requests (including
+// cached ones), so continuing the scan is pointless until the block clears.
+// See https://central.sonatype.org/faq/429-error/
+type RateLimitError struct {
+	URL        string
+	RetryAfter time.Duration // 0 if header missing or unparsable
+}
+
+func (e *RateLimitError) Error() string {
+	var ra string
+	if e.RetryAfter > 0 {
+		ra = fmt.Sprintf(" Retry-After: %s.", e.RetryAfter.Round(time.Second))
+	}
+	return fmt.Sprintf(
+		"remote Maven repository returned 429 Too Many Requests for %s.%s "+
+			"The repository blocks all subsequent requests from this IP until the block clears. "+
+			"To avoid this, populate the local Maven cache before scanning "+
+			"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI). "+
+			"See https://central.sonatype.org/faq/429-error/",
+		e.URL, ra,
+	)
+}
+
+func newRateLimitError(req *http.Request, resp *http.Response) *RateLimitError {
+	var d time.Duration
+	if v := resp.Header.Get("Retry-After"); v != "" {
+		// Maven Central / Cloudflare send delay-seconds; HTTP-date form is allowed
+		// by RFC 7231 but not used here, so we don't parse it.
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			d = time.Duration(secs) * time.Second
+		}
+	}
+	return &RateLimitError{URL: req.URL.Redacted(), RetryAfter: d}
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/hashstructure/v2"
@@ -978,25 +977,19 @@ func shouldReturnError(err error) bool {
 }
 
 // rateLimitError builds a user-facing error for a 429 response from a remote Maven
-// repository. Maven Central rate limits are per-IP and apply to all subsequent
-// requests (including cached ones), so continuing the scan is pointless until the
-// block clears. See https://central.sonatype.org/faq/429-error/
+// repository. Rate limits are typically per-IP and apply to all subsequent requests
+// (including cached ones), so continuing the scan is pointless until the block clears.
 func rateLimitError(req *http.Request, resp *http.Response) *types.UserError {
 	var ra string
-	// Maven Central / Cloudflare send delay-seconds; HTTP-date form is allowed
-	// by RFC 7231 but not used here, so we don't parse it.
 	if v := resp.Header.Get("Retry-After"); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			ra = fmt.Sprintf(" Retry-After: %s.", (time.Duration(secs) * time.Second).Round(time.Second))
-		}
+		ra = fmt.Sprintf(" Retry-After: %s.", v)
 	}
 	return &types.UserError{
 		Message: fmt.Sprintf(
 			"remote Maven repository returned 429 Too Many Requests for %s.%s "+
 				"The repository blocks all subsequent requests from this IP until the block clears. "+
 				"To avoid this, populate the local Maven cache before scanning "+
-				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI). "+
-				"See https://central.sonatype.org/faq/429-error/",
+				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).",
 			req.URL.Redacted(), ra,
 		),
 	}

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -29,6 +29,7 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/set"
+	"github.com/aquasecurity/trivy/pkg/types"
 	xhttp "github.com/aquasecurity/trivy/pkg/x/http"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 	xslices "github.com/aquasecurity/trivy/pkg/x/slices"
@@ -852,7 +853,7 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(ctx context.Context, repoURL 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return "", newRateLimitError(req, resp)
+		return "", rateLimitError(req, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
@@ -893,7 +894,7 @@ func (p *Parser) fetchPOMFromRemoteRepository(ctx context.Context, repoURL url.U
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, newRateLimitError(req, resp)
+		return nil, rateLimitError(req, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
@@ -972,42 +973,31 @@ func shouldReturnError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	var rl *RateLimitError
-	return errors.As(err, &rl)
+	var ue *types.UserError
+	return errors.As(err, &ue)
 }
 
-// RateLimitError indicates that a remote Maven repository returned 429 Too Many Requests.
-// Maven Central rate limits are per-IP and apply to all subsequent requests (including
-// cached ones), so continuing the scan is pointless until the block clears.
-// See https://central.sonatype.org/faq/429-error/
-type RateLimitError struct {
-	URL        string
-	RetryAfter time.Duration // 0 if header missing or unparsable
-}
-
-func (e *RateLimitError) Error() string {
+// rateLimitError builds a user-facing error for a 429 response from a remote Maven
+// repository. Maven Central rate limits are per-IP and apply to all subsequent
+// requests (including cached ones), so continuing the scan is pointless until the
+// block clears. See https://central.sonatype.org/faq/429-error/
+func rateLimitError(req *http.Request, resp *http.Response) *types.UserError {
 	var ra string
-	if e.RetryAfter > 0 {
-		ra = fmt.Sprintf(" Retry-After: %s.", e.RetryAfter.Round(time.Second))
-	}
-	return fmt.Sprintf(
-		"remote Maven repository returned 429 Too Many Requests for %s.%s "+
-			"The repository blocks all subsequent requests from this IP until the block clears. "+
-			"To avoid this, populate the local Maven cache before scanning "+
-			"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI). "+
-			"See https://central.sonatype.org/faq/429-error/",
-		e.URL, ra,
-	)
-}
-
-func newRateLimitError(req *http.Request, resp *http.Response) *RateLimitError {
-	var d time.Duration
+	// Maven Central / Cloudflare send delay-seconds; HTTP-date form is allowed
+	// by RFC 7231 but not used here, so we don't parse it.
 	if v := resp.Header.Get("Retry-After"); v != "" {
-		// Maven Central / Cloudflare send delay-seconds; HTTP-date form is allowed
-		// by RFC 7231 but not used here, so we don't parse it.
 		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			d = time.Duration(secs) * time.Second
+			ra = fmt.Sprintf(" Retry-After: %s.", (time.Duration(secs) * time.Second).Round(time.Second))
 		}
 	}
-	return &RateLimitError{URL: req.URL.Redacted(), RetryAfter: d}
+	return &types.UserError{
+		Message: fmt.Sprintf(
+			"remote Maven repository returned 429 Too Many Requests for %s.%s "+
+				"The repository blocks all subsequent requests from this IP until the block clears. "+
+				"To avoid this, populate the local Maven cache before scanning "+
+				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI). "+
+				"See https://central.sonatype.org/faq/429-error/",
+			req.URL.Redacted(), ra,
+		),
+	}
 }

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -132,6 +132,7 @@ func TestPom_Parse(t *testing.T) {
 		local                     bool
 		enableRepoForSettingsRepo bool // use another repo for repository from settings.xml
 		offline                   bool
+		serverHandler             http.Handler // overrides the default file-server when set
 		want                      []ftypes.Package
 		wantDeps                  []ftypes.Dependency
 		wantErr                   string
@@ -231,6 +232,15 @@ func TestPom_Parse(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:      "remote repository returns 429 Too Many Requests",
+			inputFile: filepath.Join("testdata", "happy", "pom.xml"),
+			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "1800")
+				w.WriteHeader(http.StatusTooManyRequests)
+			}),
+			wantErr: "429 Too Many Requests",
 		},
 		{
 			name:      "snapshot dependency",
@@ -2486,7 +2496,10 @@ func TestPom_Parse(t *testing.T) {
 				t.Setenv("MAVEN_HOME", "testdata/settings/global")
 			} else {
 				// for remote repository
-				h := http.FileServer(http.Dir(filepath.Join("testdata", "repository")))
+				var h http.Handler = http.FileServer(http.Dir(filepath.Join("testdata", "repository")))
+				if tt.serverHandler != nil {
+					h = tt.serverHandler
+				}
 				ts := httptest.NewServer(h)
 				defaultRepo = ts.URL
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -2,6 +2,7 @@ package pom_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 var (
@@ -240,7 +242,16 @@ func TestPom_Parse(t *testing.T) {
 				w.Header().Set("Retry-After", "1800")
 				w.WriteHeader(http.StatusTooManyRequests)
 			}),
-			wantErr: "429 Too Many Requests",
+			wantErr: "429 Too Many Requests for http://",
+		},
+		{
+			name:      "snapshot repository returns 429 Too Many Requests on maven-metadata.xml",
+			inputFile: filepath.Join("testdata", "snapshot", "with-maven-metadata", "pom.xml"),
+			serverHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Retry-After", "1800")
+				w.WriteHeader(http.StatusTooManyRequests)
+			}),
+			wantErr: "429 Too Many Requests for http://",
 		},
 		{
 			name:      "snapshot dependency",
@@ -2517,6 +2528,9 @@ func TestPom_Parse(t *testing.T) {
 			gotPkgs, gotDeps, err := p.Parse(t.Context(), f)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
+				var ue *types.UserError
+				require.True(t, errors.As(err, &ue), "expected error to unwrap to *types.UserError")
+				assert.Contains(t, ue.Message, "Retry-After: 1800")
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -2,7 +2,6 @@ package pom_test
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -2507,7 +2506,7 @@ func TestPom_Parse(t *testing.T) {
 				t.Setenv("MAVEN_HOME", "testdata/settings/global")
 			} else {
 				// for remote repository
-				var h http.Handler = http.FileServer(http.Dir(filepath.Join("testdata", "repository")))
+				h := http.FileServer(http.Dir(filepath.Join("testdata", "repository")))
 				if tt.serverHandler != nil {
 					h = tt.serverHandler
 				}
@@ -2529,7 +2528,7 @@ func TestPom_Parse(t *testing.T) {
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				var ue *types.UserError
-				require.True(t, errors.As(err, &ue), "expected error to unwrap to *types.UserError")
+				require.ErrorAs(t, err, &ue, "expected error to unwrap to *types.UserError")
 				assert.Contains(t, ue.Message, "Retry-After: 1800")
 				return
 			}

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
 
+	pomparser "github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/licensing"
@@ -504,11 +505,17 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, eg *errgroup.Group, lim
 				Options:  opts,
 			})
 			if analyzeErr != nil {
+				var rateLimitErr *pomparser.RateLimitError
 				switch {
 				case errors.Is(analyzeErr, fos.AnalyzeOSError):
 					// The OS could not be detected.
 				case errors.Is(analyzeErr, context.DeadlineExceeded):
 					return xerrors.Errorf("analyzer timed out: %w", analyzeErr)
+				case errors.As(analyzeErr, &rateLimitErr):
+					// Remote Maven repository rate-limited the request. The block applies to all
+					// subsequent requests from this IP, so continuing the scan would produce
+					// incomplete results. Abort instead of silently swallowing.
+					return xerrors.Errorf("scan aborted: %w", analyzeErr)
 				default:
 					ag.logger.Debug("Analysis error", log.Err(err))
 					return nil

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -517,7 +517,7 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, eg *errgroup.Group, lim
 					// incomplete results without the user noticing.
 					return analyzeErr
 				default:
-					ag.logger.Debug("Analysis error", log.Err(err))
+					ag.logger.Debug("Analysis error", log.Err(analyzeErr))
 					return nil
 				}
 			}

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -16,12 +16,12 @@ import (
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
 
-	pomparser "github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
 	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
-	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/licensing"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/misconf"
+	"github.com/aquasecurity/trivy/pkg/types"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 	xslices "github.com/aquasecurity/trivy/pkg/x/slices"
 )
@@ -48,7 +48,7 @@ type AnalyzerOptions struct {
 	Parallel             int
 	FilePatterns         []string
 	DisabledAnalyzers    []Type
-	DetectionPriority    types.DetectionPriority
+	DetectionPriority    ftypes.DetectionPriority
 	MisconfScannerOption misconf.ScannerOption
 	SecretScannerOption  SecretScannerOption
 	LicenseScannerOption LicenseScannerOption
@@ -136,7 +136,7 @@ type AnalyzerGroup struct {
 	analyzers         []analyzer
 	postAnalyzers     []PostAnalyzer
 	filePatterns      map[Type]FilePatterns
-	detectionPriority types.DetectionPriority
+	detectionPriority ftypes.DetectionPriority
 }
 
 ///////////////////////////
@@ -176,13 +176,13 @@ type AnalysisOptions struct {
 
 type AnalysisResult struct {
 	m                    sync.Mutex
-	OS                   types.OS
-	Repository           *types.Repository
-	PackageInfos         []types.PackageInfo
-	Applications         []types.Application
-	Misconfigurations    []types.Misconfiguration
-	Secrets              []types.Secret
-	Licenses             []types.LicenseFile
+	OS                   ftypes.OS
+	Repository           *ftypes.Repository
+	PackageInfos         []ftypes.PackageInfo
+	Applications         []ftypes.Application
+	Misconfigurations    []ftypes.Misconfiguration
+	Secrets              []ftypes.Secret
+	Licenses             []ftypes.LicenseFile
 	SystemInstalledFiles []string // A list of files installed by OS package manager
 
 	// Digests contains SHA-256 digests of unpackaged files
@@ -190,11 +190,11 @@ type AnalysisResult struct {
 	Digests map[string]string
 
 	// For Red Hat
-	BuildInfo *types.BuildInfo
+	BuildInfo *ftypes.BuildInfo
 
 	// CustomResources hold analysis results from custom analyzers.
 	// It is for extensibility and not used in OSS.
-	CustomResources []types.CustomResource
+	CustomResources []ftypes.CustomResource
 }
 
 func NewAnalysisResult() *AnalysisResult {
@@ -375,7 +375,7 @@ func belongToGroup(groupName Group, analyzerType Type, disabledAnalyzers []Type,
 	return true
 }
 
-func normalizeApplicationsLicenses(applications []types.Application) {
+func normalizeApplicationsLicenses(applications []ftypes.Application) {
 	for i, app := range applications {
 		for j, pkg := range app.Packages {
 			applications[i].Packages[j].Licenses = licensing.NormalizeLicenses(pkg.Licenses)
@@ -505,17 +505,17 @@ func (ag AnalyzerGroup) AnalyzeFile(ctx context.Context, eg *errgroup.Group, lim
 				Options:  opts,
 			})
 			if analyzeErr != nil {
-				var rateLimitErr *pomparser.RateLimitError
+				var userErr *types.UserError
 				switch {
 				case errors.Is(analyzeErr, fos.AnalyzeOSError):
 					// The OS could not be detected.
 				case errors.Is(analyzeErr, context.DeadlineExceeded):
 					return xerrors.Errorf("analyzer timed out: %w", analyzeErr)
-				case errors.As(analyzeErr, &rateLimitErr):
-					// Remote Maven repository rate-limited the request. The block applies to all
-					// subsequent requests from this IP, so continuing the scan would produce
-					// incomplete results. Abort instead of silently swallowing.
-					return xerrors.Errorf("scan aborted: %w", analyzeErr)
+				case errors.As(analyzeErr, &userErr):
+					// User-facing errors (e.g. remote rate limit) should abort the scan
+					// rather than be silently swallowed, since continuing would yield
+					// incomplete results without the user noticing.
+					return analyzeErr
 				default:
 					ag.logger.Debug("Analysis error", log.Err(err))
 					return nil
@@ -556,7 +556,7 @@ func (ag AnalyzerGroup) PostAnalyze(ctx context.Context, compositeFS *CompositeF
 		}
 
 		skippedFiles := result.SystemInstalledFiles
-		if ag.detectionPriority == types.PriorityComprehensive {
+		if ag.detectionPriority == ftypes.PriorityComprehensive {
 			// If the detection priority is comprehensive, system files installed by the OS package manager will not be skipped.
 			// It can lead to false positives and duplicates, but it may be necessary to detect all possible vulnerabilities.
 			skippedFiles = nil


### PR DESCRIPTION
## Description

Stop the scan with an actionable error when a remote Maven repository returns `429 Too Many Requests`, instead of logging at `DEBUG` and silently skipping the dependency.

The Maven `pom` parser now returns a `*types.UserError` carrying the rate-limit URL, the raw `Retry-After` header value, and a hint to populate the local `~/.m2` cache. The analyzer layer recognises `*types.UserError` and propagates it instead of swallowing it; `cmd/trivy/main.go` already routes `*UserError` through `log.Fatal("Error", log.Err(userErr))`, so the user sees just the message without the wrapper chain.

The behaviour applies to any remote Maven repository (Maven Central, private Nexus, Artifactory, …). Empirical justification for the fail-fast strategy — threshold, observed `Retry-After` durations, block applies to cached HITs too — is in #10691.

### Before

Reproduction: trigger Maven Central rate limit, then run with the released v0.69.3 binary against a project whose dependencies are not in `~/.m2`:

```sh
HOME=/tmp/empty-home trivy -d fs \
    --cache-dir /tmp/trivy-cache \
    --skip-version-check --skip-db-update \
    /tmp/real-project
```

Relevant log lines:

```
DEBUG	[pom] Resolving...	group_id="org.apache.commons" artifact_id="commons-lang3" version="3.12.0"
DEBUG	[pom] Failed to fetch	url=".../commons-lang3-3.12.0.pom" statusCode=429
DEBUG	[pom] Repository error	err="org.apache.commons:commons-lang3:3.12.0 was not found in local/remote repositories"
INFO	Number of language-specific files	num=1
INFO	[pom] Detecting vulnerabilities...
```

Report:

```
┌─────────┬──────┬─────────────────┬─────────┐
│ Target  │ Type │ Vulnerabilities │ Secrets │
├─────────┼──────┼─────────────────┼─────────┤
│ pom.xml │ pom  │        1        │    -    │
└─────────┴──────┴─────────────────┴─────────┘
```

`exit=0`. The 429 is only visible at `--debug`. Worse than just an empty report: the direct dependency is still scanned, so the user sees `1 vulnerability` and assumes the report is complete, even though *every transitive dependency was silently dropped*.

### After

Same command against the patched binary:

```
DEBUG	[pom] Resolving...	group_id="org.apache.commons" artifact_id="commons-lang3" version="3.12.0"
FATAL	Error	remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom. Retry-After: 1319.
The repository blocks all subsequent requests from this IP until the block clears.
To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).
```

`exit=1`. CI fails, user gets the rate-limit URL, the `Retry-After` value, and a concrete remediation hint.

## Related issues
- Close #10691

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
