### PR TITLE
refactor(secret): normalize configPath once in Init

### DIFF
--- a/pkg/fanal/analyzer/secret/secret.go
+++ b/pkg/fanal/analyzer/secret/secret.go
@@ -52,18 +52,18 @@ func NewSecretAnalyzer(s secret.Scanner, configPath string) *SecretAnalyzer {
 
 // Init initializes and sets a secret scanner
 func (a *SecretAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
-	if opt.SecretScannerOption.ConfigPath == a.configPath && !lo.IsEmpty(a.scanner) {
+	configPath := cleanPath(opt.SecretScannerOption.ConfigPath)
+	if configPath == a.configPath && !lo.IsEmpty(a.scanner) {
 		// This check is for tools importing Trivy and customize analyzers
 		// Never reach here in Trivy OSS
 		return nil
 	}
-	configPath := opt.SecretScannerOption.ConfigPath
 	c, err := secret.ParseConfig(configPath)
 	if err != nil {
 		return xerrors.Errorf("secret config error: %w", err)
 	}
 	a.scanner = secret.NewScanner(c)
-	a.configPath = cleanPath(opt.SecretScannerOption.ConfigPath)
+	a.configPath = configPath
 	return nil
 }
 

--- a/pkg/fanal/analyzer/secret/secret_test.go
+++ b/pkg/fanal/analyzer/secret/secret_test.go
@@ -3,6 +3,7 @@ package secret_test
 import (
 	"cmp"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -218,6 +219,31 @@ func TestSecretAnalyzer(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestSecretAnalyzerInitReParseGuard checks that a repeated Init() with a
+// non-canonical config path (e.g. one containing "/./") hits the re-init
+// guard and does not re-parse the config.
+func TestSecretAnalyzerInitReParseGuard(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "trivy-secret.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("{}\n"), 0o600))
+
+	// Non-canonical form of the same path (contains "/./"), which Init normalizes via cleanPath.
+	nonCanonical := filepath.Dir(configPath) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(configPath)
+
+	opt := analyzer.AnalyzerOptions{
+		SecretScannerOption: analyzer.SecretScannerOption{ConfigPath: nonCanonical},
+	}
+
+	a := secret.SecretAnalyzer{}
+	require.NoError(t, a.Init(opt))
+
+	// Break the config so any re-parse would fail with a decode error.
+	require.NoError(t, os.WriteFile(configPath, []byte("- not\n- a\n- mapping\n"), 0o600))
+
+	// The second Init() must hit the re-init guard and skip parsing the (now broken) file.
+	require.NoError(t, a.Init(opt), "second Init() re-parsed the config: the re-init guard did not fire for a non-canonical path")
 }
 
 func TestSecretRequire(t *testing.T) {


### PR DESCRIPTION
## Description

Follow-up to #10666.

After #10666, `a.configPath` is stored cleaned/normalized (`filepath.ToSlash(filepath.Clean(...))`), but the re-init guard in `Init()` still compared the raw flag value (`opt.SecretScannerOption.ConfigPath`) against the stored normalized field. For tools that import Trivy and call `Init()` multiple times with a non-canonical path (e.g. `./configs/trivy-secret.yaml` or a trailing slash), the two sides no longer matched after the first call, so the guard never fired and the secret config was re-parsed on every subsequent `Init()`.

This PR applies `cleanPath()` once at the top of `Init()` and reuses the result for both the guard comparison and the stored field, so the guard fires whenever the input refers to the same config — regardless of its surface form.

**No behavior change in Trivy OSS** — this branch in `Init()` is only reachable from tools that import Trivy as a library and call `Init()` more than once. Pointed out by @knqyf263 in the review of #10666: https://github.com/aquasecurity/trivy/pull/10666#discussion_r3271648626

## Related PRs
- Follow-up to https://github.com/aquasecurity/trivy/pull/10666#discussion_r3271648626

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).