### PR TITLE
chore(deps): upgrade github.com/cenkalti/backoff dependency to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/bitnami/go-version v0.0.0-20231130084017-bb00604d650c
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/containerd/containerd/v2 v2.2.2
 	github.com/containerd/platforms v1.0.0-rc.4
@@ -208,7 +208,7 @@ require (
 	github.com/bufbuild/buf v1.56.0 // indirect
 	github.com/bufbuild/protocompile v0.14.1 // indirect
 	github.com/bufbuild/protoplugin v0.0.0-20250218205857-750e09ce93e1 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/pkg/cache/remote.go
+++ b/pkg/cache/remote.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/twitchtv/twirp"
 	"golang.org/x/xerrors"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/rpc"
@@ -45,7 +46,7 @@ func NewRemoteCache(ctx context.Context, opts RemoteOptions) *RemoteCache {
 
 // PutArtifact sends artifact to remote client
 func (c RemoteCache) PutArtifact(ctx context.Context, imageID string, artifactInfo types.ArtifactInfo) error {
-	_, err := rpc.Retry(ctx, func() (any, error) {
+	_, err := rpc.Retry(ctx, func() (*emptypb.Empty, error) {
 		return c.client.PutArtifact(c.ctx, rpc.ConvertToRPCArtifactInfo(imageID, artifactInfo))
 	})
 	if err != nil {
@@ -56,7 +57,7 @@ func (c RemoteCache) PutArtifact(ctx context.Context, imageID string, artifactIn
 
 // PutBlob sends blobInfo to remote client
 func (c RemoteCache) PutBlob(ctx context.Context, diffID string, blobInfo types.BlobInfo) error {
-	_, err := rpc.Retry(ctx, func() (any, error) {
+	_, err := rpc.Retry(ctx, func() (*emptypb.Empty, error) {
 		return c.client.PutBlob(c.ctx, rpc.ConvertToRPCPutBlobRequest(diffID, blobInfo))
 	})
 	if err != nil {
@@ -78,7 +79,7 @@ func (c RemoteCache) MissingBlobs(ctx context.Context, imageID string, layerIDs 
 
 // DeleteBlobs removes blobs by IDs from RemoteCache
 func (c RemoteCache) DeleteBlobs(ctx context.Context, blobIDs []string) error {
-	_, err := rpc.Retry(ctx, func() (any, error) {
+	_, err := rpc.Retry(ctx, func() (*emptypb.Empty, error) {
 		return c.client.DeleteBlobs(c.ctx, rpc.ConvertToDeleteBlobsRequest(blobIDs))
 	})
 	if err != nil {

--- a/pkg/cache/remote.go
+++ b/pkg/cache/remote.go
@@ -44,11 +44,9 @@ func NewRemoteCache(ctx context.Context, opts RemoteOptions) *RemoteCache {
 }
 
 // PutArtifact sends artifact to remote client
-func (c RemoteCache) PutArtifact(_ context.Context, imageID string, artifactInfo types.ArtifactInfo) error {
-	err := rpc.Retry(func() error {
-		var err error
-		_, err = c.client.PutArtifact(c.ctx, rpc.ConvertToRPCArtifactInfo(imageID, artifactInfo))
-		return err
+func (c RemoteCache) PutArtifact(ctx context.Context, imageID string, artifactInfo types.ArtifactInfo) error {
+	_, err := rpc.Retry(ctx, func() (any, error) {
+		return c.client.PutArtifact(c.ctx, rpc.ConvertToRPCArtifactInfo(imageID, artifactInfo))
 	})
 	if err != nil {
 		return xerrors.Errorf("unable to store cache on the server: %w", err)
@@ -57,11 +55,9 @@ func (c RemoteCache) PutArtifact(_ context.Context, imageID string, artifactInfo
 }
 
 // PutBlob sends blobInfo to remote client
-func (c RemoteCache) PutBlob(_ context.Context, diffID string, blobInfo types.BlobInfo) error {
-	err := rpc.Retry(func() error {
-		var err error
-		_, err = c.client.PutBlob(c.ctx, rpc.ConvertToRPCPutBlobRequest(diffID, blobInfo))
-		return err
+func (c RemoteCache) PutBlob(ctx context.Context, diffID string, blobInfo types.BlobInfo) error {
+	_, err := rpc.Retry(ctx, func() (any, error) {
+		return c.client.PutBlob(c.ctx, rpc.ConvertToRPCPutBlobRequest(diffID, blobInfo))
 	})
 	if err != nil {
 		return xerrors.Errorf("unable to store cache on the server: %w", err)
@@ -70,12 +66,9 @@ func (c RemoteCache) PutBlob(_ context.Context, diffID string, blobInfo types.Bl
 }
 
 // MissingBlobs fetches missing blobs from RemoteCache
-func (c RemoteCache) MissingBlobs(_ context.Context, imageID string, layerIDs []string) (bool, []string, error) {
-	var layers *rpcCache.MissingBlobsResponse
-	err := rpc.Retry(func() error {
-		var err error
-		layers, err = c.client.MissingBlobs(c.ctx, rpc.ConvertToMissingBlobsRequest(imageID, layerIDs))
-		return err
+func (c RemoteCache) MissingBlobs(ctx context.Context, imageID string, layerIDs []string) (bool, []string, error) {
+	layers, err := rpc.Retry(ctx, func() (*rpcCache.MissingBlobsResponse, error) {
+		return c.client.MissingBlobs(c.ctx, rpc.ConvertToMissingBlobsRequest(imageID, layerIDs))
 	})
 	if err != nil {
 		return false, nil, xerrors.Errorf("unable to fetch missing layers: %w", err)
@@ -84,11 +77,9 @@ func (c RemoteCache) MissingBlobs(_ context.Context, imageID string, layerIDs []
 }
 
 // DeleteBlobs removes blobs by IDs from RemoteCache
-func (c RemoteCache) DeleteBlobs(_ context.Context, blobIDs []string) error {
-	err := rpc.Retry(func() error {
-		var err error
-		_, err = c.client.DeleteBlobs(c.ctx, rpc.ConvertToDeleteBlobsRequest(blobIDs))
-		return err
+func (c RemoteCache) DeleteBlobs(ctx context.Context, blobIDs []string) error {
+	_, err := rpc.Retry(ctx, func() (any, error) {
+		return c.client.DeleteBlobs(c.ctx, rpc.ConvertToDeleteBlobsRequest(blobIDs))
 	})
 	if err != nil {
 		return xerrors.Errorf("unable to delete blobs on the server: %w", err)

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -84,10 +84,8 @@ func (s Service) Scan(ctx context.Context, target, artifactKey string, blobKeys 
 		}
 	}
 
-	var res *rpc.ScanResponse
-	err := r.Retry(func() error {
-		var err error
-		res, err = s.client.Scan(ctx, &rpc.ScanRequest{
+	res, err := r.Retry(ctx, func() (*rpc.ScanResponse, error) {
+		return s.client.Scan(ctx, &rpc.ScanRequest{
 			Target:     target,
 			ArtifactId: artifactKey,
 			BlobIds:    blobKeys,
@@ -102,7 +100,6 @@ func (s Service) Scan(ctx context.Context, target, artifactKey string, blobKeys 
 				VulnSeveritySources: xstrings.ToStringSlice(opts.VulnSeveritySources),
 			},
 		})
-		return err
 	})
 	if err != nil {
 		return types.ScanResponse{}, xerrors.Errorf("failed to detect vulnerabilities via RPC: %w", err)

--- a/pkg/rpc/retry.go
+++ b/pkg/rpc/retry.go
@@ -1,9 +1,10 @@
 package rpc
 
 import (
+	"context"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/twitchtv/twirp"
 
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -15,28 +16,30 @@ const (
 
 // Retry executes the function again using backoff until maxRetries or success
 func Retry(f func() error) error {
-	operation := func() error {
+	operation := func() (any, error) {
 		err := f()
 		if err != nil {
 			twerr, ok := err.(twirp.Error)
 			if !ok {
-				return backoff.Permanent(err)
+				return nil, backoff.Permanent(err)
 			}
 			if twerr.Code() == twirp.Unavailable {
-				return err
+				return nil, err
 			}
-			return backoff.Permanent(err)
+			return nil, backoff.Permanent(err)
 		}
-		return nil
+		return nil, nil
 	}
 
-	b := backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries)
-	err := backoff.RetryNotify(operation, b, func(err error, _ time.Duration) {
-		log.Warn("HTTP error", log.Err(err))
-		log.Info("Retrying HTTP request...")
-	})
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := backoff.Retry(
+		context.Background(),
+		operation,
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxTries(maxRetries),
+		backoff.WithNotify(func(err error, _ time.Duration) {
+			log.Warn("HTTP error", log.Err(err))
+			log.Info("Retrying HTTP request...")
+		}),
+	)
+	return err
 }

--- a/pkg/rpc/retry.go
+++ b/pkg/rpc/retry.go
@@ -15,24 +15,25 @@ const (
 )
 
 // Retry executes the function again using backoff until maxRetries or success
-func Retry(f func() error) error {
-	operation := func() (any, error) {
-		err := f()
+func Retry[T any](ctx context.Context, f func() (T, error)) (T, error) {
+	operation := func() (T, error) {
+		res, err := f()
 		if err != nil {
+			var zero T
 			twerr, ok := err.(twirp.Error)
 			if !ok {
-				return nil, backoff.Permanent(err)
+				return zero, backoff.Permanent(err)
 			}
 			if twerr.Code() == twirp.Unavailable {
-				return nil, err
+				return zero, err
 			}
-			return nil, backoff.Permanent(err)
+			return zero, backoff.Permanent(err)
 		}
-		return nil, nil
+		return res, nil
 	}
 
-	_, err := backoff.Retry(
-		context.Background(),
+	return backoff.Retry(
+		ctx,
 		operation,
 		backoff.WithBackOff(backoff.NewExponentialBackOff()),
 		backoff.WithMaxTries(maxRetries),
@@ -41,5 +42,4 @@ func Retry(f func() error) error {
 			log.Info("Retrying HTTP request...")
 		}),
 	)
-	return err
 }


### PR DESCRIPTION

## Description
Upgrade `github.com/cenkalti/backoff` to `v5` and update retry implementation to use context-aware API.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
