### PR TITLE
fix(image): correctly reconstruct RUN instructions built without BuildKit

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -89,7 +89,7 @@ func imageConfigToDockerfile(cfg *v1.ConfigFile) []byte {
 			}
 		case strings.HasPrefix(h.CreatedBy, "/bin/sh -c"):
 			// RUN instruction
-			createdBy = buildRunInstruction(createdBy)
+			createdBy = buildRunInstruction(h.CreatedBy)
 		case strings.HasSuffix(h.CreatedBy, "# buildkit"):
 			// buildkit instructions
 			// COPY ./foo /foo # buildkit

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -26,7 +26,7 @@ var (
 	reason         = "See " + doc.URL("guide/target/container_image", "disabled-checks")
 )
 
-const analyzerVersion = 1
+const analyzerVersion = 2
 
 func init() {
 	analyzer.RegisterConfigAnalyzer(analyzer.TypeHistoryDockerfile, newHistoryAnalyzer)

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -469,6 +469,27 @@ ENTRYPOINT ["/bin/sh"]
 			},
 			expected: "ENV TEST=\"foo bar\"\n",
 		},
+		// To reproduce test data:
+		// DOCKER_BUILDKIT=0 docker build -t test-legacy - <<'EOF'
+		// FROM alpine:3.21
+		// RUN echo hello
+		// RUN apk add --no-cache curl
+		// EOF
+		// docker history --no-trunc --format '{{json .}}' test-legacy
+		{
+			name: "legacy builder RUN instruction",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "/bin/sh -c echo hello",
+					},
+					{
+						CreatedBy: "/bin/sh -c apk add --no-cache curl",
+					},
+				},
+			},
+			expected: "RUN echo hello\nRUN apk add --no-cache curl\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Images built with `DOCKER_BUILDKIT=0` record `RUN` as `/bin/sh -c <cmd>` in history. The handler passed an empty variable to `buildRunInstruction` instead of `h.CreatedBy`, silently dropping these instructions from the reconstructed Dockerfile. Discovered in https://github.com/aquasecurity/trivy/pull/9875#discussion_r2744878372

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
