### PR TITLE
feat(spdx): add SHA-512 hash algorithm support to SPDX serializer

### DIFF
--- a/pkg/sbom/core/bom.go
+++ b/pkg/sbom/core/bom.go
@@ -177,6 +177,10 @@ type File struct {
 	Digests []digest.Digest
 }
 
+func (f File) IsEmpty() bool {
+	return f.Path == "" && len(f.Digests) == 0
+}
+
 type Property struct {
 	Name      string
 	Value     string

--- a/pkg/sbom/cyclonedx/unmarshal.go
+++ b/pkg/sbom/cyclonedx/unmarshal.go
@@ -263,6 +263,7 @@ func (b *BOM) unmarshalHashes(hashes *[]cdx.Hash) []digest.Digest {
 			alg = digest.MD5
 		default:
 			log.Warn("Unsupported hash algorithm", log.String("algorithm", string(h.Algorithm)))
+			continue
 		}
 		digests = append(digests, digest.NewDigestFromString(alg, h.Value))
 	}

--- a/pkg/sbom/io/decode.go
+++ b/pkg/sbom/io/decode.go
@@ -235,7 +235,7 @@ func (m *Decoder) decodePackage(ctx context.Context, c *core.Component) (*ftypes
 			pkg.FilePath = f.Path
 		}
 		// An empty path represents a package digest
-		if f.Path == "" && len(f.Digests) > 0 {
+		if len(f.Digests) > 0 {
 			pkg.Digest = f.Digests[0]
 		}
 	}

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -503,6 +503,8 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 			alg = spdx.SHA1
 		case digest.SHA256:
 			alg = spdx.SHA256
+		case digest.SHA512:
+			alg = spdx.SHA512
 		case digest.MD5:
 			alg = spdx.MD5
 		default:

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -508,7 +508,8 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 		case digest.MD5:
 			alg = spdx.MD5
 		default:
-			return nil
+			m.logger.Warn("Unsupported hash algorithm", log.String("algorithm", string(alg)))
+			continue
 		}
 		checksums = append(checksums, spdx.Checksum{
 			Algorithm: alg,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -479,24 +479,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 									DiffID: "sha256:ccb64cf0b7ba2e50741d0b64cae324eb5de3b1e2f580bbf177e721b67df38488",
 								},
 								FilePath: "tools/project-doe/specifications/actionpack.gemspec",
-								Digest:   "sha1:413f98442c83808042b5d1d2611a346b999bdca5",
-							},
-							{
-								Name:    "ruby-typeprof",
-								Version: "0.20.1",
-								Identifier: ftypes.PkgIdentifier{
-									PURL: &packageurl.PackageURL{
-										Type:    packageurl.TypeNPM,
-										Name:    "ruby-typeprof",
-										Version: "0.20.1",
-									},
-								},
-								Licenses: []string{"MIT"},
-								Layer: ftypes.Layer{
-									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
-								},
-								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
-								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
+								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a", // Changed for tests
 							},
 						},
 					},
@@ -507,7 +490,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "centos:latest",
-				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000007",
+				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000006",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -583,7 +566,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						PackageSupplier:       &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
 						FilesAnalyzed:         true,
 						PackageVerificationCode: &spdx.PackageVerificationCode{
-							Value: "688d98e7e5660b879fd1fc548af8c0df3b7d785a",
+							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 						},
 					},
 					{
@@ -612,31 +595,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
-						PackageSPDXIdentifier:   spdx.ElementID("Package-52b8e939bac2d133"),
-						PackageName:             "ruby-typeprof",
-						PackageVersion:          "0.20.1",
-						PackageDownloadLocation: "NONE",
-						PackageLicenseConcluded: "MIT",
-						PackageLicenseDeclared:  "MIT",
-						PrimaryPackagePurpose:   tspdx.PackagePurposeLibrary,
-						PackageSupplier:         &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
-						FilesAnalyzed:           true,
-						PackageVerificationCode: &spdx.PackageVerificationCode{
-							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-						},
-						PackageExternalReferences: []*spdx.PackageExternalReference{
-							{
-								Category: tspdx.CategoryPackageManager,
-								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
-							},
-						},
-						Annotations: []spdx.Annotation{
-							annotation(t, "LayerDiffID: sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e"),
-							annotation(t, "PkgType: gemspec"),
-						},
-					},
-					{
 						PackageSPDXIdentifier:   spdx.ElementID("OperatingSystem-20f7fa3049cc748c"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "centos",
@@ -654,8 +612,8 @@ func TestMarshaler_Marshal(t *testing.T) {
 						FileName:           "tools/project-doe/specifications/actionpack.gemspec",
 						Checksums: []spdx.Checksum{
 							{
-								Algorithm: spdx.SHA1,
-								Value:     "413f98442c83808042b5d1d2611a346b999bdca5",
+								Algorithm: spdx.SHA512,
+								Value:     "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
 							},
 						},
 					},
@@ -666,16 +624,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Algorithm: spdx.SHA1,
 								Value:     "d2f9f9aed5161f6e4116a3f9573f41cd832f137c",
-							},
-						},
-					},
-					{
-						FileSPDXIdentifier: "File-a52825a3e5bc6dfe",
-						FileName: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
-						Checksums: []common.Checksum{
-							{
-								Algorithm: common.SHA512,
-								Value: "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
 							},
 						},
 					},
@@ -716,18 +664,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 						RefB:         spdx.DocElementID{ElementRefID: "File-6a540784b0dc6d55"},
 						Relationship: "CONTAINS",
 					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "ContainerImage-413bfede37ad01fc"},
-						RefB:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
-						Relationship: "CONTAINS",
-					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
-						RefB:         spdx.DocElementID{ElementRefID: "File-a52825a3e5bc6dfe"},
-						Relationship: "CONTAINS",
-					},
 				},
-
 				OtherLicenses: nil,
 				Annotations:   nil,
 				Reviews:       nil,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -481,6 +481,23 @@ func TestMarshaler_Marshal(t *testing.T) {
 								FilePath: "tools/project-doe/specifications/actionpack.gemspec",
 								Digest:   "sha1:413f98442c83808042b5d1d2611a346b999bdca5",
 							},
+							{
+								Name:    "ruby-typeprof",
+								Version: "0.20.1",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypeNPM,
+										Name:    "ruby-typeprof",
+										Version: "0.20.1",
+									},
+								},
+								Licenses: []string{"MIT"},
+								Layer: ftypes.Layer{
+									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
+								},
+								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
+							},
 						},
 					},
 				},
@@ -490,7 +507,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "centos:latest",
-				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000006",
+				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000007",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -595,6 +612,31 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
+						PackageSPDXIdentifier:   spdx.ElementID("Package-52b8e939bac2d133"),
+						PackageName:             "ruby-typeprof",
+						PackageVersion:          "0.20.1",
+						PackageDownloadLocation: "NONE",
+						PackageLicenseConcluded: "MIT",
+						PackageLicenseDeclared:  "MIT",
+						PrimaryPackagePurpose:   tspdx.PackagePurposeLibrary,
+						PackageSupplier:         &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
+						FilesAnalyzed:           true,
+						PackageVerificationCode: &spdx.PackageVerificationCode{
+							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+						},
+						PackageExternalReferences: []*spdx.PackageExternalReference{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
+							},
+						},
+						Annotations: []spdx.Annotation{
+							annotation(t, "LayerDiffID: sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e"),
+							annotation(t, "PkgType: gemspec"),
+						},
+					},
+					{
 						PackageSPDXIdentifier:   spdx.ElementID("OperatingSystem-20f7fa3049cc748c"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "centos",
@@ -624,6 +666,16 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Algorithm: spdx.SHA1,
 								Value:     "d2f9f9aed5161f6e4116a3f9573f41cd832f137c",
+							},
+						},
+					},
+					{
+						FileSPDXIdentifier: "File-a52825a3e5bc6dfe",
+						FileName: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
+						Checksums: []common.Checksum{
+							{
+								Algorithm: common.SHA512,
+								Value: "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
 							},
 						},
 					},
@@ -662,6 +714,16 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "Package-da2cda24d2ecbfe6"},
 						RefB:         spdx.DocElementID{ElementRefID: "File-6a540784b0dc6d55"},
+						Relationship: "CONTAINS",
+					},
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "ContainerImage-413bfede37ad01fc"},
+						RefB:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
+						Relationship: "CONTAINS",
+					},
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
+						RefB:         spdx.DocElementID{ElementRefID: "File-a52825a3e5bc6dfe"},
 						Relationship: "CONTAINS",
 					},
 				},
@@ -1443,125 +1505,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "Filesystem-e340f27468b382be"},
 						RefB:         spdx.DocElementID{ElementRefID: "Application-aab0f4e8cf174c67"},
-						Relationship: "CONTAINS",
-					},
-				},
-			},
-		},
-		{
-			name: "happy path for SHA512 digest",
-			inputReport: types.Report{
-				SchemaVersion: report.SchemaVersion,
-				ArtifactName:  "http://test-aggregate",
-				ArtifactType:  ftypes.TypeRepository,
-				Results: types.Results{
-					{
-						Target: "Node.js",
-						Class:  types.ClassLangPkg,
-						Type:   ftypes.NodePkg,
-						Packages: []ftypes.Package{
-							{
-								Name:    "ruby-typeprof",
-								Version: "0.20.1",
-								Identifier: ftypes.PkgIdentifier{
-									PURL: &packageurl.PackageURL{
-										Type:    packageurl.TypeNPM,
-										Name:    "ruby-typeprof",
-										Version: "0.20.1",
-									},
-								},
-								Licenses: []string{"MIT"},
-								Layer: ftypes.Layer{
-									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
-								},
-								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
-								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
-							},
-						},
-					},
-				},
-			},
-			wantSBOM: &spdx.Document{
-				SPDXVersion:       spdx.Version,
-				DataLicense:       spdx.DataLicense,
-				SPDXIdentifier:    "DOCUMENT",
-				DocumentName:      "http://test-aggregate",
-				DocumentNamespace: "http://trivy.dev/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000003",
-				CreationInfo: &spdx.CreationInfo{
-					Creators: []common.Creator{
-						{
-							Creator:     "aquasecurity",
-							CreatorType: "Organization",
-						},
-						{
-							Creator:     "trivy-0.56.2",
-							CreatorType: "Tool",
-						},
-					},
-					Created: "2021-08-25T12:20:30Z",
-				},
-				Packages: []*spdx.Package{
-					{
-						PackageSPDXIdentifier:   spdx.ElementID("Package-52b8e939bac2d133"),
-						PackageDownloadLocation: "git+http://test-aggregate",
-						PackageName:             "ruby-typeprof",
-						PackageVersion:          "0.20.1",
-						PackageLicenseConcluded: "MIT",
-						PackageLicenseDeclared:  "MIT",
-						PackageExternalReferences: []*spdx.PackageExternalReference{
-							{
-								Category: tspdx.CategoryPackageManager,
-								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
-							},
-						},
-						Annotations: []spdx.Annotation{
-							annotation(t, "LayerDiffID: sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e"),
-							annotation(t, "PkgType: node-pkg"),
-						},
-						PrimaryPackagePurpose: tspdx.PackagePurposeLibrary,
-						PackageSupplier:       &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
-						FilesAnalyzed:         true,
-						PackageVerificationCode: &spdx.PackageVerificationCode{
-							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-						},
-					},
-					{
-						PackageSPDXIdentifier:   "Repository-1a78857c1a6a759e",
-						PackageName:             "http://test-aggregate",
-						PackageDownloadLocation: "git+http://test-aggregate",
-						Annotations: []spdx.Annotation{
-							annotation(t, "SchemaVersion: 2"),
-						},
-						PrimaryPackagePurpose: tspdx.PackagePurposeSource,
-					},
-				},
-				Files: []*spdx.File{
-					{
-						FileName:           "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
-						FileSPDXIdentifier: "File-a52825a3e5bc6dfe",
-						Checksums: []common.Checksum{
-							{
-								Algorithm: common.SHA512,
-								Value:     "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
-							},
-						},
-					},
-				},
-				Relationships: []*spdx.Relationship{
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
-						RefB:         spdx.DocElementID{ElementRefID: "Repository-1a78857c1a6a759e"},
-						Relationship: "DESCRIBES",
-					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
-						RefB:         spdx.DocElementID{ElementRefID: "File-a52825a3e5bc6dfe"},
-						Relationship: "CONTAINS",
-					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "Repository-1a78857c1a6a759e"},
-						RefB:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
 						Relationship: "CONTAINS",
 					},
 				},

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -481,23 +481,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 								FilePath: "tools/project-doe/specifications/actionpack.gemspec",
 								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a", // Changed for tests
 							},
-							{
-								Name:    "ruby-typeprof",
-								Version: "0.20.1",
-								Identifier: ftypes.PkgIdentifier{
-									PURL: &packageurl.PackageURL{
-										Type:    packageurl.TypeNPM,
-										Name:    "ruby-typeprof",
-										Version: "0.20.1",
-									},
-								},
-								Licenses: []string{"MIT"},
-								Layer: ftypes.Layer{
-									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
-								},
-								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
-								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
-							},
 						},
 					},
 				},
@@ -507,7 +490,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 				DataLicense:       spdx.DataLicense,
 				SPDXIdentifier:    "DOCUMENT",
 				DocumentName:      "centos:latest",
-				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000007",
+				DocumentNamespace: "http://trivy.dev/container_image/centos:latest-3ff14136-e09f-4df9-80ea-000000000006",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -612,31 +595,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 						},
 					},
 					{
-						PackageSPDXIdentifier:   spdx.ElementID("Package-52b8e939bac2d133"),
-						PackageName:             "ruby-typeprof",
-						PackageVersion:          "0.20.1",
-						PackageDownloadLocation: "NONE",
-						PackageLicenseConcluded: "MIT",
-						PackageLicenseDeclared:  "MIT",
-						PrimaryPackagePurpose:   tspdx.PackagePurposeLibrary,
-						PackageSupplier:         &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
-						FilesAnalyzed:           true,
-						PackageVerificationCode: &spdx.PackageVerificationCode{
-							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-						},
-						PackageExternalReferences: []*spdx.PackageExternalReference{
-							{
-								Category: tspdx.CategoryPackageManager,
-								RefType:  tspdx.RefTypePurl,
-								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
-							},
-						},
-						Annotations: []spdx.Annotation{
-							annotation(t, "LayerDiffID: sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e"),
-							annotation(t, "PkgType: gemspec"),
-						},
-					},
-					{
 						PackageSPDXIdentifier:   spdx.ElementID("OperatingSystem-20f7fa3049cc748c"),
 						PackageDownloadLocation: "NONE",
 						PackageName:             "centos",
@@ -666,16 +624,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 							{
 								Algorithm: spdx.SHA1,
 								Value:     "d2f9f9aed5161f6e4116a3f9573f41cd832f137c",
-							},
-						},
-					},
-					{
-						FileSPDXIdentifier: "File-a52825a3e5bc6dfe",
-						FileName: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
-						Checksums: []common.Checksum{
-							{
-								Algorithm: common.SHA512,
-								Value: "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
 							},
 						},
 					},
@@ -714,16 +662,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 					{
 						RefA:         spdx.DocElementID{ElementRefID: "Package-da2cda24d2ecbfe6"},
 						RefB:         spdx.DocElementID{ElementRefID: "File-6a540784b0dc6d55"},
-						Relationship: "CONTAINS",
-					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "ContainerImage-413bfede37ad01fc"},
-						RefB:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
-						Relationship: "CONTAINS",
-					},
-					{
-						RefA:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
-						RefB:         spdx.DocElementID{ElementRefID: "File-a52825a3e5bc6dfe"},
 						Relationship: "CONTAINS",
 					},
 				},

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1448,6 +1448,125 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "happy path for SHA512 digest",
+			inputReport: types.Report{
+				SchemaVersion: report.SchemaVersion,
+				ArtifactName:  "http://test-aggregate",
+				ArtifactType:  ftypes.TypeRepository,
+				Results: types.Results{
+					{
+						Target: "Node.js",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.NodePkg,
+						Packages: []ftypes.Package{
+							{
+								Name:    "ruby-typeprof",
+								Version: "0.20.1",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypeNPM,
+										Name:    "ruby-typeprof",
+										Version: "0.20.1",
+									},
+								},
+								Licenses: []string{"MIT"},
+								Layer: ftypes.Layer{
+									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
+								},
+								Digest: "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
+							},
+						},
+					},
+				},
+			},
+			wantSBOM: &spdx.Document{
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				SPDXIdentifier:    "DOCUMENT",
+				DocumentName:      "http://test-aggregate",
+				DocumentNamespace: "http://trivy.dev/repository/test-aggregate-3ff14136-e09f-4df9-80ea-000000000003",
+				CreationInfo: &spdx.CreationInfo{
+					Creators: []common.Creator{
+						{
+							Creator:     "aquasecurity",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "trivy-0.56.2",
+							CreatorType: "Tool",
+						},
+					},
+					Created: "2021-08-25T12:20:30Z",
+				},
+				Packages: []*spdx.Package{
+					{
+						PackageSPDXIdentifier:   spdx.ElementID("Package-52b8e939bac2d133"),
+						PackageDownloadLocation: "git+http://test-aggregate",
+						PackageName:             "ruby-typeprof",
+						PackageVersion:          "0.20.1",
+						PackageLicenseConcluded: "MIT",
+						PackageLicenseDeclared:  "MIT",
+						PackageExternalReferences: []*spdx.PackageExternalReference{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:npm/ruby-typeprof@0.20.1",
+							},
+						},
+						Annotations: []spdx.Annotation{
+							annotation(t, "LayerDiffID: sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e"),
+							annotation(t, "PkgType: node-pkg"),
+						},
+						PrimaryPackagePurpose: tspdx.PackagePurposeLibrary,
+						PackageSupplier:       &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
+						FilesAnalyzed:         true,
+						PackageVerificationCode: &spdx.PackageVerificationCode{
+							Value: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+						},
+					},
+					{
+						PackageSPDXIdentifier:   "Repository-1a78857c1a6a759e",
+						PackageName:             "http://test-aggregate",
+						PackageDownloadLocation: "git+http://test-aggregate",
+						Annotations: []spdx.Annotation{
+							annotation(t, "SchemaVersion: 2"),
+						},
+						PrimaryPackagePurpose: tspdx.PackagePurposeSource,
+					},
+				},
+				Files: []*spdx.File{
+					{
+						FileName:           "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
+						FileSPDXIdentifier: "File-a52825a3e5bc6dfe",
+						Checksums: []common.Checksum{
+							{
+								Algorithm: common.SHA512,
+								Value:     "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+							},
+						},
+					},
+				},
+				Relationships: []*spdx.Relationship{
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "DOCUMENT"},
+						RefB:         spdx.DocElementID{ElementRefID: "Repository-1a78857c1a6a759e"},
+						Relationship: "DESCRIBES",
+					},
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
+						RefB:         spdx.DocElementID{ElementRefID: "File-a52825a3e5bc6dfe"},
+						Relationship: "CONTAINS",
+					},
+					{
+						RefA:         spdx.DocElementID{ElementRefID: "Repository-1a78857c1a6a759e"},
+						RefB:         spdx.DocElementID{ElementRefID: "Package-52b8e939bac2d133"},
+						Relationship: "CONTAINS",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1474,7 +1474,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 								Layer: ftypes.Layer{
 									DiffID: "sha256:661c3fd3cc16b34c070f3620ca6b03b6adac150f9a7e5d0e3c707a159990f88e",
 								},
-								Digest: "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+								Digest:   "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
 								FilePath: "usr/local/lib/ruby/gems/3.1.0/gems/typeprof-0.21.1/vscode/package.json",
 							},
 						},

--- a/pkg/sbom/spdx/testdata/happy/package-hashes.json
+++ b/pkg/sbom/spdx/testdata/happy/package-hashes.json
@@ -12,8 +12,19 @@
   "name": "maven-test-projecct",
   "packages": [
     {
-      "name": "lodash",
       "SPDXID": "SPDXRef-Package-lodash-4.17.21",
+      "name": "lodash",
+      "versionInfo": "4.17.21",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:npm/lodash@4.17.21",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
       "checksums": [
         {
           "algorithm": "SHA512",

--- a/pkg/sbom/spdx/testdata/happy/package-hashes.json
+++ b/pkg/sbom/spdx/testdata/happy/package-hashes.json
@@ -1,0 +1,26 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2022-09-12T17:02:46.826609Z",
+    "creators": [
+      "Tool: trivy-dev",
+      "Organization: aquasecurity"
+    ]
+  },
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "http://trivy.dev/container/meven-test-project-eb7a0384-b04a-4fc6-8afb-1662fe59ca79",
+  "name": "maven-test-projecct",
+  "packages": [
+    {
+      "name": "lodash",
+      "SPDXID": "SPDXRef-Package-lodash-4.17.21",
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a"
+        }
+      ]
+    }
+  ],
+  "spdxVersion": "SPDX-2.3"
+}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -264,6 +264,7 @@ func (s *SPDX) unmarshalChecksums(checksums []spdx.Checksum) []digest.Digest {
 			alg = digest.MD5
 		default:
 			log.Warn("Unsupported hash algorithm", log.String("algorithm", string(h.Algorithm)))
+			continue
 		}
 		digests = append(digests, digest.NewDigestFromString(alg, h.Value))
 	}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -14,16 +14,16 @@ import (
 	"github.com/spdx/tools-golang/tagvalue"
 	"golang.org/x/xerrors"
 
-	"github.com/aquasecurity/trivy/pkg/sbom/core"
-	"github.com/aquasecurity/trivy/pkg/digest"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/sbom/core"
 )
 
 type SPDX struct {
 	*core.BOM
 
-	trivySBOM    bool
-	pkgFilePaths map[common.ElementID]string
+	trivySBOM bool
+	pkgFiles  map[common.ElementID]core.File
 }
 
 func NewTVDecoder(r io.Reader) *TVDecoder {
@@ -70,8 +70,8 @@ func (s *SPDX) UnmarshalJSON(b []byte) error {
 func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 	s.trivySBOM = s.isTrivySBOM(spdxDocument)
 
-	if s.pkgFilePaths == nil {
-		s.pkgFilePaths = make(map[common.ElementID]string)
+	if s.pkgFiles == nil {
+		s.pkgFiles = make(map[common.ElementID]core.File)
 	}
 
 	// Parse files and find file paths for packages
@@ -127,7 +127,10 @@ func (s *SPDX) parseFiles(spdxDocument *spdx.Document) {
 			if ok {
 				// Save filePaths for packages
 				// Insert filepath will be later
-				s.pkgFilePaths[rel.RefA.ElementRefID] = file.FileName
+				s.pkgFiles[rel.RefA.ElementRefID] = core.File{
+					Path:    file.FileName,
+					Digests: s.unmarshalChecksums(file.Checksums),
+				}
 			}
 			continue
 		}
@@ -186,28 +189,24 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 	}
 
 	// Files
-	// TODO: handle checksums as well
-	if path, ok := s.pkgFilePaths[spdxPkg.PackageSPDXIdentifier]; ok {
-		component.Files = []core.File{
-			{Path: path},
-		}
+	var file core.File
+	// Take filePath + digest from Files components
+	if f, ok := s.pkgFiles[spdxPkg.PackageSPDXIdentifier]; ok {
+		file = f
+		// Take filePath + digest from Package.Files (old format)
 	} else if len(spdxPkg.Files) > 0 {
-		file := spdxPkg.Files[0]
-		component.Files = []core.File{
-			{
-				Path:    file.FileName, // Take the first file name
-				Digests: s.unmarshalChecksums(file.Checksums),
-			},
+		spdxFile := spdxPkg.Files[0] // Take the first file name
+		file = core.File{
+			Path:    spdxFile.FileName,
+			Digests: s.unmarshalChecksums(spdxFile.Checksums),
 		}
+		// Take digest from Package.Checksums
+	} else if len(spdxPkg.PackageChecksums) > 0 {
+		file.Digests = s.unmarshalChecksums(spdxPkg.PackageChecksums)
 	}
-	if len(component.Files) == 0 && len(spdxPkg.PackageChecksums) > 0 {
-		// If no files are specified, use the package checksums
-		component.Files = []core.File{
-			{
-				Digests: s.unmarshalChecksums(spdxPkg.PackageChecksums),
-			},
-		}
 
+	if !file.IsEmpty() {
+		component.Files = append(component.Files, file)
 	}
 
 	// Trivy stores properties in Annotations
@@ -248,6 +247,9 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 }
 
 func (s *SPDX) unmarshalChecksums(checksums []spdx.Checksum) []digest.Digest {
+	if checksums == nil {
+		return nil
+	}
 	var digests []digest.Digest
 	for _, h := range checksums {
 		var alg digest.Algorithm

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -200,6 +200,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 									},
 								},
 								FilePath: "node_modules/yargs-parser/package.json",
+								Digest:   "sha1:69e70ec702f9df4ff64024b5fdea4644f1ce6c97",
 							},
 						},
 					},
@@ -227,6 +228,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 									},
 								},
 								FilePath: "node_modules/yargs-parser/package.json",
+								Digest:   "sha1:69e70ec702f9df4ff64024b5fdea4644f1ce6c97",
 							},
 						},
 					},
@@ -286,6 +288,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 								Name:     "co.elastic.apm:apm-agent",
 								Version:  "1.36.0",
 								FilePath: "modules/apm/elastic-apm-agent-1.36.0.jar",
+								Digest:   "sha1:d2a9ad9b159eb650d25add9395c4f4198f200066",
 								Identifier: ftypes.PkgIdentifier{
 									PURL: &packageurl.PackageURL{
 										Type:      packageurl.TypeMaven,
@@ -300,6 +303,7 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 								Name:     "co.elastic.apm:apm-agent-cached-lookup-key",
 								Version:  "1.36.0",
 								FilePath: "modules/apm/elastic-apm-agent-1.36.0.jar",
+								Digest:   "sha1:d2a9ad9b159eb650d25add9395c4f4198f200066",
 								Identifier: ftypes.PkgIdentifier{
 									PURL: &packageurl.PackageURL{
 										Type:      packageurl.TypeMaven,
@@ -345,10 +349,25 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			name:      "happy path package with hash",
 			inputFile: "testdata/happy/package-hashes.json",
 			want: types.SBOM{
-				Metadata: types.Metadata{
-					OS: &ftypes.OS{
-						Family: "alpine",
-						Name:   "3.16.0",
+				Applications: []ftypes.Application{
+					{
+						Type: ftypes.NodePkg,
+						Packages: ftypes.Packages{
+							{
+								ID:       "lodash@4.17.21",
+								Name:     "lodash",
+								Version:  "4.17.21",
+								Licenses: []string{"MIT"},
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:    packageurl.TypeNPM,
+										Name:    "lodash",
+										Version: "4.17.21",
+									},
+								},
+								Digest: "sha512:bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -341,6 +341,18 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			inputFile: "testdata/sad/invalid-purl.json",
 			wantErr:   "purl is missing type or name",
 		},
+		{
+			name:      "happy path package with hash",
+			inputFile: "testdata/happy/package-hashes.json",
+			want: types.SBOM{
+				Metadata: types.Metadata{
+					OS: &ftypes.OS{
+						Family: "alpine",
+						Name:   "3.16.0",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Add SHA-512 hash algorithm support to the SPDX SBOM serializer.

`spdxChecksums()` in `marshal.go` now handles the `digest.SHA512` case so Trivy
includes SHA-512 checksums in SPDX output. The SPDX/CycloneDX unmarshal logic is
also generalized to parse checksums from files and packages and always persist
the digest. Complements #9126.

## Related issues
- Closes #9094

## Related PRs
- [x] #9126

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
