### PR TITLE
test(java): force offline-scan for client/server integration tests

### DIFF
--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -709,6 +709,9 @@ func setupClient(t *testing.T, c csArgs, addr, cacheDir string) []string {
 		c.RemoteAddrOption,
 		"http://" + addr,
 		"--quiet",
+		// Scan offline for stable test runs: otherwise dependency resolution may reach
+		// remote registries (e.g. Maven Central), which can return a 429
+		"--offline-scan",
 	}
 
 	if c.Format != "" {

--- a/integration/repo_test.go
+++ b/integration/repo_test.go
@@ -630,6 +630,8 @@ func buildArgs(t *testing.T, cacheDir, command string, format types.Format, test
 		string(format),
 		"--parallel",
 		strconv.Itoa(testArgs.parallel),
+		// Scan offline for stable test runs: otherwise dependency resolution may reach
+		// remote registries (e.g. Maven Central), which can return a 429
 		"--offline-scan",
 		testArgs.input,
 	}


### PR DESCRIPTION
## Description

`TestClientServer/scan pox.xml ...` fails intermittently with:

> remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/.../jackson-databind-2.9.1.pom

Maven Central tightened its rate limits, and since #10693 a 429 from a remote Maven repository is surfaced as a fatal error.

This client/server test was the only pom.xml integration test that still resolved transitive dependencies from Maven Central: `TestRepository` already forces `--offline-scan` for every case in `buildArgs`, but `setupClient` does not. Enable `--offline-scan` for that test too so it stays deterministic. The golden file only contains the direct `jackson-databind` dependency, so the output is unchanged. Remote resolution remains covered by the unit tests in `pkg/dependency/parser/java/pom`.

Example of a failing run: https://github.com/aquasecurity/trivy/actions/runs/26396506240/job/77698330124?pr=10704

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
