### PR TITLE
fix(misconf): skip null cty values in AsMapValue to prevent panic

### DIFF
--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -673,8 +673,7 @@ func (a *Attribute) AsMapValue() iacTypes.MapValue {
 
 		values := make(map[string]string)
 		v.ForEachElement(func(key cty.Value, val cty.Value) (stop bool) {
-			if key.Type() == cty.String && key.IsKnown() &&
-				val.Type() == cty.String && val.IsKnown() {
+			if isDefined(key, cty.String) && isDefined(val, cty.String) {
 				values[key.AsString()] = val.AsString()
 			}
 			return false
@@ -829,6 +828,10 @@ func safeOp[T any](a *Attribute, fn func(cty.Value) T) T {
 	unmarked, _ := val.UnmarkDeep()
 
 	return fn(unmarked)
+}
+
+func isDefined(v cty.Value, t cty.Type) bool {
+	return v.Type() == t && v.IsKnown() && !v.IsNull()
 }
 
 // RewriteExpr applies the given function `transform` to the expression of the attribute,

--- a/pkg/iac/terraform/attribute_test.go
+++ b/pkg/iac/terraform/attribute_test.go
@@ -6,11 +6,88 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/json"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/aquasecurity/trivy/pkg/iac/terraform/context"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
 )
+
+func newTestAttribute(t *testing.T, expr string, vars map[string]cty.Value) *Attribute {
+	t.Helper()
+	evalCtx := &hcl.EvalContext{Variables: vars}
+	ctx := context.NewContext(evalCtx, nil)
+	exp, diags := hclsyntax.ParseExpression([]byte(expr), "", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors())
+	return NewAttribute(&hcl.Attribute{
+		Name:      "test",
+		Expr:      exp,
+		Range:     hcl.Range{},
+		NameRange: hcl.Range{},
+	}, ctx, "", types.Metadata{}, Reference{}, "", nil)
+}
+
+func Test_Attribute_AsMapValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      cty.Value
+		expected map[string]string
+	}{
+		{
+			name: "all valid string values",
+			val: cty.ObjectVal(map[string]cty.Value{
+				"env":  cty.StringVal("staging"),
+				"team": cty.StringVal("platform"),
+			}),
+			expected: map[string]string{"env": "staging", "team": "platform"},
+		},
+		{
+			name: "null value is skipped",
+			val: cty.ObjectVal(map[string]cty.Value{
+				"env":     cty.StringVal("staging"),
+				"project": cty.NullVal(cty.String),
+			}),
+			expected: map[string]string{"env": "staging"},
+		},
+		{
+			name: "all null values",
+			val: cty.ObjectVal(map[string]cty.Value{
+				"env":     cty.NullVal(cty.String),
+				"project": cty.NullVal(cty.String),
+			}),
+			expected: make(map[string]string),
+		},
+		{
+			name: "unknown value is skipped",
+			val: cty.ObjectVal(map[string]cty.Value{
+				"env":     cty.StringVal("staging"),
+				"project": cty.UnknownVal(cty.String),
+			}),
+			expected: map[string]string{"env": "staging"},
+		},
+		{
+			name: "non-string value is skipped",
+			val: cty.ObjectVal(map[string]cty.Value{
+				"env":   cty.StringVal("staging"),
+				"count": cty.NumberIntVal(5),
+			}),
+			expected: map[string]string{"env": "staging"},
+		},
+		{
+			name:     "non-map type returns nil",
+			val:      cty.StringVal("not-a-map"),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := newTestAttribute(t, "val", map[string]cty.Value{"val": tt.val})
+			assert.Equal(t, tt.expected, attr.AsMapValue().Value())
+		})
+	}
+}
 
 func Test_AllReferences(t *testing.T) {
 	cases := []struct {
@@ -70,19 +147,7 @@ func Test_AllReferences(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.input, func(t *testing.T) {
-			ctx := context.NewContext(&hcl.EvalContext{}, nil)
-
-			exp, diag := hclsyntax.ParseExpression([]byte(test.input), "", hcl.Pos{Line: 1, Column: 1})
-			if diag.HasErrors() {
-				require.NoError(t, diag)
-			}
-
-			a := NewAttribute(&hcl.Attribute{
-				Name:      "test",
-				Expr:      exp,
-				Range:     hcl.Range{},
-				NameRange: hcl.Range{},
-			}, ctx, "", types.Metadata{}, Reference{}, "", nil)
+			a := newTestAttribute(t, test.input, nil)
 
 			refs := a.AllReferences()
 			humanRefs := make([]string, 0, len(refs))


### PR DESCRIPTION
## Description

Added a check to ensure that the keys and values of the maps are not zero.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/10720

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
