### PR TITLE
fix(cloudformation): propagate AWS::EC2::Instance MetadataOptions

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/adapt_test.go
@@ -212,6 +212,34 @@ Resources:
 			},
 		},
 		{
+			name: "ec2 instance with metadata options",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  MyEC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-12345
+      InstanceType: t3.micro
+      MetadataOptions:
+        HttpEndpoint: enabled
+        HttpTokens: required
+`,
+			expected: ec2.EC2{
+				Instances: []ec2.Instance{
+					{
+						MetadataOptions: ec2.MetadataOptions{
+							HttpEndpoint: types.StringTest("enabled"),
+							HttpTokens:   types.StringTest("required"),
+						},
+						RootBlockDevice: &ec2.BlockDevice{
+							Encrypted: types.BoolTest(false),
+						},
+					},
+				},
+				VPCs: nil,
+			},
+		},
+		{
 			name: "ec2 instance with launch template, ref to name",
 			source: `AWSTemplateFormatVersion: 2010-09-09
 Resources:

--- a/pkg/iac/adapters/cloudformation/aws/ec2/instance.go
+++ b/pkg/iac/adapters/cloudformation/aws/ec2/instance.go
@@ -10,16 +10,23 @@ func getInstances(ctx parser.FileContext) (instances []ec2.Instance) {
 	instanceResources := ctx.GetResourcesByType("AWS::EC2::Instance")
 
 	for _, r := range instanceResources {
+		metadataOptions := ec2.MetadataOptions{
+			Metadata:     r.Metadata(),
+			HttpTokens:   iacTypes.StringDefault("optional", r.Metadata()),
+			HttpEndpoint: iacTypes.StringDefault("enabled", r.Metadata()),
+		}
+		if opts := r.GetProperty("MetadataOptions"); opts.IsNotNil() {
+			metadataOptions = ec2.MetadataOptions{
+				Metadata:     opts.Metadata(),
+				HttpTokens:   opts.GetStringProperty("HttpTokens", "optional"),
+				HttpEndpoint: opts.GetStringProperty("HttpEndpoint", "enabled"),
+			}
+		}
+
 		instance := ec2.Instance{
-			Metadata: r.Metadata(),
-			// metadata not supported by CloudFormation at the moment -
-			// https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/655
-			MetadataOptions: ec2.MetadataOptions{
-				Metadata:     r.Metadata(),
-				HttpTokens:   iacTypes.StringDefault("optional", r.Metadata()),
-				HttpEndpoint: iacTypes.StringDefault("enabled", r.Metadata()),
-			},
-			UserData: r.GetStringProperty("UserData"),
+			Metadata:        r.Metadata(),
+			MetadataOptions: metadataOptions,
+			UserData:        r.GetStringProperty("UserData"),
 		}
 
 		if launchTemplate, ok := findRelatedLaunchTemplate(ctx, r); ok {


### PR DESCRIPTION
## Description

The CloudFormation adapter for `AWS::EC2::Instance` hardcoded `HttpTokens`
to `"optional"` and `HttpEndpoint` to `"enabled"` regardless of the template
values, causing **AVD-AWS-0028** ("Instance does not require IMDS access to
require a token") to false-positive on instances that explicitly set
`HttpTokens: required`.

The stale comment in `pkg/iac/adapters/cloudformation/aws/ec2/instance.go`
referenced a 2019 cloudformation-coverage-roadmap issue, but
`MetadataOptions` on `AWS::EC2::Instance` has been supported by
CloudFormation for years, and the `LaunchTemplate`-backed path in
`launch_template.go` already reads these properties correctly.

This change reads `MetadataOptions` from the resource when present, falling
back to the previous defaults otherwise. It mirrors the pattern already used
by the launch-template adapter. A regression test covering the direct-on-
instance case (no `LaunchTemplate`) is included; it fails on `main` and
passes with this fix applied.

### Reproduction (before this PR)

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Resources:
  Instance:
    Type: AWS::EC2::Instance
    Properties:
      ImageId: ami-12345
      InstanceType: t3.micro
      MetadataOptions:
        HttpEndpoint: enabled
        HttpTokens: required
```

`trivy config min.yml --severity HIGH` reports `AVD-AWS-0028 (HIGH)` even
though `HttpTokens: required` satisfies the check. After this PR the same
template passes.

## Related issues
- Refs aquasecurity/trivy#10730 (discussion where this was reported)
- Related: #5793 — closed; covered the `LaunchTemplate`-backed variant of
  the same false positive. This PR addresses the simpler, direct-on-
  instance variant.
- Precedent: #6024 — `bug(cloudformation)` scope used for an analogous
  CFN-adapter false positive.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).