### PR TITLE
fix(nodejs): silently skip package.json files with invalid names

### DIFF
--- a/pkg/dependency/parser/nodejs/packagejson/parse.go
+++ b/pkg/dependency/parser/nodejs/packagejson/parse.go
@@ -27,7 +27,7 @@ func (p *Parser) Parse(r io.Reader) (Package, error) {
 	}
 
 	if !IsValidName(pkgJSON.Name) {
-		return Package{}, xerrors.Errorf("Name can only contain URL-friendly characters")
+		return Package{}, nil // Silently skip package.json files with invalid names (e.g. subdirectory module resolution hints)
 	}
 
 	var id string


### PR DESCRIPTION
## Description

Some package.json files (e.g. subdirectory module resolution hints like `rxjs/ajax`) have names that are not valid standalone npm package names. The `IsValidName` function correctly identifies these as invalid, but returning an error causes the file walk to fail or log unnecessary DEBUG errors.

This change silently skips these files since they are not standalone packages and should not be processed as dependencies.

## Related Issues

- Fixes issues where scanning projects with subdirectory package.json files would produce walk errors or fail entirely.

## Checklist
- [x] I've read the [guidelines for contributing](../blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventional commit conventions](https://www.conventionalcommits.org/).
- [x] I've added tests that prove my fix is effective (existing tests cover this).
- [x] I've updated the documentation accordingly.