### PR TITLE
chore: migrate from gomodguard to gomodguard_v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,20 +46,19 @@ linters:
     gocyclo:
       # Next highest complexity candidate: ApplyLayers in pkg/fanal/applier/docker.go (score: 28)
       min-complexity: 20
-    gomodguard:
+    gomodguard_v2:
       blocked:
-        modules:
-          - github.com/hashicorp/go-version:
-              recommendations:
-                - github.com/aquasecurity/go-version
-              reason: "`aquasecurity/go-version` is designed for our use-cases"
-          - github.com/Masterminds/semver:
-              recommendations:
-                - github.com/aquasecurity/go-version
-              reason: "`aquasecurity/go-version` is designed for our use-cases"
-          - github.com/liamg/memoryfs:
-              recommendations:
-                - github.com/aquasecurity/trivy/pkg/mapfs
+        - module: github.com/hashicorp/go-version
+          recommendations:
+            - github.com/aquasecurity/go-version
+          reason: "`aquasecurity/go-version` is designed for our use-cases"
+        - module: github.com/Masterminds/semver
+          recommendations:
+            - github.com/aquasecurity/go-version
+          reason: "`aquasecurity/go-version` is designed for our use-cases"
+        - module: github.com/liamg/memoryfs
+          recommendations:
+            - github.com/aquasecurity/trivy/pkg/mapfs
     gosec:
       excludes:
         - G101
@@ -151,7 +150,7 @@ linters:
     - depguard
     - gocritic
     - gocyclo
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - govet
     - ineffassign

--- a/magefiles/terraformplan.go
+++ b/magefiles/terraformplan.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	hversion "github.com/hashicorp/go-version" //nolint:gomodguard // hc-install uses hashicorp/go-version
+	hversion "github.com/hashicorp/go-version" //nolint:gomodguard_v2 // hc-install uses hashicorp/go-version
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/terraform-exec/tfexec"


### PR DESCRIPTION
## Description

`gomodguard` has been deprecated in favor of `gomodguard_v2`.

```
❯ CGO_ENABLED=0 mage lint:run
2026-05-27T15:50:36+06:00       INFO    Installing tools, make sure you add $GOBIN to the $PATH
WARN The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2. 
WARN Suggested new configuration:
linters:
  enable:
    - gomodguard_v2
  settings:
    gomodguard_v2:
      blocked:
        - module: github.com/hashicorp/go-version
          recommendations:
            - github.com/aquasecurity/go-version
          reason: '`aquasecurity/go-version` is designed for our use-cases'
        - module: github.com/Masterminds/semver
          recommendations:
            - github.com/aquasecurity/go-version
          reason: '`aquasecurity/go-version` is designed for our use-cases'
        - module: github.com/liamg/memoryfs
          recommendations:
            - github.com/aquasecurity/trivy/pkg/mapfs
```


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
