### PR TITLE
feat(flag): add `--follow-symlinks` for fs/rootfs scanning

### DIFF
--- a/docs/guide/advanced/telemetry-flags.md
+++ b/docs/guide/advanced/telemetry-flags.md
@@ -6,6 +6,7 @@
 --distro
 --exit-code
 --exit-on-eol
+--follow-symlinks
 --format
 --ignore-status
 --ignore-unfixed

--- a/docs/guide/references/configuration/cli/trivy_filesystem.md
+++ b/docs/guide/references/configuration/cli/trivy_filesystem.md
@@ -45,6 +45,7 @@ trivy filesystem [flags] PATH
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format
                                           Allowed values:
                                             - table

--- a/docs/guide/references/configuration/cli/trivy_image.md
+++ b/docs/guide/references/configuration/cli/trivy_image.md
@@ -61,6 +61,7 @@ trivy image [flags] IMAGE_NAME
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format
                                           Allowed values:
                                             - table

--- a/docs/guide/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/guide/references/configuration/cli/trivy_kubernetes.md
@@ -65,6 +65,7 @@ trivy kubernetes [flags] [CONTEXT]
       --exclude-owned                     exclude resources that have an owner reference
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format (allowed values: table,json,cyclonedx) (default "table")
       --helm-api-versions strings         Available API versions used for Capabilities.APIVersions. This flag is the same as the api-versions flag of the helm template command. (can specify multiple or separate values with commas: policy/v1/PodDisruptionBudget,apps/v1/Deployment)
       --helm-kube-version string          Kubernetes version used for Capabilities.KubeVersion. This flag is the same as the kube-version flag of the helm template command.

--- a/docs/guide/references/configuration/cli/trivy_repository.md
+++ b/docs/guide/references/configuration/cli/trivy_repository.md
@@ -44,6 +44,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --enable-modules strings            [EXPERIMENTAL] module names to enable
       --exit-code int                     specify exit code when any security issues are found
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format
                                           Allowed values:
                                             - table

--- a/docs/guide/references/configuration/cli/trivy_rootfs.md
+++ b/docs/guide/references/configuration/cli/trivy_rootfs.md
@@ -48,6 +48,7 @@ trivy rootfs [flags] ROOTDIR
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format
                                           Allowed values:
                                             - table

--- a/docs/guide/references/configuration/cli/trivy_sbom.md
+++ b/docs/guide/references/configuration/cli/trivy_sbom.md
@@ -36,6 +36,7 @@ trivy sbom [flags] SBOM_PATH
       --exit-code int                  specify exit code when any security issues are found
       --exit-on-eol int                exit with the specified code when the OS reaches end of service/life
       --file-patterns strings          specify config file patterns
+      --follow-symlinks                follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                  format
                                        Allowed values:
                                          - table

--- a/docs/guide/references/configuration/cli/trivy_vm.md
+++ b/docs/guide/references/configuration/cli/trivy_vm.md
@@ -44,6 +44,7 @@ trivy vm [flags] VM_IMAGE
       --exit-code int                     specify exit code when any security issues are found
       --exit-on-eol int                   exit with the specified code when the OS reaches end of service/life
       --file-patterns strings             specify config file patterns
+      --follow-symlinks                   follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)
   -f, --format string                     format
                                           Allowed values:
                                             - table

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -613,6 +613,9 @@ scan:
   # Same as '--file-patterns'
   file-patterns: []
 
+  # Same as '--follow-symlinks'
+  follow-symlinks: false
+
   # Same as '--offline-scan'
   offline: false
 

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -683,8 +683,9 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 
 			// For file walking
 			WalkerOption: walker.Option{
-				SkipFiles: opts.SkipFiles,
-				SkipDirs:  opts.SkipDirs,
+				SkipFiles:      opts.SkipFiles,
+				SkipDirs:       opts.SkipDirs,
+				FollowSymlinks: opts.FollowSymlinks,
 			},
 		},
 	}, scanOptions, nil

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -58,6 +58,26 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 				return filepath.SkipDir
 			}
 			return nil
+		case d.Type()&fs.ModeSymlink != 0:
+			// WalkDir lstat's without following symlinks; optionally follow
+			// those resolving to regular files (dir symlinks would cycle).
+			if !opt.FollowSymlinks {
+				return nil
+			}
+			target, err := os.Stat(filePath)
+			if err != nil {
+				return nil // broken symlink
+			}
+			if !target.Mode().IsRegular() {
+				return nil
+			}
+			if utils.SkipPath(relPath, opt.SkipFiles) {
+				return nil
+			}
+			if err = fn(relPath, target, fileOpener(filePath)); err != nil {
+				return xerrors.Errorf("failed to analyze file: %w", err)
+			}
+			return nil
 		case !d.Type().IsRegular():
 			return nil
 		case utils.SkipPath(relPath, opt.SkipFiles):

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -89,6 +89,85 @@ func TestFS_Walk(t *testing.T) {
 	}
 }
 
+func TestFS_Walk_FollowSymlinks(t *testing.T) {
+	// testdata/fs/sym.txt is a symlink to the regular file testdata/fs/bar.
+	tests := []struct {
+		name           string
+		followSymlinks bool
+		wantVisited    bool
+	}{
+		{
+			name:           "disabled (default): symlink skipped",
+			followSymlinks: false,
+			wantVisited:    false,
+		},
+		{
+			name:           "enabled: symlink to regular file followed",
+			followSymlinks: true,
+			wantVisited:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var visited []string
+			var symContent string
+			err := walker.NewFS().Walk("testdata/fs", walker.Option{FollowSymlinks: tt.followSymlinks},
+				func(filePath string, _ os.FileInfo, opener analyzer.Opener) error {
+					visited = append(visited, filePath)
+					if filePath == "sym.txt" {
+						r, err := opener()
+						require.NoError(t, err)
+						b, err := io.ReadAll(r)
+						require.NoError(t, err)
+						symContent = string(b)
+					}
+					return nil
+				})
+			require.NoError(t, err)
+
+			// The walker yields paths relative to the scan root, so the
+			// symlink appears as "sym.txt", not "testdata/fs/sym.txt".
+			assert.Contains(t, visited, "bar", "regular files must always be walked")
+			gotVisited := slices.Contains(visited, "sym.txt")
+			assert.Equal(t, tt.wantVisited, gotVisited)
+			if tt.wantVisited {
+				assert.Equal(t, "bar", symContent, "symlink should resolve to its target's content")
+			}
+		})
+	}
+}
+
+func TestFS_Walk_FollowSymlinks_SkipsDirsAndBrokenLinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	// A tree exercising the three symlink target kinds the walker handles.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "real.txt"), []byte("real"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "subdir", "nested.txt"), []byte("nested"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(root, "real.txt"), filepath.Join(root, "file-link")))  // -> regular file
+	require.NoError(t, os.Symlink(filepath.Join(root, "subdir"), filepath.Join(root, "dir-link")))     // -> directory
+	require.NoError(t, os.Symlink(filepath.Join(root, "missing"), filepath.Join(root, "broken-link"))) // -> nonexistent
+
+	var visited []string
+	err := walker.NewFS().Walk(root, walker.Option{FollowSymlinks: true},
+		func(filePath string, _ os.FileInfo, _ analyzer.Opener) error {
+			visited = append(visited, filePath)
+			return nil
+		})
+	require.NoError(t, err) // a broken symlink must not abort the walk
+
+	assert.Contains(t, visited, "real.txt", "regular files are always walked")
+	assert.Contains(t, visited, "subdir/nested.txt", "real subdirectories are walked")
+	assert.Contains(t, visited, "file-link", "symlink to a regular file is followed")
+	assert.NotContains(t, visited, "dir-link", "symlink to a directory is not followed")
+	assert.NotContains(t, visited, "broken-link", "broken symlink is skipped")
+	for _, p := range visited {
+		assert.False(t, strings.HasPrefix(p, "dir-link/"), "must not traverse into a directory symlink: %s", p)
+	}
+}
+
 func TestFS_BuildSkipPaths(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -18,6 +18,10 @@ var defaultSkipDirs = []string{
 type Option struct {
 	SkipFiles []string
 	SkipDirs  []string
+
+	// FollowSymlinks follows symlinks to regular files; dir symlinks are
+	// never followed (avoids traversal cycles).
+	FollowSymlinks bool
 }
 
 type WalkFunc func(filePath string, info os.FileInfo, opener analyzer.Opener) error

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -26,6 +26,12 @@ var (
 		Default:    []string{},
 		Usage:      "specify the files or glob patterns to skip",
 	}
+	FollowSymlinksFlag = Flag[bool]{
+		Name:          "follow-symlinks",
+		ConfigName:    "scan.follow-symlinks",
+		Usage:         "follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)",
+		TelemetrySafe: true,
+	}
 	OfflineScanFlag = Flag[bool]{
 		Name:          "offline-scan",
 		ConfigName:    "scan.offline",
@@ -140,6 +146,7 @@ var (
 type ScanFlagGroup struct {
 	SkipDirs          *Flag[[]string]
 	SkipFiles         *Flag[[]string]
+	FollowSymlinks    *Flag[bool]
 	OfflineScan       *Flag[bool]
 	Scanners          *Flag[[]string]
 	FilePatterns      *Flag[[]string]
@@ -157,6 +164,7 @@ type ScanOptions struct {
 	Target            string
 	SkipDirs          []string
 	SkipFiles         []string
+	FollowSymlinks    bool
 	OfflineScan       bool
 	Scanners          types.Scanners
 	FilePatterns      []string
@@ -173,6 +181,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 	return &ScanFlagGroup{
 		SkipDirs:          SkipDirsFlag.Clone(),
 		SkipFiles:         SkipFilesFlag.Clone(),
+		FollowSymlinks:    FollowSymlinksFlag.Clone(),
 		OfflineScan:       OfflineScanFlag.Clone(),
 		Scanners:          ScannersFlag.Clone(),
 		FilePatterns:      FilePatternsFlag.Clone(),
@@ -195,6 +204,7 @@ func (f *ScanFlagGroup) Flags() []Flagger {
 	return []Flagger{
 		f.SkipDirs,
 		f.SkipFiles,
+		f.FollowSymlinks,
 		f.OfflineScan,
 		f.Scanners,
 		f.FilePatterns,
@@ -237,6 +247,7 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 		Target:            target,
 		SkipDirs:          f.SkipDirs.Value(),
 		SkipFiles:         f.SkipFiles.Value(),
+		FollowSymlinks:    f.FollowSymlinks.Value(),
 		OfflineScan:       f.OfflineScan.Value(),
 		Scanners:          xstrings.ToTSlice[types.Scanner](f.Scanners.Value()),
 		FilePatterns:      f.FilePatterns.Value(),

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -16,6 +16,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 	type fields struct {
 		skipDirs         []string
 		skipFiles        []string
+		followSymlinks   bool
 		offlineScan      bool
 		scanners         string
 		distro           string
@@ -99,6 +100,16 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
+			name: "follow symlinks",
+			fields: fields{
+				followSymlinks: true,
+			},
+			want: flag.ScanOptions{
+				FollowSymlinks: true,
+			},
+			assertion: require.NoError,
+		},
+		{
 			name: "offline scan",
 			fields: fields{
 				offlineScan: true,
@@ -145,6 +156,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			t.Cleanup(viper.Reset)
 			setSliceValue(flag.SkipDirsFlag.ConfigName, tt.fields.skipDirs)
 			setSliceValue(flag.SkipFilesFlag.ConfigName, tt.fields.skipFiles)
+			setValue(flag.FollowSymlinksFlag.ConfigName, tt.fields.followSymlinks)
 			setValue(flag.OfflineScanFlag.ConfigName, tt.fields.offlineScan)
 			setValue(flag.ScannersFlag.ConfigName, tt.fields.scanners)
 			setValue(flag.DistroFlag.ConfigName, tt.fields.distro)
@@ -154,6 +166,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			f := &flag.ScanFlagGroup{
 				SkipDirs:         flag.SkipDirsFlag.Clone(),
 				SkipFiles:        flag.SkipFilesFlag.Clone(),
+				FollowSymlinks:   flag.FollowSymlinksFlag.Clone(),
 				OfflineScan:      flag.OfflineScanFlag.Clone(),
 				Scanners:         flag.ScannersFlag.Clone(),
 				DistroFlag:       flag.DistroFlag.Clone(),

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -746,6 +746,10 @@
           },
           "description": "specify the files or glob patterns to skip"
         },
+        "follow-symlinks": {
+          "type": "boolean",
+          "description": "follow symlinks that resolve to regular files and scan their targets (symlinks to directories are not followed)"
+        },
         "offline": {
           "type": "boolean",
           "description": "do not issue API requests to identify dependencies"


### PR DESCRIPTION
## Description

`trivy fs`/`rootfs` skip symlinks: the walker (`pkg/fanal/walker`) uses `filepath.WalkDir`, which `lstat`s entries and does not follow them. This adds an **opt-in** `--follow-symlinks` (default off) that follows symlinks **resolving to regular files**. Symlinks to **directories are not followed** (no traversal cycles) and **broken symlinks** are skipped, so default behavior is unchanged.

### Motivation — assemble a scan root without elevated capabilities

A common need is to scan a filesystem *assembled* from content elsewhere — e.g. a container image's effective rootfs reconstructed from a content-addressed store (Nix being the obvious case). Today that means either a full **copy** (doubles disk) or a **`mount --bind`**, which needs `CAP_SYS_ADMIN` — root or an *unprivileged user namespace*. The cheap, capability-free option — a **symlink** layout — doesn't work because the walker skips symlinks. And unprivileged userns is increasingly **restricted by default** (Ubuntu 23.10+ AppArmor, `user.max_user_namespaces=0`, container seccomp blocking `CLONE_NEWUSER`, hardened kernels). Following symlinks lets a scan root be assembled with **plain file operations — no `mount`, no `CAP_SYS_ADMIN`, no namespace.**

### Behavior

- Opt-in, default off → no change for existing users.
- Symlink → regular file: **followed** (`os.Stat`); → directory: **not followed** (avoids cycles); broken: **skipped**, no error.
- In the scan flag group → applies to `fs`, `rootfs`, `repo`.

### Before / after

A Nix-built image's effective rootfs laid out as a symlink farm, scanned with `trivy rootfs`:

- **before** (stock): `0` packages — symlinks skipped.
- **after** (`--follow-symlinks`): **identical detection to both a full dereferenced copy and a `mount --bind` assembly** — same package set, package-for-package — at a fraction of the disk, no `mount`/userns needed.

(A minimal probe confirmed it's the walker, not escape-prevention: a *within-root, relative* symlink is also skipped today.)

## Related issues
- Relates to #4505 (follow-symlinks discussion). No tracking issue exists yet; rationale and validation are in the description, per the guide's allowance for self-justified changes.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
