### PR TITLE
fix(misconf): fix rendering of nested values in terraform plan lists

### DIFF
--- a/pkg/iac/scanners/terraformplan/tfjson/parser/block.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/block.go
@@ -144,10 +144,13 @@ func (r *hclRenderer) renderSlice(vals []any) {
 	r.incIndent()
 	defer r.decIndent()
 
-	for _, v := range vals {
+	for i, v := range vals {
 		r.write(r.indent + "  ")
-		renderPrimitive(r.w, v)
-		r.writeln(",")
+		r.renderAttributeValue(v)
+		if i != len(vals)-1 {
+			r.write(",")
+		}
+		r.writeln("")
 	}
 	r.write(r.indent + "]")
 }

--- a/pkg/iac/scanners/terraformplan/tfjson/parser/block_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/block_test.go
@@ -123,6 +123,38 @@ func Test_ToHcl(t *testing.T) {
 `,
 		},
 		{
+			name: "list attribute with nested lists",
+			block: PlanBlock{
+				BlockType: "resource",
+				Type:      "foo",
+				Name:      "bar",
+				Attributes: map[string]any{
+					"nested": []any{
+						[]any{"a", "b"},
+						[]any{"c"},
+						[]any{"d", "e", "f"},
+					},
+				},
+			},
+			expected: `resource "foo" "bar" {
+  nested = [
+    [
+      "a",
+      "b"
+    ],
+    [
+      "c"
+    ],
+    [
+      "d",
+      "e",
+      "f"
+    ]
+  ]
+}
+`,
+		},
+		{
 			name: "map key doesn't valid identifier",
 			block: PlanBlock{
 				BlockType: "resource",

--- a/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
+++ b/pkg/iac/scanners/terraformplan/tfjson/parser/parser_test.go
@@ -57,7 +57,7 @@ resource "aws_security_group" "sg" {
   }
   ingress {
     cidr_blocks = [
-      "0.0.0.0/0",
+      "0.0.0.0/0"
     ]
     description = ""
     from_port = 80


### PR DESCRIPTION
## Description

Fixed rendering of nested list values in Terraform plan JSON parser.

Before:
```tf
resource "foo" "bar" {
  nested = [
    []interface {}{"a", "b"},
    []interface {}{"c"},
    []interface {}{"d", "e", "f"},
  ]
}
```

After:
```tf
resource "foo" "bar" {
  nested = [
    [
      "a",
      "b"
    ],
    [
      "c"
    ],
    [
      "d",
      "e",
      "f"
    ]
  ]
}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
