### PR TITLE
ci: replace trivy-issue-action with trivy-action and SARIF upload

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -8,18 +8,29 @@ jobs:
   build:
     name: Scan Go vulnerabilities
     runs-on: ubuntu-2404-2core
+    permissions:
+      contents: read # Required to checkout and read repo files
+      security-events: write # Required to upload SARIF files to Security tab
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Run Trivy vulnerability scanner and create GitHub issues
-        uses: knqyf263/trivy-issue-action@4466f52d1401b66dd2a2ab9e0c40cddc021829ec # v0.0.6
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          assignee: knqyf263
-          severity: CRITICAL
-          skip-dirs: integration,examples,pkg
-          label: kind/security
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          format: sarif
+          output: report.sarif
+          severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
+          skip-dirs: integration,examples,pkg,docs,internal
+          version: v0.70.0
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: report.sarif

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -9,25 +9,17 @@ jobs:
     name: Scan Go vulnerabilities
     runs-on: ubuntu-2404-2core
     permissions:
-      contents: read # Required to checkout and read repo files
       security-events: write # Required to upload SARIF files to Security tab
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln
+          scan-type: image
+          image-ref: ghcr.io/aquasecurity/trivy:canary
           format: sarif
           output: report.sarif
           severity: HIGH,CRITICAL
           limit-severities-for-sarif: true
-          skip-dirs: integration,examples,pkg,docs,internal
           version: v0.70.0
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Scan Go vulnerabilities
+    name: Scan Trivy canary image for vulnerabilities
     runs-on: ubuntu-2404-2core
     permissions:
       security-events: write # Required to upload SARIF files to Security tab


### PR DESCRIPTION
## Description

Replace `knqyf263/trivy-issue-action` (unmaintained) with the official `aquasecurity/trivy-action` + SARIF upload to GitHub Security tab for native code scanning alerts.

Test run on ghcr.io/aquasecurity/trivy:0.69.3 to check the report: https://github.com/nikpivkin/trivy/actions/runs/26821356967/job/79076553420 

Security tab: https://github.com/nikpivkin/trivy/security/code-scanning


## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
