### PR TITLE
ci: scope GitHub App tokens to minimum required permissions

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -42,6 +42,8 @@ jobs:
         with:
           client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -55,6 +55,7 @@ jobs:
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: trivy-www
+          permission-actions: write
       - name: Trigger build-docs workflow in trivy-www
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -71,6 +71,7 @@ jobs:
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: helm-charts
+          permission-actions: write
       - name: Trigger publish-chart workflow in helm-charts
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,6 +25,8 @@ jobs:
         with:
           client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Release Please
         id: release
@@ -45,6 +47,8 @@ jobs:
         with:
           client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Install Release Please CLI
         run: npm install release-please -g
@@ -84,6 +88,7 @@ jobs:
         with:
           client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Tag release
         if: ${{ steps.extract_info.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
           private-key: ${{ secrets.TRIVY_WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: trivy-repo
+          permission-actions: write
       - name: Trigger deploy-packages workflow in trivy-repo
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -56,6 +57,8 @@ jobs:
         with:
           client-id: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_TRIVY_WRITE_GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,6 +102,7 @@ jobs:
             trivy-downloads
             trivy-chocolatey
             trivy-action
+          permission-actions: write
       - name: Trigger update_version workflow in trivy-telemetry
         if: always()
         env:


### PR DESCRIPTION
## Description

All usages of `actions/create-github-app-token` were missing explicit permission-* inputs, causing tokens to inherit the full installation permissions of the app. This was detected by a new zizmor audit rule [github-app](https://docs.zizmor.sh/audits/#github-app). This fix scopes each token to the minimum permissions required for the job.

Two GitHub Apps are used across these workflows:
- repo-trivy-write: contents: write, pull-requests: write
- actions-multi-write: actions: write

Each token is scoped to the minimum permissions required for the job:

| File | Job | App | Added permissions |
|------|-----|-----|-------------------|
| `backport.yaml` | `backport` | `repo-trivy-write` | `contents: write`, `pull-requests: write` |
| `mkdocs-latest.yaml` | `trigger-trivy-www-deploy` | `actions-multi-write` | `actions: write` |
| `publish-chart.yaml` | `publish-chart` | `actions-multi-write` | `actions: write` |
| `release-please.yaml` | `release-please` | `repo-trivy-write` | `contents: write`, `pull-requests: write` |
| `release-please.yaml` | `manual-release-please` | `repo-trivy-write` | `contents: write`, `pull-requests: write` |
| `release-please.yaml` | `release-tag` | `repo-trivy-write` | `contents: write` |
| `release.yaml` | `deploy-packages` | `actions-multi-write` | `actions: write` |
| `release.yaml` | `update-chart-version` | `repo-trivy-write` | `contents: write`, `pull-requests: write` |
| `release.yaml` | `trigger-version-update` | `actions-multi-write` | `actions: write` |


Before:
```bash
56 findings (2 ignored, 45 suppressed): 0 informational, 0 low, 0 medium, 9 high
```

After:
```bash
No findings to report. Good job! (2 ignored, 45 suppressed)
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
