### PR TITLE
refactor(misconf): propagate metadata through azure Value chain

### DIFF
--- a/pkg/iac/adapters/arm/appservice/adapt.go
+++ b/pkg/iac/adapters/arm/appservice/adapt.go
@@ -32,9 +32,8 @@ func adaptServices(deployment azure.Deployment) []appservice.Service {
 
 func adaptFunctionApp(resource azure.Resource) appservice.FunctionApp {
 	return appservice.FunctionApp{
-		Metadata: resource.Metadata,
-		HTTPSOnly: resource.Properties.GetMapValue("httpsOnly").
-			AsBoolValue(false, resource.Properties.GetMetadata()),
+		Metadata:  resource.Metadata,
+		HTTPSOnly: resource.Properties.GetMapValue("httpsOnly").AsBoolValue(false),
 	}
 }
 
@@ -46,23 +45,22 @@ func adaptService(resource azure.Resource) appservice.Service {
 	return appservice.Service{
 		Metadata:         resource.Metadata,
 		Resource:         types.String("Microsoft.Web/sites", resource.Metadata),
-		EnableClientCert: props.GetMapValue("clientCertEnabled").AsBoolValue(false, props.GetMetadata()),
-		HTTPSOnly:        props.GetMapValue("httpsOnly").AsBoolValue(false, props.GetMetadata()),
+		EnableClientCert: props.GetMapValue("clientCertEnabled").AsBoolValue(false),
+		HTTPSOnly:        props.GetMapValue("httpsOnly").AsBoolValue(false),
 		Identity: appservice.Identity{
 			Metadata: identity.GetMetadata(),
-			Type: identity.GetMapValue("type").
-				AsStringValue("", props.GetMetadata()),
+			Type:     identity.GetMapValue("type").AsStringValue(""),
 		},
 		Authentication: appservice.Authentication{
 			Metadata: siteAuthSettings.GetMetadata(),
-			Enabled:  siteAuthSettings.GetMapValue("enabled").AsBoolValue(false, props.GetMetadata()),
+			Enabled:  siteAuthSettings.GetMapValue("enabled").AsBoolValue(false),
 		},
 		Site: appservice.Site{
-			EnableHTTP2:       siteConfig.GetMapValue("http20Enabled").AsBoolValue(false, siteConfig.GetMetadata()),
-			MinimumTLSVersion: siteConfig.GetMapValue("minTlsVersion").AsStringValue("", siteConfig.GetMetadata()),
-			PHPVersion:        siteConfig.GetMapValue("phpVersion").AsStringValue("", siteConfig.GetMetadata()),
-			PythonVersion:     siteConfig.GetMapValue("pythonVersion").AsStringValue("", siteConfig.GetMetadata()),
-			FTPSState:         siteConfig.GetMapValue("ftpsState").AsStringValue("", siteConfig.GetMetadata()),
+			EnableHTTP2:       siteConfig.GetMapValue("http20Enabled").AsBoolValue(false),
+			MinimumTLSVersion: siteConfig.GetMapValue("minTlsVersion").AsStringValue(""),
+			PHPVersion:        siteConfig.GetMapValue("phpVersion").AsStringValue(""),
+			PythonVersion:     siteConfig.GetMapValue("pythonVersion").AsStringValue(""),
+			FTPSState:         siteConfig.GetMapValue("ftpsState").AsStringValue(""),
 		},
 	}
 }

--- a/pkg/iac/adapters/arm/appservice/adapt.go
+++ b/pkg/iac/adapters/arm/appservice/adapt.go
@@ -33,7 +33,7 @@ func adaptServices(deployment azure.Deployment) []appservice.Service {
 func adaptFunctionApp(resource azure.Resource) appservice.FunctionApp {
 	return appservice.FunctionApp{
 		Metadata:  resource.Metadata,
-		HTTPSOnly: resource.Properties.GetMapValue("httpsOnly").AsBoolValue(false),
+		HTTPSOnly: resource.Properties.GetMapValue("httpsOnly").AsBoolValue(),
 	}
 }
 
@@ -45,22 +45,22 @@ func adaptService(resource azure.Resource) appservice.Service {
 	return appservice.Service{
 		Metadata:         resource.Metadata,
 		Resource:         types.String("Microsoft.Web/sites", resource.Metadata),
-		EnableClientCert: props.GetMapValue("clientCertEnabled").AsBoolValue(false),
-		HTTPSOnly:        props.GetMapValue("httpsOnly").AsBoolValue(false),
+		EnableClientCert: props.GetMapValue("clientCertEnabled").AsBoolValue(),
+		HTTPSOnly:        props.GetMapValue("httpsOnly").AsBoolValue(),
 		Identity: appservice.Identity{
 			Metadata: identity.GetMetadata(),
-			Type:     identity.GetMapValue("type").AsStringValue(""),
+			Type:     identity.GetMapValue("type").AsStringValue(),
 		},
 		Authentication: appservice.Authentication{
 			Metadata: siteAuthSettings.GetMetadata(),
-			Enabled:  siteAuthSettings.GetMapValue("enabled").AsBoolValue(false),
+			Enabled:  siteAuthSettings.GetMapValue("enabled").AsBoolValue(),
 		},
 		Site: appservice.Site{
-			EnableHTTP2:       siteConfig.GetMapValue("http20Enabled").AsBoolValue(false),
-			MinimumTLSVersion: siteConfig.GetMapValue("minTlsVersion").AsStringValue(""),
-			PHPVersion:        siteConfig.GetMapValue("phpVersion").AsStringValue(""),
-			PythonVersion:     siteConfig.GetMapValue("pythonVersion").AsStringValue(""),
-			FTPSState:         siteConfig.GetMapValue("ftpsState").AsStringValue(""),
+			EnableHTTP2:       siteConfig.GetMapValue("http20Enabled").AsBoolValue(),
+			MinimumTLSVersion: siteConfig.GetMapValue("minTlsVersion").AsStringValue(),
+			PHPVersion:        siteConfig.GetMapValue("phpVersion").AsStringValue(),
+			PythonVersion:     siteConfig.GetMapValue("pythonVersion").AsStringValue(),
+			FTPSState:         siteConfig.GetMapValue("ftpsState").AsStringValue(),
 		},
 	}
 }

--- a/pkg/iac/adapters/arm/authorization/adapt.go
+++ b/pkg/iac/adapters/arm/authorization/adapt.go
@@ -25,7 +25,7 @@ func adaptRoleDefinition(resource azure.Resource) authorization.RoleDefinition {
 	return authorization.RoleDefinition{
 		Metadata:         resource.Metadata,
 		Permissions:      adaptPermissions(resource),
-		AssignableScopes: resource.Properties.GetMapValue("assignableScopes").AsStringValuesList(""),
+		AssignableScopes: resource.Properties.GetMapValue("assignableScopes").AsStringValuesList(),
 	}
 }
 
@@ -39,10 +39,10 @@ func adaptRoleAssignments(deployment azure.Deployment) (roleAssignments []author
 func adaptRoleAssignment(resource azure.Resource) authorization.RoleAssignment {
 	return authorization.RoleAssignment{
 		Metadata:           resource.Metadata,
-		RoleDefinitionId:   resource.Properties.GetMapValue("roleDefinitionId").AsStringValue(""),
+		RoleDefinitionId:   resource.Properties.GetMapValue("roleDefinitionId").AsStringValue(),
 		RoleDefinitionName: iacTypes.String("", iacTypes.NewUnmanagedMetadata()),
-		PrincipalId:        resource.Properties.GetMapValue("principalId").AsStringValue(""),
-		PrincipalType:      resource.Properties.GetMapValue("principalType").AsStringValue(""),
+		PrincipalId:        resource.Properties.GetMapValue("principalId").AsStringValue(),
+		PrincipalType:      resource.Properties.GetMapValue("principalType").AsStringValue(),
 	}
 }
 
@@ -50,7 +50,7 @@ func adaptPermissions(resource azure.Resource) (permissions []authorization.Perm
 	for _, permission := range resource.Properties.GetMapValue("permissions").AsList() {
 		permissions = append(permissions, authorization.Permission{
 			Metadata: resource.Metadata,
-			Actions:  permission.GetMapValue("actions").AsStringValuesList(""),
+			Actions:  permission.GetMapValue("actions").AsStringValuesList(),
 		})
 	}
 	return permissions

--- a/pkg/iac/adapters/arm/authorization/adapt.go
+++ b/pkg/iac/adapters/arm/authorization/adapt.go
@@ -39,10 +39,10 @@ func adaptRoleAssignments(deployment azure.Deployment) (roleAssignments []author
 func adaptRoleAssignment(resource azure.Resource) authorization.RoleAssignment {
 	return authorization.RoleAssignment{
 		Metadata:           resource.Metadata,
-		RoleDefinitionId:   resource.Properties.GetMapValue("roleDefinitionId").AsStringValue("", resource.Metadata),
+		RoleDefinitionId:   resource.Properties.GetMapValue("roleDefinitionId").AsStringValue(""),
 		RoleDefinitionName: iacTypes.String("", iacTypes.NewUnmanagedMetadata()),
-		PrincipalId:        resource.Properties.GetMapValue("principalId").AsStringValue("", resource.Metadata),
-		PrincipalType:      resource.Properties.GetMapValue("principalType").AsStringValue("", resource.Metadata),
+		PrincipalId:        resource.Properties.GetMapValue("principalId").AsStringValue(""),
+		PrincipalType:      resource.Properties.GetMapValue("principalType").AsStringValue(""),
 	}
 }
 

--- a/pkg/iac/adapters/arm/compute/adapt.go
+++ b/pkg/iac/adapters/arm/compute/adapt.go
@@ -56,7 +56,7 @@ func adaptWindowsVirtualMachine(resource azure.Resource) compute.WindowsVirtualM
 		VirtualMachine: compute.VirtualMachine{
 			Metadata: resource.Metadata,
 			CustomData: resource.Properties.GetMapValue("osProfile").
-				GetMapValue("customData").AsStringValue(""),
+				GetMapValue("customData").AsStringValue(),
 			NetworkInterfaces: networkInterfaces,
 		},
 	}
@@ -81,14 +81,14 @@ func adaptLinuxVirtualMachine(resource azure.Resource) compute.LinuxVirtualMachi
 		VirtualMachine: compute.VirtualMachine{
 			Metadata: resource.Metadata,
 			CustomData: resource.Properties.GetMapValue("osProfile").
-				GetMapValue("customData").AsStringValue(""),
+				GetMapValue("customData").AsStringValue(),
 			NetworkInterfaces: networkInterfaces,
 		},
 		OSProfileLinuxConfig: compute.OSProfileLinuxConfig{
 			Metadata: resource.Metadata,
 			DisablePasswordAuthentication: resource.Properties.GetMapValue("osProfile").
 				GetMapValue("linuxConfiguration").
-				GetMapValue("disablePasswordAuthentication").AsBoolValue(false),
+				GetMapValue("disablePasswordAuthentication").AsBoolValue(),
 		},
 	}
 

--- a/pkg/iac/adapters/arm/compute/adapt.go
+++ b/pkg/iac/adapters/arm/compute/adapt.go
@@ -56,7 +56,7 @@ func adaptWindowsVirtualMachine(resource azure.Resource) compute.WindowsVirtualM
 		VirtualMachine: compute.VirtualMachine{
 			Metadata: resource.Metadata,
 			CustomData: resource.Properties.GetMapValue("osProfile").
-				GetMapValue("customData").AsStringValue("", resource.Metadata),
+				GetMapValue("customData").AsStringValue(""),
 			NetworkInterfaces: networkInterfaces,
 		},
 	}
@@ -81,14 +81,14 @@ func adaptLinuxVirtualMachine(resource azure.Resource) compute.LinuxVirtualMachi
 		VirtualMachine: compute.VirtualMachine{
 			Metadata: resource.Metadata,
 			CustomData: resource.Properties.GetMapValue("osProfile").
-				GetMapValue("customData").AsStringValue("", resource.Metadata),
+				GetMapValue("customData").AsStringValue(""),
 			NetworkInterfaces: networkInterfaces,
 		},
 		OSProfileLinuxConfig: compute.OSProfileLinuxConfig{
 			Metadata: resource.Metadata,
 			DisablePasswordAuthentication: resource.Properties.GetMapValue("osProfile").
 				GetMapValue("linuxConfiguration").
-				GetMapValue("disablePasswordAuthentication").AsBoolValue(false, resource.Metadata),
+				GetMapValue("disablePasswordAuthentication").AsBoolValue(false),
 		},
 	}
 

--- a/pkg/iac/adapters/arm/container/adapt.go
+++ b/pkg/iac/adapters/arm/container/adapt.go
@@ -20,26 +20,26 @@ func adaptKubernetesClusters(deployment azure.Deployment) []container.Kubernetes
 			Metadata: resource.Metadata,
 			NetworkProfile: container.NetworkProfile{
 				Metadata:      props.GetMapValue("networkProfile").GetMetadata(),
-				NetworkPolicy: props.GetMapValue("networkProfile").GetMapValue("networkPolicy").AsStringValue("", props.GetMapValue("networkProfile").GetMetadata()),
+				NetworkPolicy: props.GetMapValue("networkProfile").GetMapValue("networkPolicy").AsStringValue(""),
 			},
-			EnablePrivateCluster:        props.GetMapValue("apiServerAccessProfile").GetMapValue("enablePrivateCluster").AsBoolValue(false, props.GetMapValue("apiServerAccessProfile").GetMetadata()),
+			EnablePrivateCluster:        props.GetMapValue("apiServerAccessProfile").GetMapValue("enablePrivateCluster").AsBoolValue(false),
 			APIServerAuthorizedIPRanges: nil, // Extracted below
 			RoleBasedAccessControl: container.RoleBasedAccessControl{
 				Metadata: props.GetMetadata(),
-				Enabled:  props.GetMapValue("enableRBAC").AsBoolValue(false, props.GetMetadata()),
+				Enabled:  props.GetMapValue("enableRBAC").AsBoolValue(false),
 			},
 			AddonProfile: container.AddonProfile{
 				Metadata: props.GetMapValue("addonProfiles").GetMetadata(),
 				OMSAgent: container.OMSAgent{
 					Metadata: props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMetadata(),
-					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMapValue("enabled").AsBoolValue(false, props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMetadata()),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMapValue("enabled").AsBoolValue(false),
 				},
 				AzurePolicy: container.AzurePolicy{
 					Metadata: props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMetadata(),
-					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMapValue("enabled").AsBoolValue(false, props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMetadata()),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMapValue("enabled").AsBoolValue(false),
 				},
 			},
-			DiskEncryptionSetID: props.GetMapValue("diskEncryptionSetID").AsStringValue("", props.GetMetadata()),
+			DiskEncryptionSetID: props.GetMapValue("diskEncryptionSetID").AsStringValue(""),
 			AgentPools:          adaptAgentPools(resource),
 		}
 
@@ -61,8 +61,8 @@ func adaptAgentPools(resource azure.Resource) []container.AgentPool {
 		for _, profile := range profiles.AsList() {
 			pools = append(pools, container.AgentPool{
 				Metadata:            profile.GetMetadata(),
-				DiskEncryptionSetID: profile.GetMapValue("diskEncryptionSetID").AsStringValue("", profile.GetMetadata()),
-				NodeType:            profile.GetMapValue("type").AsStringValue("VirtualMachineScaleSets", profile.GetMetadata()),
+				DiskEncryptionSetID: profile.GetMapValue("diskEncryptionSetID").AsStringValue(""),
+				NodeType:            profile.GetMapValue("type").AsStringValue("VirtualMachineScaleSets"),
 			})
 		}
 	}

--- a/pkg/iac/adapters/arm/container/adapt.go
+++ b/pkg/iac/adapters/arm/container/adapt.go
@@ -20,32 +20,32 @@ func adaptKubernetesClusters(deployment azure.Deployment) []container.Kubernetes
 			Metadata: resource.Metadata,
 			NetworkProfile: container.NetworkProfile{
 				Metadata:      props.GetMapValue("networkProfile").GetMetadata(),
-				NetworkPolicy: props.GetMapValue("networkProfile").GetMapValue("networkPolicy").AsStringValue(""),
+				NetworkPolicy: props.GetMapValue("networkProfile").GetMapValue("networkPolicy").AsStringValue(),
 			},
-			EnablePrivateCluster:        props.GetMapValue("apiServerAccessProfile").GetMapValue("enablePrivateCluster").AsBoolValue(false),
+			EnablePrivateCluster:        props.GetMapValue("apiServerAccessProfile").GetMapValue("enablePrivateCluster").AsBoolValue(),
 			APIServerAuthorizedIPRanges: nil, // Extracted below
 			RoleBasedAccessControl: container.RoleBasedAccessControl{
 				Metadata: props.GetMetadata(),
-				Enabled:  props.GetMapValue("enableRBAC").AsBoolValue(false),
+				Enabled:  props.GetMapValue("enableRBAC").AsBoolValue(),
 			},
 			AddonProfile: container.AddonProfile{
 				Metadata: props.GetMapValue("addonProfiles").GetMetadata(),
 				OMSAgent: container.OMSAgent{
 					Metadata: props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMetadata(),
-					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMapValue("enabled").AsBoolValue(false),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("omsagent").GetMapValue("enabled").AsBoolValue(),
 				},
 				AzurePolicy: container.AzurePolicy{
 					Metadata: props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMetadata(),
-					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMapValue("enabled").AsBoolValue(false),
+					Enabled:  props.GetMapValue("addonProfiles").GetMapValue("azurepolicy").GetMapValue("enabled").AsBoolValue(),
 				},
 			},
-			DiskEncryptionSetID: props.GetMapValue("diskEncryptionSetID").AsStringValue(""),
+			DiskEncryptionSetID: props.GetMapValue("diskEncryptionSetID").AsStringValue(),
 			AgentPools:          adaptAgentPools(resource),
 		}
 
 		// API Server Authorized IP Ranges
 		if ranges := props.GetMapValue("apiServerAccessProfile").GetMapValue("authorizedIPRanges"); !ranges.IsNull() {
-			cluster.APIServerAuthorizedIPRanges = ranges.AsStringValuesList("")
+			cluster.APIServerAuthorizedIPRanges = ranges.AsStringValuesList()
 		}
 
 		clusters = append(clusters, cluster)
@@ -61,7 +61,7 @@ func adaptAgentPools(resource azure.Resource) []container.AgentPool {
 		for _, profile := range profiles.AsList() {
 			pools = append(pools, container.AgentPool{
 				Metadata:            profile.GetMetadata(),
-				DiskEncryptionSetID: profile.GetMapValue("diskEncryptionSetID").AsStringValue(""),
+				DiskEncryptionSetID: profile.GetMapValue("diskEncryptionSetID").AsStringValue(),
 				NodeType:            profile.GetMapValue("type").AsStringValue("VirtualMachineScaleSets"),
 			})
 		}

--- a/pkg/iac/adapters/arm/database/adapt.go
+++ b/pkg/iac/adapters/arm/database/adapt.go
@@ -26,9 +26,9 @@ func adaptMySQLServer(resource azure.Resource, _ azure.Deployment) database.MySQ
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false, resource.Metadata),
-			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled", resource.Metadata),
-			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false, resource.Metadata),
+			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
+			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
 			FirewallRules:             addFirewallRule(resource),
 		},
 	}

--- a/pkg/iac/adapters/arm/database/adapt.go
+++ b/pkg/iac/adapters/arm/database/adapt.go
@@ -26,9 +26,9 @@ func adaptMySQLServer(resource azure.Resource, _ azure.Deployment) database.MySQ
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(),
 			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
-			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
+			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(),
 			FirewallRules:             addFirewallRule(resource),
 		},
 	}

--- a/pkg/iac/adapters/arm/database/firewall.go
+++ b/pkg/iac/adapters/arm/database/firewall.go
@@ -12,8 +12,8 @@ func addFirewallRule(resource azure.Resource) []database.FirewallRule {
 	for _, rule := range resource.Properties.GetMapValue("firewallRules").AsMap() {
 		rules = append(rules, database.FirewallRule{
 			Metadata: rule.GetMetadata(),
-			StartIP:  rule.GetMapValue("startIpAddress").AsStringValue(""),
-			EndIP:    rule.GetMapValue("endIpAddress").AsStringValue(""),
+			StartIP:  rule.GetMapValue("startIpAddress").AsStringValue(),
+			EndIP:    rule.GetMapValue("endIpAddress").AsStringValue(),
 		})
 	}
 	return rules

--- a/pkg/iac/adapters/arm/database/firewall.go
+++ b/pkg/iac/adapters/arm/database/firewall.go
@@ -12,8 +12,8 @@ func addFirewallRule(resource azure.Resource) []database.FirewallRule {
 	for _, rule := range resource.Properties.GetMapValue("firewallRules").AsMap() {
 		rules = append(rules, database.FirewallRule{
 			Metadata: rule.GetMetadata(),
-			StartIP:  rule.GetMapValue("startIpAddress").AsStringValue("", rule.GetMetadata()),
-			EndIP:    rule.GetMapValue("endIpAddress").AsStringValue("", rule.GetMetadata()),
+			StartIP:  rule.GetMapValue("startIpAddress").AsStringValue(""),
+			EndIP:    rule.GetMapValue("endIpAddress").AsStringValue(""),
 		})
 	}
 	return rules

--- a/pkg/iac/adapters/arm/database/maria.go
+++ b/pkg/iac/adapters/arm/database/maria.go
@@ -18,9 +18,9 @@ func adaptMariaDBServer(resource azure.Resource, _ azure.Deployment) database.Ma
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false, resource.Metadata),
-			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled", resource.Metadata),
-			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false, resource.Metadata),
+			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
+			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
 			FirewallRules:             addFirewallRule(resource),
 		},
 	}

--- a/pkg/iac/adapters/arm/database/maria.go
+++ b/pkg/iac/adapters/arm/database/maria.go
@@ -18,9 +18,9 @@ func adaptMariaDBServer(resource azure.Resource, _ azure.Deployment) database.Ma
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			EnableSSLEnforcement:      resource.Properties.GetMapValue("sslEnforcement").AsBoolValue(),
 			MinimumTLSVersion:         resource.Properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
-			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
+			EnablePublicNetworkAccess: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(),
 			FirewallRules:             addFirewallRule(resource),
 		},
 	}

--- a/pkg/iac/adapters/arm/database/mssql.go
+++ b/pkg/iac/adapters/arm/database/mssql.go
@@ -15,13 +15,13 @@ func adaptMSSQLServers(deployment azure2.Deployment) (msSQlServers []database.MS
 
 func adaptMSSQLServer(resource azure2.Resource, deployment azure2.Deployment) database.MSSQLServer {
 	properties := resource.Properties
-	administratorLogin := properties.GetMapValue("administratorLogin").AsStringValue("")
+	administratorLogin := properties.GetMapValue("administratorLogin").AsStringValue()
 
 	// Support for azureadAdministrator block (ARM uses administrators property)
 	var adAdmins []database.ActiveDirectoryAdministrator
 	administrators := properties.GetMapValue("administrators")
 	if administrators.Kind != azure2.KindNull {
-		login := administrators.GetMapValue("login").AsStringValue("")
+		login := administrators.GetMapValue("login").AsStringValue()
 		if !login.IsEmpty() {
 			adAdmins = append(adAdmins, database.ActiveDirectoryAdministrator{
 				Metadata: administrators.GetMetadata(),
@@ -35,9 +35,9 @@ func adaptMSSQLServer(resource azure2.Resource, deployment azure2.Deployment) da
 		Server: database.Server{
 			Metadata: resource.Metadata,
 			// TODO: this property doesn't exist.
-			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(),
 			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
-			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
+			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(),
 			FirewallRules:             addFirewallRule(resource),
 		},
 		ExtendedAuditingPolicies:      adaptExtendedAuditingPolicies(resource, deployment),
@@ -52,7 +52,7 @@ func adaptExtendedAuditingPolicies(_ azure2.Resource, deployment azure2.Deployme
 	for _, policy := range deployment.GetResourcesByType("Microsoft.Sql/servers/extendedAuditingSettings") {
 		policies = append(policies, database.ExtendedAuditingPolicy{
 			Metadata:        policy.Metadata,
-			RetentionInDays: policy.Properties.GetMapValue("retentionDays").AsIntValue(0),
+			RetentionInDays: policy.Properties.GetMapValue("retentionDays").AsIntValue(),
 		})
 	}
 
@@ -65,7 +65,7 @@ func adaptSecurityAlertPolicies(_ azure2.Resource, deployment azure2.Deployment)
 			Metadata:           policy.Metadata,
 			EmailAddresses:     adaptStringList(policy.Properties.GetMapValue("emailAddresses")),
 			DisabledAlerts:     adaptStringList(policy.Properties.GetMapValue("disabledAlerts")),
-			EmailAccountAdmins: policy.Properties.GetMapValue("emailAccountAdmins").AsBoolValue(false),
+			EmailAccountAdmins: policy.Properties.GetMapValue("emailAccountAdmins").AsBoolValue(),
 		})
 	}
 	return policies
@@ -74,7 +74,7 @@ func adaptSecurityAlertPolicies(_ azure2.Resource, deployment azure2.Deployment)
 func adaptStringList(value azure2.Value) []iacTypes.StringValue {
 	var list []iacTypes.StringValue
 	for _, v := range value.AsList() {
-		list = append(list, v.AsStringValue(""))
+		list = append(list, v.AsStringValue())
 	}
 	return list
 }

--- a/pkg/iac/adapters/arm/database/mssql.go
+++ b/pkg/iac/adapters/arm/database/mssql.go
@@ -15,13 +15,13 @@ func adaptMSSQLServers(deployment azure2.Deployment) (msSQlServers []database.MS
 
 func adaptMSSQLServer(resource azure2.Resource, deployment azure2.Deployment) database.MSSQLServer {
 	properties := resource.Properties
-	administratorLogin := properties.GetMapValue("administratorLogin").AsStringValue("", resource.Metadata)
+	administratorLogin := properties.GetMapValue("administratorLogin").AsStringValue("")
 
 	// Support for azureadAdministrator block (ARM uses administrators property)
 	var adAdmins []database.ActiveDirectoryAdministrator
 	administrators := properties.GetMapValue("administrators")
 	if administrators.Kind != azure2.KindNull {
-		login := administrators.GetMapValue("login").AsStringValue("", administrators.GetMetadata())
+		login := administrators.GetMapValue("login").AsStringValue("")
 		if !login.IsEmpty() {
 			adAdmins = append(adAdmins, database.ActiveDirectoryAdministrator{
 				Metadata: administrators.GetMetadata(),
@@ -35,9 +35,9 @@ func adaptMSSQLServer(resource azure2.Resource, deployment azure2.Deployment) da
 		Server: database.Server{
 			Metadata: resource.Metadata,
 			// TODO: this property doesn't exist.
-			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false, resource.Metadata),
-			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled", resource.Metadata),
-			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false, resource.Metadata),
+			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
+			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
 			FirewallRules:             addFirewallRule(resource),
 		},
 		ExtendedAuditingPolicies:      adaptExtendedAuditingPolicies(resource, deployment),
@@ -52,7 +52,7 @@ func adaptExtendedAuditingPolicies(_ azure2.Resource, deployment azure2.Deployme
 	for _, policy := range deployment.GetResourcesByType("Microsoft.Sql/servers/extendedAuditingSettings") {
 		policies = append(policies, database.ExtendedAuditingPolicy{
 			Metadata:        policy.Metadata,
-			RetentionInDays: policy.Properties.GetMapValue("retentionDays").AsIntValue(0, policy.Metadata),
+			RetentionInDays: policy.Properties.GetMapValue("retentionDays").AsIntValue(0),
 		})
 	}
 
@@ -65,7 +65,7 @@ func adaptSecurityAlertPolicies(_ azure2.Resource, deployment azure2.Deployment)
 			Metadata:           policy.Metadata,
 			EmailAddresses:     adaptStringList(policy.Properties.GetMapValue("emailAddresses")),
 			DisabledAlerts:     adaptStringList(policy.Properties.GetMapValue("disabledAlerts")),
-			EmailAccountAdmins: policy.Properties.GetMapValue("emailAccountAdmins").AsBoolValue(false, policy.Metadata),
+			EmailAccountAdmins: policy.Properties.GetMapValue("emailAccountAdmins").AsBoolValue(false),
 		})
 	}
 	return policies
@@ -74,7 +74,7 @@ func adaptSecurityAlertPolicies(_ azure2.Resource, deployment azure2.Deployment)
 func adaptStringList(value azure2.Value) []iacTypes.StringValue {
 	var list []iacTypes.StringValue
 	for _, v := range value.AsList() {
-		list = append(list, v.AsStringValue("", value.GetMetadata()))
+		list = append(list, v.AsStringValue(""))
 	}
 	return list
 }

--- a/pkg/iac/adapters/arm/database/postgresql.go
+++ b/pkg/iac/adapters/arm/database/postgresql.go
@@ -20,7 +20,7 @@ func adaptPostgreSQLServers(deployment azure.Deployment) (databases []database.P
 func adaptPostgreSQLServer(resource azure.Resource, deployment azure.Deployment) database.PostgreSQLServer {
 	properties := resource.Properties
 	geoRedundantBackup := properties.GetMapValue("storageProfile").GetMapValue("geoRedundantBackup")
-	geoRedundantBackupEnabled := geoRedundantBackup.AsStringValue("Disabled", resource.Metadata)
+	geoRedundantBackupEnabled := geoRedundantBackup.AsStringValue("Disabled")
 
 	threatDetectionPolicy := adaptThreatDetectionPolicy(resource, deployment)
 
@@ -28,9 +28,9 @@ func adaptPostgreSQLServer(resource azure.Resource, deployment azure.Deployment)
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false, resource.Metadata),
-			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled", resource.Metadata),
-			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false, resource.Metadata),
+			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
+			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
 			FirewallRules:             addFirewallRule(resource),
 		},
 		Config:                    adaptPostgreSQLConfiguration(resource, deployment),
@@ -57,19 +57,19 @@ func adaptPostgreSQLConfiguration(resource azure.Resource, deployment azure.Depl
 		}
 		val := configuration.Properties.GetMapValue("value")
 		if strings.HasSuffix(configuration.Name.AsString(), "log_checkpoints") {
-			config.LogCheckpoints = val.AsBoolValue(false, configuration.Metadata)
+			config.LogCheckpoints = val.AsBoolValue(false)
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "log_connections") {
-			config.LogConnections = val.AsBoolValue(false, configuration.Metadata)
+			config.LogConnections = val.AsBoolValue(false)
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "connection_throttling") {
-			config.ConnectionThrottling = val.AsBoolValue(false, configuration.Metadata)
+			config.ConnectionThrottling = val.AsBoolValue(false)
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "log_disconnections") {
-			config.LogDisconnections = val.AsBoolValue(false, configuration.Metadata)
+			config.LogDisconnections = val.AsBoolValue(false)
 			continue
 		}
 	}
@@ -91,7 +91,7 @@ func adaptThreatDetectionPolicy(resource azure.Resource, deployment azure.Deploy
 			continue
 		}
 		// Found the security alert policy for this server
-		state := policy.Properties.GetMapValue("state").AsStringValue("Disabled", policy.Metadata)
+		state := policy.Properties.GetMapValue("state").AsStringValue("Disabled")
 		enabled = state.EqualTo("Enabled")
 		metadata = policy.Properties.GetMapValue("state").GetMetadata()
 		break

--- a/pkg/iac/adapters/arm/database/postgresql.go
+++ b/pkg/iac/adapters/arm/database/postgresql.go
@@ -28,9 +28,9 @@ func adaptPostgreSQLServer(resource azure.Resource, deployment azure.Deployment)
 		Metadata: resource.Metadata,
 		Server: database.Server{
 			Metadata:                  resource.Metadata,
-			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(false),
+			EnableSSLEnforcement:      properties.GetMapValue("sslEnforcement").AsBoolValue(),
 			MinimumTLSVersion:         properties.GetMapValue("minimalTlsVersion").AsStringValue("TLSEnforcementDisabled"),
-			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(false),
+			EnablePublicNetworkAccess: properties.GetMapValue("publicNetworkAccess").AsBoolValue(),
 			FirewallRules:             addFirewallRule(resource),
 		},
 		Config:                    adaptPostgreSQLConfiguration(resource, deployment),
@@ -57,19 +57,19 @@ func adaptPostgreSQLConfiguration(resource azure.Resource, deployment azure.Depl
 		}
 		val := configuration.Properties.GetMapValue("value")
 		if strings.HasSuffix(configuration.Name.AsString(), "log_checkpoints") {
-			config.LogCheckpoints = val.AsBoolValue(false)
+			config.LogCheckpoints = val.AsBoolValue()
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "log_connections") {
-			config.LogConnections = val.AsBoolValue(false)
+			config.LogConnections = val.AsBoolValue()
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "connection_throttling") {
-			config.ConnectionThrottling = val.AsBoolValue(false)
+			config.ConnectionThrottling = val.AsBoolValue()
 			continue
 		}
 		if strings.HasSuffix(configuration.Name.AsString(), "log_disconnections") {
-			config.LogDisconnections = val.AsBoolValue(false)
+			config.LogDisconnections = val.AsBoolValue()
 			continue
 		}
 	}

--- a/pkg/iac/adapters/arm/datafactory/adapt.go
+++ b/pkg/iac/adapters/arm/datafactory/adapt.go
@@ -24,6 +24,6 @@ func adaptDataFactory(resource azure.Resource) datafactory.Factory {
 		Metadata: resource.Metadata,
 		// TODO: publicNetworkAccess is string
 		// https://learn.microsoft.com/en-us/azure/templates/microsoft.datafactory/factories?pivots=deployment-language-arm-template#factoryproperties-1
-		EnablePublicNetwork: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(true, resource.Metadata),
+		EnablePublicNetwork: resource.Properties.GetMapValue("publicNetworkAccess").AsBoolValue(true),
 	}
 }

--- a/pkg/iac/adapters/arm/datalake/adapt.go
+++ b/pkg/iac/adapters/arm/datalake/adapt.go
@@ -25,6 +25,6 @@ func adaptStore(resource azure.Resource) datalake.Store {
 		Metadata: resource.Metadata,
 		// TODO: encryptionState is string
 		// https://learn.microsoft.com/en-us/azure/templates/microsoft.datalakestore/accounts?pivots=deployment-language-arm-template#createdatalakestoreaccountpropertiesordatalakestoreaccountproperties-1
-		EnableEncryption: resource.Properties.GetMapValue("encryptionState").AsBoolValue(false, resource.Metadata),
+		EnableEncryption: resource.Properties.GetMapValue("encryptionState").AsBoolValue(false),
 	}
 }

--- a/pkg/iac/adapters/arm/datalake/adapt.go
+++ b/pkg/iac/adapters/arm/datalake/adapt.go
@@ -25,6 +25,6 @@ func adaptStore(resource azure.Resource) datalake.Store {
 		Metadata: resource.Metadata,
 		// TODO: encryptionState is string
 		// https://learn.microsoft.com/en-us/azure/templates/microsoft.datalakestore/accounts?pivots=deployment-language-arm-template#createdatalakestoreaccountpropertiesordatalakestoreaccountproperties-1
-		EnableEncryption: resource.Properties.GetMapValue("encryptionState").AsBoolValue(false),
+		EnableEncryption: resource.Properties.GetMapValue("encryptionState").AsBoolValue(),
 	}
 }

--- a/pkg/iac/adapters/arm/keyvault/adapt.go
+++ b/pkg/iac/adapters/arm/keyvault/adapt.go
@@ -24,11 +24,11 @@ func adaptVault(resource azure.Resource, deployment azure.Deployment) keyvault.V
 		Metadata:                resource.Metadata,
 		Secrets:                 adaptSecrets(resource, deployment),
 		Keys:                    adaptKeys(resource, deployment),
-		EnablePurgeProtection:   resource.Properties.GetMapValue("enablePurgeProtection").AsBoolValue(false, resource.Metadata),
-		SoftDeleteRetentionDays: resource.Properties.GetMapValue("softDeleteRetentionInDays").AsIntValue(7, resource.Metadata),
+		EnablePurgeProtection:   resource.Properties.GetMapValue("enablePurgeProtection").AsBoolValue(false),
+		SoftDeleteRetentionDays: resource.Properties.GetMapValue("softDeleteRetentionInDays").AsIntValue(7),
 		NetworkACLs: keyvault.NetworkACLs{
 			Metadata:      resource.Metadata,
-			DefaultAction: resource.Properties.GetMapValue("properties").GetMapValue("networkAcls").GetMapValue("defaultAction").AsStringValue("", resource.Metadata),
+			DefaultAction: resource.Properties.GetMapValue("properties").GetMapValue("networkAcls").GetMapValue("defaultAction").AsStringValue(""),
 		},
 	}
 }
@@ -44,7 +44,7 @@ func adaptKeys(_ azure.Resource, deployment azure.Deployment) (keys []keyvault.K
 func adaptKey(resource azure.Resource) keyvault.Key {
 	return keyvault.Key{
 		Metadata:   resource.Metadata,
-		ExpiryDate: resource.Properties.GetMapValue("attributes").GetMapValue("exp").AsTimeValue(resource.Metadata),
+		ExpiryDate: resource.Properties.GetMapValue("attributes").GetMapValue("exp").AsTimeValue(),
 	}
 }
 
@@ -58,7 +58,7 @@ func adaptSecrets(_ azure.Resource, deployment azure.Deployment) (secrets []keyv
 func adaptSecret(resource azure.Resource) keyvault.Secret {
 	return keyvault.Secret{
 		Metadata:    resource.Metadata,
-		ContentType: resource.Properties.GetMapValue("contentType").AsStringValue("", resource.Metadata),
-		ExpiryDate:  resource.Properties.GetMapValue("attributes").GetMapValue("exp").AsTimeValue(resource.Metadata),
+		ContentType: resource.Properties.GetMapValue("contentType").AsStringValue(""),
+		ExpiryDate:  resource.Properties.GetMapValue("attributes").GetMapValue("exp").AsTimeValue(),
 	}
 }

--- a/pkg/iac/adapters/arm/keyvault/adapt.go
+++ b/pkg/iac/adapters/arm/keyvault/adapt.go
@@ -24,11 +24,11 @@ func adaptVault(resource azure.Resource, deployment azure.Deployment) keyvault.V
 		Metadata:                resource.Metadata,
 		Secrets:                 adaptSecrets(resource, deployment),
 		Keys:                    adaptKeys(resource, deployment),
-		EnablePurgeProtection:   resource.Properties.GetMapValue("enablePurgeProtection").AsBoolValue(false),
+		EnablePurgeProtection:   resource.Properties.GetMapValue("enablePurgeProtection").AsBoolValue(),
 		SoftDeleteRetentionDays: resource.Properties.GetMapValue("softDeleteRetentionInDays").AsIntValue(7),
 		NetworkACLs: keyvault.NetworkACLs{
 			Metadata:      resource.Metadata,
-			DefaultAction: resource.Properties.GetMapValue("properties").GetMapValue("networkAcls").GetMapValue("defaultAction").AsStringValue(""),
+			DefaultAction: resource.Properties.GetMapValue("properties").GetMapValue("networkAcls").GetMapValue("defaultAction").AsStringValue(),
 		},
 	}
 }
@@ -58,7 +58,7 @@ func adaptSecrets(_ azure.Resource, deployment azure.Deployment) (secrets []keyv
 func adaptSecret(resource azure.Resource) keyvault.Secret {
 	return keyvault.Secret{
 		Metadata:    resource.Metadata,
-		ContentType: resource.Properties.GetMapValue("contentType").AsStringValue(""),
+		ContentType: resource.Properties.GetMapValue("contentType").AsStringValue(),
 		ExpiryDate:  resource.Properties.GetMapValue("attributes").GetMapValue("exp").AsTimeValue(),
 	}
 }

--- a/pkg/iac/adapters/arm/monitor/adapt.go
+++ b/pkg/iac/adapters/arm/monitor/adapt.go
@@ -25,21 +25,21 @@ func adaptLogProfile(resource azure.Resource) monitor.LogProfile {
 	categories := resource.Properties.GetMapValue("categories").AsList()
 	var categoriesList []types.StringValue
 	for _, category := range categories {
-		categoriesList = append(categoriesList, category.AsStringValue(""))
+		categoriesList = append(categoriesList, category.AsStringValue())
 	}
 
 	locations := resource.Properties.GetMapValue("locations").AsList()
 	var locationsList []types.StringValue
 	for _, location := range locations {
-		locationsList = append(locationsList, location.AsStringValue(""))
+		locationsList = append(locationsList, location.AsStringValue())
 	}
 
 	return monitor.LogProfile{
 		Metadata: resource.Metadata,
 		RetentionPolicy: monitor.RetentionPolicy{
 			Metadata: resource.Metadata,
-			Enabled:  resource.Properties.GetMapValue("retentionPolicy").GetMapValue("enabled").AsBoolValue(false),
-			Days:     resource.Properties.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0),
+			Enabled:  resource.Properties.GetMapValue("retentionPolicy").GetMapValue("enabled").AsBoolValue(),
+			Days:     resource.Properties.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(),
 		},
 		Categories: categoriesList,
 		Locations:  locationsList,

--- a/pkg/iac/adapters/arm/monitor/adapt.go
+++ b/pkg/iac/adapters/arm/monitor/adapt.go
@@ -25,21 +25,21 @@ func adaptLogProfile(resource azure.Resource) monitor.LogProfile {
 	categories := resource.Properties.GetMapValue("categories").AsList()
 	var categoriesList []types.StringValue
 	for _, category := range categories {
-		categoriesList = append(categoriesList, category.AsStringValue("", category.GetMetadata()))
+		categoriesList = append(categoriesList, category.AsStringValue(""))
 	}
 
 	locations := resource.Properties.GetMapValue("locations").AsList()
 	var locationsList []types.StringValue
 	for _, location := range locations {
-		locationsList = append(locationsList, location.AsStringValue("", location.GetMetadata()))
+		locationsList = append(locationsList, location.AsStringValue(""))
 	}
 
 	return monitor.LogProfile{
 		Metadata: resource.Metadata,
 		RetentionPolicy: monitor.RetentionPolicy{
 			Metadata: resource.Metadata,
-			Enabled:  resource.Properties.GetMapValue("retentionPolicy").GetMapValue("enabled").AsBoolValue(false, resource.Metadata),
-			Days:     resource.Properties.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0, resource.Metadata),
+			Enabled:  resource.Properties.GetMapValue("retentionPolicy").GetMapValue("enabled").AsBoolValue(false),
+			Days:     resource.Properties.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0),
 		},
 		Categories: categoriesList,
 		Locations:  locationsList,

--- a/pkg/iac/adapters/arm/network/adapt.go
+++ b/pkg/iac/adapters/arm/network/adapt.go
@@ -42,8 +42,8 @@ func adaptSecurityGroupRules(deployment azure.Deployment) (rules []network.Secur
 }
 
 func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
-	sourceAddressPrefixes := resource.Properties.GetMapValue("sourceAddressPrefixes").AsStringValuesList("")
-	if prefix := resource.Properties.GetMapValue("sourceAddressPrefix").AsStringValue(""); prefix.IsNotEmpty() {
+	sourceAddressPrefixes := resource.Properties.GetMapValue("sourceAddressPrefixes").AsStringValuesList()
+	if prefix := resource.Properties.GetMapValue("sourceAddressPrefix").AsStringValue(); prefix.IsNotEmpty() {
 		sourceAddressPrefixes = append(sourceAddressPrefixes, prefix)
 	}
 
@@ -58,8 +58,8 @@ func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
 		sourcePortRanges = append(sourcePortRanges, rng)
 	}
 
-	destinationAddressPrefixes := resource.Properties.GetMapValue("destinationAddressPrefixes").AsStringValuesList("")
-	if prefix := resource.Properties.GetMapValue("destinationAddressPrefix").AsStringValue(""); prefix.IsNotEmpty() {
+	destinationAddressPrefixes := resource.Properties.GetMapValue("destinationAddressPrefixes").AsStringValuesList()
+	if prefix := resource.Properties.GetMapValue("destinationAddressPrefix").AsStringValue(); prefix.IsNotEmpty() {
 		destinationAddressPrefixes = append(destinationAddressPrefixes, prefix)
 	}
 
@@ -92,7 +92,7 @@ func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
 		SourcePorts:          sourcePortRanges,
 		DestinationAddresses: destinationAddressPrefixes,
 		DestinationPorts:     destinationPortRanges,
-		Protocol:             resource.Properties.GetMapValue("protocol").AsStringValue(""),
+		Protocol:             resource.Properties.GetMapValue("protocol").AsStringValue(),
 	}
 }
 
@@ -104,7 +104,7 @@ func adaptNetworkWatcherFlowLogs(deployment azure.Deployment) (flowLogs []networ
 }
 
 func adaptNetworkWatcherFlowLog(resource azure.Resource) network.NetworkWatcherFlowLog {
-	enabled := resource.Properties.GetMapValue("enabled").AsBoolValue(false)
+	enabled := resource.Properties.GetMapValue("enabled").AsBoolValue()
 	retentionPolicy := resource.Properties.GetMapValue("retentionPolicy")
 
 	return network.NetworkWatcherFlowLog{
@@ -112,8 +112,8 @@ func adaptNetworkWatcherFlowLog(resource azure.Resource) network.NetworkWatcherF
 		Enabled:  enabled,
 		RetentionPolicy: network.RetentionPolicy{
 			Metadata: resource.Metadata,
-			Enabled:  retentionPolicy.GetMapValue("enabled").AsBoolValue(false),
-			Days:     retentionPolicy.GetMapValue("days").AsIntValue(0),
+			Enabled:  retentionPolicy.GetMapValue("enabled").AsBoolValue(),
+			Days:     retentionPolicy.GetMapValue("days").AsIntValue(),
 		},
 	}
 }
@@ -129,7 +129,7 @@ func adaptNetworkInterfaces(deployment azure.Deployment) []network.NetworkInterf
 func adaptNetworkInterface(resource azure.Resource, _ azure.Deployment) network.NetworkInterface {
 	ni := network.NetworkInterface{
 		Metadata:           resource.Metadata,
-		EnableIPForwarding: resource.Properties.GetMapValue("enableIPForwarding").AsBoolValue(false),
+		EnableIPForwarding: resource.Properties.GetMapValue("enableIPForwarding").AsBoolValue(),
 		HasPublicIP:        iacTypes.BoolDefault(false, resource.Metadata),
 		PublicIPAddress:    iacTypes.StringDefault("", resource.Metadata),
 		SubnetID:           iacTypes.StringDefault("", resource.Metadata),
@@ -146,10 +146,10 @@ func adaptNetworkInterface(resource azure.Resource, _ azure.Deployment) network.
 		ni.IPConfigurations = append(ni.IPConfigurations, network.IPConfiguration{
 			Metadata: resource.Metadata,
 			PublicIPAddress: ipConfigProps.GetMapValue("publicIPAddress").
-				GetMapValue("id").AsStringValue(""),
+				GetMapValue("id").AsStringValue(),
 			SubnetID: ipConfigProps.GetMapValue("subnet").
-				GetMapValue("id").AsStringValue(""),
-			Primary: ipConfigProps.GetMapValue("primary").AsBoolValue(false),
+				GetMapValue("id").AsStringValue(),
+			Primary: ipConfigProps.GetMapValue("primary").AsBoolValue(),
 		})
 	}
 	ni.Setup()

--- a/pkg/iac/adapters/arm/network/adapt.go
+++ b/pkg/iac/adapters/arm/network/adapt.go
@@ -43,7 +43,7 @@ func adaptSecurityGroupRules(deployment azure.Deployment) (rules []network.Secur
 
 func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
 	sourceAddressPrefixes := resource.Properties.GetMapValue("sourceAddressPrefixes").AsStringValuesList("")
-	if prefix := resource.Properties.GetMapValue("sourceAddressPrefix").AsStringValue("", resource.Metadata); prefix.IsNotEmpty() {
+	if prefix := resource.Properties.GetMapValue("sourceAddressPrefix").AsStringValue(""); prefix.IsNotEmpty() {
 		sourceAddressPrefixes = append(sourceAddressPrefixes, prefix)
 	}
 
@@ -59,7 +59,7 @@ func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
 	}
 
 	destinationAddressPrefixes := resource.Properties.GetMapValue("destinationAddressPrefixes").AsStringValuesList("")
-	if prefix := resource.Properties.GetMapValue("destinationAddressPrefix").AsStringValue("", resource.Metadata); prefix.IsNotEmpty() {
+	if prefix := resource.Properties.GetMapValue("destinationAddressPrefix").AsStringValue(""); prefix.IsNotEmpty() {
 		destinationAddressPrefixes = append(destinationAddressPrefixes, prefix)
 	}
 
@@ -92,7 +92,7 @@ func adaptSecurityGroupRule(resource azure.Resource) network.SecurityGroupRule {
 		SourcePorts:          sourcePortRanges,
 		DestinationAddresses: destinationAddressPrefixes,
 		DestinationPorts:     destinationPortRanges,
-		Protocol:             resource.Properties.GetMapValue("protocol").AsStringValue("", resource.Metadata),
+		Protocol:             resource.Properties.GetMapValue("protocol").AsStringValue(""),
 	}
 }
 
@@ -104,7 +104,7 @@ func adaptNetworkWatcherFlowLogs(deployment azure.Deployment) (flowLogs []networ
 }
 
 func adaptNetworkWatcherFlowLog(resource azure.Resource) network.NetworkWatcherFlowLog {
-	enabled := resource.Properties.GetMapValue("enabled").AsBoolValue(false, resource.Metadata)
+	enabled := resource.Properties.GetMapValue("enabled").AsBoolValue(false)
 	retentionPolicy := resource.Properties.GetMapValue("retentionPolicy")
 
 	return network.NetworkWatcherFlowLog{
@@ -112,8 +112,8 @@ func adaptNetworkWatcherFlowLog(resource azure.Resource) network.NetworkWatcherF
 		Enabled:  enabled,
 		RetentionPolicy: network.RetentionPolicy{
 			Metadata: resource.Metadata,
-			Enabled:  retentionPolicy.GetMapValue("enabled").AsBoolValue(false, resource.Metadata),
-			Days:     retentionPolicy.GetMapValue("days").AsIntValue(0, resource.Metadata),
+			Enabled:  retentionPolicy.GetMapValue("enabled").AsBoolValue(false),
+			Days:     retentionPolicy.GetMapValue("days").AsIntValue(0),
 		},
 	}
 }
@@ -129,7 +129,7 @@ func adaptNetworkInterfaces(deployment azure.Deployment) []network.NetworkInterf
 func adaptNetworkInterface(resource azure.Resource, _ azure.Deployment) network.NetworkInterface {
 	ni := network.NetworkInterface{
 		Metadata:           resource.Metadata,
-		EnableIPForwarding: resource.Properties.GetMapValue("enableIPForwarding").AsBoolValue(false, resource.Metadata),
+		EnableIPForwarding: resource.Properties.GetMapValue("enableIPForwarding").AsBoolValue(false),
 		HasPublicIP:        iacTypes.BoolDefault(false, resource.Metadata),
 		PublicIPAddress:    iacTypes.StringDefault("", resource.Metadata),
 		SubnetID:           iacTypes.StringDefault("", resource.Metadata),
@@ -146,10 +146,10 @@ func adaptNetworkInterface(resource azure.Resource, _ azure.Deployment) network.
 		ni.IPConfigurations = append(ni.IPConfigurations, network.IPConfiguration{
 			Metadata: resource.Metadata,
 			PublicIPAddress: ipConfigProps.GetMapValue("publicIPAddress").
-				GetMapValue("id").AsStringValue("", resource.Metadata),
+				GetMapValue("id").AsStringValue(""),
 			SubnetID: ipConfigProps.GetMapValue("subnet").
-				GetMapValue("id").AsStringValue("", resource.Metadata),
-			Primary: ipConfigProps.GetMapValue("primary").AsBoolValue(false, resource.Metadata),
+				GetMapValue("id").AsStringValue(""),
+			Primary: ipConfigProps.GetMapValue("primary").AsBoolValue(false),
 		})
 	}
 	ni.Setup()

--- a/pkg/iac/adapters/arm/securitycenter/adapt.go
+++ b/pkg/iac/adapters/arm/securitycenter/adapt.go
@@ -23,8 +23,8 @@ func adaptContacts(deployment azure.Deployment) []securitycenter.Contact {
 }
 
 func adaptContact(resource azure.Resource) securitycenter.Contact {
-	alertsToAdminsState := resource.Properties.GetMapValue("notificationsByRole").GetMapValue("state").AsStringValue("")
-	isEnabledValue := resource.Properties.GetMapValue("isEnabled").AsBoolValue(false)
+	alertsToAdminsState := resource.Properties.GetMapValue("notificationsByRole").GetMapValue("state").AsStringValue()
+	isEnabledValue := resource.Properties.GetMapValue("isEnabled").AsBoolValue()
 
 	enableAlertNotifications, minimalSeverity := extractNotificationSettings(resource, isEnabledValue)
 
@@ -32,8 +32,8 @@ func adaptContact(resource azure.Resource) securitycenter.Contact {
 		Metadata:                 resource.Metadata,
 		EnableAlertNotifications: enableAlertNotifications,
 		EnableAlertsToAdmins:     iacTypes.Bool(alertsToAdminsState.EqualTo("On"), resource.Metadata),
-		Email:                    resource.Properties.GetMapValue("emails").AsStringValue(""),
-		Phone:                    resource.Properties.GetMapValue("phone").AsStringValue(""),
+		Email:                    resource.Properties.GetMapValue("emails").AsStringValue(),
+		Phone:                    resource.Properties.GetMapValue("phone").AsStringValue(),
 		IsEnabled:                isEnabledValue,
 		MinimalSeverity:          minimalSeverity,
 	}
@@ -45,7 +45,7 @@ func extractNotificationSettings(resource azure.Resource, isEnabled iacTypes.Boo
 		return extractFromNotificationsSources(notificationsSources, isEnabled, resource)
 	}
 
-	enableAlertNotifications := resource.Properties.GetMapValue("alertNotifications").AsBoolValue(false)
+	enableAlertNotifications := resource.Properties.GetMapValue("alertNotifications").AsBoolValue()
 	minimalSeverity := iacTypes.StringDefault("", resource.Metadata)
 	return enableAlertNotifications, minimalSeverity
 }
@@ -60,12 +60,12 @@ func extractFromNotificationsSources(notificationsSources azure.Value, isEnabled
 		}
 
 		sourceType, hasSourceType := sourceMap["sourceType"]
-		if !hasSourceType || !sourceType.AsStringValue("").EqualTo("Alert") {
+		if !hasSourceType || !sourceType.AsStringValue().EqualTo("Alert") {
 			continue
 		}
 
 		if minimalSeverityVal, hasMinimalSeverity := sourceMap["minimalSeverity"]; hasMinimalSeverity {
-			minimalSeverity = minimalSeverityVal.AsStringValue("")
+			minimalSeverity = minimalSeverityVal.AsStringValue()
 		}
 		break
 	}

--- a/pkg/iac/adapters/arm/securitycenter/adapt.go
+++ b/pkg/iac/adapters/arm/securitycenter/adapt.go
@@ -23,8 +23,8 @@ func adaptContacts(deployment azure.Deployment) []securitycenter.Contact {
 }
 
 func adaptContact(resource azure.Resource) securitycenter.Contact {
-	alertsToAdminsState := resource.Properties.GetMapValue("notificationsByRole").GetMapValue("state").AsStringValue("", resource.Metadata)
-	isEnabledValue := resource.Properties.GetMapValue("isEnabled").AsBoolValue(false, resource.Metadata)
+	alertsToAdminsState := resource.Properties.GetMapValue("notificationsByRole").GetMapValue("state").AsStringValue("")
+	isEnabledValue := resource.Properties.GetMapValue("isEnabled").AsBoolValue(false)
 
 	enableAlertNotifications, minimalSeverity := extractNotificationSettings(resource, isEnabledValue)
 
@@ -32,8 +32,8 @@ func adaptContact(resource azure.Resource) securitycenter.Contact {
 		Metadata:                 resource.Metadata,
 		EnableAlertNotifications: enableAlertNotifications,
 		EnableAlertsToAdmins:     iacTypes.Bool(alertsToAdminsState.EqualTo("On"), resource.Metadata),
-		Email:                    resource.Properties.GetMapValue("emails").AsStringValue("", resource.Metadata),
-		Phone:                    resource.Properties.GetMapValue("phone").AsStringValue("", resource.Metadata),
+		Email:                    resource.Properties.GetMapValue("emails").AsStringValue(""),
+		Phone:                    resource.Properties.GetMapValue("phone").AsStringValue(""),
 		IsEnabled:                isEnabledValue,
 		MinimalSeverity:          minimalSeverity,
 	}
@@ -45,7 +45,7 @@ func extractNotificationSettings(resource azure.Resource, isEnabled iacTypes.Boo
 		return extractFromNotificationsSources(notificationsSources, isEnabled, resource)
 	}
 
-	enableAlertNotifications := resource.Properties.GetMapValue("alertNotifications").AsBoolValue(false, resource.Metadata)
+	enableAlertNotifications := resource.Properties.GetMapValue("alertNotifications").AsBoolValue(false)
 	minimalSeverity := iacTypes.StringDefault("", resource.Metadata)
 	return enableAlertNotifications, minimalSeverity
 }
@@ -60,12 +60,12 @@ func extractFromNotificationsSources(notificationsSources azure.Value, isEnabled
 		}
 
 		sourceType, hasSourceType := sourceMap["sourceType"]
-		if !hasSourceType || !sourceType.AsStringValue("", resource.Metadata).EqualTo("Alert") {
+		if !hasSourceType || !sourceType.AsStringValue("").EqualTo("Alert") {
 			continue
 		}
 
 		if minimalSeverityVal, hasMinimalSeverity := sourceMap["minimalSeverity"]; hasMinimalSeverity {
-			minimalSeverity = minimalSeverityVal.AsStringValue("", resource.Metadata)
+			minimalSeverity = minimalSeverityVal.AsStringValue("")
 		}
 		break
 	}
@@ -85,6 +85,6 @@ func adaptSubscriptions(deployment azure.Deployment) []securitycenter.Subscripti
 func adaptSubscription(resource azure.Resource) securitycenter.SubscriptionPricing {
 	return securitycenter.SubscriptionPricing{
 		Metadata: resource.Metadata,
-		Tier:     resource.Properties.GetMapValue("pricingTier").AsStringValue("Free", resource.Metadata),
+		Tier:     resource.Properties.GetMapValue("pricingTier").AsStringValue("Free"),
 	}
 }

--- a/pkg/iac/adapters/arm/storage/adapt.go
+++ b/pkg/iac/adapters/arm/storage/adapt.go
@@ -23,7 +23,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 		for _, queueResource := range resource.GetResourcesByType("queueServices/queues") {
 			queues = append(queues, storage.Queue{
 				Metadata: queueResource.Metadata,
-				Name:     queueResource.Name.AsStringValue("", queueResource.Metadata),
+				Name:     queueResource.Name.AsStringValue(""),
 			})
 		}
 
@@ -31,7 +31,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 		for _, containerResource := range resource.GetResourcesByType("containerServices/containers") {
 			containers = append(containers, storage.Container{
 				Metadata:     containerResource.Metadata,
-				PublicAccess: containerResource.Properties.GetMapValue("publicAccess").AsStringValue("None", containerResource.Metadata),
+				PublicAccess: containerResource.Properties.GetMapValue("publicAccess").AsStringValue("None"),
 			})
 		}
 
@@ -39,29 +39,28 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 			Metadata:     resource.Metadata,
 			NetworkRules: xslices.ZeroToNil(adaptNetworkRules(resource)),
 			// The default value is true since API version 2019-04-01.
-			EnforceHTTPS: resource.Properties.GetMapValue("supportsHttpsTrafficOnly").AsBoolValue(true, resource.Properties.GetMetadata()),
+			EnforceHTTPS: resource.Properties.GetMapValue("supportsHttpsTrafficOnly").AsBoolValue(true),
 			Containers:   containers,
 			QueueProperties: storage.QueueProperties{
 				Metadata:      resource.Properties.GetMetadata(),
 				EnableLogging: types.BoolDefault(false, resource.Properties.GetMetadata()),
 			},
 			// The default interpretation is TLS 1.0 for this property.
-			MinimumTLSVersion: resource.Properties.GetMapValue("minimumTlsVersion").
-				AsStringValue("TLS1_0", resource.Properties.GetMetadata()),
-			Queues: queues,
+			MinimumTLSVersion: resource.Properties.GetMapValue("minimumTlsVersion").AsStringValue("TLS1_0"),
+			Queues:            queues,
 			BlobProperties: storage.BlobProperties{
 				Metadata: resource.Properties.GetMetadata(),
 				DeleteRetentionPolicy: storage.DeleteRetentionPolicy{
 					Metadata: resource.Properties.GetMetadata(),
-					Days:     resource.Properties.GetMapValue("blobServices").GetMapValue("properties").GetMapValue("deleteRetentionPolicy").GetMapValue("days").AsIntValue(0, resource.Properties.GetMetadata()),
+					Days:     resource.Properties.GetMapValue("blobServices").GetMapValue("properties").GetMapValue("deleteRetentionPolicy").GetMapValue("days").AsIntValue(0),
 				},
 			},
-			AccountReplicationType:          resource.Properties.GetMapValue("sku").GetMapValue("name").AsStringValue("", resource.Properties.GetMetadata()),
-			InfrastructureEncryptionEnabled: resource.Properties.GetMapValue("encryption").GetMapValue("requireInfrastructureEncryption").AsBoolValue(false, resource.Properties.GetMetadata()),
+			AccountReplicationType:          resource.Properties.GetMapValue("sku").GetMapValue("name").AsStringValue(""),
+			InfrastructureEncryptionEnabled: resource.Properties.GetMapValue("encryption").GetMapValue("requireInfrastructureEncryption").AsBoolValue(false),
 			CustomerManagedKey: storage.CustomerManagedKey{
 				Metadata:               resource.Properties.GetMetadata(),
-				KeyVaultKeyId:          resource.Properties.GetMapValue("encryption").GetMapValue("keyVaultProperties").GetMapValue("keyUri").AsStringValue("", resource.Properties.GetMetadata()),
-				UserAssignedIdentityId: resource.Properties.GetMapValue("encryption").GetMapValue("identity").GetMapValue("userAssignedIdentity").AsStringValue("", resource.Properties.GetMetadata()),
+				KeyVaultKeyId:          resource.Properties.GetMapValue("encryption").GetMapValue("keyVaultProperties").GetMapValue("keyUri").AsStringValue(""),
+				UserAssignedIdentityId: resource.Properties.GetMapValue("encryption").GetMapValue("identity").GetMapValue("userAssignedIdentity").AsStringValue(""),
 			},
 		}
 
@@ -70,11 +69,11 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 		if !queueServiceLogging.IsNull() {
 			account.QueueProperties.Logging = storage.QueueLogging{
 				Metadata:            queueServiceLogging.GetMetadata(),
-				Delete:              queueServiceLogging.GetMapValue("delete").AsBoolValue(false, queueServiceLogging.GetMetadata()),
-				Read:                queueServiceLogging.GetMapValue("read").AsBoolValue(false, queueServiceLogging.GetMetadata()),
-				Write:               queueServiceLogging.GetMapValue("write").AsBoolValue(false, queueServiceLogging.GetMetadata()),
-				Version:             queueServiceLogging.GetMapValue("version").AsStringValue("", queueServiceLogging.GetMetadata()),
-				RetentionPolicyDays: queueServiceLogging.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0, queueServiceLogging.GetMetadata()),
+				Delete:              queueServiceLogging.GetMapValue("delete").AsBoolValue(false),
+				Read:                queueServiceLogging.GetMapValue("read").AsBoolValue(false),
+				Write:               queueServiceLogging.GetMapValue("write").AsBoolValue(false),
+				Version:             queueServiceLogging.GetMapValue("version").AsStringValue(""),
+				RetentionPolicyDays: queueServiceLogging.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0),
 			}
 			if account.QueueProperties.Logging.Delete.IsTrue() || account.QueueProperties.Logging.Read.IsTrue() || account.QueueProperties.Logging.Write.IsTrue() {
 				account.QueueProperties.EnableLogging = types.Bool(true, queueServiceLogging.GetMetadata())
@@ -83,7 +82,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 
 		publicNetworkAccess := resource.Properties.GetMapValue("publicNetworkAccess")
 		account.PublicNetworkAccess = types.Bool(
-			publicNetworkAccess.AsStringValue("Enabled", publicNetworkAccess.GetMetadata()).EqualTo("Enabled"),
+			publicNetworkAccess.AsStringValue("Enabled").EqualTo("Enabled"),
 			publicNetworkAccess.GetMetadata(),
 		)
 		accounts = append(accounts, account)

--- a/pkg/iac/adapters/arm/storage/adapt.go
+++ b/pkg/iac/adapters/arm/storage/adapt.go
@@ -23,7 +23,7 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 		for _, queueResource := range resource.GetResourcesByType("queueServices/queues") {
 			queues = append(queues, storage.Queue{
 				Metadata: queueResource.Metadata,
-				Name:     queueResource.Name.AsStringValue(""),
+				Name:     queueResource.Name.AsStringValue(),
 			})
 		}
 
@@ -52,15 +52,15 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 				Metadata: resource.Properties.GetMetadata(),
 				DeleteRetentionPolicy: storage.DeleteRetentionPolicy{
 					Metadata: resource.Properties.GetMetadata(),
-					Days:     resource.Properties.GetMapValue("blobServices").GetMapValue("properties").GetMapValue("deleteRetentionPolicy").GetMapValue("days").AsIntValue(0),
+					Days:     resource.Properties.GetMapValue("blobServices").GetMapValue("properties").GetMapValue("deleteRetentionPolicy").GetMapValue("days").AsIntValue(),
 				},
 			},
-			AccountReplicationType:          resource.Properties.GetMapValue("sku").GetMapValue("name").AsStringValue(""),
-			InfrastructureEncryptionEnabled: resource.Properties.GetMapValue("encryption").GetMapValue("requireInfrastructureEncryption").AsBoolValue(false),
+			AccountReplicationType:          resource.Properties.GetMapValue("sku").GetMapValue("name").AsStringValue(),
+			InfrastructureEncryptionEnabled: resource.Properties.GetMapValue("encryption").GetMapValue("requireInfrastructureEncryption").AsBoolValue(),
 			CustomerManagedKey: storage.CustomerManagedKey{
 				Metadata:               resource.Properties.GetMetadata(),
-				KeyVaultKeyId:          resource.Properties.GetMapValue("encryption").GetMapValue("keyVaultProperties").GetMapValue("keyUri").AsStringValue(""),
-				UserAssignedIdentityId: resource.Properties.GetMapValue("encryption").GetMapValue("identity").GetMapValue("userAssignedIdentity").AsStringValue(""),
+				KeyVaultKeyId:          resource.Properties.GetMapValue("encryption").GetMapValue("keyVaultProperties").GetMapValue("keyUri").AsStringValue(),
+				UserAssignedIdentityId: resource.Properties.GetMapValue("encryption").GetMapValue("identity").GetMapValue("userAssignedIdentity").AsStringValue(),
 			},
 		}
 
@@ -69,11 +69,11 @@ func adaptAccounts(deployment azure.Deployment) []storage.Account {
 		if !queueServiceLogging.IsNull() {
 			account.QueueProperties.Logging = storage.QueueLogging{
 				Metadata:            queueServiceLogging.GetMetadata(),
-				Delete:              queueServiceLogging.GetMapValue("delete").AsBoolValue(false),
-				Read:                queueServiceLogging.GetMapValue("read").AsBoolValue(false),
-				Write:               queueServiceLogging.GetMapValue("write").AsBoolValue(false),
-				Version:             queueServiceLogging.GetMapValue("version").AsStringValue(""),
-				RetentionPolicyDays: queueServiceLogging.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(0),
+				Delete:              queueServiceLogging.GetMapValue("delete").AsBoolValue(),
+				Read:                queueServiceLogging.GetMapValue("read").AsBoolValue(),
+				Write:               queueServiceLogging.GetMapValue("write").AsBoolValue(),
+				Version:             queueServiceLogging.GetMapValue("version").AsStringValue(),
+				RetentionPolicyDays: queueServiceLogging.GetMapValue("retentionPolicy").GetMapValue("days").AsIntValue(),
 			}
 			if account.QueueProperties.Logging.Delete.IsTrue() || account.QueueProperties.Logging.Read.IsTrue() || account.QueueProperties.Logging.Write.IsTrue() {
 				account.QueueProperties.EnableLogging = types.Bool(true, queueServiceLogging.GetMetadata())

--- a/pkg/iac/scanners/azure/value.go
+++ b/pkg/iac/scanners/azure/value.go
@@ -45,7 +45,6 @@ var NullValue = Value{
 var boolTrueValues = set.NewCaseInsensitive("true", "1", "yes", "on", "enabled")
 
 func NewValue(value any, metadata types.Metadata) Value {
-
 	v := Value{
 		metadata: &metadata,
 	}
@@ -198,15 +197,15 @@ func (v Value) AsFloat() float64 {
 	return v.rLit.(float64)
 }
 
-func (v Value) AsIntValue(defaultValue int) types.IntValue {
+func (v Value) AsIntValue(defaultValue ...int) types.IntValue {
 	v.Resolve()
 	if v.Kind != KindNumber {
-		return types.Int(defaultValue, v.GetMetadata())
+		return types.Int(firstOrZero(defaultValue), v.GetMetadata())
 	}
 	return types.Int(v.AsInt(), v.GetMetadata())
 }
 
-func (v Value) AsBoolValue(defaultValue bool) types.BoolValue {
+func (v Value) AsBoolValue(defaultValue ...bool) types.BoolValue {
 	v.Resolve()
 	if v.Kind == KindString {
 		if boolTrueValues.Contains(v.rLit.(string)) {
@@ -215,7 +214,7 @@ func (v Value) AsBoolValue(defaultValue bool) types.BoolValue {
 	}
 
 	if v.Kind != KindBoolean {
-		return types.Bool(defaultValue, v.GetMetadata())
+		return types.Bool(firstOrZero(defaultValue), v.GetMetadata())
 	}
 
 	return types.Bool(v.rLit.(bool), v.GetMetadata())
@@ -230,10 +229,10 @@ func (v Value) EqualTo(value any) bool {
 	}
 }
 
-func (v Value) AsStringValue(defaultValue string) types.StringValue {
+func (v Value) AsStringValue(defaultValue ...string) types.StringValue {
 	v.Resolve()
 	if v.Kind != KindString {
-		return types.StringDefault(defaultValue, v.GetMetadata())
+		return types.StringDefault(firstOrZero(defaultValue), v.GetMetadata())
 	}
 	return types.String(v.rLit.(string), v.GetMetadata())
 }
@@ -318,13 +317,13 @@ func (v Value) AsTimeValue() types.TimeValue {
 	}
 }
 
-func (v Value) AsStringValuesList(defaultValue string) (stringValues []types.StringValue) {
+func (v Value) AsStringValuesList(defaultValue ...string) (stringValues []types.StringValue) {
 	v.Resolve()
 	if v.Kind != KindArray {
 		return
 	}
 	for _, item := range v.rArr {
-		stringValues = append(stringValues, item.AsStringValue(defaultValue))
+		stringValues = append(stringValues, item.AsStringValue(defaultValue...))
 	}
 
 	return stringValues
@@ -332,4 +331,12 @@ func (v Value) AsStringValuesList(defaultValue string) (stringValues []types.Str
 
 func (v Value) IsNull() bool {
 	return v.Kind == KindNull
+}
+
+func firstOrZero[T any](values []T) T {
+	if len(values) > 0 {
+		return values[0]
+	}
+	var zero T
+	return zero
 }

--- a/pkg/iac/scanners/azure/value.go
+++ b/pkg/iac/scanners/azure/value.go
@@ -198,24 +198,24 @@ func (v Value) AsFloat() float64 {
 	return v.rLit.(float64)
 }
 
-func (v Value) AsIntValue(defaultValue int, metadata types.Metadata) types.IntValue {
+func (v Value) AsIntValue(defaultValue int) types.IntValue {
 	v.Resolve()
 	if v.Kind != KindNumber {
-		return types.Int(defaultValue, metadata)
+		return types.Int(defaultValue, v.GetMetadata())
 	}
-	return types.Int(v.AsInt(), metadata)
+	return types.Int(v.AsInt(), v.GetMetadata())
 }
 
-func (v Value) AsBoolValue(defaultValue bool, metadata types.Metadata) types.BoolValue {
+func (v Value) AsBoolValue(defaultValue bool) types.BoolValue {
 	v.Resolve()
 	if v.Kind == KindString {
 		if boolTrueValues.Contains(v.rLit.(string)) {
-			return types.Bool(true, metadata)
+			return types.Bool(true, v.GetMetadata())
 		}
 	}
 
 	if v.Kind != KindBoolean {
-		return types.Bool(defaultValue, metadata)
+		return types.Bool(defaultValue, v.GetMetadata())
 	}
 
 	return types.Bool(v.rLit.(bool), v.GetMetadata())
@@ -230,10 +230,10 @@ func (v Value) EqualTo(value any) bool {
 	}
 }
 
-func (v Value) AsStringValue(defaultValue string, metadata types.Metadata) types.StringValue {
+func (v Value) AsStringValue(defaultValue string) types.StringValue {
 	v.Resolve()
 	if v.Kind != KindString {
-		return types.StringDefault(defaultValue, metadata)
+		return types.StringDefault(defaultValue, v.GetMetadata())
 	}
 	return types.String(v.rLit.(string), v.GetMetadata())
 }
@@ -241,13 +241,13 @@ func (v Value) AsStringValue(defaultValue string, metadata types.Metadata) types
 func (v Value) GetMapValue(key string) Value {
 	v.Resolve()
 	if v.Kind != KindObject {
-		return NullValue
+		return Value{Kind: KindNull, metadata: v.metadata}
 	}
-	v, exists := v.rMap[key]
+	child, exists := v.rMap[key]
 	if !exists {
-		return NullValue
+		return Value{Kind: KindNull, metadata: v.metadata}
 	}
-	return v
+	return child
 }
 
 func (v Value) AsMap() map[string]Value {
@@ -294,14 +294,14 @@ func (v Value) HasKey(key string) bool {
 	return ok
 }
 
-func (v Value) AsTimeValue(parentMeta types.Metadata) types.TimeValue {
+func (v Value) AsTimeValue() types.TimeValue {
 	v.Resolve()
 
 	switch v.Kind {
 	case KindString:
 		t, err := time.Parse(time.RFC3339, v.rLit.(string))
 		if err != nil {
-			return types.Time(time.Time{}, parentMeta)
+			return types.Time(time.Time{}, v.GetMetadata())
 		}
 		return types.Time(t, v.GetMetadata())
 	case KindNumber:
@@ -314,7 +314,7 @@ func (v Value) AsTimeValue(parentMeta types.Metadata) types.TimeValue {
 		}
 		return types.Time(time.Unix(tv, 0), v.GetMetadata())
 	default:
-		return types.Time(time.Time{}, parentMeta)
+		return types.Time(time.Time{}, v.GetMetadata())
 	}
 }
 
@@ -324,7 +324,7 @@ func (v Value) AsStringValuesList(defaultValue string) (stringValues []types.Str
 		return
 	}
 	for _, item := range v.rArr {
-		stringValues = append(stringValues, item.AsStringValue(defaultValue, item.GetMetadata()))
+		stringValues = append(stringValues, item.AsStringValue(defaultValue))
 	}
 
 	return stringValues

--- a/pkg/iac/scanners/azure/value_test.go
+++ b/pkg/iac/scanners/azure/value_test.go
@@ -45,8 +45,32 @@ func Test_ValueAsTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			val := NewValue(tt.val, types.NewTestMetadata())
-			got := val.AsTimeValue(types.NewTestMetadata()).Value()
+			got := val.AsTimeValue().Value()
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func Test_GetMapValue_MetadataPropagation(t *testing.T) {
+	parentMeta := types.NewMetadata(types.NewRange("test.json", 1, 10, "", nil), "parent")
+	childMeta := types.NewMetadata(types.NewRange("test.json", 3, 5, "", nil), "child")
+
+	obj := NewValue(map[string]Value{
+		"existing": NewValue("hello", childMeta),
+	}, parentMeta)
+
+	t.Run("existing key returns own metadata", func(t *testing.T) {
+		got := obj.GetMapValue("existing").AsStringValue("")
+		assert.Equal(t, childMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
+	})
+
+	t.Run("missing key propagates parent metadata", func(t *testing.T) {
+		got := obj.GetMapValue("missing").AsStringValue("")
+		assert.Equal(t, parentMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
+	})
+
+	t.Run("chained missing keys propagate metadata", func(t *testing.T) {
+		got := obj.GetMapValue("missing").GetMapValue("also_missing").AsBoolValue(false)
+		assert.Equal(t, parentMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
+	})
 }

--- a/pkg/iac/scanners/azure/value_test.go
+++ b/pkg/iac/scanners/azure/value_test.go
@@ -60,17 +60,17 @@ func Test_GetMapValue_MetadataPropagation(t *testing.T) {
 	}, parentMeta)
 
 	t.Run("existing key returns own metadata", func(t *testing.T) {
-		got := obj.GetMapValue("existing").AsStringValue("")
+		got := obj.GetMapValue("existing").AsStringValue()
 		assert.Equal(t, childMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
 	})
 
 	t.Run("missing key propagates parent metadata", func(t *testing.T) {
-		got := obj.GetMapValue("missing").AsStringValue("")
+		got := obj.GetMapValue("missing").AsStringValue()
 		assert.Equal(t, parentMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
 	})
 
 	t.Run("chained missing keys propagate metadata", func(t *testing.T) {
-		got := obj.GetMapValue("missing").GetMapValue("also_missing").AsBoolValue(false)
+		got := obj.GetMapValue("missing").GetMapValue("also_missing").AsBoolValue()
 		assert.Equal(t, parentMeta.Range().GetStartLine(), got.GetMetadata().Range().GetStartLine())
 	})
 }


### PR DESCRIPTION
## Description

Previously, callers had to manually pass a fallback metadata to every `As*Value` call. This led to two problems: verbose
and repetitive code in adapters, and incorrect metadata in reports — callers would pass `resource.Metadata` even for
deeply nested values, so misconfiguration findings would point to the resource root instead of the actual location in the
template. With metadata propagation through the chain, findings now point to the closest existing ancestor, which is
semantically more accurate.

- `Value` now always carries metadata: `GetMapValue` propagates parent metadata to the returned value when a key is
 absent or the receiver is not an object
- `As*Value` methods use the value's own metadata instead of requiring it as a parameter
- Default values in `As*Value` methods are now variadic — zero values (`false`, `""`, `0`) can be omitted at call sites,
 non-zero defaults remain explicit

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
