### PR TITLE
test: fix flaky containerd integration test

### DIFF
--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -52,15 +52,23 @@ func setupContainerd(t *testing.T, ctx context.Context, namespace string) *clien
 
 	startContainerd(t, ctx, tmpDir)
 
-	// Retry up to 3 times until containerd is ready
+	// Retry up to 5 times until containerd is ready.
+	// client.New uses lazy gRPC dialing, so we verify actual connectivity with
+	// a real RPC call (Version) to catch "permission denied" on the socket before
+	// returning the client to callers.
 	var c *client.Client
-	iteration, _, err := lo.AttemptWhileWithDelay(3, 1*time.Second, func(int, time.Duration) (error, bool) {
+	iteration, _, err := lo.AttemptWhileWithDelay(5, 1*time.Second, func(int, time.Duration) (error, bool) {
 		c, err = client.New(socketPath)
 		if err != nil {
 			if !errors.Is(err, os.ErrPermission) {
 				return err, false // unexpected error
 			}
 			return err, true
+		}
+		// Force actual dial to detect socket permission issues early.
+		if _, vErr := c.Version(ctx); vErr != nil {
+			_ = c.Close()
+			return vErr, true
 		}
 		t.Cleanup(func() {
 			require.NoError(t, c.Close())
@@ -103,12 +111,13 @@ func startContainerd(t *testing.T, ctx context.Context, hostPath string) {
 	require.NoError(t, err)
 	testcontainers.CleanupContainer(t, containerdC)
 
-	_, _, err = containerdC.Exec(ctx, []string{
+	exitCode, _, err := containerdC.Exec(ctx, []string{
 		"chmod",
 		"666",
 		"/run/containerd/containerd.sock",
 	})
 	require.NoError(t, err)
+	require.Zero(t, exitCode, "chmod containerd.sock failed")
 }
 
 // Each of these tests imports an image and tags it with the name found in the

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -52,7 +52,7 @@ func setupContainerd(t *testing.T, ctx context.Context, namespace string) *clien
 
 	startContainerd(t, ctx, tmpDir)
 
-	// Retry up to 5 times until containerd is ready.
+	// Retry until containerd is ready.
 	// client.New uses lazy gRPC dialing, so we verify actual connectivity with
 	// a real RPC call (Version) to catch "permission denied" on the socket before
 	// returning the client to callers.

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -57,7 +57,7 @@ func setupContainerd(t *testing.T, ctx context.Context, namespace string) *clien
 	// a real RPC call (Version) to catch "permission denied" on the socket before
 	// returning the client to callers.
 	var c *client.Client
-	iteration, _, err := lo.AttemptWhileWithDelay(5, 1*time.Second, func(int, time.Duration) (error, bool) {
+	iteration, _, err := lo.AttemptWhileWithDelay(3, 1*time.Second, func(int, time.Duration) (error, bool) {
 		c, err = client.New(socketPath)
 		if err != nil {
 			if !errors.Is(err, os.ErrPermission) {


### PR DESCRIPTION
## Description

Fix a flaky integration test for containerd caused by a race between socket permission setup and the first real gRPC connection.

https://pkg.go.dev/google.golang.org/grpc#NewClient uses lazy gRPC dialing — it creates a client object without actually connecting to the socket. The retry loop in `setupContainerd` always succeeded on the first attempt (no error from `client.New`), but the real dial happened later at `client.Import()` in the subtest, where it could hit `permission denied` if the `chmod 666` on the socket hadn't taken effect yet.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
