### PR TITLE
feat(flag): add --color flag to control table output coloring

### DIFF
--- a/docs/guide/advanced/telemetry-flags.md
+++ b/docs/guide/advanced/telemetry-flags.md
@@ -1,5 +1,6 @@
 ```
 --clear-cache
+--color
 --debug
 --dependency-tree
 --detection-priority

--- a/docs/guide/references/configuration/cli/trivy_config.md
+++ b/docs/guide/references/configuration/cli/trivy_config.md
@@ -17,6 +17,7 @@ trivy config [flags] DIR
       --cf-params strings                 specify paths to override the CloudFormation parameters files
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string                 compliance report to generate
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded

--- a/docs/guide/references/configuration/cli/trivy_convert.md
+++ b/docs/guide/references/configuration/cli/trivy_convert.md
@@ -18,6 +18,7 @@ trivy convert [flags] RESULT_JSON
 ### Options
 
 ```
+      --color string               control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string          compliance report to generate
       --dependency-tree            [EXPERIMENTAL] show dependency origin tree of vulnerable packages
       --exit-code int              specify exit code when any security issues are found

--- a/docs/guide/references/configuration/cli/trivy_filesystem.md
+++ b/docs/guide/references/configuration/cli/trivy_filesystem.md
@@ -27,6 +27,7 @@ trivy filesystem [flags] PATH
       --cf-params strings                 specify paths to override the CloudFormation parameters files
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string                 compliance report to generate
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded

--- a/docs/guide/references/configuration/cli/trivy_image.md
+++ b/docs/guide/references/configuration/cli/trivy_image.md
@@ -41,6 +41,7 @@ trivy image [flags] IMAGE_NAME
       --cache-ttl duration                cache TTL when using redis as cache backend
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string                 compliance report to generate (built-in compliance's: docker-cis-1.6.0)
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded

--- a/docs/guide/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/guide/references/configuration/cli/trivy_kubernetes.md
@@ -37,6 +37,7 @@ trivy kubernetes [flags] [CONTEXT]
       --cache-ttl duration                cache TTL when using redis as cache backend
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string                 compliance report to generate
                                           Built-in compliance's:
                                             - k8s-nsa-1.0

--- a/docs/guide/references/configuration/cli/trivy_repository.md
+++ b/docs/guide/references/configuration/cli/trivy_repository.md
@@ -27,6 +27,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --cf-params strings                 specify paths to override the CloudFormation parameters files
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --commit string                     pass the commit hash to be scanned
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded

--- a/docs/guide/references/configuration/cli/trivy_rootfs.md
+++ b/docs/guide/references/configuration/cli/trivy_rootfs.md
@@ -30,6 +30,7 @@ trivy rootfs [flags] ROOTDIR
       --cf-params strings                 specify paths to override the CloudFormation parameters files
       --check-namespaces strings          Rego namespaces
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --config-check strings              specify the paths to the Rego check files or to the directories containing them, applying config files
       --config-data strings               specify paths from which data for the Rego checks will be recursively loaded
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking

--- a/docs/guide/references/configuration/cli/trivy_sbom.md
+++ b/docs/guide/references/configuration/cli/trivy_sbom.md
@@ -22,6 +22,7 @@ trivy sbom [flags] SBOM_PATH
 ```
       --cache-backend string           [EXPERIMENTAL] cache backend (e.g. redis://localhost:6379) (default "memory")
       --cache-ttl duration             cache TTL when using redis as cache backend
+      --color string                   control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string              compliance report to generate
       --custom-headers strings         custom headers in client mode
       --db-repository strings          OCI repository(ies) to retrieve trivy-db in order of priority (default [mirror.gcr.io/aquasec/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2])

--- a/docs/guide/references/configuration/cli/trivy_vm.md
+++ b/docs/guide/references/configuration/cli/trivy_vm.md
@@ -27,6 +27,7 @@ trivy vm [flags] VM_IMAGE
       --cache-backend string              [EXPERIMENTAL] cache backend (e.g. redis://localhost:6379) (default "fs")
       --cache-ttl duration                cache TTL when using redis as cache backend
       --checks-bundle-repository string   OCI registry URL to retrieve checks bundle from (default "mirror.gcr.io/aquasec/trivy-checks:2")
+      --color string                      control colored output (only for 'table' format) (allowed values: auto,always,never) (default "auto")
       --compliance string                 compliance report to generate
       --config-file-schemas strings       specify paths to JSON configuration file schemas to determine that a file matches some configuration and pass the schema to Rego checks for type checking
       --custom-headers strings            custom headers in client mode

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -529,6 +529,9 @@ rego:
 ## Report options
 
 ```yaml
+# Same as '--color'
+color: "auto"
+
 # Same as '--dependency-tree'
 dependency-tree: false
 

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -126,6 +126,14 @@ var (
 		Values:     xstrings.ToStringSlice(types.SupportedTableModes),
 		Usage:      "[EXPERIMENTAL] tables that will be displayed in 'table' format",
 	}
+	ColorFlag = Flag[string]{
+		Name:          "color",
+		ConfigName:    "color",
+		Default:       string(types.ColorAuto),
+		Values:        xstrings.ToStringSlice(types.SupportedColorModes),
+		Usage:         "control colored output (only for 'table' format)",
+		TelemetrySafe: true,
+	}
 )
 
 // ReportFlagGroup composes common printer flag structs
@@ -146,6 +154,7 @@ type ReportFlagGroup struct {
 	Compliance      *Flag[string]
 	ShowSuppressed  *Flag[bool]
 	TableMode       *Flag[[]string]
+	Color           *Flag[string]
 }
 
 type ReportOptions struct {
@@ -164,6 +173,7 @@ type ReportOptions struct {
 	Compliance       spec.ComplianceSpec
 	ShowSuppressed   bool
 	TableModes       []types.TableMode
+	Color            types.ColorMode
 }
 
 func NewReportFlagGroup() *ReportFlagGroup {
@@ -183,6 +193,7 @@ func NewReportFlagGroup() *ReportFlagGroup {
 		Compliance:      ComplianceFlag.Clone(),
 		ShowSuppressed:  ShowSuppressedFlag.Clone(),
 		TableMode:       TableModeFlag.Clone(),
+		Color:           ColorFlag.Clone(),
 	}
 }
 
@@ -207,6 +218,7 @@ func (f *ReportFlagGroup) Flags() []Flagger {
 		f.Compliance,
 		f.ShowSuppressed,
 		f.TableMode,
+		f.Color,
 	}
 }
 
@@ -257,6 +269,8 @@ func (f *ReportFlagGroup) ToOptions(opts *Options) error {
 		return xerrors.New(`"--table-mode" can be used only with "--format table".`)
 	}
 
+	f.warnColorOnlyForTable(format)
+
 	cs, err := loadComplianceTypes(f.Compliance.Value())
 	if err != nil {
 		return xerrors.Errorf("unable to load compliance spec: %w", err)
@@ -290,8 +304,17 @@ func (f *ReportFlagGroup) ToOptions(opts *Options) error {
 		Compliance:       cs,
 		ShowSuppressed:   f.ShowSuppressed.Value(),
 		TableModes:       xstrings.ToTSlice[types.TableMode](tableModes),
+		Color:            types.ColorMode(f.Color.Value()),
 	}
 	return nil
+}
+
+// warnColorOnlyForTable warns when "--color" is set with a non-table format,
+// where it has no effect.
+func (f *ReportFlagGroup) warnColorOnlyForTable(format types.Format) {
+	if f.Color.IsSet() && format != types.FormatTable {
+		log.Warn(`"--color" is ignored because it can be used only with "--format table".`)
+	}
 }
 
 func loadComplianceTypes(compliance string) (spec.ComplianceSpec, error) {

--- a/pkg/flag/report_flags_test.go
+++ b/pkg/flag/report_flags_test.go
@@ -34,6 +34,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 		debug            bool
 		pkgTypes         string
 		tableModes       []string
+		color            string
 	}
 	tests := []struct {
 		name     string
@@ -56,6 +57,31 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			want: flag.ReportOptions{
 				Severities: []dbTypes.Severity{dbTypes.SeverityCritical},
 				Format:     types.FormatCycloneDX,
+			},
+		},
+		{
+			name: "happy path with --color=never",
+			fields: fields{
+				format: "table",
+				color:  "never",
+			},
+			want: flag.ReportOptions{
+				Format: types.FormatTable,
+				Color:  types.ColorNever,
+			},
+		},
+		{
+			name: "--color is ignored with non-table format",
+			fields: fields{
+				format: "json",
+				color:  "always",
+			},
+			wantLogs: []string{
+				`"--color" is ignored because it can be used only with "--format table".`,
+			},
+			want: flag.ReportOptions{
+				Format: types.FormatJSON,
+				Color:  types.ColorAlways,
 			},
 		},
 		{
@@ -238,6 +264,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 			setValue(flag.SeverityFlag.ConfigName, tt.fields.severities)
 			setValue(flag.ComplianceFlag.ConfigName, tt.fields.compliance)
 			setSliceValue(flag.TableModeFlag.ConfigName, tt.fields.tableModes)
+			setValue(flag.ColorFlag.ConfigName, tt.fields.color)
 
 			// Assert options
 			f := &flag.ReportFlagGroup{
@@ -254,6 +281,7 @@ func TestReportFlagGroup_ToOptions(t *testing.T) {
 				Severity:        flag.SeverityFlag.Clone(),
 				Compliance:      flag.ComplianceFlag.Clone(),
 				TableMode:       flag.TableModeFlag.Clone(),
+				Color:           flag.ColorFlag.Clone(),
 			}
 
 			flags := flag.Flags{f}

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -58,6 +58,9 @@ type Options struct {
 	// Show/hide summary/detailed tables
 	TableModes []types.TableMode
 
+	// Control colored output (auto, always, never). Empty defaults to auto.
+	ColorMode types.ColorMode
+
 	// For misconfigurations
 	IncludeNonFailures bool
 	Trace              bool
@@ -70,7 +73,7 @@ type Options struct {
 
 func NewWriter(options Options) *Writer {
 	buf := bytes.NewBuffer([]byte{})
-	isTerminal := IsOutputToTerminal(options.Output)
+	isTerminal := colorEnabled(options.ColorMode, options.Output)
 	return &Writer{
 		buf: buf,
 
@@ -171,6 +174,25 @@ func summarize(specifiedSeverities []dbTypes.Severity, severityCount map[string]
 	}
 
 	return total, summaries
+}
+
+// colorEnabled resolves whether the table renderer should produce styled output,
+// based on the --color mode (auto, always, never) layered on top of TTY detection.
+// For the explicit "always"/"never" modes it also pins the global fatih/color
+// switch so the color helpers (SeverityColor, ColorizeSeverity) follow the same
+// decision. In "auto" mode the global is intentionally left to fatih/color's own
+// detection, which already honors both TTY presence and the NO_COLOR env var.
+func colorEnabled(mode types.ColorMode, output io.Writer) bool {
+	switch mode {
+	case types.ColorAlways:
+		color.NoColor = false
+		return true
+	case types.ColorNever:
+		color.NoColor = true
+		return false
+	default: // auto (and empty value for backward compatibility)
+		return IsOutputToTerminal(output)
+	}
 }
 
 func IsOutputToTerminal(output io.Writer) bool {

--- a/pkg/report/table/table_internal_test.go
+++ b/pkg/report/table/table_internal_test.go
@@ -1,0 +1,60 @@
+package table
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestColorEnabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         types.ColorMode
+		wantTerminal bool
+		wantNoColor  bool
+	}{
+		{
+			name:         "always forces styled output on and color globally enabled",
+			mode:         types.ColorAlways,
+			wantTerminal: true,
+			wantNoColor:  false,
+		},
+		{
+			name:         "never forces styled output off and color globally disabled",
+			mode:         types.ColorNever,
+			wantTerminal: false,
+			wantNoColor:  true,
+		},
+		{
+			name:         "auto falls back to TTY detection (a buffer is never a terminal)",
+			mode:         types.ColorAuto,
+			wantTerminal: false,
+		},
+		{
+			name:         "empty mode behaves like auto for backward compatibility",
+			mode:         types.ColorMode(""),
+			wantTerminal: false,
+		},
+	}
+
+	// No t.Parallel(): the cases mutate the process-global color.NoColor.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore the global fatih/color switch toggled by colorEnabled.
+			orig := color.NoColor
+			t.Cleanup(func() { color.NoColor = orig })
+
+			got := colorEnabled(tt.mode, &bytes.Buffer{})
+			assert.Equal(t, tt.wantTerminal, got)
+
+			// color.NoColor is only overridden for the explicit always/never modes.
+			if tt.mode == types.ColorAlways || tt.mode == types.ColorNever {
+				assert.Equal(t, tt.wantNoColor, color.NoColor)
+			}
+		})
+	}
+}

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -62,6 +62,7 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 			LicenseRiskThreshold: option.LicenseRiskThreshold,
 			IgnoredLicenses:      option.IgnoredLicenses,
 			TableModes:           option.TableModes,
+			ColorMode:            option.Color,
 		})
 	case types.FormatJSON:
 		writer = &JSONWriter{

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -69,6 +69,7 @@ type Results []Result
 type ResultClass string
 type Compliance = string
 type Format string
+type ColorMode string
 
 const (
 	ClassUnknown     ResultClass = "unknown"
@@ -99,6 +100,10 @@ const (
 	FormatSPDXJSON   Format = "spdx-json"
 	FormatGitHub     Format = "github"
 	FormatCosignVuln Format = "cosign-vuln"
+
+	ColorAuto   ColorMode = "auto"   // Colorize output only when writing to a terminal
+	ColorAlways ColorMode = "always" // Always colorize output
+	ColorNever  ColorMode = "never"  // Never colorize output
 )
 
 var BuiltInK8sCompliances = []string{
@@ -127,6 +132,11 @@ var (
 		FormatSPDX,
 		FormatSPDXJSON,
 		FormatGitHub,
+	}
+	SupportedColorModes = []ColorMode{
+		ColorAuto,
+		ColorAlways,
+		ColorNever,
 	}
 	SupportedCompliances = []string{
 		ComplianceK8sNsa10,

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -822,6 +822,15 @@
       },
       "description": "[EXPERIMENTAL] tables that will be displayed in 'table' format"
     },
+    "color": {
+      "type": "string",
+      "description": "control colored output (only for 'table' format)",
+      "enum": [
+        "auto",
+        "always",
+        "never"
+      ]
+    },
     "repository": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Description

Adds a `--color=auto|always|never` flag (default `auto`) to control coloring of the table output, resolving #1091.

- `auto` (default) — preserves current behavior: color when stdout is a TTY, no color when piped/redirected (honors `NO_COLOR`).
- `always` — force color on even when the output is piped or redirected.
- `never` — disable color entirely.

Scope is intentionally limited to the **table renderer + the `fatih/color` global**, following the design direction set by the maintainer in #9783 (tri-state `auto|always|never`, not a bare `--no-color`).

Follow-up (out of scope here): `alecthomas/chroma` syntax highlighting used for IaC output does not honor `NO_COLOR` / this flag yet — that will be a separate PR.

## Validation

- `go build`, `go vet`, `go test ./pkg/flag/ ./pkg/report/... ./pkg/types/...` — all pass (with `GOEXPERIMENT=jsonv2`).
- `golangci-lint` over the changed packages — 0 issues.
- Docs regenerated via `mage docs:generate` — `docs/` is clean after regen.
- Manual E2E against a built binary: secret scan piped to a file → `--color=always` emits ANSI color, `--color=never` and `--color=auto` (non-TTY) emit none.

## Checklist

- [x] Follows trivy conventions (Conventional Commits, additive struct fields only — no exported-signature changes)
- [x] Tests added/updated (`pkg/flag`, `pkg/report/table`)
- [x] Docs + schema regenerated (not hand-edited)

Close #1091