### PR TITLE
fix(spdx): guard against nil root component in SPDX marshaler

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -134,21 +134,29 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*spdx.Document,
 	timeNow := clock.Now(ctx).UTC().Format(time.RFC3339)
 
 	root := bom.Root()
-	pkgDownloadLocation := m.packageDownloadLocation(root)
 
 	// Component ID => SPDX ID
 	packageIDs := make(map[uuid.UUID]spdx.ElementID)
 
-	// Root package contains OS, OS packages, language-specific packages and so on.
-	rootPkg, err := m.rootSPDXPackage(root, timeNow, pkgDownloadLocation)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to generate a root package: %w", err)
+	// pkgDownloadLocation defaults to NONE when there is no root component.
+	pkgDownloadLocation := noneField
+	if root != nil {
+		pkgDownloadLocation = m.packageDownloadLocation(root)
+
+		// Root package contains OS, OS packages, language-specific packages and so on.
+		rootPkg, err := m.rootSPDXPackage(root, timeNow, pkgDownloadLocation)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to generate a root package: %w", err)
+		}
+		packages = append(packages, rootPkg)
+		relationShips = append(relationShips,
+			m.spdxRelationShip(DocumentSPDXIdentifier, rootPkg.PackageSPDXIdentifier, RelationShipDescribe),
+		)
+		packageIDs[root.ID()] = rootPkg.PackageSPDXIdentifier
+	} else {
+		// Since we reuse the scanned SBOM, the root component can be empty.
+		m.logger.Debug("Root component not found")
 	}
-	packages = append(packages, rootPkg)
-	relationShips = append(relationShips,
-		m.spdxRelationShip(DocumentSPDXIdentifier, rootPkg.PackageSPDXIdentifier, RelationShipDescribe),
-	)
-	packageIDs[root.ID()] = rootPkg.PackageSPDXIdentifier
 
 	var files []*spdx.File
 	var otherLicenses []*spdx.OtherLicense
@@ -224,7 +232,7 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*spdx.Document,
 		SPDXVersion:       spdx.Version,
 		DataLicense:       spdx.DataLicense,
 		SPDXIdentifier:    DocumentSPDXIdentifier,
-		DocumentName:      root.Name,
+		DocumentName:      rootDocumentName(root),
 		DocumentNamespace: getDocumentNamespace(root),
 		CreationInfo: &spdx.CreationInfo{
 			Creators: []common.Creator{
@@ -628,7 +636,17 @@ func elementID(elementType, pkgID string) spdx.ElementID {
 	return spdx.ElementID(fmt.Sprintf("%s-%s", elementType, pkgID))
 }
 
+func rootDocumentName(root *core.Component) string {
+	if root == nil {
+		return ""
+	}
+	return root.Name
+}
+
 func getDocumentNamespace(root *core.Component) string {
+	if root == nil {
+		return fmt.Sprintf("%s/unknown/%s", DocumentNamespace, uuid.New().String())
+	}
 	return fmt.Sprintf("%s/%s/%s-%s",
 		DocumentNamespace,
 		string(root.Type),

--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -36,6 +36,7 @@ const (
 	CreatorTool            = "trivy"
 	noneField              = "NONE"
 	noAssertionField       = "NOASSERTION"
+	noRoot                 = "unknown"
 )
 
 const (
@@ -140,7 +141,9 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*spdx.Document,
 
 	// pkgDownloadLocation defaults to NONE when there is no root component.
 	pkgDownloadLocation := noneField
+	rootDocumentName := noRoot
 	if root != nil {
+		rootDocumentName = root.Name
 		pkgDownloadLocation = m.packageDownloadLocation(root)
 
 		// Root package contains OS, OS packages, language-specific packages and so on.
@@ -232,8 +235,8 @@ func (m *Marshaler) Marshal(ctx context.Context, bom *core.BOM) (*spdx.Document,
 		SPDXVersion:       spdx.Version,
 		DataLicense:       spdx.DataLicense,
 		SPDXIdentifier:    DocumentSPDXIdentifier,
-		DocumentName:      rootDocumentName(root),
-		DocumentNamespace: getDocumentNamespace(root),
+		DocumentName:      rootDocumentName,
+		DocumentNamespace: rootDocumentNamespace(root),
 		CreationInfo: &spdx.CreationInfo{
 			Creators: []common.Creator{
 				{
@@ -636,16 +639,9 @@ func elementID(elementType, pkgID string) spdx.ElementID {
 	return spdx.ElementID(fmt.Sprintf("%s-%s", elementType, pkgID))
 }
 
-func rootDocumentName(root *core.Component) string {
+func rootDocumentNamespace(root *core.Component) string {
 	if root == nil {
-		return ""
-	}
-	return root.Name
-}
-
-func getDocumentNamespace(root *core.Component) string {
-	if root == nil {
-		return fmt.Sprintf("%s/unknown/%s", DocumentNamespace, uuid.New().String())
+		return fmt.Sprintf("%s/%s/%s", DocumentNamespace, noRoot, uuid.New().String())
 	}
 	return fmt.Sprintf("%s/%s/%s-%s",
 		DocumentNamespace,

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -42,6 +42,7 @@ func TestMarshaler_Marshal(t *testing.T) {
 	testCases := []struct {
 		name        string
 		inputReport types.Report
+		inputBOM    *core.BOM // when set, Marshal is called directly instead of MarshalReport
 		wantSBOM    *spdx.Document
 	}{
 		{
@@ -1482,42 +1483,78 @@ func TestMarshaler_Marshal(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression for https://github.com/aquasecurity/trivy/issues/10764:
+			// Marshal must not panic when the BOM has no root component (e.g. an SPDX
+			// SBOM without a DESCRIBES relationship from SPDXRef-DOCUMENT).
+			name:     "no root component",
+			inputBOM: core.NewBOM(core.Options{}),
+			wantSBOM: &spdx.Document{
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				SPDXIdentifier:    tspdx.DocumentSPDXIdentifier,
+				DocumentName:      "unknown",
+				DocumentNamespace: "http://trivy.dev/unknown/unknown-3ff14136-e09f-4df9-80ea-000000000001",
+				CreationInfo: &spdx.CreationInfo{
+					Creators: []common.Creator{
+						{
+							Creator:     "aquasecurity",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "trivy-0.56.2",
+							CreatorType: "Tool",
+						},
+					},
+					Created: "2021-08-25T12:20:30Z",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Fake function calculating the hash value
-			h := fnv.New64()
-			hasher := func(v any, _ hashstructure.Format, _ *hashstructure.HashOptions) (uint64, error) {
-				h.Reset()
-
-				var str string
-				switch vv := v.(type) {
-				case *core.Component:
-					str = vv.Name + vv.Version + vv.SrcFile
-					for _, f := range vv.Files {
-						str += f.Path
-					}
-				case spdx.OtherLicense:
-					str = vv.ExtractedText + vv.LicenseName
-				case string:
-					str = vv
-				default:
-					require.Failf(t, "unknown type", "%T", v)
-				}
-
-				if _, err := h.Write([]byte(str)); err != nil {
-					return 0, err
-				}
-
-				return h.Sum64(), nil
-			}
-
 			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
-			marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))
-			spdxDoc, err := marshaler.MarshalReport(ctx, tc.inputReport)
+			var (
+				spdxDoc *spdx.Document
+				err     error
+			)
+			if tc.inputBOM != nil {
+				// Some test cases exercise the Marshal path directly (e.g. nil-root BOM).
+				marshaler := tspdx.NewMarshaler("0.56.2")
+				spdxDoc, err = marshaler.Marshal(ctx, tc.inputBOM)
+			} else {
+				// Fake function calculating the hash value
+				h := fnv.New64()
+				hasher := func(v any, _ hashstructure.Format, _ *hashstructure.HashOptions) (uint64, error) {
+					h.Reset()
+
+					var str string
+					switch vv := v.(type) {
+					case *core.Component:
+						str = vv.Name + vv.Version + vv.SrcFile
+						for _, f := range vv.Files {
+							str += f.Path
+						}
+					case spdx.OtherLicense:
+						str = vv.ExtractedText + vv.LicenseName
+					case string:
+						str = vv
+					default:
+						require.Failf(t, "unknown type", "%T", v)
+					}
+
+					if _, err := h.Write([]byte(str)); err != nil {
+						return 0, err
+					}
+
+					return h.Sum64(), nil
+				}
+				marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))
+				spdxDoc, err = marshaler.MarshalReport(ctx, tc.inputReport)
+			}
 			require.NoError(t, err)
 
 			assert.NoError(t, spdxlib.ValidateDocument(spdxDoc))
@@ -1526,39 +1563,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 	}
 }
 
-func TestMarshaler_Marshal_NoRoot(t *testing.T) {
-	// Regression for https://github.com/aquasecurity/trivy/issues/10764
-	// When the input BOM has no root component (e.g. an SPDX SBOM without a
-	// DESCRIBES relationship from SPDXRef-DOCUMENT), Marshal must not panic,
-	// must produce a valid SPDX document, and must not emit a DESCRIBES relationship.
-	ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
-	uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
-
-	bom := core.NewBOM(core.Options{})
-	// Add a library component without marking it as root, so bom.Root() == nil.
-	bom.AddComponent(&core.Component{
-		Type: core.TypeLibrary,
-		Name: "openssl",
-	})
-
-	marshaler := tspdx.NewMarshaler("0.56.2")
-	doc, err := marshaler.Marshal(ctx, bom)
-	require.NoError(t, err)
-	require.NotNil(t, doc)
-
-	// DocumentName must not be empty — the SPDX spec forbids an empty name field.
-	assert.Equal(t, "unknown", doc.DocumentName,
-		"DocumentName must be 'unknown' when there is no root component")
-
-	// The document must be valid per the SPDX spec.
-	assert.NoError(t, spdxlib.ValidateDocument(doc))
-
-	// No DESCRIBES relationship should be emitted when there is no root.
-	for _, rel := range doc.Relationships {
-		assert.NotEqual(t, "DESCRIBES", rel.Relationship,
-			"unexpected DESCRIBES relationship when there is no root component")
-	}
-}
 
 func TestMarshaler_normalizeLicenses(t *testing.T) {
 	tests := []struct {

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -38,11 +38,31 @@ func annotation(t *testing.T, comment string) spdx.Annotation {
 	}
 }
 
+// bomWithoutRoot returns a BOM that has components but no root component,
+// e.g. an SPDX SBOM without a DESCRIBES relationship from SPDXRef-DOCUMENT.
+func bomWithoutRoot() *core.BOM {
+	bom := core.NewBOM(core.Options{})
+	bom.AddComponent(&core.Component{
+		Type:    core.TypeLibrary,
+		Name:    "jackson-databind",
+		Group:   "com.fasterxml.jackson.core",
+		Version: "2.13.4.1",
+		PkgIdentifier: ftypes.PkgIdentifier{
+			PURL: &packageurl.PackageURL{
+				Type:      packageurl.TypeMaven,
+				Namespace: "com.fasterxml.jackson.core",
+				Name:      "jackson-databind",
+				Version:   "2.13.4.1",
+			},
+		},
+	})
+	return bom
+}
+
 func TestMarshaler_Marshal(t *testing.T) {
 	testCases := []struct {
 		name        string
 		inputReport types.Report
-		inputBOM    *core.BOM // when set, Marshal is called directly instead of MarshalReport
 		wantSBOM    *spdx.Document
 	}{
 		{
@@ -1486,15 +1506,22 @@ func TestMarshaler_Marshal(t *testing.T) {
 		{
 			// Regression for https://github.com/aquasecurity/trivy/issues/10764:
 			// Marshal must not panic when the BOM has no root component (e.g. an SPDX
-			// SBOM without a DESCRIBES relationship from SPDXRef-DOCUMENT).
-			name:     "no root component",
-			inputBOM: core.NewBOM(core.Options{}),
+			// SBOM without a DESCRIBES relationship from SPDXRef-DOCUMENT). Components
+			// must still be marshaled and no DESCRIBES relationship must be emitted.
+			name: "no root component",
+			inputReport: types.Report{
+				SchemaVersion: report.SchemaVersion,
+				ArtifactName:  "empty/path",
+				ArtifactType:  ftypes.TypeFilesystem,
+				BOM:           bomWithoutRoot(),
+			},
 			wantSBOM: &spdx.Document{
-				SPDXVersion:       spdx.Version,
-				DataLicense:       spdx.DataLicense,
-				SPDXIdentifier:    tspdx.DocumentSPDXIdentifier,
+				SPDXVersion:    spdx.Version,
+				DataLicense:    spdx.DataLicense,
+				SPDXIdentifier: tspdx.DocumentSPDXIdentifier,
+				// DocumentName and DocumentNamespace fall back to "unknown" when there is no root.
 				DocumentName:      "unknown",
-				DocumentNamespace: "http://trivy.dev/unknown/unknown-3ff14136-e09f-4df9-80ea-000000000001",
+				DocumentNamespace: "http://trivy.dev/unknown/3ff14136-e09f-4df9-80ea-000000000001",
 				CreationInfo: &spdx.CreationInfo{
 					Creators: []common.Creator{
 						{
@@ -1508,53 +1535,64 @@ func TestMarshaler_Marshal(t *testing.T) {
 					},
 					Created: "2021-08-25T12:20:30Z",
 				},
+				// The component is still marshaled, but no root package and no DESCRIBES relationship are emitted.
+				Packages: []*spdx.Package{
+					{
+						PackageSPDXIdentifier:   spdx.ElementID("Package-a6073b1f888c9899"),
+						PackageDownloadLocation: "NONE",
+						PackageName:             "com.fasterxml.jackson.core:jackson-databind",
+						PackageVersion:          "2.13.4.1",
+						PackageLicenseConcluded: "NOASSERTION",
+						PackageLicenseDeclared:  "NOASSERTION",
+						PackageExternalReferences: []*spdx.PackageExternalReference{
+							{
+								Category: tspdx.CategoryPackageManager,
+								RefType:  tspdx.RefTypePurl,
+								Locator:  "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.1",
+							},
+						},
+						PrimaryPackagePurpose: tspdx.PackagePurposeLibrary,
+						PackageSupplier:       &spdx.Supplier{Supplier: tspdx.PackageSupplierNoAssertion},
+					},
+				},
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Fake function calculating the hash value
+			h := fnv.New64()
+			hasher := func(v any, _ hashstructure.Format, _ *hashstructure.HashOptions) (uint64, error) {
+				h.Reset()
+
+				var str string
+				switch vv := v.(type) {
+				case *core.Component:
+					str = vv.Name + vv.Version + vv.SrcFile
+					for _, f := range vv.Files {
+						str += f.Path
+					}
+				case spdx.OtherLicense:
+					str = vv.ExtractedText + vv.LicenseName
+				case string:
+					str = vv
+				default:
+					require.Failf(t, "unknown type", "%T", v)
+				}
+
+				if _, err := h.Write([]byte(str)); err != nil {
+					return 0, err
+				}
+
+				return h.Sum64(), nil
+			}
+
 			ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
 			uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
-			var (
-				spdxDoc *spdx.Document
-				err     error
-			)
-			if tc.inputBOM != nil {
-				// Some test cases exercise the Marshal path directly (e.g. nil-root BOM).
-				marshaler := tspdx.NewMarshaler("0.56.2")
-				spdxDoc, err = marshaler.Marshal(ctx, tc.inputBOM)
-			} else {
-				// Fake function calculating the hash value
-				h := fnv.New64()
-				hasher := func(v any, _ hashstructure.Format, _ *hashstructure.HashOptions) (uint64, error) {
-					h.Reset()
-
-					var str string
-					switch vv := v.(type) {
-					case *core.Component:
-						str = vv.Name + vv.Version + vv.SrcFile
-						for _, f := range vv.Files {
-							str += f.Path
-						}
-					case spdx.OtherLicense:
-						str = vv.ExtractedText + vv.LicenseName
-					case string:
-						str = vv
-					default:
-						require.Failf(t, "unknown type", "%T", v)
-					}
-
-					if _, err := h.Write([]byte(str)); err != nil {
-						return 0, err
-					}
-
-					return h.Sum64(), nil
-				}
-				marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))
-				spdxDoc, err = marshaler.MarshalReport(ctx, tc.inputReport)
-			}
+			marshaler := tspdx.NewMarshaler("0.56.2", tspdx.WithHasher(hasher))
+			spdxDoc, err := marshaler.MarshalReport(ctx, tc.inputReport)
 			require.NoError(t, err)
 
 			assert.NoError(t, spdxlib.ValidateDocument(spdxDoc))
@@ -1562,7 +1600,6 @@ func TestMarshaler_Marshal(t *testing.T) {
 		})
 	}
 }
-
 
 func TestMarshaler_normalizeLicenses(t *testing.T) {
 	tests := []struct {

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1526,6 +1526,30 @@ func TestMarshaler_Marshal(t *testing.T) {
 	}
 }
 
+func TestMarshaler_Marshal_NoRoot(t *testing.T) {
+	// When the input BOM has no root component (e.g. an SPDX SBOM without a
+	// DESCRIBES relationship from SPDXRef-DOCUMENT), Marshal must not panic.
+	// Regression for https://github.com/aquasecurity/trivy/issues/10764
+	ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+
+	bom := core.NewBOM(core.Options{})
+	// Add a library component without marking it as root, so bom.Root() == nil.
+	bom.AddComponent(&core.Component{
+		Type: core.TypeLibrary,
+		Name: "openssl",
+	})
+
+	marshaler := tspdx.NewMarshaler("0.56.2")
+	doc, err := marshaler.Marshal(ctx, bom)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	// The document must not have a DESCRIBES relationship since there is no root.
+	for _, rel := range doc.Relationships {
+		assert.NotEqual(t, "DESCRIBES", rel.Relationship,
+			"unexpected DESCRIBES relationship when there is no root component")
+	}
+}
+
 func TestMarshaler_normalizeLicenses(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/sbom/spdx/marshal_test.go
+++ b/pkg/sbom/spdx/marshal_test.go
@@ -1527,10 +1527,12 @@ func TestMarshaler_Marshal(t *testing.T) {
 }
 
 func TestMarshaler_Marshal_NoRoot(t *testing.T) {
-	// When the input BOM has no root component (e.g. an SPDX SBOM without a
-	// DESCRIBES relationship from SPDXRef-DOCUMENT), Marshal must not panic.
 	// Regression for https://github.com/aquasecurity/trivy/issues/10764
+	// When the input BOM has no root component (e.g. an SPDX SBOM without a
+	// DESCRIBES relationship from SPDXRef-DOCUMENT), Marshal must not panic,
+	// must produce a valid SPDX document, and must not emit a DESCRIBES relationship.
 	ctx := clock.With(t.Context(), time.Date(2021, 8, 25, 12, 20, 30, 5, time.UTC))
+	uuid.SetFakeUUID(t, "3ff14136-e09f-4df9-80ea-%012d")
 
 	bom := core.NewBOM(core.Options{})
 	// Add a library component without marking it as root, so bom.Root() == nil.
@@ -1543,7 +1545,15 @@ func TestMarshaler_Marshal_NoRoot(t *testing.T) {
 	doc, err := marshaler.Marshal(ctx, bom)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
-	// The document must not have a DESCRIBES relationship since there is no root.
+
+	// DocumentName must not be empty — the SPDX spec forbids an empty name field.
+	assert.Equal(t, "unknown", doc.DocumentName,
+		"DocumentName must be 'unknown' when there is no root component")
+
+	// The document must be valid per the SPDX spec.
+	assert.NoError(t, spdxlib.ValidateDocument(doc))
+
+	// No DESCRIBES relationship should be emitted when there is no root.
 	for _, rel := range doc.Relationships {
 		assert.NotEqual(t, "DESCRIBES", rel.Relationship,
 			"unexpected DESCRIBES relationship when there is no root component")


### PR DESCRIPTION
Fixes #10764.

## Problem

When marshaling to SPDX format from a BOM that has no root component
(e.g. an SPDX SBOM without a `DESCRIBES` relationship from
`SPDXRef-DOCUMENT`, or a CycloneDX input without `metadata.component`),
the SPDX marshaler panics with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

`bom.Root()` returns `nil` in this case, but the code passes it
directly into `packageDownloadLocation`, `rootSPDXPackage`, `root.ID()`,
`root.Name`, and `getDocumentNamespace` without a nil check.

## Fix

The CycloneDX marshaler already handles this case gracefully:

```go
// pkg/sbom/cyclonedx/marshal.go
if root == nil {
    m.logger.Debug("Root component not found")
    return nil, nil
}
```

This PR applies the same pattern to the SPDX marshaler:

- Skip the root SPDX package and `DESCRIBES` relationship when `root` is nil.
- Fall back to `NONE` for `pkgDownloadLocation`.
- Use an empty string for `DocumentName`.
- Generate a UUID-based namespace (`http://trivy.dev/unknown/<uuid>`) for `DocumentNamespace`.

A regression test is added that creates a BOM without a root component
and verifies `Marshal` returns without error and without a `DESCRIBES`
relationship.