### PR TITLE
ci: bump GoReleaser to v2.16.0

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -106,7 +106,7 @@ jobs:
         id: goreleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
-          version: v2.1.0
+          version: v2.16.0
           args: release -f=${{ inputs.goreleaser_config}} ${{ inputs.goreleaser_options}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -256,7 +256,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
       with:
-        version: v2.1.0
+        version: v2.16.0
         args: build --snapshot --clean --timeout 90m ${{ steps.goreleaser_id.outputs.id }}
 
   # This job intentionally runs on all PRs (not scoped to .github/ path changes)

--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -25,7 +25,7 @@ builds:
 
 archives:
   -
-    format: tar.gz
+    formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}macOS
@@ -39,4 +39,4 @@ archives:
       - contrib/*.tpl
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -113,7 +113,7 @@ nfpms:
 
 archives:
   - id: archive
-    format: tar.gz
+    formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}macOS
@@ -135,7 +135,7 @@ archives:
       - contrib/*.tpl
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 
 dockers:
@@ -280,8 +280,6 @@ docker_manifests:
 
 signs:
 - cmd: cosign
-  env:
-  - COSIGN_EXPERIMENTAL=1
   signature: "${artifact}.sigstore.json"
   args:
     - "sign-blob"
@@ -293,8 +291,6 @@ signs:
 
 docker_signs:
 - cmd: cosign
-  env:
-  - COSIGN_EXPERIMENTAL=1
   artifacts: manifests
   output: true
   args:


### PR DESCRIPTION
## Description

GoReleaser was pinned at v2.1.0 (July 2024). goreleaser-action v7.1.0 added cosign verification of the GoReleaser binary, which expects `checksums.txt.sigstore.json` that v2.1.0 does not produce, resulting in a CI warning.

The goreleaser signature now verifies successfully:
```bash
Verifying checksums.txt signature with cosign (identity: https://github.com/goreleaser/goreleaser/.github/workflows/release.yml@refs/tags/v2.16.0)
/home/runner/.cosign/cosign verify-blob --certificate-identity https://github.com/goreleaser/goreleaser/.github/workflows/release.yml@refs/tags/v2.16.0 --certificate-oidc-issuer https://token.actions.githubusercontent.com/ --bundle /home/runner/work/_temp/3e412e2b-1639-4ce1-87c6-40fa3555467a /home/runner/work/_temp/4cf339a0-5c9c-4e73-b9a3-a30c53d85914
Verified OK
cosign signature verified
```

## Changes

- Bump GoReleaser: `v2.1.0` → `v2.16.0` (`reusable-release.yaml`, `test.yaml`)
- `archives.format` → `formats` (`goreleaser.yml`, `goreleaser-canary.yml`)
- Remove `COSIGN_EXPERIMENTAL=1` — not required since cosign v2 when Sigstore services became stable

## Testing

Test run: https://github.com/nikpivkin/trivy/actions/runs/26937025541/job/79469111186 (failed at the step of creating a discussion)
Release: https://github.com/nikpivkin/trivy/releases/tag/v0.110.0
Images: https://github.com/nikpivkin/trivy/pkgs/container/trivy

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
