### PR TITLE
docs: fix broken nixpkgs reference link in installation guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -161,7 +161,7 @@ Nix package manager for Linux and macOS.
 
 References: 
 
--  https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/trivy/default.nix
+-  https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/tr/trivy/package.nix
 
 ## FreeBSD (Official)
 


### PR DESCRIPTION
### Summary

The Nix/NixOS installation reference in `docs/getting-started/installation.md` links to:

`https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/trivy/default.nix`

which now returns **HTTP 404**, because nixpkgs migrated the package to the `by-name` layout. This updates the link to the current location:

`https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/tr/trivy/package.nix` (**HTTP 200**)

### Verification

| URL | Status |
| --- | --- |
| Old (`pkgs/tools/admin/trivy/default.nix`) | HTTP 404 |
| New (`pkgs/by-name/tr/trivy/package.nix`) | HTTP 200 |

Single-line, docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)