### PR TITLE
fix(image): deterministic OS package deduplication for images with embedded SBOMs

### DIFF
--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -3,6 +3,7 @@ package applier
 import (
 	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/dependency"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/purl"
@@ -240,6 +242,29 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 
 	// Filter OS packages with mismatched PURL namespace
 	mergedLayer.Packages = filterMismatchedOSPkgs(mergedLayer.OS.Family, mergedLayer.Packages)
+
+	// When an image embeds per-package SBOMs (e.g. Chainguard/Wolfi
+	// /var/lib/db/sbom/*.spdx.json), the same OS package is reported by both the
+	// OS package-DB analyzer (apk/dpkg/rpm), which derives the correct SrcName from
+	// the package origin, and the SBOM analyzer, which falls back to SrcName=Name
+	// when the embedded SBOM omits source info. These collide on the same dedup key,
+	// and lo.UniqBy below keeps a non-deterministic entry due to randomized map
+	// iteration upstream. Order SBOM-derived entries last so the OS package-DB
+	// analyzer's entry always wins, making the result deterministic and SrcName correct.
+	// cf. https://github.com/aquasecurity/trivy/discussions/10751
+	slices.SortStableFunc(mergedLayer.Packages, func(a, b ftypes.Package) int {
+		// A lower value is kept by lo.UniqBy below, so SBOM-derived entries are ordered last.
+		switch {
+		case a.AnalyzedBy == b.AnalyzedBy:
+			return 0
+		case a.AnalyzedBy == analyzer.TypeSBOM:
+			return 1
+		case b.AnalyzedBy == analyzer.TypeSBOM:
+			return -1
+		default:
+			return 0
+		}
+	})
 
 	// De-duplicate same debian packages from different dirs
 	// cf. https://github.com/aquasecurity/trivy/issues/8297

--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -243,17 +243,17 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 	// Filter OS packages with mismatched PURL namespace
 	mergedLayer.Packages = filterMismatchedOSPkgs(mergedLayer.OS.Family, mergedLayer.Packages)
 
-	// When an image embeds per-package SBOMs (e.g. Chainguard/Wolfi
-	// /var/lib/db/sbom/*.spdx.json), the same OS package is reported by both the
-	// OS package-DB analyzer (apk/dpkg/rpm), which derives the correct SrcName from
-	// the package origin, and the SBOM analyzer, which falls back to SrcName=Name
-	// when the embedded SBOM omits source info. These collide on the same dedup key,
-	// and lo.UniqBy below keeps a non-deterministic entry due to randomized map
-	// iteration upstream. Order SBOM-derived entries last so the OS package-DB
-	// analyzer's entry always wins, making the result deterministic and SrcName correct.
-	// cf. https://github.com/aquasecurity/trivy/discussions/10751
+	// If an image contains embedded per-package SBOMs (e.g. Chainguard/Wolfi
+	// /var/lib/db/sbom/*.spdx.json), both the OS package-DB analyzer (apk/dpkg/rpm) and
+	// the SBOM analyzer report the same OS package, colliding on the same dedup key.
+	// To get a deterministic result, we sort packages before the deduplication below,
+	// giving packages from the OS package managers priority, because:
+	//   1. SBOM-derived packages may carry less complete metadata (e.g. missing source
+	//      info, so SrcName falls back to Name).
+	//   2. package-manager DB files are standardized and hold authoritative package
+	//      info (e.g. source/origin from apk o: / dpkg Source: / rpm source RPM).
+	// cf. https://github.com/aquasecurity/trivy/issues/10778
 	slices.SortStableFunc(mergedLayer.Packages, func(a, b ftypes.Package) int {
-		// A lower value is kept by lo.UniqBy below, so SBOM-derived entries are ordered last.
 		switch {
 		case a.AnalyzedBy == b.AnalyzedBy:
 			return 0


### PR DESCRIPTION
## Description

When an image embeds per-package SBOMs (e.g. Chainguard/Wolfi `/var/lib/db/sbom/<name>-<version>.spdx.json`), the same OS package is reported by **two** analyzers running on the same layer:

- the **OS package-DB analyzer** (apk/dpkg/rpm), which derives the authoritative `SrcName` from the package origin (apk `o:` / dpkg `Source:` / RPM source RPM);
- the **SBOM analyzer**, which decodes the embedded SPDX. These SBOMs omit source info for the top-level component, so `SrcName` falls back to `Name`.

Both entries collide on the same dedup key in `applier.ApplyLayers`, and `lo.UniqBy` keeps the **first** occurrence. The slice order comes from `nested.Walk`, which iterates a Go map — so the surviving entry (and thus the whole package: `SrcName`, PURL qualifiers, `AnalyzedBy`, …) is **non-deterministic** across runs of the same image.

The most visible impact is `SrcName`: apk-based matchers (alpine/wolfi/chainguard) query the advisory DB by source/origin name, so when the SBOM entry wins, `SrcName` becomes the binary name (e.g. `libcrypto3` instead of `openssl`), the wrong DB bucket is queried, and the package's CVEs silently disappear — producing a day-over-day flap in reported vulnerabilities for the same image digest.

**Fix:** before the `lo.UniqBy` deduplication, stably order SBOM-analyzer-derived entries last, so the OS package-DB analyzer's entry always wins the collision. This makes the deduplicated result deterministic.

### Before / after

`cgr.dev/chainguard/python` (older digest with vulnerable `libcrypto3 3.x`, origin `openssl`), scanned repeatedly:

**Before** (winner varies):

| run | `libcrypto3` SrcName | os CVEs |
|----|----------------------|---------|
| most runs | `openssl` ✓ | 17 |
| occasional | `libcrypto3` ✗ | 0 |

**After** (deterministic across all runs):

| run | `libcrypto3` SrcName | os CVEs |
|----|----------------------|---------|
| all | `openssl` ✓ | 17 |

## Related issues
- Close #10778

## Related PRs
- [x] #9866 (earlier fix for the mismatched-namespace variant of this class)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
