### PR TITLE
feat(report): add invocation start/end times to SARIF output

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	containerName "github.com/google/go-containerregistry/pkg/name"
 	"github.com/owenrumney/go-sarif/v2/sarif"
@@ -48,6 +49,18 @@ type SarifWriter struct {
 	run           *sarif.Run
 	locationCache map[string][]location
 	Target        string
+
+	// Clock is an injectable time source used to populate SARIF invocation
+	// start/end timestamps. If nil, time.Now (UTC) is used. Tests may set
+	// Clock to a deterministic function.
+	Clock func() time.Time
+}
+
+func (sw *SarifWriter) now() time.Time {
+	if sw.Clock != nil {
+		return sw.Clock()
+	}
+	return time.Now().UTC()
 }
 
 type sarifData struct {
@@ -126,6 +139,8 @@ func pathToFileURI(path string) string {
 }
 
 func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
+	startTime := sw.now()
+
 	sarifReport, err := sarif.New(sarif.Version210)
 	if err != nil {
 		return xerrors.Errorf("error creating a new sarif template: %w", err)
@@ -268,6 +283,17 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			},
 		}
 	}
+
+	// Record invocation start/end times so downstream tools (e.g., GitHub Code
+	// Scanning) can deduplicate and timestamp findings. See SARIF 2.1.0 §3.20.
+	endTime := sw.now()
+	sw.run.Invocations = append(sw.run.Invocations,
+		sarif.NewInvocation().
+			WithStartTimeUTC(startTime).
+			WithEndTimeUTC(endTime).
+			WithExecutionSuccess(true),
+	)
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -746,6 +746,21 @@ func TestReportWriter_Sarif(t *testing.T) {
 			result := &sarif.Report{}
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
 			require.NoError(t, err)
+
+			// Each run must record exactly one invocation with both start and end
+			// times set, end >= start, and execution marked successful. Strip the
+			// invocations after asserting them so the rest of the report can be
+			// compared by deep equality against the per-test `want` fixture.
+			for _, run := range result.Runs {
+				require.Len(t, run.Invocations, 1)
+				inv := run.Invocations[0]
+				require.NotNil(t, inv.StartTimeUTC, "startTimeUtc should be set")
+				require.NotNil(t, inv.EndTimeUTC, "endTimeUtc should be set")
+				assert.False(t, inv.EndTimeUTC.Before(*inv.StartTimeUTC), "endTimeUtc should be >= startTimeUtc")
+				require.NotNil(t, inv.ExecutionSuccessful, "executionSuccessful should be set")
+				assert.True(t, *inv.ExecutionSuccessful)
+				run.Invocations = nil
+			}
 			assert.Equal(t, tt.want, result)
 		})
 	}


### PR DESCRIPTION
## Description

Adds `invocations[0].startTimeUtc` and `invocations[0].endTimeUtc` (plus `executionSuccessful: true`) to every SARIF run produced by Trivy, per SARIF 2.1.0 §3.20.

Closes #3226. This revives the work from #8255 by @anupamme, which stalled on a CLA paperwork issue in January 2025 and has not progressed since; the original author is credited as a co-author on the commit.

## Why

Downstream consumers of SARIF (GitHub Code Scanning, DefectDojo, etc.) use the invocation timestamps to deduplicate findings across scans and correlate them with CI pipelines. Without them, every scan appears as a "fresh" set of findings.

## Implementation notes

- `SarifWriter` gains an optional `Clock func() time.Time` field for deterministic testing. Production code falls back to `time.Now().UTC()`.
- `startTime` is captured at the top of `Write`; `endTime` is captured right before `sarifReport.AddRun`. An invocation is then appended to `sw.run.Invocations` using the `go-sarif/v2` builder API (`WithStartTimeUTC`, `WithEndTimeUTC`, `WithExecutionSuccess`).
- Existing test fixtures (`want`) are intentionally NOT modified. The test runner now strips `Invocations` after asserting their structure separately, so each fixture continues to deep-equal the rest of the SARIF report. This avoids 6 large mechanical edits to fixtures and keeps the time assertion at the level it actually matters: "both timestamps exist, end >= start, execution successful."

## Before and after

`./trivy fs --format sarif ...` on `main`:

```json
"runs": [
  {
    "tool": { ... },
    "results": [ ... ],
    "columnKind": "utf16CodeUnits"
  }
]
```

Same command with this change:

```json
"runs": [
  {
    "tool": { ... },
    "results": [ ... ],
    "columnKind": "utf16CodeUnits",
    "invocations": [
      {
        "startTimeUtc": "2026-06-03T06:18:41.143425786Z",
        "endTimeUtc": "2026-06-03T06:18:41.143430476Z",
        "executionSuccessful": true
      }
    ]
  }
]
```

## Tests

- `go test ./pkg/report/...` passes locally.
- Tests assert that each run has exactly one invocation with both timestamps set, `endTimeUtc >= startTimeUtc`, and `executionSuccessful: true`.
- `golangci-lint run ./pkg/report/...` clean (0 issues).