### PR TITLE
refactor(misconf): propagate metadata through terraform Value chain

### DIFF
--- a/pkg/iac/adapters/terraform/aws/accessanalyzer/accessanalyzer.go
+++ b/pkg/iac/adapters/terraform/aws/accessanalyzer/accessanalyzer.go
@@ -24,17 +24,10 @@ func adaptTrails(modules terraform.Modules) []accessanalyzer.Analyzer {
 }
 
 func adaptAnalyzers(resource *terraform.Block) accessanalyzer.Analyzer {
-
-	analyzerName := resource.GetAttribute("analyzer_name")
-	analyzerNameAttr := analyzerName.AsStringValueOrDefault("", resource)
-
-	arnAnalyzer := resource.GetAttribute("arn")
-	arnAnalyzerAttr := arnAnalyzer.AsStringValueOrDefault("", resource)
-
 	return accessanalyzer.Analyzer{
 		Metadata: resource.GetMetadata(),
-		Name:     analyzerNameAttr,
-		ARN:      arnAnalyzerAttr,
+		Name:     resource.GetAttribute("analyzer_name").AsStringValue(),
+		ARN:      resource.GetAttribute("arn").AsStringValue(),
 		Active:   types.BoolDefault(false, resource.GetMetadata()),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/apigateway/apiv1.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/apiv1.go
@@ -23,9 +23,9 @@ func adaptAPIMethodsV1(modules terraform.Modules, resourceBlock *terraform.Block
 	for _, methodBlock := range modules.GetReferencingResources(resourceBlock, "aws_api_gateway_method", "resource_id") {
 		method := v1.Method{
 			Metadata:          methodBlock.GetMetadata(),
-			HTTPMethod:        methodBlock.GetAttribute("http_method").AsStringValueOrDefault("", methodBlock),
-			AuthorizationType: methodBlock.GetAttribute("authorization").AsStringValueOrDefault("", methodBlock),
-			APIKeyRequired:    methodBlock.GetAttribute("api_key_required").AsBoolValueOrDefault(false, methodBlock),
+			HTTPMethod:        methodBlock.GetAttribute("http_method").AsStringValue(),
+			AuthorizationType: methodBlock.GetAttribute("authorization").AsStringValue(),
+			APIKeyRequired:    methodBlock.GetAttribute("api_key_required").AsBoolValue(),
 		}
 		methods = append(methods, method)
 	}
@@ -40,7 +40,7 @@ func adaptAPIsV1(modules terraform.Modules) []v1.API {
 	for _, apiBlock := range modules.GetResourcesByType("aws_api_gateway_rest_api") {
 		api := v1.API{
 			Metadata:  apiBlock.GetMetadata(),
-			Name:      apiBlock.GetAttribute("name").AsStringValueOrDefault("", apiBlock),
+			Name:      apiBlock.GetAttribute("name").AsStringValue(),
 			Stages:    nil,
 			Resources: adaptAPIResourcesV1(modules, apiBlock),
 		}
@@ -74,12 +74,12 @@ func adaptAPIsV1(modules terraform.Modules) []v1.API {
 func adaptStageV1(stageBlock *terraform.Block, modules terraform.Modules) v1.Stage {
 	stage := v1.Stage{
 		Metadata: stageBlock.GetMetadata(),
-		Name:     stageBlock.GetAttribute("name").AsStringValueOrDefault("", stageBlock),
+		Name:     stageBlock.GetAttribute("name").AsStringValue(),
 		AccessLogging: v1.AccessLogging{
 			Metadata:              stageBlock.GetMetadata(),
 			CloudwatchLogGroupARN: iacTypes.StringDefault("", stageBlock.GetMetadata()),
 		},
-		XRayTracingEnabled: stageBlock.GetAttribute("xray_tracing_enabled").AsBoolValueOrDefault(false, stageBlock),
+		XRayTracingEnabled: stageBlock.GetAttribute("xray_tracing_enabled").AsBoolValue(),
 	}
 	for _, methodSettings := range modules.GetReferencingResources(stageBlock, "aws_api_gateway_method_settings", "stage_name") {
 
@@ -92,20 +92,20 @@ func adaptStageV1(stageBlock *terraform.Block, modules terraform.Modules) v1.Sta
 
 		if settings := methodSettings.GetBlock("settings"); settings.IsNotNil() {
 			if encrypted := settings.GetAttribute("cache_data_encrypted"); encrypted.IsNotNil() {
-				restMethodSettings.CacheDataEncrypted = settings.GetAttribute("cache_data_encrypted").AsBoolValueOrDefault(false, settings)
+				restMethodSettings.CacheDataEncrypted = settings.GetAttribute("cache_data_encrypted").AsBoolValue()
 			}
 			if encrypted := settings.GetAttribute("caching_enabled"); encrypted.IsNotNil() {
-				restMethodSettings.CacheEnabled = settings.GetAttribute("caching_enabled").AsBoolValueOrDefault(false, settings)
+				restMethodSettings.CacheEnabled = settings.GetAttribute("caching_enabled").AsBoolValue()
 			}
 		}
 
 		stage.RESTMethodSettings = append(stage.RESTMethodSettings, restMethodSettings)
 	}
 
-	stage.Name = stageBlock.GetAttribute("stage_name").AsStringValueOrDefault("", stageBlock)
+	stage.Name = stageBlock.GetAttribute("stage_name").AsStringValue()
 	if accessLogging := stageBlock.GetBlock("access_log_settings"); accessLogging.IsNotNil() {
 		stage.AccessLogging.Metadata = accessLogging.GetMetadata()
-		stage.AccessLogging.CloudwatchLogGroupARN = accessLogging.GetAttribute("destination_arn").AsStringValueOrDefault("", accessLogging)
+		stage.AccessLogging.CloudwatchLogGroupARN = accessLogging.GetAttribute("destination_arn").AsStringValue()
 	} else {
 		stage.AccessLogging.Metadata = stageBlock.GetMetadata()
 		stage.AccessLogging.CloudwatchLogGroupARN = iacTypes.StringDefault("", stageBlock.GetMetadata())

--- a/pkg/iac/adapters/terraform/aws/apigateway/apiv2.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/apiv2.go
@@ -15,8 +15,8 @@ func adaptAPIsV2(modules terraform.Modules) []v2.API {
 		for _, apiBlock := range module.GetResourcesByType("aws_apigatewayv2_api") {
 			api := v2.API{
 				Metadata:     apiBlock.GetMetadata(),
-				Name:         apiBlock.GetAttribute("name").AsStringValueOrDefault("", apiBlock),
-				ProtocolType: apiBlock.GetAttribute("protocol_type").AsStringValueOrDefault("", apiBlock),
+				Name:         apiBlock.GetAttribute("name").AsStringValue(),
+				ProtocolType: apiBlock.GetAttribute("protocol_type").AsStringValue(),
 				Stages:       nil,
 			}
 
@@ -52,7 +52,7 @@ func adaptAPIsV2(modules terraform.Modules) []v2.API {
 func adaptStageV2(stageBlock *terraform.Block) v2.Stage {
 	stage := v2.Stage{
 		Metadata: stageBlock.GetMetadata(),
-		Name:     stageBlock.GetAttribute("name").AsStringValueOrDefault("", stageBlock),
+		Name:     stageBlock.GetAttribute("name").AsStringValue(),
 		AccessLogging: v2.AccessLogging{
 			Metadata:              stageBlock.GetMetadata(),
 			CloudwatchLogGroupARN: iacTypes.StringDefault("", stageBlock.GetMetadata()),
@@ -60,7 +60,7 @@ func adaptStageV2(stageBlock *terraform.Block) v2.Stage {
 	}
 	if accessLogging := stageBlock.GetBlock("access_log_settings"); accessLogging.IsNotNil() {
 		stage.AccessLogging.Metadata = accessLogging.GetMetadata()
-		stage.AccessLogging.CloudwatchLogGroupARN = accessLogging.GetAttribute("destination_arn").AsStringValueOrDefault("", accessLogging)
+		stage.AccessLogging.CloudwatchLogGroupARN = accessLogging.GetAttribute("destination_arn").AsStringValue()
 	} else {
 		stage.AccessLogging.Metadata = stageBlock.GetMetadata()
 		stage.AccessLogging.CloudwatchLogGroupARN = iacTypes.StringDefault("", stageBlock.GetMetadata())

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv1.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv1.go
@@ -13,8 +13,8 @@ func adaptDomainNamesV1(modules terraform.Modules) []v1.DomainName {
 		for _, nameBlock := range module.GetResourcesByType("aws_api_gateway_domain_name") {
 			domainName := v1.DomainName{
 				Metadata:       nameBlock.GetMetadata(),
-				Name:           nameBlock.GetAttribute("domain_name").AsStringValueOrDefault("", nameBlock),
-				SecurityPolicy: nameBlock.GetAttribute("security_policy").AsStringValueOrDefault("TLS_1_0", nameBlock),
+				Name:           nameBlock.GetAttribute("domain_name").AsStringValue(),
+				SecurityPolicy: nameBlock.GetAttribute("security_policy").AsStringValue("TLS_1_0"),
 			}
 			domainNames = append(domainNames, domainName)
 		}

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv2.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv2.go
@@ -14,11 +14,11 @@ func adaptDomainNamesV2(modules terraform.Modules) []v2.DomainName {
 		for _, nameBlock := range module.GetResourcesByType("aws_apigatewayv2_domain_name") {
 			domainName := v2.DomainName{
 				Metadata:       nameBlock.GetMetadata(),
-				Name:           nameBlock.GetAttribute("domain_name").AsStringValueOrDefault("", nameBlock),
+				Name:           nameBlock.GetAttribute("domain_name").AsStringValue(),
 				SecurityPolicy: types.StringDefault("TLS_1_0", nameBlock.GetMetadata()),
 			}
 			if config := nameBlock.GetBlock("domain_name_configuration"); config.IsNotNil() {
-				domainName.SecurityPolicy = config.GetAttribute("security_policy").AsStringValueOrDefault("TLS_1_0", config)
+				domainName.SecurityPolicy = config.GetAttribute("security_policy").AsStringValue("TLS_1_0")
 			}
 			domainNames = append(domainNames, domainName)
 		}

--- a/pkg/iac/adapters/terraform/aws/athena/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/athena/adapt.go
@@ -36,7 +36,7 @@ func adaptWorkgroups(modules terraform.Modules) []athena.Workgroup {
 func adaptDatabase(resource *terraform.Block) athena.Database {
 	database := athena.Database{
 		Metadata: resource.GetMetadata(),
-		Name:     resource.GetAttribute("name").AsStringValueOrDefault("", resource),
+		Name:     resource.GetAttribute("name").AsStringValue(),
 		Encryption: athena.EncryptionConfiguration{
 			Metadata: resource.GetMetadata(),
 			Type:     iacTypes.StringDefault("", resource.GetMetadata()),
@@ -45,7 +45,7 @@ func adaptDatabase(resource *terraform.Block) athena.Database {
 	if encryptionConfigBlock := resource.GetBlock("encryption_configuration"); encryptionConfigBlock.IsNotNil() {
 		database.Encryption.Metadata = encryptionConfigBlock.GetMetadata()
 		encryptionOptionAttr := encryptionConfigBlock.GetAttribute("encryption_option")
-		database.Encryption.Type = encryptionOptionAttr.AsStringValueOrDefault("", encryptionConfigBlock)
+		database.Encryption.Type = encryptionOptionAttr.AsStringValue()
 	}
 
 	return database
@@ -54,7 +54,7 @@ func adaptDatabase(resource *terraform.Block) athena.Database {
 func adaptWorkgroup(resource *terraform.Block) athena.Workgroup {
 	workgroup := athena.Workgroup{
 		Metadata: resource.GetMetadata(),
-		Name:     resource.GetAttribute("name").AsStringValueOrDefault("", resource),
+		Name:     resource.GetAttribute("name").AsStringValue(),
 		Encryption: athena.EncryptionConfiguration{
 			Metadata: resource.GetMetadata(),
 			Type:     iacTypes.StringDefault("", resource.GetMetadata()),
@@ -65,13 +65,13 @@ func adaptWorkgroup(resource *terraform.Block) athena.Workgroup {
 	if configBlock := resource.GetBlock("configuration"); configBlock.IsNotNil() {
 
 		enforceWGConfigAttr := configBlock.GetAttribute("enforce_workgroup_configuration")
-		workgroup.EnforceConfiguration = enforceWGConfigAttr.AsBoolValueOrDefault(true, configBlock)
+		workgroup.EnforceConfiguration = enforceWGConfigAttr.AsBoolValue(true)
 
 		if resultConfigBlock := configBlock.GetBlock("result_configuration"); configBlock.IsNotNil() {
 			if encryptionConfigBlock := resultConfigBlock.GetBlock("encryption_configuration"); encryptionConfigBlock.IsNotNil() {
 				encryptionOptionAttr := encryptionConfigBlock.GetAttribute("encryption_option")
 				workgroup.Encryption.Metadata = encryptionConfigBlock.GetMetadata()
-				workgroup.Encryption.Type = encryptionOptionAttr.AsStringValueOrDefault("", encryptionConfigBlock)
+				workgroup.Encryption.Type = encryptionOptionAttr.AsStringValue()
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
@@ -42,24 +42,24 @@ func adaptDistribution(resource *terraform.Block) cloudfront.Distribution {
 		},
 	}
 
-	distribution.WAFID = resource.GetAttribute("web_acl_id").AsStringValueOrDefault("", resource)
+	distribution.WAFID = resource.GetAttribute("web_acl_id").AsStringValue()
 
 	if loggingBlock := resource.GetBlock("logging_config"); loggingBlock.IsNotNil() {
 		distribution.Logging.Metadata = loggingBlock.GetMetadata()
 		bucketAttr := loggingBlock.GetAttribute("bucket")
-		distribution.Logging.Bucket = bucketAttr.AsStringValueOrDefault("", loggingBlock)
+		distribution.Logging.Bucket = bucketAttr.AsStringValue()
 	}
 
 	if defaultCacheBlock := resource.GetBlock("default_cache_behavior"); defaultCacheBlock.IsNotNil() {
 		distribution.DefaultCacheBehaviour.Metadata = defaultCacheBlock.GetMetadata()
 		viewerProtocolPolicyAttr := defaultCacheBlock.GetAttribute("viewer_protocol_policy")
-		distribution.DefaultCacheBehaviour.ViewerProtocolPolicy = viewerProtocolPolicyAttr.AsStringValueOrDefault("", defaultCacheBlock)
+		distribution.DefaultCacheBehaviour.ViewerProtocolPolicy = viewerProtocolPolicyAttr.AsStringValue()
 	}
 
 	orderedCacheBlocks := resource.GetBlocks("ordered_cache_behavior")
 	for _, orderedCacheBlock := range orderedCacheBlocks {
 		viewerProtocolPolicyAttr := orderedCacheBlock.GetAttribute("viewer_protocol_policy")
-		viewerProtocolPolicyVal := viewerProtocolPolicyAttr.AsStringValueOrDefault("", orderedCacheBlock)
+		viewerProtocolPolicyVal := viewerProtocolPolicyAttr.AsStringValue()
 		distribution.OrdererCacheBehaviours = append(distribution.OrdererCacheBehaviours, cloudfront.CacheBehaviour{
 			Metadata:             orderedCacheBlock.GetMetadata(),
 			ViewerProtocolPolicy: viewerProtocolPolicyVal,
@@ -69,9 +69,9 @@ func adaptDistribution(resource *terraform.Block) cloudfront.Distribution {
 	if viewerCertBlock := resource.GetBlock("viewer_certificate"); viewerCertBlock.IsNotNil() {
 		distribution.ViewerCertificate = cloudfront.ViewerCertificate{
 			Metadata:                     viewerCertBlock.GetMetadata(),
-			MinimumProtocolVersion:       viewerCertBlock.GetAttribute("minimum_protocol_version").AsStringValueOrDefault("TLSv1", viewerCertBlock),
-			SSLSupportMethod:             viewerCertBlock.GetAttribute("ssl_support_method").AsStringValueOrDefault("", viewerCertBlock),
-			CloudfrontDefaultCertificate: viewerCertBlock.GetAttribute("cloudfront_default_certificate").AsBoolValueOrDefault(false, viewerCertBlock),
+			MinimumProtocolVersion:       viewerCertBlock.GetAttribute("minimum_protocol_version").AsStringValue("TLSv1"),
+			SSLSupportMethod:             viewerCertBlock.GetAttribute("ssl_support_method").AsStringValue(),
+			CloudfrontDefaultCertificate: viewerCertBlock.GetAttribute("cloudfront_default_certificate").AsBoolValue(),
 		}
 	}
 

--- a/pkg/iac/adapters/terraform/aws/cloudtrail/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudtrail/adapt.go
@@ -24,16 +24,16 @@ func adaptTrails(modules terraform.Modules) []cloudtrail.Trail {
 
 func adaptTrail(resource *terraform.Block) cloudtrail.Trail {
 	nameAttr := resource.GetAttribute("name")
-	nameVal := nameAttr.AsStringValueOrDefault("", resource)
+	nameVal := nameAttr.AsStringValue()
 
 	enableLogFileValidationAttr := resource.GetAttribute("enable_log_file_validation")
-	enableLogFileValidationVal := enableLogFileValidationAttr.AsBoolValueOrDefault(false, resource)
+	enableLogFileValidationVal := enableLogFileValidationAttr.AsBoolValue()
 
 	isMultiRegionAttr := resource.GetAttribute("is_multi_region_trail")
-	isMultiRegionVal := isMultiRegionAttr.AsBoolValueOrDefault(false, resource)
+	isMultiRegionVal := isMultiRegionAttr.AsBoolValue()
 
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	KMSKeyIDVal := KMSKeyIDAttr.AsStringValueOrDefault("", resource)
+	KMSKeyIDVal := KMSKeyIDAttr.AsStringValue()
 
 	var selectors []cloudtrail.EventSelector
 	for _, selBlock := range resource.GetBlocks("event_selector") {
@@ -41,14 +41,14 @@ func adaptTrail(resource *terraform.Block) cloudtrail.Trail {
 		for _, resBlock := range selBlock.GetBlocks("data_resource") {
 			resources = append(resources, cloudtrail.DataResource{
 				Metadata: resBlock.GetMetadata(),
-				Type:     resBlock.GetAttribute("type").AsStringValueOrDefault("", resBlock),
+				Type:     resBlock.GetAttribute("type").AsStringValue(),
 				Values:   resBlock.GetAttribute("values").AsStringValues(),
 			})
 		}
 		selector := cloudtrail.EventSelector{
 			Metadata:      selBlock.GetMetadata(),
 			DataResources: resources,
-			ReadWriteType: selBlock.GetAttribute("read_write_type").AsStringValueOrDefault("All", selBlock),
+			ReadWriteType: selBlock.GetAttribute("read_write_type").AsStringValue("All"),
 		}
 		selectors = append(selectors, selector)
 	}
@@ -59,9 +59,9 @@ func adaptTrail(resource *terraform.Block) cloudtrail.Trail {
 		EnableLogFileValidation:   enableLogFileValidationVal,
 		IsMultiRegion:             isMultiRegionVal,
 		KMSKeyID:                  KMSKeyIDVal,
-		CloudWatchLogsLogGroupArn: resource.GetAttribute("cloud_watch_logs_group_arn").AsStringValueOrDefault("", resource),
-		IsLogging:                 resource.GetAttribute("enable_logging").AsBoolValueOrDefault(true, resource),
-		BucketName:                resource.GetAttribute("s3_bucket_name").AsStringValueOrDefault("", resource),
+		CloudWatchLogsLogGroupArn: resource.GetAttribute("cloud_watch_logs_group_arn").AsStringValue(),
+		IsLogging:                 resource.GetAttribute("enable_logging").AsBoolValue(true),
+		BucketName:                resource.GetAttribute("s3_bucket_name").AsStringValue(),
 		EventSelectors:            selectors,
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/cloudwatch/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudwatch/adapt.go
@@ -24,17 +24,17 @@ func adaptLogGroups(modules terraform.Modules) []cloudwatch.LogGroup {
 
 func adaptLogGroup(resource *terraform.Block, module *terraform.Module) cloudwatch.LogGroup {
 	nameAttr := resource.GetAttribute("name")
-	nameVal := nameAttr.AsStringValueOrDefault("", resource)
+	nameVal := nameAttr.AsStringValue()
 
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	KMSKeyIDVal := KMSKeyIDAttr.AsStringValueOrDefault("", resource)
+	KMSKeyIDVal := KMSKeyIDAttr.AsStringValue()
 
 	if keyBlock, err := module.GetReferencedBlock(KMSKeyIDAttr, resource); err == nil {
 		KMSKeyIDVal = types.String(keyBlock.FullName(), keyBlock.GetMetadata())
 	}
 
 	retentionInDaysAttr := resource.GetAttribute("retention_in_days")
-	retentionInDaysVal := retentionInDaysAttr.AsIntValueOrDefault(0, resource)
+	retentionInDaysVal := retentionInDaysAttr.AsIntValue()
 
 	return cloudwatch.LogGroup{
 		Metadata:        resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/config/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/config/adapt.go
@@ -25,7 +25,7 @@ func adaptConfigurationAggregrator(modules terraform.Modules) config.Configurati
 			configurationAggregrator.SourceAllRegions = iacTypes.Bool(false, resource.GetMetadata())
 		} else {
 			allRegionsAttr := aggregationBlock.GetAttribute("all_regions")
-			allRegionsVal := allRegionsAttr.AsBoolValueOrDefault(false, aggregationBlock)
+			allRegionsVal := allRegionsAttr.AsBoolValue()
 			configurationAggregrator.SourceAllRegions = allRegionsVal
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/documentdb/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/documentdb/adapt.go
@@ -24,7 +24,7 @@ func adaptClusters(modules terraform.Modules) []documentdb.Cluster {
 
 func adaptCluster(resource *terraform.Block, module *terraform.Module) documentdb.Cluster {
 	identifierAttr := resource.GetAttribute("cluster_identifier")
-	identifierVal := identifierAttr.AsStringValueOrDefault("", resource)
+	identifierVal := identifierAttr.AsStringValue()
 
 	var enabledLogExports []types.StringValue
 	var instances []documentdb.Instance
@@ -37,7 +37,7 @@ func adaptCluster(resource *terraform.Block, module *terraform.Module) documentd
 	instancesRes := module.GetReferencingResources(resource, "aws_docdb_cluster_instance", "cluster_identifier")
 	for _, instanceRes := range instancesRes {
 		keyIDAttr := instanceRes.GetAttribute("kms_key_id")
-		keyIDVal := keyIDAttr.AsStringValueOrDefault("", instanceRes)
+		keyIDVal := keyIDAttr.AsStringValue()
 
 		instances = append(instances, documentdb.Instance{
 			Metadata: instanceRes.GetMetadata(),
@@ -46,16 +46,16 @@ func adaptCluster(resource *terraform.Block, module *terraform.Module) documentd
 	}
 
 	storageEncryptedAttr := resource.GetAttribute("storage_encrypted")
-	storageEncryptedVal := storageEncryptedAttr.AsBoolValueOrDefault(false, resource)
+	storageEncryptedVal := storageEncryptedAttr.AsBoolValue()
 
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	KMSKeyIDVal := KMSKeyIDAttr.AsStringValueOrDefault("", resource)
+	KMSKeyIDVal := KMSKeyIDAttr.AsStringValue()
 
 	return documentdb.Cluster{
 		Metadata:              resource.GetMetadata(),
 		Identifier:            identifierVal,
 		EnabledLogExports:     enabledLogExports,
-		BackupRetentionPeriod: resource.GetAttribute("backup_retention_period").AsIntValueOrDefault(0, resource),
+		BackupRetentionPeriod: resource.GetAttribute("backup_retention_period").AsIntValue(),
 		Instances:             instances,
 		StorageEncrypted:      storageEncryptedVal,
 		KMSKeyID:              KMSKeyIDVal,

--- a/pkg/iac/adapters/terraform/aws/dynamodb/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/dynamodb/adapt.go
@@ -48,12 +48,12 @@ func adaptCluster(resource *terraform.Block, _ *terraform.Module) dynamodb.DAXCl
 	if ssEncryptionBlock := resource.GetBlock("server_side_encryption"); ssEncryptionBlock.IsNotNil() {
 		cluster.ServerSideEncryption.Metadata = ssEncryptionBlock.GetMetadata()
 		enabledAttr := ssEncryptionBlock.GetAttribute("enabled")
-		cluster.ServerSideEncryption.Enabled = enabledAttr.AsBoolValueOrDefault(false, ssEncryptionBlock)
+		cluster.ServerSideEncryption.Enabled = enabledAttr.AsBoolValue()
 	}
 
 	if recoveryBlock := resource.GetBlock("point_in_time_recovery"); recoveryBlock.IsNotNil() {
 		recoveryEnabledAttr := recoveryBlock.GetAttribute("enabled")
-		cluster.PointInTimeRecovery = recoveryEnabledAttr.AsBoolValueOrDefault(false, recoveryBlock)
+		cluster.PointInTimeRecovery = recoveryEnabledAttr.AsBoolValue()
 	}
 
 	return cluster
@@ -74,10 +74,10 @@ func adaptTable(resource *terraform.Block, module *terraform.Module) dynamodb.Ta
 	if ssEncryptionBlock := resource.GetBlock("server_side_encryption"); ssEncryptionBlock.IsNotNil() {
 		table.ServerSideEncryption.Metadata = ssEncryptionBlock.GetMetadata()
 		enabledAttr := ssEncryptionBlock.GetAttribute("enabled")
-		table.ServerSideEncryption.Enabled = enabledAttr.AsBoolValueOrDefault(false, ssEncryptionBlock)
+		table.ServerSideEncryption.Enabled = enabledAttr.AsBoolValue()
 
 		kmsKeyIdAttr := ssEncryptionBlock.GetAttribute("kms_key_arn")
-		table.ServerSideEncryption.KMSKeyID = kmsKeyIdAttr.AsStringValueOrDefault(dynamodb.DefaultKMSKeyID, ssEncryptionBlock)
+		table.ServerSideEncryption.KMSKeyID = kmsKeyIdAttr.AsStringValue(dynamodb.DefaultKMSKeyID)
 
 		kmsBlock, err := module.GetReferencedBlock(kmsKeyIdAttr, resource)
 		if err == nil && kmsBlock.IsNotNil() {
@@ -87,7 +87,7 @@ func adaptTable(resource *terraform.Block, module *terraform.Module) dynamodb.Ta
 
 	if recoveryBlock := resource.GetBlock("point_in_time_recovery"); recoveryBlock.IsNotNil() {
 		recoveryEnabledAttr := recoveryBlock.GetAttribute("enabled")
-		table.PointInTimeRecovery = recoveryEnabledAttr.AsBoolValueOrDefault(false, recoveryBlock)
+		table.PointInTimeRecovery = recoveryEnabledAttr.AsBoolValue()
 	}
 
 	return table

--- a/pkg/iac/adapters/terraform/aws/ec2/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/adapt.go
@@ -33,7 +33,7 @@ func getInstances(modules terraform.Modules) []ec2.Instance {
 		instance := ec2.Instance{
 			Metadata:        b.GetMetadata(),
 			MetadataOptions: getMetadataOptions(b),
-			UserData:        b.GetAttribute("user_data").AsStringValueOrDefault("", b),
+			UserData:        b.GetAttribute("user_data").AsStringValue(),
 		}
 
 		if launchTemplate := findRelatedLaunchTemplate(modules, b); launchTemplate != nil {
@@ -50,14 +50,14 @@ func getInstances(modules terraform.Modules) []ec2.Instance {
 		if rootBlockDevice := b.GetBlock("root_block_device"); rootBlockDevice.IsNotNil() {
 			instance.RootBlockDevice = &ec2.BlockDevice{
 				Metadata:  rootBlockDevice.GetMetadata(),
-				Encrypted: rootBlockDevice.GetAttribute("encrypted").AsBoolValueOrDefault(false, b),
+				Encrypted: rootBlockDevice.GetAttribute("encrypted").AsBoolValue(),
 			}
 		}
 
 		for _, ebsBlock := range b.GetBlocks("ebs_block_device") {
 			instance.EBSBlockDevices = append(instance.EBSBlockDevices, &ec2.BlockDevice{
 				Metadata:  ebsBlock.GetMetadata(),
-				Encrypted: ebsBlock.GetAttribute("encrypted").AsBoolValueOrDefault(false, b),
+				Encrypted: ebsBlock.GetAttribute("encrypted").AsBoolValue(),
 			})
 		}
 
@@ -91,7 +91,7 @@ func findRelatedLaunchTemplate(modules terraform.Modules, instanceBlock *terrafo
 
 	if templateRef.IsString() {
 		for _, r := range modules.GetResourcesByType("aws_launch_template") {
-			templateName := r.GetAttribute("name").AsStringValueOrDefault("", r).Value()
+			templateName := r.GetAttribute("name").AsStringValue().Value()
 			if templateRef.Equals(r.ID()) || templateRef.Equals(templateName) {
 				launchTemplate := adaptLaunchTemplate(r)
 				return &launchTemplate

--- a/pkg/iac/adapters/terraform/aws/ec2/autoscaling.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/autoscaling.go
@@ -25,7 +25,7 @@ func adaptLaunchTemplate(b *terraform.Block) ec2.LaunchTemplate {
 		Instance: ec2.Instance{
 			Metadata:        b.GetMetadata(),
 			MetadataOptions: getMetadataOptions(b),
-			UserData:        b.GetAttribute("user_data").AsStringValueOrDefault("", b),
+			UserData:        b.GetAttribute("user_data").AsStringValue(),
 		},
 	}
 }
@@ -55,7 +55,7 @@ func adaptLaunchConfiguration(resource *terraform.Block) ec2.LaunchConfiguration
 	launchConfig := ec2.LaunchConfiguration{
 		Metadata:          resource.GetMetadata(),
 		Name:              iacTypes.StringDefault("", resource.GetMetadata()),
-		AssociatePublicIP: resource.GetAttribute("associate_public_ip_address").AsBoolValueOrDefault(false, resource),
+		AssociatePublicIP: resource.GetAttribute("associate_public_ip_address").AsBoolValue(),
 		RootBlockDevice: &ec2.BlockDevice{
 			Metadata:  resource.GetMetadata(),
 			Encrypted: iacTypes.BoolDefault(false, resource.GetMetadata()),
@@ -68,19 +68,19 @@ func adaptLaunchConfiguration(resource *terraform.Block) ec2.LaunchConfiguration
 	//#nosec G101 -- False positive
 	if resource.TypeLabel() == "aws_launch_configuration" {
 		nameAttr := resource.GetAttribute("name")
-		launchConfig.Name = nameAttr.AsStringValueOrDefault("", resource)
+		launchConfig.Name = nameAttr.AsStringValue()
 	}
 
 	if rootBlockDeviceBlock := resource.GetBlock("root_block_device"); rootBlockDeviceBlock.IsNotNil() {
 		encryptedAttr := rootBlockDeviceBlock.GetAttribute("encrypted")
-		launchConfig.RootBlockDevice.Encrypted = encryptedAttr.AsBoolValueOrDefault(false, rootBlockDeviceBlock)
+		launchConfig.RootBlockDevice.Encrypted = encryptedAttr.AsBoolValue()
 		launchConfig.RootBlockDevice.Metadata = rootBlockDeviceBlock.GetMetadata()
 	}
 
 	EBSBlockDevicesBlocks := resource.GetBlocks("ebs_block_device")
 	for _, EBSBlockDevicesBlock := range EBSBlockDevicesBlocks {
 		encryptedAttr := EBSBlockDevicesBlock.GetAttribute("encrypted")
-		encryptedVal := encryptedAttr.AsBoolValueOrDefault(false, EBSBlockDevicesBlock)
+		encryptedVal := encryptedAttr.AsBoolValue()
 		launchConfig.EBSBlockDevices = append(launchConfig.EBSBlockDevices, &ec2.BlockDevice{
 			Metadata:  EBSBlockDevicesBlock.GetMetadata(),
 			Encrypted: encryptedVal,
@@ -88,7 +88,7 @@ func adaptLaunchConfiguration(resource *terraform.Block) ec2.LaunchConfiguration
 	}
 
 	if userDataAttr := resource.GetAttribute("user_data"); userDataAttr.IsNotNil() {
-		launchConfig.UserData = userDataAttr.AsStringValueOrDefault("", resource)
+		launchConfig.UserData = userDataAttr.AsStringValue()
 	} else if userDataBase64Attr := resource.GetAttribute("user_data_base64"); userDataBase64Attr.IsString() {
 		encoded, err := base64.StdEncoding.DecodeString(userDataBase64Attr.Value().AsString())
 		if err == nil {
@@ -108,8 +108,8 @@ func getMetadataOptions(b *terraform.Block) ec2.MetadataOptions {
 
 	if metadataOptions := b.GetBlock("metadata_options"); metadataOptions.IsNotNil() {
 		options.Metadata = metadataOptions.GetMetadata()
-		options.HttpTokens = metadataOptions.GetAttribute("http_tokens").AsStringValueOrDefault("", metadataOptions)
-		options.HttpEndpoint = metadataOptions.GetAttribute("http_endpoint").AsStringValueOrDefault("", metadataOptions)
+		options.HttpTokens = metadataOptions.GetAttribute("http_tokens").AsStringValue()
+		options.HttpEndpoint = metadataOptions.GetAttribute("http_endpoint").AsStringValue()
 	}
 
 	return options

--- a/pkg/iac/adapters/terraform/aws/ec2/subnet.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/subnet.go
@@ -17,7 +17,7 @@ func adaptSubnets(modules terraform.Modules) []ec2.Subnet {
 
 func adaptSubnet(resource *terraform.Block) ec2.Subnet {
 	mapPublicIpOnLaunchAttr := resource.GetAttribute("map_public_ip_on_launch")
-	mapPublicIpOnLaunchVal := mapPublicIpOnLaunchAttr.AsBoolValueOrDefault(false, resource)
+	mapPublicIpOnLaunchVal := mapPublicIpOnLaunchAttr.AsBoolValue()
 
 	return ec2.Subnet{
 		Metadata:            resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/ec2/volume.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/volume.go
@@ -18,10 +18,10 @@ func adaptVolumes(modules terraform.Modules) []ec2.Volume {
 
 func adaptVolume(resource *terraform.Block, module *terraform.Module) ec2.Volume {
 	encryptedAttr := resource.GetAttribute("encrypted")
-	encryptedVal := encryptedAttr.AsBoolValueOrDefault(false, resource)
+	encryptedVal := encryptedAttr.AsBoolValue()
 
 	kmsKeyAttr := resource.GetAttribute("kms_key_id")
-	kmsKeyVal := kmsKeyAttr.AsStringValueOrDefault("", resource)
+	kmsKeyVal := kmsKeyAttr.AsStringValue()
 
 	if kmsKeyAttr.IsResourceBlockReference("aws_kms_key") {
 		if kmsKeyBlock, err := module.GetReferencedBlock(kmsKeyAttr, resource); err == nil {

--- a/pkg/iac/adapters/terraform/aws/ec2/vpc.go
+++ b/pkg/iac/adapters/terraform/aws/ec2/vpc.go
@@ -123,7 +123,7 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 	var egressRules []ec2.SecurityGroupRule
 
 	descriptionAttr := resource.GetAttribute("description")
-	descriptionVal := descriptionAttr.AsStringValueOrDefault("Managed by Terraform", resource)
+	descriptionVal := descriptionAttr.AsStringValue("Managed by Terraform")
 
 	ingressBlocks := resource.GetBlocks("ingress")
 	for _, ingressBlock := range ingressBlocks {
@@ -161,13 +161,13 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 		IngressRules: ingressRules,
 		EgressRules:  egressRules,
 		IsDefault:    iacTypes.Bool(false, iacTypes.NewUnmanagedMetadata()),
-		VPCID:        resource.GetAttribute("vpc_id").AsStringValueOrDefault("", resource),
+		VPCID:        resource.GetAttribute("vpc_id").AsStringValue(),
 	}
 }
 
 func adaptSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
 	ruleDescAttr := resource.GetAttribute("description")
-	ruleDescVal := ruleDescAttr.AsStringValueOrDefault("", resource)
+	ruleDescVal := ruleDescAttr.AsStringValue()
 
 	var cidrs []iacTypes.StringValue
 
@@ -183,7 +183,7 @@ func adaptSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
 	}
 
 	protocolAddr := resource.GetAttribute("protocol")
-	protocol := protocolAddr.AsStringValueOrDefault("", resource)
+	protocol := protocolAddr.AsStringValue()
 	if protocolAddr.IsNumber() {
 		protocol = iacTypes.String(strconv.Itoa(int(protocolAddr.AsNumber())), protocolAddr.GetMetadata())
 	}
@@ -192,30 +192,30 @@ func adaptSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
 		Metadata:    resource.GetMetadata(),
 		Description: ruleDescVal,
 		CIDRs:       cidrs,
-		FromPort:    resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
-		ToPort:      resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
+		FromPort:    resource.GetAttribute("from_port").AsIntValue(-1),
+		ToPort:      resource.GetAttribute("to_port").AsIntValue(-1),
 		Protocol:    protocol,
 	}
 }
 
 func adaptSingleSGRule(resource *terraform.Block) ec2.SecurityGroupRule {
-	description := resource.GetAttribute("description").AsStringValueOrDefault("", resource)
+	description := resource.GetAttribute("description").AsStringValue()
 
 	var cidrs []iacTypes.StringValue
 	if ipv4 := resource.GetAttribute("cidr_ipv4"); ipv4.IsNotNil() {
-		cidrs = append(cidrs, ipv4.AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, ipv4.AsStringValue())
 	}
 	if ipv6 := resource.GetAttribute("cidr_ipv6"); ipv6.IsNotNil() {
-		cidrs = append(cidrs, ipv6.AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, ipv6.AsStringValue())
 	}
 
 	return ec2.SecurityGroupRule{
 		Metadata:    resource.GetMetadata(),
 		Description: description,
 		CIDRs:       cidrs,
-		FromPort:    resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
-		ToPort:      resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
-		Protocol:    resource.GetAttribute("ip_protocol").AsStringValueOrDefault("", resource),
+		FromPort:    resource.GetAttribute("from_port").AsIntValue(-1),
+		ToPort:      resource.GetAttribute("to_port").AsIntValue(-1),
+		Protocol:    resource.GetAttribute("ip_protocol").AsStringValue(),
 	}
 }
 
@@ -246,18 +246,18 @@ func adaptNetworkACLRule(resource *terraform.Block) ec2.NetworkACLRule {
 	}
 
 	actionAttr := resource.GetAttribute("rule_action")
-	actionVal := actionAttr.AsStringValueOrDefault("", resource)
+	actionVal := actionAttr.AsStringValue()
 
 	protocolAtrr := resource.GetAttribute("protocol")
-	protocolVal := protocolAtrr.AsStringValueOrDefault("", resource)
+	protocolVal := protocolAtrr.AsStringValue()
 
 	cidrAttr := resource.GetAttribute("cidr_block")
 	if cidrAttr.IsNotNil() {
-		cidrs = append(cidrs, cidrAttr.AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, cidrAttr.AsStringValue())
 	}
 	ipv4cidrAttr := resource.GetAttribute("ipv6_cidr_block")
 	if ipv4cidrAttr.IsNotNil() {
-		cidrs = append(cidrs, ipv4cidrAttr.AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, ipv4cidrAttr.AsStringValue())
 	}
 
 	return ec2.NetworkACLRule{
@@ -266,7 +266,7 @@ func adaptNetworkACLRule(resource *terraform.Block) ec2.NetworkACLRule {
 		Action:   actionVal,
 		Protocol: protocolVal,
 		CIDRs:    cidrs,
-		FromPort: resource.GetAttribute("from_port").AsIntValueOrDefault(-1, resource),
-		ToPort:   resource.GetAttribute("to_port").AsIntValueOrDefault(-1, resource),
+		FromPort: resource.GetAttribute("from_port").AsIntValue(-1),
+		ToPort:   resource.GetAttribute("to_port").AsIntValue(-1),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/ecr/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ecr/adapt.go
@@ -44,7 +44,7 @@ func adaptRepository(resource *terraform.Block, module *terraform.Module, module
 	if imageScanningBlock := resource.GetBlock("image_scanning_configuration"); imageScanningBlock.IsNotNil() {
 		repo.ImageScanning.Metadata = imageScanningBlock.GetMetadata()
 		scanOnPushAttr := imageScanningBlock.GetAttribute("scan_on_push")
-		repo.ImageScanning.ScanOnPush = scanOnPushAttr.AsBoolValueOrDefault(false, imageScanningBlock)
+		repo.ImageScanning.ScanOnPush = scanOnPushAttr.AsBoolValue()
 	}
 
 	mutabilityAttr := resource.GetAttribute("image_tag_mutability")
@@ -98,10 +98,10 @@ func adaptRepository(resource *terraform.Block, module *terraform.Module, module
 	if encryptBlock := resource.GetBlock("encryption_configuration"); encryptBlock.IsNotNil() {
 		repo.Encryption.Metadata = encryptBlock.GetMetadata()
 		encryptionTypeAttr := encryptBlock.GetAttribute("encryption_type")
-		repo.Encryption.Type = encryptionTypeAttr.AsStringValueOrDefault("AES256", encryptBlock)
+		repo.Encryption.Type = encryptionTypeAttr.AsStringValue("AES256")
 
 		kmsKeyAttr := encryptBlock.GetAttribute("kms_key")
-		repo.Encryption.KMSKeyID = kmsKeyAttr.AsStringValueOrDefault("", encryptBlock)
+		repo.Encryption.KMSKeyID = kmsKeyAttr.AsStringValue()
 		if kmsKeyAttr.IsResourceBlockReference("aws_kms_key") {
 			if keyBlock, err := module.GetReferencedBlock(kmsKeyAttr, encryptBlock); err == nil {
 				repo.Encryption.KMSKeyID = iacTypes.String(keyBlock.FullName(), keyBlock.GetMetadata())

--- a/pkg/iac/adapters/terraform/aws/efs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/efs/adapt.go
@@ -23,7 +23,7 @@ func adaptFileSystems(modules terraform.Modules) []efs.FileSystem {
 
 func adaptFileSystem(resource *terraform.Block) efs.FileSystem {
 	encryptedAttr := resource.GetAttribute("encrypted")
-	encryptedVal := encryptedAttr.AsBoolValueOrDefault(false, resource)
+	encryptedVal := encryptedAttr.AsBoolValue()
 
 	return efs.FileSystem{
 		Metadata:  resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/eks/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/eks/adapt.go
@@ -69,13 +69,13 @@ func adaptCluster(resource *terraform.Block) eks.Cluster {
 		}
 		if providerBlock := encryptBlock.GetBlock("provider"); providerBlock.IsNotNil() {
 			keyArnAttr := providerBlock.GetAttribute("key_arn")
-			cluster.Encryption.KMSKeyID = keyArnAttr.AsStringValueOrDefault("", providerBlock)
+			cluster.Encryption.KMSKeyID = keyArnAttr.AsStringValue()
 		}
 	}
 
 	if vpcBlock := resource.GetBlock("vpc_config"); vpcBlock.IsNotNil() {
 		publicAccessAttr := vpcBlock.GetAttribute("endpoint_public_access")
-		cluster.PublicAccessEnabled = publicAccessAttr.AsBoolValueOrDefault(true, vpcBlock)
+		cluster.PublicAccessEnabled = publicAccessAttr.AsBoolValue(true)
 
 		publicAccessCidrsAttr := vpcBlock.GetAttribute("public_access_cidrs")
 		cidrList := publicAccessCidrsAttr.AsStringValues()

--- a/pkg/iac/adapters/terraform/aws/elasticache/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/elasticache/adapt.go
@@ -44,13 +44,13 @@ func adaptSecurityGroups(modules terraform.Modules) []elasticache.SecurityGroup 
 
 func adaptCluster(resource *terraform.Block) elasticache.Cluster {
 	engineAttr := resource.GetAttribute("engine")
-	engineVal := engineAttr.AsStringValueOrDefault("", resource)
+	engineVal := engineAttr.AsStringValue()
 
 	nodeTypeAttr := resource.GetAttribute("node_type")
-	nodeTypeVal := nodeTypeAttr.AsStringValueOrDefault("", resource)
+	nodeTypeVal := nodeTypeAttr.AsStringValue()
 
 	snapshotRetentionAttr := resource.GetAttribute("snapshot_retention_limit")
-	snapshotRetentionVal := snapshotRetentionAttr.AsIntValueOrDefault(0, resource)
+	snapshotRetentionVal := snapshotRetentionAttr.AsIntValue()
 
 	return elasticache.Cluster{
 		Metadata:               resource.GetMetadata(),
@@ -62,10 +62,10 @@ func adaptCluster(resource *terraform.Block) elasticache.Cluster {
 
 func adaptReplicationGroup(resource *terraform.Block) elasticache.ReplicationGroup {
 	transitEncryptionAttr := resource.GetAttribute("transit_encryption_enabled")
-	transitEncryptionVal := transitEncryptionAttr.AsBoolValueOrDefault(false, resource)
+	transitEncryptionVal := transitEncryptionAttr.AsBoolValue()
 
 	atRestEncryptionAttr := resource.GetAttribute("at_rest_encryption_enabled")
-	atRestEncryptionVal := atRestEncryptionAttr.AsBoolValueOrDefault(false, resource)
+	atRestEncryptionVal := atRestEncryptionAttr.AsBoolValue()
 
 	return elasticache.ReplicationGroup{
 		Metadata:                 resource.GetMetadata(),
@@ -76,7 +76,7 @@ func adaptReplicationGroup(resource *terraform.Block) elasticache.ReplicationGro
 
 func adaptSecurityGroup(resource *terraform.Block) elasticache.SecurityGroup {
 	descriptionAttr := resource.GetAttribute("description")
-	descriptionVal := descriptionAttr.AsStringValueOrDefault("Managed by Terraform", resource)
+	descriptionVal := descriptionAttr.AsStringValue("Managed by Terraform")
 
 	return elasticache.SecurityGroup{
 		Metadata:    resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/elasticsearch/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/elasticsearch/adapt.go
@@ -26,8 +26,8 @@ func adaptDomain(resource *terraform.Block) elasticsearch.Domain {
 	domain := elasticsearch.Domain{
 		Metadata:               resource.GetMetadata(),
 		DomainName:             iacTypes.StringDefault("", resource.GetMetadata()),
-		AccessPolicies:         resource.GetAttribute("access_policies").AsStringValueOrDefault("", resource),
-		VpcId:                  resource.GetAttribute("vpc_options.0.vpc_id").AsStringValueOrDefault("", resource),
+		AccessPolicies:         resource.GetAttribute("access_policies").AsStringValue(),
+		VpcId:                  resource.GetAttribute("vpc_options.0.vpc_id").AsStringValue(),
 		DedicatedMasterEnabled: iacTypes.Bool(false, resource.GetMetadata()),
 		LogPublishing: elasticsearch.LogPublishing{
 			Metadata:              resource.GetMetadata(),
@@ -58,13 +58,13 @@ func adaptDomain(resource *terraform.Block) elasticsearch.Domain {
 	}
 
 	nameAttr := resource.GetAttribute("domain_name")
-	domain.DomainName = nameAttr.AsStringValueOrDefault("", resource)
+	domain.DomainName = nameAttr.AsStringValue()
 
 	for _, logOptionsBlock := range resource.GetBlocks("log_publishing_options") {
 		domain.LogPublishing.Metadata = logOptionsBlock.GetMetadata()
-		domain.LogPublishing.CloudWatchLogGroupArn = logOptionsBlock.GetAttribute("cloudwatch_log_group_arn").AsStringValueOrDefault("", resource)
+		domain.LogPublishing.CloudWatchLogGroupArn = logOptionsBlock.GetAttribute("cloudwatch_log_group_arn").AsStringValue()
 		enabledAttr := logOptionsBlock.GetAttribute("enabled")
-		enabledVal := enabledAttr.AsBoolValueOrDefault(true, logOptionsBlock)
+		enabledVal := enabledAttr.AsBoolValue(true)
 		logTypeAttr := logOptionsBlock.GetAttribute("log_type")
 		if logTypeAttr.Equals("AUDIT_LOGS") {
 			domain.LogPublishing.AuditEnabled = enabledVal
@@ -74,26 +74,26 @@ func adaptDomain(resource *terraform.Block) elasticsearch.Domain {
 	if transitEncryptBlock := resource.GetBlock("node_to_node_encryption"); transitEncryptBlock.IsNotNil() {
 		enabledAttr := transitEncryptBlock.GetAttribute("enabled")
 		domain.TransitEncryption.Metadata = transitEncryptBlock.GetMetadata()
-		domain.TransitEncryption.Enabled = enabledAttr.AsBoolValueOrDefault(false, transitEncryptBlock)
+		domain.TransitEncryption.Enabled = enabledAttr.AsBoolValue()
 	}
 
 	if clusterconfigBlock := resource.GetBlock("cluster_config"); clusterconfigBlock.IsNotNil() {
-		domain.DedicatedMasterEnabled = clusterconfigBlock.GetAttribute("dedicated_master_enabled").AsBoolValueOrDefault(false, clusterconfigBlock)
+		domain.DedicatedMasterEnabled = clusterconfigBlock.GetAttribute("dedicated_master_enabled").AsBoolValue()
 	}
 
 	if atRestEncryptBlock := resource.GetBlock("encrypt_at_rest"); atRestEncryptBlock.IsNotNil() {
 		enabledAttr := atRestEncryptBlock.GetAttribute("enabled")
 		domain.AtRestEncryption.Metadata = atRestEncryptBlock.GetMetadata()
-		domain.AtRestEncryption.Enabled = enabledAttr.AsBoolValueOrDefault(false, atRestEncryptBlock)
-		domain.AtRestEncryption.KmsKeyId = atRestEncryptBlock.GetAttribute("kms_key_id").AsStringValueOrDefault("", resource)
+		domain.AtRestEncryption.Enabled = enabledAttr.AsBoolValue()
+		domain.AtRestEncryption.KmsKeyId = atRestEncryptBlock.GetAttribute("kms_key_id").AsStringValue()
 	}
 
 	if endpointBlock := resource.GetBlock("domain_endpoint_options"); endpointBlock.IsNotNil() {
 		domain.Endpoint.Metadata = endpointBlock.GetMetadata()
 		enforceHTTPSAttr := endpointBlock.GetAttribute("enforce_https")
-		domain.Endpoint.EnforceHTTPS = enforceHTTPSAttr.AsBoolValueOrDefault(true, endpointBlock)
+		domain.Endpoint.EnforceHTTPS = enforceHTTPSAttr.AsBoolValue(true)
 		TLSPolicyAttr := endpointBlock.GetAttribute("tls_security_policy")
-		domain.Endpoint.TLSPolicy = TLSPolicyAttr.AsStringValueOrDefault("", endpointBlock)
+		domain.Endpoint.TLSPolicy = TLSPolicyAttr.AsStringValue()
 	}
 
 	return domain

--- a/pkg/iac/adapters/terraform/aws/elb/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/elb/adapt.go
@@ -55,13 +55,13 @@ func (a *adapter) adaptLoadBalancer(resource *terraform.Block, module terraform.
 	var listeners []elb.Listener
 
 	typeAttr := resource.GetAttribute("load_balancer_type")
-	typeVal := typeAttr.AsStringValueOrDefault("application", resource)
+	typeVal := typeAttr.AsStringValue("application")
 
 	dropInvalidHeadersAttr := resource.GetAttribute("drop_invalid_header_fields")
-	dropInvalidHeadersVal := dropInvalidHeadersAttr.AsBoolValueOrDefault(false, resource)
+	dropInvalidHeadersVal := dropInvalidHeadersAttr.AsBoolValue()
 
 	internalAttr := resource.GetAttribute("internal")
-	internalVal := internalAttr.AsBoolValueOrDefault(false, resource)
+	internalVal := internalAttr.AsBoolValue()
 
 	listenerBlocks := module.GetReferencingResources(resource, "aws_lb_listener", "load_balancer_arn")
 	listenerBlocks = append(listenerBlocks, module.GetReferencingResources(resource, "aws_alb_listener", "load_balancer_arn")...)
@@ -81,7 +81,7 @@ func (a *adapter) adaptLoadBalancer(resource *terraform.Block, module terraform.
 
 func (a *adapter) adaptClassicLoadBalancer(resource *terraform.Block, _ terraform.Modules) elb.LoadBalancer {
 	internalAttr := resource.GetAttribute("internal")
-	internalVal := internalAttr.AsBoolValueOrDefault(false, resource)
+	internalVal := internalAttr.AsBoolValue()
 
 	return elb.LoadBalancer{
 		Metadata:                resource.GetMetadata(),
@@ -102,16 +102,16 @@ func adaptListener(listenerBlock *terraform.Block, typeVal string) elb.Listener 
 
 	protocolAttr := listenerBlock.GetAttribute("protocol")
 	if typeVal == "application" {
-		listener.Protocol = protocolAttr.AsStringValueOrDefault("HTTP", listenerBlock)
+		listener.Protocol = protocolAttr.AsStringValue("HTTP")
 	}
 
 	sslPolicyAttr := listenerBlock.GetAttribute("ssl_policy")
-	listener.TLSPolicy = sslPolicyAttr.AsStringValueOrDefault("", listenerBlock)
+	listener.TLSPolicy = sslPolicyAttr.AsStringValue()
 
 	for _, defaultActionBlock := range listenerBlock.GetBlocks("default_action") {
 		action := elb.Action{
 			Metadata: defaultActionBlock.GetMetadata(),
-			Type:     defaultActionBlock.GetAttribute("type").AsStringValueOrDefault("", defaultActionBlock),
+			Type:     defaultActionBlock.GetAttribute("type").AsStringValue(),
 		}
 		listener.DefaultActions = append(listener.DefaultActions, action)
 	}

--- a/pkg/iac/adapters/terraform/aws/emr/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/emr/adapt.go
@@ -42,8 +42,8 @@ func adaptSecurityConfiguration(resource *terraform.Block) emr.SecurityConfigura
 
 	return emr.SecurityConfiguration{
 		Metadata:      resource.GetMetadata(),
-		Name:          resource.GetAttribute("name").AsStringValueOrDefault("", resource),
-		Configuration: resource.GetAttribute("configuration").AsStringValueOrDefault("", resource),
+		Name:          resource.GetAttribute("name").AsStringValue(),
+		Configuration: resource.GetAttribute("configuration").AsStringValue(),
 	}
 
 }

--- a/pkg/iac/adapters/terraform/aws/iam/groups.go
+++ b/pkg/iac/adapters/terraform/aws/iam/groups.go
@@ -11,7 +11,7 @@ func adaptGroups(modules terraform.Modules) []iam.Group {
 	for _, groupBlock := range modules.GetResourcesByType("aws_iam_group") {
 		group := iam.Group{
 			Metadata: groupBlock.GetMetadata(),
-			Name:     groupBlock.GetAttribute("name").AsStringValueOrDefault("", groupBlock),
+			Name:     groupBlock.GetAttribute("name").AsStringValue(),
 		}
 
 		if policy, ok := applyForDependentResource(

--- a/pkg/iac/adapters/terraform/aws/iam/policies.go
+++ b/pkg/iac/adapters/terraform/aws/iam/policies.go
@@ -13,7 +13,7 @@ func parsePolicy(policyBlock *terraform.Block, modules terraform.Modules) (iam.P
 	nameAttr := policyBlock.GetAttribute("name")
 	policy := iam.Policy{
 		Metadata: policyBlock.GetMetadata(),
-		Name:     nameAttr.AsStringValueOrDefault("", policyBlock),
+		Name:     nameAttr.AsStringValue(),
 		Document: iam.Document{
 			Metadata: iacTypes.NewUnmanagedMetadata(),
 			Parsed:   iamgo.Document{},
@@ -95,7 +95,7 @@ func applyForDependentResource[T any](
 }
 
 func isDependentBlock(refBlock *terraform.Block, refAttrName string, relatedAttr *terraform.Attribute) bool {
-	refAttr := refBlock.GetAttribute(refAttrName).AsStringValueOrDefault("", refBlock).Value()
+	refAttr := refBlock.GetAttribute(refAttrName).AsStringValue().Value()
 	return relatedAttr.Equals(refBlock.ID()) || relatedAttr.Equals(refAttr) || relatedAttr.ReferencesBlock(refBlock)
 }
 

--- a/pkg/iac/adapters/terraform/aws/iam/roles.go
+++ b/pkg/iac/adapters/terraform/aws/iam/roles.go
@@ -10,7 +10,7 @@ func adaptRoles(modules terraform.Modules) []iam.Role {
 	for _, roleBlock := range modules.GetResourcesByType("aws_iam_role") {
 		role := iam.Role{
 			Metadata: roleBlock.GetMetadata(),
-			Name:     roleBlock.GetAttribute("name").AsStringValueOrDefault("", roleBlock),
+			Name:     roleBlock.GetAttribute("name").AsStringValue(),
 		}
 
 		if inlineBlock := roleBlock.GetBlock("inline_policy"); inlineBlock.IsNotNil() {

--- a/pkg/iac/adapters/terraform/aws/iam/users.go
+++ b/pkg/iac/adapters/terraform/aws/iam/users.go
@@ -12,7 +12,7 @@ func adaptUsers(modules terraform.Modules) []iam.User {
 	for _, userBlock := range modules.GetResourcesByType("aws_iam_user") {
 		user := iam.User{
 			Metadata:   userBlock.GetMetadata(),
-			Name:       userBlock.GetAttribute("name").AsStringValueOrDefault("", userBlock),
+			Name:       userBlock.GetAttribute("name").AsStringValue(),
 			LastAccess: iacTypes.TimeUnresolvable(userBlock.GetMetadata()),
 		}
 

--- a/pkg/iac/adapters/terraform/aws/kinesis/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/kinesis/adapt.go
@@ -34,8 +34,8 @@ func adaptStream(resource *terraform.Block) kinesis.Stream {
 	}
 
 	encryptionTypeAttr := resource.GetAttribute("encryption_type")
-	stream.Encryption.Type = encryptionTypeAttr.AsStringValueOrDefault("NONE", resource)
+	stream.Encryption.Type = encryptionTypeAttr.AsStringValue("NONE")
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	stream.Encryption.KMSKeyID = KMSKeyIDAttr.AsStringValueOrDefault("", resource)
+	stream.Encryption.KMSKeyID = KMSKeyIDAttr.AsStringValue()
 	return stream
 }

--- a/pkg/iac/adapters/terraform/aws/kms/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/kms/adapt.go
@@ -23,10 +23,10 @@ func adaptKeys(modules terraform.Modules) []kms.Key {
 
 func adaptKey(resource *terraform.Block) kms.Key {
 	usageAttr := resource.GetAttribute("key_usage")
-	usageVal := usageAttr.AsStringValueOrDefault("ENCRYPT_DECRYPT", resource)
+	usageVal := usageAttr.AsStringValue("ENCRYPT_DECRYPT")
 
 	enableKeyRotationAttr := resource.GetAttribute("enable_key_rotation")
-	enableKeyRotationVal := enableKeyRotationAttr.AsBoolValueOrDefault(false, resource)
+	enableKeyRotationVal := enableKeyRotationAttr.AsBoolValue()
 
 	return kms.Key{
 		Metadata:        resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/aws/lambda/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/lambda/adapt.go
@@ -72,7 +72,7 @@ func (a *adapter) adaptTracing(function *terraform.Block) lambda.Tracing {
 	if tracingConfig := function.GetBlock("tracing_config"); tracingConfig.IsNotNil() {
 		return lambda.Tracing{
 			Metadata: tracingConfig.GetMetadata(),
-			Mode:     tracingConfig.GetAttribute("mode").AsStringValueOrDefault("", tracingConfig),
+			Mode:     tracingConfig.GetAttribute("mode").AsStringValue(),
 		}
 	}
 
@@ -84,7 +84,7 @@ func (a *adapter) adaptTracing(function *terraform.Block) lambda.Tracing {
 
 func (a *adapter) adaptPermission(permission *terraform.Block) lambda.Permission {
 	sourceARNAttr := permission.GetAttribute("source_arn")
-	sourceARN := sourceARNAttr.AsStringValueOrDefault("", permission)
+	sourceARN := sourceARNAttr.AsStringValue()
 
 	if refs := sourceARNAttr.AllReferences(); len(refs) > 0 {
 		sourceARN = iacTypes.String(refs[0].NameLabel(), sourceARNAttr.GetMetadata())
@@ -92,7 +92,7 @@ func (a *adapter) adaptPermission(permission *terraform.Block) lambda.Permission
 
 	return lambda.Permission{
 		Metadata:  permission.GetMetadata(),
-		Principal: permission.GetAttribute("principal").AsStringValueOrDefault("", permission),
+		Principal: permission.GetAttribute("principal").AsStringValue(),
 		SourceARN: sourceARN,
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/mq/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/mq/adapt.go
@@ -35,13 +35,13 @@ func adaptBroker(resource *terraform.Block) mq.Broker {
 	}
 
 	publicAccessAttr := resource.GetAttribute("publicly_accessible")
-	broker.PublicAccess = publicAccessAttr.AsBoolValueOrDefault(false, resource)
+	broker.PublicAccess = publicAccessAttr.AsBoolValue()
 	if logsBlock := resource.GetBlock("logs"); logsBlock.IsNotNil() {
 		broker.Logging.Metadata = logsBlock.GetMetadata()
 		auditAttr := logsBlock.GetAttribute("audit")
-		broker.Logging.Audit = auditAttr.AsBoolValueOrDefault(false, logsBlock)
+		broker.Logging.Audit = auditAttr.AsBoolValue()
 		generalAttr := logsBlock.GetAttribute("general")
-		broker.Logging.General = generalAttr.AsBoolValueOrDefault(false, logsBlock)
+		broker.Logging.General = generalAttr.AsBoolValue()
 	}
 
 	return broker

--- a/pkg/iac/adapters/terraform/aws/msk/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/msk/adapt.go
@@ -58,13 +58,13 @@ func adaptCluster(resource *terraform.Block) msk.Cluster {
 		if encryptionInTransitBlock := encryptBlock.GetBlock("encryption_in_transit"); encryptionInTransitBlock.IsNotNil() {
 			cluster.EncryptionInTransit.Metadata = encryptionInTransitBlock.GetMetadata()
 			if clientBrokerAttr := encryptionInTransitBlock.GetAttribute("client_broker"); clientBrokerAttr.IsNotNil() {
-				cluster.EncryptionInTransit.ClientBroker = clientBrokerAttr.AsStringValueOrDefault("TLS", encryptionInTransitBlock)
+				cluster.EncryptionInTransit.ClientBroker = clientBrokerAttr.AsStringValue("TLS")
 			}
 		}
 
 		if encryptionAtRestAttr := encryptBlock.GetAttribute("encryption_at_rest_kms_key_arn"); encryptionAtRestAttr.IsNotNil() {
 			cluster.EncryptionAtRest.Metadata = encryptionAtRestAttr.GetMetadata()
-			cluster.EncryptionAtRest.KMSKeyARN = encryptionAtRestAttr.AsStringValueOrDefault("", encryptBlock)
+			cluster.EncryptionAtRest.KMSKeyARN = encryptionAtRestAttr.AsStringValue()
 			cluster.EncryptionAtRest.Enabled = iacTypes.Bool(true, encryptionAtRestAttr.GetMetadata())
 		}
 	}
@@ -76,17 +76,17 @@ func adaptCluster(resource *terraform.Block) msk.Cluster {
 			if s3Block := brokerLogsBlock.GetBlock("s3"); s3Block.IsNotNil() {
 				s3enabledAttr := s3Block.GetAttribute("enabled")
 				cluster.Logging.Broker.S3.Metadata = s3Block.GetMetadata()
-				cluster.Logging.Broker.S3.Enabled = s3enabledAttr.AsBoolValueOrDefault(false, s3Block)
+				cluster.Logging.Broker.S3.Enabled = s3enabledAttr.AsBoolValue()
 			}
 			if cloudwatchBlock := brokerLogsBlock.GetBlock("cloudwatch_logs"); cloudwatchBlock.IsNotNil() {
 				cwEnabledAttr := cloudwatchBlock.GetAttribute("enabled")
 				cluster.Logging.Broker.Cloudwatch.Metadata = cloudwatchBlock.GetMetadata()
-				cluster.Logging.Broker.Cloudwatch.Enabled = cwEnabledAttr.AsBoolValueOrDefault(false, cloudwatchBlock)
+				cluster.Logging.Broker.Cloudwatch.Enabled = cwEnabledAttr.AsBoolValue()
 			}
 			if firehoseBlock := brokerLogsBlock.GetBlock("firehose"); firehoseBlock.IsNotNil() {
 				firehoseEnabledAttr := firehoseBlock.GetAttribute("enabled")
 				cluster.Logging.Broker.Firehose.Metadata = firehoseBlock.GetMetadata()
-				cluster.Logging.Broker.Firehose.Enabled = firehoseEnabledAttr.AsBoolValueOrDefault(false, firehoseBlock)
+				cluster.Logging.Broker.Firehose.Enabled = firehoseEnabledAttr.AsBoolValue()
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/aws/neptune/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/neptune/adapt.go
@@ -41,10 +41,10 @@ func adaptCluster(resource *terraform.Block) neptune.Cluster {
 	}
 
 	storageEncryptedAttr := resource.GetAttribute("storage_encrypted")
-	cluster.StorageEncrypted = storageEncryptedAttr.AsBoolValueOrDefault(false, resource)
+	cluster.StorageEncrypted = storageEncryptedAttr.AsBoolValue()
 
 	KMSKeyAttr := resource.GetAttribute("kms_key_arn")
-	cluster.KMSKeyID = KMSKeyAttr.AsStringValueOrDefault("", resource)
+	cluster.KMSKeyID = KMSKeyAttr.AsStringValue()
 
 	return cluster
 }

--- a/pkg/iac/adapters/terraform/aws/provider/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/provider/adapt.go
@@ -137,11 +137,7 @@ func adaptEndpoints(p *terraform.Block) types.MapValue {
 }
 
 func adaptDefaultTags(p *terraform.Block) aws.DefaultTags {
-	attr, _ := p.GetNestedAttribute("default_tags.tags")
-	if attr.IsNil() {
-		return aws.DefaultTags{}
-	}
-
+	attr := p.GetNestedAttribute("default_tags.tags")
 	return aws.DefaultTags{
 		Metadata: attr.GetMetadata(),
 		Tags:     attr.AsMapValue(),

--- a/pkg/iac/adapters/terraform/aws/provider/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/provider/adapt.go
@@ -45,24 +45,24 @@ func adaptProvider(b *terraform.Block) aws.TerraformProvider {
 		ForbiddenAccountIDs:            b.GetAttribute("forbidden_account_ids").AsStringValueSliceOrEmpty(),
 		HttpProxy:                      getStringAttrValue("http_proxy", b),
 		IgnoreTags:                     adaptIgnoreTags(b),
-		Insecure:                       b.GetAttribute("insecure").AsBoolValueOrDefault(false, b),
-		MaxRetries:                     b.GetAttribute("max_retries").AsIntValueOrDefault(defaultMaxRetires, b),
+		Insecure:                       b.GetAttribute("insecure").AsBoolValue(),
+		MaxRetries:                     b.GetAttribute("max_retries").AsIntValue(defaultMaxRetires),
 		Profile:                        getStringAttrValue("profile", b),
 		Region:                         getStringAttrValue("region", b),
 		RetryMode:                      getStringAttrValue("retry_mode", b),
-		S3UsePathStyle:                 b.GetAttribute("s3_use_path_style").AsBoolValueOrDefault(false, b),
+		S3UsePathStyle:                 b.GetAttribute("s3_use_path_style").AsBoolValue(),
 		S3USEast1RegionalEndpoint:      getStringAttrValue("s3_us_east_1_regional_endpoint", b),
 		SecretKey:                      getStringAttrValue("secret_key", b),
-		SharedConfigFiles:              b.GetAttribute("shared_config_files").AsStringValuesOrDefault(b, defaultSharedConfigFile),
-		SharedCredentialsFiles:         b.GetAttribute("shared_credentials_files").AsStringValuesOrDefault(b, defaultSharedCredentialsFile),
-		SkipCredentialsValidation:      b.GetAttribute("skip_credentials_validation").AsBoolValueOrDefault(false, b),
-		SkipMetadataAPICheck:           b.GetAttribute("skip_metadata_api_check").AsBoolValueOrDefault(false, b),
-		SkipRegionValidation:           b.GetAttribute("skip_region_validation").AsBoolValueOrDefault(false, b),
-		SkipRequestingAccountID:        b.GetAttribute("skip_requesting_account_id").AsBoolValueOrDefault(false, b),
+		SharedConfigFiles:              b.GetAttribute("shared_config_files").AsStringValuesOrDefault(defaultSharedConfigFile),
+		SharedCredentialsFiles:         b.GetAttribute("shared_credentials_files").AsStringValuesOrDefault(defaultSharedCredentialsFile),
+		SkipCredentialsValidation:      b.GetAttribute("skip_credentials_validation").AsBoolValue(),
+		SkipMetadataAPICheck:           b.GetAttribute("skip_metadata_api_check").AsBoolValue(),
+		SkipRegionValidation:           b.GetAttribute("skip_region_validation").AsBoolValue(),
+		SkipRequestingAccountID:        b.GetAttribute("skip_requesting_account_id").AsBoolValue(),
 		STSRegion:                      getStringAttrValue("sts_region", b),
 		Token:                          getStringAttrValue("token", b),
-		UseDualstackEndpoint:           b.GetAttribute("use_dualstack_endpoint").AsBoolValueOrDefault(false, b),
-		UseFIPSEndpoint:                b.GetAttribute("use_fips_endpoint").AsBoolValueOrDefault(false, b),
+		UseDualstackEndpoint:           b.GetAttribute("use_dualstack_endpoint").AsBoolValue(),
+		UseFIPSEndpoint:                b.GetAttribute("use_fips_endpoint").AsBoolValue(),
 	}
 }
 
@@ -130,7 +130,7 @@ func adaptEndpoints(p *terraform.Block) types.MapValue {
 	values := make(map[string]string)
 
 	for name, attr := range block.Attributes() {
-		values[name] = attr.AsStringValueOrDefault("", block).Value()
+		values[name] = attr.AsStringValue().Value()
 	}
 
 	return types.Map(values, block.GetMetadata())
@@ -162,5 +162,5 @@ func adaptIgnoreTags(p *terraform.Block) aws.IgnoreTags {
 }
 
 func getStringAttrValue(name string, parent *terraform.Block) types.StringValue {
-	return parent.GetAttribute(name).AsStringValueOrDefault("", parent)
+	return parent.GetAttribute(name).AsStringValue()
 }

--- a/pkg/iac/adapters/terraform/aws/rds/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/rds/adapt.go
@@ -95,7 +95,7 @@ func getClassic(modules terraform.Modules) rds.Classic {
 
 func adaptClusterInstance(resource *terraform.Block, modules terraform.Modules) rds.ClusterInstance {
 	clusterIdAttr := resource.GetAttribute("cluster_identifier")
-	clusterId := clusterIdAttr.AsStringValueOrDefault("", resource)
+	clusterId := clusterIdAttr.AsStringValue()
 
 	if clusterIdAttr.IsResourceBlockReference("aws_rds_cluster") {
 		if referenced, err := modules.GetReferencedBlock(clusterIdAttr, resource); err == nil {
@@ -147,21 +147,21 @@ func adaptInstance(resource *terraform.Block, modules terraform.Modules) rds.Ins
 	}
 	return rds.Instance{
 		Metadata:                         resource.GetMetadata(),
-		BackupRetentionPeriodDays:        resource.GetAttribute("backup_retention_period").AsIntValueOrDefault(0, resource),
+		BackupRetentionPeriodDays:        resource.GetAttribute("backup_retention_period").AsIntValue(),
 		ReplicationSourceARN:             iacTypes.StringExplicit(replicaSourceValue, resource.GetMetadata()),
 		PerformanceInsights:              adaptPerformanceInsights(resource),
 		Encryption:                       adaptEncryption(resource),
-		PublicAccess:                     resource.GetAttribute("publicly_accessible").AsBoolValueOrDefault(false, resource),
-		Engine:                           resource.GetAttribute("engine").AsStringValueOrDefault(rds.EngineAurora, resource),
-		IAMAuthEnabled:                   resource.GetAttribute("iam_database_authentication_enabled").AsBoolValueOrDefault(false, resource),
-		DeletionProtection:               resource.GetAttribute("deletion_protection").AsBoolValueOrDefault(false, resource),
-		DBInstanceArn:                    resource.GetAttribute("arn").AsStringValueOrDefault("", resource),
-		StorageEncrypted:                 resource.GetAttribute("storage_encrypted").AsBoolValueOrDefault(true, resource),
-		DBInstanceIdentifier:             resource.GetAttribute("identifier").AsStringValueOrDefault("", resource),
-		EngineVersion:                    resource.GetAttribute("engine_version").AsStringValueOrDefault("", resource),
-		AutoMinorVersionUpgrade:          resource.GetAttribute("auto_minor_version_upgrade").AsBoolValueOrDefault(false, resource),
-		MultiAZ:                          resource.GetAttribute("multi_az").AsBoolValueOrDefault(false, resource),
-		PubliclyAccessible:               resource.GetAttribute("publicly_accessible").AsBoolValueOrDefault(false, resource),
+		PublicAccess:                     resource.GetAttribute("publicly_accessible").AsBoolValue(),
+		Engine:                           resource.GetAttribute("engine").AsStringValue(rds.EngineAurora),
+		IAMAuthEnabled:                   resource.GetAttribute("iam_database_authentication_enabled").AsBoolValue(),
+		DeletionProtection:               resource.GetAttribute("deletion_protection").AsBoolValue(),
+		DBInstanceArn:                    resource.GetAttribute("arn").AsStringValue(),
+		StorageEncrypted:                 resource.GetAttribute("storage_encrypted").AsBoolValue(true),
+		DBInstanceIdentifier:             resource.GetAttribute("identifier").AsStringValue(),
+		EngineVersion:                    resource.GetAttribute("engine_version").AsStringValue(),
+		AutoMinorVersionUpgrade:          resource.GetAttribute("auto_minor_version_upgrade").AsBoolValue(),
+		MultiAZ:                          resource.GetAttribute("multi_az").AsBoolValue(),
+		PubliclyAccessible:               resource.GetAttribute("publicly_accessible").AsBoolValue(),
 		LatestRestorableTime:             iacTypes.TimeUnresolvable(resource.GetMetadata()),
 		ReadReplicaDBInstanceIdentifiers: ReadReplicaDBInstanceIdentifiers,
 		TagList:                          TagList,
@@ -184,8 +184,8 @@ func adaptDBParameterGroups(resource *terraform.Block, _ terraform.Modules) rds.
 
 	return rds.ParameterGroups{
 		Metadata:               resource.GetMetadata(),
-		DBParameterGroupName:   resource.GetAttribute("name").AsStringValueOrDefault("", resource),
-		DBParameterGroupFamily: resource.GetAttribute("family").AsStringValueOrDefault("", resource),
+		DBParameterGroupName:   resource.GetAttribute("name").AsStringValue(),
+		DBParameterGroupFamily: resource.GetAttribute("family").AsStringValue(),
 		Parameters:             Parameters,
 	}
 }
@@ -194,10 +194,10 @@ func adaptDBSnapshots(resource *terraform.Block, _ terraform.Modules) rds.Snapsh
 
 	return rds.Snapshots{
 		Metadata:             resource.GetMetadata(),
-		DBSnapshotIdentifier: resource.GetAttribute("db_snapshot_identifier").AsStringValueOrDefault("", resource),
-		DBSnapshotArn:        resource.GetAttribute("db_snapshot_arn").AsStringValueOrDefault("", resource),
-		Encrypted:            resource.GetAttribute("encrypted").AsBoolValueOrDefault(true, resource),
-		KmsKeyId:             resource.GetAttribute("kms_key_id").AsStringValueOrDefault("", resource),
+		DBSnapshotIdentifier: resource.GetAttribute("db_snapshot_identifier").AsStringValue(),
+		DBSnapshotArn:        resource.GetAttribute("db_snapshot_arn").AsStringValue(),
+		Encrypted:            resource.GetAttribute("encrypted").AsBoolValue(true),
+		KmsKeyId:             resource.GetAttribute("kms_key_id").AsStringValue(),
 		SnapshotAttributes:   nil,
 	}
 }
@@ -216,16 +216,16 @@ func adaptCluster(resource *terraform.Block, modules terraform.Modules) (rds.Clu
 
 	return rds.Cluster{
 		Metadata:                  resource.GetMetadata(),
-		BackupRetentionPeriodDays: resource.GetAttribute("backup_retention_period").AsIntValueOrDefault(1, resource),
-		ReplicationSourceARN:      resource.GetAttribute("replication_source_identifier").AsStringValueOrDefault("", resource),
+		BackupRetentionPeriodDays: resource.GetAttribute("backup_retention_period").AsIntValue(1),
+		ReplicationSourceARN:      resource.GetAttribute("replication_source_identifier").AsStringValue(),
 		PerformanceInsights:       adaptPerformanceInsights(resource),
 		Instances:                 clusterInstances,
 		Encryption:                adaptEncryption(resource),
 		PublicAccess:              iacTypes.Bool(public, resource.GetMetadata()),
-		Engine:                    resource.GetAttribute("engine").AsStringValueOrDefault(rds.EngineAurora, resource),
+		Engine:                    resource.GetAttribute("engine").AsStringValue(rds.EngineAurora),
 		LatestRestorableTime:      iacTypes.TimeUnresolvable(resource.GetMetadata()),
 		AvailabilityZones:         resource.GetAttribute("availability_zones").AsStringValueSliceOrEmpty(),
-		DeletionProtection:        resource.GetAttribute("deletion_protection").AsBoolValueOrDefault(false, resource),
+		DeletionProtection:        resource.GetAttribute("deletion_protection").AsBoolValue(),
 	}, ids
 }
 
@@ -242,15 +242,15 @@ func getClusterInstances(resource *terraform.Block, modules terraform.Modules) (
 func adaptPerformanceInsights(resource *terraform.Block) rds.PerformanceInsights {
 	return rds.PerformanceInsights{
 		Metadata: resource.GetMetadata(),
-		Enabled:  resource.GetAttribute("performance_insights_enabled").AsBoolValueOrDefault(false, resource),
-		KMSKeyID: resource.GetAttribute("performance_insights_kms_key_id").AsStringValueOrDefault("", resource),
+		Enabled:  resource.GetAttribute("performance_insights_enabled").AsBoolValue(),
+		KMSKeyID: resource.GetAttribute("performance_insights_kms_key_id").AsStringValue(),
 	}
 }
 
 func adaptEncryption(resource *terraform.Block) rds.Encryption {
 	return rds.Encryption{
 		Metadata:       resource.GetMetadata(),
-		EncryptStorage: resource.GetAttribute("storage_encrypted").AsBoolValueOrDefault(false, resource),
-		KMSKeyID:       resource.GetAttribute("kms_key_id").AsStringValueOrDefault("", resource),
+		EncryptStorage: resource.GetAttribute("storage_encrypted").AsBoolValue(),
+		KMSKeyID:       resource.GetAttribute("kms_key_id").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/redshift/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/redshift/adapt.go
@@ -50,14 +50,14 @@ func adaptParameters(modules terraform.Modules) []redshift.ClusterParameter {
 func adaptCluster(resource *terraform.Block, module *terraform.Module) redshift.Cluster {
 	cluster := redshift.Cluster{
 		Metadata:                         resource.GetMetadata(),
-		ClusterIdentifier:                resource.GetAttribute("cluster_identifier").AsStringValueOrDefault("", resource),
-		NodeType:                         resource.GetAttribute("node_type").AsStringValueOrDefault("", resource),
-		MasterUsername:                   resource.GetAttribute("master_username").AsStringValueOrDefault("", resource),
-		NumberOfNodes:                    resource.GetAttribute("number_of_nodes").AsIntValueOrDefault(1, resource),
-		PubliclyAccessible:               resource.GetAttribute("publicly_accessible").AsBoolValueOrDefault(true, resource),
+		ClusterIdentifier:                resource.GetAttribute("cluster_identifier").AsStringValue(),
+		NodeType:                         resource.GetAttribute("node_type").AsStringValue(),
+		MasterUsername:                   resource.GetAttribute("master_username").AsStringValue(),
+		NumberOfNodes:                    resource.GetAttribute("number_of_nodes").AsIntValue(1),
+		PubliclyAccessible:               resource.GetAttribute("publicly_accessible").AsBoolValue(true),
 		LoggingEnabled:                   iacTypes.Bool(false, resource.GetMetadata()),
 		AutomatedSnapshotRetentionPeriod: iacTypes.Int(0, resource.GetMetadata()),
-		AllowVersionUpgrade:              resource.GetAttribute("allow_version_upgrade").AsBoolValueOrDefault(true, resource),
+		AllowVersionUpgrade:              resource.GetAttribute("allow_version_upgrade").AsBoolValue(true),
 		VpcId:                            iacTypes.String("", resource.GetMetadata()),
 		Encryption: redshift.Encryption{
 			Metadata: resource.GetMetadata(),
@@ -66,25 +66,25 @@ func adaptCluster(resource *terraform.Block, module *terraform.Module) redshift.
 		},
 		EndPoint: redshift.EndPoint{
 			Metadata: resource.GetMetadata(),
-			Port:     resource.GetAttribute("port").AsIntValueOrDefault(5439, resource),
+			Port:     resource.GetAttribute("port").AsIntValue(5439),
 		},
 		SubnetGroupName: iacTypes.StringDefault("", resource.GetMetadata()),
 	}
 
 	encryptedAttr := resource.GetAttribute("encrypted")
-	cluster.Encryption.Enabled = encryptedAttr.AsBoolValueOrDefault(false, resource)
+	cluster.Encryption.Enabled = encryptedAttr.AsBoolValue()
 
 	if logBlock := resource.GetBlock("logging"); logBlock.IsNotNil() {
-		cluster.LoggingEnabled = logBlock.GetAttribute("enable").AsBoolValueOrDefault(false, logBlock)
+		cluster.LoggingEnabled = logBlock.GetAttribute("enable").AsBoolValue()
 	}
 
 	if snapBlock := resource.GetBlock("snapshot_copy"); snapBlock.IsNotNil() {
 		snapAttr := snapBlock.GetAttribute("retention_period")
-		cluster.AutomatedSnapshotRetentionPeriod = snapAttr.AsIntValueOrDefault(7, snapBlock)
+		cluster.AutomatedSnapshotRetentionPeriod = snapAttr.AsIntValue(7)
 	}
 
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	cluster.Encryption.KMSKeyID = KMSKeyIDAttr.AsStringValueOrDefault("", resource)
+	cluster.Encryption.KMSKeyID = KMSKeyIDAttr.AsStringValue()
 	if KMSKeyIDAttr.IsResourceBlockReference("aws_kms_key") {
 		if kmsKeyBlock, err := module.GetReferencedBlock(KMSKeyIDAttr, resource); err == nil {
 			cluster.Encryption.KMSKeyID = iacTypes.String(kmsKeyBlock.FullName(), kmsKeyBlock.GetMetadata())
@@ -92,14 +92,14 @@ func adaptCluster(resource *terraform.Block, module *terraform.Module) redshift.
 	}
 
 	subnetGroupNameAttr := resource.GetAttribute("cluster_subnet_group_name")
-	cluster.SubnetGroupName = subnetGroupNameAttr.AsStringValueOrDefault("", resource)
+	cluster.SubnetGroupName = subnetGroupNameAttr.AsStringValue()
 
 	return cluster
 }
 
 func adaptSecurityGroup(resource *terraform.Block) redshift.SecurityGroup {
 	descriptionAttr := resource.GetAttribute("description")
-	descriptionVal := descriptionAttr.AsStringValueOrDefault("Managed by Terraform", resource)
+	descriptionVal := descriptionAttr.AsStringValue("Managed by Terraform")
 
 	return redshift.SecurityGroup{
 		Metadata:    resource.GetMetadata(),
@@ -111,7 +111,7 @@ func adaptParameter(resource *terraform.Block) redshift.ClusterParameter {
 
 	return redshift.ClusterParameter{
 		Metadata:       resource.GetMetadata(),
-		ParameterName:  resource.GetAttribute("name").AsStringValueOrDefault("", resource),
-		ParameterValue: resource.GetAttribute("value").AsStringValueOrDefault("", resource),
+		ParameterName:  resource.GetAttribute("name").AsStringValue(),
+		ParameterValue: resource.GetAttribute("value").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/s3/bucket.go
+++ b/pkg/iac/adapters/terraform/aws/s3/bucket.go
@@ -19,7 +19,7 @@ func (a *adapter) adaptBuckets() []s3.Bucket {
 	for _, block := range a.modules.GetResourcesByType("aws_s3_bucket") {
 		bucket := &s3.Bucket{
 			Metadata:                      block.GetMetadata(),
-			Name:                          block.GetAttribute("bucket").AsStringValueOrDefault("", block),
+			Name:                          block.GetAttribute("bucket").AsStringValue(),
 			PublicAccessBlock:             nil,
 			BucketPolicies:                nil,
 			Encryption:                    getEncryption(block, a),
@@ -28,7 +28,7 @@ func (a *adapter) adaptBuckets() []s3.Bucket {
 			ACL:                           getBucketAcl(block, a),
 			Grants:                        getGrants(block, a),
 			AccelerateConfigurationStatus: getAccelerateStatus(block, a),
-			BucketLocation:                block.GetAttribute("region").AsStringValueOrDefault("", block),
+			BucketLocation:                block.GetAttribute("region").AsStringValue(),
 			LifecycleConfiguration:        getLifecycle(block, a),
 			Website:                       getWebsite(block, a),
 			Objects:                       getObject(block, a),
@@ -48,7 +48,7 @@ func (a *adapter) adaptBuckets() []s3.Bucket {
 }
 
 func getEncryption(block *terraform.Block, a *adapter) s3.Encryption {
-	if sseConfgihuration := block.GetBlock("server_side_encryption_configuration"); sseConfgihuration != nil {
+	if sseConfgihuration := block.GetBlock("server_side_encryption_configuration"); sseConfgihuration.IsNotNil() {
 		return newS3Encryption(block, sseConfgihuration)
 	}
 	if val, ok := applyForBucketRelatedResource(a, block, "aws_s3_bucket_server_side_encryption_configuration", func(resource *terraform.Block) s3.Encryption {
@@ -72,14 +72,14 @@ func newS3Encryption(root, sseConfgihuration *terraform.Block) s3.Encryption {
 			sseConfgihuration,
 			"rule.apply_server_side_encryption_by_default.sse_algorithm",
 			func(attr *terraform.Attribute, parent *terraform.Block) iacTypes.StringValue {
-				return attr.AsStringValueOrDefault("", parent)
+				return attr.AsStringValue()
 			},
 		),
 		KMSKeyId: terraform.MapNestedAttribute(
 			sseConfgihuration,
 			"rule.apply_server_side_encryption_by_default.kms_master_key_id",
 			func(attr *terraform.Attribute, parent *terraform.Block) iacTypes.StringValue {
-				return attr.AsStringValueOrDefault("", parent)
+				return attr.AsStringValue()
 			},
 		),
 	}
@@ -91,14 +91,14 @@ func getVersioning(block *terraform.Block, a *adapter) s3.Versioning {
 		Enabled:   iacTypes.BoolDefault(false, block.GetMetadata()),
 		MFADelete: iacTypes.BoolDefault(false, block.GetMetadata()),
 	}
-	if lockBlock := block.GetBlock("object_lock_configuration"); lockBlock != nil {
+	if lockBlock := block.GetBlock("object_lock_configuration"); lockBlock.IsNotNil() {
 		if enabled := isObjeckLockEnabled(lockBlock); enabled != nil {
 			versioning.Enabled = *enabled
 		}
 	}
-	if vBlock := block.GetBlock("versioning"); vBlock != nil {
-		versioning.Enabled = vBlock.GetAttribute("enabled").AsBoolValueOrDefault(true, vBlock)
-		versioning.MFADelete = vBlock.GetAttribute("mfa_delete").AsBoolValueOrDefault(false, vBlock)
+	if vBlock := block.GetBlock("versioning"); vBlock.IsNotNil() {
+		versioning.Enabled = vBlock.GetAttribute("enabled").AsBoolValue(true)
+		versioning.MFADelete = vBlock.GetAttribute("mfa_delete").AsBoolValue()
 	}
 
 	if enabled, ok := applyForBucketRelatedResource(a, block, "aws_s3_bucket_object_lock_configuration", func(resource *terraform.Block) *iacTypes.BoolValue {
@@ -136,7 +136,7 @@ func getVersioningFromResource(block *terraform.Block) s3.Versioning {
 		Enabled:   iacTypes.BoolDefault(false, block.GetMetadata()),
 		MFADelete: iacTypes.BoolDefault(false, block.GetMetadata()),
 	}
-	if config := block.GetBlock("versioning_configuration"); config != nil {
+	if config := block.GetBlock("versioning_configuration"); config.IsNotNil() {
 		if status := config.GetAttribute("status"); status.IsNotNil() {
 			versioning.Enabled = iacTypes.Bool(status.Equals("Enabled", terraform.IgnoreCase), status.GetMetadata())
 		}
@@ -149,7 +149,7 @@ func getVersioningFromResource(block *terraform.Block) s3.Versioning {
 
 func getLogging(block *terraform.Block, a *adapter) s3.Logging {
 	if loggingBlock := block.GetBlock("logging"); loggingBlock.IsNotNil() {
-		targetBucket := loggingBlock.GetAttribute("target_bucket").AsStringValueOrDefault("", loggingBlock)
+		targetBucket := loggingBlock.GetAttribute("target_bucket").AsStringValue()
 		if referencedBlock, err := a.modules.GetReferencedBlock(loggingBlock.GetAttribute("target_bucket"), loggingBlock); err == nil {
 			targetBucket = iacTypes.String(referencedBlock.FullName(), loggingBlock.GetAttribute("target_bucket").GetMetadata())
 		}
@@ -161,7 +161,7 @@ func getLogging(block *terraform.Block, a *adapter) s3.Logging {
 	}
 
 	if val, ok := applyForBucketRelatedResource(a, block, "aws_s3_bucket_logging", func(resource *terraform.Block) s3.Logging {
-		targetBucket := resource.GetAttribute("target_bucket").AsStringValueOrDefault("", resource)
+		targetBucket := resource.GetAttribute("target_bucket").AsStringValue()
 		if referencedBlock, err := a.modules.GetReferencedBlock(resource.GetAttribute("target_bucket"), resource); err == nil {
 			targetBucket = iacTypes.String(referencedBlock.FullName(), resource.GetAttribute("target_bucket").GetMetadata())
 		}
@@ -184,11 +184,11 @@ func getLogging(block *terraform.Block, a *adapter) s3.Logging {
 func getBucketAcl(block *terraform.Block, a *adapter) iacTypes.StringValue {
 	aclAttr := block.GetAttribute("acl")
 	if aclAttr.IsString() {
-		return aclAttr.AsStringValueOrDefault("private", block)
+		return aclAttr.AsStringValue("private")
 	}
 
 	if val, ok := applyForBucketRelatedResource(a, block, "aws_s3_bucket_acl", func(resource *terraform.Block) iacTypes.StringValue {
-		return resource.GetAttribute("acl").AsStringValueOrDefault("private", resource)
+		return resource.GetAttribute("acl").AsStringValue("private")
 	}); ok {
 		return val
 	}
@@ -204,15 +204,15 @@ func getGrants(block *terraform.Block, a *adapter) []s3.Grant {
 				grant := s3.Grant{
 					Metadata: grantBlock.GetMetadata(),
 					Permissions: iacTypes.StringValueList{
-						grantBlock.GetAttribute("permission").AsStringValueOrDefault("", grantBlock),
+						grantBlock.GetAttribute("permission").AsStringValue(),
 					},
 				}
 
 				if granteeBlock := grantBlock.GetBlock("grantee"); granteeBlock.IsNotNil() {
 					grant.Grantee = s3.Grantee{
 						Metadata: granteeBlock.GetMetadata(),
-						Type:     granteeBlock.GetAttribute("type").AsStringValueOrDefault("", granteeBlock),
-						URI:      granteeBlock.GetAttribute("uri").AsStringValueOrDefault("", granteeBlock),
+						Type:     granteeBlock.GetAttribute("type").AsStringValue(),
+						URI:      granteeBlock.GetAttribute("uri").AsStringValue(),
 					}
 				}
 
@@ -233,8 +233,8 @@ func getGrants(block *terraform.Block, a *adapter) []s3.Grant {
 			Permissions: grantBlock.GetAttribute("permissions").AsStringValueSliceOrEmpty(),
 			Grantee: s3.Grantee{
 				Metadata: grantBlock.GetMetadata(),
-				Type:     grantBlock.GetAttribute("type").AsStringValueOrDefault("", grantBlock),
-				URI:      grantBlock.GetAttribute("uri").AsStringValueOrDefault("", grantBlock),
+				Type:     grantBlock.GetAttribute("type").AsStringValue(),
+				URI:      grantBlock.GetAttribute("uri").AsStringValue(),
 			},
 		}
 
@@ -283,7 +283,7 @@ func getLifecycle(b *terraform.Block, a *adapter) []s3.Rules {
 		for _, rule := range ruleblock {
 			rules = append(rules, s3.Rules{
 				Metadata: rule.GetMetadata(),
-				Status:   rule.GetAttribute("status").AsStringValueOrDefault("Enabled", rule),
+				Status:   rule.GetAttribute("status").AsStringValue("Enabled"),
 			})
 		}
 	}
@@ -312,7 +312,7 @@ func getObject(b *terraform.Block, a *adapter) []s3.Contents {
 func getAccelerateStatus(b *terraform.Block, a *adapter) iacTypes.StringValue {
 	var status iacTypes.StringValue
 	for _, r := range a.modules.GetReferencingResources(b, "aws_s3_bucket_accelerate_configuration", "bucket") {
-		status = r.GetAttribute("status").AsStringValueOrDefault("Enabled", r)
+		status = r.GetAttribute("status").AsStringValue("Enabled")
 	}
 	return status
 }
@@ -322,7 +322,7 @@ func applyForBucketRelatedResource[T any](a *adapter, block *terraform.Block, re
 		bucketAttr := resource.GetAttribute("bucket")
 		if bucketAttr.IsNotNil() {
 			if bucketAttr.IsString() {
-				actualBucketName := block.GetAttribute("bucket").AsStringValueOrDefault("", block).Value()
+				actualBucketName := block.GetAttribute("bucket").AsStringValue().Value()
 				if bucketAttr.Equals(block.ID()) || bucketAttr.Equals(actualBucketName) {
 					return fn(resource), true
 				}

--- a/pkg/iac/adapters/terraform/aws/s3/bucket.go
+++ b/pkg/iac/adapters/terraform/aws/s3/bucket.go
@@ -65,23 +65,13 @@ func getEncryption(block *terraform.Block, a *adapter) s3.Encryption {
 }
 
 func newS3Encryption(root, sseConfgihuration *terraform.Block) s3.Encryption {
+	algoAttr := sseConfgihuration.GetNestedAttribute("rule.apply_server_side_encryption_by_default.sse_algorithm")
+	kmsAttr := sseConfgihuration.GetNestedAttribute("rule.apply_server_side_encryption_by_default.kms_master_key_id")
 	return s3.Encryption{
-		Metadata: root.GetMetadata(),
-		Enabled:  isEncrypted(sseConfgihuration),
-		Algorithm: terraform.MapNestedAttribute(
-			sseConfgihuration,
-			"rule.apply_server_side_encryption_by_default.sse_algorithm",
-			func(attr *terraform.Attribute, parent *terraform.Block) iacTypes.StringValue {
-				return attr.AsStringValue()
-			},
-		),
-		KMSKeyId: terraform.MapNestedAttribute(
-			sseConfgihuration,
-			"rule.apply_server_side_encryption_by_default.kms_master_key_id",
-			func(attr *terraform.Attribute, parent *terraform.Block) iacTypes.StringValue {
-				return attr.AsStringValue()
-			},
-		),
+		Metadata:  root.GetMetadata(),
+		Enabled:   isEncrypted(sseConfgihuration),
+		Algorithm: algoAttr.AsStringValue(),
+		KMSKeyId:  kmsAttr.AsStringValue(),
 	}
 }
 
@@ -245,21 +235,10 @@ func getGrants(block *terraform.Block, a *adapter) []s3.Grant {
 }
 
 func isEncrypted(sseConfgihuration *terraform.Block) iacTypes.BoolValue {
-	return terraform.MapNestedAttribute(
-		sseConfgihuration,
-		"rule.apply_server_side_encryption_by_default.sse_algorithm",
-		func(attr *terraform.Attribute, parent *terraform.Block) iacTypes.BoolValue {
-			if attr.IsNil() || !attr.IsString() {
-				return iacTypes.BoolDefault(false, parent.GetMetadata())
-			}
-			algoVal := attr.Value().AsString()
-			isValidAlgo := slices.Contains(s3types.ServerSideEncryption("").Values(), s3types.ServerSideEncryption(algoVal))
-			return iacTypes.Bool(
-				isValidAlgo,
-				attr.GetMetadata(),
-			)
-		},
-	)
+	attr := sseConfgihuration.GetNestedAttribute("rule.apply_server_side_encryption_by_default.sse_algorithm")
+	algoVal := attr.AsStringValue()
+	isValid := slices.Contains(s3types.ServerSideEncryption("").Values(), s3types.ServerSideEncryption(algoVal.Value()))
+	return iacTypes.Bool(isValid, algoVal.GetMetadata())
 }
 
 func hasLogging(b *terraform.Block) iacTypes.BoolValue {

--- a/pkg/iac/adapters/terraform/aws/s3/public_access_block.go
+++ b/pkg/iac/adapters/terraform/aws/s3/public_access_block.go
@@ -10,10 +10,10 @@ func (a *adapter) adaptPublicAccessBlocks() {
 
 		pba := s3.PublicAccessBlock{
 			Metadata:              b.GetMetadata(),
-			BlockPublicACLs:       b.GetAttribute("block_public_acls").AsBoolValueOrDefault(false, b),
-			BlockPublicPolicy:     b.GetAttribute("block_public_policy").AsBoolValueOrDefault(false, b),
-			IgnorePublicACLs:      b.GetAttribute("ignore_public_acls").AsBoolValueOrDefault(false, b),
-			RestrictPublicBuckets: b.GetAttribute("restrict_public_buckets").AsBoolValueOrDefault(false, b),
+			BlockPublicACLs:       b.GetAttribute("block_public_acls").AsBoolValue(),
+			BlockPublicPolicy:     b.GetAttribute("block_public_policy").AsBoolValue(),
+			IgnorePublicACLs:      b.GetAttribute("ignore_public_acls").AsBoolValue(),
+			RestrictPublicBuckets: b.GetAttribute("restrict_public_buckets").AsBoolValue(),
 		}
 
 		var bucketName string

--- a/pkg/iac/adapters/terraform/aws/sns/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/sns/adapt.go
@@ -33,6 +33,6 @@ func adaptTopic(resourceBlock *terraform.Block) sns.Topic {
 func adaptEncryption(resourceBlock *terraform.Block) sns.Encryption {
 	return sns.Encryption{
 		Metadata: resourceBlock.GetMetadata(),
-		KMSKeyID: resourceBlock.GetAttribute("kms_master_key_id").AsStringValueOrDefault("", resourceBlock),
+		KMSKeyID: resourceBlock.GetAttribute("kms_master_key_id").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/aws/sqs/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/sqs/adapt.go
@@ -97,7 +97,7 @@ func (a *adapter) adaptQueues() []sqs.Queue {
 func (a *adapter) adaptQueue(resource *terraform.Block) {
 
 	kmsKeyIdAttr := resource.GetAttribute("kms_master_key_id")
-	kmsKeyIdVal := kmsKeyIdAttr.AsStringValueOrDefault("", resource)
+	kmsKeyIdVal := kmsKeyIdAttr.AsStringValue()
 	managedEncryption := resource.GetAttribute("sqs_managed_sse_enabled")
 
 	var policies []iamp.Policy
@@ -159,7 +159,7 @@ func (a *adapter) adaptQueue(resource *terraform.Block) {
 		QueueURL: iacTypes.StringDefault("", resource.GetMetadata()),
 		Encryption: sqs.Encryption{
 			Metadata:          resource.GetMetadata(),
-			ManagedEncryption: managedEncryption.AsBoolValueOrDefault(false, resource),
+			ManagedEncryption: managedEncryption.AsBoolValue(),
 			KMSKeyID:          kmsKeyIdVal,
 		},
 		Policies: policies,

--- a/pkg/iac/adapters/terraform/aws/ssm/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/ssm/adapt.go
@@ -24,7 +24,7 @@ func adaptSecrets(modules terraform.Modules) []ssm.Secret {
 
 func adaptSecret(resource *terraform.Block, module *terraform.Module) ssm.Secret {
 	KMSKeyIDAttr := resource.GetAttribute("kms_key_id")
-	KMSKeyIDVal := KMSKeyIDAttr.AsStringValueOrDefault("alias/aws/secretsmanager", resource)
+	KMSKeyIDVal := KMSKeyIDAttr.AsStringValue("alias/aws/secretsmanager")
 
 	if KMSKeyIDAttr.IsResourceBlockReference("aws_kms_key") {
 		kmsBlock, err := module.GetReferencedBlock(KMSKeyIDAttr, resource)

--- a/pkg/iac/adapters/terraform/aws/workspaces/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/workspaces/adapt.go
@@ -44,13 +44,13 @@ func adaptWorkspace(resource *terraform.Block) workspaces.WorkSpace {
 	if rootVolumeEncryptAttr := resource.GetAttribute("root_volume_encryption_enabled"); rootVolumeEncryptAttr.IsNotNil() {
 		workspace.RootVolume.Metadata = rootVolumeEncryptAttr.GetMetadata()
 		workspace.RootVolume.Encryption.Metadata = rootVolumeEncryptAttr.GetMetadata()
-		workspace.RootVolume.Encryption.Enabled = rootVolumeEncryptAttr.AsBoolValueOrDefault(false, resource)
+		workspace.RootVolume.Encryption.Enabled = rootVolumeEncryptAttr.AsBoolValue()
 	}
 
 	if userVolumeEncryptAttr := resource.GetAttribute("user_volume_encryption_enabled"); userVolumeEncryptAttr.IsNotNil() {
 		workspace.UserVolume.Metadata = userVolumeEncryptAttr.GetMetadata()
 		workspace.UserVolume.Encryption.Metadata = userVolumeEncryptAttr.GetMetadata()
-		workspace.UserVolume.Encryption.Enabled = userVolumeEncryptAttr.AsBoolValueOrDefault(false, resource)
+		workspace.UserVolume.Encryption.Enabled = userVolumeEncryptAttr.AsBoolValue()
 	}
 
 	return workspace

--- a/pkg/iac/adapters/terraform/azure/appservice/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/appservice/adapt.go
@@ -38,8 +38,8 @@ func adaptService(resource *terraform.Block) appservice.Service {
 	service := appservice.Service{
 		Metadata:         resource.GetMetadata(),
 		Resource:         types.String(resource.TypeLabel(), resource.GetMetadata()),
-		EnableClientCert: resource.GetAttribute("client_cert_enabled").AsBoolValueOrDefault(false, resource),
-		HTTPSOnly:        resource.GetAttribute("https_only").AsBoolValueOrDefault(false, resource),
+		EnableClientCert: resource.GetAttribute("client_cert_enabled").AsBoolValue(),
+		HTTPSOnly:        resource.GetAttribute("https_only").AsBoolValue(),
 		Site: appservice.Site{
 			Metadata:          resource.GetMetadata(),
 			MinimumTLSVersion: types.StringDefault("1.2", resource.GetMetadata()),
@@ -49,25 +49,25 @@ func adaptService(resource *terraform.Block) appservice.Service {
 	if identityBlock := resource.GetBlock("identity"); identityBlock.IsNotNil() {
 		service.Identity = appservice.Identity{
 			Metadata: identityBlock.GetMetadata(),
-			Type:     identityBlock.GetAttribute("type").AsStringValueOrDefault("", identityBlock),
+			Type:     identityBlock.GetAttribute("type").AsStringValue(),
 		}
 	}
 
 	if authBlock := resource.GetBlock("auth_settings"); authBlock.IsNotNil() {
 		service.Authentication = appservice.Authentication{
 			Metadata: authBlock.GetMetadata(),
-			Enabled:  authBlock.GetAttribute("enabled").AsBoolValueOrDefault(false, authBlock),
+			Enabled:  authBlock.GetAttribute("enabled").AsBoolValue(),
 		}
 	}
 
 	if siteBlock := resource.GetBlock("site_config"); siteBlock.IsNotNil() {
 		service.Site = appservice.Site{
 			Metadata:          siteBlock.GetMetadata(),
-			EnableHTTP2:       siteBlock.GetAttribute("http2_enabled").AsBoolValueOrDefault(false, siteBlock),
-			MinimumTLSVersion: siteBlock.GetAttribute("min_tls_version").AsStringValueOrDefault("1.2", siteBlock),
-			PHPVersion:        siteBlock.GetAttribute("php_version").AsStringValueOrDefault("", siteBlock),
-			PythonVersion:     siteBlock.GetAttribute("python_version").AsStringValueOrDefault("", siteBlock),
-			FTPSState:         siteBlock.GetAttribute("ftps_state").AsStringValueOrDefault("", siteBlock),
+			EnableHTTP2:       siteBlock.GetAttribute("http2_enabled").AsBoolValue(),
+			MinimumTLSVersion: siteBlock.GetAttribute("min_tls_version").AsStringValue("1.2"),
+			PHPVersion:        siteBlock.GetAttribute("php_version").AsStringValue(),
+			PythonVersion:     siteBlock.GetAttribute("python_version").AsStringValue(),
+			FTPSState:         siteBlock.GetAttribute("ftps_state").AsStringValue(),
 		}
 	}
 
@@ -77,7 +77,7 @@ func adaptService(resource *terraform.Block) appservice.Service {
 func adaptFunctionApp(resource *terraform.Block) appservice.FunctionApp {
 	return appservice.FunctionApp{
 		Metadata:  resource.GetMetadata(),
-		HTTPSOnly: resource.GetAttribute("https_only").AsBoolValueOrDefault(false, resource),
+		HTTPSOnly: resource.GetAttribute("https_only").AsBoolValue(),
 	}
 }
 
@@ -85,8 +85,8 @@ func adaptWebApp(resource *terraform.Block) appservice.Service {
 	service := appservice.Service{
 		Metadata:         resource.GetMetadata(),
 		Resource:         types.String(resource.TypeLabel(), resource.GetMetadata()),
-		EnableClientCert: resource.GetAttribute("client_certificate_enabled").AsBoolValueOrDefault(false, resource),
-		HTTPSOnly:        resource.GetAttribute("https_only").AsBoolValueOrDefault(false, resource),
+		EnableClientCert: resource.GetAttribute("client_certificate_enabled").AsBoolValue(),
+		HTTPSOnly:        resource.GetAttribute("https_only").AsBoolValue(),
 		Site: appservice.Site{
 			Metadata:          resource.GetMetadata(),
 			FTPSState:         types.StringDefault("Disabled", resource.GetMetadata()),
@@ -97,34 +97,34 @@ func adaptWebApp(resource *terraform.Block) appservice.Service {
 	if identityBlock := resource.GetBlock("identity"); identityBlock.IsNotNil() {
 		service.Identity = appservice.Identity{
 			Metadata: identityBlock.GetMetadata(),
-			Type:     identityBlock.GetAttribute("type").AsStringValueOrDefault("", identityBlock),
+			Type:     identityBlock.GetAttribute("type").AsStringValue(),
 		}
 	}
 
 	if authBlock := resource.GetBlock("auth_settings"); authBlock.IsNotNil() {
 		service.Authentication = appservice.Authentication{
 			Metadata: authBlock.GetMetadata(),
-			Enabled:  authBlock.GetAttribute("enabled").AsBoolValueOrDefault(false, authBlock),
+			Enabled:  authBlock.GetAttribute("enabled").AsBoolValue(),
 		}
 	}
 
 	if siteBlock := resource.GetBlock("site_config"); siteBlock.IsNotNil() {
 		service.Site = appservice.Site{
 			Metadata:          siteBlock.GetMetadata(),
-			EnableHTTP2:       siteBlock.GetAttribute("http2_enabled").AsBoolValueOrDefault(false, siteBlock),
-			MinimumTLSVersion: siteBlock.GetAttribute("minimum_tls_version").AsStringValueOrDefault("1.2", siteBlock),
-			FTPSState:         siteBlock.GetAttribute("ftps_state").AsStringValueOrDefault("Disabled", siteBlock),
+			EnableHTTP2:       siteBlock.GetAttribute("http2_enabled").AsBoolValue(),
+			MinimumTLSVersion: siteBlock.GetAttribute("minimum_tls_version").AsStringValue("1.2"),
+			FTPSState:         siteBlock.GetAttribute("ftps_state").AsStringValue("Disabled"),
 		}
 
 		if appStack := siteBlock.GetBlock("application_stack"); appStack.IsNotNil() {
 			switch resource.TypeLabel() {
 			case "azurerm_linux_web_app":
-				service.Site.PHPVersion = appStack.GetAttribute("php_version").AsStringValueOrDefault("", appStack)
-				service.Site.PythonVersion = appStack.GetAttribute("python_version").AsStringValueOrDefault("", appStack)
+				service.Site.PHPVersion = appStack.GetAttribute("php_version").AsStringValue()
+				service.Site.PythonVersion = appStack.GetAttribute("python_version").AsStringValue()
 			case "azurerm_windows_web_app":
 				// azurerm_windows_web_app does not support configuring the python version
 				appStack := siteBlock.GetBlock("application_stack")
-				service.Site.PHPVersion = appStack.GetAttribute("php_version").AsStringValueOrDefault("", appStack)
+				service.Site.PHPVersion = appStack.GetAttribute("php_version").AsStringValue()
 			}
 		}
 	}

--- a/pkg/iac/adapters/terraform/azure/authorization/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/authorization/adapt.go
@@ -60,9 +60,9 @@ func adaptRoleAssignment(resource *terraform.Block) authorization.RoleAssignment
 
 	return authorization.RoleAssignment{
 		Metadata:           resource.GetMetadata(),
-		RoleDefinitionId:   roleDefIdAttr.AsStringValueOrDefault("", resource),
-		RoleDefinitionName: roleDefNameAttr.AsStringValueOrDefault("", resource),
-		PrincipalId:        principalIdAttr.AsStringValueOrDefault("", resource),
-		PrincipalType:      principalTypeAttr.AsStringValueOrDefault("", resource),
+		RoleDefinitionId:   roleDefIdAttr.AsStringValue(),
+		RoleDefinitionName: roleDefNameAttr.AsStringValue(),
+		PrincipalId:        principalIdAttr.AsStringValue(),
+		PrincipalType:      principalTypeAttr.AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/compute/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/compute/adapt.go
@@ -64,7 +64,7 @@ func adaptManagedDisk(resource *terraform.Block) compute.ManagedDisk {
 	if encryptionBlock.IsNotNil() {
 		disk.Encryption.Metadata = encryptionBlock.GetMetadata()
 		enabledAttr := encryptionBlock.GetAttribute("enabled")
-		disk.Encryption.Enabled = enabledAttr.AsBoolValueOrDefault(true, encryptionBlock)
+		disk.Encryption.Enabled = enabledAttr.AsBoolValue(true)
 	}
 
 	return disk
@@ -94,7 +94,7 @@ func adaptLinuxVM(resource *terraform.Block, modules terraform.Modules) compute.
 		workingBlock = resource.GetBlock("os_profile_linux_config")
 	}
 	disablePasswordAuthAttr := workingBlock.GetAttribute("disable_password_authentication")
-	disablePasswordAuthVal := disablePasswordAuthAttr.AsBoolValueOrDefault(true, workingBlock)
+	disablePasswordAuthVal := disablePasswordAuthAttr.AsBoolValue(true)
 
 	return compute.LinuxVirtualMachine{
 		Metadata: resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/azure/container/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/container/adapt.go
@@ -56,11 +56,11 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 	if networkProfileBlock.IsNotNil() {
 		networkPolicyAttr := networkProfileBlock.GetAttribute("network_policy")
 		cluster.NetworkProfile.Metadata = networkProfileBlock.GetMetadata()
-		cluster.NetworkProfile.NetworkPolicy = networkPolicyAttr.AsStringValueOrDefault("", networkProfileBlock)
+		cluster.NetworkProfile.NetworkPolicy = networkPolicyAttr.AsStringValue()
 	}
 
 	privateClusterEnabledAttr := resource.GetAttribute("private_cluster_enabled")
-	cluster.EnablePrivateCluster = privateClusterEnabledAttr.AsBoolValueOrDefault(false, resource)
+	cluster.EnablePrivateCluster = privateClusterEnabledAttr.AsBoolValue()
 
 	if apiServerBlock := resource.GetBlock("api_server_access_profile"); apiServerBlock.IsNotNil() {
 		authorizedIPRangesAttr := apiServerBlock.GetAttribute("authorized_ip_ranges")
@@ -73,14 +73,14 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 		if block := addonProfileBlock.GetBlock("oms_agent"); block.IsNotNil() {
 			cluster.AddonProfile.OMSAgent = container.OMSAgent{
 				Metadata: block.GetMetadata(),
-				Enabled:  block.GetAttribute("enabled").AsBoolValueOrDefault(false, block),
+				Enabled:  block.GetAttribute("enabled").AsBoolValue(),
 			}
 		}
 
 		if block := addonProfileBlock.GetBlock("azure_policy"); block.IsNotNil() {
 			cluster.AddonProfile.AzurePolicy = container.AzurePolicy{
 				Metadata: block.GetMetadata(),
-				Enabled:  block.GetAttribute("enabled").AsBoolValueOrDefault(false, block),
+				Enabled:  block.GetAttribute("enabled").AsBoolValue(),
 			}
 		}
 	}
@@ -97,7 +97,7 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 	if attr := resource.GetAttribute("azure_policy_enabled"); attr.IsNotNil() {
 		cluster.AddonProfile.AzurePolicy = container.AzurePolicy{
 			Metadata: attr.GetMetadata(),
-			Enabled:  attr.AsBoolValueOrDefault(false, resource),
+			Enabled:  attr.AsBoolValue(),
 		}
 	}
 
@@ -105,13 +105,13 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 	if rbacBlock := resource.GetBlock("role_based_access_control"); rbacBlock.IsNotNil() {
 		rbEnabledAttr := rbacBlock.GetAttribute("enabled")
 		cluster.RoleBasedAccessControl.Metadata = rbacBlock.GetMetadata()
-		cluster.RoleBasedAccessControl.Enabled = rbEnabledAttr.AsBoolValueOrDefault(false, rbacBlock)
+		cluster.RoleBasedAccessControl.Enabled = rbEnabledAttr.AsBoolValue()
 	}
 
 	if rbacEnabledAttr := resource.GetAttribute("role_based_access_control_enabled"); rbacEnabledAttr.IsNotNil() {
 		// azurerm >= 2.99.0
 		cluster.RoleBasedAccessControl.Metadata = rbacEnabledAttr.GetMetadata()
-		cluster.RoleBasedAccessControl.Enabled = rbacEnabledAttr.AsBoolValueOrDefault(false, resource)
+		cluster.RoleBasedAccessControl.Enabled = rbacEnabledAttr.AsBoolValue()
 	}
 
 	if block := resource.GetBlock("azure_active_directory_role_based_access_control"); block.IsNotNil() {
@@ -119,13 +119,13 @@ func adaptCluster(resource *terraform.Block) container.KubernetesCluster {
 		if enabledAttr.IsNotNil() {
 			if !cluster.RoleBasedAccessControl.Enabled.IsTrue() {
 				cluster.RoleBasedAccessControl.Metadata = block.GetMetadata()
-				cluster.RoleBasedAccessControl.Enabled = enabledAttr.AsBoolValueOrDefault(false, block)
+				cluster.RoleBasedAccessControl.Enabled = enabledAttr.AsBoolValue()
 			}
 		}
 	}
 
 	if diskEncryptionSetIDAttr := resource.GetAttribute("disk_encryption_set_id"); diskEncryptionSetIDAttr.IsNotNil() {
-		cluster.DiskEncryptionSetID = diskEncryptionSetIDAttr.AsStringValueOrDefault("", resource)
+		cluster.DiskEncryptionSetID = diskEncryptionSetIDAttr.AsStringValue()
 	}
 
 	cluster.AgentPools = adaptAgentPools(resource)
@@ -146,7 +146,7 @@ func adaptAgentPools(resource *terraform.Block) []container.AgentPool {
 func adaptAgentPool(block *terraform.Block) container.AgentPool {
 	return container.AgentPool{
 		Metadata:            block.GetMetadata(),
-		DiskEncryptionSetID: block.GetAttribute("disk_encryption_set_id").AsStringValueOrDefault("", block),
-		NodeType:            block.GetAttribute("type").AsStringValueOrDefault("VirtualMachineScaleSets", block),
+		DiskEncryptionSetID: block.GetAttribute("disk_encryption_set_id").AsStringValue(),
+		NodeType:            block.GetAttribute("type").AsStringValue("VirtualMachineScaleSets"),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/cosmosdb/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/cosmosdb/adapt.go
@@ -33,7 +33,7 @@ func adaptCosmosDBAccount(resource *terraform.Block) cosmosdb.Account {
 	} else {
 		switch ipRangeFilterAttr.Type() {
 		case cty.String:
-			ipRangeFilterVal = []iacTypes.StringValue{ipRangeFilterAttr.AsStringValueOrDefault("", resource)}
+			ipRangeFilterVal = []iacTypes.StringValue{ipRangeFilterAttr.AsStringValue()}
 		default:
 			ipRangeFilterVal = ipRangeFilterAttr.AsStringValues()
 		}

--- a/pkg/iac/adapters/terraform/azure/database/common.go
+++ b/pkg/iac/adapters/terraform/azure/database/common.go
@@ -29,7 +29,7 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 		case nameAttr.Equals("require_secure_transport"):
 			params.requireSecureTransport, _ = iacTypes.BoolFromCtyValue(valAttr.Value(), valAttr.GetMetadata())
 		case nameAttr.Equals("tls_version"):
-			params.tlsVersion = valAttr.AsStringValueOrDefault("TLS1_2", config)
+			params.tlsVersion = valAttr.AsStringValue("TLS1_2")
 		}
 	}
 
@@ -40,8 +40,8 @@ func adaptFirewallRule(resource *terraform.Block) database.FirewallRule {
 	return database.FirewallRule{
 		Metadata: resource.GetMetadata(),
 		StartIP: resource.GetAttribute("start_ip_address").
-			AsStringValueOrDefault("", resource),
+			AsStringValue(""),
 		EndIP: resource.GetAttribute("end_ip_address").
-			AsStringValueOrDefault("", resource),
+			AsStringValue(""),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/database/mariadb.go
+++ b/pkg/iac/adapters/terraform/azure/database/mariadb.go
@@ -29,10 +29,10 @@ func adaptMariaDBServer(resource *terraform.Block, module *terraform.Module) dat
 		Server: database.Server{
 			Metadata: resource.GetMetadata(),
 			EnableSSLEnforcement: resource.GetAttribute("ssl_enforcement_enabled").
-				AsBoolValueOrDefault(false, resource),
+				AsBoolValue(false),
 			MinimumTLSVersion: iacTypes.StringDefault("", resource.GetMetadata()),
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
-				AsBoolValueOrDefault(true, resource),
+				AsBoolValue(true),
 			FirewallRules: firewallRules,
 		},
 	}

--- a/pkg/iac/adapters/terraform/azure/database/mssql.go
+++ b/pkg/iac/adapters/terraform/azure/database/mssql.go
@@ -23,9 +23,9 @@ func adaptMSSQLServer(resource *terraform.Block, module *terraform.Module) datab
 
 	if resource.TypeLabel() == "azurerm_mssql_server" {
 		minTLSVersionAttr := resource.GetAttribute("minimum_tls_version")
-		minTLSVersionVal = minTLSVersionAttr.AsStringValueOrDefault("1.2", resource)
+		minTLSVersionVal = minTLSVersionAttr.AsStringValue("1.2")
 		publicAccessAttr := resource.GetAttribute("public_network_access_enabled")
-		publicAccessVal = publicAccessAttr.AsBoolValueOrDefault(true, resource)
+		publicAccessVal = publicAccessAttr.AsBoolValue(true)
 	}
 
 	var alertPolicies []database.SecurityAlertPolicy
@@ -79,7 +79,7 @@ func adaptMSSQLServer(resource *terraform.Block, module *terraform.Module) datab
 		},
 		ExtendedAuditingPolicies:      auditingPolicies,
 		SecurityAlertPolicies:         alertPolicies,
-		AdministratorLogin:            resource.GetAttribute("administrator_login").AsStringValueOrDefault("", resource),
+		AdministratorLogin:            resource.GetAttribute("administrator_login").AsStringValue(),
 		ActiveDirectoryAdministrators: adAdmins,
 	}
 }
@@ -90,21 +90,21 @@ func adaptMSSQLSecurityAlertPolicy(resource *terraform.Block) database.SecurityA
 		EmailAddresses: resource.GetAttribute("email_addresses").AsStringValues(),
 		DisabledAlerts: resource.GetAttribute("disabled_alerts").AsStringValues(),
 		EmailAccountAdmins: resource.GetAttribute("email_account_admins").
-			AsBoolValueOrDefault(false, resource),
+			AsBoolValue(false),
 	}
 }
 
 func adaptMSSQLExtendedAuditingPolicy(resource *terraform.Block) database.ExtendedAuditingPolicy {
 	return database.ExtendedAuditingPolicy{
 		Metadata:        resource.GetMetadata(),
-		RetentionInDays: resource.GetAttribute("retention_in_days").AsIntValueOrDefault(0, resource),
+		RetentionInDays: resource.GetAttribute("retention_in_days").AsIntValue(),
 	}
 }
 
 func adaptActiveDirectoryAdministrator(resource *terraform.Block) database.ActiveDirectoryAdministrator {
 	return database.ActiveDirectoryAdministrator{
 		Metadata: resource.GetMetadata(),
-		Login:    resource.GetAttribute("login").AsStringValueOrDefault("", resource),
+		Login:    resource.GetAttribute("login").AsStringValue(),
 	}
 }
 
@@ -113,6 +113,6 @@ func adaptAzureADAdministratorBlock(block *terraform.Block) database.ActiveDirec
 		Metadata: block.GetMetadata(),
 		// The azuread_administrator block uses login_username attribute
 		Login: block.GetFirstAttributeOf("login_username", "login").
-			AsStringValueOrDefault("", block),
+			AsStringValue(""),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/database/mysql.go
+++ b/pkg/iac/adapters/terraform/azure/database/mysql.go
@@ -32,11 +32,11 @@ func adaptMySQLServer(resource *terraform.Block, module *terraform.Module) datab
 		Server: database.Server{
 			Metadata: resource.GetMetadata(),
 			EnableSSLEnforcement: resource.GetAttribute("ssl_enforcement_enabled").
-				AsBoolValueOrDefault(false, resource),
+				AsBoolValue(false),
 			MinimumTLSVersion: resource.GetAttribute("ssl_minimal_tls_version_enforced").
-				AsStringValueOrDefault("TLS1_2", resource),
+				AsStringValue("TLS1_2"),
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
-				AsBoolValueOrDefault(true, resource),
+				AsBoolValue(true),
 			FirewallRules: firewallRules,
 		},
 	}
@@ -65,7 +65,7 @@ func adaptMySQLFlexibleServer(resource *terraform.Block, module *terraform.Modul
 			EnableSSLEnforcement: params.requireSecureTransport,
 			MinimumTLSVersion:    params.tlsVersion,
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
-				AsBoolValueOrDefault(true, resource),
+				AsBoolValue(true),
 			FirewallRules: firewallRules,
 		},
 	}

--- a/pkg/iac/adapters/terraform/azure/database/postgresql.go
+++ b/pkg/iac/adapters/terraform/azure/database/postgresql.go
@@ -36,16 +36,16 @@ func adaptPostgreSQLServer(resource *terraform.Block, module *terraform.Module) 
 		Server: database.Server{
 			Metadata: resource.GetMetadata(),
 			EnableSSLEnforcement: resource.GetAttribute("ssl_enforcement_enabled").
-				AsBoolValueOrDefault(false, resource),
+				AsBoolValue(false),
 			MinimumTLSVersion: resource.GetAttribute("ssl_minimal_tls_version_enforced").
-				AsStringValueOrDefault("TLS1_2", resource),
+				AsStringValue("TLS1_2"),
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
-				AsBoolValueOrDefault(true, resource),
+				AsBoolValue(true),
 			FirewallRules: firewallRules,
 		},
 		Config: config,
 		GeoRedundantBackupEnabled: resource.GetAttribute("geo_redundant_backup_enabled").
-			AsBoolValueOrDefault(false, resource),
+			AsBoolValue(false),
 		ThreatDetectionPolicy: adaptThreatDetectionPolicy(resource, resource.GetMetadata()),
 	}
 }
@@ -74,12 +74,12 @@ func adaptPostgreSQLFlexibleServer(resource *terraform.Block, module *terraform.
 			EnableSSLEnforcement: params.requireSecureTransport,
 			MinimumTLSVersion:    params.tlsVersion,
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
-				AsBoolValueOrDefault(true, resource),
+				AsBoolValue(true),
 			FirewallRules: firewallRules,
 		},
 		Config: config,
 		GeoRedundantBackupEnabled: resource.GetAttribute("geo_redundant_backup_enabled").
-			AsBoolValueOrDefault(false, resource),
+			AsBoolValue(false),
 
 		// Threat Detection is not configurable via Terraform for PostgreSQL Flexible Server
 		// It can only be configured via Azure CLI, so we mark it as unmanaged to avoid false positives
@@ -136,6 +136,6 @@ func adaptThreatDetectionPolicy(resource *terraform.Block, defaultMetadata iacTy
 
 	return database.ThreatDetectionPolicy{
 		Metadata: block.GetMetadata(),
-		Enabled:  block.GetAttribute("enabled").AsBoolValueOrDefault(false, block),
+		Enabled:  block.GetAttribute("enabled").AsBoolValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/azure/datafactory/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/datafactory/adapt.go
@@ -24,7 +24,7 @@ func adaptFactories(modules terraform.Modules) []datafactory.Factory {
 
 func adaptFactory(resource *terraform.Block) datafactory.Factory {
 	enablePublicNetworkAttr := resource.GetAttribute("public_network_enabled")
-	enablePublicNetworkVal := enablePublicNetworkAttr.AsBoolValueOrDefault(true, resource)
+	enablePublicNetworkVal := enablePublicNetworkAttr.AsBoolValue(true)
 
 	return datafactory.Factory{
 		Metadata:            resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/azure/keyvault/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/keyvault/adapt.go
@@ -96,16 +96,16 @@ func (a *adapter) adaptVault(resource *terraform.Block, module *terraform.Module
 	}
 
 	purgeProtectionAttr := resource.GetAttribute("purge_protection_enabled")
-	purgeProtectionVal := purgeProtectionAttr.AsBoolValueOrDefault(false, resource)
+	purgeProtectionVal := purgeProtectionAttr.AsBoolValue()
 
 	softDeleteRetentionDaysAttr := resource.GetAttribute("soft_delete_retention_days")
-	softDeleteRetentionDaysVal := softDeleteRetentionDaysAttr.AsIntValueOrDefault(0, resource)
+	softDeleteRetentionDaysVal := softDeleteRetentionDaysAttr.AsIntValue()
 
 	aclMetadata := iacTypes.NewUnmanagedMetadata()
 	if aclBlock := resource.GetBlock("network_acls"); aclBlock.IsNotNil() {
 		aclMetadata = aclBlock.GetMetadata()
 		defaultActionAttr := aclBlock.GetAttribute("default_action")
-		defaultActionVal = defaultActionAttr.AsStringValueOrDefault("", resource.GetBlock("network_acls"))
+		defaultActionVal = defaultActionAttr.AsStringValue()
 	}
 
 	return keyvault.Vault{
@@ -123,7 +123,7 @@ func (a *adapter) adaptVault(resource *terraform.Block, module *terraform.Module
 
 func adaptSecret(resource *terraform.Block) keyvault.Secret {
 	contentTypeAttr := resource.GetAttribute("content_type")
-	contentTypeVal := contentTypeAttr.AsStringValueOrDefault("", resource)
+	contentTypeVal := contentTypeAttr.AsStringValue()
 
 	return keyvault.Secret{
 		Metadata:    resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/azure/monitor/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/monitor/adapt.go
@@ -39,9 +39,9 @@ func adaptLogProfile(resource *terraform.Block) monitor.LogProfile {
 	if retentionPolicyBlock := resource.GetBlock("retention_policy"); retentionPolicyBlock.IsNotNil() {
 		logProfile.RetentionPolicy.Metadata = retentionPolicyBlock.GetMetadata()
 		enabledAttr := retentionPolicyBlock.GetAttribute("enabled")
-		logProfile.RetentionPolicy.Enabled = enabledAttr.AsBoolValueOrDefault(false, resource)
+		logProfile.RetentionPolicy.Enabled = enabledAttr.AsBoolValue()
 		daysAttr := retentionPolicyBlock.GetAttribute("days")
-		logProfile.RetentionPolicy.Days = daysAttr.AsIntValueOrDefault(0, resource)
+		logProfile.RetentionPolicy.Days = daysAttr.AsIntValue()
 	}
 
 	if categoriesAttr := resource.GetAttribute("categories"); categoriesAttr.IsNotNil() {

--- a/pkg/iac/adapters/terraform/azure/network/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/network/adapt.go
@@ -93,7 +93,7 @@ func (a *adapter) adaptSecurityGroup(resource *terraform.Block) {
 func adaptWatcherLog(resource *terraform.Block) network.NetworkWatcherFlowLog {
 	flowLog := network.NetworkWatcherFlowLog{
 		Metadata: resource.GetMetadata(),
-		Enabled:  resource.GetAttribute("enabled").AsBoolValueOrDefault(false, resource),
+		Enabled:  resource.GetAttribute("enabled").AsBoolValue(),
 		RetentionPolicy: network.RetentionPolicy{
 			Metadata: resource.GetMetadata(),
 			Enabled:  iacTypes.BoolDefault(false, resource.GetMetadata()),
@@ -105,9 +105,9 @@ func adaptWatcherLog(resource *terraform.Block) network.NetworkWatcherFlowLog {
 		flowLog.RetentionPolicy = network.RetentionPolicy{
 			Metadata: retentionPolicyBlock.GetMetadata(),
 			Enabled: retentionPolicyBlock.GetAttribute("enabled").
-				AsBoolValueOrDefault(false, retentionPolicyBlock),
+				AsBoolValue(false),
 			Days: retentionPolicyBlock.GetAttribute("days").
-				AsIntValueOrDefault(0, retentionPolicyBlock),
+				AsIntValue(0),
 		}
 	}
 	return flowLog
@@ -130,7 +130,7 @@ func AdaptNetworkInterface(resource *terraform.Block, modules terraform.Modules)
 		Metadata: resource.GetMetadata(),
 		// Support both ip_forwarding_enabled (new) and enable_ip_forwarding (old) attributes
 		EnableIPForwarding: resource.GetFirstAttributeOf("ip_forwarding_enabled", "enable_ip_forwarding").
-			AsBoolValueOrDefault(false, resource),
+			AsBoolValue(false),
 		HasPublicIP:     iacTypes.BoolDefault(false, resource.GetMetadata()),
 		PublicIPAddress: iacTypes.StringDefault("", resource.GetMetadata()),
 		SubnetID:        iacTypes.StringDefault("", resource.GetMetadata()),
@@ -143,9 +143,9 @@ func AdaptNetworkInterface(resource *terraform.Block, modules terraform.Modules)
 	for _, ipConfig := range ipConfigs {
 		ni.IPConfigurations = append(ni.IPConfigurations, network.IPConfiguration{
 			Metadata:        ipConfig.GetMetadata(),
-			PublicIPAddress: ipConfig.GetAttribute("public_ip_address_id").AsStringValueOrDefault("", ipConfig),
-			SubnetID:        ipConfig.GetAttribute("subnet_id").AsStringValueOrDefault("", ipConfig),
-			Primary:         ipConfig.GetAttribute("primary").AsBoolValueOrDefault(false, ipConfig),
+			PublicIPAddress: ipConfig.GetAttribute("public_ip_address_id").AsStringValue(),
+			SubnetID:        ipConfig.GetAttribute("subnet_id").AsStringValue(),
+			Primary:         ipConfig.GetAttribute("primary").AsBoolValue(),
 		})
 	}
 

--- a/pkg/iac/adapters/terraform/azure/network/common.go
+++ b/pkg/iac/adapters/terraform/azure/network/common.go
@@ -17,7 +17,7 @@ func AdaptSGRule(ruleBlock *terraform.Block) network.SecurityGroupRule {
 		SourcePorts:          nil,
 		DestinationAddresses: nil,
 		DestinationPorts:     nil,
-		Protocol:             ruleBlock.GetAttribute("protocol").AsStringValueOrDefault("", ruleBlock),
+		Protocol:             ruleBlock.GetAttribute("protocol").AsStringValue(),
 	}
 
 	accessAttr := ruleBlock.GetAttribute("access")
@@ -42,7 +42,7 @@ func AdaptSGRule(ruleBlock *terraform.Block) network.SecurityGroupRule {
 
 func adaptSource(ruleBlock *terraform.Block, rule *network.SecurityGroupRule) {
 	if sourceAddressAttr := ruleBlock.GetAttribute("source_address_prefix"); sourceAddressAttr.IsString() {
-		rule.SourceAddresses = append(rule.SourceAddresses, sourceAddressAttr.AsStringValueOrDefault("", ruleBlock))
+		rule.SourceAddresses = append(rule.SourceAddresses, sourceAddressAttr.AsStringValue())
 	} else if sourceAddressPrefixesAttr := ruleBlock.GetAttribute("source_address_prefixes"); sourceAddressPrefixesAttr.IsNotNil() {
 		rule.SourceAddresses = append(rule.SourceAddresses, sourceAddressPrefixesAttr.AsStringValues()...)
 	}
@@ -72,7 +72,7 @@ func adaptSource(ruleBlock *terraform.Block, rule *network.SecurityGroupRule) {
 
 func adaptDestination(ruleBlock *terraform.Block, rule *network.SecurityGroupRule) {
 	if destAddressAttr := ruleBlock.GetAttribute("destination_address_prefix"); destAddressAttr.IsString() {
-		rule.DestinationAddresses = append(rule.DestinationAddresses, destAddressAttr.AsStringValueOrDefault("", ruleBlock))
+		rule.DestinationAddresses = append(rule.DestinationAddresses, destAddressAttr.AsStringValue())
 	} else if destAddressPrefixesAttr := ruleBlock.GetAttribute("destination_address_prefixes"); destAddressPrefixesAttr.IsNotNil() {
 		rule.DestinationAddresses = append(rule.DestinationAddresses, destAddressPrefixesAttr.AsStringValues()...)
 	}

--- a/pkg/iac/adapters/terraform/azure/securitycenter/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/securitycenter/adapt.go
@@ -37,17 +37,17 @@ func adaptSubscriptions(modules terraform.Modules) []securitycenter.Subscription
 
 func adaptContact(resource *terraform.Block) securitycenter.Contact {
 	enableAlertNotifAttr := resource.GetAttribute("alert_notifications")
-	enableAlertNotifVal := enableAlertNotifAttr.AsBoolValueOrDefault(false, resource)
+	enableAlertNotifVal := enableAlertNotifAttr.AsBoolValue()
 
 	// TODO: add support for the new format https://github.com/hashicorp/terraform-provider-azurerm/issues/30797
 	alertsToAdminsAttr := resource.GetAttribute("alerts_to_admins")
-	alertsToAdminsVal := alertsToAdminsAttr.AsBoolValueOrDefault(false, resource)
+	alertsToAdminsVal := alertsToAdminsAttr.AsBoolValue()
 
 	emailAttr := resource.GetAttribute("email")
-	emailVal := emailAttr.AsStringValueOrDefault("", resource)
+	emailVal := emailAttr.AsStringValue()
 
 	phoneAttr := resource.GetAttribute("phone")
-	phoneVal := phoneAttr.AsStringValueOrDefault("", resource)
+	phoneVal := phoneAttr.AsStringValue()
 
 	return securitycenter.Contact{
 		Metadata:                 resource.GetMetadata(),
@@ -62,7 +62,7 @@ func adaptContact(resource *terraform.Block) securitycenter.Contact {
 
 func adaptSubscription(resource *terraform.Block) securitycenter.SubscriptionPricing {
 	tierAttr := resource.GetAttribute("tier")
-	tierVal := tierAttr.AsStringValueOrDefault("Free", resource)
+	tierVal := tierAttr.AsStringValue("Free")
 
 	return securitycenter.SubscriptionPricing{
 		Metadata: resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/azure/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/storage/adapt.go
@@ -119,7 +119,7 @@ func adaptAccounts(modules terraform.Modules) ([]storage.Account, []string, []st
 			for _, queueBlock := range queueResource {
 				queue := storage.Queue{
 					Metadata: queueBlock.GetMetadata(),
-					Name:     queueBlock.GetAttribute("name").AsStringValueOrDefault("", queueBlock),
+					Name:     queueBlock.GetAttribute("name").AsStringValue(),
 				}
 				account.Queues = append(account.Queues, queue)
 			}
@@ -130,15 +130,15 @@ func adaptAccounts(modules terraform.Modules) ([]storage.Account, []string, []st
 				for _, cmkResource := range customerManagedKeyResources {
 					keyVaultKeyIdAttr := cmkResource.GetAttribute("key_vault_key_id")
 					if keyVaultKeyIdAttr.IsNotNil() {
-						account.CustomerManagedKey.KeyVaultKeyId = keyVaultKeyIdAttr.AsStringValueOrDefault("", cmkResource)
+						account.CustomerManagedKey.KeyVaultKeyId = keyVaultKeyIdAttr.AsStringValue()
 						account.CustomerManagedKey.Metadata = cmkResource.GetMetadata()
 					} else {
 						// If key_vault_key_id is not directly set, try to construct from key_vault_id and key_name
 						keyVaultIdAttr := cmkResource.GetAttribute("key_vault_id")
 						keyNameAttr := cmkResource.GetAttribute("key_name")
 						if keyVaultIdAttr.IsNotNil() && keyNameAttr.IsNotNil() {
-							keyVaultId := keyVaultIdAttr.AsStringValueOrDefault("", cmkResource)
-							keyName := keyNameAttr.AsStringValueOrDefault("", cmkResource)
+							keyVaultId := keyVaultIdAttr.AsStringValue()
+							keyName := keyNameAttr.AsStringValue()
 							if !keyVaultId.IsEmpty() && !keyName.IsEmpty() {
 								// Construct the full key ID format: https://{keyVaultId}/keys/{keyName}
 								keyId := keyVaultId.Value() + "/keys/" + keyName.Value()
@@ -149,7 +149,7 @@ func adaptAccounts(modules terraform.Modules) ([]storage.Account, []string, []st
 					}
 					userAssignedIdentityIdAttr := cmkResource.GetAttribute("user_assigned_identity_id")
 					if userAssignedIdentityIdAttr.IsNotNil() {
-						account.CustomerManagedKey.UserAssignedIdentityId = userAssignedIdentityIdAttr.AsStringValueOrDefault("", cmkResource)
+						account.CustomerManagedKey.UserAssignedIdentityId = userAssignedIdentityIdAttr.AsStringValue()
 					}
 					break // Only process the first matching resource
 				}
@@ -172,7 +172,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 			EnableLogging: iacTypes.BoolDefault(false, resource.GetMetadata()),
 		},
 		MinimumTLSVersion:   iacTypes.StringDefault(minimumTlsVersionOneTwo, resource.GetMetadata()),
-		PublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").AsBoolValueOrDefault(true, resource),
+		PublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").AsBoolValue(true),
 		BlobProperties: storage.BlobProperties{
 			Metadata: resource.GetMetadata(),
 			DeleteRetentionPolicy: storage.DeleteRetentionPolicy{
@@ -180,8 +180,8 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 				Days:     iacTypes.IntDefault(7, resource.GetMetadata()),
 			},
 		},
-		AccountReplicationType:          resource.GetAttribute("account_replication_type").AsStringValueOrDefault("", resource),
-		InfrastructureEncryptionEnabled: resource.GetAttribute("infrastructure_encryption_enabled").AsBoolValueOrDefault(false, resource),
+		AccountReplicationType:          resource.GetAttribute("account_replication_type").AsStringValue(),
+		InfrastructureEncryptionEnabled: resource.GetAttribute("infrastructure_encryption_enabled").AsBoolValue(),
 		CustomerManagedKey: storage.CustomerManagedKey{
 			Metadata:               resource.GetMetadata(),
 			KeyVaultKeyId:          iacTypes.StringDefault("", resource.GetMetadata()),
@@ -197,7 +197,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 	account.EnforceHTTPS = resource.GetFirstAttributeOf(
 		"enable_https_traffic_only",
 		"https_traffic_only_enabled", // provider above version 4
-	).AsBoolValueOrDefault(true, resource)
+	).AsBoolValue(true)
 
 	// Adapt blob properties
 	blobPropertiesBlock := resource.GetBlock("blob_properties")
@@ -208,7 +208,7 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 			account.BlobProperties.DeleteRetentionPolicy.Metadata = deleteRetentionPolicyBlock.GetMetadata()
 			daysAttr := deleteRetentionPolicyBlock.GetAttribute("days")
 			if daysAttr.IsNotNil() {
-				account.BlobProperties.DeleteRetentionPolicy.Days = daysAttr.AsIntValueOrDefault(7, deleteRetentionPolicyBlock)
+				account.BlobProperties.DeleteRetentionPolicy.Days = daysAttr.AsIntValue(7)
 			}
 		}
 	}
@@ -219,11 +219,11 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 		account.CustomerManagedKey.Metadata = customerManagedKeyBlock.GetMetadata()
 		keyVaultKeyIdAttr := customerManagedKeyBlock.GetAttribute("key_vault_key_id")
 		if keyVaultKeyIdAttr.IsNotNil() {
-			account.CustomerManagedKey.KeyVaultKeyId = keyVaultKeyIdAttr.AsStringValueOrDefault("", customerManagedKeyBlock)
+			account.CustomerManagedKey.KeyVaultKeyId = keyVaultKeyIdAttr.AsStringValue()
 		}
 		userAssignedIdentityIdAttr := customerManagedKeyBlock.GetAttribute("user_assigned_identity_id")
 		if userAssignedIdentityIdAttr.IsNotNil() {
-			account.CustomerManagedKey.UserAssignedIdentityId = userAssignedIdentityIdAttr.AsStringValueOrDefault("", customerManagedKeyBlock)
+			account.CustomerManagedKey.UserAssignedIdentityId = userAssignedIdentityIdAttr.AsStringValue()
 		}
 	}
 
@@ -236,17 +236,17 @@ func adaptAccount(resource *terraform.Block) storage.Account {
 			account.QueueProperties.EnableLogging = iacTypes.Bool(true, loggingBlock.GetMetadata())
 			account.QueueProperties.Logging = storage.QueueLogging{
 				Metadata:            loggingBlock.GetMetadata(),
-				Delete:              loggingBlock.GetAttribute("delete").AsBoolValueOrDefault(false, loggingBlock),
-				Read:                loggingBlock.GetAttribute("read").AsBoolValueOrDefault(false, loggingBlock),
-				Write:               loggingBlock.GetAttribute("write").AsBoolValueOrDefault(false, loggingBlock),
-				Version:             loggingBlock.GetAttribute("version").AsStringValueOrDefault("", loggingBlock),
-				RetentionPolicyDays: loggingBlock.GetAttribute("retention_policy_days").AsIntValueOrDefault(0, loggingBlock),
+				Delete:              loggingBlock.GetAttribute("delete").AsBoolValue(),
+				Read:                loggingBlock.GetAttribute("read").AsBoolValue(),
+				Write:               loggingBlock.GetAttribute("write").AsBoolValue(),
+				Version:             loggingBlock.GetAttribute("version").AsStringValue(),
+				RetentionPolicyDays: loggingBlock.GetAttribute("retention_policy_days").AsIntValue(),
 			}
 		}
 	}
 
 	minTLSVersionAttr := resource.GetAttribute("min_tls_version")
-	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValueOrDefault(minimumTlsVersionOneTwo, resource)
+	account.MinimumTLSVersion = minTLSVersionAttr.AsStringValue(minimumTlsVersionOneTwo)
 	return account
 }
 

--- a/pkg/iac/adapters/terraform/azure/synapse/adapt.go
+++ b/pkg/iac/adapters/terraform/azure/synapse/adapt.go
@@ -23,7 +23,7 @@ func adaptWorkspaces(modules terraform.Modules) []synapse.Workspace {
 
 func adaptWorkspace(resource *terraform.Block) synapse.Workspace {
 	enableManagedVNAttr := resource.GetAttribute("managed_virtual_network_enabled")
-	enableManagedVNVal := enableManagedVNAttr.AsBoolValueOrDefault(false, resource)
+	enableManagedVNVal := enableManagedVNAttr.AsBoolValue()
 
 	return synapse.Workspace{
 		Metadata:                    resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/digitalocean/compute/adapt.go
+++ b/pkg/iac/adapters/terraform/digitalocean/compute/adapt.go
@@ -81,13 +81,13 @@ func adaptLoadBalancers(module terraform.Modules) (loadBalancers []compute.LoadB
 		for _, fRule := range forwardingRules {
 			rule := compute.ForwardingRule{
 				Metadata:      fRule.GetMetadata(),
-				EntryProtocol: fRule.GetAttribute("entry_protocol").AsStringValueOrDefault("", fRule),
+				EntryProtocol: fRule.GetAttribute("entry_protocol").AsStringValue(),
 			}
 			fRules = append(fRules, rule)
 		}
 		loadBalancers = append(loadBalancers, compute.LoadBalancer{
 			Metadata:            block.GetMetadata(),
-			RedirectHttpToHttps: block.GetAttribute("redirect_http_to_https").AsBoolValueOrDefault(false, block),
+			RedirectHttpToHttps: block.GetAttribute("redirect_http_to_https").AsBoolValue(),
 			ForwardingRules:     fRules,
 		})
 	}
@@ -99,8 +99,8 @@ func adaptKubernetesClusters(module terraform.Modules) (kubernetesClusters []com
 	for _, block := range module.GetResourcesByType("digitalocean_kubernetes_cluster") {
 		kubernetesClusters = append(kubernetesClusters, compute.KubernetesCluster{
 			Metadata:     block.GetMetadata(),
-			AutoUpgrade:  block.GetAttribute("auto_upgrade").AsBoolValueOrDefault(false, block),
-			SurgeUpgrade: block.GetAttribute("surge_upgrade").AsBoolValueOrDefault(false, block),
+			AutoUpgrade:  block.GetAttribute("auto_upgrade").AsBoolValue(),
+			SurgeUpgrade: block.GetAttribute("surge_upgrade").AsBoolValue(),
 		})
 	}
 	return kubernetesClusters

--- a/pkg/iac/adapters/terraform/digitalocean/spaces/adapt.go
+++ b/pkg/iac/adapters/terraform/digitalocean/spaces/adapt.go
@@ -22,10 +22,10 @@ func adaptBuckets(modules terraform.Modules) []spaces.Bucket {
 
 			bucket := spaces.Bucket{
 				Metadata:     block.GetMetadata(),
-				Name:         block.GetAttribute("name").AsStringValueOrDefault("", block),
+				Name:         block.GetAttribute("name").AsStringValue(),
 				Objects:      nil,
-				ACL:          block.GetAttribute("acl").AsStringValueOrDefault("private", block),
-				ForceDestroy: block.GetAttribute("force_destroy").AsBoolValueOrDefault(false, block),
+				ACL:          block.GetAttribute("acl").AsStringValue("private"),
+				ForceDestroy: block.GetAttribute("force_destroy").AsBoolValue(),
 				Versioning: spaces.Versioning{
 					Metadata: block.GetMetadata(),
 					Enabled:  iacTypes.BoolDefault(false, block.GetMetadata()),
@@ -35,7 +35,7 @@ func adaptBuckets(modules terraform.Modules) []spaces.Bucket {
 			if versioning := block.GetBlock("versioning"); versioning.IsNotNil() {
 				bucket.Versioning = spaces.Versioning{
 					Metadata: versioning.GetMetadata(),
-					Enabled:  versioning.GetAttribute("enabled").AsBoolValueOrDefault(false, versioning),
+					Enabled:  versioning.GetAttribute("enabled").AsBoolValue(),
 				}
 			}
 			bucketMap[block.ID()] = bucket
@@ -43,7 +43,7 @@ func adaptBuckets(modules terraform.Modules) []spaces.Bucket {
 		for _, block := range module.GetResourcesByType("digitalocean_spaces_bucket_object") {
 			object := spaces.Object{
 				Metadata: block.GetMetadata(),
-				ACL:      block.GetAttribute("acl").AsStringValueOrDefault("private", block),
+				ACL:      block.GetAttribute("acl").AsStringValue("private"),
 			}
 			bucketName := block.GetAttribute("bucket")
 			var found bool

--- a/pkg/iac/adapters/terraform/github/branch_protections/adapt.go
+++ b/pkg/iac/adapters/terraform/github/branch_protections/adapt.go
@@ -23,7 +23,7 @@ func adaptBranchProtection(resource *terraform.Block) github.BranchProtection {
 
 	branchProtection := github.BranchProtection{
 		Metadata:             resource.GetMetadata(),
-		RequireSignedCommits: resource.GetAttribute("require_signed_commits").AsBoolValueOrDefault(false, resource),
+		RequireSignedCommits: resource.GetAttribute("require_signed_commits").AsBoolValue(),
 	}
 
 	return branchProtection

--- a/pkg/iac/adapters/terraform/github/repositories/adapt.go
+++ b/pkg/iac/adapters/terraform/github/repositories/adapt.go
@@ -25,8 +25,8 @@ func adaptRepository(resource *terraform.Block) github.Repository {
 	repo := github.Repository{
 		Metadata:            resource.GetMetadata(),
 		Public:              types.Bool(true, resource.GetMetadata()),
-		VulnerabilityAlerts: resource.GetAttribute("vulnerability_alerts").AsBoolValueOrDefault(false, resource),
-		Archived:            resource.GetAttribute("archived").AsBoolValueOrDefault(false, resource),
+		VulnerabilityAlerts: resource.GetAttribute("vulnerability_alerts").AsBoolValue(),
+		Archived:            resource.GetAttribute("archived").AsBoolValue(),
 	}
 
 	privateAttr := resource.GetAttribute("private")

--- a/pkg/iac/adapters/terraform/github/secrets/adapt.go
+++ b/pkg/iac/adapters/terraform/github/secrets/adapt.go
@@ -22,11 +22,11 @@ func adaptSecrets(modules terraform.Modules) []github.EnvironmentSecret {
 func adaptSecret(resource *terraform.Block) github.EnvironmentSecret {
 	secret := github.EnvironmentSecret{
 		Metadata:       resource.GetMetadata(),
-		Repository:     resource.GetAttribute("repository").AsStringValueOrDefault("", resource),
-		Environment:    resource.GetAttribute("environment").AsStringValueOrDefault("", resource),
-		SecretName:     resource.GetAttribute("secret_name").AsStringValueOrDefault("", resource),
-		PlainTextValue: resource.GetAttribute("plaintext_value").AsStringValueOrDefault("", resource),
-		EncryptedValue: resource.GetAttribute("encrypted_value").AsStringValueOrDefault("", resource),
+		Repository:     resource.GetAttribute("repository").AsStringValue(),
+		Environment:    resource.GetAttribute("environment").AsStringValue(),
+		SecretName:     resource.GetAttribute("secret_name").AsStringValue(),
+		PlainTextValue: resource.GetAttribute("plaintext_value").AsStringValue(),
+		EncryptedValue: resource.GetAttribute("encrypted_value").AsStringValue(),
 	}
 	return secret
 }

--- a/pkg/iac/adapters/terraform/google/bigquery/adapt.go
+++ b/pkg/iac/adapters/terraform/google/bigquery/adapt.go
@@ -23,20 +23,20 @@ func adaptDatasets(modules terraform.Modules) []bigquery.Dataset {
 
 func adaptDataset(resource *terraform.Block) bigquery.Dataset {
 	IDAttr := resource.GetAttribute("dataset_id")
-	IDVal := IDAttr.AsStringValueOrDefault("", resource)
+	IDVal := IDAttr.AsStringValue()
 
 	var accessGrants []bigquery.AccessGrant
 
 	accessBlocks := resource.GetBlocks("access")
 	for _, accessBlock := range accessBlocks {
 		roleAttr := accessBlock.GetAttribute("role")
-		roleVal := roleAttr.AsStringValueOrDefault("", accessBlock)
+		roleVal := roleAttr.AsStringValue()
 
 		domainAttr := accessBlock.GetAttribute("domain")
-		domainVal := domainAttr.AsStringValueOrDefault("", accessBlock)
+		domainVal := domainAttr.AsStringValue()
 
 		specialGrAttr := accessBlock.GetAttribute("special_group")
-		specialGrVal := specialGrAttr.AsStringValueOrDefault("", accessBlock)
+		specialGrVal := specialGrAttr.AsStringValue()
 
 		accessGrants = append(accessGrants, bigquery.AccessGrant{
 			Metadata:     accessBlock.GetMetadata(),

--- a/pkg/iac/adapters/terraform/google/compute/disks.go
+++ b/pkg/iac/adapters/terraform/google/compute/disks.go
@@ -11,7 +11,7 @@ func adaptDisks(modules terraform.Modules) (disks []compute.Disk) {
 	for _, diskBlock := range modules.GetResourcesByType("google_compute_disk") {
 		disk := compute.Disk{
 			Metadata: diskBlock.GetMetadata(),
-			Name:     diskBlock.GetAttribute("name").AsStringValueOrDefault("", diskBlock),
+			Name:     diskBlock.GetAttribute("name").AsStringValue(),
 			Encryption: compute.DiskEncryption{
 				Metadata:   diskBlock.GetMetadata(),
 				RawKey:     iacTypes.BytesDefault(nil, diskBlock.GetMetadata()),
@@ -21,7 +21,7 @@ func adaptDisks(modules terraform.Modules) (disks []compute.Disk) {
 		if encBlock := diskBlock.GetBlock("disk_encryption_key"); encBlock.IsNotNil() {
 			disk.Encryption.Metadata = encBlock.GetMetadata()
 			kmsKeyAttr := encBlock.GetAttribute("kms_key_self_link")
-			disk.Encryption.KMSKeyLink = kmsKeyAttr.AsStringValueOrDefault("", encBlock)
+			disk.Encryption.KMSKeyLink = kmsKeyAttr.AsStringValue()
 
 			if kmsKeyAttr.IsResourceBlockReference("google_kms_crypto_key") {
 				if kmsKeyBlock, err := modules.GetReferencedBlock(kmsKeyAttr, encBlock); err == nil {
@@ -29,7 +29,7 @@ func adaptDisks(modules terraform.Modules) (disks []compute.Disk) {
 				}
 			}
 
-			disk.Encryption.RawKey = encBlock.GetAttribute("raw_key").AsBytesValueOrDefault(nil, encBlock)
+			disk.Encryption.RawKey = encBlock.GetAttribute("raw_key").AsBytesValue(nil)
 		}
 		disks = append(disks, disk)
 	}

--- a/pkg/iac/adapters/terraform/google/compute/instances.go
+++ b/pkg/iac/adapters/terraform/google/compute/instances.go
@@ -12,7 +12,7 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 
 		instance := compute.Instance{
 			Metadata: instanceBlock.GetMetadata(),
-			Name:     instanceBlock.GetAttribute("name").AsStringValueOrDefault("", instanceBlock),
+			Name:     instanceBlock.GetAttribute("name").AsStringValue(),
 			ShieldedVM: compute.ShieldedVMConfig{
 				Metadata:                   instanceBlock.GetMetadata(),
 				SecureBootEnabled:          iacTypes.BoolDefault(false, instanceBlock.GetMetadata()),
@@ -25,7 +25,7 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 				IsDefault: iacTypes.BoolDefault(false, instanceBlock.GetMetadata()),
 				Scopes:    nil,
 			},
-			CanIPForward:                instanceBlock.GetAttribute("can_ip_forward").AsBoolValueOrDefault(false, instanceBlock),
+			CanIPForward:                instanceBlock.GetAttribute("can_ip_forward").AsBoolValue(),
 			OSLoginEnabled:              iacTypes.BoolDefault(true, instanceBlock.GetMetadata()),
 			EnableProjectSSHKeyBlocking: iacTypes.BoolDefault(false, instanceBlock.GetMetadata()),
 			EnableSerialPort:            iacTypes.BoolDefault(false, instanceBlock.GetMetadata()),
@@ -49,9 +49,9 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 		// vm shielding
 		if shieldedBlock := instanceBlock.GetBlock("shielded_instance_config"); shieldedBlock.IsNotNil() {
 			instance.ShieldedVM.Metadata = shieldedBlock.GetMetadata()
-			instance.ShieldedVM.IntegrityMonitoringEnabled = shieldedBlock.GetAttribute("enable_integrity_monitoring").AsBoolValueOrDefault(true, shieldedBlock)
-			instance.ShieldedVM.VTPMEnabled = shieldedBlock.GetAttribute("enable_vtpm").AsBoolValueOrDefault(true, shieldedBlock)
-			instance.ShieldedVM.SecureBootEnabled = shieldedBlock.GetAttribute("enable_secure_boot").AsBoolValueOrDefault(false, shieldedBlock)
+			instance.ShieldedVM.IntegrityMonitoringEnabled = shieldedBlock.GetAttribute("enable_integrity_monitoring").AsBoolValue(true)
+			instance.ShieldedVM.VTPMEnabled = shieldedBlock.GetAttribute("enable_vtpm").AsBoolValue(true)
+			instance.ShieldedVM.SecureBootEnabled = shieldedBlock.GetAttribute("enable_secure_boot").AsBoolValue()
 		}
 
 		// metadata
@@ -66,11 +66,11 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 		for _, diskBlock := range instanceBlock.GetBlocks("boot_disk") {
 			disk := compute.Disk{
 				Metadata: diskBlock.GetMetadata(),
-				Name:     diskBlock.GetAttribute("device_name").AsStringValueOrDefault("", diskBlock),
+				Name:     diskBlock.GetAttribute("device_name").AsStringValue(),
 				Encryption: compute.DiskEncryption{
 					Metadata:   diskBlock.GetMetadata(),
-					RawKey:     diskBlock.GetAttribute("disk_encryption_key_raw").AsBytesValueOrDefault(nil, diskBlock),
-					KMSKeyLink: diskBlock.GetAttribute("kms_key_self_link").AsStringValueOrDefault("", diskBlock),
+					RawKey:     diskBlock.GetAttribute("disk_encryption_key_raw").AsBytesValue(nil),
+					KMSKeyLink: diskBlock.GetAttribute("kms_key_self_link").AsStringValue(),
 				},
 			}
 			instance.BootDisks = append(instance.BootDisks, disk)
@@ -78,11 +78,11 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 		for _, diskBlock := range instanceBlock.GetBlocks("attached_disk") {
 			disk := compute.Disk{
 				Metadata: diskBlock.GetMetadata(),
-				Name:     diskBlock.GetAttribute("device_name").AsStringValueOrDefault("", diskBlock),
+				Name:     diskBlock.GetAttribute("device_name").AsStringValue(),
 				Encryption: compute.DiskEncryption{
 					Metadata:   diskBlock.GetMetadata(),
-					RawKey:     diskBlock.GetAttribute("disk_encryption_key_raw").AsBytesValueOrDefault(nil, diskBlock),
-					KMSKeyLink: diskBlock.GetAttribute("kms_key_self_link").AsStringValueOrDefault("", diskBlock),
+					RawKey:     diskBlock.GetAttribute("disk_encryption_key_raw").AsBytesValue(nil),
+					KMSKeyLink: diskBlock.GetAttribute("kms_key_self_link").AsStringValue(),
 				},
 			}
 			instance.AttachedDisks = append(instance.AttachedDisks, disk)
@@ -90,7 +90,7 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 
 		if serviceAccountBlock := instanceBlock.GetBlock("service_account"); serviceAccountBlock.IsNotNil() {
 			emailAttr := serviceAccountBlock.GetAttribute("email")
-			instance.ServiceAccount.Email = emailAttr.AsStringValueOrDefault("", serviceAccountBlock)
+			instance.ServiceAccount.Email = emailAttr.AsStringValue()
 
 			if instance.ServiceAccount.Email.IsEmpty() || instance.ServiceAccount.Email.EndsWith("-compute@developer.gserviceaccount.com") {
 				instance.ServiceAccount.IsDefault = iacTypes.Bool(true, serviceAccountBlock.GetMetadata())
@@ -99,7 +99,7 @@ func adaptInstances(modules terraform.Modules) (instances []compute.Instance) {
 			if emailAttr.IsResourceBlockReference("google_service_account") {
 				if accBlock, err := modules.GetReferencedBlock(emailAttr, instanceBlock); err == nil {
 					instance.ServiceAccount.IsDefault = iacTypes.Bool(false, serviceAccountBlock.GetMetadata())
-					instance.ServiceAccount.Email = accBlock.GetAttribute("email").AsStringValueOrDefault("", accBlock)
+					instance.ServiceAccount.Email = accBlock.GetAttribute("email").AsStringValue()
 				}
 			}
 

--- a/pkg/iac/adapters/terraform/google/compute/networks.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks.go
@@ -28,10 +28,10 @@ func adaptNetworks(modules terraform.Modules) (networks []compute.Network) {
 
 		subnetwork := compute.SubNetwork{
 			Metadata:              subnetworkBlock.GetMetadata(),
-			Name:                  subnetworkBlock.GetAttribute("name").AsStringValueOrDefault("", subnetworkBlock),
-			Purpose:               subnetworkBlock.GetAttribute("purpose").AsStringValueOrDefault(defaultSubnetPurpose, subnetworkBlock),
+			Name:                  subnetworkBlock.GetAttribute("name").AsStringValue(),
+			Purpose:               subnetworkBlock.GetAttribute("purpose").AsStringValue(defaultSubnetPurpose),
 			EnableFlowLogs:        iacTypes.BoolDefault(false, subnetworkBlock.GetMetadata()),
-			PrivateIPGoogleAccess: subnetworkBlock.GetAttribute("private_ip_google_access").AsBoolValueOrDefault(false, subnetworkBlock),
+			PrivateIPGoogleAccess: subnetworkBlock.GetAttribute("private_ip_google_access").AsBoolValue(),
 		}
 
 		// logging
@@ -63,7 +63,7 @@ func adaptNetworks(modules terraform.Modules) (networks []compute.Network) {
 
 		firewall := compute.Firewall{
 			Metadata:     firewallBlock.GetMetadata(),
-			Name:         firewallBlock.GetAttribute("name").AsStringValueOrDefault("", firewallBlock),
+			Name:         firewallBlock.GetAttribute("name").AsStringValue(),
 			IngressRules: nil,
 			EgressRules:  nil,
 			SourceTags:   firewallBlock.GetAttribute("source_tags").AsStringValueSliceOrEmpty(),
@@ -128,7 +128,7 @@ func adaptFirewallRule(firewall *compute.Firewall, firewallBlock, ruleBlock *ter
 		Metadata: firewallBlock.GetMetadata(),
 		Enforced: iacTypes.BoolDefault(true, firewallBlock.GetMetadata()),
 		IsAllow:  iacTypes.Bool(allow, ruleBlock.GetMetadata()),
-		Protocol: protocolAttr.AsStringValueOrDefault("tcp", ruleBlock),
+		Protocol: protocolAttr.AsStringValue("tcp"),
 		Ports:    rngs,
 	}
 

--- a/pkg/iac/adapters/terraform/google/compute/ssl.go
+++ b/pkg/iac/adapters/terraform/google/compute/ssl.go
@@ -9,9 +9,9 @@ func adaptSSLPolicies(modules terraform.Modules) (policies []compute.SSLPolicy) 
 	for _, policyBlock := range modules.GetResourcesByType("google_compute_ssl_policy") {
 		policy := compute.SSLPolicy{
 			Metadata:          policyBlock.GetMetadata(),
-			Name:              policyBlock.GetAttribute("name").AsStringValueOrDefault("", policyBlock),
-			Profile:           policyBlock.GetAttribute("profile").AsStringValueOrDefault("", policyBlock),
-			MinimumTLSVersion: policyBlock.GetAttribute("min_tls_version").AsStringValueOrDefault("TLS_1_0", policyBlock),
+			Name:              policyBlock.GetAttribute("name").AsStringValue(),
+			Profile:           policyBlock.GetAttribute("profile").AsStringValue(),
+			MinimumTLSVersion: policyBlock.GetAttribute("min_tls_version").AsStringValue("TLS_1_0"),
 		}
 		policies = append(policies, policy)
 	}

--- a/pkg/iac/adapters/terraform/google/dns/adapt.go
+++ b/pkg/iac/adapters/terraform/google/dns/adapt.go
@@ -25,7 +25,7 @@ func adaptManagedZones(modules terraform.Modules) []dns.ManagedZone {
 func adaptManagedZone(resource *terraform.Block) dns.ManagedZone {
 	zone := dns.ManagedZone{
 		Metadata:   resource.GetMetadata(),
-		Visibility: resource.GetAttribute("visibility").AsStringValueOrDefault("public", resource),
+		Visibility: resource.GetAttribute("visibility").AsStringValue("public"),
 		DNSSec:     adaptDNSSec(resource),
 	}
 	return zone
@@ -56,8 +56,8 @@ func adaptKeySpecs(b *terraform.Block) []dns.KeySpecs {
 	for _, keySpecsBlock := range b.GetBlocks("default_key_specs") {
 		keySpecs = append(keySpecs, dns.KeySpecs{
 			Metadata:  keySpecsBlock.GetMetadata(),
-			Algorithm: keySpecsBlock.GetAttribute("algorithm").AsStringValueOrDefault("", keySpecsBlock),
-			KeyType:   keySpecsBlock.GetAttribute("key_type").AsStringValueOrDefault("", keySpecsBlock),
+			Algorithm: keySpecsBlock.GetAttribute("algorithm").AsStringValue(),
+			KeyType:   keySpecsBlock.GetAttribute("key_type").AsStringValue(),
 		})
 	}
 	return keySpecs

--- a/pkg/iac/adapters/terraform/google/gke/adapt.go
+++ b/pkg/iac/adapters/terraform/google/gke/adapt.go
@@ -64,7 +64,7 @@ func (a *adapter) adaptCluster(resource *terraform.Block) {
 			Enabled:  iacTypes.BoolDefault(false, resource.GetMetadata()),
 		},
 		DatapathProvider: resource.GetAttribute("datapath_provider").
-			AsStringValueOrDefault("DATAPATH_PROVIDER_UNSPECIFIED", resource),
+			AsStringValue("DATAPATH_PROVIDER_UNSPECIFIED"),
 		PrivateCluster: gke.PrivateCluster{
 			Metadata:           resource.GetMetadata(),
 			EnablePrivateNodes: iacTypes.BoolDefault(false, resource.GetMetadata()),
@@ -109,19 +109,19 @@ func (a *adapter) adaptCluster(resource *terraform.Block) {
 	if policyBlock := resource.GetBlock("network_policy"); policyBlock.IsNotNil() {
 		enabledAttr := policyBlock.GetAttribute("enabled")
 		cluster.NetworkPolicy.Metadata = policyBlock.GetMetadata()
-		cluster.NetworkPolicy.Enabled = enabledAttr.AsBoolValueOrDefault(false, policyBlock)
+		cluster.NetworkPolicy.Enabled = enabledAttr.AsBoolValue()
 	}
 
 	if privBlock := resource.GetBlock("private_cluster_config"); privBlock.IsNotNil() {
 		privateNodesEnabledAttr := privBlock.GetAttribute("enable_private_nodes")
 		cluster.PrivateCluster.Metadata = privBlock.GetMetadata()
-		cluster.PrivateCluster.EnablePrivateNodes = privateNodesEnabledAttr.AsBoolValueOrDefault(false, privBlock)
+		cluster.PrivateCluster.EnablePrivateNodes = privateNodesEnabledAttr.AsBoolValue()
 	}
 
 	loggingAttr := resource.GetAttribute("logging_service")
-	cluster.LoggingService = loggingAttr.AsStringValueOrDefault("logging.googleapis.com/kubernetes", resource)
+	cluster.LoggingService = loggingAttr.AsStringValue("logging.googleapis.com/kubernetes")
 	monitoringServiceAttr := resource.GetAttribute("monitoring_service")
-	cluster.MonitoringService = monitoringServiceAttr.AsStringValueOrDefault("monitoring.googleapis.com/kubernetes", resource)
+	cluster.MonitoringService = monitoringServiceAttr.AsStringValue("monitoring.googleapis.com/kubernetes")
 
 	if masterBlock := resource.GetBlock("master_auth"); masterBlock.IsNotNil() {
 		cluster.MasterAuth = adaptMasterAuth(masterBlock)
@@ -134,31 +134,31 @@ func (a *adapter) adaptCluster(resource *terraform.Block) {
 	if autoScalingBlock := resource.GetBlock("cluster_autoscaling"); autoScalingBlock.IsNotNil() {
 		cluster.AutoScaling = gke.AutoScaling{
 			Metadata: autoScalingBlock.GetMetadata(),
-			Enabled:  autoScalingBlock.GetAttribute("enabled").AsBoolValueOrDefault(false, autoScalingBlock),
+			Enabled:  autoScalingBlock.GetAttribute("enabled").AsBoolValue(),
 		}
 
 		if b := autoScalingBlock.GetBlock("auto_provisioning_defaults"); b.IsNotNil() {
 			cluster.AutoScaling.AutoProvisioningDefaults = gke.AutoProvisioningDefaults{
 				Metadata:       b.GetMetadata(),
-				ServiceAccount: b.GetAttribute("service_account").AsStringValueOrDefault("", b),
+				ServiceAccount: b.GetAttribute("service_account").AsStringValue(),
 				Management:     adaptManagement(b),
-				ImageType:      b.GetAttribute("image_type").AsStringValueOrDefault("", b),
+				ImageType:      b.GetAttribute("image_type").AsStringValue(),
 			}
 		}
 	}
-	cluster.EnableShieldedNodes = resource.GetAttribute("enable_shielded_nodes").AsBoolValueOrDefault(true, resource)
+	cluster.EnableShieldedNodes = resource.GetAttribute("enable_shielded_nodes").AsBoolValue(true)
 
 	enableLegacyABACAttr := resource.GetAttribute("enable_legacy_abac")
-	cluster.EnableLegacyABAC = enableLegacyABACAttr.AsBoolValueOrDefault(false, resource)
+	cluster.EnableLegacyABAC = enableLegacyABACAttr.AsBoolValue()
 
-	cluster.EnableAutpilot = resource.GetAttribute("enable_autopilot").AsBoolValueOrDefault(false, resource)
+	cluster.EnableAutpilot = resource.GetAttribute("enable_autopilot").AsBoolValue()
 
 	resourceLabelsAttr := resource.GetAttribute("resource_labels")
 	if resourceLabelsAttr.IsNotNil() {
 		cluster.ResourceLabels = resourceLabelsAttr.AsMapValue()
 	}
 
-	cluster.RemoveDefaultNodePool = resource.GetAttribute("remove_default_node_pool").AsBoolValueOrDefault(false, resource)
+	cluster.RemoveDefaultNodePool = resource.GetAttribute("remove_default_node_pool").AsBoolValue()
 
 	a.clusterMap[resource.ID()] = cluster
 }
@@ -175,8 +175,8 @@ func adaptManagement(parent *terraform.Block) gke.Management {
 
 	return gke.Management{
 		Metadata:          b.GetMetadata(),
-		EnableAutoRepair:  b.GetAttribute("auto_repair").AsBoolValueOrDefault(false, b),
-		EnableAutoUpgrade: b.GetAttribute("auto_upgrade").AsBoolValueOrDefault(false, b),
+		EnableAutoRepair:  b.GetAttribute("auto_repair").AsBoolValue(),
+		EnableAutoUpgrade: b.GetAttribute("auto_upgrade").AsBoolValue(),
 	}
 }
 
@@ -273,12 +273,12 @@ func adaptNodeConfig(resource *terraform.Block) gke.NodeConfig {
 
 	config := gke.NodeConfig{
 		Metadata:  resource.GetMetadata(),
-		ImageType: resource.GetAttribute("image_type").AsStringValueOrDefault("", resource),
+		ImageType: resource.GetAttribute("image_type").AsStringValue(),
 		WorkloadMetadataConfig: gke.WorkloadMetadataConfig{
 			Metadata:     resource.GetMetadata(),
 			NodeMetadata: iacTypes.StringDefault("UNSPECIFIED", resource.GetMetadata()),
 		},
-		ServiceAccount:        resource.GetAttribute("service_account").AsStringValueOrDefault("", resource),
+		ServiceAccount:        resource.GetAttribute("service_account").AsStringValue(),
 		EnableLegacyEndpoints: iacTypes.BoolDefault(true, resource.GetMetadata()),
 	}
 
@@ -296,7 +296,7 @@ func adaptNodeConfig(resource *terraform.Block) gke.NodeConfig {
 		if modeAttr.IsNil() {
 			modeAttr = workloadBlock.GetAttribute("mode") // try newest version
 		}
-		config.WorkloadMetadataConfig.NodeMetadata = modeAttr.AsStringValueOrDefault("UNSPECIFIED", workloadBlock)
+		config.WorkloadMetadataConfig.NodeMetadata = modeAttr.AsStringValue("UNSPECIFIED")
 	}
 
 	return config
@@ -310,12 +310,12 @@ func adaptMasterAuth(resource *terraform.Block) gke.MasterAuth {
 
 	if certConfigBlock := resource.GetBlock("client_certificate_config"); certConfigBlock.IsNotNil() {
 		clientCertAttr := certConfigBlock.GetAttribute("issue_client_certificate")
-		clientCert.IssueCertificate = clientCertAttr.AsBoolValueOrDefault(false, certConfigBlock)
+		clientCert.IssueCertificate = clientCertAttr.AsBoolValue()
 		clientCert.Metadata = certConfigBlock.GetMetadata()
 	}
 
-	username := resource.GetAttribute("username").AsStringValueOrDefault("", resource)
-	password := resource.GetAttribute("password").AsStringValueOrDefault("", resource)
+	username := resource.GetAttribute("username").AsStringValue()
+	password := resource.GetAttribute("password").AsStringValue()
 
 	return gke.MasterAuth{
 		Metadata:          resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/google/iam/convert.go
+++ b/pkg/iac/adapters/terraform/google/iam/convert.go
@@ -12,7 +12,7 @@ func ParsePolicyBlock(block *terraform.Block) []iam.Binding {
 		binding := iam.Binding{
 			Metadata:                      bindingBlock.GetMetadata(),
 			Members:                       nil,
-			Role:                          bindingBlock.GetAttribute("role").AsStringValueOrDefault("", bindingBlock),
+			Role:                          bindingBlock.GetAttribute("role").AsStringValue(),
 			IncludesDefaultServiceAccount: iacTypes.BoolDefault(false, bindingBlock.GetMetadata()),
 		}
 		membersAttr := bindingBlock.GetAttribute("members")

--- a/pkg/iac/adapters/terraform/google/iam/project_iam.go
+++ b/pkg/iac/adapters/terraform/google/iam/project_iam.go
@@ -30,7 +30,7 @@ func (a *adapter) adaptProjects() {
 
 		a.projects[projectBlock.ID()] = &iam.Project{
 			Metadata:          projectBlock.GetMetadata().Root(),
-			AutoCreateNetwork: projectBlock.GetAttribute("auto_create_network").AsBoolValueOrDefault(true, projectBlock),
+			AutoCreateNetwork: projectBlock.GetAttribute("auto_create_network").AsBoolValue(true),
 		}
 	}
 }
@@ -42,8 +42,8 @@ func (a *adapter) adaptMember(iamBlock *terraform.Block) iam.Member {
 func AdaptMember(iamBlock *terraform.Block, modules terraform.Modules) iam.Member {
 	member := iam.Member{
 		Metadata:              iamBlock.GetMetadata(),
-		Member:                iamBlock.GetAttribute("member").AsStringValueOrDefault("", iamBlock),
-		Role:                  iamBlock.GetAttribute("role").AsStringValueOrDefault("", iamBlock),
+		Member:                iamBlock.GetAttribute("member").AsStringValue(),
+		Role:                  iamBlock.GetAttribute("role").AsStringValue(),
 		DefaultServiceAccount: iacTypes.BoolDefault(false, iamBlock.GetMetadata()),
 	}
 
@@ -101,7 +101,7 @@ func AdaptBinding(iamBlock *terraform.Block, modules terraform.Modules) iam.Bind
 	binding := iam.Binding{
 		Metadata:                      iamBlock.GetMetadata(),
 		Members:                       nil,
-		Role:                          iamBlock.GetAttribute("role").AsStringValueOrDefault("", iamBlock),
+		Role:                          iamBlock.GetAttribute("role").AsStringValue(),
 		IncludesDefaultServiceAccount: iacTypes.BoolDefault(false, iamBlock.GetMetadata()),
 	}
 	membersAttr := iamBlock.GetAttribute("members")
@@ -233,13 +233,13 @@ func (a *adapter) adaptProjectAuditConfigs() {
 func AdaptAuditConfig(block *terraform.Block) iam.AuditConfig {
 	auditConfig := iam.AuditConfig{
 		Metadata: block.GetMetadata(),
-		Service:  block.GetAttribute("service").AsStringValueOrDefault("", block),
+		Service:  block.GetAttribute("service").AsStringValue(),
 	}
 
 	for _, logConfigBlock := range block.GetBlocks("audit_log_config") {
 		logConfig := iam.AuditLogConfig{
 			Metadata: logConfigBlock.GetMetadata(),
-			LogType:  logConfigBlock.GetAttribute("log_type").AsStringValueOrDefault("", logConfigBlock),
+			LogType:  logConfigBlock.GetAttribute("log_type").AsStringValue(),
 		}
 
 		// Parse exempted_members array

--- a/pkg/iac/adapters/terraform/google/iam/workload_identity_pool_providers.go
+++ b/pkg/iac/adapters/terraform/google/iam/workload_identity_pool_providers.go
@@ -10,9 +10,9 @@ func (a *adapter) adaptWorkloadIdentityPoolProviders() {
 	for _, resource := range a.modules.GetResourcesByType("google_iam_workload_identity_pool_provider") {
 		a.workloadIdentityPoolProviders = append(a.workloadIdentityPoolProviders, iam.WorkloadIdentityPoolProvider{
 			Metadata:                       resource.GetMetadata(),
-			WorkloadIdentityPoolId:         resource.GetAttribute("workload_identity_pool_id").AsStringValueOrDefault("", resource),
-			WorkloadIdentityPoolProviderId: resource.GetAttribute("workload_identity_pool_provider_id").AsStringValueOrDefault("", resource),
-			AttributeCondition:             resource.GetAttribute("attribute_condition").AsStringValueOrDefault("", resource),
+			WorkloadIdentityPoolId:         resource.GetAttribute("workload_identity_pool_id").AsStringValue(),
+			WorkloadIdentityPoolProviderId: resource.GetAttribute("workload_identity_pool_provider_id").AsStringValue(),
+			AttributeCondition:             resource.GetAttribute("attribute_condition").AsStringValue(),
 		})
 	}
 }

--- a/pkg/iac/adapters/terraform/google/sql/adapt.go
+++ b/pkg/iac/adapters/terraform/google/sql/adapt.go
@@ -28,7 +28,7 @@ func adaptInstance(resource *terraform.Block) sql.DatabaseInstance {
 
 	instance := sql.DatabaseInstance{
 		Metadata:        resource.GetMetadata(),
-		DatabaseVersion: resource.GetAttribute("database_version").AsStringValueOrDefault("", resource),
+		DatabaseVersion: resource.GetAttribute("database_version").AsStringValue(),
 		IsReplica:       iacTypes.BoolDefault(false, resource.GetMetadata()),
 		Settings: sql.Settings{
 			Metadata: resource.GetMetadata(),
@@ -71,7 +71,7 @@ func adaptInstance(resource *terraform.Block) sql.DatabaseInstance {
 		if backupBlock := settingsBlock.GetBlock("backup_configuration"); backupBlock.IsNotNil() {
 			instance.Settings.Backups.Metadata = backupBlock.GetMetadata()
 			backupConfigEnabledAttr := backupBlock.GetAttribute("enabled")
-			instance.Settings.Backups.Enabled = backupConfigEnabledAttr.AsBoolValueOrDefault(false, backupBlock)
+			instance.Settings.Backups.Enabled = backupConfigEnabledAttr.AsBoolValue()
 		}
 		if ipConfBlock := settingsBlock.GetBlock("ip_configuration"); ipConfBlock.IsNotNil() {
 			instance.Settings.IPConfiguration = adaptIPConfig(ipConfBlock)
@@ -97,7 +97,7 @@ func adaptFlags(resources terraform.Blocks, flags *sql.Flags) {
 				flags.LogTempFileSize = iacTypes.Int(logTempInt, nameAttr.GetMetadata())
 			}
 		case "log_min_messages":
-			flags.LogMinMessages = valueAttr.AsStringValueOrDefault("", resource)
+			flags.LogMinMessages = valueAttr.AsStringValue()
 		case "log_min_duration_statement":
 			if logMinDS, err := strconv.Atoi(valueAttr.Value().AsString()); err == nil {
 				flags.LogMinDurationStatement = iacTypes.Int(logMinDS, nameAttr.GetMetadata())
@@ -128,8 +128,8 @@ func adaptIPConfig(resource *terraform.Block) sql.IPConfiguration {
 
 	authNetworksBlocks := resource.GetBlocks("authorized_networks")
 	for _, authBlock := range authNetworksBlocks {
-		nameVal := authBlock.GetAttribute("name").AsStringValueOrDefault("", authBlock)
-		cidrVal := authBlock.GetAttribute("value").AsStringValueOrDefault("", authBlock)
+		nameVal := authBlock.GetAttribute("name").AsStringValue()
+		cidrVal := authBlock.GetAttribute("value").AsStringValue()
 
 		authorizedNetworks = append(authorizedNetworks, struct {
 			Name iacTypes.StringValue
@@ -142,9 +142,9 @@ func adaptIPConfig(resource *terraform.Block) sql.IPConfiguration {
 
 	return sql.IPConfiguration{
 		Metadata:           resource.GetMetadata(),
-		RequireTLS:         resource.GetAttribute("require_ssl").AsBoolValueOrDefault(false, resource),
-		SSLMode:            resource.GetAttribute("ssl_mode").AsStringValueOrDefault("", resource),
-		EnableIPv4:         resource.GetAttribute("ipv4_enabled").AsBoolValueOrDefault(true, resource),
+		RequireTLS:         resource.GetAttribute("require_ssl").AsBoolValue(),
+		SSLMode:            resource.GetAttribute("ssl_mode").AsStringValue(),
+		EnableIPv4:         resource.GetAttribute("ipv4_enabled").AsBoolValue(true),
 		AuthorizedNetworks: authorizedNetworks,
 	}
 }

--- a/pkg/iac/adapters/terraform/google/storage/adapt.go
+++ b/pkg/iac/adapters/terraform/google/storage/adapt.go
@@ -82,14 +82,14 @@ func (a *adapter) adaptBuckets() []storage.Bucket {
 func (a *adapter) adaptBucketResource(resourceBlock *terraform.Block) storage.Bucket {
 
 	nameAttr := resourceBlock.GetAttribute("name")
-	nameValue := nameAttr.AsStringValueOrDefault("", resourceBlock)
+	nameValue := nameAttr.AsStringValue()
 
 	locationAttr := resourceBlock.GetAttribute("location")
-	locationValue := locationAttr.AsStringValueOrDefault("", resourceBlock)
+	locationValue := locationAttr.AsStringValue()
 
 	// See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#uniform_bucket_level_access
 	ublaAttr := resourceBlock.GetAttribute("uniform_bucket_level_access")
-	ublaValue := ublaAttr.AsBoolValueOrDefault(false, resourceBlock)
+	ublaValue := ublaAttr.AsBoolValue()
 
 	bucket := storage.Bucket{
 		Metadata:                       resourceBlock.GetMetadata(),
@@ -116,18 +116,18 @@ func (a *adapter) adaptBucketResource(resourceBlock *terraform.Block) storage.Bu
 	if encBlock := resourceBlock.GetBlock("encryption"); encBlock.IsNotNil() {
 		bucket.Encryption.Metadata = encBlock.GetMetadata()
 		kmsKeyNameAttr := encBlock.GetAttribute("default_kms_key_name")
-		bucket.Encryption.DefaultKMSKeyName = kmsKeyNameAttr.AsStringValueOrDefault("", encBlock)
+		bucket.Encryption.DefaultKMSKeyName = kmsKeyNameAttr.AsStringValue()
 	}
 
 	if logBlock := resourceBlock.GetBlock("logging"); logBlock.IsNotNil() {
 		bucket.Logging.Metadata = logBlock.GetMetadata()
-		bucket.Logging.LogBucket = logBlock.GetAttribute("log_bucket").AsStringValueOrDefault("", logBlock)
-		bucket.Logging.LogObjectPrefix = logBlock.GetAttribute("log_object_prefix").AsStringValueOrDefault("", logBlock)
+		bucket.Logging.LogBucket = logBlock.GetAttribute("log_bucket").AsStringValue()
+		bucket.Logging.LogObjectPrefix = logBlock.GetAttribute("log_object_prefix").AsStringValue()
 	}
 
 	if versioningBlock := resourceBlock.GetBlock("versioning"); versioningBlock.IsNotNil() {
 		bucket.Versioning.Metadata = versioningBlock.GetMetadata()
-		bucket.Versioning.Enabled = versioningBlock.GetAttribute("enabled").AsBoolValueOrDefault(false, versioningBlock)
+		bucket.Versioning.Enabled = versioningBlock.GetAttribute("enabled").AsBoolValue()
 	}
 
 	var name string

--- a/pkg/iac/adapters/terraform/kubernetes/adapt.go
+++ b/pkg/iac/adapters/terraform/kubernetes/adapt.go
@@ -50,10 +50,10 @@ func adaptNetworkPolicy(resourceBlock *terraform.Block) kubernetes.NetworkPolicy
 			policy.Spec.Egress.Metadata = egressBlock.GetMetadata()
 			for _, port := range egressBlock.GetBlocks("ports") {
 				numberAttr := port.GetAttribute("number")
-				numberVal := numberAttr.AsStringValueOrDefault("", port)
+				numberVal := numberAttr.AsStringValue()
 
 				protocolAttr := port.GetAttribute("protocol")
-				protocolVal := protocolAttr.AsStringValueOrDefault("", port)
+				protocolVal := protocolAttr.AsStringValue()
 
 				policy.Spec.Egress.Ports = append(policy.Spec.Egress.Ports, kubernetes.Port{
 					Metadata: port.GetMetadata(),
@@ -64,7 +64,7 @@ func adaptNetworkPolicy(resourceBlock *terraform.Block) kubernetes.NetworkPolicy
 
 			for _, to := range egressBlock.GetBlocks("to") {
 				cidrAtrr := to.GetBlock("ip_block").GetAttribute("cidr")
-				cidrVal := cidrAtrr.AsStringValueOrDefault("", to)
+				cidrVal := cidrAtrr.AsStringValue()
 
 				policy.Spec.Egress.DestinationCIDRs = append(policy.Spec.Egress.DestinationCIDRs, cidrVal)
 			}
@@ -74,10 +74,10 @@ func adaptNetworkPolicy(resourceBlock *terraform.Block) kubernetes.NetworkPolicy
 			policy.Spec.Ingress.Metadata = ingressBlock.GetMetadata()
 			for _, port := range ingressBlock.GetBlocks("ports") {
 				numberAttr := port.GetAttribute("number")
-				numberVal := numberAttr.AsStringValueOrDefault("", port)
+				numberVal := numberAttr.AsStringValue()
 
 				protocolAttr := port.GetAttribute("protocol")
-				protocolVal := protocolAttr.AsStringValueOrDefault("", port)
+				protocolVal := protocolAttr.AsStringValue()
 
 				policy.Spec.Ingress.Ports = append(policy.Spec.Ingress.Ports, kubernetes.Port{
 					Metadata: port.GetMetadata(),
@@ -88,7 +88,7 @@ func adaptNetworkPolicy(resourceBlock *terraform.Block) kubernetes.NetworkPolicy
 
 			for _, from := range ingressBlock.GetBlocks("from") {
 				cidrAtrr := from.GetBlock("ip_block").GetAttribute("cidr")
-				cidrVal := cidrAtrr.AsStringValueOrDefault("", from)
+				cidrVal := cidrAtrr.AsStringValue()
 
 				policy.Spec.Ingress.SourceCIDRs = append(policy.Spec.Ingress.SourceCIDRs, cidrVal)
 			}

--- a/pkg/iac/adapters/terraform/nifcloud/computing/instance.go
+++ b/pkg/iac/adapters/terraform/nifcloud/computing/instance.go
@@ -22,14 +22,14 @@ func adaptInstance(resource *terraform.Block) computing.Instance {
 			networkInterfaces,
 			computing.NetworkInterface{
 				Metadata:  networkInterfaceBlock.GetMetadata(),
-				NetworkID: networkInterfaceBlock.GetAttribute("network_id").AsStringValueOrDefault("", resource),
+				NetworkID: networkInterfaceBlock.GetAttribute("network_id").AsStringValue(),
 			},
 		)
 	}
 
 	return computing.Instance{
 		Metadata:          resource.GetMetadata(),
-		SecurityGroup:     resource.GetAttribute("security_group").AsStringValueOrDefault("", resource),
+		SecurityGroup:     resource.GetAttribute("security_group").AsStringValue(),
 		NetworkInterfaces: networkInterfaces,
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/computing/security_group.go
+++ b/pkg/iac/adapters/terraform/nifcloud/computing/security_group.go
@@ -40,7 +40,7 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 	var ingressRules, egressRules []computing.SecurityGroupRule
 
 	descriptionAttr := resource.GetAttribute("description")
-	descriptionVal := descriptionAttr.AsStringValueOrDefault("", resource)
+	descriptionVal := descriptionAttr.AsStringValue()
 
 	rulesBlocks := module.GetReferencingResources(resource, "nifcloud_security_group_rule", "security_group_names")
 	for _, ruleBlock := range rulesBlocks {
@@ -63,10 +63,10 @@ func (a *sgAdapter) adaptSecurityGroup(resource *terraform.Block, module terrafo
 
 func adaptSGRule(resource *terraform.Block, _ terraform.Modules) computing.SecurityGroupRule {
 	ruleDescAttr := resource.GetAttribute("description")
-	ruleDescVal := ruleDescAttr.AsStringValueOrDefault("", resource)
+	ruleDescVal := ruleDescAttr.AsStringValue()
 
 	cidrAttr := resource.GetAttribute("cidr_ip")
-	cidrVal := cidrAttr.AsStringValueOrDefault("", resource)
+	cidrVal := cidrAttr.AsStringValue()
 
 	return computing.SecurityGroupRule{
 		Metadata:    resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/nifcloud/dns/record.go
+++ b/pkg/iac/adapters/terraform/nifcloud/dns/record.go
@@ -17,7 +17,7 @@ func adaptRecords(modules terraform.Modules) []dns.Record {
 func adaptRecord(resource *terraform.Block) dns.Record {
 	return dns.Record{
 		Metadata: resource.GetMetadata(),
-		Record:   resource.GetAttribute("record").AsStringValueOrDefault("", resource),
-		Type:     resource.GetAttribute("type").AsStringValueOrDefault("", resource),
+		Record:   resource.GetAttribute("record").AsStringValue(),
+		Type:     resource.GetAttribute("type").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/nas/nas_instance.go
+++ b/pkg/iac/adapters/terraform/nifcloud/nas/nas_instance.go
@@ -17,6 +17,6 @@ func adaptNASInstances(modules terraform.Modules) []nas.NASInstance {
 func adaptNASInstance(resource *terraform.Block) nas.NASInstance {
 	return nas.NASInstance{
 		Metadata:  resource.GetMetadata(),
-		NetworkID: resource.GetAttribute("network_id").AsStringValueOrDefault("net-COMMON_PRIVATE", resource),
+		NetworkID: resource.GetAttribute("network_id").AsStringValue("net-COMMON_PRIVATE"),
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/nas/nas_security_group.go
+++ b/pkg/iac/adapters/terraform/nifcloud/nas/nas_security_group.go
@@ -19,12 +19,12 @@ func adaptNASSecurityGroup(resource *terraform.Block) nas.NASSecurityGroup {
 	var cidrs []iacTypes.StringValue
 
 	for _, rule := range resource.GetBlocks("rule") {
-		cidrs = append(cidrs, rule.GetAttribute("cidr_ip").AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, rule.GetAttribute("cidr_ip").AsStringValue())
 	}
 
 	return nas.NASSecurityGroup{
 		Metadata:    resource.GetMetadata(),
-		Description: resource.GetAttribute("description").AsStringValueOrDefault("", resource),
+		Description: resource.GetAttribute("description").AsStringValue(),
 		CIDRs:       cidrs,
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/network/elastic_load_balancer.go
+++ b/pkg/iac/adapters/terraform/nifcloud/network/elastic_load_balancer.go
@@ -24,8 +24,8 @@ func adaptElasticLoadBalancer(resource *terraform.Block, modules terraform.Modul
 			networkInterfaces,
 			network.NetworkInterface{
 				Metadata:     networkInterfaceBlock.GetMetadata(),
-				NetworkID:    networkInterfaceBlock.GetAttribute("network_id").AsStringValueOrDefault("", resource),
-				IsVipNetwork: networkInterfaceBlock.GetAttribute("is_vip_network").AsBoolValueOrDefault(true, resource),
+				NetworkID:    networkInterfaceBlock.GetAttribute("network_id").AsStringValue(),
+				IsVipNetwork: networkInterfaceBlock.GetAttribute("is_vip_network").AsBoolValue(true),
 			},
 		)
 	}
@@ -45,6 +45,6 @@ func adaptElasticLoadBalancer(resource *terraform.Block, modules terraform.Modul
 func adaptElasticLoadBalancerListener(resource *terraform.Block) network.ElasticLoadBalancerListener {
 	return network.ElasticLoadBalancerListener{
 		Metadata: resource.GetMetadata(),
-		Protocol: resource.GetAttribute("protocol").AsStringValueOrDefault("", resource),
+		Protocol: resource.GetAttribute("protocol").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/network/load_balancer.go
+++ b/pkg/iac/adapters/terraform/nifcloud/network/load_balancer.go
@@ -51,12 +51,12 @@ func adaptListener(resource *terraform.Block) network.LoadBalancerListener {
 
 	policyIDAttr := resource.GetAttribute("ssl_policy_id")
 	if policyIDAttr.IsNotNil() && policyIDAttr.IsString() {
-		policyVal = policyIDAttr.AsStringValueOrDefault("", resource)
+		policyVal = policyIDAttr.AsStringValue()
 	}
 
 	policyNameAttr := resource.GetAttribute("ssl_policy_name")
 	if policyNameAttr.IsNotNil() && policyNameAttr.IsString() {
-		policyVal = policyNameAttr.AsStringValueOrDefault("", resource)
+		policyVal = policyNameAttr.AsStringValue()
 	}
 
 	return network.LoadBalancerListener{

--- a/pkg/iac/adapters/terraform/nifcloud/network/router.go
+++ b/pkg/iac/adapters/terraform/nifcloud/network/router.go
@@ -23,7 +23,7 @@ func adaptRouter(resource *terraform.Block) network.Router {
 			networkInterfaces,
 			network.NetworkInterface{
 				Metadata:     networkInterfaceBlock.GetMetadata(),
-				NetworkID:    networkInterfaceBlock.GetAttribute("network_id").AsStringValueOrDefault("", resource),
+				NetworkID:    networkInterfaceBlock.GetAttribute("network_id").AsStringValue(),
 				IsVipNetwork: types.Bool(false, networkInterfaceBlock.GetMetadata()),
 			},
 		)
@@ -31,7 +31,7 @@ func adaptRouter(resource *terraform.Block) network.Router {
 
 	return network.Router{
 		Metadata:          resource.GetMetadata(),
-		SecurityGroup:     resource.GetAttribute("security_group").AsStringValueOrDefault("", resource),
+		SecurityGroup:     resource.GetAttribute("security_group").AsStringValue(),
 		NetworkInterfaces: networkInterfaces,
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/network/vpn_gateway.go
+++ b/pkg/iac/adapters/terraform/nifcloud/network/vpn_gateway.go
@@ -17,6 +17,6 @@ func adaptVpnGateways(modules terraform.Modules) []network.VpnGateway {
 func adaptVpnGateway(resource *terraform.Block) network.VpnGateway {
 	return network.VpnGateway{
 		Metadata:      resource.GetMetadata(),
-		SecurityGroup: resource.GetAttribute("security_group").AsStringValueOrDefault("", resource),
+		SecurityGroup: resource.GetAttribute("security_group").AsStringValue(),
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/rdb/db_instance.go
+++ b/pkg/iac/adapters/terraform/nifcloud/rdb/db_instance.go
@@ -17,10 +17,10 @@ func adaptDBInstances(modules terraform.Modules) []rdb.DBInstance {
 func adaptDBInstance(resource *terraform.Block) rdb.DBInstance {
 	return rdb.DBInstance{
 		Metadata:                  resource.GetMetadata(),
-		BackupRetentionPeriodDays: resource.GetAttribute("backup_retention_period").AsIntValueOrDefault(0, resource),
-		Engine:                    resource.GetAttribute("engine").AsStringValueOrDefault("", resource),
-		EngineVersion:             resource.GetAttribute("engine_version").AsStringValueOrDefault("", resource),
-		NetworkID:                 resource.GetAttribute("network_id").AsStringValueOrDefault("net-COMMON_PRIVATE", resource),
-		PublicAccess:              resource.GetAttribute("publicly_accessible").AsBoolValueOrDefault(true, resource),
+		BackupRetentionPeriodDays: resource.GetAttribute("backup_retention_period").AsIntValue(),
+		Engine:                    resource.GetAttribute("engine").AsStringValue(),
+		EngineVersion:             resource.GetAttribute("engine_version").AsStringValue(),
+		NetworkID:                 resource.GetAttribute("network_id").AsStringValue("net-COMMON_PRIVATE"),
+		PublicAccess:              resource.GetAttribute("publicly_accessible").AsBoolValue(true),
 	}
 }

--- a/pkg/iac/adapters/terraform/nifcloud/rdb/db_security_group.go
+++ b/pkg/iac/adapters/terraform/nifcloud/rdb/db_security_group.go
@@ -19,12 +19,12 @@ func adaptDBSecurityGroup(resource *terraform.Block) rdb.DBSecurityGroup {
 	var cidrs []iacTypes.StringValue
 
 	for _, rule := range resource.GetBlocks("rule") {
-		cidrs = append(cidrs, rule.GetAttribute("cidr_ip").AsStringValueOrDefault("", resource))
+		cidrs = append(cidrs, rule.GetAttribute("cidr_ip").AsStringValue())
 	}
 
 	return rdb.DBSecurityGroup{
 		Metadata:    resource.GetMetadata(),
-		Description: resource.GetAttribute("description").AsStringValueOrDefault("", resource),
+		Description: resource.GetAttribute("description").AsStringValue(),
 		CIDRs:       cidrs,
 	}
 }

--- a/pkg/iac/adapters/terraform/openstack/adapt.go
+++ b/pkg/iac/adapters/terraform/openstack/adapt.go
@@ -27,7 +27,7 @@ func adaptCompute(modules terraform.Modules) openstack.Compute {
 
 func adaptInstance(resourceBlock *terraform.Block) openstack.Instance {
 	adminPassAttr := resourceBlock.GetAttribute("admin_pass")
-	adminPassVal := adminPassAttr.AsStringValueOrDefault("", resourceBlock)
+	adminPassVal := adminPassAttr.AsStringValue()
 
 	return openstack.Instance{
 		Metadata:      resourceBlock.GetMetadata(),
@@ -45,19 +45,19 @@ func adaptFirewall(modules terraform.Modules) openstack.Firewall {
 		for _, resource := range module.GetResourcesByType("openstack_fw_rule_v1") {
 
 			sourceAttr := resource.GetAttribute("source_ip_address")
-			sourceVal := sourceAttr.AsStringValueOrDefault("", resource)
+			sourceVal := sourceAttr.AsStringValue()
 
 			destinationAttr := resource.GetAttribute("destination_ip_address")
-			destinationVal := destinationAttr.AsStringValueOrDefault("", resource)
+			destinationVal := destinationAttr.AsStringValue()
 
 			sourcePortAttr := resource.GetAttribute("source_port")
-			sourcePortVal := sourcePortAttr.AsStringValueOrDefault("", resource)
+			sourcePortVal := sourcePortAttr.AsStringValue()
 
 			destinationPortAttr := resource.GetAttribute("destination_port")
-			destinationPortVal := destinationPortAttr.AsStringValueOrDefault("", resource)
+			destinationPortVal := destinationPortAttr.AsStringValue()
 
 			enabledAttr := resource.GetAttribute("enabled")
-			enabledVal := enabledAttr.AsBoolValueOrDefault(true, resource)
+			enabledVal := enabledAttr.AsBoolValue(true)
 
 			if resource.GetAttribute("action").Equals("allow") {
 				firewall.AllowRules = append(firewall.AllowRules, openstack.FirewallRule{

--- a/pkg/iac/adapters/terraform/openstack/networking.go
+++ b/pkg/iac/adapters/terraform/openstack/networking.go
@@ -19,8 +19,8 @@ func adaptSecurityGroups(modules terraform.Modules) []openstack.SecurityGroup {
 	for _, groupBlock := range modules.GetResourcesByType("openstack_networking_secgroup_v2") {
 		group := openstack.SecurityGroup{
 			Metadata:    groupBlock.GetMetadata(),
-			Name:        groupBlock.GetAttribute("name").AsStringValueOrDefault("", groupBlock),
-			Description: groupBlock.GetAttribute("description").AsStringValueOrDefault("", groupBlock),
+			Name:        groupBlock.GetAttribute("name").AsStringValue(),
+			Description: groupBlock.GetAttribute("description").AsStringValue(),
 			Rules:       nil,
 		}
 		groupMap[groupBlock.ID()] = group
@@ -31,10 +31,10 @@ func adaptSecurityGroups(modules terraform.Modules) []openstack.SecurityGroup {
 			Metadata:  ruleBlock.GetMetadata(),
 			IsIngress: iacTypes.Bool(true, ruleBlock.GetMetadata()),
 			EtherType: iacTypes.IntDefault(4, ruleBlock.GetMetadata()),
-			Protocol:  ruleBlock.GetAttribute("protocol").AsStringValueOrDefault("tcp", ruleBlock),
-			PortMin:   ruleBlock.GetAttribute("port_range_min").AsIntValueOrDefault(0, ruleBlock),
-			PortMax:   ruleBlock.GetAttribute("port_range_max").AsIntValueOrDefault(0, ruleBlock),
-			CIDR:      ruleBlock.GetAttribute("remote_ip_prefix").AsStringValueOrDefault("", ruleBlock),
+			Protocol:  ruleBlock.GetAttribute("protocol").AsStringValue("tcp"),
+			PortMin:   ruleBlock.GetAttribute("port_range_min").AsIntValue(),
+			PortMax:   ruleBlock.GetAttribute("port_range_max").AsIntValue(),
+			CIDR:      ruleBlock.GetAttribute("remote_ip_prefix").AsStringValue(),
 		}
 
 		switch etherType := ruleBlock.GetAttribute("ethertype"); {

--- a/pkg/iac/adapters/terraform/oracle/adapt.go
+++ b/pkg/iac/adapters/terraform/oracle/adapt.go
@@ -19,7 +19,7 @@ func adaptCompute(modules terraform.Modules) oracle.Compute {
 	for _, module := range modules {
 		for _, resource := range module.GetResourcesByType("opc_compute_ip_address_reservation") {
 			addressPoolAttr := resource.GetAttribute("ip_address_pool")
-			addressPoolVal := addressPoolAttr.AsStringValueOrDefault("", resource)
+			addressPoolVal := addressPoolAttr.AsStringValue()
 			compute.AddressReservations = append(compute.AddressReservations, oracle.AddressReservation{
 				Metadata: resource.GetMetadata(),
 				Pool:     addressPoolVal,

--- a/pkg/iac/scanners/terraform/block_test.go
+++ b/pkg/iac/scanners/terraform/block_test.go
@@ -75,7 +75,7 @@ resource "aws_s3_bucket" "my-bucket" {
 			modules := createModulesFromSource(t, test.source, ".tf")
 			for _, module := range modules {
 				for _, block := range module.GetBlocks() {
-					assert.Nil(t, block.GetAttribute(test.expectedAttribute))
+					assert.True(t, block.GetAttribute(test.expectedAttribute).IsNil())
 				}
 			}
 		})

--- a/pkg/iac/scanners/terraform/parser/load_module.go
+++ b/pkg/iac/scanners/terraform/parser/load_module.go
@@ -132,7 +132,7 @@ func (e *evaluator) loadExternalModule(ctx context.Context, b *terraform.Block, 
 
 	e.logger.Debug("Locating non-initialized module", log.String("source", source))
 
-	version := b.GetAttribute("version").AsStringValueOrDefault("", b).Value()
+	version := b.GetAttribute("version").AsStringValue().Value()
 	opt := resolvers.Options{
 		Source:          source,
 		OriginalSource:  source,

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -328,7 +328,7 @@ func (p *Parser) Load(_ context.Context) (*evaluator, error) {
 func missingVariableValues(blocks terraform.Blocks, inputVars map[string]cty.Value) []*terraform.Block {
 	var missing []*terraform.Block
 	for _, varBlock := range blocks.OfType("variable") {
-		if varBlock.GetAttribute("default") == nil {
+		if varBlock.GetAttribute("default").IsNil() {
 			if _, ok := inputVars[varBlock.TypeLabel()]; !ok {
 				missing = append(missing, varBlock)
 			}

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -662,8 +662,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this2" {
 	assert.Len(t, blocks, 2)
 
 	for _, block := range blocks {
-		attr, parent := block.GetNestedAttribute("rule.apply_server_side_encryption_by_default.kms_master_key_id")
-		assert.Equal(t, "apply_server_side_encryption_by_default", parent.Type())
+		attr := block.GetNestedAttribute("rule.apply_server_side_encryption_by_default.kms_master_key_id")
 		assert.NotNil(t, attr)
 		assert.NotEmpty(t, attr.Value().AsString())
 	}
@@ -1719,7 +1718,7 @@ resource "test_resource" "this" {
 	resources := modules.GetResourcesByType("test_resource")
 	require.Len(t, resources, 1)
 
-	attr, _ := resources[0].GetNestedAttribute("dynamic_block.some_attr")
+	attr := resources[0].GetNestedAttribute("dynamic_block.some_attr")
 	require.NotNil(t, attr)
 
 	assert.Equal(t, "test_value", attr.GetRawValue())
@@ -1944,7 +1943,7 @@ module "invalid" {
 	require.Len(t, resources, 1)
 
 	for _, res := range resources {
-		attr, _ := res.GetNestedAttribute("names")
+		attr := res.GetNestedAttribute("names")
 		require.NotNil(t, attr, res.FullName())
 		assert.Equal(t, []string{"Brooklyn", "Queens"}, attr.GetRawValue())
 	}
@@ -2145,7 +2144,7 @@ output "test_out" {
 	require.Len(t, resources, 2)
 
 	for _, res := range resources {
-		attr, _ := res.GetNestedAttribute("dynamic_block.some_attr")
+		attr := res.GetNestedAttribute("dynamic_block.some_attr")
 		require.NotNil(t, attr, res.FullName())
 		assert.Equal(t, "test_value", attr.GetRawValue())
 	}

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -697,7 +697,7 @@ resource "aws_s3_bucket" "main" {
 
 	block := blocks[0]
 
-	assert.Equal(t, "test_bucket", block.GetAttribute("bucket").AsStringValueOrDefault("", block).Value())
+	assert.Equal(t, "test_bucket", block.GetAttribute("bucket").AsStringValue().Value())
 }
 
 func Test_ForEachRefToLocals(t *testing.T) {
@@ -732,7 +732,7 @@ resource "aws_s3_bucket" "this" {
 	for _, block := range blocks {
 		attr := block.GetAttribute("bucket")
 		require.NotNil(t, attr)
-		assert.Contains(t, []string{"foo", "bar"}, attr.AsStringValueOrDefault("", block).Value())
+		assert.Contains(t, []string{"foo", "bar"}, attr.AsStringValue().Value())
 	}
 }
 
@@ -766,7 +766,7 @@ resource "aws_s3_bucket" "this" {
 	for _, block := range blocks {
 		attr := block.GetAttribute("bucket")
 		require.NotNil(t, attr)
-		assert.Contains(t, []string{"foo", "bar"}, attr.AsStringValueOrDefault("", block).Value())
+		assert.Contains(t, []string{"foo", "bar"}, attr.AsStringValue().Value())
 	}
 }
 
@@ -819,10 +819,10 @@ policy_rules = {
 
 	block := blocks[0]
 
-	assert.Equal(t, "secure-tag-1", block.GetAttribute("name").AsStringValueOrDefault("", block).Value())
-	assert.True(t, block.GetAttribute("enabled").AsBoolValueOrDefault(false, block).Value())
-	assert.Equal(t, "host() != 'google.com'", block.GetAttribute("session_matcher").AsStringValueOrDefault("", block).Value())
-	assert.Equal(t, 1001, block.GetAttribute("priority").AsIntValueOrDefault(0, block).Value())
+	assert.Equal(t, "secure-tag-1", block.GetAttribute("name").AsStringValue().Value())
+	assert.True(t, block.GetAttribute("enabled").AsBoolValue().Value())
+	assert.Equal(t, "host() != 'google.com'", block.GetAttribute("session_matcher").AsStringValue().Value())
+	assert.Equal(t, 1001, block.GetAttribute("priority").AsIntValue().Value())
 }
 
 func Test_ForEachRefersToMapThatContainsSameStringValues(t *testing.T) {

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -116,9 +116,17 @@ func (a *Attribute) GetRawValue() any {
 	})
 }
 
-func (a *Attribute) AsBytesValueOrDefault(defaultValue []byte, parent *Block) iacTypes.BytesValue {
+func firstOrZero[T any](values []T) T {
+	if len(values) > 0 {
+		return values[0]
+	}
+	var zero T
+	return zero
+}
+
+func (a *Attribute) AsBytesValue(defaultValue []byte) iacTypes.BytesValue {
 	if a.IsNil() {
-		return iacTypes.BytesDefault(defaultValue, parent.GetMetadata())
+		return iacTypes.BytesDefault(defaultValue, a.metadata)
 	}
 	if !a.IsResolvable() || !a.IsString() {
 		return iacTypes.BytesUnresolvable(a.GetMetadata())
@@ -129,9 +137,9 @@ func (a *Attribute) AsBytesValueOrDefault(defaultValue []byte, parent *Block) ia
 	)
 }
 
-func (a *Attribute) AsStringValueOrDefault(defaultValue string, parent *Block) iacTypes.StringValue {
+func (a *Attribute) AsStringValue(defaultValue ...string) iacTypes.StringValue {
 	if a.IsNil() {
-		return iacTypes.StringDefault(defaultValue, parent.GetMetadata())
+		return iacTypes.StringDefault(firstOrZero(defaultValue), a.metadata)
 	}
 	if !a.IsResolvable() || !a.IsString() {
 		return iacTypes.StringUnresolvable(a.GetMetadata())
@@ -149,20 +157,20 @@ func (a *Attribute) AsStringValueSliceOrEmpty() (stringValues []iacTypes.StringV
 	return a.AsStringValues()
 }
 
-func (a *Attribute) AsStringValuesOrDefault(parent *Block, defaults ...string) []iacTypes.StringValue {
+func (a *Attribute) AsStringValuesOrDefault(defaults ...string) []iacTypes.StringValue {
 	if a.IsNil() {
 		res := make(iacTypes.StringValueList, 0, len(defaults))
 		for _, def := range defaults {
-			res = append(res, iacTypes.StringDefault(def, parent.GetMetadata()))
+			res = append(res, iacTypes.StringDefault(def, a.metadata))
 		}
 		return res
 	}
 	return a.AsStringValues()
 }
 
-func (a *Attribute) AsBoolValueOrDefault(defaultValue bool, parent *Block) iacTypes.BoolValue {
+func (a *Attribute) AsBoolValue(defaultValue ...bool) iacTypes.BoolValue {
 	if a.IsNil() {
-		return iacTypes.BoolDefault(defaultValue, parent.GetMetadata())
+		return iacTypes.BoolDefault(firstOrZero(defaultValue), a.metadata)
 	}
 	if !a.IsResolvable() || !a.IsBool() {
 		return iacTypes.BoolUnresolvable(a.GetMetadata())
@@ -173,43 +181,42 @@ func (a *Attribute) AsBoolValueOrDefault(defaultValue bool, parent *Block) iacTy
 	)
 }
 
-func (a *Attribute) AsIntValueOrDefault(defaultValue int, parent *Block) iacTypes.IntValue {
+func (a *Attribute) AsIntValue(defaultValue ...int) iacTypes.IntValue {
 	if a.IsNil() {
-		return iacTypes.IntDefault(defaultValue, parent.GetMetadata())
+		return iacTypes.IntDefault(firstOrZero(defaultValue), a.metadata)
 	}
 	if !a.IsResolvable() || !a.IsNumber() {
 		return iacTypes.IntUnresolvable(a.GetMetadata())
 	}
-	flt := a.AsNumber()
 	return iacTypes.IntExplicit(
-		int(flt),
+		int(a.AsNumber()),
 		a.GetMetadata(),
 	)
 }
 
 func (a *Attribute) IsLiteral() bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	return len(a.hclAttribute.Expr.Variables()) == 0
 }
 
 func (a *Attribute) IsResolvable() bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	return a.Value() != cty.NilVal && a.Value().IsKnown()
 }
 
 func (a *Attribute) Type() cty.Type {
-	if a == nil {
+	if a.IsNil() {
 		return cty.NilType
 	}
 	return a.Value().Type()
 }
 
 func (a *Attribute) IsIterable() bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 
@@ -219,7 +226,7 @@ func (a *Attribute) IsIterable() bool {
 }
 
 func (a *Attribute) Each(f func(key cty.Value, val cty.Value)) error {
-	if a == nil {
+	if a.IsNil() {
 		return nil
 	}
 	var outerErr error
@@ -278,7 +285,7 @@ func (a *Attribute) IsBool() bool {
 }
 
 func (a *Attribute) Value() (ctyVal cty.Value) {
-	if a == nil {
+	if a == nil || a.hclAttribute == nil {
 		return cty.NilVal
 	}
 	defer func() {
@@ -295,7 +302,7 @@ func (a *Attribute) Value() (ctyVal cty.Value) {
 
 // Allows a null value for a variable https://developer.hashicorp.com/terraform/language/expressions/types#null
 func (a *Attribute) NullableValue() (ctyVal cty.Value) {
-	if a == nil {
+	if a == nil || a.hclAttribute == nil {
 		return cty.NilVal
 	}
 	defer func() {
@@ -311,14 +318,14 @@ func (a *Attribute) NullableValue() (ctyVal cty.Value) {
 }
 
 func (a *Attribute) Name() string {
-	if a == nil {
+	if a.IsNil() {
 		return ""
 	}
 	return a.hclAttribute.Name
 }
 
 func (a *Attribute) AsStringValues() iacTypes.StringValueList {
-	if a == nil {
+	if a.IsNil() {
 		return nil
 	}
 	return a.getStringValues(a.hclAttribute.Expr, a.ctx.Inner())
@@ -598,7 +605,7 @@ func (a *Attribute) IsFalse() bool {
 }
 
 func (a *Attribute) IsEmpty() bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	val := a.Value()
@@ -629,7 +636,7 @@ func (a *Attribute) IsEmpty() bool {
 }
 
 func (a *Attribute) isNullAttributeEmpty() bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	switch t := a.hclAttribute.Expr.(type) {
@@ -706,7 +713,7 @@ func createDotReferenceFromTraversal(parentRef string, traversals ...hcl.Travers
 }
 
 func (a *Attribute) ReferencesBlock(b *Block) bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	for _, ref := range a.AllReferences() {
@@ -718,7 +725,7 @@ func (a *Attribute) ReferencesBlock(b *Block) bool {
 }
 
 func (a *Attribute) AllReferences() []*Reference {
-	if a == nil {
+	if a.IsNil() {
 		return nil
 	}
 	return a.referencesFromExpression(a.hclAttribute.Expr)
@@ -752,7 +759,7 @@ func (a *Attribute) referencesFromExpression(expr hcl.Expression) []*Reference {
 }
 
 func (a *Attribute) IsResourceBlockReference(resourceType string) bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	if t, ok := a.hclAttribute.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
@@ -763,7 +770,7 @@ func (a *Attribute) IsResourceBlockReference(resourceType string) bool {
 }
 
 func (a *Attribute) References(r Reference) bool {
-	if a == nil {
+	if a.IsNil() {
 		return false
 	}
 	for _, ref := range a.AllReferences() {
@@ -792,7 +799,7 @@ func getRawValue(value cty.Value) any {
 }
 
 func (a *Attribute) IsNil() bool {
-	return a == nil
+	return a == nil || a.hclAttribute == nil
 }
 
 func (a *Attribute) IsNotNil() bool {
@@ -816,7 +823,7 @@ func (a *Attribute) AsNumber() float64 {
 
 func safeOp[T any](a *Attribute, fn func(cty.Value) T) T {
 	var res T
-	if a == nil {
+	if a.IsNil() {
 		return res
 	}
 
@@ -837,7 +844,7 @@ func isDefined(v cty.Value, t cty.Type) bool {
 // RewriteExpr applies the given function `transform` to the expression of the attribute,
 // recursively traversing and transforming it.
 func (a *Attribute) RewriteExpr(transform func(hclsyntax.Expression) hclsyntax.Expression) {
-	if a == nil || a.hclAttribute == nil {
+	if a.IsNil() {
 		return
 	}
 	expr, ok := a.hclAttribute.Expr.(hclsyntax.Expression)

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -448,7 +448,7 @@ func getValueByPath(val cty.Value, path []string) (cty.Value, error) {
 	return val, nil
 }
 
-func (b *Block) GetNestedAttribute(name string) (*Attribute, *Block) {
+func (b *Block) GetNestedAttribute(name string) *Attribute {
 	parts := strings.Split(name, ".")
 	blocks := parts[:len(parts)-1]
 	attrName := parts[len(parts)-1]
@@ -457,16 +457,12 @@ func (b *Block) GetNestedAttribute(name string) (*Attribute, *Block) {
 	for _, subBlock := range blocks {
 		checkBlock := working.GetBlock(subBlock)
 		if checkBlock.IsNil() {
-			return b.nullAttribute(), working
+			return b.nullAttribute()
 		}
 		working = checkBlock
 	}
 
-	return working.GetAttribute(attrName), working
-}
-
-func MapNestedAttribute[T any](block *Block, path string, f func(attr *Attribute, parent *Block) T) T {
-	return f(block.GetNestedAttribute(path))
+	return working.GetAttribute(attrName)
 }
 
 // LocalName is the name relative to the current module

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -263,28 +263,34 @@ func (b *Block) createAttributes() hcl.Attributes {
 	}
 }
 
+func (b *Block) nullBlock() *Block {
+	if b == nil {
+		return &Block{}
+	}
+	return &Block{metadata: b.metadata}
+}
+
 func (b *Block) GetBlock(name string) *Block {
-	var returnBlock *Block
-	if b == nil || b.hclBlock == nil {
-		return returnBlock
+	if b.IsNil() {
+		return b.nullBlock()
 	}
 	for _, child := range b.childBlocks {
 		if child.Type() == name {
 			return child
 		}
 	}
-	return returnBlock
+	return b.nullBlock()
 }
 
 func (b *Block) AllBlocks() Blocks {
-	if b == nil || b.hclBlock == nil {
+	if b.IsNil() {
 		return nil
 	}
 	return b.childBlocks
 }
 
 func (b *Block) GetBlocks(name string) Blocks {
-	if b == nil || b.hclBlock == nil {
+	if b.IsNil() {
 		return nil
 	}
 	var results []*Block
@@ -297,7 +303,7 @@ func (b *Block) GetBlocks(name string) Blocks {
 }
 
 func (b *Block) GetAttributes() []*Attribute {
-	if b == nil {
+	if b.IsNil() {
 		return nil
 	}
 	return b.attributes
@@ -307,9 +313,16 @@ func (b *Block) GetAttribute(name string) *Attribute {
 	return b.GetFirstAttributeOf(name)
 }
 
+func (b *Block) nullAttribute() *Attribute {
+	if b == nil {
+		return &Attribute{}
+	}
+	return &Attribute{metadata: b.metadata}
+}
+
 func (b *Block) GetFirstAttributeOf(names ...string) *Attribute {
-	if b == nil || b.hclBlock == nil || len(names) == 0 {
-		return nil
+	if b.IsNil() || len(names) == 0 {
+		return b.nullAttribute()
 	}
 
 	nameSet := set.New(names...)
@@ -319,7 +332,7 @@ func (b *Block) GetFirstAttributeOf(names ...string) *Attribute {
 			return attr
 		}
 	}
-	return nil
+	return b.nullAttribute()
 }
 
 // GetValueByPath returns the value of the attribute located at the given path.
@@ -345,7 +358,7 @@ func (b *Block) GetValueByPath(path string) cty.Value {
 
 	attr, restPath := b.getAttributeByPath(path)
 
-	if attr == nil {
+	if attr.IsNil() {
 		return cty.NilVal
 	}
 
@@ -443,19 +456,13 @@ func (b *Block) GetNestedAttribute(name string) (*Attribute, *Block) {
 	working := b
 	for _, subBlock := range blocks {
 		checkBlock := working.GetBlock(subBlock)
-		if checkBlock == nil {
-			return nil, working
+		if checkBlock.IsNil() {
+			return b.nullAttribute(), working
 		}
 		working = checkBlock
 	}
 
-	if working != nil {
-		if attr := working.GetAttribute(attrName); attr != nil {
-			return attr, working
-		}
-	}
-
-	return nil, b
+	return working.GetAttribute(attrName), working
 }
 
 func MapNestedAttribute[T any](block *Block, path string, f func(attr *Attribute, parent *Block) T) T {
@@ -524,7 +531,7 @@ func (b *Block) NameLabel() string {
 }
 
 func (b *Block) InModule() bool {
-	if b == nil {
+	if b.IsNil() {
 		return false
 	}
 	return b.moduleBlock != nil
@@ -574,7 +581,7 @@ func (b *Block) values(allowNull bool) cty.Value {
 }
 
 func (b *Block) IsNil() bool {
-	return b == nil
+	return b == nil || b.hclBlock == nil
 }
 
 func (b *Block) IsNotNil() bool {
@@ -647,7 +654,7 @@ func (b *Block) expandDynamic() ([]*Block, error) {
 		})
 		forEachCtx.Set(obj, iteratorName)
 
-		if content := b.GetBlock("content"); content != nil {
+		if content := b.GetBlock("content"); content.IsNotNil() {
 			inherited := content.inherit(forEachCtx)
 			inherited.hclBlock.Labels = []string{}
 			inherited.hclBlock.Type = realBlockType
@@ -669,7 +676,7 @@ func (b *Block) expandDynamic() ([]*Block, error) {
 
 func (b *Block) validateForEach() (cty.Value, error) {
 	forEachAttr := b.GetAttribute("for_each")
-	if forEachAttr == nil {
+	if forEachAttr.IsNil() {
 		return cty.NilVal, errors.New("for_each attribute required")
 	}
 
@@ -684,7 +691,7 @@ func (b *Block) validateForEach() (cty.Value, error) {
 
 func (b *Block) iteratorName(blockType string) (string, error) {
 	iteratorAttr := b.GetAttribute("iterator")
-	if iteratorAttr == nil {
+	if iteratorAttr.IsNil() {
 		return blockType, nil
 	}
 

--- a/pkg/iac/terraform/module.go
+++ b/pkg/iac/terraform/module.go
@@ -146,7 +146,7 @@ func (c *Module) GetReferencingBlocks(originalBlock *Block, referencingType, ref
 	var results Blocks
 	for _, block := range blocks {
 		attr := block.GetAttribute(referencingAttributeName)
-		if attr == nil {
+		if attr.IsNil() {
 			continue
 		}
 		if attr.References(originalBlock.reference) {


### PR DESCRIPTION
## Description

Previously, callers had to manually pass a parent `*Block` to every `As*ValueOrDefault` call. This led to two problems: verbose and repetitive code in adapters, and incorrect metadata in reports — callers would pass `resource` block even for deeply nested values, so misconfiguration findings would point to the resource root instead of the actual location in the template. With metadata propagation through the chain, findings now point to the closest existing ancestor, which is semantically more accurate.

- `GetBlock` now propagates parent metadata to the returned block when a key is absent
- `GetAttribute` now propagates parent/block metadata to the returned attribute when a key is absent
- `As*Value` methods use the attribute's own metadata instead of requiring `*Block` as a parameter
- Default values in `As*Value` methods are now variadic — zero values (`false`, `""`, `0`) can be omitted at call sites, non-zero defaults remain explicit

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
