### PR TITLE
ci!: migrate docker config to dockers_v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.23.4
 RUN apk --no-cache add ca-certificates git
-COPY trivy /usr/local/bin/trivy
+# Default "." supports local builds; dockers_v2 sets this to e.g. linux/amd64
+ARG TARGETPLATFORM=.
+COPY ${TARGETPLATFORM}/trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.23.4
 RUN apk --no-cache add ca-certificates git
-# Default "." supports local builds; dockers_v2 sets this to e.g. linux/amd64
-ARG TARGETPLATFORM=.
+ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/
 ENTRYPOINT ["trivy"]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -155,6 +155,16 @@ dockers_v2:
       - linux/ppc64le
     extra_files:
       - contrib/
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: "A Fast Vulnerability Scanner for Containers"
+      org.opencontainers.image.vendor: "Aqua Security"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.source: "https://github.com/aquasecurity/trivy"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.url: "https://www.aquasec.com/products/trivy/"
+      org.opencontainers.image.documentation: "https://trivy.dev/v{{ .Version }}/"
     annotations:
       org.opencontainers.image.title: "{{ .ProjectName }}"
       org.opencontainers.image.description: "A Fast Vulnerability Scanner for Containers"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -138,145 +138,33 @@ archives:
         formats: [zip]
 
 
-dockers:
-  - image_templates:
-      - "docker.io/aquasec/trivy:{{ .Version }}-amd64"
-      - "docker.io/aquasec/trivy:latest-amd64"
-      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64"
-      - "ghcr.io/aquasecurity/trivy:latest-amd64"
-      - "public.ecr.aws/aquasecurity/trivy:latest-amd64"
-      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64"
-    use: buildx
-    goos: linux
-    goarch: amd64
-    ids:
+dockers_v2:
+  - ids:
       - build-linux
-    build_flag_templates:
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
-      - "--label=org.opencontainers.image.vendor=Aqua Security"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
-      - "--platform=linux/amd64"
+    images:
+      - docker.io/aquasec/trivy
+      - ghcr.io/aquasecurity/trivy
+      - public.ecr.aws/aquasecurity/trivy
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/s390x
+      - linux/ppc64le
     extra_files:
-    - contrib/
-  - image_templates:
-      - "docker.io/aquasec/trivy:{{ .Version }}-arm64"
-      - "docker.io/aquasec/trivy:latest-arm64"
-      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64"
-      - "ghcr.io/aquasecurity/trivy:latest-arm64"
-      - "public.ecr.aws/aquasecurity/trivy:latest-arm64"
-      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64"
-    use: buildx
-    goos: linux
-    goarch: arm64
-    ids:
-      - build-linux
-    build_flag_templates:
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
-      - "--label=org.opencontainers.image.vendor=Aqua Security"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
-      - "--platform=linux/arm64"
-    extra_files:
-    - contrib/
-  - image_templates:
-      - "docker.io/aquasec/trivy:{{ .Version }}-s390x"
-      - "docker.io/aquasec/trivy:latest-s390x"
-      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x"
-      - "ghcr.io/aquasecurity/trivy:latest-s390x"
-      - "public.ecr.aws/aquasecurity/trivy:latest-s390x"
-      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x"
-    use: buildx
-    goos: linux
-    goarch: s390x
-    ids:
-      - build-linux
-    build_flag_templates:
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
-      - "--label=org.opencontainers.image.vendor=Aqua Security"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
-      - "--platform=linux/s390x"
-    extra_files:
-    - contrib/
-  - image_templates:
-      - "docker.io/aquasec/trivy:{{ .Version }}-ppc64le"
-      - "docker.io/aquasec/trivy:latest-ppc64le"
-      - "ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le"
-      - "ghcr.io/aquasecurity/trivy:latest-ppc64le"
-      - "public.ecr.aws/aquasecurity/trivy:latest-ppc64le"
-      - "public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le"
-    use: buildx
-    goos: linux
-    goarch: ppc64le
-    ids:
-      - build-linux
-    build_flag_templates:
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A Fast Vulnerability Scanner for Containers"
-      - "--label=org.opencontainers.image.vendor=Aqua Security"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/trivy"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.url=https://www.aquasec.com/products/trivy/"
-      - "--label=org.opencontainers.image.documentation=https://trivy.dev/v{{ .Version }}/"
-      - "--platform=linux/ppc64le"
-    extra_files:
-    - contrib/
-
-docker_manifests:
-  - name_template: 'aquasec/trivy:{{ .Version }}'
-    image_templates:
-    - 'aquasec/trivy:{{ .Version }}-amd64'
-    - 'aquasec/trivy:{{ .Version }}-arm64'
-    - 'aquasec/trivy:{{ .Version }}-s390x'
-    - 'aquasec/trivy:{{ .Version }}-ppc64le'
-  - name_template: 'ghcr.io/aquasecurity/trivy:{{ .Version }}'
-    image_templates:
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
-  - name_template: 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}'
-    image_templates:
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
-  - name_template: 'aquasec/trivy:latest'
-    image_templates:
-    - 'aquasec/trivy:{{ .Version }}-amd64'
-    - 'aquasec/trivy:{{ .Version }}-arm64'
-    - 'aquasec/trivy:{{ .Version }}-s390x'
-    - 'aquasec/trivy:{{ .Version }}-ppc64le'
-  - name_template: 'ghcr.io/aquasecurity/trivy:latest'
-    image_templates:
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-amd64'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-arm64'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-s390x'
-    - 'ghcr.io/aquasecurity/trivy:{{ .Version }}-ppc64le'
-  - name_template: 'public.ecr.aws/aquasecurity/trivy:latest'
-    image_templates:
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-amd64'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-arm64'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-s390x'
-    - 'public.ecr.aws/aquasecurity/trivy:{{ .Version }}-ppc64le'
+      - contrib/
+    annotations:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: "A Fast Vulnerability Scanner for Containers"
+      org.opencontainers.image.vendor: "Aqua Security"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.source: "https://github.com/aquasecurity/trivy"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.url: "https://www.aquasec.com/products/trivy/"
+      org.opencontainers.image.documentation: "https://trivy.dev/v{{ .Version }}/"
 
 signs:
 - cmd: cosign


### PR DESCRIPTION
## Description

`dockers_v2` is production-ready in GoReleaser v2.16.0. It replaces the separate `dockers` + `docker_manifests` blocks with a single entry that uses `docker buildx` for native multi-arch builds.

**Breaking change (architecture-specific image tags)**: The old dockers approach published separate per-arch images with name suffixes (e.g. trivy:0.x.y-amd64, trivy:0.x.y-arm64) before merging them into a manifest list via `docker_manifests`. With `dockers_v2` / `docker buildx`, the multi-arch manifest is built directly — intermediate per-arch tagged images are no longer pushed. If any consumers pin to an architecture-specific suffix tag, they will need to switch to the plain tag and let the registry resolve the correct arch.

## Changes

### `goreleaser.yml`
- Replace 4 `dockers` entries + 6 `docker_manifests` entries with a single `dockers_v2` block with `platforms`, `images`, and `annotations`
- OCI annotations moved to `annotations` field (previously in `labels`)

### `Dockerfile`
- `COPY ${TARGETPLATFORM}/trivy` — `dockers_v2` places pre-built binaries into platform-specific subdirectories (linux/amd64/, linux/arm64/, etc.). `TARGETPLATFORM` is declared without a default so buildx injects the real value.

## Testing

Test run: https://github.com/nikpivkin/trivy/actions/runs/27143971308/job/80116467065

- Multi-arch manifest (amd64, arm64, s390x, ppc64le) ✓
- OCI annotations on manifest index ✓
- Config labels ✓
- `docker run --rm ghcr.io/nikpivkin/trivy:0.112.0 version` → `Version: 0.112.0` ✓

## Notes on dockers_v2

`dockers_v2` is currently a provisional name in GoReleaser v2. It is planned to replace both `dockers` and `docker_manifests` as the single canonical block in GoReleaser v3 (no ETA). When this project upgrades to GoReleaser v3, a further migration step will be required (likely a simple rename of the block key). This PR deliberately adopts `dockers_v2` now so that the v3 migration is a trivial diff rather than a full rebuild of the config.

## Related PRs
- [x] https://github.com/aquasecurity/trivy/pull/10774

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
