### PR TITLE
fix: dedupe Packages with same Application type but different filepath

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -65,7 +65,7 @@ func setupTestEnvironment(t *testing.T, env *testscript.Env) error {
 	env.Setenv("TRIVY_DB_DIGEST", "sha256:b4d3718a89a78d4a6b02250953e92fcd87776de4774e64e818c1d0e01c928025")
 	// Disable VEX notice in test environment
 	env.Setenv("TRIVY_DISABLE_VEX_NOTICE", "true")
-	
+
 	// Define test image
 	testImage := "alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b"
 	env.Setenv("TEST_IMAGE", testImage)

--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -101,6 +101,9 @@ func lookupOriginLayerForLib(filePath string, lib ftypes.Package, layers []ftype
 func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 	sep := "/"
 	nestedMap := nested.Nested{}
+	applications := make(map[string]ftypes.Application)
+	applicationKeysByFilePath := make(map[string]map[string]struct{})
+	sbomApplicationKeysByPackageFilePath := make(map[string]map[string]struct{})
 	secretsMap := make(map[string]ftypes.Secret)
 	var mergedLayer ftypes.ArtifactDetail
 
@@ -108,9 +111,11 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 		for _, opqDir := range layer.OpaqueDirs {
 			opqDir = strings.TrimSuffix(opqDir, sep)  // this is necessary so that an empty element is not contribute into the array of the DeleteByString function
 			_ = nestedMap.DeleteByString(opqDir, sep) // nolint
+			deleteApplications(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, opqDir, sep)
 		}
 		for _, whFile := range layer.WhiteoutFiles {
 			_ = nestedMap.DeleteByString(whFile, sep) // nolint
+			deleteApplications(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, whFile, sep)
 		}
 
 		mergedLayer.OS.Merge(layer.OS)
@@ -127,7 +132,7 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 
 		// Apply language-specific packages
 		for _, app := range layer.Applications {
-			setApplication(nestedMap, app, sep)
+			setApplication(nestedMap, applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, app, sep)
 		}
 
 		// Apply misconfigurations
@@ -299,58 +304,155 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 	return mergedLayer
 }
 
-func setApplication(nestedMap nested.Nested, app ftypes.Application, sep string) {
-	key := applicationKey(app)
-	existingKey, existing, ok := findMergeableApplication(nestedMap, app, sep)
+func setApplication(nestedMap nested.Nested, applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, app ftypes.Application, sep string) {
+	existingKey, existing, ok := findMergeableApplication(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, app)
 	if !ok {
-		nestedMap.SetByString(key, sep, app)
+		setApplicationByKey(nestedMap, applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, app, sep)
 		return
 	}
 
 	merged := mergeApplications(existing, app)
 	mergedKey := applicationKey(merged)
 	if existingKey != mergedKey {
-		_ = nestedMap.DeleteByString(existingKey, sep) // nolint
+		deleteApplicationByKey(nestedMap, applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, existingKey, sep)
 	}
-	nestedMap.SetByString(mergedKey, sep, merged)
+	setApplicationByKey(nestedMap, applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, merged, sep)
 }
 
 func applicationKey(app ftypes.Application) string {
 	return fmt.Sprintf("%s/type:%s", app.FilePath, app.Type)
 }
 
-func findMergeableApplication(nestedMap nested.Nested, app ftypes.Application, sep string) (string, ftypes.Application, bool) {
-	var appKey string
-	var matched ftypes.Application
-
-	// nolint
-	_ = nestedMap.Walk(func(keys []string, value any) error {
-		existing, ok := value.(ftypes.Application)
-		if !ok || !shouldMergeApplications(existing, app) {
-			return nil
-		}
-
-		appKey = strings.Join(keys, sep)
-		matched = existing
-		return nil
-	})
-
-	return appKey, matched, appKey != ""
+func findMergeableApplication(applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, app ftypes.Application) (string, ftypes.Application, bool) {
+	if isSBOMApplication(app) {
+		return findApplicationCoveredBySBOM(applications, applicationKeysByFilePath, app)
+	}
+	return findSBOMApplicationCoveringFilePath(applications, sbomApplicationKeysByPackageFilePath, app.FilePath)
 }
 
-func shouldMergeApplications(a, b ftypes.Application) bool {
-	if a.Type != b.Type || a.FilePath == b.FilePath {
-		return false
+func findApplicationCoveredBySBOM(applications map[string]ftypes.Application, applicationKeysByFilePath map[string]map[string]struct{},
+	app ftypes.Application) (string, ftypes.Application, bool) {
+	for _, pkg := range app.Packages {
+		if pkg.FilePath == "" {
+			continue
+		}
+		if appKey, app, ok := findApplicationByFilePath(applications, applicationKeysByFilePath, pkg.FilePath, false); ok {
+			return appKey, app, true
+		}
 	}
+	return "", ftypes.Application{}, false
+}
 
-	aSBOM, bSBOM := isSBOMApplication(a), isSBOMApplication(b)
-	if aSBOM == bSBOM {
-		return false
+func findSBOMApplicationCoveringFilePath(applications map[string]ftypes.Application, sbomApplicationKeysByPackageFilePath map[string]map[string]struct{},
+	filePath string) (string, ftypes.Application, bool) {
+	if filePath == "" {
+		return "", ftypes.Application{}, false
 	}
-	if !applicationPathsMatch(a, b, bSBOM) {
-		return false
+	appKeys := sortedApplicationKeys(sbomApplicationKeysByPackageFilePath[filePath])
+	for _, appKey := range appKeys {
+		app, ok := applications[appKey]
+		if ok && isSBOMApplication(app) {
+			return appKey, app, true
+		}
 	}
-	return compatiblePackageSets(a.Type, a.Packages, b.Packages)
+	return "", ftypes.Application{}, false
+}
+
+func findApplicationByFilePath(applications map[string]ftypes.Application, applicationKeysByFilePath map[string]map[string]struct{},
+	filePath string, sbom bool) (string, ftypes.Application, bool) {
+	appKeys := sortedApplicationKeys(applicationKeysByFilePath[filePath])
+	for _, appKey := range appKeys {
+		app, ok := applications[appKey]
+		if ok && isSBOMApplication(app) == sbom {
+			return appKey, app, true
+		}
+	}
+	return "", ftypes.Application{}, false
+}
+
+func sortedApplicationKeys(applicationKeys map[string]struct{}) []string {
+	keys := make([]string, 0, len(applicationKeys))
+	for key := range applicationKeys {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func setApplicationByKey(nestedMap nested.Nested, applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, app ftypes.Application, sep string) {
+	appKey := applicationKey(app)
+	if existing, ok := applications[appKey]; ok {
+		deleteApplicationIndexes(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, appKey, existing)
+	}
+	nestedMap.SetByString(appKey, sep, app)
+	applications[appKey] = app
+	addApplicationIndexes(applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, appKey, app)
+}
+
+func deleteApplications(applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, filePath, sep string) {
+	if filePath == "" {
+		return
+	}
+	for appKey, app := range applications {
+		if appKey == filePath || strings.HasPrefix(appKey, filePath+sep) {
+			deleteApplicationIndexes(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, appKey, app)
+		}
+	}
+}
+
+func deleteApplicationByKey(nestedMap nested.Nested, applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, appKey, sep string) {
+	if app, ok := applications[appKey]; ok {
+		deleteApplicationIndexes(applications, applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath, appKey, app)
+	}
+	_ = nestedMap.DeleteByString(appKey, sep) // nolint
+}
+
+func addApplicationIndexes(applicationKeysByFilePath, sbomApplicationKeysByPackageFilePath map[string]map[string]struct{},
+	appKey string, app ftypes.Application) {
+	addApplicationIndex(applicationKeysByFilePath, app.FilePath, appKey)
+	if !isSBOMApplication(app) {
+		return
+	}
+	for _, pkg := range app.Packages {
+		addApplicationIndex(sbomApplicationKeysByPackageFilePath, pkg.FilePath, appKey)
+	}
+}
+
+func deleteApplicationIndexes(applications map[string]ftypes.Application, applicationKeysByFilePath,
+	sbomApplicationKeysByPackageFilePath map[string]map[string]struct{}, appKey string, app ftypes.Application) {
+	delete(applications, appKey)
+	deleteApplicationIndex(applicationKeysByFilePath, app.FilePath, appKey)
+	if !isSBOMApplication(app) {
+		return
+	}
+	for _, pkg := range app.Packages {
+		deleteApplicationIndex(sbomApplicationKeysByPackageFilePath, pkg.FilePath, appKey)
+	}
+}
+
+func addApplicationIndex(index map[string]map[string]struct{}, filePath, appKey string) {
+	if filePath == "" {
+		return
+	}
+	if index[filePath] == nil {
+		index[filePath] = make(map[string]struct{})
+	}
+	index[filePath][appKey] = struct{}{}
+}
+
+func deleteApplicationIndex(index map[string]map[string]struct{}, filePath, appKey string) {
+	if filePath == "" {
+		return
+	}
+	delete(index[filePath], appKey)
+	if len(index[filePath]) == 0 {
+		delete(index, filePath)
+	}
 }
 
 func mergeApplications(a, b ftypes.Application) ftypes.Application {
@@ -383,33 +485,6 @@ func mergeApplicationPackages(appType ftypes.LangType, pkgs, extra ftypes.Packag
 		}
 	}
 	return xslices.ZeroToNil(merged)
-}
-
-func compatiblePackageSets(appType ftypes.LangType, a, b ftypes.Packages) bool {
-	aSet, bSet := packageIdentitySet(appType, a), packageIdentitySet(appType, b)
-	if len(aSet) == 0 || len(bSet) == 0 {
-		return false
-	}
-	return packageIdentitySetContains(aSet, bSet) || packageIdentitySetContains(bSet, aSet)
-}
-
-func packageIdentitySet(appType ftypes.LangType, pkgs ftypes.Packages) map[string]struct{} {
-	ids := make(map[string]struct{})
-	for _, pkg := range pkgs {
-		if id := packageIdentity(appType, pkg); id != "" {
-			ids[id] = struct{}{}
-		}
-	}
-	return ids
-}
-
-func packageIdentitySetContains(superset, subset map[string]struct{}) bool {
-	for id := range subset {
-		if _, ok := superset[id]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func packageIdentity(appType ftypes.LangType, pkg ftypes.Package) string {
@@ -452,64 +527,6 @@ func isSBOMFilePath(filePath string) bool {
 		strings.HasSuffix(filePath, ".spdx.json") ||
 		strings.HasSuffix(filePath, ".cdx") ||
 		strings.HasSuffix(filePath, ".cdx.json")
-}
-
-func applicationPathsMatch(a, b ftypes.Application, bSBOM bool) bool {
-	sbomApp, otherApp := a, b
-	if bSBOM {
-		sbomApp, otherApp = b, a
-	}
-
-	if pathReferencesApplication(sbomApp.FilePath, otherApp.FilePath) {
-		return true
-	}
-	for _, pkg := range sbomApp.Packages {
-		if pathReferencesApplication(pkg.FilePath, otherApp.FilePath) {
-			return true
-		}
-	}
-	return !hasApplicationPathEvidence(sbomApp)
-}
-
-func hasApplicationPathEvidence(app ftypes.Application) bool {
-	if pathToken(app.FilePath) != "" {
-		return true
-	}
-	return slices.ContainsFunc(app.Packages, func(pkg ftypes.Package) bool {
-		return pkg.FilePath != ""
-	})
-}
-
-func pathReferencesApplication(sbomPath, appPath string) bool {
-	if sbomPath == "" || appPath == "" {
-		return false
-	}
-	if strings.Trim(sbomPath, "/") == strings.Trim(appPath, "/") {
-		return true
-	}
-	sbomToken, appToken := pathToken(sbomPath), pathToken(appPath)
-	return sbomToken != "" && appToken != "" && strings.Contains(sbomToken, appToken)
-}
-
-func pathToken(filePath string) string {
-	base := filePath
-	if i := strings.LastIndex(base, "/"); i >= 0 {
-		base = base[i+1:]
-	}
-	for _, suffix := range []string{".spdx.json", ".cdx.json", ".spdx", ".cdx"} {
-		base = strings.TrimSuffix(base, suffix)
-	}
-	for _, prefix := range []string{".spdx-", ".cdx-", "spdx-", "cdx-"} {
-		base = strings.TrimPrefix(base, prefix)
-	}
-	base = strings.ToLower(base)
-	base = strings.NewReplacer("-", "", "_", "", ".", "").Replace(base)
-	switch base {
-	case "", "sbom", "bom":
-		return ""
-	default:
-		return base
-	}
 }
 
 func newPURL(pkgType ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) *packageurl.PackageURL {

--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -3,6 +3,7 @@ package applier
 import (
 	"cmp"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -126,8 +127,7 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 
 		// Apply language-specific packages
 		for _, app := range layer.Applications {
-			key := fmt.Sprintf("%s/type:%s", app.FilePath, app.Type)
-			nestedMap.SetByString(key, sep, app)
+			setApplication(nestedMap, app, sep)
 		}
 
 		// Apply misconfigurations
@@ -297,6 +297,219 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 	mergedLayer.Sort()
 
 	return mergedLayer
+}
+
+func setApplication(nestedMap nested.Nested, app ftypes.Application, sep string) {
+	key := applicationKey(app)
+	existingKey, existing, ok := findMergeableApplication(nestedMap, app, sep)
+	if !ok {
+		nestedMap.SetByString(key, sep, app)
+		return
+	}
+
+	merged := mergeApplications(existing, app)
+	mergedKey := applicationKey(merged)
+	if existingKey != mergedKey {
+		_ = nestedMap.DeleteByString(existingKey, sep) // nolint
+	}
+	nestedMap.SetByString(mergedKey, sep, merged)
+}
+
+func applicationKey(app ftypes.Application) string {
+	return fmt.Sprintf("%s/type:%s", app.FilePath, app.Type)
+}
+
+func findMergeableApplication(nestedMap nested.Nested, app ftypes.Application, sep string) (string, ftypes.Application, bool) {
+	var appKey string
+	var matched ftypes.Application
+
+	// nolint
+	_ = nestedMap.Walk(func(keys []string, value any) error {
+		existing, ok := value.(ftypes.Application)
+		if !ok || !shouldMergeApplications(existing, app) {
+			return nil
+		}
+
+		appKey = strings.Join(keys, sep)
+		matched = existing
+		return nil
+	})
+
+	return appKey, matched, appKey != ""
+}
+
+func shouldMergeApplications(a, b ftypes.Application) bool {
+	if a.Type != b.Type || a.FilePath == b.FilePath {
+		return false
+	}
+
+	aSBOM, bSBOM := isSBOMApplication(a), isSBOMApplication(b)
+	if aSBOM == bSBOM {
+		return false
+	}
+	if !applicationPathsMatch(a, b, bSBOM) {
+		return false
+	}
+	return compatiblePackageSets(a.Type, a.Packages, b.Packages)
+}
+
+func mergeApplications(a, b ftypes.Application) ftypes.Application {
+	if isSBOMApplication(a) && !isSBOMApplication(b) {
+		a, b = b, a
+	}
+	a.Packages = mergeApplicationPackages(a.Type, a.Packages, b.Packages)
+	return a
+}
+
+func mergeApplicationPackages(appType ftypes.LangType, pkgs, extra ftypes.Packages) ftypes.Packages {
+	merged := slices.Clone(pkgs)
+	for _, pkg := range extra {
+		if slices.ContainsFunc(merged, func(existing ftypes.Package) bool {
+			return reflect.DeepEqual(existing, pkg)
+		}) {
+			continue
+		}
+
+		identity := packageIdentity(appType, pkg)
+		index := slices.IndexFunc(merged, func(existing ftypes.Package) bool {
+			return identity != "" && packageIdentity(appType, existing) == identity
+		})
+		if index == -1 {
+			merged = append(merged, pkg)
+			continue
+		}
+		if merged[index].AnalyzedBy == analyzer.TypeSBOM && pkg.AnalyzedBy != analyzer.TypeSBOM {
+			merged[index] = pkg
+		}
+	}
+	return xslices.ZeroToNil(merged)
+}
+
+func compatiblePackageSets(appType ftypes.LangType, a, b ftypes.Packages) bool {
+	aSet, bSet := packageIdentitySet(appType, a), packageIdentitySet(appType, b)
+	if len(aSet) == 0 || len(bSet) == 0 {
+		return false
+	}
+	return packageIdentitySetContains(aSet, bSet) || packageIdentitySetContains(bSet, aSet)
+}
+
+func packageIdentitySet(appType ftypes.LangType, pkgs ftypes.Packages) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, pkg := range pkgs {
+		if id := packageIdentity(appType, pkg); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
+}
+
+func packageIdentitySetContains(superset, subset map[string]struct{}) bool {
+	for id := range subset {
+		if _, ok := superset[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func packageIdentity(appType ftypes.LangType, pkg ftypes.Package) string {
+	name := pkg.Name
+	version := pkg.Version
+	if pkg.Identifier.PURL != nil {
+		name = cmp.Or(name, pkg.Identifier.PURL.Name)
+		version = cmp.Or(version, pkg.Identifier.PURL.Version)
+	}
+	name = cmp.Or(name, pkg.ID)
+	if name == "" {
+		return ""
+	}
+	version = normalizePackageVersion(appType, version)
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%d", appType, name, version, pkg.Release, pkg.Arch, pkg.Epoch)
+}
+
+func normalizePackageVersion(appType ftypes.LangType, version string) string {
+	if (appType == ftypes.GoBinary || appType == ftypes.GoModule) &&
+		len(version) > 1 && version[0] == 'v' && version[1] >= '0' && version[1] <= '9' {
+		return version[1:]
+	}
+	return version
+}
+
+func isSBOMApplication(app ftypes.Application) bool {
+	if isSBOMFilePath(app.FilePath) {
+		return true
+	}
+	if len(app.Packages) == 0 {
+		return false
+	}
+	return lo.EveryBy(app.Packages, func(pkg ftypes.Package) bool {
+		return pkg.AnalyzedBy == analyzer.TypeSBOM
+	})
+}
+
+func isSBOMFilePath(filePath string) bool {
+	return strings.HasSuffix(filePath, ".spdx") ||
+		strings.HasSuffix(filePath, ".spdx.json") ||
+		strings.HasSuffix(filePath, ".cdx") ||
+		strings.HasSuffix(filePath, ".cdx.json")
+}
+
+func applicationPathsMatch(a, b ftypes.Application, bSBOM bool) bool {
+	sbomApp, otherApp := a, b
+	if bSBOM {
+		sbomApp, otherApp = b, a
+	}
+
+	if pathReferencesApplication(sbomApp.FilePath, otherApp.FilePath) {
+		return true
+	}
+	for _, pkg := range sbomApp.Packages {
+		if pathReferencesApplication(pkg.FilePath, otherApp.FilePath) {
+			return true
+		}
+	}
+	return !hasApplicationPathEvidence(sbomApp)
+}
+
+func hasApplicationPathEvidence(app ftypes.Application) bool {
+	if pathToken(app.FilePath) != "" {
+		return true
+	}
+	return slices.ContainsFunc(app.Packages, func(pkg ftypes.Package) bool {
+		return pkg.FilePath != ""
+	})
+}
+
+func pathReferencesApplication(sbomPath, appPath string) bool {
+	if sbomPath == "" || appPath == "" {
+		return false
+	}
+	if strings.Trim(sbomPath, "/") == strings.Trim(appPath, "/") {
+		return true
+	}
+	sbomToken, appToken := pathToken(sbomPath), pathToken(appPath)
+	return sbomToken != "" && appToken != "" && strings.Contains(sbomToken, appToken)
+}
+
+func pathToken(filePath string) string {
+	base := filePath
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, suffix := range []string{".spdx.json", ".cdx.json", ".spdx", ".cdx"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+	for _, prefix := range []string{".spdx-", ".cdx-", "spdx-", "cdx-"} {
+		base = strings.TrimPrefix(base, prefix)
+	}
+	base = strings.ToLower(base)
+	base = strings.NewReplacer("-", "", "_", "", ".", "").Replace(base)
+	switch base {
+	case "", "sbom", "bom":
+		return ""
+	default:
+		return base
+	}
 }
 
 func newPURL(pkgType ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) *packageurl.PackageURL {

--- a/pkg/fanal/applier/docker_test.go
+++ b/pkg/fanal/applier/docker_test.go
@@ -1657,6 +1657,7 @@ func TestApplyLayersDeduplicatesSBOMApplications(t *testing.T) {
 								ID:         "github.com/acme/api@v1.0.0",
 								Name:       "github.com/acme/api",
 								Version:    "v1.0.0",
+								FilePath:   "opt/app/bin/api",
 								AnalyzedBy: analyzer.TypeSBOM,
 							},
 						},
@@ -1678,8 +1679,7 @@ func TestApplyLayersDeduplicatesSBOMApplications(t *testing.T) {
 		})
 
 		require.Len(t, got.Applications, 2)
-		assert.Equal(t, "opt/app/.spdx-api.spdx", got.Applications[0].FilePath)
-		assert.Equal(t, "opt/app/bin/worker", got.Applications[1].FilePath)
+		assert.ElementsMatch(t, []string{"opt/app/.spdx-api.spdx", "opt/app/bin/worker"}, applicationFilePaths(got.Applications))
 	})
 
 	t.Run("overlapping package sets are merged without duplicate packages", func(t *testing.T) {
@@ -1694,6 +1694,7 @@ func TestApplyLayersDeduplicatesSBOMApplications(t *testing.T) {
 								ID:         "stdlib@v1.22.11",
 								Name:       "stdlib",
 								Version:    "1.22.11",
+								FilePath:   "opt/app/bin/app",
 								AnalyzedBy: analyzer.TypeSBOM,
 							},
 							{
@@ -1736,10 +1737,54 @@ func TestApplyLayersDeduplicatesSBOMApplications(t *testing.T) {
 		assert.Equal(t, 1, stdlibCount)
 	})
 
+	t.Run("shared dependency without matching file path remains separate", func(t *testing.T) {
+		got := applier.ApplyLayers([]types.BlobInfo{
+			{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/sbom.spdx",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "1.22.11",
+								AnalyzedBy: analyzer.TypeSBOM,
+							},
+						},
+					},
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/bin/app",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "v1.22.11",
+								AnalyzedBy: analyzer.TypeGoBinary,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, got.Applications, 2)
+		assert.ElementsMatch(t, []string{"opt/app/bin/app", "opt/app/sbom.spdx"}, applicationFilePaths(got.Applications))
+	})
+
 	t.Run("empty layer does not panic", func(t *testing.T) {
 		got := applier.ApplyLayers([]types.BlobInfo{{}})
 		assert.Equal(t, types.ArtifactDetail{}, got)
 	})
+}
+
+func applicationFilePaths(apps types.Applications) []string {
+	filePaths := make([]string, 0, len(apps))
+	for _, app := range apps {
+		filePaths = append(filePaths, app.FilePath)
+	}
+	return filePaths
 }
 
 func packageNames(pkgs types.Packages) []string {

--- a/pkg/fanal/applier/docker_test.go
+++ b/pkg/fanal/applier/docker_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 )
@@ -1593,4 +1595,157 @@ func TestApplyLayers(t *testing.T) {
 			assert.Equal(t, tt.want, got, tt.name)
 		})
 	}
+}
+
+func TestApplyLayersDeduplicatesSBOMApplications(t *testing.T) {
+	t.Run("same application from SBOM and file is merged", func(t *testing.T) {
+		got := applier.ApplyLayers([]types.BlobInfo{
+			{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/.spdx-app.spdx",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "1.22.11",
+								FilePath:   "opt/app/bin/app",
+								AnalyzedBy: analyzer.TypeSBOM,
+							},
+						},
+					},
+				},
+			},
+			{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/bin/app",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "v1.22.11",
+								AnalyzedBy: analyzer.TypeGoBinary,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, got.Applications, 1)
+		app := got.Applications[0]
+		assert.Equal(t, types.GoBinary, app.Type)
+		assert.Equal(t, "opt/app/bin/app", app.FilePath)
+		require.Len(t, app.Packages, 1)
+		assert.Equal(t, "stdlib", app.Packages[0].Name)
+		assert.Equal(t, "v1.22.11", app.Packages[0].Version)
+		assert.Equal(t, analyzer.TypeGoBinary, app.Packages[0].AnalyzedBy)
+	})
+
+	t.Run("different applications with same type remain separate", func(t *testing.T) {
+		got := applier.ApplyLayers([]types.BlobInfo{
+			{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/.spdx-api.spdx",
+						Packages: types.Packages{
+							{
+								ID:         "github.com/acme/api@v1.0.0",
+								Name:       "github.com/acme/api",
+								Version:    "v1.0.0",
+								AnalyzedBy: analyzer.TypeSBOM,
+							},
+						},
+					},
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/bin/worker",
+						Packages: types.Packages{
+							{
+								ID:         "github.com/acme/worker@v1.0.0",
+								Name:       "github.com/acme/worker",
+								Version:    "v1.0.0",
+								AnalyzedBy: analyzer.TypeGoBinary,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, got.Applications, 2)
+		assert.Equal(t, "opt/app/.spdx-api.spdx", got.Applications[0].FilePath)
+		assert.Equal(t, "opt/app/bin/worker", got.Applications[1].FilePath)
+	})
+
+	t.Run("overlapping package sets are merged without duplicate packages", func(t *testing.T) {
+		got := applier.ApplyLayers([]types.BlobInfo{
+			{
+				Applications: []types.Application{
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/.spdx-app.spdx",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "1.22.11",
+								AnalyzedBy: analyzer.TypeSBOM,
+							},
+							{
+								ID:         "github.com/acme/shared@v1.0.0",
+								Name:       "github.com/acme/shared",
+								Version:    "v1.0.0",
+								AnalyzedBy: analyzer.TypeSBOM,
+							},
+						},
+					},
+					{
+						Type:     types.GoBinary,
+						FilePath: "opt/app/bin/app",
+						Packages: types.Packages{
+							{
+								ID:         "stdlib@v1.22.11",
+								Name:       "stdlib",
+								Version:    "v1.22.11",
+								AnalyzedBy: analyzer.TypeGoBinary,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.Len(t, got.Applications, 1)
+		app := got.Applications[0]
+		assert.Equal(t, "opt/app/bin/app", app.FilePath)
+		require.Len(t, app.Packages, 2)
+		assert.ElementsMatch(t, []string{"github.com/acme/shared", "stdlib"}, packageNames(app.Packages))
+
+		var stdlibCount int
+		for _, pkg := range app.Packages {
+			if pkg.Name == "stdlib" {
+				stdlibCount++
+				assert.Equal(t, analyzer.TypeGoBinary, pkg.AnalyzedBy)
+			}
+		}
+		assert.Equal(t, 1, stdlibCount)
+	})
+
+	t.Run("empty layer does not panic", func(t *testing.T) {
+		got := applier.ApplyLayers([]types.BlobInfo{{}})
+		assert.Equal(t, types.ArtifactDetail{}, got)
+	})
+}
+
+func packageNames(pkgs types.Packages) []string {
+	names := make([]string, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		names = append(names, pkg.Name)
+	}
+	return names
 }


### PR DESCRIPTION
## Summary

Coalesces the same logical application that arrives under two different file paths (SBOM vs on-disk scan) so its packages are no longer duplicated in the merged result.

## Why

The language-package merge in `pkg/fanal/applier/docker.go` keyed on `app.FilePath + "/type:" + app.Type`, so the same application arriving twice with two different file paths got two distinct keys and was retained twice. Issue #8993 reports that this duplicates the application's packages in the merged scan output (for example when the same app is seen once from an SBOM and once from an on-disk scan), inflating results.

## Description

The language-package merge in `pkg/fanal/applier/docker.go` keyed on `app.FilePath + "/type:" + app.Type`, so the same logical application arriving twice with two different file paths (for example once from an SBOM and once from an on-disk scan) got two distinct keys and was retained twice, duplicating its packages in the merged result. `ApplyLayers` now routes each application through `setApplication`, which detects the same-Type/different-FilePath SBOM-vs-scanned case (`shouldMergeApplications`) and coalesces them (`mergeApplications`), preferring the scanned source and dropping byte-for-byte duplicate packages. Genuinely distinct applications keep their per-filepath behavior, so non-duplicate cases are unchanged, and OS-package and misconfiguration merging in the same loop are not touched.

## Related issues
- Closes #8993

## Related PRs
- None.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
