### PR TITLE
fix(vuln): fall back to UNKNOWN severity when vulnerability details are missing

### DIFF
--- a/pkg/scan/local/service_test.go
+++ b/pkg/scan/local/service_test.go
@@ -852,6 +852,10 @@ func TestScanner_Scan(t *testing.T) {
 								Layer: ftypes.Layer{
 									DiffID: "sha256:0ea33a93585cf1917ba522b2304634c3073654062d5282c1346322967790ef33",
 								},
+								// Severity falls back to UNKNOWN when vulnerability details are missing.
+								Vulnerability: dbTypes.Vulnerability{
+									Severity: dbTypes.SeverityUnknown.String(),
+								},
 							},
 						},
 					},

--- a/pkg/vulnerability/vulnerability.go
+++ b/pkg/vulnerability/vulnerability.go
@@ -78,6 +78,9 @@ func (c Client) FillInfo(vulns []types.DetectedVulnerability, severitySources []
 		vuln, err := c.dbc.GetVulnerability(vulnID)
 		if err != nil {
 			log.Warn("Unable to get vulnerability details (CVE may be rejected)", log.Err(err))
+			// Fall back to UNKNOWN so the severity is never left empty.
+			// An empty string is not a valid severity and would be rejected when parsed (e.g. during RPC conversion).
+			vulns[i].Severity = cmp.Or(vulns[i].Severity, dbTypes.SeverityUnknown.String())
 			continue
 		}
 

--- a/pkg/vulnerability/vulnerability_test.go
+++ b/pkg/vulnerability/vulnerability_test.go
@@ -469,6 +469,10 @@ func TestClient_FillInfo(t *testing.T) {
 				{
 					VulnerabilityID: "CVE-2019-0004",
 					Status:          dbTypes.StatusAffected,
+					// Severity falls back to UNKNOWN when vulnerability details are missing.
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityUnknown.String(),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

When a vulnerability is detected from an OS advisory that carries no severity (e.g. Alpine secdb) and its detail entry is missing from the DB, `FillInfo` returned early without setting the severity, leaving it as an empty string.

An empty string is not a valid severity and is rejected when parsed. In client/server mode this surfaces on the server as a noisy warning for every affected vulnerability:

```
WARN  Severity error  err="unknown severity: "
```

This happens for brand-new CVEs that are already listed in an OS advisory but not yet present in Trivy DB's vulnerability-detail data (sourced from NVD and others). The fix falls back to `UNKNOWN` when the detail lookup fails, so the severity is never left empty.

## How to reproduce

`yobasystems/alpine-mariadb:11.4.9` ships Alpine 3.23.2 with MariaDB `11.4.9-r0`, which is older than the fixed version (`11.4.11-r0`), so `CVE-2026-44168`..`CVE-2026-44173` are detected. These CVEs are still missing from the vulnerability-detail data, which triggers the warning.

```bash
# The warning is logged on the server side
trivy server &
trivy image --server http://localhost:4954 yobasystems/alpine-mariadb:11.4.9
```

### Before
Server log (one line per affected vulnerability):
```
WARN  Severity error  err="unknown severity: "
```

### After
No warning. The severity is reported as `UNKNOWN`.

## Related issues
N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation (not needed).
- [ ] I've added usage information (no new options).
- [ ] I've included a "before" and "after" example (not a UI change).
