### PR TITLE
feat(sarif): add invocation startTimeUtc and endTimeUtc to SARIF output

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	containerName "github.com/google/go-containerregistry/pkg/name"
 	"github.com/owenrumney/go-sarif/v2/sarif"
@@ -48,6 +49,7 @@ type SarifWriter struct {
 	run           *sarif.Run
 	locationCache map[string][]location
 	Target        string
+	StartTime     time.Time
 }
 
 type sarifData struct {
@@ -268,6 +270,17 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			},
 		}
 	}
+
+	endTime := time.Now().UTC()
+	startTime := sw.StartTime.UTC()
+	if startTime.IsZero() {
+		startTime = endTime
+	}
+	sw.run.AddInvocations(sarif.NewInvocation().
+		WithExecutionSuccess(true).
+		WithStartTimeUTC(startTime.Format(time.RFC3339Nano)).
+		WithEndTimeUTC(endTime.Format(time.RFC3339Nano)))
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -746,6 +746,18 @@ func TestReportWriter_Sarif(t *testing.T) {
 			result := &sarif.Report{}
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
 			require.NoError(t, err)
+
+			// Verify that every run contains exactly one invocation with the
+			// expected execution status and non-empty timestamps, then clear it
+			// so the remainder of the struct can be compared with tt.want.
+			require.Len(t, result.Runs, 1)
+			invocations := result.Runs[0].Invocations
+			require.Len(t, invocations, 1, "expected one invocation in SARIF run")
+			assert.True(t, *invocations[0].ExecutionSuccessful, "invocation must report executionSuccessful=true")
+			assert.NotEmpty(t, invocations[0].StartTimeUTC, "invocation startTimeUtc must not be empty")
+			assert.NotEmpty(t, invocations[0].EndTimeUTC, "invocation endTimeUtc must not be empty")
+			result.Runs[0].Invocations = nil
+
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
@@ -98,9 +99,10 @@ func Write(ctx context.Context, report types.Report, option flag.Options) (err e
 			target = option.Target
 		}
 		writer = &SarifWriter{
-			Output:  output,
-			Version: option.AppVersion,
-			Target:  target,
+			Output:    output,
+			Version:   option.AppVersion,
+			Target:    target,
+			StartTime: time.Now(),
 		}
 	case types.FormatCosignVuln:
 		writer = predicate.NewVulnWriter(output, option.AppVersion)


### PR DESCRIPTION
## Summary

Adds a SARIF [`invocations`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317574) block to every run, containing:

| Field | Value |
|---|---|
| `startTimeUtc` | When `SarifWriter` was initialised (approximates scan start) |
| `endTimeUtc` | When `Write()` returns (scan completion) |
| `executionSuccessful` | Always `true` (SARIF is only produced on success) |

Example output:

```json
"invocations": [
  {
    "startTimeUtc": "2026-03-26T20:53:52.123456789Z",
    "endTimeUtc":   "2026-03-26T20:53:53.063429591Z",
    "executionSuccessful": true
  }
]
```

## Motivation

Closes #3226

Consumers of SARIF output often need to verify scan freshness. Without `invocations`, there is no timestamp inside the SARIF file itself. This change lets monitoring tools (dashboards, CI gates, compliance pipelines) check the report age without relying on filesystem metadata or external systems.

## Changes

- `pkg/report/sarif.go` — added `StartTime time.Time` field to `SarifWriter`; `Write()` appends an invocation before adding the run to the report.
- `pkg/report/writer.go` — initialises `StartTime` to `time.Now()` when the `SarifWriter` is created for `--format sarif`.
- `pkg/report/sarif_test.go` — extended the test loop to assert one invocation exists per run with `executionSuccessful=true` and non-empty timestamps; invocations are stripped before the remaining struct equality check so no existing `want` entries need updating.

## SARIF conformance

Both `startTimeUtc` and `endTimeUtc` are defined as optional in SARIF 2.1.0 §3.20.6–3.20.7 and use the RFC 3339 format required by the spec.