### PR TITLE
fix(module): pass size argument to WASM free function

### DIFF
--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -461,7 +461,7 @@ func (m *wasmModule) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 	if err != nil {
 		return nil, xerrors.Errorf("failed to write string to memory: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) // nolint: errcheck
+	defer m.free.Call(ctx, inputPtr, inputSize) // nolint: errcheck
 
 	// 2. Call analyze
 	analyzeRes, err := m.analyze.Call(ctx, inputPtr, inputSize)
@@ -511,7 +511,7 @@ func (m *wasmModule) PostScan(ctx context.Context, results types.Results) (types
 	if err != nil {
 		return nil, xerrors.Errorf("post scan marshal error: %w", err)
 	}
-	defer m.free.Call(ctx, inputPtr) //nolint: errcheck
+	defer m.free.Call(ctx, inputPtr, inputSize) //nolint: errcheck
 
 	analyzeRes, err := m.postScan.Call(ctx, inputPtr, inputSize)
 	if err != nil {


### PR DESCRIPTION
## Description

Closes #10392

The WASM SDK exports `free(ptr uint32, size uint32)` with two parameters, but `wasmModule.Analyze()` and `wasmModule.PostScan()` in `pkg/module/module.go` called `m.free.Call(ctx, inputPtr)` with only one argument. wazero enforces strict parameter count validation, so the call always returned an error. Since the error was silently discarded, `free()` never actually executed, allocated WASM memory was never reclaimed, and after enough invocations the WASM memory was exhausted.

## Fix

Pass both `inputPtr` and `inputSize` to `m.free.Call()` in both methods.

## Tests

All module tests pass:

```
=== RUN   TestManager_Register/happy_path
=== RUN   TestManager_Register/only_analyzer
=== RUN   TestManager_Register/only_post_scanner
=== RUN   TestManager_Register/no_module_dir
=== RUN   TestManager_Register/pass_enabled_modules
--- PASS: TestManager_Register (6.40s)
PASS
ok  github.com/aquasecurity/trivy/pkg/module
```