### PR TITLE
fix: correct format verbs in diagnostic messages

### DIFF
--- a/pkg/sbom/spdx/marshal.go
+++ b/pkg/sbom/spdx/marshal.go
@@ -523,7 +523,7 @@ func (m *Marshaler) spdxChecksums(digests []digest.Digest) []common.Checksum {
 		case digest.MD5:
 			alg = spdx.MD5
 		default:
-			m.logger.Warn("Unsupported hash algorithm", log.String("algorithm", string(alg)))
+			m.logger.Warn("Unsupported hash algorithm", log.String("algorithm", d.Algorithm().String()))
 			continue
 		}
 		checksums = append(checksums, spdx.Checksum{

--- a/pkg/vex/sbomref.go
+++ b/pkg/vex/sbomref.go
@@ -84,7 +84,7 @@ func retrieveExternalVEXDocument(ctx context.Context, vexUrl *url.URL, report *t
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, xerrors.Errorf("did not receive 2xx status code: %d", res.StatusCode)
+		return nil, xerrors.Errorf("unexpected status code %d from %s", res.StatusCode, vexUrl.Redacted())
 	}
 
 	val, err := io.ReadAll(res.Body)

--- a/pkg/vex/sbomref.go
+++ b/pkg/vex/sbomref.go
@@ -84,7 +84,7 @@ func retrieveExternalVEXDocument(ctx context.Context, vexUrl *url.URL, report *t
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, xerrors.Errorf("did not receive 2xx status code: %w", res.StatusCode)
+		return nil, xerrors.Errorf("did not receive 2xx status code: %d", res.StatusCode)
 	}
 
 	val, err := io.ReadAll(res.Body)

--- a/pkg/vex/sbomref_test.go
+++ b/pkg/vex/sbomref_test.go
@@ -79,10 +79,11 @@ func TestRetrieveExternalVEXDocuments(t *testing.T) {
 	t.Cleanup(s.Close)
 
 	tests := []struct {
-		name      string
-		input     *types.Report
-		wantVEXes int
-		wantErr   bool
+		name       string
+		input      *types.Report
+		wantVEXes  int
+		wantErr    bool
+		wantErrMsg string
 	}{
 		{
 			name:      "external vex retrieval",
@@ -96,9 +97,10 @@ func TestRetrieveExternalVEXDocuments(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "vex not found",
-			input:   setupTestReport(s, vexNotFound),
-			wantErr: true,
+			name:       "vex not found",
+			input:      setupTestReport(s, vexNotFound),
+			wantErr:    true,
+			wantErrMsg: "did not receive 2xx status code: 404",
 		},
 		{
 			name:      "no external reference",
@@ -113,6 +115,9 @@ func TestRetrieveExternalVEXDocuments(t *testing.T) {
 			got, err := vex.NewSBOMReferenceSet(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.wantErrMsg != "" {
+					require.ErrorContains(t, err, tt.wantErrMsg)
+				}
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/vex/sbomref_test.go
+++ b/pkg/vex/sbomref_test.go
@@ -79,45 +79,38 @@ func TestRetrieveExternalVEXDocuments(t *testing.T) {
 	t.Cleanup(s.Close)
 
 	tests := []struct {
-		name       string
-		input      *types.Report
-		wantVEXes  int
-		wantErr    bool
-		wantErrMsg string
+		name      string
+		input     *types.Report
+		wantVEXes int
+		wantErr   string
 	}{
 		{
 			name:      "external vex retrieval",
 			input:     setupTestReport(s, vexExternalRef),
 			wantVEXes: 1,
-			wantErr:   false,
 		},
 		{
 			name:    "incompatible external vex",
 			input:   setupTestReport(s, vexUnknown),
-			wantErr: true,
+			wantErr: "unable to load VEX from external reference",
 		},
 		{
-			name:       "vex not found",
-			input:      setupTestReport(s, vexNotFound),
-			wantErr:    true,
-			wantErrMsg: "did not receive 2xx status code: 404",
+			name:    "vex not found",
+			input:   setupTestReport(s, vexNotFound),
+			wantErr: "unexpected status code 404",
 		},
 		{
 			name:      "no external reference",
 			input:     setupEmptyTestReport(),
 			wantVEXes: 0,
-			wantErr:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := vex.NewSBOMReferenceSet(tt.input)
-			if tt.wantErr {
-				require.Error(t, err)
-				if tt.wantErrMsg != "" {
-					require.ErrorContains(t, err, tt.wantErrMsg)
-				}
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

While reviewing the codebase I found two small bugs that produce misleading diagnostic output:

1. **`pkg/vex/sbomref.go`** — when fetching an external VEX document, a non-2xx HTTP response is reported with:
   ```go
   xerrors.Errorf("did not receive 2xx status code: %w", res.StatusCode)
   ```
   `res.StatusCode` is an `int`, but `%w` expects an `error`. So a failed fetch renders as:
   ```
   did not receive 2xx status code: %!w(int=404)
   ```
   Switched to `%d` so the actual status code is shown. (`go vet` flags this class of mistake.)

2. **`pkg/sbom/spdx/marshal.go`** — the "Unsupported hash algorithm" warning logs the `alg` variable from the `default` branch of the switch, where it is still the zero value:
   ```go
   var alg spdx.ChecksumAlgorithm
   switch d.Algorithm() {
   ...
   default:
       m.logger.Warn("Unsupported hash algorithm", log.String("algorithm", string(alg))) // always ""
   }
   ```
   So the warning never names the offending algorithm. Changed it to log `d.Algorithm()`.

I also strengthened the existing `"vex not found"` test case to assert that the status code appears in the returned error message. The previous test only checked `require.Error`, which still passes with the garbled `%!w(int=404)` output — so it would not have caught this regression.

## Related issues
N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
