### PR TITLE
fix: forward ospkg detector options through ospkg.NewScanner

### DIFF
--- a/pkg/scan/ospkg/scan.go
+++ b/pkg/scan/ospkg/scan.go
@@ -3,7 +3,6 @@ package ospkg
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 
 	"golang.org/x/xerrors"

--- a/pkg/scan/ospkg/scan.go
+++ b/pkg/scan/ospkg/scan.go
@@ -16,10 +16,14 @@ type Scanner interface {
 	Scan(ctx context.Context, target types.ScanTarget, options types.ScanOptions) (types.Result, bool, error)
 }
 
-type scanner struct{}
+type scanner struct {
+	opts []ospkgDetector.Option
+}
 
-func NewScanner() Scanner {
-	return &scanner{}
+// NewScanner creates a new OS package scanner.
+// The given options are forwarded to ospkgDetector.NewDetector during Scan.
+func NewScanner(opts ...ospkgDetector.Option) Scanner {
+	return &scanner{opts: opts}
 }
 
 func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.ScanOptions) (types.Result, bool, error) {
@@ -55,7 +59,7 @@ func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.
 		return result, false, nil
 	}
 
-	detector, err := ospkgDetector.NewDetector(target)
+	detector, err := ospkgDetector.NewDetector(target, s.opts...)
 	if err != nil {
 		return result, false, xerrors.Errorf("unable to initialize Detector for OS packages: %w", err)
 	}

--- a/pkg/scan/ospkg/scan.go
+++ b/pkg/scan/ospkg/scan.go
@@ -24,7 +24,7 @@ type scanner struct {
 // NewScanner creates a new OS package scanner.
 // The given options are forwarded to ospkgDetector.NewDetector during Scan.
 func NewScanner(opts ...ospkgDetector.Option) Scanner {
-	return &scanner{opts: slices.Clone(opts)} // Clone to avoid sharing the backing array with the caller
+	return &scanner{opts: opts}
 }
 
 func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.ScanOptions) (types.Result, bool, error) {

--- a/pkg/scan/ospkg/scan.go
+++ b/pkg/scan/ospkg/scan.go
@@ -3,6 +3,7 @@ package ospkg
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	"golang.org/x/xerrors"
@@ -23,7 +24,7 @@ type scanner struct {
 // NewScanner creates a new OS package scanner.
 // The given options are forwarded to ospkgDetector.NewDetector during Scan.
 func NewScanner(opts ...ospkgDetector.Option) Scanner {
-	return &scanner{opts: opts}
+	return &scanner{opts: slices.Clone(opts)} // Clone to avoid sharing the backing array with the caller
 }
 
 func (s *scanner) Scan(ctx context.Context, target types.ScanTarget, opts types.ScanOptions) (types.Result, bool, error) {

--- a/pkg/scan/ospkg/scan_test.go
+++ b/pkg/scan/ospkg/scan_test.go
@@ -1,0 +1,58 @@
+package ospkg_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ospkgDetector "github.com/aquasecurity/trivy/pkg/detector/ospkg"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/scan/ospkg"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+type mockDriver struct {
+	called bool
+	vulns  []types.DetectedVulnerability
+}
+
+func (m *mockDriver) Detect(_ context.Context, _ string, _ *ftypes.Repository, _ []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	m.called = true
+	return m.vulns, nil
+}
+
+func (m *mockDriver) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
+	return true
+}
+
+// TestScanner_Scan_ForwardsOptions verifies that options passed to NewScanner
+// are forwarded to ospkgDetector.NewDetector during Scan.
+func TestScanner_Scan_ForwardsOptions(t *testing.T) {
+	target := types.ScanTarget{
+		OS: ftypes.OS{
+			Family: ftypes.CentOS,
+			Name:   "7",
+		},
+		Packages: []ftypes.Package{
+			{Name: "vim"},
+		},
+	}
+	opts := types.ScanOptions{
+		Scanners: types.Scanners{types.VulnerabilityScanner},
+	}
+
+	want := []types.DetectedVulnerability{
+		{VulnerabilityID: "CVE-2024-0001"},
+	}
+
+	mockDrv := &mockDriver{vulns: want}
+	s := ospkg.NewScanner(ospkgDetector.WithDriver(target.OS.Family, mockDrv))
+
+	result, _, err := s.Scan(t.Context(), target, opts)
+	require.NoError(t, err)
+
+	assert.True(t, mockDrv.called, "expected the driver registered via the option to be used")
+	assert.Equal(t, want, result.Vulnerabilities)
+}


### PR DESCRIPTION
## Description

Allow Trivy-as-a-library consumers to set OS package detection driver/provider overrides through the public `ospkg.NewScanner` constructor, so the options reach `ospkgDetector.NewDetector` without callers reaching into the inner detector constructor.

`ospkg.NewScanner(opts ...ospkgDetector.Option)` now stores the options and forwards them to `ospkgDetector.NewDetector(target, s.opts...)` inside `(*scanner).Scan`. This follows the standard functional-options pattern (no global mutable state), mirroring the `grpc.NewServer(opts ...ServerOption)` approach where the top-level constructor threads options down to the components it builds internally.

The constructor stays backward compatible: it is variadic, so existing `ospkg.NewScanner()` calls keep working unchanged.

Usage:

```go
osScanner := ospkg.NewScanner(ospkgDetector.WithProvider(myProvider))
svc := local.NewService(app, osScanner, langScanner, vulnClient)
```

## Related issues
- Close #10817

## Related PRs
- [ ] #10740

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
