### PR TITLE
ci: expect GitHub App bot as backport PR author

### DIFF
--- a/.github/workflows/release-pr-check.yaml
+++ b/.github/workflows/release-pr-check.yaml
@@ -14,7 +14,7 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ "$PR_AUTHOR" != "aqua-bot" ]; then
+          if [ "$PR_AUTHOR" != "repo-trivy-write-33ed3c[bot]" ]; then
             echo "::error::This branch is intended for automated backporting by bot. Please refer to the documentation:"
             echo "::error::https://trivy.dev/docs/latest/community/maintainer/backporting/"
             exit 1


### PR DESCRIPTION
## Description
After migrating backporting from a PAT (`aqua-bot`) to a GitHub App, the backport workflow creates PRs using an App installation token (`actions/create-github-app-token`).
As a result, `github.event.pull_request.user.login` is now the App's bot account (`repo-trivy-write-33ed3c[bot]`, type `Bot`) instead of `aqua-bot`.

The `release-pr-check.yaml` workflow still expected `aqua-bot`, so the author check failed on every backport PR (e.g. https://github.com/aquasecurity/trivy/actions/runs/27127764774/job/80060684036?pr=10812).

This updates the check to expect the GitHub App bot login.

## Related PRs
- [x] #10628

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
