### PR TITLE
fix(vex): load VEX documents from within the repository directory

### DIFF
--- a/pkg/vex/repo.go
+++ b/pkg/vex/repo.go
@@ -114,7 +114,11 @@ func (rs *RepositorySet) NotAffected(vuln types.DetectedVulnerability, product, 
 }
 
 func (rs *RepositorySet) OpenDocument(source, dir string, entry repo.PackageEntry) (VEX, error) {
-	f, err := os.Open(filepath.Join(dir, entry.Location))
+	// dir is the repository cache directory computed by Trivy, while
+	// entry.Location comes from the repository metadata (external input).
+	// os.OpenInRoot keeps the resolved path within dir, so a location pointing
+	// outside it is not opened.
+	f, err := os.OpenInRoot(dir, entry.Location)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open the VEX document: %w", err)
 	}

--- a/pkg/vex/repo_test.go
+++ b/pkg/vex/repo_test.go
@@ -78,6 +78,24 @@ repositories:
 			product:         bashComponent,
 			wantNotAffected: false,
 		},
+		{
+			// The index entry's location ("../bash-vex.json") points to a file in
+			// the parent of the repository directory. VEX documents are only loaded
+			// from within the repository directory, so the document is not loaded
+			// and the finding is returned unmodified (not affected = false), even
+			// though that file marks it as not_affected.
+			name:     "entry location in a parent directory is not loaded",
+			cacheDir: "testdata/parent-location-repo",
+			configContent: `
+repositories:
+  - name: default
+    url: https://example.com/vex/default
+    enabled: true
+`,
+			vuln:            vuln3,
+			product:         bashComponent,
+			wantNotAffected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vex/testdata/parent-location-repo/vex/repositories/default/0.1/index.json
+++ b/pkg/vex/testdata/parent-location-repo/vex/repositories/default/0.1/index.json
@@ -1,0 +1,10 @@
+{
+  "updated_at": "2024-07-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "pkg:deb/debian/bash",
+      "location": "../bash-vex.json",
+      "format": "openvex"
+    }
+  ]
+}

--- a/pkg/vex/testdata/parent-location-repo/vex/repositories/default/bash-vex.json
+++ b/pkg/vex/testdata/parent-location-repo/vex/repositories/default/bash-vex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5d6e2706",
+  "author": "Example Author",
+  "role": "Document Creator",
+  "timestamp": "2023-07-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "CVE-2022-3715"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/bash@5.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/pkg/vex/testdata/parent-location-repo/vex/repositories/default/vex-repository.json
+++ b/pkg/vex/testdata/parent-location-repo/vex/repositories/default/vex-repository.json
@@ -1,0 +1,15 @@
+{
+  "name": "Test VEX Repository",
+  "description": "VEX Repository for Testing",
+  "versions": [
+    {
+      "spec_version": "0.1",
+      "locations": [
+        {
+          "url": "never used"
+        }
+      ],
+      "update_interval": "24h"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

A VEX repository is something the user explicitly adds and trusts. Each document
in it is referenced by a `location` entry in the index and is expected to live
inside the repository directory, so `OpenDocument` now uses `os.OpenInRoot`
(Go 1.24+) to load documents from within that directory.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
