### PR TITLE
docs: fix repository scan heading typo

### DIFF
--- a/docs/guide/target/repository.md
+++ b/docs/guide/target/repository.md
@@ -146,7 +146,7 @@ Pass a `--branch` argument with a valid branch name on the remote repository pro
 $ trivy repo --branch <branch-name> <repo-name>
 ```
 
-### Scanning upto a Commit
+### Scanning up to a Commit
 
 Pass a `--commit` argument with a valid commit hash on the remote repository provided:
 


### PR DESCRIPTION
## Description
Fixes a small typo in the repository scan documentation heading: `upto` -> `up to`.

## Validation
- `git diff --check`
- `npx --yes markdownlint-cli2 docs/guide/target/repository.md` (reports existing style issues in this file; this PR only changes one heading word and does not introduce those violations)