### PR TITLE
refactor: use ParseErrorsAllowlist instead of ParseErrorsWhitelist

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -206,7 +206,7 @@ func (p *Parser) ParseLDFlags(name string, flags []string) string {
 	fset := pflag.NewFlagSet("ldflags", pflag.ContinueOnError)
 	// This prevents the flag set from erroring out if other flags were provided.
 	// This helps keep the implementation small, so that only the -X flag is needed.
-	fset.ParseErrorsWhitelist.UnknownFlags = true
+	fset.ParseErrorsAllowlist.UnknownFlags = true
 	// The shorthand name is needed here because setting the full name
 	// to `X` will cause the flag set to look for `--X` instead of `-X`.
 	// The flag can also be set multiple times, so a string slice is needed


### PR DESCRIPTION
## Description

Replace the deprecated `ParseErrorsWhitelist` with `ParseErrorsAllowlist`. The old field will be removed in a future release. (see https://github.com/spf13/pflag/releases/tag/v1.0.9)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
