### PR TITLE
feat(report): add invocation start/end times to SARIF output

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -268,6 +268,15 @@ func (sw *SarifWriter) Write(_ context.Context, report types.Report) error {
 			},
 		}
 	}
+	// Record the scan time as an invocation so consumers can tell when the
+	// report was produced. Trivy tracks a single report timestamp, so it is
+	// reported as both the start and end of the invocation.
+	if !report.CreatedAt.IsZero() {
+		sw.run.AddInvocation(true).
+			WithStartTimeUTC(report.CreatedAt).
+			WithEndTimeUTC(report.CreatedAt)
+	}
+
 	sarifReport.AddRun(sw.run)
 	return sarifReport.PrettyWrite(sw.Output)
 }

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/owenrumney/go-sarif/v2/sarif"
 	"github.com/stretchr/testify/assert"
@@ -747,6 +748,46 @@ func TestReportWriter_Sarif(t *testing.T) {
 			err = json.Unmarshal(sarifWritten.Bytes(), result)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestReportWriter_SarifInvocation(t *testing.T) {
+	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input types.Report
+		want  []*sarif.Invocation
+	}{
+		{
+			name:  "report with a creation time",
+			input: types.Report{CreatedAt: createdAt},
+			want: []*sarif.Invocation{
+				{
+					ExecutionSuccessful: new(true),
+					StartTimeUTC:        new(createdAt),
+					EndTimeUTC:          new(createdAt),
+				},
+			},
+		},
+		{
+			name:  "report without a creation time",
+			input: types.Report{},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sarifWritten := bytes.NewBuffer(nil)
+			w := report.SarifWriter{Output: sarifWritten}
+			require.NoError(t, w.Write(t.Context(), tt.input))
+
+			result := &sarif.Report{}
+			require.NoError(t, json.Unmarshal(sarifWritten.Bytes(), result))
+			require.Len(t, result.Runs, 1)
+			assert.Equal(t, tt.want, result.Runs[0].Invocations)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Adds `invocations[].startTimeUtc` and `invocations[].endTimeUtc` to Trivy's SARIF output, as requested in #3226.

The SARIF writer now emits an [invocation](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317574) populated from `report.CreatedAt`. This lets consumers tell when a report was produced (e.g. to verify a SARIF report is current). Trivy tracks a single report timestamp, so it is reported as both the start and end of the invocation. The invocation is only emitted when a creation time is present, so existing output is unchanged when it is not set.

## Example output

```json
"invocations": [
  {
    "executionSuccessful": true,
    "startTimeUtc": "2024-01-02T03:04:05Z",
    "endTimeUtc": "2024-01-02T03:04:05Z"
  }
]
```

## Tests

- Added `TestReportWriter_SarifInvocation` covering both the present and absent creation-time cases.
- Existing SARIF tests and the full `pkg/report` suite pass (`GOEXPERIMENT=jsonv2 go test ./pkg/report/`).

Closes #3226