### PR TITLE
fix(terraform): avoid concurrent map write on global getter.Getters

### DIFF
--- a/pkg/iac/scanners/terraform/parser/resolvers/remote.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -70,8 +71,12 @@ func (r *remoteResolver) download(ctx context.Context, opt Options, dst string) 
 		return err
 	}
 
+	// Clone the global map so that it will not be accessed concurrently.
+	// cf. pkg/downloader/download.go
+	getters := maps.Clone(getter.Getters)
+
 	// Overwrite the file getter so that a file will be copied
-	getter.Getters["file"] = &getter.FileGetter{Copy: true}
+	getters["file"] = &getter.FileGetter{Copy: true}
 
 	opt.Logger.Debug("Downloading module", log.String("source", opt.Source))
 
@@ -81,7 +86,7 @@ func (r *remoteResolver) download(ctx context.Context, opt Options, dst string) 
 		Src:     opt.Source,
 		Dst:     dst,
 		Pwd:     opt.WorkingDir,
-		Getters: getter.Getters,
+		Getters: getters,
 		Mode:    getter.ClientModeAny,
 	}
 

--- a/pkg/iac/scanners/terraform/parser/resolvers/remote_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/remote_test.go
@@ -1,0 +1,61 @@
+package resolvers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-getter"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+func init() {
+	// Replace the non-thread-safe DeferredHandler with a real handler so that
+	// concurrent download() calls don't trigger an unrelated logger data race.
+	log.InitLogger(true, true)
+}
+
+// TestRemoteDownloadDoesNotMutateGlobalGetters verifies that download() does not
+// write to the package-global getter.Getters map. Concurrent download() calls
+// must only read the shared map (safe) and never write it.
+//
+// Run with -race to also catch concurrent map writes:
+//
+//	go test -race -run TestRemoteDownloadDoesNotMutateGlobalGetters ./pkg/iac/scanners/terraform/parser/resolvers/...
+func TestRemoteDownloadDoesNotMutateGlobalGetters(t *testing.T) {
+	// Snapshot the original global "file" getter.
+	// go-getter initialises it to &FileGetter{} (Copy: false) at package init.
+	original := getter.Getters["file"]
+	require.NotNil(t, original, "precondition: global file getter should exist")
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "module.tf"), []byte("# test"), 0o600))
+
+	// Run downloads concurrently — under -race this catches the concurrent map write.
+	const concurrency = 10
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			opt := Options{
+				Source:     "file://" + filepath.ToSlash(srcDir),
+				WorkingDir: srcDir,
+				Logger:     log.WithPrefix("test"),
+			}
+			// Download error is irrelevant — the global mutation at the (unfixed)
+			// line 74 happens before client.Get(), which is what we are testing.
+			_ = Remote.download(context.Background(), opt, filepath.Join(t.TempDir(), "dst"))
+		}()
+	}
+	wg.Wait()
+
+	// The global map must not have been mutated by download().
+	// Without the fix, line 74 overwrites this with &FileGetter{Copy: true}.
+	require.Same(t, original, getter.Getters["file"],
+		"download() must not mutate the package-global getter.Getters map — clone locally instead")
+}


### PR DESCRIPTION
## Description

`remoteResolver.download()` wrote to the package-global `getter.Getters` map on every call without synchronization:

```go
getter.Getters["file"] = &getter.FileGetter{Copy: true}
```

Concurrent `download()` calls (e.g. `trivy image --parallel`, default 5 layers at a time) are a concurrent map write, which the Go runtime may detect and abort the process over.

### Fix

Clone the global map per call and override `"file"` on the local copy, then pass the local map to the getter client:

```go
getters := maps.Clone(getter.Getters)
getters["file"] = &getter.FileGetter{Copy: true}
client := &getter.Client{..., Getters: getters}
```

After this change nothing writes `getter.Getters`, so the global becomes read-only and concurrent clones are safe.

This is the same pattern already used in `pkg/downloader/download.go:67-71`.

### Verification

- Added `remote_test.go` with a `-race` regression test that runs `download()` concurrently and asserts the global `getter.Getters["file"]` is not mutated.
- Confirmed the test **fails** before the fix (race detector: "concurrent map writes" at `remote.go:74` + `require.Same` assertion failure).
- Confirmed the test **passes** after the fix under `-race`.
- `grep getter.Getters[` across the codebase returns **0 production writes** after the fix.

## Related issues
- Fixes #10832

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Notes
- Issue #10833 (`GIT_TERMINAL_PROMPT` TOCTOU) is a **separate** concern in the same function (different root cause, has an open design question) and is intentionally left for a separate PR.
