### PR TITLE
feat(misconf): Adds CloudFront standard logging v2 support to AVD-AWS-0010

### DIFF
--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -803,11 +803,11 @@ func TestContainerd_PullImage(t *testing.T) {
 					},
 					History: []v1.History{
 						{
-							Created:   v1.Time{time.Date(2019, 8, 20, 20, 19, 55, 62606894, time.UTC)},
+							Created:   v1.Time{Time: time.Date(2019, 8, 20, 20, 19, 55, 62606894, time.UTC)},
 							CreatedBy: "/bin/sh -c #(nop) ADD file:fe64057fbb83dccb960efabbf1cd8777920ef279a7fa8dbca0a8801c651bdf7c in / ",
 						},
 						{
-							Created:    v1.Time{time.Date(2019, 8, 20, 20, 19, 55, 211423266, time.UTC)},
+							Created:    v1.Time{Time: time.Date(2019, 8, 20, 20, 19, 55, 211423266, time.UTC)},
 							CreatedBy:  "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
 							EmptyLayer: true,
 						},

--- a/pkg/fanal/test/integration/containerd_test.go
+++ b/pkg/fanal/test/integration/containerd_test.go
@@ -803,11 +803,11 @@ func TestContainerd_PullImage(t *testing.T) {
 					},
 					History: []v1.History{
 						{
-							Created:   v1.Time{Time: time.Date(2019, 8, 20, 20, 19, 55, 62606894, time.UTC)},
+							Created:   v1.Time{time.Date(2019, 8, 20, 20, 19, 55, 62606894, time.UTC)},
 							CreatedBy: "/bin/sh -c #(nop) ADD file:fe64057fbb83dccb960efabbf1cd8777920ef279a7fa8dbca0a8801c651bdf7c in / ",
 						},
 						{
-							Created:    v1.Time{Time: time.Date(2019, 8, 20, 20, 19, 55, 211423266, time.UTC)},
+							Created:    v1.Time{time.Date(2019, 8, 20, 20, 19, 55, 211423266, time.UTC)},
 							CreatedBy:  "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
 							EmptyLayer: true,
 						},

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/cloudfront_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/cloudfront_test.go
@@ -134,6 +134,87 @@ Resources:
 				},
 			},
 		},
+
+		{
+			name: "v2 logging with non-access log_type yields false",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          ViewerProtocolPolicy: "redirect-to-https"
+
+  CloudFrontAccessLogsDeliverySource:
+    Type: AWS::Logs::DeliverySource
+    Properties:
+      LogType: ERROR_LOGS
+      Name: cloudfront-log-delivery-source
+      ResourceArn: !Sub
+        - arn:aws:cloudfront::${AWS::AccountId}:distribution/${D}
+        - D: !GetAtt CloudFrontDistribution.Id
+
+  CloudFrontAccessLogsDelivery:
+    Type: AWS::Logs::Delivery
+    Properties:
+      DeliverySourceName: cloudfront-log-delivery-source
+`,
+			expected: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Logging: cloudfront.Logging{
+							V2: cloudfront.LoggingV2{
+								Enabled: types.BoolTest(false),
+							},
+						},
+						DefaultCacheBehaviour: cloudfront.CacheBehaviour{
+							ViewerProtocolPolicy: types.StringTest("redirect-to-https"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "v2 logging delivery source ref via logical ID yields true",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          ViewerProtocolPolicy: "redirect-to-https"
+
+  CloudFrontAccessLogsDeliverySource:
+    Type: AWS::Logs::DeliverySource
+    Properties:
+      LogType: ACCESS_LOGS
+      Name: cloudfront-log-delivery-source
+      ResourceArn: !Sub
+        - arn:aws:cloudfront::${AWS::AccountId}:distribution/${D}
+        - D: !GetAtt CloudFrontDistribution.Id
+
+  CloudFrontAccessLogsDelivery:
+    Type: AWS::Logs::Delivery
+    Properties:
+      DeliverySourceName: !Ref CloudFrontAccessLogsDeliverySource
+`,
+			expected: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Logging: cloudfront.Logging{
+							V2: cloudfront.LoggingV2{
+								Enabled: types.BoolTest(true),
+							},
+						},
+						DefaultCacheBehaviour: cloudfront.CacheBehaviour{
+							ViewerProtocolPolicy: types.StringTest("redirect-to-https"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/cloudfront_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/cloudfront_test.go
@@ -58,6 +58,82 @@ Resources:
 				Distributions: []cloudfront.Distribution{{}},
 			},
 		},
+
+		{
+			name: "v2 logging configured",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          ViewerProtocolPolicy: "redirect-to-https"
+
+  CloudFrontAccessLogsDeliverySource:
+    Type: AWS::Logs::DeliverySource
+    Properties:
+      LogType: ACCESS_LOGS
+      Name: cloudfront-log-delivery-source
+      ResourceArn: !Sub
+        - arn:aws:cloudfront::${AWS::AccountId}:distribution/${D}
+        - D: !GetAtt CloudFrontDistribution.Id
+
+  CloudFrontAccessLogsDelivery:
+    Type: AWS::Logs::Delivery
+    Properties:
+      DeliverySourceName: cloudfront-log-delivery-source
+`,
+			expected: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Logging: cloudfront.Logging{
+							V2: cloudfront.LoggingV2{
+								Enabled: types.BoolTest(true),
+							},
+						},
+						DefaultCacheBehaviour: cloudfront.CacheBehaviour{
+							ViewerProtocolPolicy: types.StringTest("redirect-to-https"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "v2 logging source exists but no delivery",
+			source: `AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          ViewerProtocolPolicy: "redirect-to-https"
+
+  CloudFrontAccessLogsDeliverySource:
+    Type: AWS::Logs::DeliverySource
+    Properties:
+      LogType: ACCESS_LOGS
+      Name: cloudfront-log-delivery-source
+      ResourceArn: !Sub
+        - arn:aws:cloudfront::${AWS::AccountId}:distribution/${D}
+        - D: !GetAtt CloudFrontDistribution.Id
+`,
+			expected: cloudfront.Cloudfront{
+				Distributions: []cloudfront.Distribution{
+					{
+						Logging: cloudfront.Logging{
+							V2: cloudfront.LoggingV2{
+								Enabled: types.BoolTest(false),
+							},
+						},
+						DefaultCacheBehaviour: cloudfront.CacheBehaviour{
+							ViewerProtocolPolicy: types.StringTest("redirect-to-https"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
@@ -53,7 +53,7 @@ func getDefaultCacheBehaviour(r *parser.Resource) cloudfront.CacheBehaviour {
 	}
 }
 
-func hasV2Logging(distribution *parser.Resource, deliverySources []*parser.Resource, deliveries []*parser.Resource) iacTypes.BoolValue {
+func hasV2Logging(distribution *parser.Resource, deliverySources, deliveries []*parser.Resource) iacTypes.BoolValue {
 
 	for _, source := range deliverySources {
 		logType := source.GetStringProperty("LogType")

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
@@ -68,7 +68,7 @@ func hasV2Logging(distribution *parser.Resource, deliverySources, deliveries []*
 		for _, delivery := range deliveries {
 			deliverySourceName := delivery.GetStringProperty("DeliverySourceName")
 			if deliverySourceName.Value() == sourceName.Value() || deliverySourceName.Value() == source.ID() {
-				return iacTypes.Bool(true, distribution.Metadata())
+				return iacTypes.Bool(true, delivery.Metadata())
 			}
 		}
 

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
@@ -56,8 +56,7 @@ func getDefaultCacheBehaviour(r *parser.Resource) cloudfront.CacheBehaviour {
 func hasV2Logging(distribution *parser.Resource, deliverySources, deliveries []*parser.Resource) iacTypes.BoolValue {
 
 	for _, source := range deliverySources {
-		logType := source.GetStringProperty("LogType")
-		if logType.Value() != "ACCESS_LOGS" {
+		if !source.GetStringProperty("LogType").EqualTo("ACCESS_LOGS") {
 			continue
 		}
 		resourceArn := source.GetStringProperty("ResourceArn")

--- a/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
+++ b/pkg/iac/adapters/cloudformation/aws/cloudfront/distribution.go
@@ -1,13 +1,18 @@
 package cloudfront
 
 import (
+	"strings"
+
 	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/cloudfront"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser"
+	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
 
 func getDistributions(ctx parser.FileContext) (distributions []cloudfront.Distribution) {
 
 	distributionResources := ctx.GetResourcesByType("AWS::CloudFront::Distribution")
+	deliverySources := ctx.GetResourcesByType("AWS::Logs::DeliverySource")
+	deliveries := ctx.GetResourcesByType("AWS::Logs::Delivery")
 
 	for _, r := range distributionResources {
 		distribution := cloudfront.Distribution{
@@ -16,6 +21,10 @@ func getDistributions(ctx parser.FileContext) (distributions []cloudfront.Distri
 			Logging: cloudfront.Logging{
 				Metadata: r.Metadata(),
 				Bucket:   r.GetStringProperty("DistributionConfig.Logging.Bucket"),
+				V2: cloudfront.LoggingV2{
+					Metadata: r.Metadata(),
+					Enabled:  hasV2Logging(r, deliverySources, deliveries),
+				},
 			},
 			DefaultCacheBehaviour:  getDefaultCacheBehaviour(r),
 			OrdererCacheBehaviours: nil,
@@ -42,4 +51,28 @@ func getDefaultCacheBehaviour(r *parser.Resource) cloudfront.CacheBehaviour {
 		Metadata:             defaultCache.Metadata(),
 		ViewerProtocolPolicy: defaultCache.GetStringProperty("ViewerProtocolPolicy"),
 	}
+}
+
+func hasV2Logging(distribution *parser.Resource, deliverySources []*parser.Resource, deliveries []*parser.Resource) iacTypes.BoolValue {
+
+	for _, source := range deliverySources {
+		logType := source.GetStringProperty("LogType")
+		if logType.Value() != "ACCESS_LOGS" {
+			continue
+		}
+		resourceArn := source.GetStringProperty("ResourceArn")
+		if !strings.Contains(resourceArn.Value(), distribution.ID()) {
+			continue
+		}
+		sourceName := source.GetStringProperty("Name")
+
+		for _, delivery := range deliveries {
+			deliverySourceName := delivery.GetStringProperty("DeliverySourceName")
+			if deliverySourceName.Value() == sourceName.Value() || deliverySourceName.Value() == source.ID() {
+				return iacTypes.Bool(true, distribution.Metadata())
+			}
+		}
+
+	}
+	return iacTypes.Bool(false, distribution.Metadata())
 }

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
@@ -90,8 +90,7 @@ func hasV2Logging(modules terraform.Modules, distributionBlock *terraform.Block)
 
 	sources := modules.GetReferencingResources(distributionBlock, "aws_cloudwatch_log_delivery_source", "resource_arn")
 	for _, source := range sources {
-		logType := source.GetAttribute("log_type").AsStringValueOrDefault("", source)
-		if logType.Value() != "ACCESS_LOGS" {
+		if !source.GetAttribute("log_type").Equals("ACCESS_LOGS") {
 			continue
 		}
 

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
@@ -16,7 +16,14 @@ func adaptDistributions(modules terraform.Modules) []cloudfront.Distribution {
 	var distributions []cloudfront.Distribution
 	for _, module := range modules {
 		for _, resource := range module.GetResourcesByType("aws_cloudfront_distribution") {
-			distributions = append(distributions, adaptDistribution(resource))
+			distribution := adaptDistribution(resource)
+
+			distribution.Logging.V2 = cloudfront.LoggingV2{
+				Metadata: resource.GetMetadata(),
+				Enabled:  hasV2Logging(modules, resource),
+			}
+
+			distributions = append(distributions, distribution)
 		}
 	}
 	return distributions
@@ -76,4 +83,24 @@ func adaptDistribution(resource *terraform.Block) cloudfront.Distribution {
 	}
 
 	return distribution
+}
+
+func hasV2Logging(modules terraform.Modules, distributionBlock *terraform.Block) types.BoolValue {
+	metadata := distributionBlock.GetMetadata()
+
+	sources := modules.GetReferencingResources(distributionBlock, "aws_cloudwatch_log_delivery_source", "resource_arn")
+	for _, source := range sources {
+		logType := source.GetAttribute("log_type").AsStringValueOrDefault("", source)
+		if logType.Value() != "ACCESS_LOGS" {
+			continue
+		}
+
+		deliveries := modules.GetReferencingResources(source, "aws_cloudwatch_log_delivery", "delivery_source_name")
+		if len(deliveries) > 0 {
+			return types.Bool(true, metadata)
+		}
+	}
+
+	return types.Bool(false, metadata)
+
 }

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt.go
@@ -96,7 +96,7 @@ func hasV2Logging(modules terraform.Modules, distributionBlock *terraform.Block)
 
 		deliveries := modules.GetReferencingResources(source, "aws_cloudwatch_log_delivery", "delivery_source_name")
 		if len(deliveries) > 0 {
-			return types.Bool(true, metadata)
+			return types.Bool(true, deliveries[0].GetMetadata())
 		}
 	}
 

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
@@ -89,6 +89,72 @@ func Test_adaptDistribution(t *testing.T) {
 	}
 }
 
+func Test_adaptDistributionV2(t *testing.T) {
+	tests := []struct {
+		name      string
+		terraform string
+		expected  cloudfront.Distribution
+	}{
+		{
+			name: "v2 logging configured",
+			terraform: `
+			resource "aws_cloudfront_distribution" "example" {}
+
+			resource "aws_cloudwatch_log_delivery_source" "example" {
+				log_type     = "ACCESS_LOGS"
+				resource_arn = aws_cloudfront_distribution.example.arn
+			}
+
+			resource "aws_cloudwatch_log_delivery" "example" {
+				delivery_source_name = aws_cloudwatch_log_delivery_source.example.name
+			}
+`,
+			expected: cloudfront.Distribution{
+				Logging: cloudfront.Logging{
+					V2: cloudfront.LoggingV2{
+						Enabled: iacTypes.BoolTest(true),
+					},
+				},
+				DefaultCacheBehaviour: cloudfront.CacheBehaviour{},
+				ViewerCertificate: cloudfront.ViewerCertificate{
+					MinimumProtocolVersion: iacTypes.StringTest("TLSv1"),
+				},
+			},
+		},
+		{
+			name: "v2 logging source exists but no delivery",
+			terraform: `
+			resource "aws_cloudfront_distribution" "example" {}
+
+			resource "aws_cloudwatch_log_delivery_source" "example" {
+				log_type     = "ACCESS_LOGS"
+				resource_arn = aws_cloudfront_distribution.example.arn
+			}
+`,
+			expected: cloudfront.Distribution{
+				Logging: cloudfront.Logging{
+					V2: cloudfront.LoggingV2{
+						Enabled: iacTypes.BoolTest(false),
+					},
+				},
+				DefaultCacheBehaviour: cloudfront.CacheBehaviour{},
+				ViewerCertificate: cloudfront.ViewerCertificate{
+					MinimumProtocolVersion: iacTypes.StringTest("TLSv1"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules := tftestutil.CreateModulesFromSource(t, test.terraform, ".tf")
+			adapted := Adapt(modules)
+			require.Len(t, adapted.Distributions, 1)
+			testutil.AssertDefsecEqual(t, test.expected, adapted.Distributions[0])
+		})
+	}
+}
+
 func TestLines(t *testing.T) {
 	src := `
 	resource "aws_cloudfront_distribution" "example" {

--- a/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
+++ b/pkg/iac/adapters/terraform/aws/cloudfront/adapt_test.go
@@ -143,6 +143,33 @@ func Test_adaptDistributionV2(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "v2 logging with non-access log_type",
+			terraform: `
+            resource "aws_cloudfront_distribution" "example" {}
+
+            resource "aws_cloudwatch_log_delivery_source" "example" {
+                log_type     = "ERROR_LOGS"
+                resource_arn = aws_cloudfront_distribution.example.arn
+            }
+
+            resource "aws_cloudwatch_log_delivery" "example" {
+                delivery_source_name = aws_cloudwatch_log_delivery_source.example.name
+            }
+`,
+			expected: cloudfront.Distribution{
+				Logging: cloudfront.Logging{
+					V2: cloudfront.LoggingV2{
+						Enabled: iacTypes.BoolTest(false),
+					},
+				},
+				DefaultCacheBehaviour: cloudfront.CacheBehaviour{},
+				ViewerCertificate: cloudfront.ViewerCertificate{
+					MinimumProtocolVersion: iacTypes.StringTest("TLSv1"),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/iac/providers/aws/cloudfront/cloudfront.go
+++ b/pkg/iac/providers/aws/cloudfront/cloudfront.go
@@ -17,9 +17,15 @@ type Distribution struct {
 	ViewerCertificate      ViewerCertificate
 }
 
+type LoggingV2 struct {
+	Metadata iacTypes.Metadata
+	Enabled  iacTypes.BoolValue
+}
+
 type Logging struct {
 	Metadata iacTypes.Metadata
 	Bucket   iacTypes.StringValue
+	V2       LoggingV2
 }
 
 type CacheBehaviour struct {

--- a/pkg/iac/rego/schemas/cloud.json
+++ b/pkg/iac/rego/schemas/cloud.json
@@ -944,6 +944,23 @@
         "bucket": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
+        },
+        "v2": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.aws.cloudfront.LoggingV2"
+        }
+      }
+    },
+    "github.com.aquasecurity.trivy.pkg.iac.providers.aws.cloudfront.LoggingV2": {
+      "type": "object",
+      "properties": {
+        "__defsec_metadata": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.Metadata"
+        },
+        "enabled": {
+          "type": "object",
+          "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.BoolValue"
         }
       }
     },
@@ -4566,7 +4583,7 @@
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.providers.azure.appservice.Identity"
         },
-        "platform": {
+        "resource": {
           "type": "object",
           "$ref": "#/definitions/github.com.aquasecurity.trivy.pkg.iac.types.StringValue"
         },


### PR DESCRIPTION
## Description

This PR adds v2 logging support to AVD-AWS-0010.

- **Modified data model to include v2 logging struct**

- **V2 delivery chains detection added to cloudformation and terraform**
     1. Implemented `hasV2Logging` as discussed as a helper to ensure smooth integration with original adapter.
     2. `types.BoolValue` used instead of `iacTypes.BoolValue` in  **Terraform** to follow the previous implementations in the file.
     3. Different `hasV2Logging` helper at cloudformation as well s a clean solution to ensure minimal disruption to other        implementations.
     4. Directly integrated V2 logging struct with Logging at `getDistributions`

- **Added respective tests**

### Additional Notes
Lint fixed a few other lint related issues in the repo as well.  

## Related issues
- Close #10622 

## Related PRs
[feat(misconf): Adds CloudFront standard logging v2 support to AVD-AWS-0010
](https://github.com/aquasecurity/trivy/pull/10848)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.

