### PR TITLE
docs: fix typos

### DIFF
--- a/pkg/iac/scanners/ansible/orderedmap/orderedmap.go
+++ b/pkg/iac/scanners/ansible/orderedmap/orderedmap.go
@@ -28,7 +28,7 @@ func NewWithData[K comparable, V any](keys []K, data map[K]V) *OrderedMap[K, V] 
 	}
 }
 
-// Len returns the number of entires in the map
+// Len returns the number of entries in the map
 func (m *OrderedMap[K, V]) Len() int {
 	return len(m.keys)
 }

--- a/pkg/k8s/report/cyclonedx.go
+++ b/pkg/k8s/report/cyclonedx.go
@@ -17,7 +17,7 @@ type CycloneDXWriter struct {
 	marshaler cyclonedx.Marshaler
 }
 
-// NewCycloneDXWriter constract new CycloneDXWriter
+// NewCycloneDXWriter constructs a new CycloneDXWriter
 func NewCycloneDXWriter(output io.Writer, format cdx.BOMFileFormat, appVersion string) CycloneDXWriter {
 	encoder := cdx.NewBOMEncoder(output, format)
 	encoder.SetPretty(true)


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check