### PR TITLE
fix(nodejs): parse project dependencies from multi-document pnpm-lock.yaml

### DIFF
--- a/pkg/dependency/parser/nodejs/pnpm/parse.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse.go
@@ -2,7 +2,9 @@ package pnpm
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,9 +32,29 @@ func NewParser() *Parser {
 }
 
 func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
+	// pnpm 11+ stores the env lockfile (config and package manager dependencies)
+	// as a separate YAML document in pnpm-lock.yaml, separated by `---`.
+	// Decode all documents and use the project lockfile, skipping the env one.
+	dec := yaml.NewDecoder(r)
 	var lockFile LockFile
-	if err := yaml.NewDecoder(r).Decode(&lockFile); err != nil {
-		return nil, nil, xerrors.Errorf("decode error: %w", err)
+	var found bool
+	for {
+		var doc LockFile
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, nil, xerrors.Errorf("decode error: %w", err)
+		}
+		if doc.isEnvLockfile() {
+			continue
+		}
+		lockFile = doc
+		found = true
+		break
+	}
+	if !found {
+		return nil, nil, nil
 	}
 
 	lockVer := p.parseLockfileVersion(lockFile)

--- a/pkg/dependency/parser/nodejs/pnpm/parse.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse.go
@@ -36,27 +36,24 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 	// as a separate YAML document in pnpm-lock.yaml, separated by `---`.
 	// Decode all documents and use the project lockfile, skipping the env one.
 	dec := yaml.NewDecoder(r)
-	var lockFile LockFile
-	var found bool
 	for {
-		var doc LockFile
-		if err := dec.Decode(&doc); err != nil {
+		var lockFile LockFile
+		if err := dec.Decode(&lockFile); err != nil {
 			if errors.Is(err, io.EOF) {
-				break
+				// No project document (empty file or env-only lockfile).
+				p.logger.Debug("No project lockfile document found")
+				return nil, nil, nil
 			}
 			return nil, nil, xerrors.Errorf("decode error: %w", err)
 		}
-		if doc.isEnvLockfile() {
+		if lockFile.isEnvLockfile() {
 			continue
 		}
-		lockFile = doc
-		found = true
-		break
+		return p.parseLockFile(lockFile)
 	}
-	if !found {
-		return nil, nil, nil
-	}
+}
 
+func (p *Parser) parseLockFile(lockFile LockFile) ([]ftypes.Package, []ftypes.Dependency, error) {
 	lockVer := p.parseLockfileVersion(lockFile)
 	if lockVer < 0 {
 		return nil, nil, nil

--- a/pkg/dependency/parser/nodejs/pnpm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_test.go
@@ -71,6 +71,12 @@ func TestParse(t *testing.T) {
 			want:     pnpmV9SameVersDiffPeers,
 			wantDeps: pnpmV9SameVersDiffPeersDeps,
 		},
+		{
+			name:     "v9 with multiple documents",
+			file:     "testdata/pnpm-lock_v9_multiple_documents.yaml",
+			want:     pnpmV9MultipleDocuments,
+			wantDeps: pnpmV9MultipleDocumentsDeps,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
@@ -1069,4 +1069,82 @@ var (
 			},
 		},
 	}
+
+	// pnpm 11 stores the env lockfile (config and package manager dependencies)
+	// as the first YAML document, separated by `---`. Only the project
+	// dependencies from the second document must be parsed; the package manager
+	// environment (pnpm, @pnpm/exe, etc.) is skipped.
+	//
+	// docker run --rm node@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 sh -c '
+	//   npm install -g pnpm@11.7.0
+	//   mkdir /app && cd /app
+	//   pnpm init
+	//   pnpm add is-even@1.0.0
+	//   pnpm add -D left-pad@1.3.0
+	//   cat pnpm-lock.yaml'
+	pnpmV9MultipleDocuments = []ftypes.Package{
+		{
+			ID:           "is-buffer@1.1.6",
+			Name:         "is-buffer",
+			Version:      "1.1.6",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "is-even@1.0.0",
+			Name:         "is-even",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipDirect,
+		},
+		{
+			ID:           "is-number@3.0.0",
+			Name:         "is-number",
+			Version:      "3.0.0",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "is-odd@0.1.2",
+			Name:         "is-odd",
+			Version:      "0.1.2",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "kind-of@3.2.2",
+			Name:         "kind-of",
+			Version:      "3.2.2",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "left-pad@1.3.0",
+			Name:         "left-pad",
+			Version:      "1.3.0",
+			Dev:          true,
+			Relationship: ftypes.RelationshipDirect,
+		},
+	}
+	pnpmV9MultipleDocumentsDeps = []ftypes.Dependency{
+		{
+			ID: "is-even@1.0.0",
+			DependsOn: []string{
+				"is-odd@0.1.2",
+			},
+		},
+		{
+			ID: "is-number@3.0.0",
+			DependsOn: []string{
+				"kind-of@3.2.2",
+			},
+		},
+		{
+			ID: "is-odd@0.1.2",
+			DependsOn: []string{
+				"is-number@3.0.0",
+			},
+		},
+		{
+			ID: "kind-of@3.2.2",
+			DependsOn: []string{
+				"is-buffer@1.1.6",
+			},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
@@ -1079,72 +1079,15 @@ var (
 	//   npm install -g pnpm@11.7.0
 	//   mkdir /app && cd /app
 	//   pnpm init
-	//   pnpm add is-even@1.0.0
-	//   pnpm add -D left-pad@1.3.0
+	//   pnpm add is-number@7.0.0
 	//   cat pnpm-lock.yaml'
 	pnpmV9MultipleDocuments = []ftypes.Package{
 		{
-			ID:           "is-buffer@1.1.6",
-			Name:         "is-buffer",
-			Version:      "1.1.6",
-			Relationship: ftypes.RelationshipIndirect,
-		},
-		{
-			ID:           "is-even@1.0.0",
-			Name:         "is-even",
-			Version:      "1.0.0",
-			Relationship: ftypes.RelationshipDirect,
-		},
-		{
-			ID:           "is-number@3.0.0",
+			ID:           "is-number@7.0.0",
 			Name:         "is-number",
-			Version:      "3.0.0",
-			Relationship: ftypes.RelationshipIndirect,
-		},
-		{
-			ID:           "is-odd@0.1.2",
-			Name:         "is-odd",
-			Version:      "0.1.2",
-			Relationship: ftypes.RelationshipIndirect,
-		},
-		{
-			ID:           "kind-of@3.2.2",
-			Name:         "kind-of",
-			Version:      "3.2.2",
-			Relationship: ftypes.RelationshipIndirect,
-		},
-		{
-			ID:           "left-pad@1.3.0",
-			Name:         "left-pad",
-			Version:      "1.3.0",
-			Dev:          true,
+			Version:      "7.0.0",
 			Relationship: ftypes.RelationshipDirect,
 		},
 	}
-	pnpmV9MultipleDocumentsDeps = []ftypes.Dependency{
-		{
-			ID: "is-even@1.0.0",
-			DependsOn: []string{
-				"is-odd@0.1.2",
-			},
-		},
-		{
-			ID: "is-number@3.0.0",
-			DependsOn: []string{
-				"kind-of@3.2.2",
-			},
-		},
-		{
-			ID: "is-odd@0.1.2",
-			DependsOn: []string{
-				"is-number@3.0.0",
-			},
-		},
-		{
-			ID: "kind-of@3.2.2",
-			DependsOn: []string{
-				"is-buffer@1.1.6",
-			},
-		},
-	}
+	pnpmV9MultipleDocumentsDeps = []ftypes.Dependency{}
 )

--- a/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multiple_documents.yaml
+++ b/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multiple_documents.yaml
@@ -1,4 +1,3 @@
----
 lockfileVersion: '9.0'
 
 importers:
@@ -8,51 +7,51 @@ importers:
     packageManagerDependencies:
       '@pnpm/exe':
         specifier: ^11.7.0
-        version: 11.7.0
+        version: 11.9.0
       pnpm:
         specifier: ^11.7.0
-        version: 11.7.0
+        version: 11.9.0
 
 packages:
 
-  '@pnpm/exe@11.7.0':
-    resolution: {integrity: sha512-3CujpSSp2PIDE0pwu7mWSdjhdDqaZa7OppVooECWWaNEoA/z66s9FZts1MhDO+2yq1XER4gBHh84DVbFN/r1rA==}
+  '@pnpm/exe@11.9.0':
+    resolution: {integrity: sha512-pPPOpR79qW3nsNhlyDIdfstli4Bi78mk8r22ySxpFRwMbO8KXSjGrVzGmJBsVX39NnJTh7/WADj527nZhG9H9g==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.7.0':
-    resolution: {integrity: sha512-ANTX2SlMO+d2y/4bYQhHCwHPX7gSSADJ5+pMUIiDFzIsybnFFaJdZboaFfq9NOxCbETcnDxqZ95Rz3+NHx1JIw==}
+  '@pnpm/linux-arm64@11.9.0':
+    resolution: {integrity: sha512-XYmY2qadHauBA3QaHi2R7fI6kt5Flje0WHz9MVrbH0kVH/XLpfOLnwPeE1+EX6K/nDa2CBvzp35VjYCNGFJa9A==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.7.0':
-    resolution: {integrity: sha512-fr75tqixXoS8cnA81HQIomjOGEPnsOsd3xCDL5pMNY5raOXbKurtgRV+RjATvjxlJxSLIVFKegABlxAiB7q72A==}
+  '@pnpm/linux-x64@11.9.0':
+    resolution: {integrity: sha512-fl7W5imnSmmgXIqMQFZ/rPaVvk9OkKF8/anqHZE3XEDfWcn3BlWGndyOEas/JN7u2BXWYjs63DJZ3rnG6WOhLA==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.7.0':
-    resolution: {integrity: sha512-Q++pgzvXkGeqnVRl26/uqmpMGdttQus0rGyL3XIfYGLCi8ZfajYUaCKdZID2MH7+CNOuugWDdFDup3r7BR7Rfg==}
+  '@pnpm/linuxstatic-arm64@11.9.0':
+    resolution: {integrity: sha512-fif8xbnzVEAIlvaU4yIgWKXeXYb4Kj6WMEl/KvM2x1Rp3AKAjBW/53SGzxO4cZP9doAqUzOIpMRGFVbHGeMDRw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.7.0':
-    resolution: {integrity: sha512-z1+exW6ocU/rmOvJnmU3FUBJYaryCUqFoaXN6KZW5BqTj7BPJb7HJcAyXRlirNZMJlEiUY5rXbfStGPQJhGsVA==}
+  '@pnpm/linuxstatic-x64@11.9.0':
+    resolution: {integrity: sha512-9dKu3QdShqOpnWrjW9owARpIJeP0ul8UgIIbBUv8VDGEYibt+g49zQsNaD7SdMD3WeRSjExPQ1zIhplzr5cwvQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.7.0':
-    resolution: {integrity: sha512-gD34/k3JT5oab4BYaqrUor3e4VdwXvkfLNlEI+lvDtX1MHT+2Nauc9p9NsQnpn1zE8blQEflzbF8wAUQ6Dmvkw==}
+  '@pnpm/macos-arm64@11.9.0':
+    resolution: {integrity: sha512-MWzBTgeI5p3odjdVltYvFXaSWAjF2Xk5YaxiP/u2RmW8N6PHsLyIyj37Ds992CrXgFM8fO1RpvsEirozhsD6KA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.7.0':
-    resolution: {integrity: sha512-hRTcDmm2j7KoRwbqNo0rUAu9A1kVJN98Eob7H09U0uPJbEMax85JGOmERkT3Lf6HjVJuFNBvfaJ3OTI3HmlVGg==}
+  '@pnpm/win-arm64@11.9.0':
+    resolution: {integrity: sha512-u/QxEcbKJZxC1t3zUYCZiHzu7TaZ/iXc6EGZoQjkeVT0LXmEVR6ypcK3ByjhIqbxQ3HGX75gnpIpR+VjRjubfw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.7.0':
-    resolution: {integrity: sha512-r/1NuKY7Z+6ZXVIzVrUEMj6TTEBdR63geV4Rlm8HKEhgQTdxyIsJoqV3FJGqoyzbRaScObqAwRfMaK9dskPddQ==}
+  '@pnpm/win-x64@11.9.0':
+    resolution: {integrity: sha512-HqJVHmZG5UKfLi38AjMl2azVmq87TlWRhwSW+f4q9LLaZeAkFyIZ7LY/pN6mh4VlH9yWj90C+tsb1yKiy7OKnw==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +115,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.7.0:
-    resolution: {integrity: sha512-GcyFLBIMcSV2DyRD7mvgyltA+fUFmN4aCaHxd1A+AQ5Xwjx3ZG4B52HeWb+HT7IqM5jDOrlpH8E+uUa28PTWIA==}
+  pnpm@11.9.0:
+    resolution: {integrity: sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.7.0':
+  '@pnpm/exe@11.9.0':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.7.0
-      '@pnpm/linux-x64': 11.7.0
-      '@pnpm/linuxstatic-arm64': 11.7.0
-      '@pnpm/linuxstatic-x64': 11.7.0
-      '@pnpm/macos-arm64': 11.7.0
-      '@pnpm/win-arm64': 11.7.0
-      '@pnpm/win-x64': 11.7.0
+      '@pnpm/linux-arm64': 11.9.0
+      '@pnpm/linux-x64': 11.9.0
+      '@pnpm/linuxstatic-arm64': 11.9.0
+      '@pnpm/linuxstatic-x64': 11.9.0
+      '@pnpm/macos-arm64': 11.9.0
+      '@pnpm/win-arm64': 11.9.0
+      '@pnpm/win-x64': 11.9.0
 
-  '@pnpm/linux-arm64@11.7.0':
+  '@pnpm/linux-arm64@11.9.0':
     optional: true
 
-  '@pnpm/linux-x64@11.7.0':
+  '@pnpm/linux-x64@11.9.0':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.7.0':
+  '@pnpm/linuxstatic-arm64@11.9.0':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.7.0':
+  '@pnpm/linuxstatic-x64@11.9.0':
     optional: true
 
-  '@pnpm/macos-arm64@11.7.0':
+  '@pnpm/macos-arm64@11.9.0':
     optional: true
 
-  '@pnpm/win-arm64@11.7.0':
+  '@pnpm/win-arm64@11.9.0':
     optional: true
 
-  '@pnpm/win-x64@11.7.0':
+  '@pnpm/win-x64@11.9.0':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +193,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.7.0: {}
+  pnpm@11.9.0: {}
 
 ---
 lockfileVersion: '9.0'
@@ -207,57 +206,16 @@ importers:
 
   .:
     dependencies:
-      is-even:
-        specifier: 1.0.0
-        version: 1.0.0
-    devDependencies:
-      left-pad:
-        specifier: 1.3.0
-        version: 1.3.0
+      is-number:
+        specifier: 7.0.0
+        version: 7.0.0
 
 packages:
 
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
-  is-even@1.0.0:
-    resolution: {integrity: sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==}
-    engines: {node: '>=0.10.0'}
-
-  is-number@3.0.0:
-    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
-    engines: {node: '>=0.10.0'}
-
-  is-odd@0.1.2:
-    resolution: {integrity: sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==}
-    engines: {node: '>=0.10.0'}
-
-  kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
-    engines: {node: '>=0.10.0'}
-
-  left-pad@1.3.0:
-    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
-    deprecated: use String.prototype.padStart()
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
 snapshots:
 
-  is-buffer@1.1.6: {}
-
-  is-even@1.0.0:
-    dependencies:
-      is-odd: 0.1.2
-
-  is-number@3.0.0:
-    dependencies:
-      kind-of: 3.2.2
-
-  is-odd@0.1.2:
-    dependencies:
-      is-number: 3.0.0
-
-  kind-of@3.2.2:
-    dependencies:
-      is-buffer: 1.1.6
-
-  left-pad@1.3.0: {}
+  is-number@7.0.0: {}

--- a/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multiple_documents.yaml
+++ b/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multiple_documents.yaml
@@ -1,0 +1,263 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: ^11.7.0
+        version: 11.7.0
+      pnpm:
+        specifier: ^11.7.0
+        version: 11.7.0
+
+packages:
+
+  '@pnpm/exe@11.7.0':
+    resolution: {integrity: sha512-3CujpSSp2PIDE0pwu7mWSdjhdDqaZa7OppVooECWWaNEoA/z66s9FZts1MhDO+2yq1XER4gBHh84DVbFN/r1rA==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.7.0':
+    resolution: {integrity: sha512-ANTX2SlMO+d2y/4bYQhHCwHPX7gSSADJ5+pMUIiDFzIsybnFFaJdZboaFfq9NOxCbETcnDxqZ95Rz3+NHx1JIw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.7.0':
+    resolution: {integrity: sha512-fr75tqixXoS8cnA81HQIomjOGEPnsOsd3xCDL5pMNY5raOXbKurtgRV+RjATvjxlJxSLIVFKegABlxAiB7q72A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.7.0':
+    resolution: {integrity: sha512-Q++pgzvXkGeqnVRl26/uqmpMGdttQus0rGyL3XIfYGLCi8ZfajYUaCKdZID2MH7+CNOuugWDdFDup3r7BR7Rfg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.7.0':
+    resolution: {integrity: sha512-z1+exW6ocU/rmOvJnmU3FUBJYaryCUqFoaXN6KZW5BqTj7BPJb7HJcAyXRlirNZMJlEiUY5rXbfStGPQJhGsVA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.7.0':
+    resolution: {integrity: sha512-gD34/k3JT5oab4BYaqrUor3e4VdwXvkfLNlEI+lvDtX1MHT+2Nauc9p9NsQnpn1zE8blQEflzbF8wAUQ6Dmvkw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.7.0':
+    resolution: {integrity: sha512-hRTcDmm2j7KoRwbqNo0rUAu9A1kVJN98Eob7H09U0uPJbEMax85JGOmERkT3Lf6HjVJuFNBvfaJ3OTI3HmlVGg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.7.0':
+    resolution: {integrity: sha512-r/1NuKY7Z+6ZXVIzVrUEMj6TTEBdR63geV4Rlm8HKEhgQTdxyIsJoqV3FJGqoyzbRaScObqAwRfMaK9dskPddQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.7.0:
+    resolution: {integrity: sha512-GcyFLBIMcSV2DyRD7mvgyltA+fUFmN4aCaHxd1A+AQ5Xwjx3ZG4B52HeWb+HT7IqM5jDOrlpH8E+uUa28PTWIA==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.7.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.7.0
+      '@pnpm/linux-x64': 11.7.0
+      '@pnpm/linuxstatic-arm64': 11.7.0
+      '@pnpm/linuxstatic-x64': 11.7.0
+      '@pnpm/macos-arm64': 11.7.0
+      '@pnpm/win-arm64': 11.7.0
+      '@pnpm/win-x64': 11.7.0
+
+  '@pnpm/linux-arm64@11.7.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.7.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.7.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.7.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.7.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.7.0':
+    optional: true
+
+  '@pnpm/win-x64@11.7.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.7.0: {}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-even:
+        specifier: 1.0.0
+        version: 1.0.0
+    devDependencies:
+      left-pad:
+        specifier: 1.3.0
+        version: 1.3.0
+
+packages:
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-even@1.0.0:
+    resolution: {integrity: sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@3.0.0:
+    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@0.1.2:
+    resolution: {integrity: sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw==}
+    engines: {node: '>=0.10.0'}
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
+
+  left-pad@1.3.0:
+    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
+    deprecated: use String.prototype.padStart()
+
+snapshots:
+
+  is-buffer@1.1.6: {}
+
+  is-even@1.0.0:
+    dependencies:
+      is-odd: 0.1.2
+
+  is-number@3.0.0:
+    dependencies:
+      kind-of: 3.2.2
+
+  is-odd@0.1.2:
+    dependencies:
+      is-number: 3.0.0
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
+
+  left-pad@1.3.0: {}

--- a/pkg/dependency/parser/nodejs/pnpm/types.go
+++ b/pkg/dependency/parser/nodejs/pnpm/types.go
@@ -55,7 +55,7 @@ type Importer struct {
 // environment, not the project dependencies, so it must be skipped.
 func (l LockFile) isEnvLockfile() bool {
 	for _, importer := range l.Importers {
-		if len(importer.ConfigDependencies) > 0 || len(importer.PackageManagerDependencies) > 0 {
+		if importer.ConfigDependencies != nil || importer.PackageManagerDependencies != nil {
 			return true
 		}
 	}

--- a/pkg/dependency/parser/nodejs/pnpm/types.go
+++ b/pkg/dependency/parser/nodejs/pnpm/types.go
@@ -43,8 +43,23 @@ type LockFile struct {
 }
 
 type Importer struct {
-	Dependencies    map[string]ImporterDepVersion `yaml:"dependencies,omitempty"`
-	DevDependencies map[string]ImporterDepVersion `yaml:"devDependencies,omitempty"`
+	Dependencies               map[string]ImporterDepVersion `yaml:"dependencies,omitempty"`
+	DevDependencies            map[string]ImporterDepVersion `yaml:"devDependencies,omitempty"`
+	ConfigDependencies         map[string]any                `yaml:"configDependencies,omitempty"`
+	PackageManagerDependencies map[string]any                `yaml:"packageManagerDependencies,omitempty"`
+}
+
+// isEnvLockfile reports whether this YAML document is the pnpm env lockfile
+// (config and package manager dependencies), which pnpm 11 stores as a
+// separate document in pnpm-lock.yaml. It holds the package manager
+// environment, not the project dependencies, so it must be skipped.
+func (l LockFile) isEnvLockfile() bool {
+	for _, importer := range l.Importers {
+		if len(importer.ConfigDependencies) > 0 || len(importer.PackageManagerDependencies) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 type ImporterDepVersion struct {


### PR DESCRIPTION
## Description

pnpm 11 may write `pnpm-lock.yaml` as a stream of multiple YAML documents separated by `---`. The first document is the env lockfile (`configDependencies` and `packageManagerDependencies` with the package manager environment), and the project dependencies live in a later document. This format was introduced in pnpm/pnpm#10964 (the env lockfile, previously a separate `pnpm-lock.env.yaml`, is now stored as the first document in `pnpm-lock.yaml`), see the [pnpm 11.0.0 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.0.0).

The parser decoded only a single YAML document, so only the first document was parsed. As a result no project dependencies were extracted and nothing was scanned, even though the lock file was detected. This is a silent false negative.

This PR decodes every document in the stream and uses the project lockfile, skipping the env document. The env document is detected by the presence of `configDependencies`/`packageManagerDependencies` in its importers, so detection does not rely on document order.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/10859

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
