### PR TITLE
feat: add --no-color flag to disable colored output

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/xerrors"
@@ -209,6 +210,8 @@ func NewRootCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 			}
 			// Initialize logger
 			log.InitLogger(opts.Debug, opts.Quiet)
+			// Disable colored output globally if requested
+			color.NoColor = opts.NoColor
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -86,6 +86,13 @@ var (
 		TelemetrySafe: true,
 		Internal:      true, // Hidden from help output, intended for maintainer debugging only
 	}
+	NoColorFlag = Flag[bool]{
+		Name:          "no-color",
+		ConfigName:    "no-color",
+		Usage:         "disable colored output",
+		Persistent:    true,
+		TelemetrySafe: true,
+	}
 )
 
 // GlobalFlagGroup composes global flags
@@ -100,6 +107,7 @@ type GlobalFlagGroup struct {
 	CacheDir              *Flag[string]
 	GenerateDefaultConfig *Flag[bool]
 	TraceHTTP             *Flag[bool]
+	NoColor               *Flag[bool]
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -114,6 +122,7 @@ type GlobalOptions struct {
 	CacheDir              string
 	GenerateDefaultConfig bool
 	TraceHTTP             bool
+	NoColor              bool
 }
 
 func NewGlobalFlagGroup() *GlobalFlagGroup {
@@ -128,6 +137,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		CacheDir:              CacheDirFlag.Clone(),
 		GenerateDefaultConfig: GenerateDefaultConfigFlag.Clone(),
 		TraceHTTP:             TraceHTTPFlag.Clone(),
+		NoColor:               NoColorFlag.Clone(),
 	}
 }
 
@@ -147,6 +157,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.CacheDir,
 		f.GenerateDefaultConfig,
 		f.TraceHTTP,
+		f.NoColor,
 	}
 }
 


### PR DESCRIPTION
## Description
Adds a global `--no-color` flag to disable colored terminal output across Trivy.

## Related issues
Closes #1091

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).