### PR TITLE
chore(deps): bump alpine to 3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 RUN apk --no-cache add ca-certificates git
 COPY trivy /usr/local/bin/trivy
 COPY contrib/*.tpl contrib/

--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 RUN apk --no-cache add ca-certificates git
 
 # binaries were created with GoReleaser


### PR DESCRIPTION
## Description

Bumps the base image in `Dockerfile` and `Dockerfile.canary` from `alpine:3.23.4` to `alpine:3.24.1` (the latest patch of the 3.24 series).

The Trivy image only installs `ca-certificates` and `git` on top of Alpine. Both packages install cleanly on 3.24.1 (verified by building the image: `ca-certificates 20260611-r0`, `git 2.54.0`), and none of the Alpine 3.24 breaking changes (setuptools `pkg_resources` removal, GTK2/Qt5/libsoup2 removals, qemu-binfmt deprecation, GRUB) touch our base image.

Test fixture Dockerfiles (`alpine:3.13`) are intentionally left untouched — they are scan test inputs, not the runtime base image.

## Verification

Built the image from the updated `Dockerfile` and ran it:

```console
$ docker build -t trivy:alpine-3.24.1 .
[+] Building 11.2s (13/13) FINISHED                              docker:desktop-linux
 => [internal] load build definition from Dockerfile                            0.0s
 => => transferring dockerfile: 182B                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:3.24.1                1.3s
 => [internal] load .dockerignore                                               0.0s
 => => transferring context: 87B                                                0.0s
 => [1/4] FROM docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5b...  0.0s
 => [2/4] RUN apk --no-cache add ca-certificates git                           0.0s
 => [internal] load build context                                              3.3s
 => => transferring context: 218.45MB                                          3.3s
 => [3/4] COPY trivy /usr/local/bin/trivy                                       0.5s
 => [4/4] COPY contrib/*.tpl contrib/                                           0.0s
 => exporting to image                                                          5.1s
 => => naming to docker.io/library/trivy:alpine-3.24.1                          0.0s

$ docker run --rm trivy:alpine-3.24.1 --version
Version: dev
```

(`Version: dev` because the binary was built locally without the GoReleaser version ldflags; the point here is that the image builds on `alpine:3.24.1` and `trivy` starts inside the container.)

Scanned the new base image itself — no known vulnerabilities:

```console
$ trivy -q image --table-mode summary alpine:3.24.1

Report Summary

┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ alpine:3.24.1 (alpine 3.24.1) │ alpine │        0        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
