### PR TITLE
chore(deps): upgrade github.com/google/go-github to v90

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/gocsaf/csaf/v3 v3.6.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-containerregistry v0.21.9
-	github.com/google/go-github/v62 v62.0.0
+	github.com/google/go-github/v90 v90.0.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/google/licenseclassifier/v2 v2.0.0
 	github.com/google/uuid v1.6.0
@@ -290,7 +290,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v31 v31.0.0 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/gocsaf/csaf/v3 v3.5.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-containerregistry v0.21.7
-	github.com/google/go-github/v62 v62.0.0
+	github.com/google/go-github/v89 v89.0.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/google/licenseclassifier/v2 v2.0.0
 	github.com/google/uuid v1.6.0
@@ -290,7 +290,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v31 v31.0.0 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -557,11 +557,11 @@ github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/2
 github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
-github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnO
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
-github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/go.sum
+++ b/go.sum
@@ -559,11 +559,11 @@ github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnO
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
-github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
-github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/2
 github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
-github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
+github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnO
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwMmHdhl4=
-github.com/google/go-github/v62 v62.0.0/go.mod h1:EMxeUqGJq2xRu9DYBMwel/mr7kZrzUOfQmmpYrZn2a4=
+github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
+github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/2
 github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwMmHdhl4=
-github.com/google/go-github/v62 v62.0.0/go.mod h1:EMxeUqGJq2xRu9DYBMwel/mr7kZrzUOfQmmpYrZn2a4=
+github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
+github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/google/go-containerregistry v0.21.9 h1:F+D4uZ3iA3DLMJLfhaqMdHJbzeqm/2
 github.com/google/go-containerregistry v0.21.9/go.mod h1:dP5XNKcL7kMFF/TB3LfvWmVhAcv7iqkHb3oDK8aauTo=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
-github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
-github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
+github.com/google/go-github/v90 v90.0.0 h1:EnX9HvTfqvuJbUSWu1/jLrYH6JJLMz0w0qfQVbTxPzE=
+github.com/google/go-github/v90 v90.0.0/go.mod h1:pLzt1FZURZyoTHT5/Z1UQY3b9fYyrbXH6aj7X+qgID4=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v62/github"
+	"github.com/google/go-github/v67/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v67/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/go-getter"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
@@ -148,7 +148,11 @@ func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	transport := xhttp.RoundTripper(req.Context(), xhttp.WithInsecure(t.insecure))
 	if req.URL.Host == "github.com" {
-		transport = NewGitHubTransport(req.URL, t.auth.Token)
+		var err error
+		transport, err = NewGitHubTransport(req.URL, t.auth.Token)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to create github transport: %w", err)
+		}
 	}
 
 	res, err := transport.RoundTrip(req)
@@ -167,13 +171,16 @@ func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
-func NewGitHubTransport(u *url.URL, token string) http.RoundTripper {
-	client := newGitHubClient(token)
+func NewGitHubTransport(u *url.URL, token string) (http.RoundTripper, error) {
+	client, err := newGitHubClient(token)
+	if err != nil {
+		return nil, err
+	}
 	ss := strings.SplitN(u.Path, "/", 4)
 	if len(ss) < 4 || strings.HasPrefix(ss[3], "archive/") || strings.HasPrefix(ss[3], "releases/") ||
 		strings.HasPrefix(ss[3], "tags/") {
 		// Use the default transport from go-github for authentication
-		return client.Client().Transport
+		return client.Client().Transport, nil
 	}
 
 	return &GitHubContentTransport{
@@ -181,7 +188,7 @@ func NewGitHubTransport(u *url.URL, token string) http.RoundTripper {
 		repo:     ss[2],
 		filePath: ss[3],
 		client:   client,
-	}
+	}, nil
 }
 
 // GitHubContentTransport is a round tripper for downloading the GitHub content.
@@ -201,11 +208,10 @@ func (t *GitHubContentTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return res.Response, nil
 }
 
-func newGitHubClient(token string) *github.Client {
-	client := github.NewClient(xhttp.Client())
+func newGitHubClient(token string) (*github.Client, error) {
 	token = cmp.Or(token, os.Getenv("GITHUB_TOKEN"))
 	if token != "" {
-		client = client.WithAuthToken(token)
+		return github.NewClient(github.WithHTTPClient(xhttp.Client()), github.WithAuthToken(token))
 	}
-	return client
+	return github.NewClient(github.WithHTTPClient(xhttp.Client()))
 }

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -171,8 +171,8 @@ func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
-func NewGitHubTransport(u *url.URL, token string) (http.RoundTripper, error) {
-	client, err := newGitHubClient(token)
+func NewGitHubTransport(u *url.URL, token string, baseURL ...string) (http.RoundTripper, error) {
+	client, err := newGitHubClient(token, baseURL...)
 	if err != nil {
 		return nil, err
 	}
@@ -206,23 +206,27 @@ func (t *GitHubContentTransport) RoundTrip(req *http.Request) (*http.Response, e
 		return nil, xerrors.Errorf("failed to get the file content: %w", err)
 	}
 
-	if res != nil && res.Response != nil {
-		if err := github.CheckResponse(res.Response); err != nil {
-			if rc != nil {
-				rc.Close()
-			}
-			return nil, xerrors.Errorf("failed to download the file: %w", err)
-		}
+	if err := github.CheckResponse(res.Response); err != nil {
 		if rc != nil {
-			res.Response.Body = rc
+			rc.Close()
 		}
+		return nil, xerrors.Errorf("failed to download the file: %w", err)
+	}
+	if rc != nil {
+		res.Response.Body = rc
+		res.Response.ContentLength = -1
+		res.Response.Header.Del("Content-Length")
+		res.Response.Header.Del("Content-Type")
 	}
 	return res.Response, nil
 }
 
-func newGitHubClient(token string) (*github.Client, error) {
+func newGitHubClient(token string, baseURL ...string) (*github.Client, error) {
 	opts := []github.ClientOptionsFunc{
 		github.WithHTTPClient(xhttp.Client()),
+	}
+	if len(baseURL) > 0 && baseURL[0] != "" {
+		opts = append(opts, github.WithEnterpriseURLs(baseURL[0], baseURL[0]))
 	}
 	token = cmp.Or(token, os.Getenv("GITHUB_TOKEN"))
 	if token != "" {

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -201,17 +201,23 @@ type GitHubContentTransport struct {
 
 // RoundTrip calls the GitHub API to download the content.
 func (t *GitHubContentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	_, res, err := t.client.Repositories.DownloadContents(req.Context(), t.owner, t.repo, t.filePath, nil)
+	rc, res, err := t.client.Repositories.DownloadContents(req.Context(), t.owner, t.repo, t.filePath, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get the file content: %w", err)
+	}
+	if rc != nil && res != nil && res.Response != nil {
+		res.Response.Body = rc
 	}
 	return res.Response, nil
 }
 
 func newGitHubClient(token string) (*github.Client, error) {
+	opts := []github.ClientOptionsFunc{
+		github.WithHTTPClient(xhttp.Client()),
+	}
 	token = cmp.Or(token, os.Getenv("GITHUB_TOKEN"))
 	if token != "" {
-		return github.NewClient(github.WithHTTPClient(xhttp.Client()), github.WithAuthToken(token))
+		opts = append(opts, github.WithAuthToken(token))
 	}
-	return github.NewClient(github.WithHTTPClient(xhttp.Client()))
+	return github.NewClient(opts...)
 }

--- a/pkg/downloader/download.go
+++ b/pkg/downloader/download.go
@@ -205,8 +205,17 @@ func (t *GitHubContentTransport) RoundTrip(req *http.Request) (*http.Response, e
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get the file content: %w", err)
 	}
-	if rc != nil && res != nil && res.Response != nil {
-		res.Response.Body = rc
+
+	if res != nil && res.Response != nil {
+		if err := github.CheckResponse(res.Response); err != nil {
+			if rc != nil {
+				rc.Close()
+			}
+			return nil, xerrors.Errorf("failed to download the file: %w", err)
+		}
+		if rc != nil {
+			res.Response.Body = rc
+		}
 	}
 	return res.Response, nil
 }

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -1,8 +1,10 @@
 package downloader_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -134,6 +136,105 @@ func TestDownloadWithETag(t *testing.T) {
 			assert.Equal(t, tt.wantContent, string(content))
 
 			assert.NoFileExists(t, dst+".backup")
+		})
+	}
+}
+
+func TestGitHubContentTransport(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantContent string
+		wantErr     string
+		checkResp   func(t *testing.T, resp *http.Response)
+	}{
+		{
+			name: "content returned inline",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/v3/repos/owner/repo/contents/path/to/file.txt", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{
+					"name": "file.txt",
+					"path": "path/to/file.txt",
+					"encoding": "base64",
+					"content": "aGVsbG8gd29ybGQ=\n"
+				}`))
+			},
+			wantContent: "hello world",
+			checkResp: func(t *testing.T, resp *http.Response) {
+				t.Helper()
+				assert.Equal(t, int64(-1), resp.ContentLength)
+				assert.Empty(t, resp.Header.Get("Content-Length"))
+				assert.Empty(t, resp.Header.Get("Content-Type"))
+			},
+		},
+		{
+			name: "content fetched from download_url",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v3/repos/owner/repo/contents/path/to/file.txt" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					downloadURL := "http://" + r.Host + "/download/file.txt"
+					_, _ = w.Write([]byte(`{
+						"name": "file.txt",
+						"path": "path/to/file.txt",
+						"download_url": "` + downloadURL + `"
+					}`))
+					return
+				}
+				if r.URL.Path == "/download/file.txt" {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("content from download_url"))
+					return
+				}
+				http.NotFound(w, r)
+			},
+			wantContent: "content from download_url",
+		},
+		{
+			name: "non-2xx response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+			},
+			wantErr: "failed to get the file content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(tt.handler)
+			defer ts.Close()
+
+			rawURL := "https://github.com/owner/repo/path/to/file.txt"
+			u, err := url.Parse(rawURL)
+			require.NoError(t, err)
+
+			transport, err := downloader.NewGitHubTransport(u, "", ts.URL)
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, rawURL, http.NoBody)
+			require.NoError(t, err)
+
+			resp, err := transport.RoundTrip(req)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			if tt.checkResp != nil {
+				tt.checkResp(t, resp)
+			}
+
+			got, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantContent, string(got))
 		})
 	}
 }


### PR DESCRIPTION
## Description
* Upgrade `github.com/google/go-github/v62` to `github.com/google/go-github/v90`
*  Transitioned from passing an `*http.Client` directly into `github.NewClient` to using the new `ClientOptionsFunc` pattern (e.g., `github.WithHTTPClient()` and `github.WithAuthToken()`).

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
