### PR TITLE
fix(cyclonedx): dedupe advisory URLs using canonical URIs

### DIFF
--- a/pkg/sbom/cyclonedx/advisories_test.go
+++ b/pkg/sbom/cyclonedx/advisories_test.go
@@ -1,0 +1,128 @@
+package cyclonedx
+
+import (
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	syntheticApacheEncoded = "https://lists.apache.org/thread.html/example%40%3Cdev.apache.org%3E"
+	syntheticApachePartial = "https://lists.apache.org/thread.html/example@%3Cdev.apache.org%3E"
+	syntheticApacheLiteral = "https://lists.apache.org/thread.html/example@<dev.apache.org>"
+	syntheticApacheCanon   = "https://lists.apache.org/thread.html/example@%3Cdev.apache.org%3E"
+)
+
+func TestAdvisories_equivalentPathEncodingVariants(t *testing.T) {
+	m := Marshaler{}
+	advs := m.advisories([]string{
+		syntheticApacheEncoded,
+		syntheticApachePartial,
+		syntheticApacheLiteral,
+	})
+	require.NotNil(t, advs)
+	require.Len(t, *advs, 1)
+	assert.Equal(t, syntheticApacheCanon, (*advs)[0].URL)
+}
+
+func TestAdvisories_primaryURLAndReferencesDedup(t *testing.T) {
+	m := Marshaler{}
+	advs := m.advisories([]string{
+		syntheticApacheEncoded,
+		syntheticApacheLiteral,
+	})
+	require.NotNil(t, advs)
+	require.Len(t, *advs, 1)
+	assert.Equal(t, syntheticApacheCanon, (*advs)[0].URL)
+}
+
+func TestAdvisories_noRawAngleBracketsInURLs(t *testing.T) {
+	m := Marshaler{}
+	advs := m.advisories([]string{
+		syntheticApacheEncoded,
+		syntheticApachePartial,
+		syntheticApacheLiteral,
+	})
+	require.NotNil(t, advs)
+	for _, adv := range *advs {
+		assert.NotContains(t, adv.URL, "<")
+		assert.NotContains(t, adv.URL, ">")
+	}
+}
+
+func TestAdvisories_distinctURLsRemainDistinct(t *testing.T) {
+	m := Marshaler{}
+	advs := m.advisories([]string{
+		"https://example.com/advisory/one",
+		"https://example.com/advisory/two",
+	})
+	require.NotNil(t, advs)
+	require.Len(t, *advs, 2)
+	urls := advisoryURLs(advs)
+	assert.Contains(t, urls, "https://example.com/advisory/one")
+	assert.Contains(t, urls, "https://example.com/advisory/two")
+}
+
+func TestAdvisories_trimNonURLInfoPreservesFirstURLToken(t *testing.T) {
+	m := Marshaler{}
+	advs := m.advisories([]string{
+		"https://example.com/advisory/one additional text",
+	})
+	require.NotNil(t, advs)
+	require.Len(t, *advs, 1)
+	assert.Equal(t, "https://example.com/advisory/one", (*advs)[0].URL)
+}
+
+func TestCanonicalizeAdvisoryURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:   "encoded path",
+			raw:    syntheticApacheEncoded,
+			want:   syntheticApacheCanon,
+			wantOK: true,
+		},
+		{
+			name:   "literal angle brackets",
+			raw:    syntheticApacheLiteral,
+			want:   syntheticApacheCanon,
+			wantOK: true,
+		},
+		{
+			name:   "invalid url",
+			raw:    "not-a-url",
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "missing host",
+			raw:    "https:///path",
+			want:   "",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := canonicalizeAdvisoryURL(tt.raw)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func advisoryURLs(advs *[]cdx.Advisory) []string {
+	if advs == nil {
+		return nil
+	}
+	urls := make([]string, 0, len(*advs))
+	for _, adv := range *advs {
+		urls = append(urls, adv.URL)
+	}
+	return urls
+}

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -394,23 +394,48 @@ func (*Marshaler) affects(ref, version string) cdx.Affects {
 }
 
 func (*Marshaler) advisories(refs []string) *[]cdx.Advisory {
-	refs = lo.Uniq(refs)
-	advs := lo.FilterMap(refs, func(ref string, _ int) (cdx.Advisory, bool) {
-		// There are cases when `ref` contains extra info
-		// But we need to use only URL.
-		// cf. https://github.com/aquasecurity/trivy/issues/6801
+	canonical := make([]string, 0, len(refs))
+	for _, ref := range refs {
 		ref = trimNonUrlInfo(ref)
-		return cdx.Advisory{URL: ref}, ref != ""
-	})
+		if ref == "" {
+			continue
+		}
+		c, ok := canonicalizeAdvisoryURL(ref)
+		if !ok {
+			continue
+		}
+		canonical = append(canonical, c)
+	}
+	canonical = lo.Uniq(canonical)
 
 	// cyclonedx converts link to empty `[]cdx.Advisory` to `null`
 	// `bom-1.5.schema.json` doesn't support this - `Invalid type. Expected: array, given: null`
 	// we need to explicitly set `nil` for empty `refs` slice
-	if len(advs) == 0 {
+	if len(canonical) == 0 {
 		return nil
 	}
 
+	advs := lo.Map(canonical, func(ref string, _ int) cdx.Advisory {
+		return cdx.Advisory{URL: ref}
+	})
 	return &advs
+}
+
+func canonicalizeAdvisoryURL(raw string) (string, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", false
+	}
+
+	out := &url.URL{
+		Scheme:   u.Scheme,
+		Host:     u.Host,
+		Path:     u.Path,
+		RawQuery: u.RawQuery,
+		Fragment: u.Fragment,
+	}
+
+	return out.String(), true
 }
 
 // trimNonUrlInfo returns first valid URL.


### PR DESCRIPTION
> **Note:** Superseded by [aquasecurity/trivy-db#678](https://github.com/aquasecurity/trivy-db/pull/678)

## Description

This PR canonicalizes CycloneDX advisory URLs before deduplication.

CycloneDX advisories were previously deduplicated using raw URL strings. Equivalent URI references from different advisory sources could therefore survive as separate advisory entries when the same advisory URL was provided using different path encodings.

For example, these synthetic references identify the same semantic URI path but differ as raw strings:

```text
https://lists.apache.org/thread.html/example%40%3Cdev.apache.org%3E
https://lists.apache.org/thread.html/example@%3Cdev.apache.org%3E
https://lists.apache.org/thread.html/example@<dev.apache.org>
```

Before this change, these values could be emitted as separate CycloneDX advisory entries.

The root cause is that advisory URLs were deduplicated before URI canonicalization. A simple `url.Parse(raw).String()` roundtrip is not sufficient here because Go may preserve `RawPath`, causing equivalent paths such as:

```text
...%40%3Cdev.apache.org%3E
...@%3Cdev.apache.org%3E
```

to remain serialized differently.

This PR fixes the issue by canonicalizing advisory URLs before deduplication:

1. Parse the advisory URL.
2. Rebuild a new `url.URL` from decoded URL components.
3. Do not preserve `RawPath`.
4. Serialize the rebuilt URL with `String()`.
5. Deduplicate the canonical serialized URLs.
6. Emit the canonical URLs in CycloneDX advisories.

The change is intentionally limited to CycloneDX advisory output. It does not change JSON report generation, vulnerability database records, upstream reference collection, SPDX output, or non-SBOM vulnerability reporting.

Before:

```json
[
  {
    "url": "https://lists.apache.org/thread.html/example%40%3Cdev.apache.org%3E"
  },
  {
    "url": "https://lists.apache.org/thread.html/example@%3Cdev.apache.org%3E"
  },
  {
    "url": "https://lists.apache.org/thread.html/example@<dev.apache.org>"
  }
]
```

After:

```json
[
  {
    "url": "https://lists.apache.org/thread.html/example@%3Cdev.apache.org%3E"
  }
]
```

The output no longer contains raw `<` or `>` characters in advisory URLs.

Tests added cover:

* equivalent advisory URLs with different path encodings
* duplicate advisory URLs across `PrimaryURL` and `References`
* canonical output without raw `<` or `>` characters
* preservation of distinct advisory URLs
* existing behavior for extracting the first URL token from strings with additional text

Test command:

```console
GOEXPERIMENT=jsonv2 go test -vet=off ./pkg/sbom/cyclonedx/...
```

Result:

```text
PASS
```

Note: without `GOEXPERIMENT=jsonv2`, this checkout fails to compile due to the repository's `encoding/json/v2` dependency. The failure is unrelated to this change.

## Related issues

N/A

## Checklist

* [x] I've read the [[guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/)](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
* [x] I've followed the [[conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title)](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
* [x] I've added tests that prove my fix is effective or that my feature works.
* [x] I've updated the [[documentation](https://github.com/aquasecurity/trivy/blob/main/docs)](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
* [x] I've added usage information (if the PR introduces new options)
* [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).