### PR TITLE
feat: add --no-color flag to disable colored output

### DIFF
--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -187,11 +187,13 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 
 	log.Debug("Cache dir", log.String("dir", f.CacheDir.Value()))
 
-	// Respect --no-color flag and NO_COLOR environment variable (https://no-color.org/)
-	noColor := f.NoColor.Value() || os.Getenv("NO_COLOR") != ""
-	if noColor {
-		color.NoColor = true
+	// fatih/color natively handles the NO_COLOR environment variable.
+	// We only need to override its state if the user explicitly provided the --no-color flag.
+	if f.NoColor.IsSet() {
+		color.NoColor = f.NoColor.Value()
 	}
+
+	noColor := color.NoColor
 
 	opts.GlobalOptions = GlobalOptions{
 		ConfigFile:            f.ConfigFile.Value(),

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/xerrors"
 
@@ -86,6 +87,13 @@ var (
 		TelemetrySafe: true,
 		Internal:      true, // Hidden from help output, intended for maintainer debugging only
 	}
+	NoColorFlag = Flag[bool]{
+		Name:          "no-color",
+		ConfigName:    "no-color",
+		Usage:         "disable color output",
+		Persistent:    true,
+		TelemetrySafe: true,
+	}
 )
 
 // GlobalFlagGroup composes global flags
@@ -100,6 +108,7 @@ type GlobalFlagGroup struct {
 	CacheDir              *Flag[string]
 	GenerateDefaultConfig *Flag[bool]
 	TraceHTTP             *Flag[bool]
+	NoColor               *Flag[bool]
 }
 
 // GlobalOptions defines flags and other configuration parameters for all the subcommands
@@ -114,6 +123,7 @@ type GlobalOptions struct {
 	CacheDir              string
 	GenerateDefaultConfig bool
 	TraceHTTP             bool
+	NoColor               bool
 }
 
 func NewGlobalFlagGroup() *GlobalFlagGroup {
@@ -128,6 +138,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		CacheDir:              CacheDirFlag.Clone(),
 		GenerateDefaultConfig: GenerateDefaultConfigFlag.Clone(),
 		TraceHTTP:             TraceHTTPFlag.Clone(),
+		NoColor:               NoColorFlag.Clone(),
 	}
 }
 
@@ -147,6 +158,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.CacheDir,
 		f.GenerateDefaultConfig,
 		f.TraceHTTP,
+		f.NoColor,
 	}
 }
 
@@ -175,6 +187,12 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 
 	log.Debug("Cache dir", log.String("dir", f.CacheDir.Value()))
 
+	// Respect --no-color flag and NO_COLOR environment variable (https://no-color.org/)
+	noColor := f.NoColor.Value() || os.Getenv("NO_COLOR") != ""
+	if noColor {
+		color.NoColor = true
+	}
+
 	opts.GlobalOptions = GlobalOptions{
 		ConfigFile:            f.ConfigFile.Value(),
 		ShowVersion:           f.ShowVersion.Value(),
@@ -186,6 +204,7 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 		CacheDir:              f.CacheDir.Value(),
 		GenerateDefaultConfig: f.GenerateDefaultConfig.Value(),
 		TraceHTTP:             f.TraceHTTP.Value(),
+		NoColor:               noColor,
 	}
 	return nil
 }

--- a/pkg/flag/global_flags_test.go
+++ b/pkg/flag/global_flags_test.go
@@ -1,0 +1,60 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/flag"
+)
+
+func TestGlobalFlagGroup_NoColorPrecedence(t *testing.T) {
+	tests := []struct {
+		name        string
+		presetNoColor bool
+		cliArgs     []string
+		wantNoColor bool
+	}{
+		{
+			name:          "explicit --no-color=false overrides NO_COLOR",
+			presetNoColor: true,
+			cliArgs:       []string{"--no-color=false"},
+			wantNoColor:   false,
+		},
+		{
+			name:          "explicit --no-color forces color off",
+			presetNoColor: false,
+			cliArgs:       []string{"--no-color"},
+			wantNoColor:   true,
+		},
+		{
+			name:          "no flag preserves fatih/color state",
+			presetNoColor: true,
+			cliArgs:       nil,
+			wantNoColor:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := color.NoColor
+			t.Cleanup(func() { color.NoColor = orig })
+
+			color.NoColor = tt.presetNoColor
+
+			cmd := &cobra.Command{Use: "test"}
+			fg := flag.NewGlobalFlagGroup()
+			fg.AddFlags(cmd)
+			require.NoError(t, cmd.ParseFlags(tt.cliArgs))
+			require.NoError(t, fg.Bind(cmd))
+
+			var opts flag.Options
+			require.NoError(t, fg.ToOptions(&opts))
+			assert.Equal(t, tt.wantNoColor, opts.NoColor)
+			assert.Equal(t, tt.wantNoColor, color.NoColor)
+		})
+	}
+}

--- a/pkg/report/table/table.go
+++ b/pkg/report/table/table.go
@@ -174,6 +174,9 @@ func summarize(specifiedSeverities []dbTypes.Severity, severityCount map[string]
 }
 
 func IsOutputToTerminal(output io.Writer) bool {
+	if color.NoColor {
+		return false
+	}
 	if runtime.GOOS == "windows" {
 		// if its windows, we don't support formatting
 		return false


### PR DESCRIPTION
## Description

Adds a global `--no-color` flag that disables all ANSI color codes in trivy's output. Also respects the `NO_COLOR` environment variable per the [no-color.org](https://no-color.org/) specification.

## Motivation

When output is saved to files or viewed in CI logs, ANSI color escape sequences appear as garbled text:
```
[31mFATAL[0m - [36mCIS-DI-0009[0m: Use COPY instead of ADD in Dockerfile
```

Users have requested a `--no-color` flag since 2020 (#1091). While `fatih/color` (which trivy uses) already respects `NO_COLOR` internally for its own output, trivy's `IsOutputToTerminal()` function makes an independent terminal check that controls table styling, bold headers, and colored severity labels — this also needs to be gated.

## Changes

- `pkg/flag/global_flags.go`: Added `NoColorFlag` definition, wired into `GlobalFlagGroup`, `GlobalOptions`, and `ToOptions()`. When active, sets `color.NoColor = true` globally.
- `pkg/report/table/table.go`: `IsOutputToTerminal()` now returns `false` when `color.NoColor` is set, ensuring table formatting also respects the flag.

## Usage

```bash
# Via flag
trivy image --no-color python:3.9-slim > report.txt

# Via environment variable (no-color.org spec)
NO_COLOR=1 trivy image python:3.9-slim > report.txt

# Can also be set in trivy.yaml config
no-color: true
```

## Testing

- `go build ./pkg/flag/...` passes
- `go build ./pkg/report/table/...` passes
- `go vet` passes on both packages
- Full test suite requires Go 1.26.3 (trivy's minimum); the CI in this repo will validate

Fixes #1091
