### PR TITLE
feat(echo): support Echo Maven and npm package scanning

### DIFF
--- a/pkg/detector/library/all/import.go
+++ b/pkg/detector/library/all/import.go
@@ -1,10 +1,11 @@
 // Package all registers all built-in library vulnerability vendors.
 // Import it for side effects to enable vendor-specific advisory detection
-// (e.g., Seal Security):
+// (e.g., Seal Security, Echo):
 //
 //	import _ "github.com/aquasecurity/trivy/pkg/detector/library/all"
 package all
 
 import (
+	_ "github.com/aquasecurity/trivy/pkg/detector/library/echo"
 	_ "github.com/aquasecurity/trivy/pkg/detector/library/seal"
 )

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -14,6 +14,7 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
 
+	_ "github.com/aquasecurity/trivy/pkg/detector/library/echo" // register Echo vendor
 	_ "github.com/aquasecurity/trivy/pkg/detector/library/seal" // register Seal Security vendor
 )
 
@@ -362,6 +363,31 @@ func TestDriver_Detect(t *testing.T) {
 						ID:   vulnerability.Seal,
 						Name: "Seal Security Database",
 						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			name: "echo pip package",
+			fixtures: []string{
+				"testdata/fixtures/echo.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.PythonPkg,
+			args: args{
+				pkgName: "requests",
+				pkgVer:  "2.14.2+echo.1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2023-32681",
+					PkgName:          "requests",
+					InstalledVersion: "2.14.2+echo.1",
+					FixedVersion:     "2.14.2+echo.999",
+					DataSource: &dbTypes.DataSource{
+						ID:   "echo-osv",
+						Name: "Echo OSV",
+						URL:  "https://advisory.echohq.com/osv",
 					},
 				},
 			},

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -417,6 +417,44 @@ func TestDriver_Detect(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "echo npm package",
+			fixtures: []string{
+				"testdata/fixtures/echo.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.NodePkg,
+			args: args{
+				pkgName: "@babel/traverse",
+				pkgVer:  "7.23.2+echo.1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2024-66666",
+					PkgName:          "@babel/traverse",
+					InstalledVersion: "7.23.2+echo.1",
+					FixedVersion:     "7.23.2+echo.999",
+					DataSource: &dbTypes.DataSource{
+						ID:   "echo-osv",
+						Name: "Echo OSV",
+						URL:  "https://advisory.echohq.com/osv",
+					},
+				},
+			},
+		},
+		{
+			name: "echo npm package at the fixed echo build",
+			fixtures: []string{
+				"testdata/fixtures/echo.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.NodePkg,
+			args: args{
+				pkgName: "@babel/traverse",
+				pkgVer:  "7.23.2+echo.999",
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -392,6 +392,31 @@ func TestDriver_Detect(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "echo maven package",
+			fixtures: []string{
+				"testdata/fixtures/echo.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.Jar,
+			args: args{
+				pkgName: "org.apache.commons:commons-lang3",
+				pkgVer:  "3.14.0+echo.1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2024-88888",
+					PkgName:          "org.apache.commons:commons-lang3",
+					InstalledVersion: "3.14.0+echo.1",
+					FixedVersion:     "3.14.0+echo.999",
+					DataSource: &dbTypes.DataSource{
+						ID:   "echo-osv",
+						Name: "Echo OSV",
+						URL:  "https://advisory.echohq.com/osv",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -2,13 +2,17 @@ package echo
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
 )
+
+// echoLocalSegmentRe matches the Echo-specific PEP 440 local version segment,
+// e.g. "+echo.1" in "2.14.2+echo.1".
+var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.\d+`)
 
 func init() {
 	library.RegisterVendor(echoVendor{
@@ -30,12 +34,13 @@ func (echoVendor) Name() string {
 
 // Match determines whether a package is provided by Echo.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
-// Echo packages are identified by a "+echo." segment in the version string.
+// Echo packages are identified by a "+echo.N" segment in the version string,
+// where N is a numeric revision (e.g. "2.14.2+echo.1").
 func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
 	if eco != ecosystem.Pip {
 		return false
 	}
-	return strings.Contains(pkgVer, "+echo.")
+	return echoLocalSegmentRe.MatchString(pkgVer)
 }
 
 // BucketPrefix returns the vendor-specific advisory bucket prefix.

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -11,9 +11,10 @@ import (
 )
 
 // echoLocalSegmentRe matches the Echo-specific version segment "+echo.N",
-// e.g. "+echo.1" in "2.14.2+echo.1". This appears both as a PEP 440 local
-// version (pip) and as a Maven build suffix (maven).
-var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.\d+`)
+// e.g. "+echo.1" in "2.14.2+echo.1". This appears as a PEP 440 local version
+// (pip), a Maven build suffix (maven), and SemVer build metadata (npm).
+// The build number N is captured for the npm comparer's tie-breaking.
+var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.(\d+)`)
 
 func init() {
 	library.RegisterVendor(echoVendor{
@@ -22,9 +23,9 @@ func init() {
 }
 
 // echoVendor matches language packages patched by Echo.
-// Echo provides patched versions of Python (pip) and Java (maven) packages with
-// their own vulnerability advisories. Their packages are identified by a version
-// suffix of the form "+echo.N" (e.g. "2.14.2+echo.1").
+// Echo provides patched versions of Python (pip), Java (maven), and JavaScript
+// (npm) packages with their own vulnerability advisories. Their packages are
+// identified by a version suffix of the form "+echo.N" (e.g. "2.14.2+echo.1").
 type echoVendor struct {
 	pipComparer compare.Comparer
 }
@@ -36,11 +37,12 @@ func (echoVendor) Name() string {
 // Match determines whether a package is provided by Echo.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
 // Echo packages are identified by a "+echo.N" segment in the version string,
-// where N is a numeric revision (e.g. "2.14.2+echo.1"). Echo patches both
-// Python (pip) and Java (maven) packages using this same suffix convention.
+// where N is a numeric revision (e.g. "2.14.2+echo.1"). Echo patches Python
+// (pip), Java (maven), and JavaScript (npm) packages using this same suffix
+// convention.
 func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
 	switch eco {
-	case ecosystem.Pip, ecosystem.Maven:
+	case ecosystem.Pip, ecosystem.Maven, ecosystem.Npm:
 		return strings.Contains(pkgVer, "+echo.") && echoLocalSegmentRe.MatchString(pkgVer)
 	default:
 		return false
@@ -55,11 +57,17 @@ func (e echoVendor) BucketPrefix(eco ecosystem.Type) string {
 // Comparer returns a version comparer for the given ecosystem.
 // For pip (Python), it enables local version specifiers so PEP 440 ordering
 // keeps the Echo suffix (e.g. "2.14.2+echo.1") instead of discarding it.
+// For npm, it breaks SemVer ties on the "+echo.N" build number, which SemVer
+// excludes from precedence (see npmComparer).
 // For maven (and other ecosystems) the default comparer already orders the
 // "+echo.N" suffix correctly, so it is returned unchanged.
 func (e echoVendor) Comparer(eco ecosystem.Type, defaultComparer compare.Comparer) compare.Comparer {
-	if eco == ecosystem.Pip {
+	switch eco {
+	case ecosystem.Pip:
 		return e.pipComparer
+	case ecosystem.Npm:
+		return npmComparer{}
+	default:
+		return defaultComparer
 	}
-	return defaultComparer
 }

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -9,8 +9,9 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
 )
 
-// echoLocalSegmentRe matches the Echo-specific PEP 440 local version segment,
-// e.g. "+echo.1" in "2.14.2+echo.1".
+// echoLocalSegmentRe matches the Echo-specific version segment "+echo.N",
+// e.g. "+echo.1" in "2.14.2+echo.1". This appears both as a PEP 440 local
+// version (pip) and as a Maven build suffix (maven).
 var echoLocalSegmentRe = regexp.MustCompile(`\+echo\.\d+`)
 
 func init() {
@@ -19,10 +20,10 @@ func init() {
 	})
 }
 
-// echoVendor matches pip packages patched by Echo.
-// Echo provides patched versions of Python packages with their own vulnerability
-// advisories. Their packages are identified by a PEP 440 local version suffix
-// of the form "+echo.N" (e.g. "2.14.2+echo.1").
+// echoVendor matches language packages patched by Echo.
+// Echo provides patched versions of Python (pip) and Java (maven) packages with
+// their own vulnerability advisories. Their packages are identified by a version
+// suffix of the form "+echo.N" (e.g. "2.14.2+echo.1").
 type echoVendor struct {
 	pipComparer compare.Comparer
 }
@@ -34,12 +35,15 @@ func (echoVendor) Name() string {
 // Match determines whether a package is provided by Echo.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
 // Echo packages are identified by a "+echo.N" segment in the version string,
-// where N is a numeric revision (e.g. "2.14.2+echo.1").
+// where N is a numeric revision (e.g. "2.14.2+echo.1"). Echo patches both
+// Python (pip) and Java (maven) packages using this same suffix convention.
 func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
-	if eco != ecosystem.Pip {
+	switch eco {
+	case ecosystem.Pip, ecosystem.Maven:
+		return echoLocalSegmentRe.MatchString(pkgVer)
+	default:
 		return false
 	}
-	return echoLocalSegmentRe.MatchString(pkgVer)
 }
 
 // BucketPrefix returns the vendor-specific advisory bucket prefix.
@@ -48,9 +52,10 @@ func (e echoVendor) BucketPrefix(eco ecosystem.Type) string {
 }
 
 // Comparer returns a version comparer for the given ecosystem.
-// For pip (Python), it enables local version specifiers to correctly handle
-// Echo version suffixes (e.g. "2.14.2+echo.1").
-// For other ecosystems, it returns the default comparer unchanged.
+// For pip (Python), it enables local version specifiers so PEP 440 ordering
+// keeps the Echo suffix (e.g. "2.14.2+echo.1") instead of discarding it.
+// For maven (and other ecosystems) the default comparer already orders the
+// "+echo.N" suffix correctly, so it is returned unchanged.
 func (e echoVendor) Comparer(eco ecosystem.Type, defaultComparer compare.Comparer) compare.Comparer {
 	if eco == ecosystem.Pip {
 		return e.pipComparer

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -1,0 +1,55 @@
+package echo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
+	"github.com/aquasecurity/trivy/pkg/detector/library"
+	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
+	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
+)
+
+func init() {
+	library.RegisterVendor(echoVendor{
+		pipComparer: pep440.NewComparer(pep440.AllowLocalSpecifier()),
+	})
+}
+
+// echoVendor matches pip packages patched by Echo.
+// Echo provides patched versions of Python packages with their own vulnerability
+// advisories. Their packages are identified by a PEP 440 local version suffix
+// of the form "+echo.N" (e.g. "2.14.2+echo.1").
+type echoVendor struct {
+	pipComparer compare.Comparer
+}
+
+func (echoVendor) Name() string {
+	return "echo"
+}
+
+// Match determines whether a package is provided by Echo.
+// It expects a normalized package name (see vulnerability.NormalizePkgName).
+// Echo packages are identified by a "+echo." segment in the version string.
+func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
+	if eco != ecosystem.Pip {
+		return false
+	}
+	return strings.Contains(pkgVer, "+echo.")
+}
+
+// BucketPrefix returns the vendor-specific advisory bucket prefix.
+func (e echoVendor) BucketPrefix(eco ecosystem.Type) string {
+	return fmt.Sprintf("%s %s::", e.Name(), eco)
+}
+
+// Comparer returns a version comparer for the given ecosystem.
+// For pip (Python), it enables local version specifiers to correctly handle
+// Echo version suffixes (e.g. "2.14.2+echo.1").
+// For other ecosystems, it returns the default comparer unchanged.
+func (e echoVendor) Comparer(eco ecosystem.Type, defaultComparer compare.Comparer) compare.Comparer {
+	if eco == ecosystem.Pip {
+		return e.pipComparer
+	}
+	return defaultComparer
+}

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -1,7 +1,6 @@
 package echo
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
@@ -45,7 +44,7 @@ func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
 
 // BucketPrefix returns the vendor-specific advisory bucket prefix.
 func (e echoVendor) BucketPrefix(eco ecosystem.Type) string {
-	return fmt.Sprintf("%s %s::", e.Name(), eco)
+	return e.Name() + " " + string(eco) + "::"
 }
 
 // Comparer returns a version comparer for the given ecosystem.

--- a/pkg/detector/library/echo/echo.go
+++ b/pkg/detector/library/echo/echo.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
@@ -40,7 +41,7 @@ func (echoVendor) Name() string {
 func (echoVendor) Match(eco ecosystem.Type, _, pkgVer string) bool {
 	switch eco {
 	case ecosystem.Pip, ecosystem.Maven:
-		return echoLocalSegmentRe.MatchString(pkgVer)
+		return strings.Contains(pkgVer, "+echo.") && echoLocalSegmentRe.MatchString(pkgVer)
 	default:
 		return false
 	}

--- a/pkg/detector/library/echo/echo_test.go
+++ b/pkg/detector/library/echo/echo_test.go
@@ -66,10 +66,24 @@ func TestEchoVendor_Match(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "maven package is not supported",
+			name:    "maven package with +echo.1 suffix",
 			eco:     ecosystem.Maven,
 			pkgName: "org.apache.logging.log4j:log4j-core",
 			pkgVer:  "2.13.3+echo.1",
+			want:    true,
+		},
+		{
+			name:    "maven package with +echo.999 suffix",
+			eco:     ecosystem.Maven,
+			pkgName: "org.apache.commons:commons-lang3",
+			pkgVer:  "3.14.0+echo.999",
+			want:    true,
+		},
+		{
+			name:    "maven package without echo suffix",
+			eco:     ecosystem.Maven,
+			pkgName: "org.apache.commons:commons-lang3",
+			pkgVer:  "3.14.0",
 			want:    false,
 		},
 		{

--- a/pkg/detector/library/echo/echo_test.go
+++ b/pkg/detector/library/echo/echo_test.go
@@ -52,10 +52,24 @@ func TestEchoVendor_Match(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "npm package is not supported",
+			name:    "npm package with +echo.1 suffix",
 			eco:     ecosystem.Npm,
 			pkgName: "ejs",
 			pkgVer:  "3.1.8+echo.1",
+			want:    true,
+		},
+		{
+			name:    "scoped npm package with +echo.2 suffix",
+			eco:     ecosystem.Npm,
+			pkgName: "@babel/traverse",
+			pkgVer:  "7.23.2+echo.2",
+			want:    true,
+		},
+		{
+			name:    "npm package without echo suffix",
+			eco:     ecosystem.Npm,
+			pkgName: "ejs",
+			pkgVer:  "3.1.8",
 			want:    false,
 		},
 		{

--- a/pkg/detector/library/echo/echo_test.go
+++ b/pkg/detector/library/echo/echo_test.go
@@ -1,0 +1,98 @@
+package echo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
+)
+
+func TestEchoVendor_Match(t *testing.T) {
+	tests := []struct {
+		name    string
+		eco     ecosystem.Type
+		pkgName string
+		pkgVer  string
+		want    bool
+	}{
+		{
+			name:    "pip package with +echo.1 suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2+echo.1",
+			want:    true,
+		},
+		{
+			name:    "pip package with +echo.999 suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "django",
+			pkgVer:  "4.2.8+echo.999",
+			want:    true,
+		},
+		{
+			name:    "pip package with +echo.2 suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "flask",
+			pkgVer:  "3.0.0+echo.2",
+			want:    true,
+		},
+		{
+			name:    "pip package without echo suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2",
+			want:    false,
+		},
+		{
+			name:    "pip package with different local suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2+local.1",
+			want:    false,
+		},
+		{
+			name:    "npm package is not supported",
+			eco:     ecosystem.Npm,
+			pkgName: "ejs",
+			pkgVer:  "3.1.8+echo.1",
+			want:    false,
+		},
+		{
+			name:    "go package is not supported",
+			eco:     ecosystem.Go,
+			pkgName: "golang.org/x/crypto",
+			pkgVer:  "0.26.0+echo.1",
+			want:    false,
+		},
+		{
+			name:    "maven package is not supported",
+			eco:     ecosystem.Maven,
+			pkgName: "org.apache.logging.log4j:log4j-core",
+			pkgVer:  "2.13.3+echo.1",
+			want:    false,
+		},
+		{
+			name:    "empty version",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "",
+			want:    false,
+		},
+		{
+			name:    "version containing echo but not as local segment",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2-echo.1",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := echoVendor{}
+			got := v.Match(tt.eco, tt.pkgName, tt.pkgVer)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/library/echo/echo_test.go
+++ b/pkg/detector/library/echo/echo_test.go
@@ -86,6 +86,20 @@ func TestEchoVendor_Match(t *testing.T) {
 			pkgVer:  "2.14.2-echo.1",
 			want:    false,
 		},
+		{
+			name:    "pip package with +echo. but no digits",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2+echo.",
+			want:    false,
+		},
+		{
+			name:    "pip package with +echo. followed by non-digit",
+			eco:     ecosystem.Pip,
+			pkgName: "requests",
+			pkgVer:  "2.14.2+echo.beta",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/detector/library/echo/npm.go
+++ b/pkg/detector/library/echo/npm.go
@@ -1,0 +1,124 @@
+package echo
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	npm "github.com/aquasecurity/go-npm-version/pkg"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
+)
+
+// npmComparer compares npm package versions with Echo-aware ordering.
+// npm follows SemVer, which excludes build metadata from precedence, so the
+// standard npm comparer treats "2.14.2+echo.1" and "2.14.2+echo.2" as equal
+// and cannot tell one Echo build from another. Echo publishes successive
+// patched builds that differ only in the "+echo.N" build number, so SemVer
+// ties are broken by N (a version without the suffix has N=0):
+// 2.14.2 < 2.14.2+echo.1 < 2.14.2+echo.2 < 2.14.3.
+type npmComparer struct{}
+
+// IsVulnerable checks if the package version is vulnerable to the advisory.
+func (n npmComparer) IsVulnerable(ver string, advisory dbTypes.Advisory) bool {
+	return compare.IsVulnerable(ver, advisory, n.matchVersion)
+}
+
+// matchVersion checks if the package version satisfies the given constraint:
+// "||"-separated groups of comma-separated comparators, e.g.
+// ">=1.2.3+echo.1, <1.2.3+echo.2 || 2.0.0+echo.1". A comparator without an
+// operator is an exact match.
+func (n npmComparer) matchVersion(currentVersion, constraint string) (bool, error) {
+	ver, err := newEchoNpmVersion(currentVersion)
+	if err != nil {
+		return false, xerrors.Errorf("npm version error (%s): %w", currentVersion, err)
+	}
+
+	for _, group := range strings.Split(constraint, "||") {
+		ok, err := matchComparators(ver, group)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func matchComparators(ver echoNpmVersion, group string) (bool, error) {
+	for _, comparator := range strings.Split(group, ",") {
+		comparator = strings.TrimSpace(comparator)
+		if comparator == "" {
+			continue
+		}
+
+		op := "="
+		verStr := comparator
+		for _, prefix := range []string{">=", "<=", "==", ">", "<", "="} {
+			if strings.HasPrefix(comparator, prefix) {
+				op = prefix
+				verStr = strings.TrimSpace(strings.TrimPrefix(comparator, prefix))
+				break
+			}
+		}
+
+		other, err := newEchoNpmVersion(verStr)
+		if err != nil {
+			return false, xerrors.Errorf("npm constraint error (%s): %w", comparator, err)
+		}
+
+		var ok bool
+		switch c := ver.compare(other); op {
+		case "=", "==":
+			ok = c == 0
+		case ">":
+			ok = c > 0
+		case ">=":
+			ok = c >= 0
+		case "<":
+			ok = c < 0
+		case "<=":
+			ok = c <= 0
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// echoNpmVersion is an npm version plus its Echo build number.
+type echoNpmVersion struct {
+	npm.Version
+	echoBuild int
+}
+
+func newEchoNpmVersion(s string) (echoNpmVersion, error) {
+	v, err := npm.NewVersion(s)
+	if err != nil {
+		return echoNpmVersion{}, err
+	}
+	var build int
+	if m := echoLocalSegmentRe.FindStringSubmatch(s); m != nil {
+		build, err = strconv.Atoi(m[1])
+		if err != nil {
+			return echoNpmVersion{}, xerrors.Errorf("invalid echo build number (%s): %w", s, err)
+		}
+	}
+	return echoNpmVersion{Version: v, echoBuild: build}, nil
+}
+
+func (v echoNpmVersion) compare(other echoNpmVersion) int {
+	if c := v.Version.Compare(other.Version); c != 0 {
+		return c
+	}
+	switch {
+	case v.echoBuild < other.echoBuild:
+		return -1
+	case v.echoBuild > other.echoBuild:
+		return 1
+	}
+	return 0
+}

--- a/pkg/detector/library/echo/npm_test.go
+++ b/pkg/detector/library/echo/npm_test.go
@@ -1,0 +1,124 @@
+package echo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+)
+
+func TestNpmComparer_IsVulnerable(t *testing.T) {
+	tests := []struct {
+		name     string
+		ver      string
+		advisory dbTypes.Advisory
+		want     bool
+	}{
+		{
+			name: "installed echo build below the fixed echo build",
+			ver:  "7.23.2+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{">=7.23.2+echo.1, <7.23.2+echo.2"},
+				PatchedVersions:    []string{"7.23.2+echo.2"},
+			},
+			want: true,
+		},
+		{
+			name: "installed echo build equals the fixed echo build",
+			ver:  "7.23.2+echo.2",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{">=7.23.2+echo.1, <7.23.2+echo.2"},
+				PatchedVersions:    []string{"7.23.2+echo.2"},
+			},
+			want: false,
+		},
+		{
+			name: "installed echo build above the fixed echo build",
+			ver:  "7.23.2+echo.10",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{">=7.23.2+echo.1, <7.23.2+echo.2"},
+				PatchedVersions:    []string{"7.23.2+echo.2"},
+			},
+			want: false,
+		},
+		{
+			name: "echo build of an older base version",
+			ver:  "7.23.1+echo.5",
+			advisory: dbTypes.Advisory{
+				// {"introduced": "0"} ranges drop the ">=0" comparator.
+				VulnerableVersions: []string{"<7.23.2+echo.1"},
+				PatchedVersions:    []string{"7.23.2+echo.1"},
+			},
+			want: true,
+		},
+		{
+			name: "echo build of a newer base version",
+			ver:  "7.23.3+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"<7.23.2+echo.1"},
+				PatchedVersions:    []string{"7.23.2+echo.1"},
+			},
+			want: false,
+		},
+		{
+			name: "spaces between operator and version",
+			ver:  "3.1.8+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{">= 3.1.8+echo.1, < 3.1.8+echo.999"},
+				PatchedVersions:    []string{"3.1.8+echo.999"},
+			},
+			want: true,
+		},
+		{
+			name: "multiple vulnerable ranges (OR)",
+			ver:  "2.0.0+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"<1.0.0+echo.9", ">=2.0.0, <2.0.0+echo.2"},
+				PatchedVersions:    []string{"1.0.0+echo.9", "2.0.0+echo.2"},
+			},
+			want: true,
+		},
+		{
+			name: "echo build of a prerelease below the fixed prerelease build",
+			ver:  "19.0.0-next.3+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"<19.0.0-next.3+echo.2"},
+				PatchedVersions:    []string{"19.0.0-next.3+echo.2"},
+			},
+			want: true,
+		},
+		{
+			name: "echo build of a prerelease equals the fixed prerelease build",
+			ver:  "19.0.0-next.3+echo.2",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"<19.0.0-next.3+echo.2"},
+				PatchedVersions:    []string{"19.0.0-next.3+echo.2"},
+			},
+			want: false,
+		},
+		{
+			name: "exact match without operator",
+			ver:  "1.2.3+echo.1",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"1.2.3+echo.1"},
+			},
+			want: true,
+		},
+		{
+			name: "unparseable installed version is not vulnerable",
+			ver:  "not-a-version",
+			advisory: dbTypes.Advisory{
+				VulnerableVersions: []string{"<1.0.0+echo.1"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := npmComparer{}.IsVulnerable(tt.ver, tt.advisory)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/library/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/library/testdata/fixtures/data-source.yaml
@@ -65,3 +65,8 @@
         ID: "echo-osv"
         Name: "Echo OSV"
         URL: "https://advisory.echohq.com/osv"
+    - key: "echo maven::Echo OSV"
+      value:
+        ID: "echo-osv"
+        Name: "Echo OSV"
+        URL: "https://advisory.echohq.com/osv"

--- a/pkg/detector/library/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/library/testdata/fixtures/data-source.yaml
@@ -60,3 +60,8 @@
         ID: "seal"
         Name: "Seal Security Database"
         URL: "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip"
+    - key: "echo pip::Echo OSV"
+      value:
+        ID: "echo-osv"
+        Name: "Echo OSV"
+        URL: "https://advisory.echohq.com/osv"

--- a/pkg/detector/library/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/library/testdata/fixtures/data-source.yaml
@@ -70,3 +70,8 @@
         ID: "echo-osv"
         Name: "Echo OSV"
         URL: "https://advisory.echohq.com/osv"
+    - key: "echo npm::Echo OSV"
+      value:
+        ID: "echo-osv"
+        Name: "Echo OSV"
+        URL: "https://advisory.echohq.com/osv"

--- a/pkg/detector/library/testdata/fixtures/echo.yaml
+++ b/pkg/detector/library/testdata/fixtures/echo.yaml
@@ -18,3 +18,13 @@
               - "3.14.0+echo.999"
             VulnerableVersions:
               - ">= 3.14.0+echo.1, < 3.14.0+echo.999"
+- bucket: "echo npm::Echo OSV"
+  pairs:
+    - bucket: "@babel/traverse"
+      pairs:
+        - key: CVE-2024-66666
+          value:
+            PatchedVersions:
+              - "7.23.2+echo.999"
+            VulnerableVersions:
+              - ">= 7.23.2+echo.1, < 7.23.2+echo.999"

--- a/pkg/detector/library/testdata/fixtures/echo.yaml
+++ b/pkg/detector/library/testdata/fixtures/echo.yaml
@@ -1,0 +1,10 @@
+- bucket: "echo pip::Echo OSV"
+  pairs:
+    - bucket: requests
+      pairs:
+        - key: CVE-2023-32681
+          value:
+            PatchedVersions:
+              - "2.14.2+echo.999"
+            VulnerableVersions:
+              - ">= 2.14.2+echo.1, < 2.14.2+echo.999"

--- a/pkg/detector/library/testdata/fixtures/echo.yaml
+++ b/pkg/detector/library/testdata/fixtures/echo.yaml
@@ -8,3 +8,13 @@
               - "2.14.2+echo.999"
             VulnerableVersions:
               - ">= 2.14.2+echo.1, < 2.14.2+echo.999"
+- bucket: "echo maven::Echo OSV"
+  pairs:
+    - bucket: "org.apache.commons:commons-lang3"
+      pairs:
+        - key: CVE-2024-88888
+          value:
+            PatchedVersions:
+              - "3.14.0+echo.999"
+            VulnerableVersions:
+              - ">= 3.14.0+echo.1, < 3.14.0+echo.999"

--- a/pkg/detector/library/vendor_test.go
+++ b/pkg/detector/library/vendor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
 
+	_ "github.com/aquasecurity/trivy/pkg/detector/library/echo" // register Echo vendor
 	_ "github.com/aquasecurity/trivy/pkg/detector/library/seal" // register Seal Security vendor
 )
 
@@ -21,6 +22,7 @@ func Test_lookupVendor(t *testing.T) {
 		name                string
 		eco                 ecosystem.Type
 		pkgName             string
+		pkgVer              string
 		wantMatch           bool
 		wantPrefix          string
 		wantDefaultComparer bool
@@ -66,6 +68,29 @@ func Test_lookupVendor(t *testing.T) {
 			wantDefaultComparer: true,
 		},
 		{
+			name:                "echo pip package returns vendor prefix and pep440 comparer",
+			eco:                 ecosystem.Pip,
+			pkgName:             "requests",
+			pkgVer:              "2.14.2+echo.1",
+			wantMatch:           true,
+			wantPrefix:          "echo pip::",
+			wantDefaultComparer: false,
+		},
+		{
+			name:      "non-echo pip package without version suffix returns no match",
+			eco:       ecosystem.Pip,
+			pkgName:   "requests",
+			pkgVer:    "2.14.2",
+			wantMatch: false,
+		},
+		{
+			name:      "echo version suffix on non-pip ecosystem returns no match",
+			eco:       ecosystem.Npm,
+			pkgName:   "ejs",
+			pkgVer:    "3.1.8+echo.1",
+			wantMatch: false,
+		},
+		{
 			name:      "non-seal pip package returns no match",
 			eco:       ecosystem.Pip,
 			pkgName:   "requests",
@@ -81,7 +106,7 @@ func Test_lookupVendor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v, ok := library.LookupVendor(tt.eco, tt.pkgName, "")
+			v, ok := library.LookupVendor(tt.eco, tt.pkgName, tt.pkgVer)
 			require.Equal(t, tt.wantMatch, ok)
 			if !ok {
 				return

--- a/pkg/detector/library/vendor_test.go
+++ b/pkg/detector/library/vendor_test.go
@@ -84,10 +84,19 @@ func Test_lookupVendor(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name:      "echo version suffix on non-pip ecosystem returns no match",
-			eco:       ecosystem.Npm,
-			pkgName:   "ejs",
-			pkgVer:    "3.1.8+echo.1",
+			name:                "echo npm package returns vendor prefix and echo npm comparer",
+			eco:                 ecosystem.Npm,
+			pkgName:             "@babel/traverse",
+			pkgVer:              "7.23.2+echo.1",
+			wantMatch:           true,
+			wantPrefix:          "echo npm::",
+			wantDefaultComparer: false,
+		},
+		{
+			name:      "echo version suffix on unsupported ecosystem returns no match",
+			eco:       ecosystem.Go,
+			pkgName:   "golang.org/x/crypto",
+			pkgVer:    "0.26.0+echo.1",
 			wantMatch: false,
 		},
 		{
@@ -117,8 +126,13 @@ func Test_lookupVendor(t *testing.T) {
 				// When no custom comparer is needed, the default should be returned unchanged.
 				assert.Equal(t, defaultComparer, comparer)
 			} else {
-				// For seal pip, a custom pep440 comparer with AllowLocalSpecifier should be returned.
-				assert.IsType(t, pep440.Comparer{}, comparer)
+				// A vendor-specific comparer should replace the default one,
+				// e.g. pep440 with AllowLocalSpecifier for pip, the Echo npm
+				// comparer for npm.
+				assert.NotEqual(t, defaultComparer, comparer)
+				if tt.eco == ecosystem.Pip {
+					assert.IsType(t, pep440.Comparer{}, comparer)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Extends the Echo vendor (introduced in #10555) to also match **Maven** packages
patched by Echo. Echo publishes patched Java packages with a `+echo.N` version
suffix (e.g. `org.apache.commons:commons-lang3@3.14.0+echo.1`) and its own
advisories via the Echo OSV feed.

`Match` now recognizes the `ecosystem.Maven` + `+echo.N` combination so those
advisories are applied during scanning. No custom comparer is needed: the default
Maven comparer (`go-mvn-version`) already orders `+echo.N` correctly.

> Stacked on #10555; the diff will be clean once that merges and this is rebased onto main.

## Related issues
- Relates to #10519

## Related PRs
- [ ] #10555 — feat(echo): Support echo language package scanning (base — must merge first)
- [ ] aquasecurity/trivy-db#<your trivy-db Maven PR>
- [ ] aquasecurity/vuln-list-update#<your vuln-list-update Maven PR>

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (not needed — extends an existing vendor, no new options).
- [ ] I've added usage information (n/a — no new options).
- [ ] I've included a "before" and "after" example to the description (n/a — not a user-interface change).
