### PR TITLE
fix(nodejs): support pnpm workspaces with overlapping packages

### DIFF
--- a/pkg/dependency/parser/nodejs/pnpm/parse.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse.go
@@ -133,14 +133,20 @@ func (p *Parser) parseV9(lockFile LockFile) ([]ftypes.Package, []ftypes.Dependen
 	// The "importers" section contains the dependencies defined in package.json files.
 	// We need to identify which packages are direct dependencies (vs transitive)
 	// and which are development dependencies (vs production dependencies).
-	devDeps := make(map[string]string) // name -> version for dev dependencies
-	deps := make(map[string]string)    // name -> version for production dependencies
+	//
+	// Sets hold packageID(name, version) so that every (name, version) pair from
+	// every importer is recorded independently. Using name alone would cause the
+	// last importer to silently overwrite earlier ones, producing non-deterministic
+	// dev/prod classification when multiple workspaces pin different versions of the
+	// same package.
+	directDevDeps := set.New[string]()  // packageIDs of direct dev dependencies
+	directProdDeps := set.New[string]() // packageIDs of direct production dependencies
 	for _, importer := range lockFile.Importers {
 		for n, v := range importer.DevDependencies {
-			devDeps[n] = v.Version
+			directDevDeps.Append(packageID(n, p.trimPeerDeps(v.Version, lockVer)))
 		}
 		for n, v := range importer.Dependencies {
-			deps[n] = v.Version
+			directProdDeps.Append(packageID(n, p.trimPeerDeps(v.Version, lockVer)))
 		}
 	}
 
@@ -156,7 +162,8 @@ func (p *Parser) parseV9(lockFile LockFile) ([]ftypes.Package, []ftypes.Dependen
 		// Try to get the exact version from the "packages" section if available.
 		// The "packages" section may contain more accurate version information
 		// for packages installed from non-standard sources (git, local files, etc.).
-		pkgKey := PackageKey(packageID(name, version))
+		pkgID := packageID(name, version)
+		pkgKey := PackageKey(pkgID)
 		if pkgInfo, ok := lockFile.Packages[pkgKey]; ok && pkgInfo.Version != "" {
 			parsedVer = pkgInfo.Version
 		}
@@ -167,12 +174,11 @@ func (p *Parser) parseV9(lockFile LockFile) ([]ftypes.Package, []ftypes.Dependen
 		dev := true
 		relationship := ftypes.RelationshipIndirect // Assume transitive by default
 
-		// Check if this package matches a direct dev dependency
-		if v, ok := devDeps[name]; ok && p.trimPeerDeps(v, lockVer) == version {
+		// Check if this package matches a direct dev or production dependency.
+		if directDevDeps.Contains(pkgID) {
 			relationship = ftypes.RelationshipDirect
 		}
-		// Check if this package matches a direct production dependency
-		if v, ok := deps[name]; ok && p.trimPeerDeps(v, lockVer) == version {
+		if directProdDeps.Contains(pkgID) {
 			relationship = ftypes.RelationshipDirect
 			dev = false // This is a production dependency, not a dev dependency
 		}

--- a/pkg/dependency/parser/nodejs/pnpm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_test.go
@@ -77,6 +77,12 @@ func TestParse(t *testing.T) {
 			want:     pnpmV9MultipleDocuments,
 			wantDeps: pnpmV9MultipleDocumentsDeps,
 		},
+		{
+			name:     "v9 with same package at different versions across importers",
+			file:     "testdata/pnpm-lock_v9_multi_version.yaml",
+			want:     pnpmV9MultiVersion,
+			wantDeps: pnpmV9MultiVersionDeps,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
@@ -1090,4 +1090,37 @@ var (
 		},
 	}
 	pnpmV9MultipleDocumentsDeps = []ftypes.Dependency{}
+
+	// pnpmV9MultiVersion tests that when multiple workspaces depend on the same
+	// package at different versions, all versions are reported. This guards against
+	// a bug where deps[name]=version (name-only key) caused the last importer
+	// iterated in Go's random map order to silently overwrite earlier versions.
+	//
+	// docker run --rm node@sha256:b46a10d964ad15136ebdf9012142131481caa0697d7a4d4eafe4bbabd818f876 sh -c '
+	// npm install -g pnpm@11.9.0
+	// mkdir /app && cd /app
+	// mkdir app-a app-b
+	// cat > pnpm-workspace.yaml <<EOF
+	// packages:
+	// - app-a
+	// - app-b
+	// EOF
+	// (cd app-a && pnpm init && pnpm add is-number@6.0.0)
+	// (cd app-b && pnpm init && pnpm add is-number@7.0.0)
+	// cat pnpm-lock.yaml'
+	pnpmV9MultiVersion = []ftypes.Package{
+		{
+			ID:           "is-number@6.0.0",
+			Name:         "is-number",
+			Version:      "6.0.0",
+			Relationship: ftypes.RelationshipDirect,
+		},
+		{
+			ID:           "is-number@7.0.0",
+			Name:         "is-number",
+			Version:      "7.0.0",
+			Relationship: ftypes.RelationshipDirect,
+		},
+	}
+	pnpmV9MultiVersionDeps = []ftypes.Dependency{}
 )

--- a/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multi_version.yaml
+++ b/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_multi_version.yaml
@@ -1,0 +1,35 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  app-a:
+    dependencies:
+      is-number:
+        specifier: 6.0.0
+        version: 6.0.0
+
+  app-b:
+    dependencies:
+      is-number:
+        specifier: 7.0.0
+        version: 7.0.0
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-number@7.0.0: {}


### PR DESCRIPTION
## Description

The pnpm lockfile format supports workspaces, and the direct dependencies in the `importers` key were previously combined. This means that the following would randomly (go hash order) select one of the two packages to include in the output. This combines nastily when one is a development dependency.

```
lockfileVersion: '9.0'

importers:
  app-a:
    dependencies:
      axios:
        specifier: ^0.21.0
        version: 0.21.4

  app-b:
    dependencies:
      axios:
        specifier: ^1.7.2
        version: 1.7.7

packages:
  axios@0.21.4:
    resolution: {integrity: sha512-oBR83sYPh5KFqyvuBTPmPTLJehhJQRRS2EHW7bSxACW3d/SQSM1iqSqAEjJXLx/KkEBBcnHdpOlT/pMF7GPGA==}

  axios@1.7.7:
    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}

snapshots:
  axios@0.21.4: {}
  axios@1.7.7: {}
```

## Related issues

- Close https://github.com/aquasecurity/trivy/issues/10910

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Disclosure

This PR is LLM-assisted.