### PR TITLE
Add Trivy workflow examples and hardened CI templates

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,0 +1,83 @@
+name: Image Release Scan
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/image-release.yaml'
+      - 'examples/workflows/**'
+      - 'contrib/install.sh'
+      - 'contrib/workflows/**'
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: OCI image reference to scan
+        required: true
+        default: ghcr.io/aquasecurity/trivy:latest
+  schedule:
+    - cron: '33 2 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-image:
+    runs-on: ubuntu-2404-2core
+    env:
+      IMAGE_REF_RAW: ${{ github.event.inputs.image_ref || 'ghcr.io/aquasecurity/trivy:latest' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Trivy from repo script
+        run: |
+          set -euo pipefail
+          ./contrib/install.sh -b /usr/local/bin
+          trivy --version
+
+      - name: Validate image reference input
+        env:
+          IMAGE_REF_RAW: ${{ github.event.inputs.image_ref || 'ghcr.io/aquasecurity/trivy:latest' }}
+        run: |
+          set -euo pipefail
+          IMAGE_REF=$(printf '%s' "$IMAGE_REF_RAW" | tr -d '\r')
+          if ! printf '%s' "$IMAGE_REF" | grep -Eq '^[A-Za-z0-9._/:@+-]+$'; then
+            echo 'Invalid image_ref input' >&2
+            exit 1
+          fi
+          printf 'IMAGE_REF=%s\n' "$IMAGE_REF" >> "$GITHUB_ENV"
+
+      - name: Scan image and emit reports
+        run: |
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --format json \
+            --output trivy-image.json \
+            "$IMAGE_REF"
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --format cyclonedx \
+            --output trivy-image.cdx.json \
+            "$IMAGE_REF"
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            "$IMAGE_REF"
+
+      - name: Upload image scan artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-image-artifacts
+          path: |
+            trivy-image.json
+            trivy-image.cdx.json

--- a/.github/workflows/kubernetes-cluster.yaml
+++ b/.github/workflows/kubernetes-cluster.yaml
@@ -1,0 +1,93 @@
+name: Kubernetes Cluster Scan
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/kubernetes-cluster.yaml'
+      - 'examples/workflows/**'
+      - 'contrib/install.sh'
+      - 'contrib/workflows/**'
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: Optional namespace to scope the scan
+        required: false
+        default: ''
+  schedule:
+    - cron: '11 4 * * 6'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kubernetes-cluster-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  k8s-scan:
+    runs-on: ubuntu-2404-2core
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Trivy from repo script
+        run: |
+          set -euo pipefail
+          ./contrib/install.sh -b /usr/local/bin
+          trivy --version
+
+      - name: Validate kubeconfig secret presence
+        run: |
+          set -euo pipefail
+          test -n '${{ secrets.KUBECONFIG }}'
+
+      - name: Write kubeconfig
+        run: |
+          set -euo pipefail
+          install -d -m 700 ~/.kube
+          printf '%s' '${{ secrets.KUBECONFIG }}' > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Validate namespace input
+        env:
+          NAMESPACE_RAW: ${{ github.event.inputs.namespace }}
+        run: |
+          set -euo pipefail
+          NAMESPACE=$(printf '%s' "$NAMESPACE_RAW" | tr -d '\r')
+          if [ -n "$NAMESPACE" ] && ! printf '%s' "$NAMESPACE" | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'; then
+            echo 'Invalid namespace input' >&2
+            exit 1
+          fi
+          printf 'NAMESPACE=%s\n' "$NAMESPACE" >> "$GITHUB_ENV"
+
+      - name: Scan Kubernetes cluster
+        run: |
+          namespace_args=()
+          if [ -n "$NAMESPACE" ]; then
+            namespace_args+=(--include-namespaces "$NAMESPACE")
+          fi
+          trivy k8s \
+            --kubeconfig ~/.kube/config \
+            --report summary \
+            --severity HIGH,CRITICAL \
+            --format json \
+            --output trivy-k8s.json \
+            "${namespace_args[@]}" \
+            cluster
+          trivy k8s \
+            --kubeconfig ~/.kube/config \
+            --report summary \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "${namespace_args[@]}" \
+            cluster
+
+      - name: Upload Kubernetes scan artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-k8s-artifacts
+          path: trivy-k8s.json

--- a/.github/workflows/repo-and-iac-pr.yaml
+++ b/.github/workflows/repo-and-iac-pr.yaml
@@ -1,0 +1,73 @@
+name: Repo and IaC PR Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/repo-and-iac-pr.yaml'
+      - 'examples/workflows/**'
+      - 'contrib/install.sh'
+      - 'contrib/workflows/**'
+      - 'docs/tutorials/integrations/workflow-examples.md'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-and-iac-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-pr:
+    runs-on: ubuntu-2404-2core
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Trivy from repo script
+        run: |
+          set -euo pipefail
+          ./contrib/install.sh -b /usr/local/bin
+          trivy --version
+
+      - name: Filesystem scan for dependencies and secrets
+        run: |
+          trivy fs \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,secret \
+            --format sarif \
+            --output trivy-fs.sarif \
+            .
+          trivy fs \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,secret \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            .
+
+      - name: IaC misconfiguration scan
+        run: |
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --format sarif \
+            --output trivy-config.sarif \
+            .
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            .
+
+      - name: Upload SARIF artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-pr-sarif
+          path: |
+            trivy-fs.sarif
+            trivy-config.sarif

--- a/.github/workflows/repository-vex-scheduled.yaml
+++ b/.github/workflows/repository-vex-scheduled.yaml
@@ -1,0 +1,87 @@
+name: Repository VEX Scheduled Scan
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/repository-vex-scheduled.yaml'
+      - 'examples/workflows/**'
+      - 'contrib/install.sh'
+      - 'contrib/workflows/**'
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        description: Git URL to scan
+        required: true
+        default: https://github.com/aquasecurity/trivy
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-vex-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-scan:
+    runs-on: ubuntu-2404-2core
+    env:
+      REPOSITORY_URL_RAW: ${{ github.event.inputs.repository_url || 'https://github.com/aquasecurity/trivy' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Trivy from repo script
+        run: |
+          set -euo pipefail
+          ./contrib/install.sh -b /usr/local/bin
+          trivy --version
+
+      - name: Validate repository URL input
+        env:
+          REPOSITORY_URL_RAW: ${{ github.event.inputs.repository_url || 'https://github.com/aquasecurity/trivy' }}
+        run: |
+          set -euo pipefail
+          REPOSITORY_URL=$(printf '%s' "$REPOSITORY_URL_RAW" | tr -d '\r')
+          if ! printf '%s' "$REPOSITORY_URL" | grep -Eq '^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/?$'; then
+            echo 'Invalid repository_url input; expected https://github.com/<owner>/<repo>' >&2
+            exit 1
+          fi
+          printf 'REPOSITORY_URL=%s\n' "$REPOSITORY_URL" >> "$GITHUB_ENV"
+
+      - name: Scheduled repository scan with VEX context
+        run: |
+          trivy repo \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,misconfig,secret,license \
+            --severity HIGH,CRITICAL \
+            --vex repo \
+            --format json \
+            --output trivy-repo.json \
+            "$REPOSITORY_URL"
+          trivy convert \
+            --format sarif \
+            --output trivy-repo.sarif \
+            trivy-repo.json
+          trivy repo \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,misconfig,secret,license \
+            --severity HIGH,CRITICAL \
+            --vex repo \
+            --exit-code 1 \
+            "$REPOSITORY_URL"
+
+      - name: Upload scheduled repository artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-repository-artifacts
+          path: |
+            trivy-repo.json
+            trivy-repo.sarif

--- a/.github/workflows/sbom-audit.yaml
+++ b/.github/workflows/sbom-audit.yaml
@@ -1,0 +1,86 @@
+name: SBOM Audit
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/sbom-audit.yaml'
+      - 'examples/workflows/**'
+      - 'contrib/install.sh'
+      - 'contrib/workflows/**'
+  workflow_dispatch:
+    inputs:
+      sbom_path:
+        description: Path to a CycloneDX or SPDX SBOM checked into the repository
+        required: true
+        default: sbom.cdx.json
+  schedule:
+    - cron: '43 2 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom-audit:
+    runs-on: ubuntu-2404-2core
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Trivy from repo script
+        run: |
+          set -euo pipefail
+          ./contrib/install.sh -b /usr/local/bin
+          trivy --version
+
+      - name: Validate SBOM path input
+        env:
+          SBOM_PATH_RAW: ${{ github.event.inputs.sbom_path || 'sbom.cdx.json' }}
+        run: |
+          set -euo pipefail
+          SBOM_PATH=$(printf '%s' "$SBOM_PATH_RAW" | tr -d '\r')
+          if ! printf '%s' "$SBOM_PATH" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo 'Invalid sbom_path input' >&2
+            exit 1
+          fi
+          case "$SBOM_PATH" in
+            /*|../*|*/../*|*".."*)
+              echo 'sbom_path must stay within the repository workspace' >&2
+              exit 1
+              ;;
+          esac
+          printf 'SBOM_PATH=%s\n' "$SBOM_PATH" >> "$GITHUB_ENV"
+
+      - name: Scan SBOM for vulnerabilities and licenses
+        run: |
+          test -f "$SBOM_PATH"
+          trivy sbom \
+            --scanners vuln,license \
+            --severity HIGH,CRITICAL \
+            --format json \
+            --output trivy-sbom.json \
+            "$SBOM_PATH"
+          trivy convert \
+            --format sarif \
+            --output trivy-sbom.sarif \
+            trivy-sbom.json
+          trivy sbom \
+            --scanners vuln,license \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "$SBOM_PATH"
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-sbom-artifacts
+          path: |
+            trivy-sbom.json
+            trivy-sbom.sarif

--- a/contrib/workflows/README.md
+++ b/contrib/workflows/README.md
@@ -1,0 +1,21 @@
+# Trivy workflow examples for GitLab CI
+
+This directory complements `examples/workflows` by showing how the same scanning lanes can be wired into GitLab CI.
+
+Included jobs in `Trivy.gitlab-ci.workflows.yml`:
+
+- `trivy_fs_and_secret`: local repository / filesystem dependency and secret scanning
+- `trivy_iac`: misconfiguration and IaC scanning
+- `trivy_image_release`: release-image scanning using `$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA`
+- `trivy_repo_vex`: scheduled or manual repository rescans with `--vex repo`
+- `trivy_sbom`: SBOM rescanning from `sbom.cdx.json`
+- `trivy_k8s`: Kubernetes cluster scanning from `$KUBECONFIG_CONTENT`
+
+Usage:
+
+```yaml
+include:
+  - local: contrib/workflows/Trivy.gitlab-ci.workflows.yml
+```
+
+Then set any required CI variables for image registry auth or kubeconfig content in your GitLab project settings.

--- a/contrib/workflows/Trivy.gitlab-ci.workflows.yml
+++ b/contrib/workflows/Trivy.gitlab-ci.workflows.yml
@@ -1,0 +1,76 @@
+stages:
+  - test
+  - audit
+
+variables:
+  TRIVY_CACHE_DIR: .trivycache/
+  TRIVY_NO_PROGRESS: "true"
+
+default:
+  image: alpine:3.22
+  before_script:
+    - apk add --no-cache curl bash docker-cli
+    - ./contrib/install.sh -b /usr/local/bin
+    - trivy --version
+  cache:
+    paths:
+      - .trivycache/
+
+trivy_fs_and_secret:
+  stage: test
+  script:
+    - trivy fs --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 .
+
+trivy_iac:
+  stage: test
+  script:
+    - trivy config --severity HIGH,CRITICAL --exit-code 1 .
+
+trivy_image_release:
+  stage: audit
+  variables:
+    IMAGE_REF: "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA"
+  script:
+    - trivy image --severity HIGH,CRITICAL --ignore-unfixed --format json --output trivy-image.json "$IMAGE_REF"
+    - trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 "$IMAGE_REF"
+  artifacts:
+    paths:
+      - trivy-image.json
+
+trivy_repo_vex:
+  stage: audit
+  variables:
+    REPOSITORY_URL: "$CI_PROJECT_URL"
+  script:
+    - trivy repo --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,misconfig,secret,license --severity HIGH,CRITICAL --vex repo --format json --output trivy-repo.json "$REPOSITORY_URL"
+    - trivy convert --format sarif --output trivy-repo.sarif trivy-repo.json
+    - trivy repo --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,misconfig,secret,license --severity HIGH,CRITICAL --vex repo --exit-code 1 "$REPOSITORY_URL"
+  artifacts:
+    paths:
+      - trivy-repo.json
+      - trivy-repo.sarif
+
+trivy_sbom:
+  stage: audit
+  script:
+    - test -f sbom.cdx.json
+    - trivy sbom --scanners vuln,license --severity HIGH,CRITICAL --format json --output trivy-sbom.json sbom.cdx.json
+    - trivy convert --format sarif --output trivy-sbom.sarif trivy-sbom.json
+    - trivy sbom --scanners vuln,license --severity HIGH,CRITICAL --exit-code 1 sbom.cdx.json
+  artifacts:
+    paths:
+      - trivy-sbom.json
+      - trivy-sbom.sarif
+
+trivy_k8s:
+  stage: audit
+  script:
+    - test -n "$KUBECONFIG_CONTENT"
+    - install -d -m 700 ~/.kube
+    - printf '%s' "$KUBECONFIG_CONTENT" > ~/.kube/config
+    - chmod 600 ~/.kube/config
+    - trivy k8s --kubeconfig ~/.kube/config --report summary --severity HIGH,CRITICAL --format json --output trivy-k8s.json cluster
+    - trivy k8s --kubeconfig ~/.kube/config --report summary --severity HIGH,CRITICAL --exit-code 1 cluster
+  artifacts:
+    paths:
+      - trivy-k8s.json

--- a/docs/tutorials/integrations/workflow-examples.md
+++ b/docs/tutorials/integrations/workflow-examples.md
@@ -1,0 +1,113 @@
+# Workflow examples
+
+This page collects concrete, copy-pasteable workflow examples for common Trivy operating modes. The files live under [`examples/workflows`](../../../examples/workflows), [`contrib/workflows`](../../../contrib/workflows), and selected live workflows under [`.github/workflows`](../../../.github/workflows) in this repository.
+
+## Included examples
+
+### Shared local files
+
+- [`examples/workflows/trivy.yaml`](../../../examples/workflows/trivy.yaml): shared baseline config for filesystem and repository scans.
+- [`examples/workflows/.trivyignore`](../../../examples/workflows/.trivyignore): example ignore file for findings your team has explicitly accepted.
+- [`examples/workflows/.pre-commit-config.yaml`](../../../examples/workflows/.pre-commit-config.yaml): local developer workflow using `trivy fs` and `trivy config` before code reaches CI.
+
+### GitHub Actions examples
+
+- [`examples/workflows/github-actions/repo-and-iac-pr.yml`](../../../examples/workflows/github-actions/repo-and-iac-pr.yml): reusable PR workflow example for dependency, secret, and IaC scanning.
+- [`examples/workflows/github-actions/image-release.yml`](../../../examples/workflows/github-actions/image-release.yml): reusable release-image gate with JSON and CycloneDX outputs.
+- [`examples/workflows/github-actions/repository-vex-scheduled.yml`](../../../examples/workflows/github-actions/repository-vex-scheduled.yml): reusable scheduled repository scan with `--vex repo` and SARIF conversion.
+- [`examples/workflows/github-actions/sbom-audit.yml`](../../../examples/workflows/github-actions/sbom-audit.yml): reusable SBOM rescanning workflow for existing CycloneDX or SPDX inventories.
+- [`examples/workflows/github-actions/kubernetes-cluster.yml`](../../../examples/workflows/github-actions/kubernetes-cluster.yml): reusable scheduled or on-demand Kubernetes cluster scan.
+
+### Live GitHub workflows added in this repository
+
+- [`.github/workflows/repo-and-iac-pr.yaml`](../../../.github/workflows/repo-and-iac-pr.yaml): active PR and manual scan workflow for this repository.
+- [`.github/workflows/image-release.yaml`](../../../.github/workflows/image-release.yaml): active scheduled/manual image scan against `ghcr.io/aquasecurity/trivy:latest` by default.
+- [`.github/workflows/repository-vex-scheduled.yaml`](../../../.github/workflows/repository-vex-scheduled.yaml): active scheduled/manual repository rescan with VEX enabled.
+- [`.github/workflows/sbom-audit.yaml`](../../../.github/workflows/sbom-audit.yaml): active scheduled/manual SBOM rescan workflow.
+- [`.github/workflows/kubernetes-cluster.yaml`](../../../.github/workflows/kubernetes-cluster.yaml): active scheduled/manual Kubernetes cluster workflow.
+
+### GitLab CI examples
+
+- [`contrib/workflows/Trivy.gitlab-ci.workflows.yml`](../../../contrib/workflows/Trivy.gitlab-ci.workflows.yml): GitLab CI bundle covering filesystem, IaC, image, repository+VEX, SBOM, and Kubernetes jobs.
+- [`contrib/workflows/README.md`](../../../contrib/workflows/README.md): quick usage notes for the GitLab workflow bundle.
+
+## Mapping from workflow to Trivy commands
+
+### Local developer checks
+
+Use `.pre-commit-config.yaml` when you want developers to catch obvious dependency, secret, and IaC issues before opening a pull request.
+
+Core commands:
+
+```bash
+trivy fs --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,secret .
+trivy config --severity HIGH,CRITICAL --exit-code 1 .
+```
+
+### Pull request repository and IaC scanning
+
+Use `repo-and-iac-pr.yml` or `.github/workflows/repo-and-iac-pr.yaml` when you want a fast PR gate that checks the working tree directly.
+
+Core commands:
+
+```bash
+trivy fs --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,secret --format sarif --output trivy-fs.sarif .
+trivy config --severity HIGH,CRITICAL --format sarif --output trivy-config.sarif .
+```
+
+### Release image scanning
+
+Use `image-release.yml`, `.github/workflows/image-release.yaml`, or the GitLab `trivy_image_release` job after building and publishing an image.
+
+Core commands:
+
+```bash
+trivy image --severity HIGH,CRITICAL --ignore-unfixed --format json --output trivy-image.json "$IMAGE_REF"
+trivy image --severity HIGH,CRITICAL --ignore-unfixed --format cyclonedx --output trivy-image.cdx.json "$IMAGE_REF"
+```
+
+### Scheduled repository scanning with VEX
+
+Use `repository-vex-scheduled.yml`, `.github/workflows/repository-vex-scheduled.yaml`, or the GitLab `trivy_repo_vex` job for nightly or daily rescans of a Git URL.
+
+Core commands:
+
+```bash
+trivy repo --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,misconfig,secret,license --severity HIGH,CRITICAL --vex repo --format json --output trivy-repo.json "$REPOSITORY_URL"
+trivy convert --format sarif --output trivy-repo.sarif trivy-repo.json
+```
+
+### SBOM rescanning
+
+Use `sbom-audit.yml`, `.github/workflows/sbom-audit.yaml`, or the GitLab `trivy_sbom` job when another stage already produced a CycloneDX or SPDX SBOM.
+
+Core commands:
+
+```bash
+trivy sbom --scanners vuln,license --severity HIGH,CRITICAL --format json --output trivy-sbom.json "$SBOM_PATH"
+trivy convert --format sarif --output trivy-sbom.sarif trivy-sbom.json
+```
+
+### Kubernetes cluster checks
+
+Use `kubernetes-cluster.yml`, `.github/workflows/kubernetes-cluster.yaml`, or the GitLab `trivy_k8s` job for scheduled cluster posture or workload checks.
+
+Core commands:
+
+```bash
+trivy k8s --kubeconfig ~/.kube/config --report summary --severity HIGH,CRITICAL --format json --output trivy-k8s.json cluster
+trivy k8s --kubeconfig ~/.kube/config --report summary --severity HIGH,CRITICAL --include-namespaces "$NAMESPACE" cluster
+```
+
+## Repo-specific tightening applied here
+
+- Live GitHub workflows are pinned to immutable action SHAs to match this repository's existing workflow style.
+- Live GitHub workflows use `ubuntu-2404-2core`, matching the runner used by existing workflows in this repository.
+- Live GitHub workflows install Trivy through `./contrib/install.sh` from the checked-out repository instead of fetching a remote script path directly.
+- The default repository/image references in the live workflows point at this project (`https://github.com/aquasecurity/trivy` and `ghcr.io/aquasecurity/trivy:latest`).
+
+## Notes
+
+- The example workflows stay reusable, while the live GitHub workflows are tightened to this repository's conventions.
+- The examples upload generated artifacts rather than wiring to a specific external reporting backend.
+- Replace accepted ignores, kubeconfig secret handling, and SBOM paths with values appropriate for your environment.

--- a/examples/workflows/.pre-commit-config.yaml
+++ b/examples/workflows/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: trivy-fs
+        name: trivy filesystem scan
+        entry: bash -c 'trivy fs --config examples/workflows/trivy.yaml --ignorefile examples/workflows/.trivyignore --scanners vuln,secret .'
+        language: system
+        pass_filenames: false
+      - id: trivy-config
+        name: trivy config scan
+        entry: bash -c 'trivy config --severity HIGH,CRITICAL --exit-code 1 .'
+        language: system
+        pass_filenames: false

--- a/examples/workflows/.trivyignore
+++ b/examples/workflows/.trivyignore
@@ -1,0 +1,4 @@
+# Example ignores for workflow demos.
+# Replace these IDs with findings your team has explicitly accepted.
+CVE-2021-99999
+AVD-DS-0002

--- a/examples/workflows/github-actions/image-release.yml
+++ b/examples/workflows/github-actions/image-release.yml
@@ -1,0 +1,55 @@
+name: trivy-image-release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: OCI image reference to scan
+        required: true
+        default: ghcr.io/example-org/example-app:latest
+
+permissions:
+  contents: read
+
+jobs:
+  scan-image:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REF: ${{ github.event.inputs.image_ref || format('ghcr.io/{0}:{1}', github.repository, github.ref_name) }}
+    steps:
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+
+      - name: Scan release image and emit reports
+        run: |
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --format json \
+            --output trivy-image.json \
+            "$IMAGE_REF"
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --format cyclonedx \
+            --output trivy-image.cdx.json \
+            "$IMAGE_REF"
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            "$IMAGE_REF"
+
+      - name: Upload image scan artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-image-artifacts
+          path: |
+            trivy-image.json
+            trivy-image.cdx.json

--- a/examples/workflows/github-actions/kubernetes-cluster.yml
+++ b/examples/workflows/github-actions/kubernetes-cluster.yml
@@ -1,0 +1,64 @@
+name: trivy-kubernetes-cluster
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: Optional namespace to scope the scan
+        required: false
+        default: ''
+  schedule:
+    - cron: '11 4 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  k8s-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+
+      - name: Write kubeconfig
+        run: |
+          set -euo pipefail
+          install -d -m 700 ~/.kube
+          printf '%s' '${{ secrets.KUBECONFIG }}' > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Scan Kubernetes cluster
+        env:
+          NAMESPACE: ${{ github.event.inputs.namespace }}
+        run: |
+          namespace_args=()
+          if [ -n "$NAMESPACE" ]; then
+            namespace_args+=(--include-namespaces "$NAMESPACE")
+          fi
+          trivy k8s \
+            --kubeconfig ~/.kube/config \
+            --report summary \
+            --severity HIGH,CRITICAL \
+            --format json \
+            --output trivy-k8s.json \
+            "${namespace_args[@]}" \
+            cluster
+          trivy k8s \
+            --kubeconfig ~/.kube/config \
+            --report summary \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "${namespace_args[@]}" \
+            cluster
+
+      - name: Upload Kubernetes scan artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-k8s-artifacts
+          path: trivy-k8s.json

--- a/examples/workflows/github-actions/repo-and-iac-pr.yml
+++ b/examples/workflows/github-actions/repo-and-iac-pr.yml
@@ -1,0 +1,59 @@
+name: trivy-repo-and-iac-pr
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+
+      - name: Filesystem scan for dependencies and secrets
+        run: |
+          trivy fs \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,secret \
+            --format sarif \
+            --output trivy-fs.sarif \
+            .
+          trivy fs \
+            --config examples/workflows/trivy.yaml \
+            --ignorefile examples/workflows/.trivyignore \
+            --scanners vuln,secret \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            .
+
+      - name: IaC misconfiguration scan
+        run: |
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --format sarif \
+            --output trivy-config.sarif \
+            .
+          trivy config \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            .
+
+      - name: Upload SARIF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-pr-sarif
+          path: |
+            trivy-fs.sarif
+            trivy-config.sarif

--- a/examples/workflows/github-actions/repository-vex-scheduled.yml
+++ b/examples/workflows/github-actions/repository-vex-scheduled.yml
@@ -1,0 +1,54 @@
+name: trivy-repository-vex-scheduled
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        description: Git URL to scan
+        required: true
+        default: https://github.com/aquasecurity/trivy
+
+permissions:
+  contents: read
+
+jobs:
+  repo-scan:
+    runs-on: ubuntu-latest
+    env:
+      REPOSITORY_URL: ${{ github.event.inputs.repository_url || format('https://github.com/{0}', github.repository) }}
+    steps:
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+
+      - name: Scheduled repository scan with VEX context
+        run: |
+          trivy repo \
+            --scanners vuln,misconfig,secret,license \
+            --severity HIGH,CRITICAL \
+            --vex repo \
+            --format json \
+            --output trivy-repo.json \
+            "$REPOSITORY_URL"
+          trivy convert \
+            --format sarif \
+            --output trivy-repo.sarif \
+            trivy-repo.json
+          trivy repo \
+            --scanners vuln,misconfig,secret,license \
+            --severity HIGH,CRITICAL \
+            --vex repo \
+            --exit-code 1 \
+            "$REPOSITORY_URL"
+
+      - name: Upload scheduled repository artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-repository-artifacts
+          path: |
+            trivy-repo.json
+            trivy-repo.sarif

--- a/examples/workflows/github-actions/sbom-audit.yml
+++ b/examples/workflows/github-actions/sbom-audit.yml
@@ -1,0 +1,56 @@
+name: trivy-sbom-audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      sbom_path:
+        description: Path to a CycloneDX or SPDX SBOM checked into the repository
+        required: true
+        default: sbom.cdx.json
+  schedule:
+    - cron: '43 2 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+          trivy --version
+
+      - name: Scan SBOM for vulnerabilities and licenses
+        env:
+          SBOM_PATH: ${{ github.event.inputs.sbom_path || 'sbom.cdx.json' }}
+        run: |
+          test -f "$SBOM_PATH"
+          trivy sbom \
+            --scanners vuln,license \
+            --severity HIGH,CRITICAL \
+            --format json \
+            --output trivy-sbom.json \
+            "$SBOM_PATH"
+          trivy convert \
+            --format sarif \
+            --output trivy-sbom.sarif \
+            trivy-sbom.json
+          trivy sbom \
+            --scanners vuln,license \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "$SBOM_PATH"
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-sbom-artifacts
+          path: |
+            trivy-sbom.json
+            trivy-sbom.sarif

--- a/examples/workflows/trivy.yaml
+++ b/examples/workflows/trivy.yaml
@@ -1,0 +1,21 @@
+timeout: 10m
+format: json
+list-all-pkgs: true
+dependency-tree: true
+severity:
+  - HIGH
+  - CRITICAL
+scan:
+  scanners:
+    - vuln
+    - misconfig
+    - secret
+    - license
+  skip-dirs:
+    - vendor
+    - node_modules
+    - .git
+vulnerability:
+  ignore-unfixed: true
+misconfiguration:
+  include-non-failures: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - CI/CD:
           - Overview: tutorials/integrations/index.md
           - GitHub Actions: tutorials/integrations/github-actions.md
+          - Workflow Examples: tutorials/integrations/workflow-examples.md
           - CircleCI: tutorials/integrations/circleci.md
           - Travis CI: tutorials/integrations/travis-ci.md
           - GitLab CI: tutorials/integrations/gitlab-ci.md


### PR DESCRIPTION
## Summary

Adds a complete Trivy workflow examples bundle across three surfaces:

- reusable example assets under `examples/workflows`
- integration docs plus a GitLab CI bundle under `docs/` and `contrib/workflows`
- live GitHub Actions workflows under `.github/workflows`

The live GitHub workflows are hardened to match existing repo conventions:

- pinned actions by SHA
- `ubuntu-2404-2core` runners
- repo-local `./contrib/install.sh` installation
- branch/path-scoped auto triggers
- explicit `workflow_dispatch` input validation before shell use
- validated values exported through `GITHUB_ENV` and consumed downstream

## Commit breakdown

1. `19c4402` `docs: add reusable workflow examples`
   - adds reusable GitHub Actions examples
   - adds shared Trivy config, ignore file, and pre-commit config

2. `ea5529b` `docs: add CI workflow integration guide`
   - adds the workflow examples guide
   - adds MkDocs nav entry
   - adds a GitLab CI workflow bundle and README

3. `5aa6d87` `ci: add hardened Trivy workflow templates`
   - adds live GitHub Actions workflow templates for repo/IaC, image, repo+VEX, SBOM, and Kubernetes scans
   - narrows auto-run triggers with branch/path filters
   - validates dispatch inputs before shell use

## Verification

Ran local verification for the changed workflow set:

- parsed all new and edited YAML with `yaml.safe_load` / PyYAML
- read back the live workflow files to confirm:
  - trigger narrowing is present
  - input validation steps exist
  - downstream steps consume the cleaned environment values rather than raw dispatch inputs
- confirmed clean split history and clean working tree after rewrite

## Notes

The workflows were not executed end-to-end in GitHub/GitLab CI from this environment, so verification here is limited to local syntax and workflow-content checks.

## Follow-ups

- If desired, push the branch and open a PR using this description.
- If maintainers want even narrower triggers, the live workflows can be further limited to only their own file plus the exact shared template/config paths they consume.
