### PR TITLE
fix(misconf): guard nil Healthcheck when building Dockerfile from history

### DIFF
--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -147,6 +147,15 @@ func buildRunInstruction(s string) string {
 }
 
 func buildHealthcheckInstruction(health *v1.HealthConfig) string {
+	// A history entry's CreatedBy can start with "HEALTHCHECK" while the
+	// resolved config carries no Healthcheck object — e.g. `HEALTHCHECK NONE`,
+	// or images built by buildah/buildkit that record a HEALTHCHECK history
+	// line without materializing cfg.Config.Healthcheck. Dereferencing the nil
+	// pointer below would crash the image-config (misconfig) scanner, so treat
+	// the absent config as the disabled form.
+	if health == nil {
+		return "HEALTHCHECK NONE"
+	}
 	var interval, timeout, startPeriod, retries, command string
 	if health.Interval != 0 {
 		interval = fmt.Sprintf("--interval=%s ", health.Interval)

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile.go
@@ -147,12 +147,8 @@ func buildRunInstruction(s string) string {
 }
 
 func buildHealthcheckInstruction(health *v1.HealthConfig) string {
-	// A history entry's CreatedBy can start with "HEALTHCHECK" while the
-	// resolved config carries no Healthcheck object — e.g. `HEALTHCHECK NONE`,
-	// or images built by buildah/buildkit that record a HEALTHCHECK history
-	// line without materializing cfg.Config.Healthcheck. Dereferencing the nil
-	// pointer below would crash the image-config (misconfig) scanner, so treat
-	// the absent config as the disabled form.
+	// Config.Healthcheck can be null even when a HEALTHCHECK history line exists
+	// if the image was re-committed by a tool that normalizes HEALTHCHECK NONE to null.
 	if health == nil {
 		return "HEALTHCHECK NONE"
 	}

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -459,6 +459,24 @@ ENTRYPOINT ["/bin/sh"]
 `,
 		},
 		{
+			// A HEALTHCHECK history line whose resolved config carries no
+			// Healthcheck object (Config.Healthcheck == nil). This happens with
+			// `HEALTHCHECK NONE` and with buildah/buildkit images that record a
+			// HEALTHCHECK history line without materializing the config object.
+			// Before the nil guard in buildHealthcheckInstruction this panicked
+			// the misconfig scanner with a nil pointer dereference.
+			name: "healthcheck history without resolved config",
+			input: &v1.ConfigFile{
+				History: []v1.History{
+					{
+						CreatedBy: "HEALTHCHECK NONE",
+					},
+				},
+				// Config.Healthcheck deliberately nil
+			},
+			expected: "HEALTHCHECK NONE\n",
+		},
+		{
 			name: "legacy env format",
 			input: &v1.ConfigFile{
 				History: []v1.History{

--- a/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
+++ b/pkg/fanal/analyzer/imgconf/dockerfile/dockerfile_test.go
@@ -459,12 +459,6 @@ ENTRYPOINT ["/bin/sh"]
 `,
 		},
 		{
-			// A HEALTHCHECK history line whose resolved config carries no
-			// Healthcheck object (Config.Healthcheck == nil). This happens with
-			// `HEALTHCHECK NONE` and with buildah/buildkit images that record a
-			// HEALTHCHECK history line without materializing the config object.
-			// Before the nil guard in buildHealthcheckInstruction this panicked
-			// the misconfig scanner with a nil pointer dereference.
 			name: "healthcheck history without resolved config",
 			input: &v1.ConfigFile{
 				History: []v1.History{
@@ -472,7 +466,6 @@ ENTRYPOINT ["/bin/sh"]
 						CreatedBy: "HEALTHCHECK NONE",
 					},
 				},
-				// Config.Healthcheck deliberately nil
 			},
 			expected: "HEALTHCHECK NONE\n",
 		},


### PR DESCRIPTION
## fix(misconf): guard nil Healthcheck when reconstructing Dockerfile from image history
  
  ### What
  `imageConfigToDockerfile()` reconstructs a Dockerfile from an image's history so the misconfig scanner can run Dockerfile checks. When a history entry's `CreatedBy` starts with `HEALTHCHECK`, it calls
  `buildHealthcheckInstruction(cfg.Config.Healthcheck)`.

  The branch is chosen from the **history line text**, but the argument comes from the **resolved config** — and these can disagree. `Config.Healthcheck` is `nil` for `HEALTHCHECK NONE` and for buildah/buildkit images that record a `HEALTHCHECK`
  history line without materializing the config object. `buildHealthcheckInstruction` dereferenced the pointer unconditionally, so such images **panic the image-config misconfig scanner** (`nil pointer dereference`) — this aborts the CLI with exit
  code 2 and crashes processes that embed Trivy as a library. We hit this on a real customer image.

  ### Fix
  Return the disabled form `HEALTHCHECK NONE` when the config is `nil` — the correct Dockerfile rendering of "no healthcheck", which parses cleanly through the misconf Dockerfile parser. One-line guard + a regression test (`healthcheck history
  without resolved config`) in `Test_ImageConfigToDockerfile`.

  ### How to reproduce
  Two conditions are both required: `--image-config-scanners misconfig` (triggers the reconstruction) and a **cold cache** (a warm cache serves a cached success and hides the panic).

  ```bash
  rm -rf /tmp/trivy-crash-cache && \
  trivy image \
    --cache-dir /tmp/trivy-crash-cache \
    --image-config-scanners misconfig \
    --scanners misconfig \
    pavelkov/trivy-nilderef:latest
   ```

  - Before: panic: nil pointer dereference at buildHealthcheckInstruction → imageConfigToDockerfile (dockerfile.go:105), exit code 2.
  - After: exits 0 and reports the Dockerfile misconfigs (DS-0002, DS-0005).

  Test image

  **docker.io/pavelkov/trivy-nilderef:latest** reproduces the customer's image shape: a real alpine layer whose config omits the Healthcheck key (→ nil) while history retains a HEALTHCHECK line. This is the nil shape produced by buildah/buildkit —
  note that docker build (BuildKit) materializes HEALTHCHECK NONE as a non-nil Healthcheck{Test:["NONE"]}, so it does not reproduce it. Verified end-to-end: unpatched upstream binary panics on this image, patched binary exits 0.

## Related issues:
- Close https://github.com/aquasecurity/trivy/issues/10909