### PR TITLE
test: close plugin manager in tests cleanup

### DIFF
--- a/pkg/plugin/index_test.go
+++ b/pkg/plugin/index_test.go
@@ -26,6 +26,7 @@ func TestManager_Update(t *testing.T) {
 
 	manager, err := plugin.NewManager(plugin.WithIndexURL(ts.URL + "/index.yaml"))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = manager.Close() })
 	err = manager.Update(t.Context(), plugin.Options{})
 	require.NoError(t, err)
 
@@ -77,6 +78,7 @@ bar                  A bar plugin                                               
 			var got bytes.Buffer
 			m, err := plugin.NewManager(plugin.WithWriter(&got))
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = m.Close() })
 			err = m.Search(t.Context(), tt.keyword)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -253,6 +253,7 @@ func TestManager_Uninstall(t *testing.T) {
 		// Uninstall the plugin
 		m, err := plugin.NewManager()
 		require.NoError(t, err)
+		t.Cleanup(func() { _ = m.Close() })
 		err = m.Uninstall(ctx, pluginName)
 		require.NoError(t, err)
 		assert.NoDirExists(t, pluginDir)
@@ -265,6 +266,7 @@ func TestManager_Uninstall(t *testing.T) {
 
 		m, err := plugin.NewManager()
 		require.NoError(t, err)
+		t.Cleanup(func() { _ = m.Close() })
 		err = m.Uninstall(ctx, pluginName)
 		require.NoError(t, err)
 		assert.Equal(t, "2021-08-25T12:20:30Z\tERROR\t[plugin] No such plugin\n", buf.String())
@@ -281,6 +283,7 @@ func TestManager_Uninstall(t *testing.T) {
 		// surfaces the error (not "No such plugin") and removes nothing.
 		m, err := plugin.NewManager()
 		require.NoError(t, err)
+		t.Cleanup(func() { _ = m.Close() })
 		err = m.Uninstall(ctx, "../secret")
 		require.Error(t, err)
 		assert.FileExists(t, sentinel)
@@ -312,6 +315,7 @@ description: A simple test plugin`
 	var got bytes.Buffer
 	manager, err := plugin.NewManager(plugin.WithWriter(&got))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = manager.Close() })
 
 	// Get Information for the plugin
 	err = manager.Information(pluginName)
@@ -365,6 +369,7 @@ func TestManager_LoadAll(t *testing.T) {
 			t.Setenv("XDG_DATA_HOME", tt.dir)
 			m, err := plugin.NewManager()
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = m.Close() })
 			got, err := m.LoadAll(t.Context())
 			require.NoError(t, err)
 			require.Len(t, got, len(tt.want))
@@ -394,6 +399,7 @@ func TestManager_Upgrade(t *testing.T) {
 	ctx := t.Context()
 	m, err := plugin.NewManager()
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Close() })
 
 	// verify initial version
 	verifyVersion(t, ctx, m, pluginName, pluginVersion)

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -226,6 +226,8 @@ func TestManager_Install(t *testing.T) {
 
 			manager, err := plugin.NewManager(plugin.WithLogger(logger))
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = manager.Close() })
+
 			got, err := manager.Install(ctx, tt.pluginName, plugin.Options{
 				Platform: ftypes.Platform{
 					Platform: &v1.Platform{


### PR DESCRIPTION
## Description

`plugin.Manager` holds an `os.Root` opened on the plugins directory, which keeps a directory handle open until `Manager.Close()` is called. Some tests never called `Close()`, so on Windows the handle stayed open and `t.TempDir()` cleanup failed with:

```bash
unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestManager_Search323454488\001\.trivy\plugins: The process cannot access the file because it is being used by another process.
```

Fixes: https://github.com/aquasecurity/trivy/actions/runs/28425653024/job/84228075703

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
