### PR TITLE
feat(seal): detect no-prefix packages by version suffix

### DIFF
--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -31,9 +31,11 @@ For details on supported scanners, features, and behavior for each base OS, refe
 
 ## Application Dependencies
 
-Seal also provides patched versions of application dependencies with their own vulnerability advisories. Trivy automatically detects Seal-patched packages based on special naming patterns specific to each ecosystem.
+Seal also provides patched versions of application dependencies with their own vulnerability advisories. Seal ships these packages under two naming schemes, and Trivy detects both.
 
-### Supported Ecosystems
+### Renamed packages
+
+Renamed packages carry an ecosystem-specific name prefix:
 
 | Ecosystem | Package Pattern | Example |
 |-----------|----------------|---------|
@@ -43,5 +45,19 @@ Seal also provides patched versions of application dependencies with their own v
 | Java (Maven) | `seal.sp*` | `seal.sp1.org.eclipse.jetty:jetty-http` |
 | Ruby (RubyGems) | `seal-*` | `seal-rack` |
 
-When Trivy detects packages matching these patterns, it automatically uses Seal Security advisories for vulnerability scanning.
+### No-prefix packages
 
+Some Seal packages keep their upstream (no-prefix) name and only add a patch-level version suffix (`+spN` / `-spN`). Trivy detects these by the version suffix:
+
+| Ecosystem | Version Suffix | Example |
+|-----------|----------------|---------|
+| Java (Maven) | `+spN` | `org.eclipse.jetty:jetty-http` `9.4.48+sp1` |
+| Python (pip) | `+spN` | `requests` `2.14.2+sp1` |
+| Node.js (npm) | `-spN` | `ejs` `3.1.8-sp1` |
+| Go | `-spN` | `golang.org/x/crypto` `0.26.0-sp1` |
+| Ruby (RubyGems) | `.spN` | `rack` `2.0.7.0.1.sp1` |
+
+For Maven and pip, the `+spN` suffix cannot collide with real package versions, so the match is authoritative.
+For npm, Go, and Ruby, the `-spN` / `.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.
+
+When Trivy detects a Seal-patched package by either scheme, it automatically uses Seal Security advisories for vulnerability scanning.

--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -43,15 +43,15 @@ For details on Seal's naming and versioning, see the Seal documentation:
 
 ### Renamed packages
 
-Renamed packages carry an ecosystem-specific name prefix. Except for Maven, the version also carries the `spN` patch-level suffix:
+Renamed packages carry an ecosystem-specific name prefix. See the [Seal documentation](https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages) for the full naming and versioning details.
 
 | Ecosystem | Package Pattern | Example |
 |-----------|----------------|---------|
-| Python (pip) | `seal-*` | `seal-requests` `2.14.2+sp1` |
-| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` `3.1.8-sp1` |
-| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` `1.1.1-sp1` |
+| Python (pip) | `seal-*` | `seal-requests` |
+| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` |
+| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` |
 | Java (Maven) | `seal.sp*` | `seal.sp1.org.eclipse.jetty:jetty-http` |
-| Ruby (RubyGems) | `seal-*` | `seal-rack` `2.0.7.0.1.sp1` |
+| Ruby (RubyGems) | `seal-*` | `seal-rack` |
 
 ### No-prefix packages
 

--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -43,15 +43,15 @@ For details on Seal's naming and versioning, see the Seal documentation:
 
 ### Renamed packages
 
-Renamed packages carry an ecosystem-specific name prefix. See the [Seal documentation](https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages) for the full naming and versioning details.
+Renamed packages carry an ecosystem-specific name prefix and, except for Maven, also carry the `spN` version suffix. See the [Seal documentation](https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages) for the full naming and versioning details.
 
 | Ecosystem | Package Pattern | Example |
 |-----------|----------------|---------|
-| Python (pip) | `seal-*` | `seal-requests` |
-| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` |
-| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` |
+| Python (pip) | `seal-*` | `seal-requests` `2.14.2+sp1` |
+| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` `3.1.8-sp1` |
+| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` `1.1.1-sp1` |
 | Java (Maven) | `seal.sp*` | `seal.sp1.org.eclipse.jetty:jetty-http` |
-| Ruby (RubyGems) | `seal-*` | `seal-rack` |
+| Ruby (RubyGems) | `seal-*` | `seal-rack` `2.0.7.0.1.sp1` |
 
 ### No-prefix packages
 

--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -57,6 +57,8 @@ Some Seal packages keep their upstream (no-prefix) name and only add a patch-lev
 | Go | `-spN` | `golang.org/x/crypto` `0.26.0-sp1` |
 | Ruby (RubyGems) | `.spN` | `rack` `2.0.7.0.1.sp1` |
 
+Both public (`spN`) and private (`spNpM`) sealed versions are recognized. A private version carries an extra `pM` iteration on top of the sealed version, for example `ejs` `3.1.8-sp2p1`.
+
 For Maven and pip, the `+spN` suffix cannot collide with real package versions, so the match is authoritative.
 For npm, Go, and Ruby, the `-spN` / `.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.
 

--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -31,7 +31,7 @@ For details on supported scanners, features, and behavior for each base OS, refe
 
 ## Application Dependencies
 
-Seal also provides patched versions of application dependencies with their own vulnerability advisories. Seal ships these packages under two naming schemes, and Trivy detects both. When Trivy detects a Seal-patched package by either scheme, it automatically uses Seal Security advisories for vulnerability scanning.
+Seal also provides patched versions of application dependencies, shipped under two naming schemes: [renamed](#renamed-packages) and [no-prefix](#no-prefix-packages). Trivy detects both and uses Seal Security's own advisories for vulnerability scanning instead of the upstream ones.
 
 Both public (`spN`) and private (`spNpM`) sealed versions are recognized. A private version carries an extra `pM` iteration on top of the sealed version, for example `ejs` `3.1.8-sp2p1`.
 
@@ -65,5 +65,6 @@ Some Seal packages keep their upstream (no-prefix) name and only add a patch-lev
 | Go | `-spN` | `golang.org/x/crypto` `0.26.0-sp1` |
 | Ruby (RubyGems) | `.0.1.spN` | `rack` `2.0.7.0.1.sp1` |
 
-For Maven and pip, the `+spN` suffix cannot collide with real package versions, so the match is authoritative.
-For npm, Go, and Ruby, the `-spN` / `.0.1.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.
+!!! note
+    For Maven and pip, the `+spN` suffix cannot collide with real package versions, so the match is authoritative.
+    For npm, Go, and Ruby, the `-spN` / `.0.1.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.

--- a/docs/guide/coverage/others/seal.md
+++ b/docs/guide/coverage/others/seal.md
@@ -31,23 +31,31 @@ For details on supported scanners, features, and behavior for each base OS, refe
 
 ## Application Dependencies
 
-Seal also provides patched versions of application dependencies with their own vulnerability advisories. Seal ships these packages under two naming schemes, and Trivy detects both.
+Seal also provides patched versions of application dependencies with their own vulnerability advisories. Seal ships these packages under two naming schemes, and Trivy detects both. When Trivy detects a Seal-patched package by either scheme, it automatically uses Seal Security advisories for vulnerability scanning.
+
+Both public (`spN`) and private (`spNpM`) sealed versions are recognized. A private version carries an extra `pM` iteration on top of the sealed version, for example `ejs` `3.1.8-sp2p1`.
+
+For details on Seal's naming and versioning, see the Seal documentation:
+
+- [The `-sp[N]` model](https://docs.sealsecurity.io/reference/naming-and-versioning/sp-model)
+- [Per-ecosystem nuances](https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem)
+- [Renamed packages](https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages)
 
 ### Renamed packages
 
-Renamed packages carry an ecosystem-specific name prefix:
+Renamed packages carry an ecosystem-specific name prefix. Except for Maven, the version also carries the `spN` patch-level suffix:
 
 | Ecosystem | Package Pattern | Example |
 |-----------|----------------|---------|
-| Python (pip) | `seal-*` | `seal-requests` |
-| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` |
-| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` |
+| Python (pip) | `seal-*` | `seal-requests` `2.14.2+sp1` |
+| Node.js (npm) | `@seal-security/*` | `@seal-security/ejs` `3.1.8-sp1` |
+| Go | `sealsecurity.io/*` | `sealsecurity.io/github.com/Masterminds/goutils` `1.1.1-sp1` |
 | Java (Maven) | `seal.sp*` | `seal.sp1.org.eclipse.jetty:jetty-http` |
-| Ruby (RubyGems) | `seal-*` | `seal-rack` |
+| Ruby (RubyGems) | `seal-*` | `seal-rack` `2.0.7.0.1.sp1` |
 
 ### No-prefix packages
 
-Some Seal packages keep their upstream (no-prefix) name and only add a patch-level version suffix (`+spN` / `-spN`). Trivy detects these by the version suffix:
+Some Seal packages keep their upstream (no-prefix) name and only add a patch-level version suffix. Trivy detects these by the version suffix:
 
 | Ecosystem | Version Suffix | Example |
 |-----------|----------------|---------|
@@ -55,11 +63,7 @@ Some Seal packages keep their upstream (no-prefix) name and only add a patch-lev
 | Python (pip) | `+spN` | `requests` `2.14.2+sp1` |
 | Node.js (npm) | `-spN` | `ejs` `3.1.8-sp1` |
 | Go | `-spN` | `golang.org/x/crypto` `0.26.0-sp1` |
-| Ruby (RubyGems) | `.spN` | `rack` `2.0.7.0.1.sp1` |
-
-Both public (`spN`) and private (`spNpM`) sealed versions are recognized. A private version carries an extra `pM` iteration on top of the sealed version, for example `ejs` `3.1.8-sp2p1`.
+| Ruby (RubyGems) | `.0.1.spN` | `rack` `2.0.7.0.1.sp1` |
 
 For Maven and pip, the `+spN` suffix cannot collide with real package versions, so the match is authoritative.
-For npm, Go, and Ruby, the `-spN` / `.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.
-
-When Trivy detects a Seal-patched package by either scheme, it automatically uses Seal Security advisories for vulnerability scanning.
+For npm, Go, and Ruby, the `-spN` / `.0.1.spN` suffix can also appear on real packages, so Trivy confirms the match by looking the package up in the Seal advisory database; if the package is not found there, it falls back to the standard ecosystem advisories.

--- a/pkg/detector/library/driver.go
+++ b/pkg/detector/library/driver.go
@@ -115,17 +115,9 @@ func (d *Driver) Type() string {
 func (d *Driver) DetectVulnerabilities(pkgID, pkgName, pkgVer string) ([]types.DetectedVulnerability, error) {
 	normalizedName := vulnerability.NormalizePkgName(d.ecosystem, pkgName)
 
-	// Resolve advisory prefix and comparer based on package info.
-	// For vendor packages (e.g. Seal Security), uses a vendor-specific prefix and comparer.
-	prefix := defaultBucketPrefix(d.ecosystem)
-	comparer := d.comparer
-	if v, ok := lookupVendor(d.ecosystem, normalizedName, pkgVer); ok {
-		prefix = v.BucketPrefix(d.ecosystem)
-		comparer = v.Comparer(d.ecosystem, d.comparer)
-	}
-	advisories, err := d.dbc.GetAdvisories(prefix, normalizedName)
+	advisories, comparer, err := d.advisories(normalizedName, pkgVer)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get %s advisories: %w", d.ecosystem, err)
+		return nil, err
 	}
 
 	var vulns []types.DetectedVulnerability
@@ -148,6 +140,33 @@ func (d *Driver) DetectVulnerabilities(pkgID, pkgName, pkgVer string) ([]types.D
 	}
 
 	return vulns, nil
+}
+
+// advisories resolves the advisory bucket for the package and returns the
+// matching advisories together with the version comparer to use.
+//
+// For vendor packages (e.g. Seal Security), it prefers the vendor-specific
+// bucket and comparer. When the vendor match is only a candidate (a version
+// suffix that can also appear on real packages, e.g. `-spN` on Go/npm), the
+// vendor bucket is used only if it actually contains advisories for the
+// package; otherwise it falls back to the default ecosystem bucket.
+func (d *Driver) advisories(normalizedName, pkgVer string) ([]dbTypes.Advisory, compare.Comparer, error) {
+	if v, res := lookupVendor(d.ecosystem, normalizedName, pkgVer); res != NoMatch {
+		advisories, err := d.dbc.GetAdvisories(v.BucketPrefix(d.ecosystem), normalizedName)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("failed to get %s advisories: %w", d.ecosystem, err)
+		}
+		if res == Matched || len(advisories) > 0 {
+			return advisories, v.Comparer(d.ecosystem, d.comparer), nil
+		}
+		// Candidate match without vendor advisories: fall back to the default bucket.
+	}
+
+	advisories, err := d.dbc.GetAdvisories(defaultBucketPrefix(d.ecosystem), normalizedName)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to get %s advisories: %w", d.ecosystem, err)
+	}
+	return advisories, d.comparer, nil
 }
 
 func createFixedVersions(advisory dbTypes.Advisory) string {

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -367,7 +367,9 @@ func TestDriver_Detect(t *testing.T) {
 			},
 		},
 		{
-			// No-prefix name (no seal- prefix) detected by the "+spN" version suffix.
+			// No-prefix name (no seal- prefix) detected by the "+spN" version
+			// suffix. Also exercises the pip AllowLocalSpecifier comparer on the
+			// Matched-by-suffix path.
 			name: "seal security pip no-prefix package",
 			fixtures: []string{
 				"testdata/fixtures/seal.yaml",
@@ -393,33 +395,7 @@ func TestDriver_Detect(t *testing.T) {
 			},
 		},
 		{
-			// No-prefix name detected by the "+spN" version suffix.
-			name: "seal security maven no-prefix package",
-			fixtures: []string{
-				"testdata/fixtures/seal.yaml",
-				"testdata/fixtures/data-source.yaml",
-			},
-			libType: ftypes.Pom,
-			args: args{
-				pkgName: "org.apache.logging.log4j:log4j-core",
-				pkgVer:  "2.13.3+sp1",
-			},
-			want: []types.DetectedVulnerability{
-				{
-					VulnerabilityID:  "CVE-2025-68161",
-					PkgName:          "org.apache.logging.log4j:log4j-core",
-					InstalledVersion: "2.13.3+sp1",
-					FixedVersion:     "2.13.3+sp999",
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.Seal,
-						Name: "Seal Security Database",
-						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
-					},
-				},
-			},
-		},
-		{
-			// No-prefix npm candidate ("-spN") confirmed against the seal bucket.
+			// No-prefix candidate ("-spN") confirmed against the seal bucket.
 			name: "seal security npm no-prefix package",
 			fixtures: []string{
 				"testdata/fixtures/seal.yaml",
@@ -436,58 +412,6 @@ func TestDriver_Detect(t *testing.T) {
 					PkgName:          "ejs",
 					InstalledVersion: "3.1.8-sp1",
 					FixedVersion:     "3.1.8-sp999",
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.Seal,
-						Name: "Seal Security Database",
-						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
-					},
-				},
-			},
-		},
-		{
-			// No-prefix Go candidate ("-spN") confirmed against the seal bucket.
-			name: "seal security go no-prefix package",
-			fixtures: []string{
-				"testdata/fixtures/seal.yaml",
-				"testdata/fixtures/data-source.yaml",
-			},
-			libType: ftypes.GoModule,
-			args: args{
-				pkgName: "golang.org/x/crypto",
-				pkgVer:  "0.26.0-sp1",
-			},
-			want: []types.DetectedVulnerability{
-				{
-					VulnerabilityID:  "CVE-2025-22869",
-					PkgName:          "golang.org/x/crypto",
-					InstalledVersion: "0.26.0-sp1",
-					FixedVersion:     "0.26.0-sp2",
-					DataSource: &dbTypes.DataSource{
-						ID:   vulnerability.Seal,
-						Name: "Seal Security Database",
-						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
-					},
-				},
-			},
-		},
-		{
-			// No-prefix RubyGems candidate (".spN") confirmed against the seal bucket.
-			name: "seal security rubygems no-prefix package",
-			fixtures: []string{
-				"testdata/fixtures/seal.yaml",
-				"testdata/fixtures/data-source.yaml",
-			},
-			libType: ftypes.Bundler,
-			args: args{
-				pkgName: "rack",
-				pkgVer:  "2.0.7.0.1.sp1",
-			},
-			want: []types.DetectedVulnerability{
-				{
-					VulnerabilityID:  "CVE-2025-61780",
-					PkgName:          "rack",
-					InstalledVersion: "2.0.7.0.1.sp1",
-					FixedVersion:     "2.0.7.0.1.sp999",
 					DataSource: &dbTypes.DataSource{
 						ID:   vulnerability.Seal,
 						Name: "Seal Security Database",

--- a/pkg/detector/library/driver_test.go
+++ b/pkg/detector/library/driver_test.go
@@ -366,6 +366,168 @@ func TestDriver_Detect(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No-prefix name (no seal- prefix) detected by the "+spN" version suffix.
+			name: "seal security pip no-prefix package",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.PythonPkg,
+			args: args{
+				pkgName: "django",
+				pkgVer:  "4.2.8+sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2023-36053",
+					PkgName:          "django",
+					InstalledVersion: "4.2.8+sp1",
+					FixedVersion:     "4.2.8+sp999",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Seal,
+						Name: "Seal Security Database",
+						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			// No-prefix name detected by the "+spN" version suffix.
+			name: "seal security maven no-prefix package",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.Pom,
+			args: args{
+				pkgName: "org.apache.logging.log4j:log4j-core",
+				pkgVer:  "2.13.3+sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2025-68161",
+					PkgName:          "org.apache.logging.log4j:log4j-core",
+					InstalledVersion: "2.13.3+sp1",
+					FixedVersion:     "2.13.3+sp999",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Seal,
+						Name: "Seal Security Database",
+						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			// No-prefix npm candidate ("-spN") confirmed against the seal bucket.
+			name: "seal security npm no-prefix package",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.Npm,
+			args: args{
+				pkgName: "ejs",
+				pkgVer:  "3.1.8-sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2024-33883",
+					PkgName:          "ejs",
+					InstalledVersion: "3.1.8-sp1",
+					FixedVersion:     "3.1.8-sp999",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Seal,
+						Name: "Seal Security Database",
+						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			// No-prefix Go candidate ("-spN") confirmed against the seal bucket.
+			name: "seal security go no-prefix package",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.GoModule,
+			args: args{
+				pkgName: "golang.org/x/crypto",
+				pkgVer:  "0.26.0-sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2025-22869",
+					PkgName:          "golang.org/x/crypto",
+					InstalledVersion: "0.26.0-sp1",
+					FixedVersion:     "0.26.0-sp2",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Seal,
+						Name: "Seal Security Database",
+						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			// No-prefix RubyGems candidate (".spN") confirmed against the seal bucket.
+			name: "seal security rubygems no-prefix package",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.Bundler,
+			args: args{
+				pkgName: "rack",
+				pkgVer:  "2.0.7.0.1.sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID:  "CVE-2025-61780",
+					PkgName:          "rack",
+					InstalledVersion: "2.0.7.0.1.sp1",
+					FixedVersion:     "2.0.7.0.1.sp999",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.Seal,
+						Name: "Seal Security Database",
+						URL:  "http://vulnfeed.sealsecurity.io/v1/osv/renamed/vulnerabilities.zip",
+					},
+				},
+			},
+		},
+		{
+			// A "-spN" Go package that is NOT in the seal bucket falls back to the
+			// default ecosystem bucket (e.g. a real package that happens to use the
+			// same suffix). Confirms the candidate fallback behavior.
+			name: "go package with sp suffix falls back to default bucket",
+			fixtures: []string{
+				"testdata/fixtures/seal.yaml",
+				"testdata/fixtures/go.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			libType: ftypes.GoModule,
+			args: args{
+				pkgName: "github.com/Masterminds/vcs",
+				pkgVer:  "v1.13.1-sp1",
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2022-21235",
+					VendorIDs: []string{
+						"GHSA-6635-c626-vj4r",
+					},
+					PkgName:          "github.com/Masterminds/vcs",
+					InstalledVersion: "v1.13.1-sp1",
+					FixedVersion:     "v1.13.2",
+					DataSource: &dbTypes.DataSource{
+						ID:   vulnerability.GLAD,
+						Name: "GitLab Advisory Database Community",
+						URL:  "https://gitlab.com/gitlab-org/advisories-community",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detector/library/seal/seal.go
+++ b/pkg/detector/library/seal/seal.go
@@ -2,6 +2,7 @@ package seal
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -11,6 +12,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
 )
 
+// sealVersionSuffix matches the Seal Security patch-level version suffix, i.e.
+// "sp" followed by a number preceded by a separator (e.g. "+sp1" on Maven/PyPI,
+// "-sp1" on npm/Go). Seal appends this suffix to the upstream package version.
+var sealVersionSuffix = regexp.MustCompile(`[-.+]sp\d+$`)
+
 func init() {
 	library.RegisterVendor(sealSecurity{
 		pipComparer: pep440.NewComparer(pep440.AllowLocalSpecifier()),
@@ -19,13 +25,22 @@ func init() {
 
 // sealSecurity matches packages patched by Seal Security.
 // Seal Security provides patched versions of open source packages with their own
-// vulnerability advisories. Their packages are identified by ecosystem-specific
-// naming patterns:
+// vulnerability advisories. Seal ships packages under two naming schemes:
+//
+// Renamed packages carry an ecosystem-specific name prefix:
 //   - Maven:   seal.sp*.$groupId:$artifactId (e.g. seal.sp1, seal.sp2)
 //   - npm:     @seal-security/$name
 //   - Python:  seal-$name
 //   - Go:      sealsecurity.io/$name
 //   - Ruby:    seal-$name
+//
+// No-prefix packages keep the upstream name and only add a version suffix
+// (e.g. "+sp1"/"-sp1"/".sp1"). They are detected by that suffix:
+//   - Maven/PyPI: the "+spN" suffix cannot collide with real versions, so a
+//     suffix match is authoritative (Matched).
+//   - Go/npm/Ruby: the "-spN"/".spN" suffix can also appear on real packages,
+//     so a suffix match is only a Candidate, confirmed against the Seal
+//     advisory bucket (see library.Driver.advisories).
 //
 // See also: pkg/detector/ospkg/seal/ for the OS package equivalent.
 type sealSecurity struct {
@@ -38,23 +53,65 @@ func (sealSecurity) Name() string {
 
 // Match determines whether a package is provided by Seal Security.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
-func (sealSecurity) Match(eco ecosystem.Type, pkgName, _ string) bool {
+func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.MatchResult {
 	switch eco {
 	case ecosystem.Maven:
-		// e.g. seal.sp1.org.eclipse.jetty:jetty-http
-		rest, ok := strings.CutPrefix(pkgName, "seal.sp")
-		return ok && rest != "" && unicode.IsDigit(rune(rest[0]))
+		// Renamed: e.g. seal.sp1.org.eclipse.jetty:jetty-http
+		if rest, ok := strings.CutPrefix(pkgName, "seal.sp"); ok && rest != "" && unicode.IsDigit(rune(rest[0])) {
+			return library.Matched
+		}
+		// No-prefix: the "+spN" version suffix cannot collide with real Maven versions.
+		if hasSealVersionSuffix(pkgVer) {
+			return library.Matched
+		}
 	case ecosystem.Npm:
-		// e.g. @seal-security/ejs
-		return strings.HasPrefix(pkgName, "@seal-security/")
-	case ecosystem.Pip, ecosystem.RubyGems:
-		// e.g. seal-django (pip), seal-rack (rubygems)
-		return strings.HasPrefix(pkgName, "seal-")
+		// Renamed: e.g. @seal-security/ejs
+		if strings.HasPrefix(pkgName, "@seal-security/") {
+			return library.Matched
+		}
+		// No-prefix: the "-spN" version suffix can also appear on real npm
+		// packages, so confirm it against the Seal advisory bucket.
+		if hasSealVersionSuffix(pkgVer) {
+			return library.Candidate
+		}
+	case ecosystem.Pip:
+		// Renamed: e.g. seal-django
+		if strings.HasPrefix(pkgName, "seal-") {
+			return library.Matched
+		}
+		// No-prefix: the "+spN" version suffix cannot collide with real PyPI versions.
+		if hasSealVersionSuffix(pkgVer) {
+			return library.Matched
+		}
 	case ecosystem.Go:
-		// e.g. sealsecurity.io/github.com/Masterminds/goutils
-		return strings.HasPrefix(pkgName, "sealsecurity.io/")
+		// Renamed: e.g. sealsecurity.io/github.com/Masterminds/goutils
+		if strings.HasPrefix(pkgName, "sealsecurity.io/") {
+			return library.Matched
+		}
+		// No-prefix: the "-spN" version suffix can also appear on real Go
+		// modules, so confirm it against the Seal advisory bucket.
+		if hasSealVersionSuffix(pkgVer) {
+			return library.Candidate
+		}
+	case ecosystem.RubyGems:
+		// Renamed: e.g. seal-rack
+		if strings.HasPrefix(pkgName, "seal-") {
+			return library.Matched
+		}
+		// No-prefix: the ".spN" version suffix (e.g. 2.0.7.0.1.sp1) can also
+		// appear on real gems as a prerelease segment, so confirm it against
+		// the Seal advisory bucket.
+		if hasSealVersionSuffix(pkgVer) {
+			return library.Candidate
+		}
 	}
-	return false
+	return library.NoMatch
+}
+
+// hasSealVersionSuffix reports whether the version carries a Seal Security
+// patch-level suffix (e.g. "+sp1", "-sp1").
+func hasSealVersionSuffix(pkgVer string) bool {
+	return sealVersionSuffix.MatchString(pkgVer)
 }
 
 // BucketPrefix returns the vendor-specific advisory bucket prefix.

--- a/pkg/detector/library/seal/seal.go
+++ b/pkg/detector/library/seal/seal.go
@@ -15,20 +15,27 @@ import (
 // Seal Security appends an ecosystem-specific patch-level suffix to the upstream
 // version of a no-prefix package. Each ecosystem uses its own separator, so the
 // suffix is matched per ecosystem rather than with a single shared pattern.
-// See https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
+//
+// Both public ("spN") and private ("spNpM") sealed versions are matched: a
+// private version carries an extra "pM" iteration on top of the sealed version
+// (e.g. "2.7.4-sp2p1"). See
+// https://docs.sealsecurity.io/reference/naming-and-versioning/sp-model and
+// https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
+//
+// The shared "spN[pM]" tail is `sp\d+(?:p\d+)?`.
 var (
-	// Maven: "$version+spN" (e.g. "9.4.48+sp1").
-	mavenSealSuffix = regexp.MustCompile(`\+sp\d+$`)
-	// PyPI: "$version+spN" (e.g. "4.2.8+sp1").
-	pipSealSuffix = regexp.MustCompile(`\+sp\d+$`)
-	// npm: "$version-spN" (e.g. "3.1.8-sp1").
-	npmSealSuffix = regexp.MustCompile(`-sp\d+$`)
-	// Go: "$version-spN", optionally followed by the "+incompatible" build
+	// Maven: "$version+spN[pM]" (e.g. "9.4.48+sp1", "9.4.48+sp1p1").
+	mavenSealSuffix = regexp.MustCompile(`\+sp\d+(?:p\d+)?$`)
+	// PyPI: "$version+spN[pM]" (e.g. "4.2.8+sp1", "4.2.8+sp1p1").
+	pipSealSuffix = regexp.MustCompile(`\+sp\d+(?:p\d+)?$`)
+	// npm: "$version-spN[pM]" (e.g. "3.1.8-sp1", "3.1.8-sp1p1").
+	npmSealSuffix = regexp.MustCompile(`-sp\d+(?:p\d+)?$`)
+	// Go: "$version-spN[pM]", optionally followed by the "+incompatible" build
 	// metadata Go adds to major-version-2+ modules without a /vN path
-	// (e.g. "v1.1.1-sp1", "v2.0.0-sp1+incompatible").
-	goSealSuffix = regexp.MustCompile(`-sp\d+(?:\+incompatible)?$`)
-	// RubyGems: "$version.0.1.spN" (e.g. "2.0.7.0.1.sp1").
-	rubySealSuffix = regexp.MustCompile(`\.0\.1\.sp\d+$`)
+	// (e.g. "v1.1.1-sp1", "v2.0.0-sp1p1+incompatible").
+	goSealSuffix = regexp.MustCompile(`-sp\d+(?:p\d+)?(?:\+incompatible)?$`)
+	// RubyGems: "$version.0.1.spN[pM]" (e.g. "2.0.7.0.1.sp1", "2.0.7.0.1.sp1p1").
+	rubySealSuffix = regexp.MustCompile(`\.0\.1\.sp\d+(?:p\d+)?$`)
 )
 
 func init() {

--- a/pkg/detector/library/seal/seal.go
+++ b/pkg/detector/library/seal/seal.go
@@ -12,10 +12,24 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare/pep440"
 )
 
-// sealVersionSuffix matches the Seal Security patch-level version suffix, i.e.
-// "sp" followed by a number preceded by a separator (e.g. "+sp1" on Maven/PyPI,
-// "-sp1" on npm/Go). Seal appends this suffix to the upstream package version.
-var sealVersionSuffix = regexp.MustCompile(`[-.+]sp\d+$`)
+// Seal Security appends an ecosystem-specific patch-level suffix to the upstream
+// version of a no-prefix package. Each ecosystem uses its own separator, so the
+// suffix is matched per ecosystem rather than with a single shared pattern.
+// See https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
+var (
+	// Maven: "$version+spN" (e.g. "9.4.48+sp1").
+	mavenSealSuffix = regexp.MustCompile(`\+sp\d+$`)
+	// PyPI: "$version+spN" (e.g. "4.2.8+sp1").
+	pipSealSuffix = regexp.MustCompile(`\+sp\d+$`)
+	// npm: "$version-spN" (e.g. "3.1.8-sp1").
+	npmSealSuffix = regexp.MustCompile(`-sp\d+$`)
+	// Go: "$version-spN", optionally followed by the "+incompatible" build
+	// metadata Go adds to major-version-2+ modules without a /vN path
+	// (e.g. "v1.1.1-sp1", "v2.0.0-sp1+incompatible").
+	goSealSuffix = regexp.MustCompile(`-sp\d+(?:\+incompatible)?$`)
+	// RubyGems: "$version.0.1.spN" (e.g. "2.0.7.0.1.sp1").
+	rubySealSuffix = regexp.MustCompile(`\.0\.1\.sp\d+$`)
+)
 
 func init() {
 	library.RegisterVendor(sealSecurity{
@@ -61,7 +75,16 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 			return library.Matched
 		}
 		// No-prefix: the "+spN" version suffix cannot collide with real Maven versions.
-		if hasSealVersionSuffix(pkgVer) {
+		if mavenSealSuffix.MatchString(pkgVer) {
+			return library.Matched
+		}
+	case ecosystem.Pip:
+		// Renamed: e.g. seal-django
+		if strings.HasPrefix(pkgName, "seal-") {
+			return library.Matched
+		}
+		// No-prefix: the "+spN" version suffix cannot collide with real PyPI versions.
+		if pipSealSuffix.MatchString(pkgVer) {
 			return library.Matched
 		}
 	case ecosystem.Npm:
@@ -71,17 +94,8 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 		}
 		// No-prefix: the "-spN" version suffix can also appear on real npm
 		// packages, so confirm it against the Seal advisory bucket.
-		if hasSealVersionSuffix(pkgVer) {
+		if npmSealSuffix.MatchString(pkgVer) {
 			return library.Candidate
-		}
-	case ecosystem.Pip:
-		// Renamed: e.g. seal-django
-		if strings.HasPrefix(pkgName, "seal-") {
-			return library.Matched
-		}
-		// No-prefix: the "+spN" version suffix cannot collide with real PyPI versions.
-		if hasSealVersionSuffix(pkgVer) {
-			return library.Matched
 		}
 	case ecosystem.Go:
 		// Renamed: e.g. sealsecurity.io/github.com/Masterminds/goutils
@@ -90,7 +104,7 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 		}
 		// No-prefix: the "-spN" version suffix can also appear on real Go
 		// modules, so confirm it against the Seal advisory bucket.
-		if hasSealVersionSuffix(pkgVer) {
+		if goSealSuffix.MatchString(pkgVer) {
 			return library.Candidate
 		}
 	case ecosystem.RubyGems:
@@ -98,20 +112,14 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 		if strings.HasPrefix(pkgName, "seal-") {
 			return library.Matched
 		}
-		// No-prefix: the ".spN" version suffix (e.g. 2.0.7.0.1.sp1) can also
-		// appear on real gems as a prerelease segment, so confirm it against
-		// the Seal advisory bucket.
-		if hasSealVersionSuffix(pkgVer) {
+		// No-prefix: the ".0.1.spN" version suffix (e.g. 2.0.7.0.1.sp1) can
+		// also appear on real gems as prerelease segments, so confirm it
+		// against the Seal advisory bucket.
+		if rubySealSuffix.MatchString(pkgVer) {
 			return library.Candidate
 		}
 	}
 	return library.NoMatch
-}
-
-// hasSealVersionSuffix reports whether the version carries a Seal Security
-// patch-level suffix (e.g. "+sp1", "-sp1").
-func hasSealVersionSuffix(pkgVer string) bool {
-	return sealVersionSuffix.MatchString(pkgVer)
 }
 
 // BucketPrefix returns the vendor-specific advisory bucket prefix.

--- a/pkg/detector/library/seal/seal.go
+++ b/pkg/detector/library/seal/seal.go
@@ -71,16 +71,6 @@ func (sealSecurity) Name() string {
 // Match determines whether a package is provided by Seal Security.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
 func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.MatchResult {
-	// A Seal package is marked either in the name (renamed packages) or in the
-	// version by the "spN" patch-level suffix (no-prefix packages). If neither
-	// marker is present, it cannot be a Seal package, so skip the per-ecosystem
-	// regexes. See
-	//   - https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages
-	//   - https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
-	if !strings.Contains(pkgName, "seal") && !strings.Contains(pkgVer, "sp") {
-		return library.NoMatch
-	}
-
 	switch eco {
 	case ecosystem.Maven:
 		// Renamed: e.g. seal.sp1.org.eclipse.jetty:jetty-http

--- a/pkg/detector/library/seal/seal.go
+++ b/pkg/detector/library/seal/seal.go
@@ -21,13 +21,9 @@ import (
 // (e.g. "2.7.4-sp2p1"). See
 // https://docs.sealsecurity.io/reference/naming-and-versioning/sp-model and
 // https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
-//
-// The shared "spN[pM]" tail is `sp\d+(?:p\d+)?`.
 var (
-	// Maven: "$version+spN[pM]" (e.g. "9.4.48+sp1", "9.4.48+sp1p1").
-	mavenSealSuffix = regexp.MustCompile(`\+sp\d+(?:p\d+)?$`)
-	// PyPI: "$version+spN[pM]" (e.g. "4.2.8+sp1", "4.2.8+sp1p1").
-	pipSealSuffix = regexp.MustCompile(`\+sp\d+(?:p\d+)?$`)
+	// Maven and PyPI: "$version+spN[pM]" (e.g. "9.4.48+sp1", "4.2.8+sp1p1").
+	plusSealSuffix = regexp.MustCompile(`\+sp\d+(?:p\d+)?$`)
 	// npm: "$version-spN[pM]" (e.g. "3.1.8-sp1", "3.1.8-sp1p1").
 	npmSealSuffix = regexp.MustCompile(`-sp\d+(?:p\d+)?$`)
 	// Go: "$version-spN[pM]", optionally followed by the "+incompatible" build
@@ -75,6 +71,16 @@ func (sealSecurity) Name() string {
 // Match determines whether a package is provided by Seal Security.
 // It expects a normalized package name (see vulnerability.NormalizePkgName).
 func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.MatchResult {
+	// A Seal package is marked either in the name (renamed packages) or in the
+	// version by the "spN" patch-level suffix (no-prefix packages). If neither
+	// marker is present, it cannot be a Seal package, so skip the per-ecosystem
+	// regexes. See
+	//   - https://docs.sealsecurity.io/reference/naming-and-versioning/renamed-packages
+	//   - https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem
+	if !strings.Contains(pkgName, "seal") && !strings.Contains(pkgVer, "sp") {
+		return library.NoMatch
+	}
+
 	switch eco {
 	case ecosystem.Maven:
 		// Renamed: e.g. seal.sp1.org.eclipse.jetty:jetty-http
@@ -82,7 +88,7 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 			return library.Matched
 		}
 		// No-prefix: the "+spN" version suffix cannot collide with real Maven versions.
-		if mavenSealSuffix.MatchString(pkgVer) {
+		if plusSealSuffix.MatchString(pkgVer) {
 			return library.Matched
 		}
 	case ecosystem.Pip:
@@ -91,7 +97,7 @@ func (sealSecurity) Match(eco ecosystem.Type, pkgName, pkgVer string) library.Ma
 			return library.Matched
 		}
 		// No-prefix: the "+spN" version suffix cannot collide with real PyPI versions.
-		if pipSealSuffix.MatchString(pkgVer) {
+		if plusSealSuffix.MatchString(pkgVer) {
 			return library.Matched
 		}
 	case ecosystem.Npm:

--- a/pkg/detector/library/seal/seal_test.go
+++ b/pkg/detector/library/seal/seal_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/trivy-db/pkg/ecosystem"
+	"github.com/aquasecurity/trivy/pkg/detector/library"
 )
 
 func TestSealSecurity_Match(t *testing.T) {
@@ -14,103 +15,143 @@ func TestSealSecurity_Match(t *testing.T) {
 		eco     ecosystem.Type
 		pkgName string
 		pkgVer  string
-		want    bool
+		want    library.MatchResult
 	}{
-		// Maven - name prefix seal.sp$X.$groupId:$artifactId
+		// Maven - renamed name prefix seal.sp$X.$groupId:$artifactId
 		{
 			name:    "maven seal package",
 			eco:     ecosystem.Maven,
 			pkgName: "seal.sp1.org.eclipse.jetty:jetty-http",
 			pkgVer:  "9.4.48.v20220622",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
 			name:    "maven seal package with sp2",
 			eco:     ecosystem.Maven,
 			pkgName: "seal.sp2.org.eclipse.jetty:jetty-http",
 			pkgVer:  "9.4.48.v20220622",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
 			name:    "maven non-seal package",
 			eco:     ecosystem.Maven,
 			pkgName: "org.eclipse.jetty:jetty-http",
 			pkgVer:  "9.4.48.v20220622",
-			want:    false,
+			want:    library.NoMatch,
 		},
 		{
 			name:    "maven non-seal package with seal.sp prefix but no digit",
 			eco:     ecosystem.Maven,
 			pkgName: "seal.space.something:artifact",
 			pkgVer:  "1.0.0",
-			want:    false,
+			want:    library.NoMatch,
 		},
-		// npm - name prefix @seal-security/
+		// Maven - no-prefix name detected by "+spN" version suffix
+		{
+			name:    "maven seal package with no-prefix name and version suffix",
+			eco:     ecosystem.Maven,
+			pkgName: "org.eclipse.jetty:jetty-http",
+			pkgVer:  "9.4.48.v20220622+sp1",
+			want:    library.Matched,
+		},
+		// npm - renamed name prefix @seal-security/
 		{
 			name:    "npm seal package",
 			eco:     ecosystem.Npm,
 			pkgName: "@seal-security/ejs",
 			pkgVer:  "3.1.8-sp1",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
 			name:    "npm seal package with seal- prefix in name",
 			eco:     ecosystem.Npm,
 			pkgName: "@seal-security/seal-ejs",
 			pkgVer:  "3.1.8-sp1",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
-			name:    "npm non-seal package",
+			name:    "npm non-seal package without version suffix",
+			eco:     ecosystem.Npm,
+			pkgName: "ejs",
+			pkgVer:  "3.1.8",
+			want:    library.NoMatch,
+		},
+		// npm - no-prefix name with "-spN" suffix is a candidate (verified against DB)
+		{
+			name:    "npm seal package with no-prefix name and version suffix",
 			eco:     ecosystem.Npm,
 			pkgName: "ejs",
 			pkgVer:  "3.1.8-sp1",
-			want:    false,
+			want:    library.Candidate,
 		},
-		// Python - name prefix seal-
+		// Python - renamed name prefix seal-
 		{
 			name:    "python seal package",
 			eco:     ecosystem.Pip,
 			pkgName: "seal-django",
 			pkgVer:  "4.2.8+sp1",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
-			name:    "python non-seal package",
+			name:    "python non-seal package without version suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "django",
+			pkgVer:  "4.2.8",
+			want:    library.NoMatch,
+		},
+		// Python - no-prefix name detected by "+spN" version suffix
+		{
+			name:    "python seal package with no-prefix name and version suffix",
 			eco:     ecosystem.Pip,
 			pkgName: "django",
 			pkgVer:  "4.2.8+sp1",
-			want:    false,
+			want:    library.Matched,
 		},
-		// Go - name prefix sealsecurity.io/
+		// Go - renamed name prefix sealsecurity.io/
 		{
 			name:    "go seal package",
 			eco:     ecosystem.Go,
 			pkgName: "sealsecurity.io/github.com/Masterminds/goutils",
 			pkgVer:  "v1.1.1-sp1",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
-			name:    "go non-seal package",
+			name:    "go non-seal package without version suffix",
+			eco:     ecosystem.Go,
+			pkgName: "github.com/Masterminds/goutils",
+			pkgVer:  "v1.1.1",
+			want:    library.NoMatch,
+		},
+		// Go - no-prefix name with "-spN" suffix is a candidate (verified against DB)
+		{
+			name:    "go seal package with no-prefix name and version suffix",
 			eco:     ecosystem.Go,
 			pkgName: "github.com/Masterminds/goutils",
 			pkgVer:  "v1.1.1-sp1",
-			want:    false,
+			want:    library.Candidate,
 		},
-		// Ruby - name prefix seal-
+		// Ruby - renamed name prefix seal-
 		{
 			name:    "ruby seal package",
 			eco:     ecosystem.RubyGems,
 			pkgName: "seal-rack",
 			pkgVer:  "2.0.7.0.1.sp1",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
-			name:    "ruby non-seal package",
+			name:    "ruby non-seal package without version suffix",
 			eco:     ecosystem.RubyGems,
 			pkgName: "rack",
 			pkgVer:  "2.0.7",
-			want:    false,
+			want:    library.NoMatch,
+		},
+		// Ruby - no-prefix name with ".spN" suffix is a candidate (verified against DB)
+		{
+			name:    "ruby seal package with no-prefix name and version suffix",
+			eco:     ecosystem.RubyGems,
+			pkgName: "rack",
+			pkgVer:  "2.0.7.0.1.sp1",
+			want:    library.Candidate,
 		},
 		// Unsupported ecosystem
 		{
@@ -118,7 +159,7 @@ func TestSealSecurity_Match(t *testing.T) {
 			eco:     ecosystem.Erlang,
 			pkgName: "seal-cowboy",
 			pkgVer:  "2.9.0",
-			want:    false,
+			want:    library.NoMatch,
 		},
 		// Edge cases
 		{
@@ -126,14 +167,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			eco:     ecosystem.Pip,
 			pkgName: "seal-requests",
 			pkgVer:  "",
-			want:    true,
+			want:    library.Matched,
 		},
 		{
 			name:    "empty package name",
 			eco:     ecosystem.Pip,
 			pkgName: "",
 			pkgVer:  "1.0.0",
-			want:    false,
+			want:    library.NoMatch,
 		},
 	}
 

--- a/pkg/detector/library/seal/seal_test.go
+++ b/pkg/detector/library/seal/seal_test.go
@@ -62,6 +62,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			pkgVer:  "9.4.48.v20220622-sp1",
 			want:    library.NoMatch,
 		},
+		{
+			// Private version: "spN" carries an extra "pM" iteration.
+			name:    "maven seal package with private version suffix",
+			eco:     ecosystem.Maven,
+			pkgName: "org.eclipse.jetty:jetty-http",
+			pkgVer:  "9.4.48.v20220622+sp1p1",
+			want:    library.Matched,
+		},
 		// npm - renamed name prefix @seal-security/
 		{
 			name:    "npm seal package",
@@ -92,6 +100,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			pkgVer:  "3.1.8-sp1",
 			want:    library.Candidate,
 		},
+		{
+			// Private version: "spN" carries an extra "pM" iteration.
+			name:    "npm seal package with private version suffix",
+			eco:     ecosystem.Npm,
+			pkgName: "ejs",
+			pkgVer:  "2.7.4-sp2p1",
+			want:    library.Candidate,
+		},
 		// Python - renamed name prefix seal-
 		{
 			name:    "python seal package",
@@ -113,6 +129,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			eco:     ecosystem.Pip,
 			pkgName: "django",
 			pkgVer:  "4.2.8+sp1",
+			want:    library.Matched,
+		},
+		{
+			// Private version: "spN" carries an extra "pM" iteration.
+			name:    "python seal package with private version suffix",
+			eco:     ecosystem.Pip,
+			pkgName: "django",
+			pkgVer:  "4.2.8+sp1p1",
 			want:    library.Matched,
 		},
 		// Go - renamed name prefix sealsecurity.io/
@@ -154,6 +178,21 @@ func TestSealSecurity_Match(t *testing.T) {
 			pkgVer:  "v1.1.1+sp1",
 			want:    library.NoMatch,
 		},
+		{
+			// Private version: "spN" carries an extra "pM" iteration.
+			name:    "go seal package with private version suffix",
+			eco:     ecosystem.Go,
+			pkgName: "github.com/Masterminds/goutils",
+			pkgVer:  "v1.1.1-sp2p1",
+			want:    library.Candidate,
+		},
+		{
+			name:    "go seal package with private version and +incompatible suffix",
+			eco:     ecosystem.Go,
+			pkgName: "github.com/Masterminds/goutils",
+			pkgVer:  "v2.0.0-sp2p1+incompatible",
+			want:    library.Candidate,
+		},
 		// Ruby - renamed name prefix seal-
 		{
 			name:    "ruby seal package",
@@ -175,6 +214,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			eco:     ecosystem.RubyGems,
 			pkgName: "rack",
 			pkgVer:  "2.0.7.0.1.sp1",
+			want:    library.Candidate,
+		},
+		{
+			// Private version: "spN" carries an extra "pM" iteration.
+			name:    "ruby seal package with private version suffix",
+			eco:     ecosystem.RubyGems,
+			pkgName: "rack",
+			pkgVer:  "2.0.7.0.1.sp1p1",
 			want:    library.Candidate,
 		},
 		// Unsupported ecosystem

--- a/pkg/detector/library/seal/seal_test.go
+++ b/pkg/detector/library/seal/seal_test.go
@@ -54,6 +54,14 @@ func TestSealSecurity_Match(t *testing.T) {
 			pkgVer:  "9.4.48.v20220622+sp1",
 			want:    library.Matched,
 		},
+		{
+			// Maven uses "+spN", not "-spN": a "-spN" version must not match.
+			name:    "maven package with npm-style -spN suffix is not matched",
+			eco:     ecosystem.Maven,
+			pkgName: "org.eclipse.jetty:jetty-http",
+			pkgVer:  "9.4.48.v20220622-sp1",
+			want:    library.NoMatch,
+		},
 		// npm - renamed name prefix @seal-security/
 		{
 			name:    "npm seal package",
@@ -129,6 +137,22 @@ func TestSealSecurity_Match(t *testing.T) {
 			pkgName: "github.com/Masterminds/goutils",
 			pkgVer:  "v1.1.1-sp1",
 			want:    library.Candidate,
+		},
+		{
+			// Go appends "+incompatible" to major-version-2+ modules without a /vN path.
+			name:    "go seal package with no-prefix name and +incompatible suffix",
+			eco:     ecosystem.Go,
+			pkgName: "github.com/Masterminds/goutils",
+			pkgVer:  "v2.0.0-sp1+incompatible",
+			want:    library.Candidate,
+		},
+		{
+			// Go uses "-spN", not "+spN": a "+spN" version must not match.
+			name:    "go package with maven-style +spN suffix is not matched",
+			eco:     ecosystem.Go,
+			pkgName: "github.com/Masterminds/goutils",
+			pkgVer:  "v1.1.1+sp1",
+			want:    library.NoMatch,
 		},
 		// Ruby - renamed name prefix seal-
 		{

--- a/pkg/detector/library/testdata/fixtures/seal.yaml
+++ b/pkg/detector/library/testdata/fixtures/seal.yaml
@@ -51,15 +51,6 @@
               - "0.26.0-sp2"
             VulnerableVersions:
               - ">= 0.26.0-sp1, < 0.26.0-sp2"
-    # No-prefix package: "-spN" candidate confirmed against this bucket
-    - bucket: "golang.org/x/crypto"
-      pairs:
-        - key: "CVE-2025-22869"
-          value:
-            PatchedVersions:
-              - "0.26.0-sp2"
-            VulnerableVersions:
-              - ">= 0.26.0-sp1, < 0.26.0-sp2"
 
 - bucket: "seal rubygems::Seal Security Database"
   pairs:
@@ -72,29 +63,11 @@
               - "2.0.7.0.1.sp999"
             VulnerableVersions:
               - ">= 2.0.7.0.1.sp1, < 2.0.7.0.1.sp999"
-    # No-prefix package: ".spN" candidate confirmed against this bucket
-    - bucket: "rack"
-      pairs:
-        - key: "CVE-2025-61780"
-          value:
-            PatchedVersions:
-              - "2.0.7.0.1.sp999"
-            VulnerableVersions:
-              - ">= 2.0.7.0.1.sp1, < 2.0.7.0.1.sp999"
 
 - bucket: "seal maven::Seal Security Database"
   pairs:
     # Renamed package: seal.sp$N.$groupId:$artifactId
     - bucket: "seal.sp1.org.apache.logging.log4j:log4j-core"
-      pairs:
-        - key: "CVE-2025-68161"
-          value:
-            PatchedVersions:
-              - "2.13.3+sp999"
-            VulnerableVersions:
-              - ">= 2.13.3, < 2.13.3+sp999"
-    # No-prefix package: detected by the "+spN" version suffix
-    - bucket: "org.apache.logging.log4j:log4j-core"
       pairs:
         - key: "CVE-2025-68161"
           value:

--- a/pkg/detector/library/testdata/fixtures/seal.yaml
+++ b/pkg/detector/library/testdata/fixtures/seal.yaml
@@ -1,5 +1,6 @@
 - bucket: "seal pip::Seal Security Database"
   pairs:
+    # Renamed package: seal-$name
     - bucket: "seal-requests"
       pairs:
         - key: "CVE-2023-32681"
@@ -8,9 +9,19 @@
               - "2.14.2+sp999"
             VulnerableVersions:
               - ">= 2.14.2+sp1, < 2.14.2+sp999"
+    # No-prefix package: detected by the "+spN" version suffix
+    - bucket: "django"
+      pairs:
+        - key: "CVE-2023-36053"
+          value:
+            PatchedVersions:
+              - "4.2.8+sp999"
+            VulnerableVersions:
+              - ">= 4.2.8+sp1, < 4.2.8+sp999"
 
 - bucket: "seal npm::Seal Security Database"
   pairs:
+    # Renamed package: @seal-security/$name
     - bucket: "@seal-security/ajv"
       pairs:
         - key: "CVE-2025-69873"
@@ -19,10 +30,29 @@
               - "5.5.2-sp999"
             VulnerableVersions:
               - ">=5.5.2-sp1 <5.5.2-sp999"
+    # No-prefix package: "-spN" candidate confirmed against this bucket
+    - bucket: "ejs"
+      pairs:
+        - key: "CVE-2024-33883"
+          value:
+            PatchedVersions:
+              - "3.1.8-sp999"
+            VulnerableVersions:
+              - ">=3.1.8-sp1 <3.1.8-sp999"
 
 - bucket: "seal go::Seal Security Database"
   pairs:
+    # Renamed package: sealsecurity.io/$name
     - bucket: "sealsecurity.io/golang.org/x/crypto"
+      pairs:
+        - key: "CVE-2025-22869"
+          value:
+            PatchedVersions:
+              - "0.26.0-sp2"
+            VulnerableVersions:
+              - ">= 0.26.0-sp1, < 0.26.0-sp2"
+    # No-prefix package: "-spN" candidate confirmed against this bucket
+    - bucket: "golang.org/x/crypto"
       pairs:
         - key: "CVE-2025-22869"
           value:
@@ -33,7 +63,17 @@
 
 - bucket: "seal rubygems::Seal Security Database"
   pairs:
+    # Renamed package: seal-$name
     - bucket: "seal-rack"
+      pairs:
+        - key: "CVE-2025-61780"
+          value:
+            PatchedVersions:
+              - "2.0.7.0.1.sp999"
+            VulnerableVersions:
+              - ">= 2.0.7.0.1.sp1, < 2.0.7.0.1.sp999"
+    # No-prefix package: ".spN" candidate confirmed against this bucket
+    - bucket: "rack"
       pairs:
         - key: "CVE-2025-61780"
           value:
@@ -44,7 +84,17 @@
 
 - bucket: "seal maven::Seal Security Database"
   pairs:
+    # Renamed package: seal.sp$N.$groupId:$artifactId
     - bucket: "seal.sp1.org.apache.logging.log4j:log4j-core"
+      pairs:
+        - key: "CVE-2025-68161"
+          value:
+            PatchedVersions:
+              - "2.13.3+sp999"
+            VulnerableVersions:
+              - ">= 2.13.3, < 2.13.3+sp999"
+    # No-prefix package: detected by the "+spN" version suffix
+    - bucket: "org.apache.logging.log4j:log4j-core"
       pairs:
         - key: "CVE-2025-68161"
           value:

--- a/pkg/detector/library/vendor.go
+++ b/pkg/detector/library/vendor.go
@@ -15,16 +15,13 @@ const (
 	// NoMatch indicates the package does not belong to the vendor.
 	NoMatch MatchResult = iota
 
-	// Matched indicates the package definitely belongs to the vendor, e.g. by a
-	// name prefix or by a version suffix that cannot collide with real packages.
-	// The vendor advisory bucket is authoritative for such packages.
+	// Matched indicates the package definitely belongs to the vendor.
 	Matched
 
 	// Candidate indicates the package might belong to the vendor, e.g. a version
 	// suffix that can also appear on real packages (`-spN` on Go/npm packages).
-	// The vendor bucket is preferred only when it actually contains advisories
-	// for the package; otherwise detection falls back to the default ecosystem
-	// bucket.
+	// Callers should confirm a Candidate before relying on it, and otherwise fall
+	// back to default (non-vendor) handling.
 	Candidate
 )
 

--- a/pkg/detector/library/vendor.go
+++ b/pkg/detector/library/vendor.go
@@ -8,6 +8,26 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library/compare"
 )
 
+// MatchResult describes how strongly a package matches a vendor.
+type MatchResult int
+
+const (
+	// NoMatch indicates the package does not belong to the vendor.
+	NoMatch MatchResult = iota
+
+	// Matched indicates the package definitely belongs to the vendor, e.g. by a
+	// name prefix or by a version suffix that cannot collide with real packages.
+	// The vendor advisory bucket is authoritative for such packages.
+	Matched
+
+	// Candidate indicates the package might belong to the vendor, e.g. a version
+	// suffix that can also appear on real packages (`-spN` on Go/npm packages).
+	// The vendor bucket is preferred only when it actually contains advisories
+	// for the package; otherwise detection falls back to the default ecosystem
+	// bucket.
+	Candidate
+)
+
 // Vendor represents a third-party security vendor that provides patched packages
 // with their own vulnerability advisories. These vendors (e.g., Seal Security)
 // offer patched versions of open source packages and maintain separate advisory
@@ -24,7 +44,7 @@ type Vendor interface {
 	// Match determines whether a package is provided by this vendor.
 	// It receives the ecosystem type, a normalized package name
 	// (see vulnerability.NormalizePkgName), and version to make the determination.
-	Match(eco ecosystem.Type, pkgName, pkgVer string) bool
+	Match(eco ecosystem.Type, pkgName, pkgVer string) MatchResult
 
 	// BucketPrefix returns the advisory bucket prefix for the given ecosystem.
 	// For example, "seal pip::" for Seal Security pip packages.
@@ -56,15 +76,15 @@ func DeregisterVendor(name string) {
 }
 
 // lookupVendor finds the matching vendor for the given package.
-// If a vendor matches, it is returned with ok=true.
-// If no vendor matches, ok is false.
-func lookupVendor(eco ecosystem.Type, pkgName, pkgVer string) (Vendor, bool) {
+// If a vendor matches, it is returned together with its match result
+// (Matched or Candidate). If no vendor matches, it returns nil and NoMatch.
+func lookupVendor(eco ecosystem.Type, pkgName, pkgVer string) (Vendor, MatchResult) {
 	for _, v := range vendors {
-		if v.Match(eco, pkgName, pkgVer) {
-			return v, true
+		if res := v.Match(eco, pkgName, pkgVer); res != NoMatch {
+			return v, res
 		}
 	}
-	return nil, false
+	return nil, NoMatch
 }
 
 // defaultBucketPrefix returns the standard ecosystem bucket prefix (e.g. "pip::").

--- a/pkg/detector/library/vendor_test.go
+++ b/pkg/detector/library/vendor_test.go
@@ -21,7 +21,8 @@ func Test_lookupVendor(t *testing.T) {
 		name                string
 		eco                 ecosystem.Type
 		pkgName             string
-		wantMatch           bool
+		pkgVer              string
+		wantMatch           library.MatchResult
 		wantPrefix          string
 		wantDefaultComparer bool
 	}{
@@ -29,7 +30,7 @@ func Test_lookupVendor(t *testing.T) {
 			name:                "seal pip package returns vendor prefix and pep440 comparer",
 			eco:                 ecosystem.Pip,
 			pkgName:             "seal-requests",
-			wantMatch:           true,
+			wantMatch:           library.Matched,
 			wantPrefix:          "seal pip::",
 			wantDefaultComparer: false,
 		},
@@ -37,7 +38,7 @@ func Test_lookupVendor(t *testing.T) {
 			name:                "seal npm package returns vendor prefix and default comparer",
 			eco:                 ecosystem.Npm,
 			pkgName:             "@seal-security/ejs",
-			wantMatch:           true,
+			wantMatch:           library.Matched,
 			wantPrefix:          "seal npm::",
 			wantDefaultComparer: true,
 		},
@@ -45,7 +46,7 @@ func Test_lookupVendor(t *testing.T) {
 			name:                "seal go package returns vendor prefix and default comparer",
 			eco:                 ecosystem.Go,
 			pkgName:             "sealsecurity.io/github.com/foo/bar",
-			wantMatch:           true,
+			wantMatch:           library.Matched,
 			wantPrefix:          "seal go::",
 			wantDefaultComparer: true,
 		},
@@ -53,7 +54,7 @@ func Test_lookupVendor(t *testing.T) {
 			name:                "seal maven package returns vendor prefix and default comparer",
 			eco:                 ecosystem.Maven,
 			pkgName:             "seal.sp1.org.eclipse.jetty:jetty-http",
-			wantMatch:           true,
+			wantMatch:           library.Matched,
 			wantPrefix:          "seal maven::",
 			wantDefaultComparer: true,
 		},
@@ -61,29 +62,38 @@ func Test_lookupVendor(t *testing.T) {
 			name:                "seal rubygems package returns vendor prefix and default comparer",
 			eco:                 ecosystem.RubyGems,
 			pkgName:             "seal-rack",
-			wantMatch:           true,
+			wantMatch:           library.Matched,
 			wantPrefix:          "seal rubygems::",
+			wantDefaultComparer: true,
+		},
+		{
+			name:                "seal go no-prefix package returns candidate match",
+			eco:                 ecosystem.Go,
+			pkgName:             "github.com/foo/bar",
+			pkgVer:              "1.2.3-sp1",
+			wantMatch:           library.Candidate,
+			wantPrefix:          "seal go::",
 			wantDefaultComparer: true,
 		},
 		{
 			name:      "non-seal pip package returns no match",
 			eco:       ecosystem.Pip,
 			pkgName:   "requests",
-			wantMatch: false,
+			wantMatch: library.NoMatch,
 		},
 		{
 			name:      "non-seal npm package returns no match",
 			eco:       ecosystem.Npm,
 			pkgName:   "ejs",
-			wantMatch: false,
+			wantMatch: library.NoMatch,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v, ok := library.LookupVendor(tt.eco, tt.pkgName, "")
-			require.Equal(t, tt.wantMatch, ok)
-			if !ok {
+			v, res := library.LookupVendor(tt.eco, tt.pkgName, tt.pkgVer)
+			require.Equal(t, tt.wantMatch, res)
+			if res == library.NoMatch {
 				return
 			}
 			assert.Equal(t, tt.wantPrefix, v.BucketPrefix(tt.eco))


### PR DESCRIPTION
## Description

Seal Security ships patched packages under two naming schemes:

- **Renamed** packages carry an ecosystem-specific name prefix (already supported): `seal-*` (pip/RubyGems), `@seal-security/*` (npm), `sealsecurity.io/*` (Go), `seal.spN.*` (Maven).
- **No-prefix** packages keep the upstream name and only add a patch-level version suffix (`+spN` / `-spN` / `.spN`). These were **not** detected before this PR.

This PR adds detection of no-prefix packages by their version suffix, while keeping the existing name-prefix detection:

- **Maven / PyPI** — the `+spN` suffix cannot collide with real versions, so a suffix match uses the Seal advisory bucket directly (`Matched`).
- **npm / Go / RubyGems** — the `-spN` / `.spN` suffix can also appear on real packages, so a suffix match is treated as a **candidate**: Trivy looks the package up in the Seal advisory bucket and uses it if present, otherwise falls back to the default ecosystem bucket. This avoids false attribution for real packages that happen to use a similar suffix (e.g. `github.com/yaklang/yaklang`).

To express this, `Vendor.Match` now returns a `MatchResult` (`NoMatch` / `Matched` / `Candidate`), and the library driver resolves advisories accordingly.

This follows the design agreed with the Trivy team and matches the [Seal per-ecosystem naming & versioning docs](https://docs.sealsecurity.io/reference/naming-and-versioning/per-ecosystem).

### Verification

Unit tests cover every ecosystem for both schemes plus the candidate-fallback path. Additionally verified end-to-end with a built binary against a real project:

| Ecosystem | Package | Version | Scheme | Result |
|-----------|---------|---------|--------|--------|
| pip | `django` | `4.2.8+sp1` | no-prefix | Seal advisory |
| npm | `ejs` | `3.1.8-sp1` | no-prefix (candidate) | Seal advisory |
| RubyGems | `rack` | `2.0.7.0.1.sp1` | no-prefix (candidate) | Seal advisory |
| Go | `golang.org/x/crypto` | `v0.26.0-sp1` | no-prefix (candidate) | Seal advisory |
| Go | `github.com/Masterminds/vcs` | `v1.13.1-sp1` | `-spN`, not a Seal pkg | **falls back** to default `go::` advisory |

## Related PRs
- [x] aquasecurity/vuln-list-update#461 — merges the renamed and no-prefix Seal feeds into the `seal/` directory (companion change)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
