### PR TITLE
ci(helm): allow trivy team to approve Chart.yaml bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,8 @@ pkg/iac/                              @nikpivkin
 
 # Helm chart
 helm/trivy/ @afdesk
+# Chart.yaml is bumped automatically by CI, so trivy team may approve it.
+helm/trivy/Chart.yaml @aquasecurity/trivy
 
 # Kubernetes scanning
 pkg/k8s/                         @afdesk


### PR DESCRIPTION
## Description
Add a dedicated CODEOWNERS rule for `helm/trivy/Chart.yaml`:
- `helm/trivy/Chart.yaml` is now owned by `@aquasecurity/trivy` instead of `@afdesk`
- This file is bumped automatically by CI on release, so the core team can approve these bumps
- Other files under `helm/trivy/` are unaffected (the last matching pattern takes precedence)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
