### PR TITLE
fix(terraform): support OpenTofu language block

### DIFF
--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -164,13 +164,7 @@ check "cats_mittens_is_special" {
 	require.NotNil(t, checkBlocks[0].GetBlock("assert"))
 }
 
-// Test_OpenTofuLanguageBlock reproduces aquasecurity/trivy#10906.
-//
-// Given a .tofu file using the OpenTofu v1.12 top-level `language` block
-// (https://opentofu.org/docs/language/settings/#language-compatibility)
-// When the parser reads the file
-// Then it must not fail with "Unsupported block type", and the nested
-// `compatible_with.opentofu` constraint must be readable.
+// Test_OpenTofuLanguageBlock: see https://github.com/aquasecurity/trivy/issues/10906
 func Test_OpenTofuLanguageBlock(t *testing.T) {
 	fs := testutil.CreateFS(map[string]string{
 		"main.tofu": `
@@ -179,34 +173,14 @@ language {
     opentofu = ">= 1.12"
   }
 }
-
-resource "cats_cat" "mittens" {
-	name = "mittens"
-}
 `,
 	})
 
 	parser := New(fs, "", OptionStopOnHCLError(true))
-	err := parser.ParseFS(t.Context(), ".")
-	require.NoError(t, err, "parser must accept the OpenTofu `language` block")
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
 
-	modules, err := parser.EvaluateAll(t.Context())
+	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
-	require.NotEmpty(t, modules)
-
-	blocks := modules[0].GetBlocks()
-
-	languageBlocks := blocks.OfType("language")
-	require.Len(t, languageBlocks, 1)
-
-	compatibleWith := languageBlocks[0].GetBlock("compatible_with")
-	require.NotNil(t, compatibleWith)
-	require.NotNil(t, compatibleWith.GetAttribute("opentofu"))
-	assert.Equal(t, ">= 1.12", compatibleWith.GetAttribute("opentofu").Value().AsString())
-
-	// sanity: the rest of the file still parses normally
-	resourceBlocks := blocks.OfType("resource")
-	require.Len(t, resourceBlocks, 1)
 }
 
 func Test_Modules(t *testing.T) {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -164,6 +164,51 @@ check "cats_mittens_is_special" {
 	require.NotNil(t, checkBlocks[0].GetBlock("assert"))
 }
 
+// Test_OpenTofuLanguageBlock reproduces aquasecurity/trivy#10906.
+//
+// Given a .tofu file using the OpenTofu v1.12 top-level `language` block
+// (https://opentofu.org/docs/language/settings/#language-compatibility)
+// When the parser reads the file
+// Then it must not fail with "Unsupported block type", and the nested
+// `compatible_with.opentofu` constraint must be readable.
+func Test_OpenTofuLanguageBlock(t *testing.T) {
+	fs := testutil.CreateFS(map[string]string{
+		"main.tofu": `
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+  }
+}
+
+resource "cats_cat" "mittens" {
+	name = "mittens"
+}
+`,
+	})
+
+	parser := New(fs, "", OptionStopOnHCLError(true))
+	err := parser.ParseFS(t.Context(), ".")
+	require.NoError(t, err, "parser must accept the OpenTofu `language` block")
+
+	modules, err := parser.EvaluateAll(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, modules)
+
+	blocks := modules[0].GetBlocks()
+
+	languageBlocks := blocks.OfType("language")
+	require.Len(t, languageBlocks, 1)
+
+	compatibleWith := languageBlocks[0].GetBlock("compatible_with")
+	require.NotNil(t, compatibleWith)
+	require.NotNil(t, compatibleWith.GetAttribute("opentofu"))
+	assert.Equal(t, ">= 1.12", compatibleWith.GetAttribute("opentofu").Value().AsString())
+
+	// sanity: the rest of the file still parses normally
+	resourceBlocks := blocks.OfType("resource")
+	require.Len(t, resourceBlocks, 1)
+}
+
 func Test_Modules(t *testing.T) {
 
 	fs := testutil.CreateFS(map[string]string{

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -164,7 +164,7 @@ check "cats_mittens_is_special" {
 	require.NotNil(t, checkBlocks[0].GetBlock("assert"))
 }
 
-// Test_OpenTofuLanguageBlock: see https://github.com/aquasecurity/trivy/issues/10906
+// Regression test for https://github.com/aquasecurity/trivy/issues/10906
 func Test_OpenTofuLanguageBlock(t *testing.T) {
 	fs := testutil.CreateFS(map[string]string{
 		"main.tofu": `

--- a/pkg/iac/terraform/schema.go
+++ b/pkg/iac/terraform/schema.go
@@ -9,6 +9,11 @@ var Schema = &hcl.BodySchema{
 			Type: "terraform",
 		},
 		{
+			// language declares OpenTofu/language compatibility constraints.
+			// Introduced in OpenTofu v1.12: https://opentofu.org/docs/language/settings/#language-compatibility
+			Type: "language",
+		},
+		{
 			Type: "required_providers",
 		},
 		{


### PR DESCRIPTION
Trivy's HCL body schema rejects OpenTofu v1.12's top-level `language` block with "Unsupported block type", which fails the whole scan.

`pkg/iac/terraform/schema.go` enumerates the allowed block types and `language` was missing. This adds it. The nested `compatible_with` block and any `edition`/`experiments` attributes decode through the existing generic block handling, so no other schema change is needed.

Added a parser test that reads a `language { compatible_with { opentofu = ">= 1.12" } }` file. It fails on current main with the exact "Unsupported block type" error and passes with the fix.

Closes #10906
