### PR TITLE
ci: create release branch with the App token to bypass the merge queue rule

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -65,7 +65,8 @@ jobs:
 
   release-tag:
     runs-on: ubuntu-2404-2core
-    if: ${{ startsWith(github.event.head_commit.message, 'release:') }}
+    # Skip the branch-creation push (created == true) to avoid re-running on the duplicate tag.
+    if: ${{ startsWith(github.event.head_commit.message, 'release:') && !github.event.created }}
     steps:
       # Since skip-github-release is specified, the outputs of googleapis/release-please-action cannot be used.
       # Therefore, we need to parse the version ourselves.
@@ -114,7 +115,8 @@ jobs:
         env:
           RELEASE_BRANCH: ${{ steps.extract_info.outputs.release_branch }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Should not trigger the workflow again
+          # GITHUB_TOKEN cannot be a ruleset bypass actor; use the App token to bypass the merge queue rule.
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const releaseBranch = process.env.RELEASE_BRANCH;
             await github.rest.git.createRef({


### PR DESCRIPTION
## Description

### Problem

Release Please failed to create `release/v0.72` ([run 28432118385](https://github.com/aquasecurity/trivy/actions/runs/28432118385)).
The `release-tag` job tagged `v0.72.0` successfully, but the "Create release branch" step got `422 Reference update failed`.

### Root cause

The `release` ruleset (id `878475`) has a `merge_queue` rule, and GitHub now evaluates it on branch creation too.
Branch creation is a direct push that cannot go through a queue, so it is always rejected.
Unlike `required_status_checks`, the merge queue rule has no "do not enforce on creation" toggle, so the only way to create such a branch is to be a bypass actor.
This appears to be a recent GitHub enforcement change ([community report, ~April 2026](https://github.com/orgs/community/discussions/193295)); earlier release branches were created without trouble.

The `422 Reference update failed` message is generic, so the exact failing rule was identified via the rule-suites API, which records every rule evaluation including failed ones:

```
$ gh api repos/aquasecurity/trivy/rulesets/rule-suites/3195426084
required_status_checks  fail  Required status check "Test (windows-latest)" is in progress.
merge_queue             fail  Changes must be made through the merge queue
non_fast_forward        pass
pull_request            pass
deletion                pass
```

`merge_queue` blocks the ref creation outright — this is the structural problem.
The default `GITHUB_TOKEN` / `github-actions[bot]` cannot be added to a ruleset bypass list (system accounts are not bypassable; only Apps, users, teams, and roles are), so it can never create the branch.

### Fix (this PR)

Switch the "Create release branch" step from `secrets.GITHUB_TOKEN` to the existing Trivy write GitHub App token, which _can_ be a bypass actor.

Switching to the App token makes the branch-creation push trigger `release-please.yaml` again (the `push: release/v*` trigger), which would re-run `release-tag` and fail on the duplicate tag/branch.
Guard against this by adding `&& !github.event.created` to the `release-tag` job condition: a branch-creation push has `created == true`, while normal release commits on `main` or `release/v*` have `created == false`.

### Required infra change (not in this PR)

The App must be added to a ruleset bypass, but only for the merge queue — not for the whole ruleset, otherwise a leaked App key could push unreviewed and untested code into release branches.
Since bypass is evaluated per ruleset, split `release` (878475) into two:

- **A. `release-protection`** (no bypass) — target `refs/heads/release/v*`; rules: `pull_request` (1 approval), `required_status_checks` with `do_not_enforce_on_create: true`, `non_fast_forward`, `deletion`.
- **B. `release-merge-queue`** (App in bypass, mode "Always") — target explicit branch names (merge queue rules cannot use `*` wildcards); rule: `merge_queue` only.

Branch creation then succeeds: A's rules all pass on creation, and B's merge queue is bypassed by the App.
Review, approvals, and status checks live in A with no bypass, so a leaked App key still cannot push unreviewed or untested code into release branches.

Bonus: the protection rules in A can finally use a `release/v*` pattern.
Today every release branch is enumerated by hand only because the merge queue rule forbids wildcards.
After the split, only B needs the explicit list; A auto-covers all release branches.

> This must land before the v0.73.0 release, since that is when `release-tag` will try to create `release/v0.73`.

### Validation

Reproduced end-to-end on a fork ([DmitriyLewen/trivy](https://github.com/DmitriyLewen/trivy)).
Personal repositories cannot enable merge queue, so a `Restrict creations` rule was used as a stand-in for `merge_queue`: it blocks branch creation the same way and is bypassable per ruleset.
The authentic `merge_queue` evidence is the upstream rule-suite above.

- **Before** — App token, single ruleset, App not a bypass actor → `422` on `createRef refs/heads/release/v0.99`: [run 28788863699](https://github.com/DmitriyLewen/trivy/actions/runs/28788863699)
- **After** — ruleset split into A + B, App in B's bypass → branch created: [run 28789540233](https://github.com/DmitriyLewen/trivy/actions/runs/28789540233)

The rule-suite for the successful creation shows the split working: the `creation` rule (from B) fails but the overall result is `bypass`, while A's rules are still evaluated and pass.

Bypass is scoped to B only — the same App is still subject to ruleset A.
It cannot delete the release branch, because A's `deletion` rule (no bypass) applies to it:

```console
$ gh api -X DELETE repos/DmitriyLewen/trivy/git/refs/heads/release/v0.99
{"message":"Repository rule violations found\n\nCannot delete this branch\n\n","documentation_url":"https://docs.github.com/rest/git/refs#delete-a-reference","status":"422"}
gh: Repository rule violations found

Cannot delete this branch

 (HTTP 422)
```

The `!github.event.created` guard was verified too: the branch-creation push re-triggered the workflow on `release/v0.99`, and the `release-tag` job was skipped ([run 28789122397](https://github.com/DmitriyLewen/trivy/actions/runs/28789122397)).

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
