### PR TITLE
docs(kubernetes): fix --exclude-namespace flag name in scan example

### DIFF
--- a/docs/guide/target/kubernetes.md
+++ b/docs/guide/target/kubernetes.md
@@ -128,7 +128,7 @@ By default, all namespaces will be included in cluster scanning.
 Example:
 
 ```sh
-trivy k8s --report summary --exclude-namespace dev-system,staging-system
+trivy k8s --report summary --exclude-namespaces dev-system,staging-system
 ```
 
 ## Control Plane and Node Components Vulnerability Scanning


### PR DESCRIPTION
## Description

The Kubernetes scanning example uses the singular flag `--exclude-namespace`:

```sh
trivy k8s --report summary --exclude-namespace dev-system,staging-system
```

but the flag is registered as `--exclude-namespaces` (plural) in `pkg/flag/kubernetes_flags.go`, so running the example verbatim fails with an unknown-flag error. The rest of the same page already uses the plural `--exclude-namespaces`, so this just fixes the one inconsistent example.

## Checklist

- [x] Docs only, no code change.