### PR TITLE
fix(fs): skip unreadable files and directories during filesystem walk

### DIFF
--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -41,7 +41,16 @@ func (w *FS) Walk(root string, opt Option, fn WalkFunc) error {
 func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 	return func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			// An error with the root itself must be returned as the scan cannot continue,
+			// but permission errors are still handled in `onError`.
+			if filePath == root {
+				return err
+			}
+			// Skip unreadable files and directories instead of aborting the whole scan
+			// as they cannot be analyzed anyway (e.g. "lstat: input/output error" on special files).
+			// cf. https://github.com/aquasecurity/trivy/issues/3259
+			log.Debug("Skipping unreadable path", log.FilePath(filePath), log.Err(err))
+			return nil
 		}
 
 		// For exported rootfs (e.g. images/alpine/etc/alpine-release)
@@ -66,7 +75,11 @@ func (w *FS) WalkDirFunc(root string, fn WalkFunc, opt Option) fs.WalkDirFunc {
 
 		info, err := d.Info()
 		if err != nil {
-			return xerrors.Errorf("file info error: %w", err)
+			// Skip unreadable files instead of aborting the whole scan
+			// (e.g. "lstat: input/output error" on special files).
+			// cf. https://github.com/aquasecurity/trivy/issues/3259
+			log.Debug("Skipping unreadable file", log.FilePath(filePath), log.Err(err))
+			return nil
 		}
 
 		if err = fn(relPath, info, fileOpener(filePath)); err != nil {

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -3,11 +3,13 @@ package walker_test
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,6 +89,58 @@ func TestFS_Walk(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// fakeDirEntry is a fs.DirEntry that fails on Info().
+type fakeDirEntry struct {
+	infoErr error
+}
+
+func (e fakeDirEntry) Name() string               { return "bad" }
+func (e fakeDirEntry) IsDir() bool                { return false }
+func (e fakeDirEntry) Type() fs.FileMode          { return 0 } // regular file
+func (e fakeDirEntry) Info() (fs.FileInfo, error) { return nil, e.infoErr }
+
+func TestFS_WalkDirFunc_UnreadablePaths(t *testing.T) {
+	root := "testdata/fs"
+	analyzeFn := func(string, os.FileInfo, analyzer.Opener) error {
+		assert.Fail(t, "analyze function must not be called for unreadable paths")
+		return nil
+	}
+	walkFn := walker.NewFS().WalkDirFunc(root, analyzeFn, walker.Option{})
+
+	t.Run("unreadable file is skipped", func(t *testing.T) {
+		// e.g. "lstat: input/output error" on a broken filesystem
+		// cf. https://github.com/aquasecurity/trivy/issues/3259
+		err := walkFn(filepath.Join(root, "bad"), nil, &fs.PathError{
+			Op:   "lstat",
+			Path: filepath.Join(root, "bad"),
+			Err:  syscall.EIO,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("error with the root is returned", func(t *testing.T) {
+		err := walkFn(root, nil, &fs.PathError{
+			Op:   "lstat",
+			Path: root,
+			Err:  syscall.EIO,
+		})
+		assert.ErrorIs(t, err, syscall.EIO)
+	})
+
+	t.Run("file with unreadable info is skipped", func(t *testing.T) {
+		err := walkFn(filepath.Join(root, "bad"), fakeDirEntry{infoErr: syscall.EIO}, nil)
+		assert.NoError(t, err)
+	})
+}
+
+func TestFS_Walk_NonExistentRoot(t *testing.T) {
+	analyzeFn := func(string, os.FileInfo, analyzer.Opener) error {
+		return nil
+	}
+	err := walker.NewFS().Walk("testdata/non-existent", walker.Option{}, analyzeFn)
+	assert.ErrorContains(t, err, "unknown error with")
 }
 
 func TestFS_BuildSkipPaths(t *testing.T) {


### PR DESCRIPTION
## Description

When `trivy fs` walks a filesystem and hits a file or directory that cannot be read (e.g. `lstat: input/output error` on special files when scanning a Windows filesystem mounted on Linux, or paths exceeding `PATH_MAX`), the whole scan is aborted with `unknown error with <path>`.

These entries cannot be analyzed anyway, so this PR skips them with a debug log instead of halting the traversal:

- An error passed to the `WalkDirFunc` for a non-root path (failed `lstat`/`ReadDir`) now skips that entry.
- A failed `d.Info()` call now skips that file.
- Errors with the root itself are still returned, since the scan cannot continue without it (and permission errors keep their existing handling).

### Before

```
$ trivy fs -q --format json ./volume
2026-07-08T13:18:50-04:00 FATAL Fatal error run error: fs scan error: scan error: scan failed: failed analysis: analyze with traversal: walk dir error: unknown error with /tmp/deep-repro/ddd...ddd: open /tmp/deep-repro/ddd...ddd: file name too long
```

(The scan dies and produces no results, even though readable lockfiles exist elsewhere in the tree. The same happens with `lstat ...: input/output error` from the original issue.)

### After

```
$ trivy fs -q --format json ./volume
(exit code 0; the readable part of the tree is scanned: package-lock.json with its packages is reported)
```

With `--debug`:

```
2026-07-08T13:19:26-04:00 DEBUG Skipping unreadable path file_path="/tmp/deep-repro/ddd...ddd" err="open /tmp/deep-repro/ddd...ddd: file name too long"
```

## Related issues
- Close #3259

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

Made with [Cursor](https://cursor.com)