### PR TITLE
perf(iac): avoid redundant parsing in file type detection

### DIFF
--- a/pkg/iac/detection/detect.go
+++ b/pkg/iac/detection/detect.go
@@ -102,26 +102,27 @@ func detectTerraform(name string, _ io.ReadSeeker) bool {
 }
 
 func detectTerraformPlanJSON(name string, r io.ReadSeeker) bool {
-	if IsType(name, r, FileTypeJSON) {
-		if resetReader(r) == nil {
-			return false
-		}
-
-		contents := make(map[string]any)
-		err := json.NewDecoder(r).Decode(&contents)
-		if err != nil {
-			return false
-		}
-
-		for _, k := range []string{"terraform_version", "format_version"} {
-			if _, ok := contents[k]; !ok {
-				return false
-			}
-		}
-
-		return true
+	if !isJSON(name) {
+		return false
 	}
-	return false
+
+	data, err := readContent(r)
+	if err != nil || !json.Valid(data) {
+		return false
+	}
+
+	var contents map[string]any
+	if err := json.Unmarshal(data, &contents); err != nil {
+		return false
+	}
+
+	for _, k := range []string{"terraform_version", "format_version"} {
+		if _, ok := contents[k]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func detectTerraformPlanSnapshot(_ string, r io.ReadSeeker) bool {
@@ -129,23 +130,25 @@ func detectTerraformPlanSnapshot(_ string, r io.ReadSeeker) bool {
 }
 
 func detectCloudFormation(name string, r io.ReadSeeker) bool {
+	data, err := readContent(r)
+	if err != nil {
+		return false
+	}
+
 	sniff := struct {
 		Resources map[string]map[string]any `json:"Resources" yaml:"Resources"`
 	}{}
 
 	switch {
-	case IsType(name, r, FileTypeYAML):
-		if resetReader(r) == nil {
+	case isYAML(name):
+		if err := yaml.Unmarshal(data, &sniff); err != nil {
 			return false
 		}
-		if err := yaml.NewDecoder(r).Decode(&sniff); err != nil {
+	case isJSON(name):
+		if !json.Valid(data) {
 			return false
 		}
-	case IsType(name, r, FileTypeJSON):
-		if resetReader(r) == nil {
-			return false
-		}
-		if err := json.NewDecoder(r).Decode(&sniff); err != nil {
+		if err := json.Unmarshal(data, &sniff); err != nil {
 			return false
 		}
 	default:
@@ -216,64 +219,26 @@ func detectDockerfile(name string, _ io.ReadSeeker) bool {
 }
 
 func detectKubernetes(name string, r io.ReadSeeker) bool {
-	if !IsType(name, r, FileTypeYAML) && !IsType(name, r, FileTypeJSON) {
-		return false
-	}
-	if resetReader(r) == nil {
+	data, err := readContent(r)
+	if err != nil {
 		return false
 	}
 
-	expectedProperties := []string{"apiVersion", "kind", "metadata"}
-
-	if IsType(name, r, FileTypeJSON) {
-		if resetReader(r) == nil {
+	switch {
+	case isJSON(name):
+		if !json.Valid(data) {
 			return false
 		}
-
 		var result map[string]any
-		if err := json.NewDecoder(r).Decode(&result); err != nil {
+		if err := json.Unmarshal(data, &result); err != nil {
 			return false
 		}
-
-		for _, expected := range expectedProperties {
-			if _, ok := result[expected]; !ok {
-				return false
-			}
-		}
-		return true
-	}
-
-	// at this point, we need to inspect bytes
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
+		return hasK8sManifestFields(result)
+	case isYAML(name):
+		return hasK8sManifestInYAML(data)
+	default:
 		return false
 	}
-	data := buf.Bytes()
-
-	marker := []byte("\n---\n")
-	altMarker := []byte("\r\n---\r\n")
-	if bytes.Contains(data, altMarker) {
-		marker = altMarker
-	}
-
-	for partial := range bytes.SplitSeq(data, marker) {
-		var result map[string]any
-		if err := yaml.Unmarshal(partial, &result); err != nil {
-			continue
-		}
-		match := true
-		for _, expected := range expectedProperties {
-			if _, ok := result[expected]; !ok {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
-		}
-	}
-
-	return false
 }
 
 func detectAnsible(name string, _ io.ReadSeeker) bool {
@@ -341,6 +306,44 @@ func resetReader(r io.Reader) io.ReadSeeker {
 		return seeker
 	}
 	return ensureSeeker(r)
+}
+
+func readContent(r io.ReadSeeker) ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return io.ReadAll(r)
+}
+
+func hasK8sManifestFields(result map[string]any) bool {
+	for _, key := range []string{"apiVersion", "kind", "metadata"} {
+		if _, ok := result[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasK8sManifestInYAML(data []byte) bool {
+	marker := []byte("\n---\n")
+	altMarker := []byte("\r\n---\r\n")
+	if bytes.Contains(data, altMarker) {
+		marker = altMarker
+	}
+
+	for partial := range bytes.SplitSeq(data, marker) {
+		var result map[string]any
+		if err := yaml.Unmarshal(partial, &result); err != nil {
+			continue
+		}
+		if hasK8sManifestFields(result) {
+			return true
+		}
+	}
+	return false
 }
 
 func isJSON(name string) bool {

--- a/pkg/iac/detection/detect_test.go
+++ b/pkg/iac/detection/detect_test.go
@@ -630,6 +630,68 @@ func BenchmarkIsType_BigFile(b *testing.B) {
 	}
 }
 
+// largeOpenAPIYAML returns a valid YAML document that is not a Kubernetes manifest.
+func largeOpenAPIYAML(repeat int) []byte {
+	chunk := `openapi: "3.0.0"
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: OK
+`
+	return bytes.Repeat([]byte(chunk), repeat)
+}
+
+func benchmarkIsTypeKubernetesYAML(b *testing.B, repeat int) {
+	data := largeOpenAPIYAML(repeat)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = IsType("openapi.yaml", bytes.NewReader(data), FileTypeKubernetes)
+	}
+}
+
+func BenchmarkIsType_Kubernetes_YAML_1x(b *testing.B) {
+	benchmarkIsTypeKubernetesYAML(b, 1)
+}
+
+func BenchmarkIsType_Kubernetes_YAML_100x(b *testing.B) {
+	benchmarkIsTypeKubernetesYAML(b, 100)
+}
+
+func benchmarkIsTypeCloudFormationYAML(b *testing.B, repeat int) {
+	data := largeOpenAPIYAML(repeat)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = IsType("template.yaml", bytes.NewReader(data), FileTypeCloudFormation)
+	}
+}
+
+func BenchmarkIsType_CloudFormation_YAML_1x(b *testing.B) {
+	benchmarkIsTypeCloudFormationYAML(b, 1)
+}
+
+func BenchmarkIsType_CloudFormation_YAML_100x(b *testing.B) {
+	benchmarkIsTypeCloudFormationYAML(b, 100)
+}
+
+func BenchmarkIsType_TerraformPlanJSON_LargeJSON(b *testing.B) {
+	chunk := []byte(`{"format_version":"0.2","terraform_version":"1.0.0","planned_values":{}}`)
+	data := bytes.Repeat(chunk, 100)
+	b.SetBytes(int64(len(data)))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = IsType("plan.json", bytes.NewReader(data), FileTypeTerraformPlanJSON)
+	}
+}
+
 func Test_IsFileMatchesSchemas(t *testing.T) {
 
 	schema := `{


### PR DESCRIPTION
## Description
- Kubernetes, CloudFormation, and Terraform Plan JSON matchers previously called `IsType` recursively, fully parsing each candidate file multiple times during misconfiguration filtering.
- Each matcher now reads file content once and unmarshals once.

On repositories with many YAML/JSON files that are not IaC (e.g. OpenAPI specs), the detection phase alone can allocate multiple GB before any policy evaluation runs. This removes the worst redundant parses without changing the public API.

## Before / after

Apple M3 Pro, `GOEXPERIMENT=jsonv2`, `go test ./pkg/iac/detection/ -bench=BenchmarkIsType -benchmem -count=10`

| Benchmark | Before | After |
|-----------|--------|-------|
| `IsType_Kubernetes_YAML_1x` | 24.6 µs/op, 371 allocs/op, 34.6 KiB/op | 13.2 µs/op, 186 allocs/op, 17.7 KiB/op (−46% / −50% / −49%) |
| `IsType_Kubernetes_YAML_100x` | 1022 µs/op, 15.3k allocs/op, 885 KiB/op | 555 µs/op, 7.6k allocs/op, 462 KiB/op (−46% / −50% / −48%) |
| `IsType_CloudFormation_YAML_1x` | 22.3 µs/op, 321 allocs/op, 31.5 KiB/op | 10.6 µs/op, 138 allocs/op, 14.9 KiB/op (−53% / −57% / −53%) |
| `IsType_CloudFormation_YAML_100x` | 902 µs/op, 12.4k allocs/op, 702 KiB/op | 385 µs/op, 4.8k allocs/op, 289 KiB/op (−57% / −61% / −59%) |
| `IsType_TerraformPlanJSON_LargeJSON` | 133 µs/op, 1966 allocs/op, 153 KiB/op | 113 µs/op, 1954 allocs/op, 120 KiB/op (−15% / −0.6% / −21%) |

Percentages are time / allocs / bytes vs main.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
