### PR TITLE
fix(conda): avoid panic on an all-operator dependency line

### DIFF
--- a/pkg/dependency/parser/conda/environment/parse.go
+++ b/pkg/dependency/parser/conda/environment/parse.go
@@ -101,6 +101,9 @@ func (p *Parser) toPackage(dep Dependency) ftypes.Package {
 func (*Parser) parseDependency(line string) (string, string) {
 	line = strings.NewReplacer(">", " >", "<", " <", "=", " ").Replace(line)
 	parts := strings.Fields(line)
+	if len(parts) == 0 {
+		return "", ""
+	}
 	name := parts[0]
 	if len(parts) == 1 {
 		return name, ""

--- a/pkg/dependency/parser/conda/environment/parse_test.go
+++ b/pkg/dependency/parser/conda/environment/parse_test.go
@@ -190,6 +190,27 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			// A dependency made up only of operators leaves nothing behind once
+			// they are replaced, so the parser must not index into the empty split.
+			name:  "dependency line contains only operators",
+			input: "testdata/operator-only-dep.yaml",
+			want: environment.Packages{
+				Packages: []ftypes.Package{
+					{
+						Name:    "numpy",
+						Version: "1.26.4",
+						Locations: ftypes.Locations{
+							{
+								StartLine: 7,
+								EndLine:   7,
+							},
+						},
+					},
+				},
+				Prefix: "/opt/conda/envs/test-env",
+			},
+		},
+		{
 			name:    "invalid yaml file",
 			input:   "testdata/invalid.yaml",
 			wantErr: "cannot unmarshal !!str `invalid` into environment.environment",

--- a/pkg/dependency/parser/conda/environment/testdata/operator-only-dep.yaml
+++ b/pkg/dependency/parser/conda/environment/testdata/operator-only-dep.yaml
@@ -1,0 +1,9 @@
+name: test-env
+channels:
+  - defaults
+dependencies:
+  - "="
+  - "=="
+  - numpy=1.26.4
+
+prefix: /opt/conda/envs/test-env


### PR DESCRIPTION
`parseDependency` normalizes a conda `environment.yml` dependency string by turning the version operators into spaces, then splits on whitespace and reads `parts[0]`:

```go
line = strings.NewReplacer(">", " >", "<", " <", "=", " ").Replace(line)
parts := strings.Fields(line)
name := parts[0]
```

If the dependency value is only operators, e.g. a stray `"="`, the replaced line is all whitespace and `strings.Fields` returns an empty slice, so `parts[0]` panics with an index-out-of-range and aborts the scan.

Repro (`environment.yml`):

```yaml
name: crash
dependencies:
  - "="
```

`"="` is a valid YAML string scalar, so it reaches `parseDependency`. The sibling text parsers (`golang/sum`, `ruby/bundler`, `rust/cargo`) all guard the empty-split case before indexing; conda did not.

The fix returns an empty name/version for such a line, which the caller already drops via its existing `if pkg.Name == "" { continue }`. `go test ./pkg/dependency/parser/conda/...` passes.