### PR TITLE
chore(go): bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0


### PR DESCRIPTION
## Summary

Bumps the minimum Go version from 1.26.3 to 1.26.5 to pull in two security fixes from the Go 1.26.5 release (2026-07-07).

## CVEs fixed

| CVE | Package | Description |
|-----|---------|-------------|
| CVE-2026-39822 | `os` | `os.Root` follows symlinks in sub-operations when the root directory itself is a symlink, enabling path traversal |
| CVE-2026-42505 | `crypto/tls` | ECH (Encrypted Client Hello) leaks session key material under certain TLS 1.3 handshake conditions |

## Notes

- Only `go.mod` changes — no dependency additions or removals.
- CI reads the Go version from `go.mod` via the `setup-go` composite action, so no workflow changes are needed.
- Alpine-based OS CVEs (libcurl, c-ares) in the published `trivy:0.72.0` Docker image require a new release to trigger a rebuild with current Alpine packages — they are not addressed here.