### PR TITLE
feat(java): support Maven 4 project settings and root repositories

### DIFF
--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -100,7 +100,7 @@ func NewParser(filePath string, opts ...option) *Parser {
 		defaultRepo: mavenCentralRepo,
 	}
 
-	s := readSettings()
+	s := readSettings(filepath.Dir(filepath.Clean(filePath)))
 	o.settingsRepos = s.effectiveRepositories()
 	localRepository := s.LocalRepository
 	if localRepository == "" {

--- a/pkg/dependency/parser/java/pom/settings.go
+++ b/pkg/dependency/parser/java/pom/settings.go
@@ -46,12 +46,13 @@ type Mirror struct {
 }
 
 type settings struct {
-	LocalRepository string    `xml:"localRepository"`
-	Servers         []Server  `xml:"servers>server"`
-	Profiles        []Profile `xml:"profiles>profile"`
-	ActiveProfiles  []string  `xml:"activeProfiles>activeProfile"`
-	Proxies         []Proxy   `xml:"proxies>proxy"`
-	Mirrors         []Mirror  `xml:"mirrors>mirror"`
+	LocalRepository string          `xml:"localRepository"`
+	Servers         []Server        `xml:"servers>server"`
+	Profiles        []Profile       `xml:"profiles>profile"`
+	ActiveProfiles  []string        `xml:"activeProfiles>activeProfile"`
+	Proxies         []Proxy         `xml:"proxies>proxy"`
+	Mirrors         []Mirror        `xml:"mirrors>mirror"`
+	Repositories    []pomRepository `xml:"repositories>repository"` // Repositories declared at the root of settings.xml (Maven 4)
 }
 
 func (s settings) effectiveRepositories() []repository {
@@ -61,6 +62,11 @@ func (s settings) effectiveRepositories() []repository {
 			pomRepos = append(pomRepos, profile.Repositories...)
 		}
 	}
+
+	// Repositories declared at the root of settings.xml (Maven 4).
+	// Profile repositories are appended first so they win when deduplicating by ID.
+	pomRepos = append(pomRepos, s.Repositories...)
+
 	pomRepos = lo.UniqBy(pomRepos, func(r pomRepository) string {
 		return r.ID
 	})
@@ -110,13 +116,28 @@ func (p Proxy) isNonProxyHost(host string) bool {
 	return false
 }
 
-func readSettings() settings {
+// readSettings loads Maven settings and merges them by precedence.
+// Maven resolves settings in the order global < project < user, so user
+// settings are dominant, followed by project settings, then global.
+// https://maven.apache.org/ref/4-LATEST/api/maven-api-settings/settings.html
+//
+// projectDir is the directory of the POM being parsed. When it contains a
+// .mvn/settings.xml file (Maven 4 project-specific settings), it is merged
+// between the user and global settings.
+func readSettings(projectDir string) settings {
 	s := settings{}
 
 	userSettingsPath := filepath.Join(os.Getenv("HOME"), ".m2", "settings.xml")
-	userSettings, err := openSettings(userSettingsPath)
-	if err == nil {
+	if userSettings, err := openSettings(userSettingsPath); err == nil {
 		s = userSettings
+	}
+
+	// Maven 4 project-specific settings (${session.rootdir}/.mvn/settings.xml).
+	if projectDir != "" {
+		projectSettingsPath := filepath.Join(projectDir, ".mvn", "settings.xml")
+		if projectSettings, err := openSettings(projectSettingsPath); err == nil {
+			mergeSettings(&s, projectSettings)
+		}
 	}
 
 	// Some package managers use this path by default
@@ -125,38 +146,40 @@ func readSettings() settings {
 		mavenHome = mHome
 	}
 	globalSettingsPath := filepath.Join(mavenHome, "conf", "settings.xml")
-	globalSettings, err := openSettings(globalSettingsPath)
-	if err == nil {
-		// We need to merge global and user settings. User settings being dominant.
-		// https://maven.apache.org/settings.html#quick-overview
-		if s.LocalRepository == "" {
-			s.LocalRepository = globalSettings.LocalRepository
-		}
-
-		// Maven servers
-		s.Servers = lo.UniqBy(append(s.Servers, globalSettings.Servers...), func(server Server) string {
-			return server.ID
-		})
-
-		// Merge profiles
-		s.Profiles = lo.UniqBy(append(s.Profiles, globalSettings.Profiles...), func(p Profile) string {
-			return p.ID
-		})
-		// Merge active profiles
-		s.ActiveProfiles = lo.Uniq(append(s.ActiveProfiles, globalSettings.ActiveProfiles...))
-
-		// Merge proxies
-		s.Proxies = lo.UniqBy(append(s.Proxies, globalSettings.Proxies...), func(p Proxy) string {
-			return p.ID
-		})
-
-		// Merge mirrors
-		s.Mirrors = lo.UniqBy(append(s.Mirrors, globalSettings.Mirrors...), func(m Mirror) string {
-			return m.ID
-		})
+	if globalSettings, err := openSettings(globalSettingsPath); err == nil {
+		mergeSettings(&s, globalSettings)
 	}
 
 	return s
+}
+
+// mergeSettings merges lower-priority settings into s. Values already present
+// in s take precedence, so callers must merge from highest to lowest priority.
+// https://maven.apache.org/settings.html#quick-overview
+func mergeSettings(s *settings, lower settings) {
+	if s.LocalRepository == "" {
+		s.LocalRepository = lower.LocalRepository
+	}
+	s.Servers = lo.UniqBy(append(s.Servers, lower.Servers...), func(server Server) string {
+		return server.ID
+	})
+	s.Profiles = lo.UniqBy(append(s.Profiles, lower.Profiles...), func(p Profile) string {
+		return p.ID
+	})
+	s.ActiveProfiles = lo.Uniq(append(s.ActiveProfiles, lower.ActiveProfiles...))
+	s.Proxies = lo.UniqBy(append(s.Proxies, lower.Proxies...), func(p Proxy) string {
+		return p.ID
+	})
+	s.Mirrors = lo.UniqBy(append(s.Mirrors, lower.Mirrors...), func(m Mirror) string {
+		return m.ID
+	})
+	// Root-level repositories are a Maven 4 addition. Merge them only when
+	// present so that settings without them keep a nil slice.
+	if len(s.Repositories) > 0 || len(lower.Repositories) > 0 {
+		s.Repositories = lo.UniqBy(append(s.Repositories, lower.Repositories...), func(r pomRepository) string {
+			return r.ID
+		})
+	}
 }
 
 func openSettings(filePath string) (settings, error) {
@@ -196,6 +219,12 @@ func expandAllEnvPlaceholders(s *settings) {
 	}
 	for i, activeProfile := range s.ActiveProfiles {
 		s.ActiveProfiles[i] = evaluateVariable(activeProfile, nil, nil)
+	}
+
+	for i, repo := range s.Repositories {
+		s.Repositories[i].ID = evaluateVariable(repo.ID, nil, nil)
+		s.Repositories[i].Name = evaluateVariable(repo.Name, nil, nil)
+		s.Repositories[i].URL = evaluateVariable(repo.URL, nil, nil)
 	}
 
 	for i, proxy := range s.Proxies {

--- a/pkg/dependency/parser/java/pom/settings_test.go
+++ b/pkg/dependency/parser/java/pom/settings_test.go
@@ -488,7 +488,7 @@ func Test_ReadSettings(t *testing.T) {
 				t.Setenv(env, settingsDir)
 			}
 
-			gotSettings := readSettings()
+			gotSettings := readSettings("")
 			require.Equal(t, tt.wantSettings, gotSettings)
 		})
 	}
@@ -764,4 +764,52 @@ func Test_effectiveProxies(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_ReadSettings_Maven4(t *testing.T) {
+	t.Run("root repositories are parsed from settings.xml", func(t *testing.T) {
+		t.Setenv("HOME", filepath.Join("testdata", "settings", "user-with-repositories"))
+		t.Setenv("MAVEN_HOME", "NOT_EXISTING_PATH")
+
+		got := readSettings("")
+		require.Equal(t, []pomRepository{
+			{
+				ID:   "maven4-root",
+				Name: "Maven 4 root repository",
+				URL:  "https://maven4.example.com/repo",
+			},
+		}, got.Repositories)
+	})
+
+	t.Run("project-specific settings from .mvn/settings.xml are loaded", func(t *testing.T) {
+		t.Setenv("HOME", "")
+		t.Setenv("MAVEN_HOME", "NOT_EXISTING_PATH")
+
+		got := readSettings(filepath.Join("testdata", "settings", "project"))
+		require.Equal(t, []Server{
+			{
+				ID:       "project-server",
+				Username: "project-user",
+			},
+		}, got.Servers)
+		require.Equal(t, []pomRepository{
+			{
+				ID:  "project-repo",
+				URL: "https://project.example.com/repo",
+			},
+		}, got.Repositories)
+	})
+
+	t.Run("settings precedence is user over project over global", func(t *testing.T) {
+		t.Setenv("HOME", filepath.Join("testdata", "settings", "precedence-user"))
+		t.Setenv("MAVEN_HOME", filepath.Join("testdata", "settings", "precedence-global"))
+
+		got := readSettings(filepath.Join("testdata", "settings", "precedence-project"))
+		require.Equal(t, []Server{
+			{ID: "shared", Username: "from-user"},
+			{ID: "user-only", Username: "user"},
+			{ID: "project-only", Username: "project"},
+			{ID: "global-only", Username: "global"},
+		}, got.Servers)
+	})
 }

--- a/pkg/dependency/parser/java/pom/testdata/settings/precedence-global/conf/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/precedence-global/conf/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>shared</id>
+            <username>from-global</username>
+        </server>
+        <server>
+            <id>global-only</id>
+            <username>global</username>
+        </server>
+    </servers>
+</settings>

--- a/pkg/dependency/parser/java/pom/testdata/settings/precedence-project/.mvn/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/precedence-project/.mvn/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>shared</id>
+            <username>from-project</username>
+        </server>
+        <server>
+            <id>project-only</id>
+            <username>project</username>
+        </server>
+    </servers>
+</settings>

--- a/pkg/dependency/parser/java/pom/testdata/settings/precedence-user/.m2/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/precedence-user/.m2/settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>shared</id>
+            <username>from-user</username>
+        </server>
+        <server>
+            <id>user-only</id>
+            <username>user</username>
+        </server>
+    </servers>
+</settings>

--- a/pkg/dependency/parser/java/pom/testdata/settings/project/.mvn/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/project/.mvn/settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>project-server</id>
+            <username>project-user</username>
+        </server>
+    </servers>
+    <repositories>
+        <repository>
+            <id>project-repo</id>
+            <url>https://project.example.com/repo</url>
+        </repository>
+    </repositories>
+</settings>

--- a/pkg/dependency/parser/java/pom/testdata/settings/user-with-repositories/.m2/settings.xml
+++ b/pkg/dependency/parser/java/pom/testdata/settings/user-with-repositories/.m2/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <localRepository>testdata/user/repository</localRepository>
+    <repositories>
+        <repository>
+            <id>maven4-root</id>
+            <name>Maven 4 root repository</name>
+            <url>https://maven4.example.com/repo</url>
+        </repository>
+    </repositories>
+</settings>


### PR DESCRIPTION
## Description

Adds support for two Maven 4 `settings.xml` behaviors to the Java POM parser:

- **Project-specific settings** at `${session.rootdir}/.mvn/settings.xml`. When the POM being parsed has a `.mvn/settings.xml` in its directory, it is now loaded and merged with the precedence Maven uses — `global < project < user` — so user settings stay dominant and project settings sit between user and global.
- **Root-level repositories** declared directly under `<settings><repositories>` (the Maven 4 schema addition), in addition to the existing profile repositories.

The existing global/user merge is extracted into a `mergeSettings` helper so all three tiers merge consistently, and env-placeholder expansion is applied to the new root repositories as well. The precedence order follows [Maven's `SettingsXmlConfigurationProcessor`](https://github.com/apache/maven/blob/e6303aae3281e5e87151489bac9db9236dd7eb97/maven-embedder/src/main/java/org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor.java#L141-L143), as noted in the issue.

## Related issues
- Close #9908

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [x] I've added tests that prove my feature works.
- [ ] I've updated the documentation (if needed) — n/a: this is parser-internal behavior and the Java coverage docs don't document `settings.xml` resolution.
- [ ] I've added usage information (if the PR introduces new options) — n/a: no new options.
- [ ] I've included a "before" and "after" example (if the PR is a user interface change) — n/a.
