### PR TITLE
chore: add schema id

### DIFF
--- a/magefiles/config_schema.go
+++ b/magefiles/config_schema.go
@@ -30,6 +30,7 @@ const configSchemaPath = "schema/trivy-config.json"
 func generateConfigSchema(outputPath string, allFlagGroups []flag.FlagGroup) error {
 	root := &jsonschema.Schema{
 		Schema:      "https://json-schema.org/draft/2020-12/schema",
+		ID: 		 "https://www.schemastore.org/trivy-config.json",
 		Type:        schemaTypeObject,
 		Title:       "Trivy Configuration",
 		Description: "Configuration file for Trivy security scanner (trivy.yaml)",

--- a/magefiles/config_schema.go
+++ b/magefiles/config_schema.go
@@ -30,7 +30,7 @@ const configSchemaPath = "schema/trivy-config.json"
 func generateConfigSchema(outputPath string, allFlagGroups []flag.FlagGroup) error {
 	root := &jsonschema.Schema{
 		Schema:      "https://json-schema.org/draft/2020-12/schema",
-		ID: 		 "https://www.schemastore.org/trivy-config.json",
+		ID:          "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json",
 		Type:        schemaTypeObject,
 		Title:       "Trivy Configuration",
 		Description: "Configuration file for Trivy security scanner (trivy.yaml)",

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -929,6 +929,7 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.schemastore.org/trivy-config.json",
   "title": "Trivy Configuration",
   "description": "Configuration file for Trivy security scanner (trivy.yaml)"
 }

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -929,7 +929,6 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://www.schemastore.org/trivy-config.json",
   "title": "Trivy Configuration",
   "description": "Configuration file for Trivy security scanner (trivy.yaml)"
 }

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -928,7 +928,7 @@
       }
     }
   },
-  "$id": "https://www.schemastore.org/trivy-config.json",
+  "$id": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Trivy Configuration",
   "description": "Configuration file for Trivy security scanner (trivy.yaml)"

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -928,6 +928,7 @@
       }
     }
   },
+  "$id": "https://www.schemastore.org/trivy-config.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Trivy Configuration",
   "description": "Configuration file for Trivy security scanner (trivy.yaml)"


### PR DESCRIPTION
## Description

Following the addition to SchemaStore via https://github.com/SchemaStore/schemastore/pull/5986, the Trivy config schema should have a unique ID. From the [draft-2020-12][draft-2020-12] spec:

> Note that this URI is an identifier and not necessarily a network locator. In the case of a network-addressable URL, a schema need not be downloadable from its canonical URI.
>
> If present, the value for this keyword MUST be a string, and MUST represent a valid [URI-reference](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#RFC3986) [[RFC3986](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#RFC3986)]. This URI-reference SHOULD be normalized, and MUST resolve to an [absolute-URI](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#RFC3986) [[RFC3986](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#RFC3986)] (without a fragment), or to a URI with an empty fragment.

The provided ID is one such example of a URI following this spec. If, for whatever reason, https://github.com/SchemaStore/schemastore/pull/5986 isn't merged, the ID can be changed to, for instance, `https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json`. Although the spec dictates that the schema need not be downloadable from its ID, this quality does avoid confusion.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

[draft-2020-12]: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-01#name-the-id-keyword
