### PR TITLE
fix(fs): scan project directories named dev

### DIFF
--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -230,6 +230,9 @@ func (r *runner) ScanFilesystem(ctx context.Context, opts flag.Options) (types.R
 func (r *runner) ScanRootfs(ctx context.Context, opts flag.Options) (types.Report, error) {
 	// Disable the lock file scanning
 	opts.DisabledAnalyzers = append(opts.DisabledAnalyzers, analyzer.TypeLockfiles...)
+	// The target is a root filesystem even when it is mounted below the host root.
+	// Avoid walking virtual system directories within it.
+	opts.SkipDirs = append(opts.SkipDirs, "dev", "proc", "sys")
 
 	return r.scanFS(ctx, opts)
 }

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -26,6 +26,9 @@ func (w *FS) Walk(root string, opt Option, fn WalkFunc) error {
 	opt.SkipFiles = w.BuildSkipPaths(root, opt.SkipFiles)
 	opt.SkipDirs = w.BuildSkipPaths(root, opt.SkipDirs)
 	opt.SkipDirs = append(opt.SkipDirs, defaultSkipDirs...)
+	if isFilesystemRoot(root) {
+		opt.SkipDirs = append(opt.SkipDirs, systemSkipDirs...)
+	}
 
 	walkDirFunc := w.WalkDirFunc(root, fn, opt)
 	walkDirFunc = w.onError(walkDirFunc)
@@ -151,6 +154,16 @@ func (w *FS) BuildSkipPaths(base string, paths []string) []string {
 
 	relativePaths = utils.CleanSkipPaths(relativePaths)
 	return relativePaths
+}
+
+func isFilesystemRoot(root string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+
+	volumeRoot := filepath.VolumeName(absRoot) + string(filepath.Separator)
+	return filepath.Clean(absRoot) == filepath.Clean(volumeRoot)
 }
 
 // fileOpener returns a function opening a file.

--- a/pkg/fanal/walker/fs_test.go
+++ b/pkg/fanal/walker/fs_test.go
@@ -89,6 +89,29 @@ func TestFS_Walk(t *testing.T) {
 	}
 }
 
+func TestFS_Walk_ProjectSystemNamedDir(t *testing.T) {
+	root := t.TempDir()
+	devDir := filepath.Join(root, "dev")
+	require.NoError(t, os.Mkdir(devDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(devDir, "main.tf"), []byte("terraform {}"), 0o600))
+
+	var visited []string
+	err := walker.NewFS().Walk(root, walker.Option{}, func(filePath string, _ os.FileInfo, _ analyzer.Opener) error {
+		visited = append(visited, filePath)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Contains(t, visited, "dev/main.tf")
+
+	visited = nil
+	err = walker.NewFS().Walk(root, walker.Option{SkipDirs: []string{"dev"}}, func(filePath string, _ os.FileInfo, _ analyzer.Opener) error {
+		visited = append(visited, filePath)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, visited, "dev/main.tf")
+}
+
 func TestFS_BuildSkipPaths(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/fanal/walker/vm.go
+++ b/pkg/fanal/walker/vm.go
@@ -58,6 +58,7 @@ func NewVM() *VM {
 func (w *VM) Walk(vreader *io.SectionReader, root string, opt Option, fn WalkFunc) error {
 	w.skipFiles = opt.SkipFiles
 	w.skipDirs = append(opt.SkipDirs, defaultSkipDirs...)
+	w.skipDirs = append(w.skipDirs, systemSkipDirs...)
 
 	// This function will be called on each file.
 	w.analyzeFn = fn

--- a/pkg/fanal/walker/walk.go
+++ b/pkg/fanal/walker/walk.go
@@ -10,6 +10,9 @@ const defaultSizeThreshold = int64(100) << 20 // 200MB
 
 var defaultSkipDirs = []string{
 	"**/.git",
+}
+
+var systemSkipDirs = []string{
 	"proc",
 	"sys",
 	"dev",


### PR DESCRIPTION
## Description

Filesystem walks currently treat `dev`, `proc`, and `sys` as relative default skip patterns. As a result, a regular project directory such as `./dev` is silently omitted from filesystem and misconfiguration scans.

This change separates repository defaults from root-filesystem defaults:

- project filesystem walks skip `.git` but visit ordinary `dev`, `proc`, and `sys` directories;
- scans whose target is the actual filesystem root continue to skip those virtual system trees;
- `rootfs` scans explicitly preserve the same skip behavior even when the root is mounted below `/`;
- VM walks continue to skip system directories.

### Before

`trivy config . --debug` in a Terraform repository containing `./dev` logs `Skipping path path="dev"` and does not analyze that environment.

### After

The same project walk visits files under `./dev`. Explicit `--skip-dirs dev` still skips it, and real root filesystem / VM system directories remain excluded.

## Related issues

- Close #6651

## Validation

- `go test ./pkg/fanal/walker ./pkg/commands/artifact ./pkg/fanal/artifact/local ./pkg/fanal/artifact/vm`
- `go mod tidy` (no changes)
- `golangci-lint run --build-tags=integration ./pkg/fanal/walker/... ./pkg/commands/artifact/...` — 0 issues
- Full repository lint reaches three pre-existing findings in unchanged `pkg/fanal/test/integration/containerd_test.go` (lines 738, 806, and 810).

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] Documentation is not needed because no user-facing option or syntax changes.
- [x] Usage information is not needed because no option is introduced.
- [x] I've included a before and after example above.