### PR TITLE
fix: guard malformed parser inputs

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -46,10 +46,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies
-			if !strings.Contains(ss[0], ":git") {
-				p.logger.Warn("Cannot parse dependency", log.String("line", line))
-			} else {
+			if len(ss) > 0 && strings.Contains(ss[0], ":git") {
 				p.logger.Debug("Skip git dependencies", log.String("name", name))
+			} else {
+				p.logger.Warn("Cannot parse dependency", log.String("line", line))
 			}
 			continue
 		}

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -3,6 +3,7 @@ package mix
 import (
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,15 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equal(t, tt.want, pkgs)
 		})
 	}
+}
+
+func TestParser_ParseEmptyDependencyBody(t *testing.T) {
+	const input = `{
+  "empty":
+}`
+
+	pkgs, deps, err := NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Empty(t, pkgs)
+	assert.Empty(t, deps)
 }

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,7 +75,11 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
-			d.Set.Append(strings.Fields(dep)[0]) // Save only name
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				continue
+			}
+			d.Set.Append(fields[0]) // Save only name
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -3,6 +3,7 @@ package pyproject_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,4 +139,14 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "Parse(%v)", tt.file)
 		})
 	}
+}
+
+func TestParser_ParseMalformedDependencies(t *testing.T) {
+	const input = `[project]
+dependencies = ["flask>=1.0", "", " ", "<", "==="]
+`
+
+	got, err := pyproject.NewParser().Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, set.New[string]("flask"), got.MainDeps())
 }

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,7 +66,9 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
-			dependsOn = append(dependsOn, s[0]) // store name only for now
+			if len(s) > 0 {
+				dependsOn = append(dependsOn, s[0]) // store name only for now
+			}
 		}
 		lineNum++
 

--- a/pkg/dependency/parser/ruby/bundler/parse_test.go
+++ b/pkg/dependency/parser/ruby/bundler/parse_test.go
@@ -3,6 +3,7 @@ package bundler_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,4 +278,34 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equalf(t, tt.wantDeps, gotDeps, "Parse(%v)", tt.file)
 		})
 	}
+}
+
+func TestParser_ParseEmptyDependency(t *testing.T) {
+	const input = "GEM\n  specs:\n    first (1.0.0)\n      \n    second (2.0.0)\n"
+
+	gotPkgs, gotDeps, err := bundler.NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []ftypes.Package{
+		{
+			ID:           "first@1.0.0",
+			Name:         "first",
+			Version:      "1.0.0",
+			Relationship: ftypes.RelationshipIndirect,
+			Locations: []ftypes.Location{{
+				StartLine: 3,
+				EndLine:   3,
+			}},
+		},
+		{
+			ID:           "second@2.0.0",
+			Name:         "second",
+			Version:      "2.0.0",
+			Relationship: ftypes.RelationshipIndirect,
+			Locations: []ftypes.Location{{
+				StartLine: 5,
+				EndLine:   5,
+			}},
+		},
+	}, gotPkgs)
+	assert.Empty(t, gotDeps)
 }

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,12 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					fields := strings.Fields(s)
+					if len(fields) == 0 {
+						p.logger.Debug("Empty direct dependency")
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], fields[0])
 				}
 			}
 		}

--- a/pkg/dependency/parser/swift/cocoapods/parse_test.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse_test.go
@@ -2,6 +2,7 @@ package cocoapods_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,20 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, tt.wantDeps, gotDeps)
 		})
 	}
+}
+
+func TestParseEmptyDirectDependency(t *testing.T) {
+	const input = `PODS:
+  - AppCenter (4.2.0):
+    - ""
+`
+
+	gotPkgs, gotDeps, err := cocoapods.NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []ftypes.Package{{
+		ID:      "AppCenter@4.2.0",
+		Name:    "AppCenter",
+		Version: "4.2.0",
+	}}, gotPkgs)
+	assert.Empty(t, gotDeps)
 }

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,11 +42,9 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
+	var ok bool
+	if osVer, ok = normalizeVersion(osVer); !ok {
+		return nil, nil
 	}
 
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
@@ -103,12 +101,24 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 // IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
+	var ok bool
+	if osVer, ok = normalizeVersion(osVer); !ok {
+		return false
 	}
 
 	return osver.Supported(ctx, eolDates, osFamily, osVer)
+}
+
+func normalizeVersion(osVer string) (string, bool) {
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return "", false
+	}
+
+	// The format `2023.xxx.xxxx` can be used.
+	osVer = osver.Major(fields[0])
+	if osVer != "2" && osVer != "2022" && osVer != "2023" {
+		osVer = "1"
+	}
+	return osVer, true
 }

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -152,6 +152,12 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name: "empty OS version",
+			args: args{
+				osVer: "",
+			},
+		},
+		{
 			name: "Get returns an error",
 			fixtures: []string{
 				"testdata/fixtures/invalid.yaml",
@@ -243,6 +249,15 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 				osVer:    "2023",
 			},
 			want: true,
+		},
+		{
+			name: "empty version",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- treat an empty Amazon Linux version as unsupported instead of indexing an empty field slice
- skip malformed empty dependency entries in the pyproject, CocoaPods, Mix, and Bundler parsers
- preserve Bundler source locations when an empty dependency line is skipped
- add regression coverage for every affected parser and both Amazon scanner entry points

Closes #10976.

## Root cause

Several parsing paths indexed the first element returned by `strings.Fields` (or an equivalent split) without checking whether the slice was empty. Malformed but container-valid input could therefore panic and abort the entire scan.

## User impact

Trivy now continues scanning when these individual malformed entries are encountered. Valid dependencies in the same file are still parsed, while an empty Amazon version is handled conservatively without assuming a release.

## Validation

- `go test ./pkg/detector/ospkg/amazon ./pkg/dependency/parser/python/pyproject ./pkg/dependency/parser/swift/cocoapods ./pkg/dependency/parser/hex/mix ./pkg/dependency/parser/ruby/bundler`
- `go vet ./pkg/detector/ospkg/amazon ./pkg/dependency/parser/python/pyproject ./pkg/dependency/parser/swift/cocoapods ./pkg/dependency/parser/hex/mix ./pkg/dependency/parser/ruby/bundler`
- `git diff --check`

## AI disclosure

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor's GitHub account.
