### PR TITLE
fix: prevent panics on malformed parser inputs

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -46,10 +46,11 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies
-			if !strings.Contains(ss[0], ":git") {
-				p.logger.Warn("Cannot parse dependency", log.String("line", line))
-			} else {
+			isGitDependency := len(ss) > 0 && strings.Contains(ss[0], ":git")
+			if isGitDependency {
 				p.logger.Debug("Skip git dependencies", log.String("name", name))
+			} else {
+				p.logger.Warn("Cannot parse dependency", log.String("line", line))
 			}
 			continue
 		}

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -3,6 +3,7 @@ package mix
 import (
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,15 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equal(t, tt.want, pkgs)
 		})
 	}
+}
+
+func TestParser_ParseMalformedDependency(t *testing.T) {
+	const input = `{
+  "empty":
+}`
+
+	pkgs, deps, err := NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Empty(t, pkgs)
+	assert.Empty(t, deps)
 }

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,7 +75,11 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
-			d.Set.Append(strings.Fields(dep)[0]) // Save only name
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				continue
+			}
+			d.Set.Append(fields[0]) // Save only name
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -3,6 +3,7 @@ package pyproject_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +137,36 @@ func TestParser_Parse(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "Parse(%v)", tt.file)
+		})
+	}
+}
+
+func TestParser_ParseMalformedDependencies(t *testing.T) {
+	tests := []struct {
+		name       string
+		dependency string
+	}{
+		{
+			name:       "empty",
+			dependency: "",
+		},
+		{
+			name:       "whitespace",
+			dependency: " ",
+		},
+		{
+			name:       "operators only",
+			dependency: "<===",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf("[project]\ndependencies = [\"flask>=1.0\", %q]\n", tt.dependency)
+
+			got, err := (&pyproject.Parser{}).Parse(strings.NewReader(input))
+			require.NoError(t, err)
+			assert.Equal(t, set.New[string]("flask"), got.MainDeps())
 		})
 	}
 }

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,7 +66,9 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
-			dependsOn = append(dependsOn, s[0]) // store name only for now
+			if len(s) > 0 {
+				dependsOn = append(dependsOn, s[0]) // store name only for now
+			}
 		}
 		lineNum++
 

--- a/pkg/dependency/parser/ruby/bundler/parse_test.go
+++ b/pkg/dependency/parser/ruby/bundler/parse_test.go
@@ -3,6 +3,7 @@ package bundler_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,4 +278,16 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equalf(t, tt.wantDeps, gotDeps, "Parse(%v)", tt.file)
 		})
 	}
+}
+
+func TestParser_ParseMalformedDependency(t *testing.T) {
+	const input = "GEM\n  specs:\n    first (1.0.0)\n      \n    second (2.0.0)\n"
+
+	gotPkgs, gotDeps, err := (&bundler.Parser{}).Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, gotPkgs, 2)
+	assert.Equal(t, "first", gotPkgs[0].Name)
+	assert.Equal(t, "second", gotPkgs[1].Name)
+	assert.Equal(t, ftypes.Locations{{StartLine: 5, EndLine: 5}}, gotPkgs[1].Locations)
+	assert.Empty(t, gotDeps)
 }

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,11 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					fields := strings.Fields(s)
+					if len(fields) == 0 {
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], fields[0])
 				}
 			}
 		}

--- a/pkg/dependency/parser/swift/cocoapods/parse_test.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse_test.go
@@ -2,6 +2,7 @@ package cocoapods_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,25 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, tt.wantDeps, gotDeps)
 		})
 	}
+}
+
+func TestParseMalformedDirectDependencies(t *testing.T) {
+	const input = `PODS:
+  - AppCenter (4.2.0):
+    - AppCenter/Core (= 4.2.0)
+    - ""
+    - "   "
+  - AppCenter/Core (4.2.0)
+`
+
+	gotPkgs, gotDeps, err := cocoapods.NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, gotPkgs, 2)
+	assert.ElementsMatch(t, []string{"AppCenter", "AppCenter/Core"}, []string{gotPkgs[0].Name, gotPkgs[1].Name})
+	assert.Equal(t, []ftypes.Dependency{
+		{
+			ID:        "AppCenter@4.2.0",
+			DependsOn: []string{"AppCenter/Core@4.2.0"},
+		},
+	}, gotDeps)
 }

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,11 +42,9 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
+	osVer, ok := parseVersion(osVer)
+	if !ok {
+		return nil, nil
 	}
 
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
@@ -103,12 +101,26 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 // IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
+	osVer, ok := parseVersion(osVer)
+	if !ok {
+		return false
 	}
 
 	return osver.Supported(ctx, eolDates, osFamily, osVer)
+}
+
+func parseVersion(osVer string) (string, bool) {
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return "", false
+	}
+
+	// The format `2023.xxx.xxxx` can be used.
+	osVer = osver.Major(fields[0])
+	switch osVer {
+	case "2", "2022", "2023":
+		return osVer, true
+	default:
+		return "1", true
+	}
 }

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -137,7 +137,7 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
-			name: "empty version",
+			name: "empty package version",
 			fixtures: []string{
 				"testdata/fixtures/amazon.yaml",
 				"testdata/fixtures/data-source.yaml",
@@ -149,6 +149,16 @@ func TestScanner_Detect(t *testing.T) {
 						Name: "bash",
 					},
 				},
+			},
+		},
+		{
+			name: "empty OS version",
+			fixtures: []string{
+				"testdata/fixtures/amazon.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "",
 			},
 		},
 		{
@@ -243,6 +253,15 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 				osVer:    "2023",
 			},
 			want: true,
+		},
+		{
+			name: "empty version",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux.go
@@ -53,6 +53,9 @@ func (a amazonlinuxOSAnalyzer) parseRelease(r io.Reader) (types.OS, error) {
 				Name:   strings.Join(fields[3:], " "),
 			}, nil
 		} else if strings.HasPrefix(line, "Amazon Linux") {
+			if len(fields) < 3 {
+				continue
+			}
 			return types.OS{
 				Family: types.Amazon,
 				Name:   strings.Join(fields[2:], " "),

--- a/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/pkg/fanal/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -80,6 +80,14 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 			wantErr: fos.AnalyzeOSError.Error(),
 		},
 		{
+			name: "sad path amazon linux without version",
+			input: analyzer.AnalysisInput{
+				FilePath: "etc/system-release",
+				Content:  strings.NewReader(`Amazon Linux`),
+			},
+			wantErr: fos.AnalyzeOSError.Error(),
+		},
+		{
 			name: "sad path",
 			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",


### PR DESCRIPTION
## Description

Closes #10976.

Several parsers and the Amazon Linux detector indexed the first element returned by `strings.Fields` or another tokenization step without first checking whether any tokens existed. Malformed but container-valid input could therefore panic and abort the entire scan.

This change handles each malformed value at the boundary where its format is understood:

- rejects an Amazon Linux release string that does not contain version information;
- centralizes defensive Amazon Linux version normalization for `Detect` and `IsSupportedVersion`;
- skips empty, whitespace-only, or operators-only entries in `pyproject.toml` dependencies;
- skips empty or whitespace-only CocoaPods child dependencies while preserving valid siblings;
- handles a Mix dependency with an empty body without indexing an empty token slice;
- ignores a blank six-space Bundler dependency line while preserving package line locations.

Each parser keeps its existing behavior for valid input. The checks remain local because the four dependency formats have different parsing rules and malformed-entry policies.

### Before

Any of the malformed inputs described in #10976 could cause `runtime error: index out of range [0] with length 0` and terminate the scan.

### After

The Amazon Linux analyzer reports its normal OS analysis error when required version information is absent. Direct Amazon detector calls also return safely. The dependency parsers skip only the malformed entry and continue parsing valid content.

## Validation

- regression tests first reproduced all five panic paths
- targeted tests for the Amazon analyzer/detector and all four dependency parsers
- `mage tidy`
- `mage fmt`
- `mage build`
- `mage docs:generate`
- `mage lint:run` (`0 issues`)
- `mage test:unit`
- `git diff --check`

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [PR title conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title).
- [x] I've added tests that prove the fix is effective.
- [x] Documentation changes are not needed because this only changes malformed-input handling.
- [x] Usage information is not needed because this introduces no new options.
- [x] The before-and-after behavior is included above.
