### PR TITLE
docs: fix comment typos

### DIFF
--- a/pkg/detector/ospkg/echo/echo.go
+++ b/pkg/detector/ospkg/echo/echo.go
@@ -77,7 +77,7 @@ func (s *Scanner) Detect(ctx context.Context, _ string, _ *ftypes.Repository, pk
 	return detectedVulns, nil
 }
 
-// Echo is a rolling distro, meaning there are no versions, and therefor no need to check the version
+// Echo is a rolling distro, meaning there are no versions, and therefore no need to check the version
 func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
 	return true
 }

--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -362,7 +362,7 @@ func aggregate(detail *ftypes.ArtifactDetail) {
 	detail.Applications = apps
 }
 
-// We must save secrets from all layers even though they are removed in the uppler layer.
+// We must save secrets from all layers even though they are removed in the upper layer.
 // If the secret was changed at the top level, we need to overwrite it.
 func mergeSecrets(secretsMap map[string]ftypes.Secret, newSecret ftypes.Secret, layer ftypes.Layer) map[string]ftypes.Secret {
 	for i := range newSecret.Findings { // add layer to the Findings from the new secret

--- a/pkg/fanal/walker/fs.go
+++ b/pkg/fanal/walker/fs.go
@@ -111,11 +111,11 @@ func (w *FS) BuildSkipPaths(base string, paths []string) []string {
 		//       e.g. $ trivy fs --skip-dirs bar ./foo
 		//     The skip dir from the root directory will be `bar/`.
 		// 2. Relative skip dirs/files from the working directory
-		//     The specified dirs and files wll be converted to the relative path from the root directory.
+		//     The specified dirs and files will be converted to the relative path from the root directory.
 		//       e.g. $ trivy fs --skip-dirs ./foo/bar ./foo
 		//     The skip dir will be converted to `bar/`.
 		// 3. Absolute skip dirs/files
-		//     The specified dirs and files wll be converted to the relative path from the root directory.
+		//     The specified dirs and files will be converted to the relative path from the root directory.
 		//       e.g. $ trivy fs --skip-dirs /bar/foo/baz ./foo
 		//     When the working directory is
 		//       3.1 /bar: the skip dir will be converted to `baz/`.

--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -97,7 +97,7 @@ func (v *VersionChecker) RunUpdateCheck(ctx context.Context) {
 			return
 		}
 
-		// enable priting if update allowed and quiet mode is not set
+		// enable printing if update allowed and quiet mode is not set
 		if !v.cliOptions.SkipVersionCheck && !v.cliOptions.Quiet {
 			v.responseReceived = true
 		}


### PR DESCRIPTION
## Description

Fix a few typos in code comments.

## Related issues

None.

## Checklist
- [x] I have read the contributing guide.
- [x] The change is small and documentation/comment-only.

## Verification

```console
GOEXPERIMENT=jsonv2 go test ./pkg/detector/ospkg/echo ./pkg/fanal/walker ./pkg/fanal/applier ./pkg/notification
```

All listed package tests passed locally.
