### PR TITLE
docs: clarify debug logs when version check or telemetry is disabled

### DIFF
--- a/docs/guide/advanced/telemetry.md
+++ b/docs/guide/advanced/telemetry.md
@@ -37,3 +37,7 @@ For example:
 ```bash
 trivy image --disable-telemetry alpine
 ```
+
+!!! note
+    Disabling telemetry stops the collection of the data described above, but Trivy still connects to `check.trivy.dev` to [check for updates](../configuration/others.md#check-for-updates) unless the `--skip-version-check` flag is specified as well.
+    See [Check updates service](./air-gap.md#check-updates-service) for details.

--- a/docs/guide/configuration/others.md
+++ b/docs/guide/configuration/others.md
@@ -167,7 +167,15 @@ Trivy periodically checks for updates and notices, and displays a message to the
 Updates checking is non-blocking and has no impact on scanning time, performance, results, or any user experience aspect besides displaying the message.  
 You can disable updates checking by specifying the `--skip-version-check` flag.
 
+!!! note
+    The version check and [telemetry](#telemetry) share a single request to `check.trivy.dev`, so the request is still sent unless telemetry is disabled as well.
+    See [Check updates service](../advanced/air-gap.md#check-updates-service) for details.
+
 ## Telemetry
 
 Trivy collected usage data for product improvement. More details in the [Telemetry document](../advanced/telemetry.md).
 You can disable telemetry collection using the `--disable-telemetry` flag.
+
+!!! note
+    The [version check](#check-for-updates) and telemetry share a single request to `check.trivy.dev`, so the request is still sent unless the version check is disabled as well.
+    See [Check updates service](../advanced/air-gap.md#check-updates-service) for details.

--- a/pkg/notification/notice.go
+++ b/pkg/notification/notice.go
@@ -48,19 +48,28 @@ func NewVersionChecker(commandName string, cliOptions *flag.Options) *VersionChe
 // RunUpdateCheck makes a best efforts request to determine the
 // latest version and any announcements
 // Logic:
-// 1. if skipUpdateCheck is true AND telemetryDisabled are both true, skip the request
-// 2. if skipUpdateCheck is true AND telemetryDisabled is false, run check with metric details but suppress output
-// 3. if skipUpdateCheck is false AND telemetryDisabled is true, run update check but don't send any metric identifiers
+// 1. if SkipVersionCheck AND DisableTelemetry are both true, skip the request
+// 2. if SkipVersionCheck is true AND DisableTelemetry is false, send the request with telemetry headers but suppress the version check output
+// 3. if SkipVersionCheck is false AND DisableTelemetry is true, run the version check but don't send any telemetry identifiers
 func (v *VersionChecker) RunUpdateCheck(ctx context.Context) {
 	logger := log.WithPrefix("notification")
 
 	if v.cliOptions.SkipVersionCheck && v.cliOptions.DisableTelemetry {
-		logger.Debug("Skipping update check and metric ping")
+		logger.Debug("Version check and telemetry are disabled, skipping request")
 		return
 	}
 
 	go func() {
-		logger.Debug("Running version check")
+		switch {
+		case v.cliOptions.SkipVersionCheck:
+			// the request is still sent to deliver anonymous telemetry,
+			// but the version check output is suppressed
+			logger.Debug("Version check is disabled, sending anonymous telemetry only")
+		case v.cliOptions.DisableTelemetry:
+			logger.Debug("Telemetry is disabled, running version check only")
+		default:
+			logger.Debug("Running version check and sending anonymous telemetry")
+		}
 		commandParts := v.getFlags()
 		client := xhttp.ClientWithContext(ctx, xhttp.WithTimeout(3*time.Second))
 
@@ -101,7 +110,11 @@ func (v *VersionChecker) RunUpdateCheck(ctx context.Context) {
 		if !v.cliOptions.SkipVersionCheck && !v.cliOptions.Quiet {
 			v.responseReceived = true
 		}
-		logger.Debug("Version check completed", log.String("latest_version", v.latestVersion.Trivy.LatestVersion))
+		if v.cliOptions.SkipVersionCheck {
+			logger.Debug("Telemetry sent")
+		} else {
+			logger.Debug("Version check completed", log.String("latest_version", v.latestVersion.Trivy.LatestVersion))
+		}
 		v.done = true
 	}()
 }


### PR DESCRIPTION
## Description

When `--skip-version-check` is used without `--disable-telemetry`, the request to `check.trivy.dev` is still sent to deliver anonymous telemetry, but the debug log misleadingly says `Running version check`.
This confused a user in discussion #10971 into thinking the flag does not work.

This PR makes the debug log messages accurately reflect the actual flag combination:

| Flags | Before | After |
|---|---|---|
| both | `Skipping update check and metric ping` | `Version check and telemetry are disabled, skipping request` |
| `--skip-version-check` only | `Running version check` | `Version check is disabled, sending anonymous telemetry only` |
| `--disable-telemetry` only | `Running version check` | `Telemetry is disabled, running version check only` |
| none | `Running version check` | `Running version check and sending anonymous telemetry` |
| on success with `--skip-version-check` | `Version check completed latest_version=...` | `Telemetry sent` |
| on success otherwise | `Version check completed latest_version=...` | `Version check completed latest_version=...` (unchanged) |

The docs are also updated: the `Check for updates` and `Telemetry` sections now cross-reference each other and note that both features share a single request to `check.trivy.dev`, linking to the [Check updates service](https://trivy.dev/docs/latest/guide/advanced/air-gap/#check-updates-service) section of the air-gap guide.

### Before

```bash
$ trivy config -d --skip-version-check .
...
DEBUG  [notification] Running version check
```

### After

```bash
$ trivy config -d --skip-version-check .
...
DEBUG  [notification] Version check is disabled, sending anonymous telemetry only
```

## Related issues
- Discussion: https://github.com/aquasecurity/trivy/discussions/10971

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
