### PR TITLE
feat(vex): discover OpenVEX in generic in-toto OCI referrers

### DIFF
--- a/docs/guide/supply-chain/vex/oci.md
+++ b/docs/guide/supply-chain/vex/oci.md
@@ -11,12 +11,17 @@ This feature allows you to automatically use VEX during container image scanning
 Trivy can automatically discover and utilize VEX attestations for container images during scanning by using the `--vex oci` flag.
 This process enhances vulnerability detection results by incorporating the information from the VEX attestation.
 
-Trivy discovers attestations in both layouts produced by Cosign:
+Trivy discovers attestations in the following layouts:
 
 - An **OCI 1.1 referrer** holding a Sigstore bundle, which is the default for `cosign attest` since Cosign v3.
+- An **OCI 1.1 referrer** holding a DSSE envelope or a bare in-toto statement under the generic `application/vnd.in-toto+json` artifact type, as published by tools such as Docker Scout.
 - The **legacy `.att` tag**, which is the default for Cosign v2.
 
 The referrer layout takes precedence; Trivy falls back to the legacy `.att` tag when no VEX referrer is found.
+
+Since a single artifact type covers every kind of attestation, an image usually exposes SBOM and provenance referrers next to the VEX one.
+Trivy uses the `in-toto.io/predicate-type` annotation to pick the VEX attestation without downloading the others, and falls back to inspecting the attestation itself when a referrer carries no annotation.
+A referrer Trivy cannot decode is skipped rather than failing the scan.
 
 To use this feature, follow these three steps:
 

--- a/docs/guide/supply-chain/vex/oci.md
+++ b/docs/guide/supply-chain/vex/oci.md
@@ -23,6 +23,12 @@ Since a single artifact type covers every kind of attestation, an image usually 
 Trivy uses the `in-toto.io/predicate-type` annotation to pick the VEX attestation without downloading the others, and falls back to inspecting the attestation itself when a referrer carries no annotation.
 A referrer Trivy cannot decode is skipped rather than failing the scan.
 
+!!! note
+    The annotation is optional:
+
+    - If any referrer is annotated as OpenVEX, Trivy uses only those referrers, even when none of them can be fetched or decoded.
+    - If no referrer is annotated as OpenVEX, Trivy downloads the unannotated referrers and inspects their contents.
+
 To use this feature, follow these three steps:
 
 1. Create a VEX document

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -25,6 +25,9 @@ type SigstoreBundle struct {
 }
 
 // Statement holds in-toto statement headers and the predicate.
+// Its UnmarshalJSON decodes a DSSE envelope and unwraps the statement from the
+// envelope's payload, so decode into it only when the input is a DSSE envelope.
+// For a bare in-toto statement (no envelope), decode into in_toto.Statement.
 type Statement in_toto.Statement
 
 func (s *Statement) UnmarshalJSON(b []byte) error {

--- a/pkg/oci/artifact.go
+++ b/pkg/oci/artifact.go
@@ -36,11 +36,18 @@ const (
 	// DSSE envelope artifact type for legacy Cosign attestations (.att tag)
 	DSSEEnvelopeArtifactType = "application/vnd.dsse.envelope.v1+json"
 
+	// Generic in-toto artifact type, used by Docker Scout for every attestation.
+	// The payload is either a bare in-toto statement or a DSSE envelope.
+	InTotoArtifactType = "application/vnd.in-toto+json"
+
 	// Media types
 	OCIImageManifest = "application/vnd.oci.image.manifest.v1+json"
 
 	// Annotations
 	titleAnnotation = "org.opencontainers.image.title"
+
+	// Optional annotation naming the in-toto predicate type of a referrer
+	PredicateTypeAnnotation = "in-toto.io/predicate-type"
 )
 
 var SupportedSBOMArtifactTypes = []string{

--- a/pkg/vex/oci/export_test.go
+++ b/pkg/vex/oci/export_test.go
@@ -1,0 +1,7 @@
+package oci
+
+// VEXCandidates exposes vexCandidates for external tests.
+var VEXCandidates = vexCandidates
+
+// DecodeInTotoPredicate exposes decodeInTotoPredicate for external tests.
+var DecodeInTotoPredicate = decodeInTotoPredicate

--- a/pkg/vex/oci/oci.go
+++ b/pkg/vex/oci/oci.go
@@ -159,10 +159,12 @@ func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOption
 }
 
 // vexCandidates narrows referrers to those that may carry an OpenVEX document,
-// preserving the registry order. Since a single artifact type covers every kind of
-// attestation (SBOM, provenance, VEX), it filters on the optional
-// `in-toto.io/predicate-type` annotation instead, dropping referrers announced as
-// non-OpenVEX without fetching them and keeping unannotated ones as a fallback.
+// preserving the registry order. A single artifact type covers every kind of
+// attestation (SBOM, provenance, VEX), so it filters on the optional
+// `in-toto.io/predicate-type` annotation instead: referrers announced as OpenVEX
+// are preferred, those announced as anything else are dropped, and unannotated ones
+// are a fallback used only when nothing is announced as OpenVEX (the annotation is
+// optional, so an unannotated referrer may still be the VEX document).
 func vexCandidates(descs []v1.Descriptor) []v1.Descriptor {
 	var openVEX, unannotated []v1.Descriptor
 	for _, desc := range descs {
@@ -178,7 +180,10 @@ func vexCandidates(descs []v1.Descriptor) []v1.Descriptor {
 			// Announced as something else (SBOM, provenance, ...): drop it.
 		}
 	}
-	return append(openVEX, unannotated...)
+	if len(openVEX) > 0 {
+		return openVEX
+	}
+	return unannotated
 }
 
 func retrieveLegacyVEX(ctx context.Context, digest name.Digest, registryOptions ftypes.RegistryOptions) (*openvex.VEX, error) {

--- a/pkg/vex/oci/oci.go
+++ b/pkg/vex/oci/oci.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	openvex "github.com/openvex/go-vex/pkg/vex"
 	"github.com/package-url/packageurl-go"
 	"github.com/samber/lo"
@@ -30,6 +31,7 @@ import (
 var supportedVEXArtifactTypes = set.New(
 	oci.SigstoreBundleArtifactType,
 	oci.DSSEEnvelopeArtifactType,
+	oci.InTotoArtifactType,
 )
 
 const (
@@ -118,9 +120,9 @@ func resolveDigest(ctx context.Context, p *purl.PackageURL, registryOptions ftyp
 }
 
 func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOptions ftypes.RegistryOptions) (*openvex.VEX, error) {
-	// A VEX artifact type (Sigstore bundle / DSSE envelope) is shared by every
-	// Cosign attestation, not just VEX, so an image may expose SBOM or SLSA
-	// provenance referrers alongside (or instead of) a VEX one.
+	// Every VEX artifact type is shared by other kinds of attestation, so an image
+	// may expose SBOM or SLSA provenance referrers alongside (or instead of) a VEX
+	// one.
 	//
 	// A registry with no referrers (API unsupported or nothing attached) yields an
 	// empty descs that falls through to the legacy path below, so an error here is
@@ -133,10 +135,19 @@ func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOption
 	// Decode each candidate and return the first OpenVEX document, skipping the
 	// rest; cap the number processed so a hostile registry cannot make us fetch
 	// unboundedly.
-	for _, desc := range lo.Slice(descs, 0, maxAttestations) {
+	for _, desc := range lo.Slice(vexCandidates(descs), 0, maxAttestations) {
 		vexDoc, err := fetchReferrerVEX(ctx, digest, desc, registryOptions)
 		if err != nil {
-			return nil, err
+			// An oversized attestation is a decompression-bomb signal (CWE-409),
+			// so fail loudly instead of skipping it.
+			if errors.Is(err, xio.ErrLimitExceeded) {
+				return nil, err
+			}
+			// Skip a referrer we cannot download or decode so another may still yield a
+			// VEX document, but log at Warn: a transient error here silently drops one.
+			log.WithPrefix("vex").Warn("Skipping referrer that could not be retrieved or decoded",
+				log.String("digest", desc.Digest.String()), log.Err(err))
+			continue
 		}
 		if vexDoc == nil {
 			continue // a valid attestation, but not OpenVEX (e.g. SBOM); try the next referrer
@@ -145,6 +156,29 @@ func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOption
 	}
 
 	return nil, nil
+}
+
+// vexCandidates narrows referrers to those that may carry an OpenVEX document,
+// preserving the registry order. Since a single artifact type covers every kind of
+// attestation (SBOM, provenance, VEX), it filters on the optional
+// `in-toto.io/predicate-type` annotation instead, dropping referrers announced as
+// non-OpenVEX without fetching them and keeping unannotated ones as a fallback.
+func vexCandidates(descs []v1.Descriptor) []v1.Descriptor {
+	var openVEX, unannotated []v1.Descriptor
+	for _, desc := range descs {
+		predicateType, ok := desc.Annotations[oci.PredicateTypeAnnotation]
+		switch {
+		case !ok:
+			// No annotation: we cannot tell what it is without fetching it.
+			unannotated = append(unannotated, desc)
+		case isOpenVEXPredicateType(predicateType):
+			// Announced as OpenVEX.
+			openVEX = append(openVEX, desc)
+		default:
+			// Announced as something else (SBOM, provenance, ...): drop it.
+		}
+	}
+	return append(openVEX, unannotated...)
 }
 
 func retrieveLegacyVEX(ctx context.Context, digest name.Digest, registryOptions ftypes.RegistryOptions) (*openvex.VEX, error) {
@@ -236,35 +270,79 @@ func fetchAttestationLayers(ctx context.Context, ref name.Reference, registryOpt
 }
 
 // decodeOpenVEXAttestation decodes an OpenVEX predicate from an attestation
-// stream. The stream is either a Sigstore bundle (Cosign v3+ new format)
-// wrapping a DSSE envelope, or a bare DSSE envelope (legacy `.att` / OCI 1.1
-// referrer). In both cases the DSSE payload is an in-toto Statement whose
-// predicate is the OpenVEX document.
+// stream. The stream is one of three layouts, each wrapping an in-toto statement
+// whose predicate is the OpenVEX document:
+//   - a Sigstore bundle (Cosign v3+ new format) wrapping a DSSE envelope;
+//   - a bare DSSE envelope (legacy `.att` / OCI 1.1 referrer);
+//   - a bare in-toto statement.
 //
-// It returns (nil, nil) when the attestation is well-formed but its predicate is
-// not OpenVEX (e.g. an SBOM or SLSA provenance attestation sharing the same
-// artifact type), so callers can skip it. An error is returned only when the
-// stream itself cannot be decoded.
+// It returns:
+//   - the OpenVEX document, when the predicate is OpenVEX;
+//   - (nil, nil), when the stream is well-formed but its predicate is not OpenVEX
+//     (e.g. an SBOM or SLSA provenance attestation sharing the same artifact type),
+//     so callers can skip it;
+//   - an error, only when the stream itself cannot be decoded.
 func decodeOpenVEXAttestation(r io.Reader, artifactType string) (*openvex.VEX, error) {
 	// Decode the in-toto predicate directly into the typed OpenVEX struct.
 	var predicate openvex.VEX
-	statement := attestation.Statement{Predicate: &predicate}
 
+	var predicateType string
 	if artifactType == oci.SigstoreBundleArtifactType {
-		bundle := attestation.SigstoreBundle{DSSEEnvelope: statement}
+		bundle := attestation.SigstoreBundle{DSSEEnvelope: attestation.Statement{Predicate: &predicate}}
 		if err := json.NewDecoder(r).Decode(&bundle); err != nil {
 			return nil, xerrors.Errorf("failed to decode Sigstore bundle: %w", err)
 		}
-		statement = bundle.DSSEEnvelope
-	} else if err := json.NewDecoder(r).Decode(&statement); err != nil {
-		return nil, xerrors.Errorf("failed to decode DSSE envelope: %w", err)
+		predicateType = bundle.DSSEEnvelope.PredicateType
+	} else {
+		b, err := io.ReadAll(r)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read attestation: %w", err)
+		}
+		if predicateType, err = decodeInTotoPredicate(b, &predicate); err != nil {
+			return nil, err
+		}
 	}
 
-	if !isOpenVEXPredicateType(statement.PredicateType) {
+	if !isOpenVEXPredicateType(predicateType) {
 		return nil, nil
 	}
 
 	return &predicate, nil
+}
+
+// decodeInTotoPredicate decodes an attestation into predicate and returns the
+// in-toto predicate type it declares. The generic in-toto artifact type covers
+// both DSSE envelopes and bare statements depending on the publishing tool, so the
+// format is detected by content rather than by artifact type: a `payloadType`
+// marks a DSSE envelope, a top-level `_type` marks a bare statement.
+func decodeInTotoPredicate(b []byte, predicate any) (string, error) {
+	var probe struct {
+		Type        string `json:"_type"`
+		PayloadType string `json:"payloadType"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return "", xerrors.Errorf("failed to decode attestation: %w", err)
+	}
+
+	switch {
+	case probe.PayloadType != "":
+		// DSSE envelope: attestation.Statement unwraps the statement from its payload.
+		statement := attestation.Statement{Predicate: predicate}
+		if err := json.Unmarshal(b, &statement); err != nil {
+			return "", xerrors.Errorf("failed to decode DSSE envelope: %w", err)
+		}
+		return statement.PredicateType, nil
+	case probe.Type != "":
+		// Bare in-toto statement: in_toto.Statement decodes the JSON as-is, without
+		// expecting a DSSE envelope around it.
+		statement := in_toto.Statement{Predicate: predicate}
+		if err := json.Unmarshal(b, &statement); err != nil {
+			return "", xerrors.Errorf("failed to decode in-toto statement: %w", err)
+		}
+		return statement.PredicateType, nil
+	default:
+		return "", xerrors.New("unknown attestation format: neither a DSSE envelope nor an in-toto statement")
+	}
 }
 
 // isOpenVEXPredicateType reports whether predicateType identifies an OpenVEX

--- a/pkg/vex/oci/oci.go
+++ b/pkg/vex/oci/oci.go
@@ -138,6 +138,11 @@ func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOption
 	for _, desc := range lo.Slice(vexCandidates(descs), 0, maxAttestations) {
 		vexDoc, err := fetchReferrerVEX(ctx, digest, desc, registryOptions)
 		if err != nil {
+			// A canceled context or an expired deadline applies to the whole discovery
+			// operation, not just this referrer, so stop instead of trying the next one.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
 			// An oversized attestation is a decompression-bomb signal (CWE-409),
 			// so fail loudly instead of skipping it.
 			if errors.Is(err, xio.ErrLimitExceeded) {
@@ -161,10 +166,13 @@ func retrieveReferrerVEX(ctx context.Context, digest name.Digest, registryOption
 // vexCandidates narrows referrers to those that may carry an OpenVEX document,
 // preserving the registry order. A single artifact type covers every kind of
 // attestation (SBOM, provenance, VEX), so it filters on the optional
-// `in-toto.io/predicate-type` annotation instead: referrers announced as OpenVEX
-// are preferred, those announced as anything else are dropped, and unannotated ones
-// are a fallback used only when nothing is announced as OpenVEX (the annotation is
-// optional, so an unannotated referrer may still be the VEX document).
+// `in-toto.io/predicate-type` annotation instead:
+//   - announced as OpenVEX: kept, and the unannotated referrers are then dropped.
+//     A publisher annotating its VEX referrers is unlikely to do so for only some of
+//     them, so looking at the announced ones alone avoids unnecessary downloads.
+//   - announced as anything else (SBOM, provenance, ...): dropped, without downloading.
+//   - unannotated: kept only when nothing is announced as OpenVEX, since the
+//     annotation is optional.
 func vexCandidates(descs []v1.Descriptor) []v1.Descriptor {
 	var openVEX, unannotated []v1.Descriptor
 	for _, desc := range descs {

--- a/pkg/vex/oci/oci_test.go
+++ b/pkg/vex/oci/oci_test.go
@@ -72,49 +72,41 @@ func createVEXAttestation(t *testing.T, vulnerabilityID string) dsse.Envelope {
 }
 
 func createVEXAttestationWithPredicateType(t *testing.T, vulnerabilityID, predicateType string) dsse.Envelope {
+	// A DSSE envelope wraps the base64-encoded bare in-toto statement.
+	return dsse.Envelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     base64.StdEncoding.EncodeToString(createBareInTotoStatement(t, vulnerabilityID, predicateType)),
+		Signatures:  nil,
+	}
+}
+
+func createVEXAttestationBlob(t *testing.T, vulnerabilityID string) []byte {
+	b, err := json.Marshal(createVEXAttestation(t, vulnerabilityID))
+	require.NoError(t, err)
+	return b
+}
+
+// createBareInTotoStatement builds an in-toto statement stored as-is, without a
+// DSSE envelope around it. Docker Scout attaches attestations to Docker Hardened
+// Images this way. Its predicate is the OpenVEX document from the shared fixture.
+func createBareInTotoStatement(t *testing.T, vulnerabilityID, predicateType string) []byte {
 	var v openvex.VEX
 	testutil.MustReadJSON(t, "../testdata/openvex-oci.json", &v)
 	v.Statements[0].Vulnerability.Name = openvex.VulnerabilityID(vulnerabilityID)
 
-	// in-toto Statement
-	statement := in_toto.Statement{
+	b, err := json.Marshal(in_toto.Statement{
 		StatementHeader: in_toto.StatementHeader{
 			Type:          "https://in-toto.io/Statement/v0.1",
 			PredicateType: predicateType,
 			Subject: []in_toto.Subject{
 				{
-					Name: "example",
-					Digest: map[string]string{
-						"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-					},
+					Name:   "example",
+					Digest: map[string]string{"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 				},
 			},
 		},
 		Predicate: v,
-	}
-
-	attestationJSON, err := json.Marshal(statement)
-	require.NoError(t, err)
-
-	// Base64 encode
-	encodedAttestation := base64.StdEncoding.EncodeToString(attestationJSON)
-
-	// Create a DSSE envelope
-	return dsse.Envelope{
-		PayloadType: "application/vnd.in-toto+json",
-		Payload:     encodedAttestation,
-		Signatures:  nil,
-	}
-}
-
-func createVEXAttestationBlobWithPredicateType(t *testing.T, vulnerabilityID, predicateType string) []byte {
-	b, err := json.Marshal(createVEXAttestationWithPredicateType(t, vulnerabilityID, predicateType))
-	require.NoError(t, err)
-	return b
-}
-
-func createVEXAttestationBlob(t *testing.T, vulnerabilityID string) []byte {
-	b, err := json.Marshal(createVEXAttestation(t, vulnerabilityID))
+	})
 	require.NoError(t, err)
 	return b
 }
@@ -249,14 +241,51 @@ func TestDiscover(t *testing.T) {
 			want: map[string]bool{"CVE-2022-3715": true},
 		},
 		{
-			name: "referrer with versioned OpenVEX predicate",
+			name: "referrer bare in-toto statement",
 			setup: func(t *testing.T) string {
-				repo := "debian/versioned-predicate"
+				repo := "debian/bare-in-toto"
 				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
-				// OpenVEX uses versioned namespaces such as ".../ns/v0.2.0"; the
-				// prefix must still be recognized as OpenVEX.
-				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.DSSEEnvelopeArtifactType,
-					createVEXAttestationBlobWithPredicateType(t, "CVE-2022-3715", "https://openvex.dev/ns/v0.2.0"))
+				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.InTotoArtifactType,
+					createBareInTotoStatement(t, "CVE-2022-3715", "https://openvex.dev/ns/v0.2.0"))
+				return registryHost + "/" + repo + ":latest"
+			},
+			want: map[string]bool{"CVE-2022-3715": true},
+		},
+		{
+			name: "referrer DSSE envelope under the in-toto artifact type",
+			setup: func(t *testing.T) string {
+				repo := "debian/in-toto-dsse"
+				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
+				// The generic in-toto artifact type also carries DSSE envelopes,
+				// depending on the publishing tool, so the format is detected by content.
+				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.InTotoArtifactType,
+					createVEXAttestationBlob(t, "CVE-2022-3715"))
+				return registryHost + "/" + repo + ":latest"
+			},
+			want: map[string]bool{"CVE-2022-3715": true},
+		},
+		{
+			name: "non-OpenVEX in-toto referrer is skipped",
+			setup: func(t *testing.T) string {
+				repo := "debian/in-toto-sbom"
+				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
+				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.InTotoArtifactType,
+					createBareInTotoStatement(t, "CVE-2022-3715", "https://spdx.dev/Document"))
+				return registryHost + "/" + repo + ":latest"
+			},
+			want: nil,
+		},
+		{
+			name: "undecodable referrer does not fail the scan",
+			setup: func(t *testing.T) string {
+				repo := "debian/undecodable-referrer"
+				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
+				// A referrer Trivy cannot decode - here an unannotated blob in an unknown
+				// format - must be skipped so that the remaining ones are still examined.
+				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.InTotoArtifactType,
+					[]byte(`{"mediaType":"application/vnd.oci.image.manifest.v1+json"}`))
+				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.InTotoArtifactType,
+					createBareInTotoStatement(t, "CVE-2022-3715", "https://openvex.dev/ns/v0.2.0"))
 				return registryHost + "/" + repo + ":latest"
 			},
 			want: map[string]bool{"CVE-2022-3715": true},
@@ -321,25 +350,11 @@ func TestDiscover(t *testing.T) {
 			wantErr: "too many layers",
 		},
 		{
-			name: "malformed sigstore bundle",
+			name: "malformed sigstore bundle is skipped",
 			setup: func(t *testing.T) string {
 				repo := "debian/malformed"
 				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
 				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.SigstoreBundleArtifactType, []byte("{"))
-				return registryHost + "/" + repo + ":latest"
-			},
-			wantErr: "failed to decode Sigstore bundle",
-		},
-		{
-			name: "non-OpenVEX referrer is skipped",
-			setup: func(t *testing.T) string {
-				repo := "debian/sbom-referrer"
-				_, subjectDesc := registrytest.PushRandomImage(t, registryHost, repo, "latest")
-				// A VEX artifact type is shared by every Cosign attestation, so a
-				// non-OpenVEX predicate (here a lookalike namespace) must be skipped,
-				// not treated as an error, and yield no VEX document.
-				registrytest.PushReferrer(t, registryHost, repo, subjectDesc, coreoci.DSSEEnvelopeArtifactType,
-					createVEXAttestationBlobWithPredicateType(t, "CVE-2022-3715", "https://openvex.dev/nsx"))
 				return registryHost + "/" + repo + ":latest"
 			},
 			want: nil,
@@ -483,6 +498,144 @@ func TestDiscoverInvalidPURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := oci.Discover(t.Context(), tt.purl, ftypes.RegistryOptions{})
 			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestVEXCandidates(t *testing.T) {
+	desc := func(name string, annotations map[string]string) v1.Descriptor {
+		return v1.Descriptor{
+			Digest:      v1.Hash{Algorithm: "sha256", Hex: name},
+			Annotations: annotations,
+		}
+	}
+	predicate := func(predicateType string) map[string]string {
+		return map[string]string{coreoci.PredicateTypeAnnotation: predicateType}
+	}
+
+	tests := []struct {
+		name  string
+		descs []v1.Descriptor
+		want  []string // digest hexes, in the expected order
+	}{
+		{
+			name: "referrer announcing OpenVEX is kept",
+			descs: []v1.Descriptor{
+				desc("vex", predicate("https://openvex.dev/ns/v0.2.0")),
+			},
+			want: []string{"vex"},
+		},
+		{
+			name: "referrers announcing another predicate are dropped",
+			descs: []v1.Descriptor{
+				desc("sbom", predicate("https://spdx.dev/Document")),
+				desc("provenance", predicate("https://slsa.dev/provenance/v1")),
+				desc("vex", predicate("https://openvex.dev/ns")),
+			},
+			want: []string{"vex"},
+		},
+		{
+			name: "a look-alike namespace is not OpenVEX",
+			descs: []v1.Descriptor{
+				desc("lookalike", predicate("https://openvex.dev/nsx")),
+			},
+			want: nil,
+		},
+		{
+			name: "the annotation is optional, so unannotated referrers are kept",
+			descs: []v1.Descriptor{
+				desc("unannotated", nil),
+				desc("empty-annotations", make(map[string]string)),
+			},
+			want: []string{"unannotated", "empty-annotations"},
+		},
+		{
+			name: "referrers announcing OpenVEX are probed before unannotated ones",
+			descs: []v1.Descriptor{
+				desc("unannotated", nil),
+				desc("sbom", predicate("https://spdx.dev/Document")),
+				desc("vex", predicate("https://openvex.dev/ns/v0.2.0")),
+			},
+			want: []string{"vex", "unannotated"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			for _, d := range oci.VEXCandidates(tt.descs) {
+				got = append(got, d.Digest.Hex)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecodeInTotoPredicate(t *testing.T) {
+	tests := []struct {
+		name              string
+		blob              []byte
+		wantPredicateType string
+		wantErr           string
+		wantMatch         bool // the OpenVEX predicate was decoded into the output
+	}{
+		{
+			name:              "bare in-toto statement",
+			blob:              createBareInTotoStatement(t, "CVE-2022-3715", "https://openvex.dev/ns"),
+			wantPredicateType: "https://openvex.dev/ns",
+			wantMatch:         true,
+		},
+		{
+			name:              "DSSE envelope",
+			blob:              createVEXAttestationBlob(t, "CVE-2022-3715"),
+			wantPredicateType: "https://openvex.dev/ns",
+			wantMatch:         true,
+		},
+		{
+			name:              "bare statement with a non-OpenVEX predicate",
+			blob:              createBareInTotoStatement(t, "CVE-2022-3715", "https://spdx.dev/Document"),
+			wantPredicateType: "https://spdx.dev/Document",
+		},
+		{
+			name:    "malformed JSON",
+			blob:    []byte("{"),
+			wantErr: "failed to decode attestation",
+		},
+		{
+			name:    "neither a DSSE envelope nor an in-toto statement",
+			blob:    []byte(`{"mediaType":"application/vnd.oci.image.manifest.v1+json"}`),
+			wantErr: "unknown attestation format",
+		},
+		{
+			name:    "DSSE envelope with a non-base64 payload",
+			blob:    []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"!!!not-base64!!!"}`),
+			wantErr: "failed to decode DSSE envelope",
+		},
+		{
+			name:    "DSSE envelope with the wrong payload type",
+			blob:    []byte(`{"payloadType":"application/vnd.other+json","payload":"e30="}`),
+			wantErr: "failed to decode DSSE envelope",
+		},
+		{
+			name:    "bare statement with a malformed body",
+			blob:    []byte(`{"_type":"https://in-toto.io/Statement/v0.1","subject":"not-an-array"}`),
+			wantErr: "failed to decode in-toto statement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var predicate openvex.VEX
+			predicateType, err := oci.DecodeInTotoPredicate(tt.blob, &predicate)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPredicateType, predicateType)
+			if tt.wantMatch {
+				requireOpenVEXMatch(t, &predicate, "CVE-2022-3715")
+			}
 		})
 	}
 }

--- a/pkg/vex/oci/oci_test.go
+++ b/pkg/vex/oci/oci_test.go
@@ -550,13 +550,24 @@ func TestVEXCandidates(t *testing.T) {
 			want: []string{"unannotated", "empty-annotations"},
 		},
 		{
-			name: "referrers announcing OpenVEX are probed before unannotated ones",
+			name: "an announced OpenVEX referrer is trusted over unannotated ones",
 			descs: []v1.Descriptor{
 				desc("unannotated", nil),
 				desc("sbom", predicate("https://spdx.dev/Document")),
 				desc("vex", predicate("https://openvex.dev/ns/v0.2.0")),
 			},
-			want: []string{"vex", "unannotated"},
+			// The publisher annotates its VEX referrer, so the unannotated one is not it.
+			want: []string{"vex"},
+		},
+		{
+			name: "unannotated referrers stand in when nothing is announced as OpenVEX",
+			descs: []v1.Descriptor{
+				desc("sbom", predicate("https://spdx.dev/Document")),
+				desc("unannotated", nil),
+			},
+			// No positive OpenVEX signal, and the annotation is optional, so the
+			// unannotated referrer may still be the VEX document - keep probing it.
+			want: []string{"unannotated"},
 		},
 	}
 


### PR DESCRIPTION
## Description

Docker Scout and Docker Hardened Images (DHI) publish attestations as OCI 1.1 referrers under the generic `application/vnd.in-toto+json` artifact type, as a bare in-toto statement rather than a DSSE envelope or Sigstore bundle. `trivy image --vex oci` dropped these before download and reported `No VEX attestations found`.

This adds the generic in-toto artifact type to the referrer filter, detects the attestation format by content (a `payloadType` marks a DSSE envelope, a top-level `_type` a bare statement), and selects the VEX referrer among the SBOM/provenance ones by the optional `in-toto.io/predicate-type` annotation, probing the unannotated referrers only when none is announced as OpenVEX (the annotation is optional).

A referrer that cannot be fetched or decoded is now skipped (logged at Warn) instead of failing the scan, so one bad attestation no longer blocks a valid VEX document in another referrer. An oversized attestation still fails the scan, as a decompression-bomb guard, as does a canceled context or an expired deadline — that applies to the whole scan rather than to a single referrer.

## Related issues
- Close #10985

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).

