### PR TITLE
fix(vex): reject non-local VEX repository names

### DIFF
--- a/pkg/vex/repo/manager.go
+++ b/pkg/vex/repo/manager.go
@@ -104,6 +104,11 @@ func (m *Manager) Config(ctx context.Context) (Config, error) {
 	}
 
 	for i, repo := range conf.Repositories {
+		// The repository name is joined onto the cache directory, so reject names that are not
+		// local relative paths to prevent path traversal (e.g., "../foo", "/foo", or "C:\foo" on Windows).
+		if !filepath.IsLocal(repo.Name) {
+			return Config{}, xerrors.Errorf("invalid repository name %q: must be a local relative path", repo.Name)
+		}
 		conf.Repositories[i].dir = filepath.Join(m.cacheDir, repoDir, repo.Name)
 	}
 

--- a/pkg/vex/repo/manager_test.go
+++ b/pkg/vex/repo/manager_test.go
@@ -59,6 +59,57 @@ func TestManager_Config(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "repository name with path traversal",
+			setup: func(t *testing.T, dir string) {
+				config := repo.Config{
+					Repositories: []repo.Repository{
+						{
+							Name:    filepath.Join("..", "..", "outside-target"),
+							URL:     "https://example.com/repo",
+							Enabled: true,
+						},
+					},
+				}
+				configPath := filepath.Join(dir, ".trivy", "vex", "repository.yaml")
+				testutil.MustWriteYAML(t, configPath, config)
+			},
+			wantErr: "invalid repository name",
+		},
+		{
+			name: "repository name with absolute path",
+			setup: func(t *testing.T, dir string) {
+				config := repo.Config{
+					Repositories: []repo.Repository{
+						{
+							Name:    filepath.Join(dir, "outside-target"),
+							URL:     "https://example.com/repo",
+							Enabled: true,
+						},
+					},
+				}
+				configPath := filepath.Join(dir, ".trivy", "vex", "repository.yaml")
+				testutil.MustWriteYAML(t, configPath, config)
+			},
+			wantErr: "invalid repository name",
+		},
+		{
+			name: "empty repository name",
+			setup: func(t *testing.T, dir string) {
+				config := repo.Config{
+					Repositories: []repo.Repository{
+						{
+							Name:    "",
+							URL:     "https://example.com/repo",
+							Enabled: true,
+						},
+					},
+				}
+				configPath := filepath.Join(dir, ".trivy", "vex", "repository.yaml")
+				testutil.MustWriteYAML(t, configPath, config)
+			},
+			wantErr: "invalid repository name",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vex/repo/manager_test.go
+++ b/pkg/vex/repo/manager_test.go
@@ -82,6 +82,7 @@ func TestManager_Config(t *testing.T) {
 				config := repo.Config{
 					Repositories: []repo.Repository{
 						{
+							// dir is t.TempDir(), i.e. an absolute path, so this yields an absolute repository name.
 							Name:    filepath.Join(dir, "outside-target"),
 							URL:     "https://example.com/repo",
 							Enabled: true,


### PR DESCRIPTION
## Description

The VEX repository name from `repository.yaml` is joined onto the cache directory (`$CACHE_DIR/vex/repositories/$NAME`) without validation, so a name such as `../../foo` would escape the cache root.
Validate it with `filepath.IsLocal` (the same approach used in `pkg/oci/artifact.go`) before building the path.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
