### PR TITLE
fix(vex): avoid panic on CSAF advisory without a CVE

### DIFF
--- a/pkg/vex/csaf.go
+++ b/pkg/vex/csaf.go
@@ -35,7 +35,7 @@ func (v *CSAF) Filter(result *types.Result, bom *core.BOM) {
 
 func (v *CSAF) NotAffected(vuln types.DetectedVulnerability, product, subProduct *core.Component) (types.ModifiedFinding, bool) {
 	found, ok := lo.Find(v.advisory.Vulnerabilities, func(item *csaf.Vulnerability) bool {
-		return string(*item.CVE) == vuln.VulnerabilityID
+		return matchesVulnerabilityID(item, vuln.VulnerabilityID)
 	})
 	if !ok {
 		return types.ModifiedFinding{}, false
@@ -46,6 +46,36 @@ func (v *CSAF) NotAffected(vuln types.DetectedVulnerability, product, subProduct
 		return types.ModifiedFinding{}, false
 	}
 	return types.NewModifiedFinding(vuln, status, v.statement(found), v.source), true
+}
+
+// matchesVulnerabilityID reports whether the CSAF vulnerability corresponds to
+// the given ID. The `cve` property is optional in CSAF, so it also checks the
+// entries in `ids` (e.g. GHSA identifiers) when no CVE matches.
+func matchesVulnerabilityID(vuln *csaf.Vulnerability, id string) bool {
+	if vuln.CVE != nil && string(*vuln.CVE) == id {
+		return true
+	}
+	for _, vulnID := range vuln.IDs {
+		if vulnID != nil && lo.FromPtr(vulnID.Text) == id {
+			return true
+		}
+	}
+	return false
+}
+
+// vulnerabilityID returns a human-readable identifier for the given CSAF
+// vulnerability, preferring the CVE and falling back to the first `ids` entry.
+// It is only used for logging.
+func vulnerabilityID(vuln *csaf.Vulnerability) string {
+	if vuln.CVE != nil {
+		return string(*vuln.CVE)
+	}
+	for _, id := range vuln.IDs {
+		if id != nil && id.Text != nil {
+			return *id.Text
+		}
+	}
+	return ""
 }
 
 func (v *CSAF) match(vuln *csaf.Vulnerability, product, subProduct *core.Component) types.FindingStatus {
@@ -60,7 +90,7 @@ func (v *CSAF) match(vuln *csaf.Vulnerability, product, subProduct *core.Compone
 	for status, productRange := range productStatusMap {
 		for _, p := range productRange {
 			productID := lo.FromPtr(p)
-			logger := v.logger.With(log.String("vulnerability-id", string(*vuln.CVE)),
+			logger := v.logger.With(log.String("vulnerability-id", vulnerabilityID(vuln)),
 				log.String("product-id", string(productID)), log.String("status", string(status)))
 
 			// Check if the product is affected

--- a/pkg/vex/testdata/csaf-no-cve.json
+++ b/pkg/vex/testdata/csaf-no-cve.json
@@ -1,0 +1,95 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Example Company VEX document. Unofficial content for demonstration purposes only.",
+        "title": "Author comment"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "Example Company ProductCERT",
+      "namespace": "https://psirt.example.com"
+    },
+    "title": "Aqua Security example VEX document",
+    "tracking": {
+      "current_release_date": "2022-03-03T11:00:00.000Z",
+      "generator": {
+        "date": "2022-03-03T11:00:00.000Z",
+        "engine": {
+          "name": "Secvisogram",
+          "version": "1.11.0"
+        }
+      },
+      "id": "2022-EVD-UC-01-A-001",
+      "initial_release_date": "2022-03-03T11:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2022-03-03T11:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "v4.0.0",
+                "product": {
+                  "name": "go-transitive v4.0.0",
+                  "product_id": "go-transitive-v4.0.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:golang/github.com/aquasecurity/go-transitive@v4.0.0"
+                  }
+                }
+              }
+            ],
+            "category": "product_name",
+            "name": "go-transitive"
+          }
+        ],
+        "category": "vendor",
+        "name": "foo"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "GitHub Security Advisory",
+          "text": "GHSA-2r2c-cx56-8933"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "Advisory identified by a GHSA ID without a CVE. The `cve` property is optional in CSAF.",
+          "title": "Advisory description"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "go-transitive-v4.0.0"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "vulnerable_code_not_in_execute_path"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -184,6 +184,12 @@ var (
 		InstalledVersion: goTransitivePackage.Version,
 		PkgIdentifier:    goTransitivePackage.Identifier,
 	}
+	vuln6 = types.DetectedVulnerability{
+		VulnerabilityID:  "GHSA-2r2c-cx56-8933",
+		PkgName:          goTransitivePackage.Name,
+		InstalledVersion: goTransitivePackage.Version,
+		PkgIdentifier:    goTransitivePackage.Identifier,
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -486,6 +492,32 @@ func TestFilter(t *testing.T) {
 				goSinglePathResult(types.Result{
 					Vulnerabilities:  []types.DetectedVulnerability{},
 					ModifiedFindings: []types.ModifiedFinding{modifiedFinding(vuln5, vulnerableCodeNotInExecutePath, "testdata/csaf.json")},
+				}),
+			}),
+		},
+		{
+			name: "CSAF without CVE, not affected",
+			args: args{
+				report: imageReport([]types.Result{
+					goSinglePathResult(types.Result{
+						Vulnerabilities: []types.DetectedVulnerability{
+							vuln6, // filtered by VEX, matched via `ids`
+						},
+					}),
+				}),
+				opts: vex.Options{
+					Sources: []vex.Source{
+						{
+							Type:     vex.TypeFile,
+							FilePath: "testdata/csaf-no-cve.json",
+						},
+					},
+				},
+			},
+			want: imageReport([]types.Result{
+				goSinglePathResult(types.Result{
+					Vulnerabilities:  []types.DetectedVulnerability{},
+					ModifiedFindings: []types.ModifiedFinding{modifiedFinding(vuln6, vulnerableCodeNotInExecutePath, "testdata/csaf-no-cve.json")},
 				}),
 			}),
 		},


### PR DESCRIPTION
## Description

Scanning with a CSAF VEX document crashes with a nil pointer panic when the document contains a vulnerability that has no `cve` property.

The `cve` property is optional in a CSAF `vulnerabilities` entry: an advisory may instead be identified only by its `ids` (for example a GitHub Security Advisory / GHSA identifier). `CSAF.NotAffected` dereferenced `*item.CVE` unconditionally while searching for the matching advisory, so any such entry triggered a segfault:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x706299f]

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/vex.(*CSAF).NotAffected.func1(...)
    github.com/aquasecurity/trivy/pkg/vex/csaf.go:38
github.com/samber/lo.Find[...](...)
    github.com/samber/lo@v1.53.0/find.go:74
github.com/aquasecurity/trivy/pkg/vex.(*CSAF).NotAffected(...)
    github.com/aquasecurity/trivy/pkg/vex/csaf.go:37
...
```

This change matches a vulnerability by its CVE when one is present and falls back to the `ids` entries otherwise. This both fixes the panic and lets GHSA-only advisories be matched by their identifier.

There is no associated issue, the fix is small and self-contained, so per the contributing guide I'm including the justification here instead.

### Before

```console
$ trivy image <image> --vex advisory.json
...
2026-... INFO  [rustbinary] Detecting vulnerabilities...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation ...]
    github.com/aquasecurity/trivy/pkg/vex/csaf.go:38
...
```

(where `advisory.json` is a CSAF document containing at least one `vulnerabilities` entry that uses `ids` instead of `cve`, e.g.)

```json
"vulnerabilities": [
  {
    "ids": [
      { "system_name": "GitHub Security Advisory", "text": "GHSA-2r2c-cx56-8933" }
    ],
    "product_status": { "known_not_affected": ["..."] },
    "threats": [{ "category": "impact", "details": "vulnerable_code_not_in_execute_path" }]
  }
]
```

### After

The scan completes normally, and a GHSA-only `known_not_affected` / `fixed` statement now filters the matching detected vulnerability just like a CVE-based one.

## Related issues

N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (not needed).
- [ ] I've added usage information (no new options).
- [x] I've included a "before" and "after" example to the description (included above).
