### PR TITLE
fix: guard index-out-of-range panics in dependency parsers and amazon detector

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -43,6 +43,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		ss := strings.FieldsFunc(body, func(r rune) bool {
 			return unicode.IsSpace(r) || r == ','
 		})
+		if len(ss) == 0 {
+			// Empty dependency body (e.g. `"x": {}`) - nothing to parse, skip it.
+			continue
+		}
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -86,3 +86,23 @@ func TestParser_Parse(t *testing.T) {
 		})
 	}
 }
+
+// TestParser_Parse_EmptyBody is a regression test: a mix.lock entry with an
+// empty body (e.g. `"x":` with nothing after the colon) used to panic with
+// "index out of range [0] with length 0" in strings.Contains(ss[0], ":git")
+// when len(ss) == 0. It must now be skipped instead of crashing.
+func TestParser_Parse_EmptyBody(t *testing.T) {
+	parser := NewParser()
+	f, err := os.Open("testdata/empty_body.mix.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	pkgs, _, err := parser.Parse(t.Context(), f)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		names = append(names, pkg.Name)
+	}
+	assert.Equal(t, []string{"bunt"}, names, "the valid entry should still be parsed; the empty-body entry should be skipped, not panic")
+}

--- a/pkg/dependency/parser/hex/mix/testdata/empty_body.mix.lock
+++ b/pkg/dependency/parser/hex/mix/testdata/empty_body.mix.lock
@@ -1,0 +1,4 @@
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "x":
+}

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,7 +75,12 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
-			d.Set.Append(strings.Fields(dep)[0]) // Save only name
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				// Empty/whitespace-only dependency entry - not a real package, skip it.
+				continue
+			}
+			d.Set.Append(fields[0]) // Save only name
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -123,6 +123,22 @@ func TestParser_Parse(t *testing.T) {
 			file:    "testdata/sad.toml",
 			wantErr: assert.Error,
 		},
+		{
+			// Regression test: an empty dependency string in a [project] list
+			// (valid TOML, invalid PEP 508) used to panic with
+			// "index out of range [0] with length 0" in strings.Fields(dep)[0].
+			// It must now be skipped instead of crashing the whole parse.
+			name: "empty dependency entry does not panic and is skipped",
+			file: "testdata/empty_dep_entry.toml",
+			want: pyproject.PyProject{
+				Project: pyproject.Project{
+					Dependencies: pyproject.Dependencies{
+						Set: set.New[string]("flask"),
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/python/pyproject/testdata/empty_dep_entry.toml
+++ b/pkg/dependency/parser/python/pyproject/testdata/empty_dep_entry.toml
@@ -1,0 +1,4 @@
+[project]
+name = "test"
+version = "1.0.0"
+dependencies = ["flask>=1.0", ""]

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,7 +66,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
-			dependsOn = append(dependsOn, s[0]) // store name only for now
+			if len(s) > 0 {
+				dependsOn = append(dependsOn, s[0]) // store name only for now
+			}
+			// else: line of only whitespace at this indent - not a real dependency, skip it.
 		}
 		lineNum++
 

--- a/pkg/dependency/parser/ruby/bundler/parse_test.go
+++ b/pkg/dependency/parser/ruby/bundler/parse_test.go
@@ -278,3 +278,32 @@ func TestParser_Parse(t *testing.T) {
 		})
 	}
 }
+
+// TestParser_Parse_EmptyDependencyGraphLine is a regression test: a
+// dependency-graph line of exactly 6 spaces (invalid Gemfile.lock, valid
+// YAML-ish text) used to panic with "index out of range [0] with length 0"
+// in strings.Fields(line)[0]. It must now be skipped instead of crashing.
+func TestParser_Parse_EmptyDependencyGraphLine(t *testing.T) {
+	f, err := os.Open("testdata/Gemfile_empty_dep_line.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	p := &bundler.Parser{}
+	pkgs, deps, err := p.Parse(t.Context(), f)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		names = append(names, pkg.Name)
+	}
+	assert.ElementsMatch(t, []string{"coderay", "concurrent-ruby"}, names,
+		"both real packages should still be parsed despite the blank dependency line")
+
+	// coderay's only dependency-graph line was blank, so it must not carry a
+	// spurious empty-string dependency.
+	for _, dep := range deps {
+		for _, name := range dep.DependsOn {
+			assert.NotEmpty(t, name, "no dependency name should be an empty string")
+		}
+	}
+}

--- a/pkg/dependency/parser/ruby/bundler/testdata/Gemfile_empty_dep_line.lock
+++ b/pkg/dependency/parser/ruby/bundler/testdata/Gemfile_empty_dep_line.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+      
+    concurrent-ruby (1.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  coderay
+  concurrent-ruby
+
+BUNDLED WITH
+   2.1.4

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,12 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					fields := strings.Fields(s)
+					if len(fields) == 0 {
+						// Empty/whitespace-only dependency string - not a real package, skip it.
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], fields[0])
 				}
 			}
 		}

--- a/pkg/dependency/parser/swift/cocoapods/parse_test.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse_test.go
@@ -94,3 +94,23 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+// TestParse_EmptyChildDependency is a regression test: an empty-string child
+// dependency entry (valid YAML, invalid Podfile.lock) used to panic with
+// "index out of range [0] with length 0" in strings.Fields(s)[0]. It must
+// now be skipped instead of crashing the whole parse.
+func TestParse_EmptyChildDependency(t *testing.T) {
+	f, err := os.Open("testdata/empty_child_dep.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	gotPkgs, _, err := cocoapods.NewParser().Parse(t.Context(), f)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(gotPkgs))
+	for _, pkg := range gotPkgs {
+		names = append(names, pkg.Name)
+	}
+	assert.ElementsMatch(t, []string{"AppCenter", "KeychainAccess"}, names,
+		"both real packages should still be parsed despite the empty child dependency entry")
+}

--- a/pkg/dependency/parser/swift/cocoapods/testdata/empty_child_dep.lock
+++ b/pkg/dependency/parser/swift/cocoapods/testdata/empty_child_dep.lock
@@ -1,0 +1,6 @@
+PODS:
+  - AppCenter (4.2.0):
+    - ""
+  - KeychainAccess (4.2.1)
+
+COCOAPODS: 1.11.2

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,7 +42,13 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		// osVer has no version token (e.g. /etc/system-release contains only
+		// "Amazon Linux" with no version) - nothing to detect against.
+		return nil, nil
+	}
+	osVer = fields[0]
 	// The format `2023.xxx.xxxx` can be used.
 	osVer = osver.Major(osVer)
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {
@@ -103,7 +109,13 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 // IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		// osVer has no version token (e.g. /etc/system-release contains only
+		// "Amazon Linux" with no version) - can't determine support, treat as unsupported.
+		return false
+	}
+	osVer = fields[0]
 	// The format `2023.xxx.xxxx` can be used.
 	osVer = osver.Major(osVer)
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -244,6 +244,18 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			// Regression test: /etc/system-release containing only "Amazon Linux"
+			// with no version token yields osVer == "" here, which used to panic
+			// with "index out of range [0] with length 0" in strings.Fields(osVer)[0].
+			name: "empty osVer does not panic and is unsupported",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #10976. Six locations indexed `strings.Fields(...)[0]` / `FieldsFunc(...)[0]` without checking the slice was non-empty, panicking on malformed-but-parseable input and aborting the whole scan:

- `pkg/detector/ospkg/amazon/amazon.go` — `IsSupportedVersion` (named in the issue) **and** `Detect` (a second, identical occurrence not mentioned in the issue — found by running the real reproduction end to end, not just from the issue's list)
- `pkg/dependency/parser/python/pyproject/pyproject.go`
- `pkg/dependency/parser/swift/cocoapods/parse.go`
- `pkg/dependency/parser/hex/mix/parse.go`
- `pkg/dependency/parser/ruby/bundler/parse.go`

Each guard follows the length-check-before-index pattern already used elsewhere in the codebase (bundler's own dependency-list function), skipping the malformed entry instead of crashing.

## Verification
- Built the binary and ran both exact reproduction commands from the issue — both previously panicked, both now exit 0:
  - `trivy rootfs` on a directory whose `/etc/system-release` contains only `Amazon Linux` (no version)
  - `trivy fs` on a `pyproject.toml` with `dependencies = ["flask>=1.0", ""]`
- 5 new regression tests using the issue's own malformed inputs (one per package)
- All 5 packages' existing test suites still pass
- Independently re-verified by a second AI model (adversarial, not just a code review): it rebuilt the binary itself, wrote its own reproduction files and its own additional adversarial probes (whitespace-only version strings, empty-list vs empty-string cocoapods entries, colon+comma-only mix lines), and confirmed the bundler fix doesn't disturb the loop's later `DEPENDENCIES` section-header check

## Test plan
- [x] `go test ./pkg/detector/ospkg/amazon/... ./pkg/dependency/parser/python/pyproject/... ./pkg/dependency/parser/swift/cocoapods/... ./pkg/dependency/parser/hex/mix/... ./pkg/dependency/parser/ruby/bundler/...`
- [x] Real binary built and both issue reproduction commands run against it, confirmed exit 0