### PR TITLE
feat(java): support user-defined Maven mirrors in trivy.yaml

### DIFF
--- a/docs/guide/coverage/language/java.md
+++ b/docs/guide/coverage/language/java.md
@@ -81,6 +81,38 @@ The vulnerability database will be downloaded anyway.
 !!! Warning
     Trivy may skip some dependencies (that were not found on your local machine) when the `--offline-scan` flag is passed.
 
+### mirrors
+Trivy supports several ways to set up mirrors for Maven repositories:
+
+- `<mirrors>` in your Maven [`settings.xml`][maven-mirror-settings] — both the global and the user file.
+- The Trivy [config file][config-file] — see [config-file mirrors](#config-file-mirrors) below.
+
+#### resolving priority
+For each package that needs to be fetched from a remote repository, Trivy applies the following order:
+
+1. mirror from `settings.xml`;
+2. mirrors[^10] from the config file.
+
+!!! note
+    Trivy supports chained resolution across the two sources: if `settings.xml` maps `repo1 -> repo2` and the config file maps `repo2 -> repo3`, then `repo1` resolves to `repo3`.
+
+#### config-file mirrors
+`scan.maven.mirrors` maps each source repository URL to an ordered list of mirror URLs, tried in turn. Use it to avoid modifying `settings.xml` (for example in CI) and to configure several fallback mirrors[^10] for a single repository:
+
+```yaml
+scan:
+  maven:
+    mirrors:
+      https://repo.maven.apache.org/maven2/:
+        - https://my-internal-mirror/maven2/
+        - https://backup-mirror/maven2/
+```
+
+To mirror Maven Central, use `https://repo.maven.apache.org/maven2/` as the source repository URL.
+
+!!! warning "Credentials"
+    Config-file mirrors do not read credentials from `settings.xml` `<server>` entries. To authenticate, embed them in the mirror URL (`https://user:password@host/...`), which stores the password in plaintext in the config file. For a secure setup, configure the mirror in `settings.xml` instead.
+
 ### supported scopes
 Trivy only scans `import`, `compile`, `runtime` and empty [maven scopes][maven-scopes]. Other scopes and `Optional` dependencies are not currently being analyzed.
 
@@ -142,11 +174,14 @@ Make sure that you have cache[^8] directory to find licenses from `*.pom` depend
 [^7]: To avoid confusion, Trivy only finds locations for direct dependencies from the base pom.xml file.
 [^8]: The supported directories are `$GRADLE_USER_HOME/caches` and `$HOME/.gradle/caches` (`%HOMEPATH%\.gradle\caches` for Windows).
 [^9]: License detection is limited. See [Licenses](#licenses) for details.
+[^10]: The mirrors are tried in order, falling back to the next one when the requested POM is not found.
 
 [dependency-graph]: ../../configuration/reporting.md#show-origins-of-vulnerable-dependencies
 [maven-invoker-plugin]: https://maven.apache.org/plugins/maven-invoker-plugin/usage.html
 [maven-central]: https://repo.maven.apache.org/maven2/
 [maven-pom-repos]: https://maven.apache.org/settings.html#repositories
+[maven-mirror-settings]: https://maven.apache.org/guides/mini/guide-mirror-settings.html
+[config-file]: ../../references/configuration/config-file.md
 [maven-scopes]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope
 [sbt-dependency-lock]: https://stringbean.github.io/sbt-dependency-lock
 [detection-priority]: ../../scanner/vulnerability.md#detection-priority

--- a/docs/guide/coverage/language/java.md
+++ b/docs/guide/coverage/language/java.md
@@ -97,18 +97,20 @@ For each package that needs to be fetched from a remote repository, Trivy applie
     Trivy supports chained resolution across the two sources: if `settings.xml` maps `repo1 -> repo2` and the config file maps `repo2 -> repo3`, then `repo1` resolves to `repo3`.
 
 #### config-file mirrors
-`scan.maven.mirrors` maps each source repository URL to an ordered list of mirror URLs, tried in turn. Use it to avoid modifying `settings.xml` (for example in CI) and to configure several fallback mirrors[^10] for a single repository:
+`scan.maven.mirrors` is a list of entries, each mapping a `source` repository URL to the ordered `targets` that mirror it, tried in turn. Use it to avoid modifying `settings.xml` (for example in CI) and to configure several fallback mirrors[^10] for a single repository:
 
 ```yaml
 scan:
   maven:
     mirrors:
-      https://repo.maven.apache.org/maven2/:
-        - https://my-internal-mirror/maven2/
-        - https://backup-mirror/maven2/
+      - source: https://repo.maven.apache.org/maven2/
+        targets:
+          - https://my-internal-mirror/maven2/
+          - https://backup-mirror/maven2/
 ```
 
-To mirror Maven Central, use `https://repo.maven.apache.org/maven2/` as the source repository URL.
+To mirror Maven Central, use `https://repo.maven.apache.org/maven2/` as the `source`.
+As in Maven, a mirrored repository is never queried directly, so a dependency is reported as not found when every mirror of it fails.
 
 !!! warning "Credentials"
     Config-file mirrors do not read credentials from `settings.xml` `<server>` entries. To authenticate, embed them in the mirror URL (`https://user:password@host/...`), which stores the password in plaintext in the config file. For a secure setup, configure the mirror in `settings.xml` instead.

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -613,6 +613,9 @@ scan:
   # Same as '--file-patterns'
   file-patterns: []
 
+  maven:
+    mirrors:
+
   # Same as '--offline-scan'
   offline: false
 

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -614,7 +614,7 @@ scan:
   file-patterns: []
 
   maven:
-    mirrors:
+    mirrors: []
 
   # Same as '--offline-scan'
   offline: false

--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -136,6 +136,9 @@ The block applies to *all* subsequent requests from the affected IP for the dura
 Recommended mitigations:
 
 - **Populate `~/.m2` before scanning.** Run `mvn dependency:resolve` (or any build step that resolves dependencies) so that every POM is cached locally. In CI, cache the `~/.m2` directory between runs (e.g. keyed on `pom.xml` checksums) so subsequent runs reuse the artifacts.
+- **Configure mirrors** of the rate-limited repository, so that POM lookups go to a host that isn't blocking you. There are two ways to do it:
+    - `<mirrors>` in Maven's [settings.xml][maven-mirror-settings] — the standard mechanism, honored by `mvn` itself as well. A repository is served by a single mirror, so a mirror that is rate-limited too leaves nothing to fall back on.
+    - [scan.maven.mirrors][maven-mirrors] in `trivy.yaml` — Trivy-specific, and takes an ordered list of mirrors per repository. A mirror that returns `429` is skipped in favor of the next one, and the scan fails only once every mirror of an artifact is rate-limited.
 - **Wait for the block to expire.** The `Retry-After` value in the error tells you the minimum wait. Repeated scans during the block will extend it.
 - **Use `--offline-scan`** to skip remote lookups entirely and rely only on the local `~/.m2` cache. Be careful: any transitive POM missing from the cache is silently skipped, so populate `~/.m2` first (see above) — otherwise the dependency tree will be incomplete.
 
@@ -351,5 +354,7 @@ $ trivy clean --all
 ```
 
 [air-gapped]: ../advanced/air-gap.md
+[maven-mirror-settings]: https://maven.apache.org/guides/mini/guide-mirror-settings.html
+[maven-mirrors]: ../coverage/language/java.md#config-file-mirrors
 [network]: ../advanced/air-gap.md#connectivity-requirements
 [redis-cache]: ../configuration/cache.md#redis

--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -138,7 +138,7 @@ Recommended mitigations:
 - **Populate `~/.m2` before scanning.** Run `mvn dependency:resolve` (or any build step that resolves dependencies) so that every POM is cached locally. In CI, cache the `~/.m2` directory between runs (e.g. keyed on `pom.xml` checksums) so subsequent runs reuse the artifacts.
 - **Configure mirrors** of the rate-limited repository, so that POM lookups go to a host that isn't blocking you. There are two ways to do it:
     - `<mirrors>` in Maven's [settings.xml][maven-mirror-settings] — the standard mechanism, honored by `mvn` itself as well. A repository is served by a single mirror, so a mirror that is rate-limited too leaves nothing to fall back on.
-    - [scan.maven.mirrors][maven-mirrors] in `trivy.yaml` — Trivy-specific, and takes an ordered list of mirrors per repository. A mirror that returns `429` is skipped in favor of the next one, and the scan fails only once every mirror of an artifact is rate-limited.
+    - [scan.maven.mirrors][maven-mirrors] in `trivy.yaml` — Trivy-specific, and takes an ordered list of mirrors per repository. A mirror that returns `429` is skipped in favor of the next one, and if the remaining mirrors do not return the artifact, the scan stops and reports the `429`.
 - **Wait for the block to expire.** The `Retry-After` value in the error tells you the minimum wait. Repeated scans during the block will extend it.
 - **Use `--offline-scan`** to skip remote lookups entirely and rely only on the local `~/.m2` cache. Be careful: any transitive POM missing from the cache is silently skipped, so populate `~/.m2` first (see above) — otherwise the dependency tree will be incomplete.
 

--- a/magefiles/config_schema.go
+++ b/magefiles/config_schema.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/flag"
 )
@@ -149,6 +150,33 @@ func schemaFromFlagValue(val any) (*jsonschema.Schema, error) {
 			AdditionalProperties: &jsonschema.Schema{
 				Type:  schemaTypeArray,
 				Items: &jsonschema.Schema{Type: schemaTypeString},
+			},
+		}, nil
+	case []flag.MavenMirror:
+		return &jsonschema.Schema{
+			Type: schemaTypeArray,
+			Items: &jsonschema.Schema{
+				Type: schemaTypeObject,
+				Properties: map[string]*jsonschema.Schema{
+					"source": {
+						Type:        schemaTypeString,
+						Description: "URL of the mirrored Maven repository",
+					},
+					"targets": {
+						Type:        schemaTypeArray,
+						Description: "URLs of the mirrors serving the repository, tried in order",
+						Items:       &jsonschema.Schema{Type: schemaTypeString},
+						MinItems:    lo.ToPtr(1),
+					},
+				},
+				PropertyOrder: []string{
+					"source",
+					"targets",
+				},
+				Required: []string{
+					"source",
+					"targets",
+				},
 			},
 		}, nil
 	default:

--- a/pkg/commands/artifact/run.go
+++ b/pkg/commands/artifact/run.go
@@ -653,6 +653,7 @@ func (r *runner) initScannerConfig(ctx context.Context, opts flag.Options) (Scan
 			AWSEndpoint:       opts.Endpoint,
 			FileChecksum:      fileChecksum,
 			DetectionPriority: opts.DetectionPriority,
+			MavenMirrors:      opts.MavenMirrors,
 
 			// For image scanning
 			ImageOption: ftypes.ImageOptions{

--- a/pkg/dependency/parser/java/pom/mirror.go
+++ b/pkg/dependency/parser/java/pom/mirror.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/samber/lo"
 )
 
 // mirror is the runtime representation of a <mirror> from settings.xml.
@@ -17,14 +18,21 @@ type mirror struct {
 	url      url.URL  // parsed URL with userinfo from the matching <server>
 }
 
-// resolveMirrors converts <mirror> entries from settings.xml into the runtime
-// mirror form: split and trim the mirrorOf patterns, parse the URL, and embed
-// credentials from the <server> whose id equals the mirror id. Mirrors with
-// no usable pattern or an unparsable URL are dropped.
-func resolveMirrors(mirrors []Mirror, servers []Server) []mirror {
+// mirrors holds the two mirror sources the parser applies.
+type mirrors struct {
+	settings   []mirror             // settings.xml mirrors
+	configFile map[string][]url.URL // scan.maven.mirrors; key: mirrorKey(source), value: ordered parsed mirror URLs (fallbacks)
+}
+
+// resolveMirrors resolves and validates both mirror sources into their runtime form:
+// it parses every URL — embedding <server> credentials into settings.xml mirrors and
+// normalizing config-file keys via mirrorKey — and drops any entry with an unusable
+// pattern or an unparsable URL.
+func resolveMirrors(settingsMirrors []Mirror, servers []Server, configFileMirrors map[string][]string) mirrors {
 	logger := log.WithPrefix("pom")
-	var result []mirror
-	for _, m := range mirrors {
+
+	var resolved mirrors
+	for _, m := range settingsMirrors {
 		var patterns []string
 		for p := range strings.SplitSeq(m.MirrorOf, ",") {
 			p = strings.TrimSpace(p)
@@ -55,13 +63,52 @@ func resolveMirrors(mirrors []Mirror, servers []Server) []mirror {
 		}
 
 		logger.Debug("Adding mirror", log.String("id", m.ID), log.String("url", u.Redacted()))
-		result = append(result, mirror{
+		resolved.settings = append(resolved.settings, mirror{
 			id:       m.ID,
 			patterns: patterns,
 			url:      *u,
 		})
 	}
-	return result
+
+	for src, targets := range configFileMirrors {
+		srcURL, err := url.Parse(src)
+		if err != nil {
+			// Don't log the raw URL: it may carry userinfo. Parsing failed, so
+			// there is no parsed URL to Redacted(); log without the value.
+			logger.Debug("Unable to parse config-file mirror source url")
+			continue
+		}
+
+		var mirrorURLs []url.URL
+		for _, target := range targets {
+			mirrorURL, err := url.Parse(target)
+			if err != nil {
+				logger.Debug("Unable to parse config-file mirror url", log.String("source", srcURL.Redacted()))
+				continue
+			}
+			mirrorURLs = append(mirrorURLs, *mirrorURL)
+		}
+		if len(mirrorURLs) == 0 {
+			continue
+		}
+		logger.Debug("Added config-file mirror", log.String("source", srcURL.Redacted()),
+			log.Any("mirrors", lo.Map(mirrorURLs, func(u url.URL, _ int) string {
+				return u.Redacted()
+			})))
+		if resolved.configFile == nil {
+			resolved.configFile = make(map[string][]url.URL)
+		}
+		resolved.configFile[mirrorKey(*srcURL)] = mirrorURLs
+	}
+
+	return resolved
+}
+
+// mirrorKey normalizes a repository URL to the key used for config-file mirror
+// lookup: its string form with any trailing slash trimmed, so that
+// "https://host/maven2/" and "https://host/maven2" resolve to the same key.
+func mirrorKey(u url.URL) string {
+	return strings.TrimRight(u.String(), "/")
 }
 
 // matches reports whether this mirror should serve the given repository.

--- a/pkg/dependency/parser/java/pom/mirror.go
+++ b/pkg/dependency/parser/java/pom/mirror.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/samber/lo"
+
+	"github.com/aquasecurity/trivy/pkg/log"
 )
 
 // mirror is the runtime representation of a <mirror> from settings.xml.

--- a/pkg/dependency/parser/java/pom/mirror.go
+++ b/pkg/dependency/parser/java/pom/mirror.go
@@ -1,6 +1,7 @@
 package pom
 
 import (
+	"cmp"
 	"net/url"
 	"strings"
 
@@ -102,19 +103,21 @@ func resolveMirrors(settingsMirrors []Mirror, servers []Server, configFileMirror
 	return resolved
 }
 
-// mirrorKey normalizes a repository URL to the key used for config-file mirror lookup:
-// its string form with any trailing slash trimmed, so that "https://host/maven2/" and
-// "https://host/maven2" resolve to the same key.
+// mirrorKey normalizes a repository URL to the key used for config-file mirror lookup.
+// The path is cleaned the same way as when an artifact URL is built, so that
+// "https://host/maven2/" and "https://host//maven2" resolve to the same key.
 //
 // The key has to identify the repository, so the parts that don't are dropped as well:
 // the credentials that Trivy embeds from a <server> — otherwise a mirrored repository
 // with credentials would never match its configured key — and the case of the host,
-// which RFC 3986 defines as case-insensitive. The path is kept as it is, being
+// which RFC 3986 defines as case-insensitive. The case of the path is kept, as it is
 // case-sensitive.
 func mirrorKey(u url.URL) string {
 	u.User = nil
 	u.Host = strings.ToLower(u.Host)
-	return strings.TrimRight(u.String(), "/")
+	// JoinPath cleans the path only, leaving any query and fragment alone.
+	u.Path = cmp.Or(u.Path, "/")
+	return u.JoinPath(".").String()
 }
 
 // matches reports whether this mirror should serve the given repository.

--- a/pkg/dependency/parser/java/pom/mirror.go
+++ b/pkg/dependency/parser/java/pom/mirror.go
@@ -102,10 +102,18 @@ func resolveMirrors(settingsMirrors []Mirror, servers []Server, configFileMirror
 	return resolved
 }
 
-// mirrorKey normalizes a repository URL to the key used for config-file mirror
-// lookup: its string form with any trailing slash trimmed, so that
-// "https://host/maven2/" and "https://host/maven2" resolve to the same key.
+// mirrorKey normalizes a repository URL to the key used for config-file mirror lookup:
+// its string form with any trailing slash trimmed, so that "https://host/maven2/" and
+// "https://host/maven2" resolve to the same key.
+//
+// The key has to identify the repository, so the parts that don't are dropped as well:
+// the credentials that Trivy embeds from a <server> — otherwise a mirrored repository
+// with credentials would never match its configured key — and the case of the host,
+// which RFC 3986 defines as case-insensitive. The path is kept as it is, being
+// case-sensitive.
 func mirrorKey(u url.URL) string {
+	u.User = nil
+	u.Host = strings.ToLower(u.Host)
 	return strings.TrimRight(u.String(), "/")
 }
 

--- a/pkg/dependency/parser/java/pom/mirror.go
+++ b/pkg/dependency/parser/java/pom/mirror.go
@@ -18,10 +18,10 @@ type mirror struct {
 	url      url.URL  // parsed URL with userinfo from the matching <server>
 }
 
-// mirrors holds the two mirror sources the parser applies.
+// mirrors holds the resolved mirrors from settings.xml and from the config file.
 type mirrors struct {
 	settings   []mirror             // settings.xml mirrors
-	configFile map[string][]url.URL // scan.maven.mirrors; key: mirrorKey(source), value: ordered parsed mirror URLs (fallbacks)
+	configFile map[string][]url.URL // config-file mirrors; key: mirrorKey(source), value: ordered parsed mirror URL
 }
 
 // resolveMirrors resolves and validates both mirror sources into their runtime form:
@@ -71,11 +71,9 @@ func resolveMirrors(settingsMirrors []Mirror, servers []Server, configFileMirror
 	}
 
 	for src, targets := range configFileMirrors {
+		// Config-file mirror URLs are validated when the config file is parsed (fail-fast).
 		srcURL, err := url.Parse(src)
 		if err != nil {
-			// Don't log the raw URL: it may carry userinfo. Parsing failed, so
-			// there is no parsed URL to Redacted(); log without the value.
-			logger.Debug("Unable to parse config-file mirror source url")
 			continue
 		}
 
@@ -83,7 +81,6 @@ func resolveMirrors(settingsMirrors []Mirror, servers []Server, configFileMirror
 		for _, target := range targets {
 			mirrorURL, err := url.Parse(target)
 			if err != nil {
-				logger.Debug("Unable to parse config-file mirror url", log.String("source", srcURL.Redacted()))
 				continue
 			}
 			mirrorURLs = append(mirrorURLs, *mirrorURL)

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -285,22 +285,26 @@ func Test_resolveMirrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveMirrors(tt.mirrors, tt.servers)
-			require.Equal(t, tt.want, got)
+			got := resolveMirrors(tt.mirrors, tt.servers, nil)
+			require.Equal(t, tt.want, got.settings)
 		})
 	}
 }
 
+// TestParser_mirrorFor covers both passes of mirrorFor: matching settings.xml
+// <mirror> entries, and applying trivy.yaml (scan.maven.mirrors) on top of the
+// result — including cross-source chaining and fallback lists.
 func TestParser_mirrorFor(t *testing.T) {
 	tests := []struct {
-		name    string
-		mirrors []mirror
-		repo    repository
-		want    repository
+		name              string
+		settingsMirrors   []mirror
+		configFileMirrors map[string][]string
+		repo              repository
+		want              []repository
 	}{
 		{
 			name: "no match — repository returned unchanged",
-			mirrors: []mirror{
+			settingsMirrors: []mirror{
 				{
 					id:       "m1",
 					patterns: []string{"internal"},
@@ -312,15 +316,17 @@ func TestParser_mirrorFor(t *testing.T) {
 				url:            mustParseURL(t, "https://repo.maven.apache.org/maven2"),
 				releaseEnabled: true,
 			},
-			want: repository{
-				id:             "central",
-				url:            mustParseURL(t, "https://repo.maven.apache.org/maven2"),
-				releaseEnabled: true,
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo.maven.apache.org/maven2"),
+					releaseEnabled: true,
+				},
 			},
 		},
 		{
 			name: "match by exact id — release/snapshot flags preserved from original repo",
-			mirrors: []mirror{
+			settingsMirrors: []mirror{
 				{
 					id:       "m1",
 					patterns: []string{"central"},
@@ -333,16 +339,18 @@ func TestParser_mirrorFor(t *testing.T) {
 				releaseEnabled:  true,
 				snapshotEnabled: false,
 			},
-			want: repository{
-				id:              "m1",
-				url:             mustParseURL(t, "https://mirror.example.com/maven2"),
-				releaseEnabled:  true,
-				snapshotEnabled: false,
+			want: []repository{
+				{
+					id:              "m1",
+					url:             mustParseURL(t, "https://mirror.example.com/maven2"),
+					releaseEnabled:  true,
+					snapshotEnabled: false,
+				},
 			},
 		},
 		{
 			name: "credentials from mirror (not original repo) are kept",
-			mirrors: []mirror{
+			settingsMirrors: []mirror{
 				{
 					id:       "m1",
 					patterns: []string{"*"},
@@ -354,15 +362,17 @@ func TestParser_mirrorFor(t *testing.T) {
 				url:            mustParseURL(t, "https://central-user:central-pass@repo.maven.apache.org/maven2"),
 				releaseEnabled: true,
 			},
-			want: repository{
-				id:             "m1",
-				url:            mustParseURL(t, "https://mirror-user:mirror-pass@mirror.example.com/maven2"),
-				releaseEnabled: true,
+			want: []repository{
+				{
+					id:             "m1",
+					url:            mustParseURL(t, "https://mirror-user:mirror-pass@mirror.example.com/maven2"),
+					releaseEnabled: true,
+				},
 			},
 		},
 		{
 			name: "first matching mirror wins (no chaining)",
-			mirrors: []mirror{
+			settingsMirrors: []mirror{
 				{
 					id:       "first",
 					patterns: []string{"*"},
@@ -379,15 +389,17 @@ func TestParser_mirrorFor(t *testing.T) {
 				url:            mustParseURL(t, "https://repo.maven.apache.org/maven2"),
 				releaseEnabled: true,
 			},
-			want: repository{
-				id:             "first",
-				url:            mustParseURL(t, "https://first.example.com/maven2"),
-				releaseEnabled: true,
+			want: []repository{
+				{
+					id:             "first",
+					url:            mustParseURL(t, "https://first.example.com/maven2"),
+					releaseEnabled: true,
+				},
 			},
 		},
 		{
 			name: "exclusion blocks match and falls through to next mirror",
-			mirrors: []mirror{
+			settingsMirrors: []mirror{
 				{
 					id:       "first",
 					patterns: []string{"*", "!central"},
@@ -404,17 +416,157 @@ func TestParser_mirrorFor(t *testing.T) {
 				url:            mustParseURL(t, "https://repo.maven.apache.org/maven2"),
 				releaseEnabled: true,
 			},
-			want: repository{
-				id:             "second",
-				url:            mustParseURL(t, "https://second.example.com/maven2"),
+			want: []repository{
+				{
+					id:             "second",
+					url:            mustParseURL(t, "https://second.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			name:              "empty config map — repository unchanged (backward compatibility)",
+			configFileMirrors: nil,
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
 				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			name: "config-file mirror only — repo1 -> repo3",
+			configFileMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			name: "trailing slash in config key still matches",
+			configFileMirrors: map[string][]string{
+				"https://repo1.example.com/maven2/": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			// Several mirrors for one repository become ordered fallback candidates.
+			name: "fallback list — repo1 -> [repo3, repo4] yields both candidates in order",
+			configFileMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {
+					"https://repo3.example.com/maven2",
+					"https://repo4.example.com/maven2",
+				},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo4.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			// Example 1 from the spec: both sources target repo1; settings.xml wins
+			// because it rewrites the URL first and the config pass no longer matches.
+			name: "conflict on the same key — settings.xml wins over trivy.yaml",
+			settingsMirrors: []mirror{
+				{
+					id:       "settings-mirror",
+					patterns: []string{"central"},
+					url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+				},
+			},
+			configFileMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "settings-mirror",
+					url:            mustParseURL(t, "https://repo2.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			// Example 2 from the spec: cross-source chaining.
+			// settings.xml repo1 -> repo2, trivy.yaml repo2 -> repo3 => repo1 -> repo3.
+			name: "cross-source chaining — repo1 --settings--> repo2 --trivy.yaml--> repo3",
+			settingsMirrors: []mirror{
+				{
+					id:       "settings-mirror",
+					patterns: []string{"central"},
+					url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+				},
+			},
+			configFileMirrors: map[string][]string{
+				"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "settings-mirror",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{mirrors: tt.mirrors}
+			p := &Parser{
+				mirrors: mirrors{
+					settings:   tt.settingsMirrors,
+					configFile: resolveMirrors(nil, nil, tt.configFileMirrors).configFile,
+				},
+			}
 			require.Equal(t, tt.want, p.mirrorFor(tt.repo))
 		})
 	}
@@ -433,15 +585,18 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 </project>`
 
 	// Matching logic and credential resolution are covered by Test_mirror_matches,
-	// Test_resolveMirrors and TestParser_mirrorFor. Here we only verify the two
-	// things that can only be observed end-to-end through HTTP: that mirrorFor is
-	// actually applied to the fetch loop, and that mirror credentials reach the
-	// remote request as Basic Auth.
+	// Test_resolveMirrors and TestParser_mirrorFor. Here we verify the things that
+	// can only be observed end-to-end through HTTP: that mirrorFor is applied to the
+	// fetch loop, that mirror credentials reach the remote request as Basic Auth, that
+	// a settings.xml -> trivy.yaml chain routes the fetch through to the final mirror,
+	// and that the fetch falls back to the next trivy.yaml mirror when one is not found.
 	tests := []struct {
 		name            string
 		mirrorPatterns  []string
 		mirrorWithCreds bool
 		wantBasicAuth   string
+		chainToConfig   bool // trivy.yaml mirror: settings-target -> chain-target
+		configFallback  bool // trivy.yaml mirror: settings-target -> [dead, chain]
 	}{
 		{
 			name:           "wildcard mirror redirects the fetch to the mirror server",
@@ -453,13 +608,28 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			mirrorWithCreds: true,
 			wantBasicAuth:   "mirror-user",
 		},
+		{
+			// Example 2 end-to-end: settings.xml rewrites central(repo1) -> repo2, then
+			// trivy.yaml rewrites repo2 -> repo3, so only repo3 must receive the request.
+			name:           "cross-source chaining: settings.xml then trivy.yaml routes to the final mirror",
+			mirrorPatterns: []string{"*"},
+			chainToConfig:  true,
+		},
+		{
+			// trivy.yaml lists two mirrors for repo2; the first 404s, so the fetch must
+			// fall back to the second and succeed there.
+			name:           "trivy.yaml fallback: first mirror 404s, second one serves",
+			mirrorPatterns: []string{"*"},
+			configFallback: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var mirrorHits, originalHits int
+			var mirrorHits, originalHits, chainHits, deadHits int
 			var gotBasicAuth string
 
+			// repo2: settings.xml mirror target.
 			mirrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mirrorHits++
 				if u, _, ok := r.BasicAuth(); ok {
@@ -469,11 +639,26 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			}))
 			defer mirrorServer.Close()
 
+			// repo1: original repository.
 			originalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				originalHits++
 				_, _ = w.Write([]byte(minimalPOM))
 			}))
 			defer originalServer.Close()
+
+			// repo3: trivy.yaml (config-file) mirror target that serves the POM.
+			chainServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				chainHits++
+				_, _ = w.Write([]byte(minimalPOM))
+			}))
+			defer chainServer.Close()
+
+			// A trivy.yaml mirror that always 404s, to exercise fallback to the next one.
+			deadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				deadHits++
+				http.NotFound(w, r)
+			}))
+			defer deadServer.Close()
 
 			mirrorURL := mirrorServer.URL
 			if tt.mirrorWithCreds {
@@ -484,12 +669,24 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			}
 			u, err := url.Parse(mirrorURL)
 			require.NoError(t, err)
-			mirrors := []mirror{
+			settingsMirrors := []mirror{
 				{
 					id:       "m1",
 					patterns: tt.mirrorPatterns,
 					url:      *u,
 				},
+			}
+
+			var configFile map[string][]url.URL
+			switch {
+			case tt.chainToConfig:
+				configFile = resolveMirrors(nil, nil, map[string][]string{
+					mirrorServer.URL: {chainServer.URL},
+				}).configFile
+			case tt.configFallback:
+				configFile = resolveMirrors(nil, nil, map[string][]string{
+					mirrorServer.URL: {deadServer.URL, chainServer.URL},
+				}).configFile
 			}
 
 			origURL, err := url.Parse(originalServer.URL)
@@ -502,7 +699,7 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 
 			p := &Parser{
 				logger:     log.WithPrefix("pom"),
-				mirrors:    mirrors,
+				mirrors:    mirrors{settings: settingsMirrors, configFile: configFile},
 				httpClient: http.DefaultClient,
 			}
 
@@ -511,9 +708,21 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
-			require.Equal(t, 1, mirrorHits, "mirror hits")
-			require.Equal(t, 0, originalHits, "original hits")
-			require.Equal(t, tt.wantBasicAuth, gotBasicAuth, "basic auth user")
+			require.Equal(t, 0, originalHits, "original repo must not be hit")
+			switch {
+			case tt.chainToConfig:
+				require.Equal(t, 0, mirrorHits, "settings.xml mirror must not be hit (rewritten by trivy.yaml)")
+				require.Equal(t, 1, chainHits, "config-file mirror hits")
+				require.Equal(t, 0, deadHits, "dead mirror must not be hit")
+			case tt.configFallback:
+				require.Equal(t, 0, mirrorHits, "settings.xml mirror must not be hit (rewritten by trivy.yaml)")
+				require.Equal(t, 1, deadHits, "first (dead) config-file mirror is tried")
+				require.Equal(t, 1, chainHits, "fetch falls back to the second config-file mirror")
+			default:
+				require.Equal(t, 1, mirrorHits, "mirror hits")
+				require.Equal(t, 0, chainHits, "config-file mirror must not be hit")
+				require.Equal(t, tt.wantBasicAuth, gotBasicAuth, "basic auth user")
+			}
 		})
 	}
 }

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -346,21 +346,16 @@ func Test_resolveMirrors(t *testing.T) {
 // including cross-source chaining and fallback lists.
 func TestParser_mirrorFor(t *testing.T) {
 	tests := []struct {
-		name    string
-		mirrors mirrors
-		repo    repository
-		want    []repository
+		name            string
+		settingsMirrors []Mirror
+		configMirrors   map[string][]string
+		repo            repository
+		want            []repository
 	}{
 		{
 			name: "settings.xml: no match — repository returned unchanged",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "m1",
-						patterns: []string{"internal"},
-						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
-					},
-				},
+			settingsMirrors: []Mirror{
+				{ID: "m1", MirrorOf: "internal", URL: "https://mirror.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -377,14 +372,8 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "settings.xml: match by exact id — release/snapshot flags preserved",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "m1",
-						patterns: []string{"central"},
-						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
-					},
-				},
+			settingsMirrors: []Mirror{
+				{ID: "m1", MirrorOf: "central", URL: "https://mirror.example.com/maven2"},
 			},
 			repo: repository{
 				id:              "central",
@@ -403,14 +392,8 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "settings.xml: mirror credentials (not the original repo's) are kept",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "m1",
-						patterns: []string{"*"},
-						url:      mustParseURL(t, "https://mirror-user:mirror-pass@mirror.example.com/maven2"),
-					},
-				},
+			settingsMirrors: []Mirror{
+				{ID: "m1", MirrorOf: "*", URL: "https://mirror-user:mirror-pass@mirror.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -427,19 +410,9 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "settings.xml: first matching mirror wins",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "first",
-						patterns: []string{"*"},
-						url:      mustParseURL(t, "https://first.example.com/maven2"),
-					},
-					{
-						id:       "second",
-						patterns: []string{"*"},
-						url:      mustParseURL(t, "https://second.example.com/maven2"),
-					},
-				},
+			settingsMirrors: []Mirror{
+				{ID: "first", MirrorOf: "*", URL: "https://first.example.com/maven2"},
+				{ID: "second", MirrorOf: "*", URL: "https://second.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -456,19 +429,9 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "settings.xml: exclusion blocks match, falls through to next mirror",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "first",
-						patterns: []string{"*", "!central"},
-						url:      mustParseURL(t, "https://first.example.com/maven2"),
-					},
-					{
-						id:       "second",
-						patterns: []string{"central"},
-						url:      mustParseURL(t, "https://second.example.com/maven2"),
-					},
-				},
+			settingsMirrors: []Mirror{
+				{ID: "first", MirrorOf: "*,!central", URL: "https://first.example.com/maven2"},
+				{ID: "second", MirrorOf: "central", URL: "https://second.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -485,10 +448,8 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "config file: single mirror — repo1 -> repo3",
-			mirrors: mirrors{
-				configFile: configFileMirrors(map[string][]string{
-					"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
-				}),
+			configMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -505,10 +466,8 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			name: "config file: trailing slash in key still matches",
-			mirrors: mirrors{
-				configFile: configFileMirrors(map[string][]string{
-					"https://repo1.example.com/maven2/": {"https://repo3.example.com/maven2"},
-				}),
+			configMirrors: map[string][]string{
+				"https://repo1.example.com/maven2/": {"https://repo3.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -526,13 +485,11 @@ func TestParser_mirrorFor(t *testing.T) {
 		{
 			// Several mirrors for one repository become ordered fallback candidates.
 			name: "config file: fallback list — repo1 -> [repo3, repo4] in order",
-			mirrors: mirrors{
-				configFile: configFileMirrors(map[string][]string{
-					"https://repo1.example.com/maven2": {
-						"https://repo3.example.com/maven2",
-						"https://repo4.example.com/maven2",
-					},
-				}),
+			configMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {
+					"https://repo3.example.com/maven2",
+					"https://repo4.example.com/maven2",
+				},
 			},
 			repo: repository{
 				id:             "central",
@@ -556,17 +513,11 @@ func TestParser_mirrorFor(t *testing.T) {
 			// Example 1 from the spec: both sources target repo1; settings.xml wins
 			// because it rewrites the URL first and the config pass no longer matches.
 			name: "cross-source: conflict on the same key — settings.xml wins",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "settings-mirror",
-						patterns: []string{"central"},
-						url:      mustParseURL(t, "https://repo2.example.com/maven2"),
-					},
-				},
-				configFile: configFileMirrors(map[string][]string{
-					"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
-				}),
+			settingsMirrors: []Mirror{
+				{ID: "settings-mirror", MirrorOf: "central", URL: "https://repo2.example.com/maven2"},
+			},
+			configMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -585,17 +536,11 @@ func TestParser_mirrorFor(t *testing.T) {
 			// Example 2 from the spec: cross-source chaining.
 			// settings.xml repo1 -> repo2, trivy.yaml repo2 -> repo3 => repo1 -> repo3.
 			name: "cross-source: chaining — repo1 --settings--> repo2 --trivy.yaml--> repo3",
-			mirrors: mirrors{
-				settings: []mirror{
-					{
-						id:       "settings-mirror",
-						patterns: []string{"central"},
-						url:      mustParseURL(t, "https://repo2.example.com/maven2"),
-					},
-				},
-				configFile: configFileMirrors(map[string][]string{
-					"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
-				}),
+			settingsMirrors: []Mirror{
+				{ID: "settings-mirror", MirrorOf: "central", URL: "https://repo2.example.com/maven2"},
+			},
+			configMirrors: map[string][]string{
+				"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
 			},
 			repo: repository{
 				id:             "central",
@@ -614,16 +559,10 @@ func TestParser_mirrorFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{mirrors: tt.mirrors}
+			p := &Parser{mirrors: resolveMirrors(tt.settingsMirrors, nil, tt.configMirrors)}
 			require.Equal(t, tt.want, p.mirrorFor(tt.repo))
 		})
 	}
-}
-
-// configFileMirrors resolves raw source->mirror URLs into the runtime config-file
-// mirror map (mirrors.configFile).
-func configFileMirrors(m map[string][]string) map[string][]url.URL {
-	return resolveMirrors(nil, nil, m).configFile
 }
 
 // Test_fetchPOMFromRemoteRepositories_mirror verifies that mirrors substitute

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -348,6 +348,7 @@ func TestParser_mirrorFor(t *testing.T) {
 	tests := []struct {
 		name            string
 		settingsMirrors []Mirror
+		servers         []Server
 		configMirrors   map[string][]string
 		repo            repository
 		want            []repository
@@ -483,6 +484,45 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
+			// Trivy embeds <server> credentials into the repository URL, so the lookup
+			// must ignore them — the configured key never carries a password.
+			name: "config file: repository credentials are ignored by the lookup",
+			configMirrors: map[string][]string{
+				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "corp",
+				url:            mustParseURL(t, "https://repo-user:repo-pass@repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "corp",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
+			// RFC 3986 defines the host as case-insensitive, unlike the path.
+			name: "config file: host case is ignored by the lookup",
+			configMirrors: map[string][]string{
+				"https://Repo1.Example.COM/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
 			// Several mirrors for one repository become ordered fallback candidates.
 			name: "config file: fallback list — repo1 -> [repo3, repo4] in order",
 			configMirrors: map[string][]string{
@@ -555,11 +595,38 @@ func TestParser_mirrorFor(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Chaining through a mirror that has <server> credentials: pass 1 rewrites the
+			// repository to the mirror URL with the credentials embedded, so the config-file
+			// lookup in pass 2 sees them and must still match the plain configured key.
+			name: "cross-source: chaining through a mirror with credentials",
+			settingsMirrors: []Mirror{
+				{ID: "settings-mirror", MirrorOf: "central", URL: "https://repo2.example.com/maven2"},
+			},
+			servers: []Server{
+				{ID: "settings-mirror", Username: "mirror-user", Password: "mirror-pass"},
+			},
+			configMirrors: map[string][]string{
+				"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "settings-mirror",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{mirrors: resolveMirrors(tt.settingsMirrors, nil, tt.configMirrors)}
+			p := &Parser{mirrors: resolveMirrors(tt.settingsMirrors, tt.servers, tt.configMirrors)}
 			require.Equal(t, tt.want, p.mirrorFor(tt.repo))
 		})
 	}

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -582,7 +582,8 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 	// can only be observed end-to-end through HTTP: that mirrorFor is applied to the
 	// fetch loop, that mirror credentials reach the remote request as Basic Auth, that
 	// a settings.xml -> trivy.yaml chain routes the fetch through to the final mirror,
-	// and that the fetch falls back to the next trivy.yaml mirror when one is not found.
+	// that the fetch falls back to the next trivy.yaml mirror on 404 or 429, and that a
+	// 429 is returned only when every mirror is rate-limited.
 	tests := []struct {
 		name            string
 		mirrorPatterns  []string
@@ -590,6 +591,7 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 		wantBasicAuth   string
 		configMirrors   map[string][]string // trivy.yaml mirrors, by server role: source-role -> []mirror-role
 		wantHits        map[string]int      // expected request count per server role
+		wantErr         string              // non-empty: fetch must fail with an error containing this
 	}{
 		{
 			name:            "settings.xml <server> credentials reach the mirror as Basic Auth",
@@ -614,6 +616,21 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			configMirrors:  map[string][]string{"mirror": {"dead", "chain"}},
 			wantHits:       map[string]int{"dead": 1, "chain": 1},
 		},
+		{
+			// The first mirror returns 429; the fetch skips it and succeeds on the second.
+			name:           "trivy.yaml fallback: first mirror 429s, second one serves",
+			mirrorPatterns: []string{"*"},
+			configMirrors:  map[string][]string{"mirror": {"limited", "chain"}},
+			wantHits:       map[string]int{"limited": 1, "chain": 1},
+		},
+		{
+			// Every mirror is rate-limited; the 429 is returned rather than "not found".
+			name:           "all mirrors rate-limited: the 429 is returned",
+			mirrorPatterns: []string{"*"},
+			configMirrors:  map[string][]string{"mirror": {"limited"}},
+			wantHits:       map[string]int{"limited": 1},
+			wantErr:        "429",
+		},
 	}
 
 	for _, tt := range tests {
@@ -622,7 +639,7 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			var gotBasicAuth string
 
 			// newServer registers an HTTP server for a role. status 200 serves the POM;
-			// any other status (e.g. 404) makes the fetch fall back to the next candidate.
+			// any other status (e.g. 404 or 429) makes the fetch fall back to the next candidate.
 			newServer := func(role string, status int) *httptest.Server {
 				s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					hits[role]++
@@ -642,10 +659,11 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			// repo1: original repository; mirror: settings.xml target; chain/dead:
 			// trivy.yaml targets (dead always 404s).
 			servers := map[string]*httptest.Server{
-				"repo1":  newServer("repo1", http.StatusOK),
-				"mirror": newServer("mirror", http.StatusOK),
-				"chain":  newServer("chain", http.StatusOK),
-				"dead":   newServer("dead", http.StatusNotFound),
+				"repo1":   newServer("repo1", http.StatusOK),
+				"mirror":  newServer("mirror", http.StatusOK),
+				"chain":   newServer("chain", http.StatusOK),
+				"dead":    newServer("dead", http.StatusNotFound),
+				"limited": newServer("limited", http.StatusTooManyRequests),
 			}
 
 			// trivy.yaml mirrors: resolve role names to server URLs.
@@ -680,8 +698,12 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 
 			paths := []string{"com", "example", "example-api", "1.0.0", "example-api-1.0.0.pom"}
 			got, err := p.fetchPOMFromRemoteRepositories(t.Context(), paths, false, []repository{pomRepo})
-			require.NoError(t, err)
-			require.NotNil(t, got)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+			}
 
 			for role := range servers {
 				require.Equal(t, tt.wantHits[role], hits[role], "request count for %q", role)

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -618,7 +618,7 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hits := map[string]int{}
+			hits := make(map[string]int)
 			var gotBasicAuth string
 
 			// newServer registers an HTTP server for a role. status 200 serves the POM;
@@ -649,7 +649,7 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			}
 
 			// trivy.yaml mirrors: resolve role names to server URLs.
-			configFileMirrors := map[string][]string{}
+			configFileMirrors := make(map[string][]string)
 			for srcRole, dstRoles := range tt.configMirrors {
 				for _, dstRole := range dstRoles {
 					src := servers[srcRole].URL

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -291,24 +292,78 @@ func Test_resolveMirrors(t *testing.T) {
 	}
 }
 
-// TestParser_mirrorFor covers both passes of mirrorFor: matching settings.xml
-// <mirror> entries, and applying trivy.yaml (scan.maven.mirrors) on top of the
-// result — including cross-source chaining and fallback lists.
-func TestParser_mirrorFor(t *testing.T) {
+// Test_resolveMirrors_configFile covers the config-file branch of resolveMirrors:
+// key normalization, target order, and dropping of unparsable/empty entries.
+func Test_resolveMirrors_configFile(t *testing.T) {
 	tests := []struct {
-		name              string
-		settingsMirrors   []mirror
-		configFileMirrors map[string][]string
-		repo              repository
-		want              []repository
+		name  string
+		input map[string][]string
+		want  map[string][]url.URL
 	}{
 		{
-			name: "no match — repository returned unchanged",
-			settingsMirrors: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"internal"},
-					url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+			name:  "nil input yields nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name: "key normalized (trailing slash trimmed), targets kept in order",
+			input: map[string][]string{
+				"https://repo.example.com/maven2/": {
+					"https://m1.example.com/maven2",
+					"https://m2.example.com/maven2",
+				},
+			},
+			want: map[string][]url.URL{
+				"https://repo.example.com/maven2": {
+					mustParseURL(t, "https://m1.example.com/maven2"),
+					mustParseURL(t, "https://m2.example.com/maven2"),
+				},
+			},
+		},
+		{
+			name: "entry with only an unparsable target is dropped",
+			input: map[string][]string{
+				"https://repo.example.com/maven2": {"http://[::1"},
+			},
+			want: nil,
+		},
+		{
+			name: "unparsable target is dropped, valid ones kept",
+			input: map[string][]string{
+				"https://repo.example.com/maven2": {"http://[::1", "https://ok.example.com/maven2"},
+			},
+			want: map[string][]url.URL{
+				"https://repo.example.com/maven2": {mustParseURL(t, "https://ok.example.com/maven2")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveMirrors(nil, nil, tt.input).configFile)
+		})
+	}
+}
+
+// TestParser_mirrorFor covers both passes of mirrorFor: matching settings.xml
+// <mirror> entries, and applying the config-file mirrors on top of the result —
+// including cross-source chaining and fallback lists.
+func TestParser_mirrorFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		mirrors mirrors
+		repo    repository
+		want    []repository
+	}{
+		{
+			name: "settings.xml: no match — repository returned unchanged",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"internal"},
+						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+					},
 				},
 			},
 			repo: repository{
@@ -325,12 +380,14 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name: "match by exact id — release/snapshot flags preserved from original repo",
-			settingsMirrors: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"central"},
-					url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+			name: "settings.xml: match by exact id — release/snapshot flags preserved",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"central"},
+						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+					},
 				},
 			},
 			repo: repository{
@@ -349,12 +406,14 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name: "credentials from mirror (not original repo) are kept",
-			settingsMirrors: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://mirror-user:mirror-pass@mirror.example.com/maven2"),
+			name: "settings.xml: mirror credentials (not the original repo's) are kept",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://mirror-user:mirror-pass@mirror.example.com/maven2"),
+					},
 				},
 			},
 			repo: repository{
@@ -371,17 +430,19 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name: "first matching mirror wins (no chaining)",
-			settingsMirrors: []mirror{
-				{
-					id:       "first",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://first.example.com/maven2"),
-				},
-				{
-					id:       "second",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://second.example.com/maven2"),
+			name: "settings.xml: first matching mirror wins",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "first",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://first.example.com/maven2"),
+					},
+					{
+						id:       "second",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://second.example.com/maven2"),
+					},
 				},
 			},
 			repo: repository{
@@ -398,17 +459,19 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name: "exclusion blocks match and falls through to next mirror",
-			settingsMirrors: []mirror{
-				{
-					id:       "first",
-					patterns: []string{"*", "!central"},
-					url:      mustParseURL(t, "https://first.example.com/maven2"),
-				},
-				{
-					id:       "second",
-					patterns: []string{"central"},
-					url:      mustParseURL(t, "https://second.example.com/maven2"),
+			name: "settings.xml: exclusion blocks match, falls through to next mirror",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "first",
+						patterns: []string{"*", "!central"},
+						url:      mustParseURL(t, "https://first.example.com/maven2"),
+					},
+					{
+						id:       "second",
+						patterns: []string{"central"},
+						url:      mustParseURL(t, "https://second.example.com/maven2"),
+					},
 				},
 			},
 			repo: repository{
@@ -425,25 +488,11 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name:              "empty config map — repository unchanged (backward compatibility)",
-			configFileMirrors: nil,
-			repo: repository{
-				id:             "central",
-				url:            mustParseURL(t, "https://repo1.example.com/maven2"),
-				releaseEnabled: true,
-			},
-			want: []repository{
-				{
-					id:             "central",
-					url:            mustParseURL(t, "https://repo1.example.com/maven2"),
-					releaseEnabled: true,
-				},
-			},
-		},
-		{
-			name: "config-file mirror only — repo1 -> repo3",
-			configFileMirrors: map[string][]string{
-				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+			name: "config file: single mirror — repo1 -> repo3",
+			mirrors: mirrors{
+				configFile: configFileMirrors(map[string][]string{
+					"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+				}),
 			},
 			repo: repository{
 				id:             "central",
@@ -459,9 +508,11 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
-			name: "trailing slash in config key still matches",
-			configFileMirrors: map[string][]string{
-				"https://repo1.example.com/maven2/": {"https://repo3.example.com/maven2"},
+			name: "config file: trailing slash in key still matches",
+			mirrors: mirrors{
+				configFile: configFileMirrors(map[string][]string{
+					"https://repo1.example.com/maven2/": {"https://repo3.example.com/maven2"},
+				}),
 			},
 			repo: repository{
 				id:             "central",
@@ -478,12 +529,14 @@ func TestParser_mirrorFor(t *testing.T) {
 		},
 		{
 			// Several mirrors for one repository become ordered fallback candidates.
-			name: "fallback list — repo1 -> [repo3, repo4] yields both candidates in order",
-			configFileMirrors: map[string][]string{
-				"https://repo1.example.com/maven2": {
-					"https://repo3.example.com/maven2",
-					"https://repo4.example.com/maven2",
-				},
+			name: "config file: fallback list — repo1 -> [repo3, repo4] in order",
+			mirrors: mirrors{
+				configFile: configFileMirrors(map[string][]string{
+					"https://repo1.example.com/maven2": {
+						"https://repo3.example.com/maven2",
+						"https://repo4.example.com/maven2",
+					},
+				}),
 			},
 			repo: repository{
 				id:             "central",
@@ -506,16 +559,18 @@ func TestParser_mirrorFor(t *testing.T) {
 		{
 			// Example 1 from the spec: both sources target repo1; settings.xml wins
 			// because it rewrites the URL first and the config pass no longer matches.
-			name: "conflict on the same key — settings.xml wins over trivy.yaml",
-			settingsMirrors: []mirror{
-				{
-					id:       "settings-mirror",
-					patterns: []string{"central"},
-					url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+			name: "cross-source: conflict on the same key — settings.xml wins",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "settings-mirror",
+						patterns: []string{"central"},
+						url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+					},
 				},
-			},
-			configFileMirrors: map[string][]string{
-				"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+				configFile: configFileMirrors(map[string][]string{
+					"https://repo1.example.com/maven2": {"https://repo3.example.com/maven2"},
+				}),
 			},
 			repo: repository{
 				id:             "central",
@@ -533,16 +588,18 @@ func TestParser_mirrorFor(t *testing.T) {
 		{
 			// Example 2 from the spec: cross-source chaining.
 			// settings.xml repo1 -> repo2, trivy.yaml repo2 -> repo3 => repo1 -> repo3.
-			name: "cross-source chaining — repo1 --settings--> repo2 --trivy.yaml--> repo3",
-			settingsMirrors: []mirror{
-				{
-					id:       "settings-mirror",
-					patterns: []string{"central"},
-					url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+			name: "cross-source: chaining — repo1 --settings--> repo2 --trivy.yaml--> repo3",
+			mirrors: mirrors{
+				settings: []mirror{
+					{
+						id:       "settings-mirror",
+						patterns: []string{"central"},
+						url:      mustParseURL(t, "https://repo2.example.com/maven2"),
+					},
 				},
-			},
-			configFileMirrors: map[string][]string{
-				"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
+				configFile: configFileMirrors(map[string][]string{
+					"https://repo2.example.com/maven2": {"https://repo3.example.com/maven2"},
+				}),
 			},
 			repo: repository{
 				id:             "central",
@@ -561,15 +618,16 @@ func TestParser_mirrorFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{
-				mirrors: mirrors{
-					settings:   tt.settingsMirrors,
-					configFile: resolveMirrors(nil, nil, tt.configFileMirrors).configFile,
-				},
-			}
+			p := &Parser{mirrors: tt.mirrors}
 			require.Equal(t, tt.want, p.mirrorFor(tt.repo))
 		})
 	}
+}
+
+// configFileMirrors resolves raw source->mirror URLs into the runtime config-file
+// mirror map (mirrors.configFile).
+func configFileMirrors(m map[string][]string) map[string][]url.URL {
+	return resolveMirrors(nil, nil, m).configFile
 }
 
 // Test_fetchPOMFromRemoteRepositories_mirror verifies that mirrors substitute
@@ -595,111 +653,93 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 		mirrorPatterns  []string
 		mirrorWithCreds bool
 		wantBasicAuth   string
-		chainToConfig   bool // trivy.yaml mirror: settings-target -> chain-target
-		configFallback  bool // trivy.yaml mirror: settings-target -> [dead, chain]
+		configMirrors   map[string][]string // trivy.yaml mirrors, by server role: source-role -> []mirror-role
+		wantHits        map[string]int      // expected request count per server role
 	}{
 		{
-			name:           "wildcard mirror redirects the fetch to the mirror server",
-			mirrorPatterns: []string{"*"},
-		},
-		{
-			name:            "credentials baked into mirror URL are sent as Basic Auth",
+			name:            "settings.xml <server> credentials reach the mirror as Basic Auth",
 			mirrorPatterns:  []string{"*"},
 			mirrorWithCreds: true,
 			wantBasicAuth:   "mirror-user",
+			wantHits:        map[string]int{"mirror": 1},
 		},
 		{
-			// Example 2 end-to-end: settings.xml rewrites central(repo1) -> repo2, then
-			// trivy.yaml rewrites repo2 -> repo3, so only repo3 must receive the request.
+			// Example 2 end-to-end: settings.xml rewrites central(repo1) -> mirror(repo2),
+			// then trivy.yaml rewrites repo2 -> chain(repo3), so only repo3 is requested.
 			name:           "cross-source chaining: settings.xml then trivy.yaml routes to the final mirror",
 			mirrorPatterns: []string{"*"},
-			chainToConfig:  true,
+			configMirrors:  map[string][]string{"mirror": {"chain"}},
+			wantHits:       map[string]int{"chain": 1},
 		},
 		{
-			// trivy.yaml lists two mirrors for repo2; the first 404s, so the fetch must
-			// fall back to the second and succeed there.
+			// trivy.yaml lists two mirrors for repo2; the first 404s, so the fetch falls
+			// back to the second and succeeds there.
 			name:           "trivy.yaml fallback: first mirror 404s, second one serves",
 			mirrorPatterns: []string{"*"},
-			configFallback: true,
+			configMirrors:  map[string][]string{"mirror": {"dead", "chain"}},
+			wantHits:       map[string]int{"dead": 1, "chain": 1},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var mirrorHits, originalHits, chainHits, deadHits int
+			hits := map[string]int{}
 			var gotBasicAuth string
 
-			// repo2: settings.xml mirror target.
-			mirrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				mirrorHits++
-				if u, _, ok := r.BasicAuth(); ok {
-					gotBasicAuth = u
+			// newServer registers an HTTP server for a role. status 200 serves the POM;
+			// any other status (e.g. 404) makes the fetch fall back to the next candidate.
+			newServer := func(role string, status int) *httptest.Server {
+				s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					hits[role]++
+					if u, _, ok := r.BasicAuth(); ok {
+						gotBasicAuth = u
+					}
+					if status != http.StatusOK {
+						w.WriteHeader(status)
+						return
+					}
+					_, _ = w.Write([]byte(minimalPOM))
+				}))
+				t.Cleanup(s.Close)
+				return s
+			}
+
+			// repo1: original repository; mirror: settings.xml target; chain/dead:
+			// trivy.yaml targets (dead always 404s).
+			servers := map[string]*httptest.Server{
+				"repo1":  newServer("repo1", http.StatusOK),
+				"mirror": newServer("mirror", http.StatusOK),
+				"chain":  newServer("chain", http.StatusOK),
+				"dead":   newServer("dead", http.StatusNotFound),
+			}
+
+			// trivy.yaml mirrors: resolve role names to server URLs.
+			configFileMirrors := map[string][]string{}
+			for srcRole, dstRoles := range tt.configMirrors {
+				for _, dstRole := range dstRoles {
+					src := servers[srcRole].URL
+					configFileMirrors[src] = append(configFileMirrors[src], servers[dstRole].URL)
 				}
-				_, _ = w.Write([]byte(minimalPOM))
-			}))
-			defer mirrorServer.Close()
+			}
 
-			// repo1: original repository.
-			originalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				originalHits++
-				_, _ = w.Write([]byte(minimalPOM))
-			}))
-			defer originalServer.Close()
-
-			// repo3: trivy.yaml (config-file) mirror target that serves the POM.
-			chainServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				chainHits++
-				_, _ = w.Write([]byte(minimalPOM))
-			}))
-			defer chainServer.Close()
-
-			// A trivy.yaml mirror that always 404s, to exercise fallback to the next one.
-			deadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				deadHits++
-				http.NotFound(w, r)
-			}))
-			defer deadServer.Close()
-
-			mirrorURL := mirrorServer.URL
+			// settings.xml mirror central -> "mirror"; creds (if any) come from a <server>.
+			var srvCreds []Server
 			if tt.mirrorWithCreds {
-				u, err := url.Parse(mirrorServer.URL)
-				require.NoError(t, err)
-				u.User = url.UserPassword("mirror-user", "mirror-pass")
-				mirrorURL = u.String()
+				srvCreds = []Server{{ID: "m1", Username: "mirror-user", Password: "mirror-pass"}}
 			}
-			u, err := url.Parse(mirrorURL)
-			require.NoError(t, err)
-			settingsMirrors := []mirror{
-				{
-					id:       "m1",
-					patterns: tt.mirrorPatterns,
-					url:      *u,
-				},
-			}
+			resolved := resolveMirrors(
+				[]Mirror{{ID: "m1", URL: servers["mirror"].URL, MirrorOf: strings.Join(tt.mirrorPatterns, ",")}},
+				srvCreds,
+				configFileMirrors,
+			)
 
-			var configFile map[string][]url.URL
-			switch {
-			case tt.chainToConfig:
-				configFile = resolveMirrors(nil, nil, map[string][]string{
-					mirrorServer.URL: {chainServer.URL},
-				}).configFile
-			case tt.configFallback:
-				configFile = resolveMirrors(nil, nil, map[string][]string{
-					mirrorServer.URL: {deadServer.URL, chainServer.URL},
-				}).configFile
-			}
-
-			origURL, err := url.Parse(originalServer.URL)
+			origURL, err := url.Parse(servers["repo1"].URL)
 			require.NoError(t, err)
-			pomRepo := repository{
-				id:             "central",
-				url:            *origURL,
-				releaseEnabled: true,
-			}
+			pomRepo := repository{id: "central", url: *origURL, releaseEnabled: true}
 
 			p := &Parser{
 				logger:     log.WithPrefix("pom"),
-				mirrors:    mirrors{settings: settingsMirrors, configFile: configFile},
+				mirrors:    resolved,
 				httpClient: http.DefaultClient,
 			}
 
@@ -708,21 +748,10 @@ func Test_fetchPOMFromRemoteRepositories_mirror(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
-			require.Equal(t, 0, originalHits, "original repo must not be hit")
-			switch {
-			case tt.chainToConfig:
-				require.Equal(t, 0, mirrorHits, "settings.xml mirror must not be hit (rewritten by trivy.yaml)")
-				require.Equal(t, 1, chainHits, "config-file mirror hits")
-				require.Equal(t, 0, deadHits, "dead mirror must not be hit")
-			case tt.configFallback:
-				require.Equal(t, 0, mirrorHits, "settings.xml mirror must not be hit (rewritten by trivy.yaml)")
-				require.Equal(t, 1, deadHits, "first (dead) config-file mirror is tried")
-				require.Equal(t, 1, chainHits, "fetch falls back to the second config-file mirror")
-			default:
-				require.Equal(t, 1, mirrorHits, "mirror hits")
-				require.Equal(t, 0, chainHits, "config-file mirror must not be hit")
-				require.Equal(t, tt.wantBasicAuth, gotBasicAuth, "basic auth user")
+			for role := range servers {
+				require.Equal(t, tt.wantHits[role], hits[role], "request count for %q", role)
 			}
+			require.Equal(t, tt.wantBasicAuth, gotBasicAuth, "basic auth user")
 		})
 	}
 }

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -504,6 +504,25 @@ func TestParser_mirrorFor(t *testing.T) {
 			},
 		},
 		{
+			// The path is cleaned, so repeated and relative segments don't break the match.
+			name: "config file: path segments are cleaned before the lookup",
+			configMirrors: map[string][]string{
+				"https://repo1.example.com//nexus/./content/../maven2/": {"https://repo3.example.com/maven2"},
+			},
+			repo: repository{
+				id:             "central",
+				url:            mustParseURL(t, "https://repo1.example.com/nexus/maven2"),
+				releaseEnabled: true,
+			},
+			want: []repository{
+				{
+					id:             "central",
+					url:            mustParseURL(t, "https://repo3.example.com/maven2"),
+					releaseEnabled: true,
+				},
+			},
+		},
+		{
 			// RFC 3986 defines the host as case-insensitive, unlike the path.
 			name: "config file: host case is ignored by the lookup",
 			configMirrors: map[string][]string{

--- a/pkg/dependency/parser/java/pom/mirror_test.go
+++ b/pkg/dependency/parser/java/pom/mirror_test.go
@@ -137,15 +137,19 @@ func Test_mirror_matches(t *testing.T) {
 	}
 }
 
+// Test_resolveMirrors covers resolveMirrors for both sources: settings.xml <mirror>
+// entries (pattern splitting, <server> credentials, dropping bad entries) and
+// config-file mirrors (key normalization, target order, dropping bad entries).
 func Test_resolveMirrors(t *testing.T) {
 	tests := []struct {
-		name    string
-		mirrors []Mirror
-		servers []Server
-		want    []mirror
+		name          string
+		mirrors       []Mirror
+		servers       []Server
+		configMirrors map[string][]string
+		want          mirrors
 	}{
 		{
-			name: "split, trim and drop empty patterns",
+			name: "settings.xml: split, trim and drop empty patterns",
 			mirrors: []Mirror{
 				{
 					ID:       "m1",
@@ -153,16 +157,18 @@ func Test_resolveMirrors(t *testing.T) {
 					MirrorOf: "  central , , !internal ,",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"central", "!internal"},
-					url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"central", "!internal"},
+						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "credentials embedded from <server> matching mirror id",
+			name: "settings.xml: credentials embedded from <server> matching mirror id",
 			mirrors: []Mirror{
 				{
 					ID:       "m1",
@@ -177,16 +183,18 @@ func Test_resolveMirrors(t *testing.T) {
 					Password: "pass",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://user:pass@mirror.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://user:pass@mirror.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "<server> credentials override userinfo embedded in mirror URL",
+			name: "settings.xml: <server> credentials override userinfo embedded in mirror URL",
 			mirrors: []Mirror{
 				{
 					ID:       "m1",
@@ -201,16 +209,18 @@ func Test_resolveMirrors(t *testing.T) {
 					Password: "server-pass",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://server-user:server-pass@mirror.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://server-user:server-pass@mirror.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "server with non-matching id is ignored",
+			name: "settings.xml: server with non-matching id is ignored",
 			mirrors: []Mirror{
 				{
 					ID:       "m1",
@@ -225,16 +235,18 @@ func Test_resolveMirrors(t *testing.T) {
 					Password: "pass",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "m1",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "m1",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "mirror with empty mirrorOf is dropped",
+			name: "settings.xml: mirror with empty mirrorOf is dropped",
 			mirrors: []Mirror{
 				{
 					ID:       "m1",
@@ -247,16 +259,18 @@ func Test_resolveMirrors(t *testing.T) {
 					MirrorOf: "central",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "m2",
-					patterns: []string{"central"},
-					url:      mustParseURL(t, "https://other.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "m2",
+						patterns: []string{"central"},
+						url:      mustParseURL(t, "https://other.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "mirror with unparsable URL is dropped",
+			name: "settings.xml: mirror with unparsable URL is dropped",
 			mirrors: []Mirror{
 				{
 					ID:       "broken",
@@ -269,78 +283,60 @@ func Test_resolveMirrors(t *testing.T) {
 					MirrorOf: "*",
 				},
 			},
-			want: []mirror{
-				{
-					id:       "ok",
-					patterns: []string{"*"},
-					url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+			want: mirrors{
+				settings: []mirror{
+					{
+						id:       "ok",
+						patterns: []string{"*"},
+						url:      mustParseURL(t, "https://mirror.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name:    "no mirrors yields nil",
-			mirrors: nil,
-			want:    nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := resolveMirrors(tt.mirrors, tt.servers, nil)
-			require.Equal(t, tt.want, got.settings)
-		})
-	}
-}
-
-// Test_resolveMirrors_configFile covers the config-file branch of resolveMirrors:
-// key normalization, target order, and dropping of unparsable/empty entries.
-func Test_resolveMirrors_configFile(t *testing.T) {
-	tests := []struct {
-		name  string
-		input map[string][]string
-		want  map[string][]url.URL
-	}{
-		{
-			name:  "nil input yields nil",
-			input: nil,
-			want:  nil,
+			name: "no input yields empty mirrors",
+			want: mirrors{},
 		},
 		{
-			name: "key normalized (trailing slash trimmed), targets kept in order",
-			input: map[string][]string{
+			name: "config file: key normalized (trailing slash trimmed), targets kept in order",
+			configMirrors: map[string][]string{
 				"https://repo.example.com/maven2/": {
 					"https://m1.example.com/maven2",
 					"https://m2.example.com/maven2",
 				},
 			},
-			want: map[string][]url.URL{
-				"https://repo.example.com/maven2": {
-					mustParseURL(t, "https://m1.example.com/maven2"),
-					mustParseURL(t, "https://m2.example.com/maven2"),
+			want: mirrors{
+				configFile: map[string][]url.URL{
+					"https://repo.example.com/maven2": {
+						mustParseURL(t, "https://m1.example.com/maven2"),
+						mustParseURL(t, "https://m2.example.com/maven2"),
+					},
 				},
 			},
 		},
 		{
-			name: "entry with only an unparsable target is dropped",
-			input: map[string][]string{
+			name: "config file: entry with only an unparsable target is dropped",
+			configMirrors: map[string][]string{
 				"https://repo.example.com/maven2": {"http://[::1"},
 			},
-			want: nil,
+			want: mirrors{},
 		},
 		{
-			name: "unparsable target is dropped, valid ones kept",
-			input: map[string][]string{
+			name: "config file: unparsable target is dropped, valid ones kept",
+			configMirrors: map[string][]string{
 				"https://repo.example.com/maven2": {"http://[::1", "https://ok.example.com/maven2"},
 			},
-			want: map[string][]url.URL{
-				"https://repo.example.com/maven2": {mustParseURL(t, "https://ok.example.com/maven2")},
+			want: mirrors{
+				configFile: map[string][]url.URL{
+					"https://repo.example.com/maven2": {mustParseURL(t, "https://ok.example.com/maven2")},
+				},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, resolveMirrors(nil, nil, tt.input).configFile)
+			require.Equal(t, tt.want, resolveMirrors(tt.mirrors, tt.servers, tt.configMirrors))
 		})
 	}
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -35,9 +35,10 @@ import (
 )
 
 type options struct {
-	offline       bool
-	defaultRepo   repository
-	settingsRepos []repository
+	offline           bool
+	defaultRepo       repository
+	settingsRepos     []repository
+	configFileMirrors map[string][]string
 }
 
 type option func(*options)
@@ -45,6 +46,15 @@ type option func(*options)
 func WithOffline(offline bool) option {
 	return func(opts *options) {
 		opts.offline = offline
+	}
+}
+
+// WithConfigFileMirrors injects Maven mirrors from Trivy's config file:
+// each source repository URL maps to an ordered list of
+// fallback mirror URLs, applied on top of the settings.xml mirrors.
+func WithConfigFileMirrors(mirrors map[string][]string) option {
+	return func(opts *options) {
+		opts.configFileMirrors = mirrors
 	}
 }
 
@@ -90,7 +100,7 @@ type Parser struct {
 	remoteRepos     repositories
 	offline         bool
 	servers         []Server
-	mirrors         []mirror
+	mirrors         mirrors
 	httpClient      *http.Client
 }
 
@@ -152,29 +162,51 @@ func NewParser(filePath string, opts ...option) *Parser {
 		remoteRepos:     remoteRepos,
 		offline:         o.offline,
 		servers:         s.Servers,
-		mirrors:         resolveMirrors(s.Mirrors, s.Servers),
+		mirrors:         resolveMirrors(s.Mirrors, s.Servers, o.configFileMirrors),
 		httpClient: &http.Client{
 			Transport: tr.Build(),
 		},
 	}
 }
 
-// mirrorFor returns a mirrored repository for repo if one of the configured
-// mirrors matches; otherwise repo is returned unchanged. The first matching
-// mirror wins — Maven does not chain mirrors.
-func (p *Parser) mirrorFor(repo repository) repository {
-	for _, m := range p.mirrors {
+// mirrorFor returns the ordered list of repositories to try for repo, after applying
+// the configured mirrors in two passes:
+//
+//  1. settings.xml <mirror> entries — the first matching mirror replaces repo (Maven
+//     first-match; no chaining within this source).
+//  2. config-file mirrors (scan.maven.mirrors) — if an entry matches the URL from
+//     pass 1, repo expands into one candidate per listed mirror, in order (fallbacks).
+//
+// The passes chain: pass 2 runs on the URL rewritten by pass 1, so settings.xml
+// repo1->repo2 followed by trivy.yaml repo2->repo3 resolves repo1 to repo3. When both
+// sources match the same repository settings.xml wins (it rewrites first, so pass 2 no
+// longer matches). With no match, the single element repo is returned unchanged.
+func (p *Parser) mirrorFor(repo repository) []repository {
+	// Pass 1: settings.xml mirrors (a single mirror, Maven first-match).
+	for _, m := range p.mirrors.settings {
 		if !m.matches(repo.id, &repo.url) {
 			continue
 		}
-		return repository{
+		repo = repository{
 			id:              m.id,
 			url:             m.url,
 			releaseEnabled:  repo.releaseEnabled,
 			snapshotEnabled: repo.snapshotEnabled,
 		}
+		break
 	}
-	return repo
+
+	// Pass 2: config-file mirrors, matched by the (possibly rewritten) repository URL.
+	// Each listed mirror becomes a fallback candidate with its URL rewritten.
+	if targets, ok := p.mirrors.configFile[mirrorKey(repo.url)]; ok {
+		return lo.Map(targets, func(target url.URL, _ int) repository {
+			r := repo
+			r.url = target
+			return r
+		})
+	}
+
+	return []repository{repo}
 }
 
 func (p *Parser) Parse(ctx context.Context, r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
@@ -817,41 +849,41 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 	// 2. remoteRepositories from pom.xml (passed as parameter)
 	// 3. default remoteRepository (Maven Central for Release repository)
 	for _, repo := range slices.Concat(p.remoteRepos.settings, pomRepos, []repository{p.remoteRepos.defaultRepo}) {
-		// Apply <mirrors> from settings.xml so that settings/pom-declared/default
-		// repositories are all routed through a matching mirror at request time.
-		repo = p.mirrorFor(repo)
+		// Route each repository through its mirrors; a config-file mirror may expand
+		// one repository into several ordered fallback candidates.
+		for _, candidate := range p.mirrorFor(repo) {
+			// After mirrorFor different source repositories may collapse to the same URL
+			// (e.g. mirrorOf=*). Maven's aggregateRepositories deduplicates the post-mirror
+			// set so a not-found artifact is fetched from each mirror only once; mirror by URL.
+			if seen.Contains(candidate.url.String()) {
+				continue
+			}
+			seen.Append(candidate.url.String())
 
-		// After mirrorFor different source repositories may collapse to the same URL
-		// (e.g. mirrorOf=*). Maven's aggregateRepositories deduplicates the post-mirror
-		// set so a not-found artifact is fetched from each mirror only once; mirror by URL.
-		if seen.Contains(repo.url.String()) {
-			continue
-		}
-		seen.Append(repo.url.String())
+			// Skip Release only repositories for snapshot artifacts and vice versa
+			if snapshot && !candidate.snapshotEnabled || !snapshot && !candidate.releaseEnabled {
+				continue
+			}
 
-		// Skip Release only repositories for snapshot artifacts and vice versa
-		if snapshot && !repo.snapshotEnabled || !snapshot && !repo.releaseEnabled {
-			continue
-		}
-
-		repoPaths := slices.Clone(paths) // Clone slice to avoid overwriting last element of `paths`
-		if snapshot {
-			pomFileName, err := p.fetchPomFileNameFromMavenMetadata(ctx, repo.url, repoPaths)
+			repoPaths := slices.Clone(paths) // Clone slice to avoid overwriting last element of `paths`
+			if snapshot {
+				pomFileName, err := p.fetchPomFileNameFromMavenMetadata(ctx, candidate.url, repoPaths)
+				if err != nil {
+					return nil, xerrors.Errorf("fetch maven-metadata.xml error: %w", err)
+				}
+				// Use file name from `maven-metadata.xml` if it exists
+				if pomFileName != "" {
+					repoPaths[len(repoPaths)-1] = pomFileName
+				}
+			}
+			fetched, err := p.fetchPOMFromRemoteRepository(ctx, candidate.url, repoPaths)
 			if err != nil {
-				return nil, xerrors.Errorf("fetch maven-metadata.xml error: %w", err)
+				return nil, xerrors.Errorf("fetch repository error: %w", err)
+			} else if fetched == nil {
+				continue
 			}
-			// Use file name from `maven-metadata.xml` if it exists
-			if pomFileName != "" {
-				repoPaths[len(repoPaths)-1] = pomFileName
-			}
+			return fetched, nil
 		}
-		fetched, err := p.fetchPOMFromRemoteRepository(ctx, repo.url, repoPaths)
-		if err != nil {
-			return nil, xerrors.Errorf("fetch repository error: %w", err)
-		} else if fetched == nil {
-			continue
-		}
-		return fetched, nil
 	}
 	return nil, xerrors.Errorf("the POM was not found in remote remoteRepositories")
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -873,7 +873,7 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 			if snapshot {
 				pomFileName, err := p.fetchPomFileNameFromMavenMetadata(ctx, candidate.url, repoPaths)
 				if err != nil {
-					if isRateLimit(err) {
+					if _, ok := errors.AsType[*rateLimitError](err); ok {
 						lastRateLimitErr = err
 						continue
 					}
@@ -886,7 +886,7 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 			}
 			fetched, err := p.fetchPOMFromRemoteRepository(ctx, candidate.url, repoPaths)
 			if err != nil {
-				if isRateLimit(err) {
+				if _, ok := errors.AsType[*rateLimitError](err); ok {
 					lastRateLimitErr = err
 					continue
 				}
@@ -1095,10 +1095,4 @@ func newRateLimitError(req *http.Request, resp *http.Response) *rateLimitError {
 			req.URL.Redacted(), ra,
 		),
 	}}
-}
-
-// isRateLimit reports whether err is (or wraps) a rateLimitError.
-func isRateLimit(err error) bool {
-	var rle *rateLimitError
-	return errors.As(err, &rle)
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -50,8 +50,7 @@ func WithOffline(offline bool) option {
 }
 
 // WithConfigFileMirrors injects Maven mirrors from Trivy's config file:
-// each source repository URL maps to an ordered list of
-// fallback mirror URLs, applied on top of the settings.xml mirrors.
+// each source repository URL maps to an ordered list of fallback mirror URLs.
 func WithConfigFileMirrors(mirrors map[string][]string) option {
 	return func(opts *options) {
 		opts.configFileMirrors = mirrors
@@ -174,12 +173,12 @@ func NewParser(filePath string, opts ...option) *Parser {
 //
 //  1. settings.xml <mirror> entries — the first matching mirror replaces repo (Maven
 //     first-match; no chaining within this source).
-//  2. config-file mirrors (scan.maven.mirrors) — if an entry matches the URL from
-//     pass 1, repo expands into one candidate per listed mirror, in order (fallbacks).
+//  2. config-file mirrors — if an entry matches repo's URL, repo expands into one
+//     candidate per listed mirror, in order (fallbacks).
 //
-// The passes chain: pass 2 runs on the URL rewritten by pass 1, so settings.xml
-// repo1->repo2 followed by trivy.yaml repo2->repo3 resolves repo1 to repo3. When both
-// sources match the same repository settings.xml wins (it rewrites first, so pass 2 no
+// The two passes chain: pass 2 runs on the URL rewritten by pass 1, so a settings.xml
+// mapping repo1->repo2 followed by a config-file mapping repo2->repo3 resolves repo1 to
+// repo3. When both map the same repo, settings.xml wins (it rewrites first, so pass 2 no
 // longer matches). With no match, the single element repo is returned unchanged.
 func (p *Parser) mirrorFor(repo repository) []repository {
 	// Pass 1: settings.xml mirrors (a single mirror, Maven first-match).
@@ -196,14 +195,16 @@ func (p *Parser) mirrorFor(repo repository) []repository {
 		break
 	}
 
-	// Pass 2: config-file mirrors, matched by the (possibly rewritten) repository URL.
-	// Each listed mirror becomes a fallback candidate with its URL rewritten.
-	if targets, ok := p.mirrors.configFile[mirrorKey(repo.url)]; ok {
-		return lo.Map(targets, func(target url.URL, _ int) repository {
-			r := repo
-			r.url = target
-			return r
-		})
+	// Pass 2: config-file mirrors, looked up by the current repository URL.
+	// Each listed mirror becomes a fallback candidate.
+	if len(p.mirrors.configFile) > 0 {
+		if targets, ok := p.mirrors.configFile[mirrorKey(repo.url)]; ok {
+			return lo.Map(targets, func(target url.URL, _ int) repository {
+				r := repo
+				r.url = target
+				return r
+			})
+		}
 	}
 
 	return []repository{repo}

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -845,6 +845,9 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 	}
 
 	seen := set.New[string]()
+	// A 429 only skips the rate-limited mirror; the last one is kept so it can be
+	// returned if every mirror turns out to be rate-limited.
+	var lastRateLimitErr error
 	// Try all remoteRepositories by following order:
 	// 1. remoteRepositories from settings.xml
 	// 2. remoteRepositories from pom.xml (passed as parameter)
@@ -870,6 +873,10 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 			if snapshot {
 				pomFileName, err := p.fetchPomFileNameFromMavenMetadata(ctx, candidate.url, repoPaths)
 				if err != nil {
+					if isRateLimit(err) {
+						lastRateLimitErr = err
+						continue
+					}
 					return nil, xerrors.Errorf("fetch maven-metadata.xml error: %w", err)
 				}
 				// Use file name from `maven-metadata.xml` if it exists
@@ -879,12 +886,19 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 			}
 			fetched, err := p.fetchPOMFromRemoteRepository(ctx, candidate.url, repoPaths)
 			if err != nil {
+				if isRateLimit(err) {
+					lastRateLimitErr = err
+					continue
+				}
 				return nil, xerrors.Errorf("fetch repository error: %w", err)
 			} else if fetched == nil {
 				continue
 			}
 			return fetched, nil
 		}
+	}
+	if lastRateLimitErr != nil {
+		return nil, lastRateLimitErr
 	}
 	return nil, xerrors.Errorf("the POM was not found in remote remoteRepositories")
 }
@@ -928,7 +942,7 @@ func (p *Parser) fetchPomFileNameFromMavenMetadata(ctx context.Context, repoURL 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return "", rateLimitError(req, resp)
+		return "", newRateLimitError(req, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
@@ -969,7 +983,7 @@ func (p *Parser) fetchPOMFromRemoteRepository(ctx context.Context, repoURL url.U
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, rateLimitError(req, resp)
+		return nil, newRateLimitError(req, resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Debug("Failed to fetch", log.String("url", req.URL.Redacted()), log.Int("statusCode", resp.StatusCode))
@@ -1056,15 +1070,23 @@ func shouldReturnError(err error) bool {
 	return errors.As(err, &ue)
 }
 
-// rateLimitError builds a user-facing error for a 429 response from a remote Maven
-// repository. Rate limits are typically per-IP and apply to all subsequent requests
-// (including cached ones), so continuing the scan is pointless until the block clears.
-func rateLimitError(req *http.Request, resp *http.Response) *types.UserError {
+// rateLimitError wraps a 429 Too Many Requests response from a remote Maven repository.
+// The wrapped *types.UserError is exposed via Unwrap so the top level still prints the
+// clean 429 message.
+type rateLimitError struct {
+	err *types.UserError
+}
+
+func (e *rateLimitError) Error() string { return e.err.Error() }
+func (e *rateLimitError) Unwrap() error { return e.err }
+
+// newRateLimitError builds a rateLimitError for a 429 response, including Retry-After.
+func newRateLimitError(req *http.Request, resp *http.Response) *rateLimitError {
 	var ra string
 	if v := resp.Header.Get("Retry-After"); v != "" {
 		ra = fmt.Sprintf(" Retry-After: %s.", v)
 	}
-	return &types.UserError{
+	return &rateLimitError{err: &types.UserError{
 		Message: fmt.Sprintf(
 			"remote Maven repository returned 429 Too Many Requests for %s.%s\n"+
 				"The repository blocks all subsequent requests from this IP until the block clears.\n"+
@@ -1072,5 +1094,11 @@ func rateLimitError(req *http.Request, resp *http.Response) *types.UserError {
 				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).",
 			req.URL.Redacted(), ra,
 		),
-	}
+	}}
+}
+
+// isRateLimit reports whether err is (or wraps) a rateLimitError.
+func isRateLimit(err error) bool {
+	var rle *rateLimitError
+	return errors.As(err, &rle)
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -845,8 +845,9 @@ func (p *Parser) fetchPOMFromRemoteRepositories(ctx context.Context, paths []str
 	}
 
 	seen := set.New[string]()
-	// A 429 only skips the rate-limited mirror; the last one is kept so it can be
-	// returned if every mirror turns out to be rate-limited.
+	// A 429 only skips the rate-limited mirror; the last one is kept so it can be returned
+	// if no other mirror serves the POM. A rate-limited mirror leaves the result unknown,
+	// so the 429 wins over the "not found" that the remaining mirrors may have returned.
 	var lastRateLimitErr error
 	// Try all remoteRepositories by following order:
 	// 1. remoteRepositories from settings.xml

--- a/pkg/fanal/analyzer/analyzer.go
+++ b/pkg/fanal/analyzer/analyzer.go
@@ -172,6 +172,9 @@ func (f FilePatterns) Match(filePath string) bool {
 type AnalysisOptions struct {
 	Offline      bool
 	FileChecksum bool
+
+	// MavenMirrors maps a Maven repository URL to an ordered list of fallback mirror URLs.
+	MavenMirrors map[string][]string
 }
 
 type AnalysisResult struct {

--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -25,7 +25,10 @@ type pomAnalyzer struct{}
 
 func (a pomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	filePath := filepath.Join(input.Dir, input.FilePath)
-	p := pom.NewParser(filePath, pom.WithOffline(input.Options.Offline))
+	p := pom.NewParser(filePath,
+		pom.WithOffline(input.Options.Offline),
+		pom.WithConfigFileMirrors(input.Options.MavenMirrors),
+	)
 	res, err := language.Analyze(ctx, types.Pom, input.FilePath, input.Content, p)
 	if err != nil {
 		return nil, xerrors.Errorf("%s parse error: %w", input.FilePath, err)

--- a/pkg/fanal/artifact/artifact.go
+++ b/pkg/fanal/artifact/artifact.go
@@ -33,6 +33,9 @@ type Option struct {
 	FileChecksum      bool // For SPDX
 	DetectionPriority types.DetectionPriority
 
+	// MavenMirrors maps a Maven repository URL to an ordered list of fallback mirror URLs.
+	MavenMirrors map[string][]string
+
 	// Original is the original target location, e.g. "github.com/aquasecurity/trivy"
 	// Currently, it is used only for remote git repositories
 	Original string

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -201,6 +201,7 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 	opts := analyzer.AnalysisOptions{
 		Offline:      a.artifactOption.Offline,
 		FileChecksum: a.artifactOption.FileChecksum,
+		MavenMirrors: a.artifactOption.MavenMirrors,
 	}
 
 	// Prepare filesystem for post analysis

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ import (
 )
 
 type FlagType interface {
-	int | string | []string | bool | time.Duration | float64 | map[string][]string
+	int | string | []string | bool | time.Duration | float64 | map[string][]string | []MavenMirror
 }
 
 type Flag[T FlagType] struct {
@@ -113,7 +114,8 @@ func (f *Flag[T]) Parse() error {
 
 	value, ok := f.cast(v).(T)
 	if !ok {
-		return xerrors.Errorf("failed to parse flag %s", f.Name)
+		// Config-only flags have no name, so the config file key is the only locator.
+		return xerrors.Errorf("failed to parse flag %s", lo.Ternary(f.Name != "", f.Name, f.ConfigName))
 	}
 
 	if f.ValueNormalize != nil {
@@ -178,6 +180,14 @@ func (f *Flag[T]) cast(val any) any {
 		return cast.ToDuration(val)
 	case map[string][]string:
 		return cast.ToStringMapStringSlice(val)
+	case []MavenMirror:
+		// cast doesn't support structs, so the config file value is decoded here.
+		var mirrors []MavenMirror
+		if err := mapstructure.Decode(val, &mirrors); err != nil {
+			// Parse turns the nil into an error, as the cast to T fails.
+			return nil
+		}
+		return mirrors
 	case []string:
 		if s, ok := val.(string); ok && strings.Contains(s, ",") {
 			// Split environmental variables by comma as it is not done by viper.

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"net/url"
 	"runtime"
 	"slices"
 	"strings"
@@ -135,6 +136,10 @@ var (
 		ConfigName: "scan.disable-telemetry",
 		Usage:      "disable sending anonymous usage data to Aqua",
 	}
+	MavenMirrorsFlag = Flag[map[string][]string]{
+		ConfigName: "scan.maven.mirrors",
+		Usage:      "map of Maven repository URLs and an ordered list of mirrors that serve each of them.",
+	}
 )
 
 type ScanFlagGroup struct {
@@ -151,6 +156,7 @@ type ScanFlagGroup struct {
 	DistroFlag        *Flag[string]
 	SkipVersionCheck  *Flag[bool]
 	DisableTelemetry  *Flag[bool]
+	MavenMirrors      *Flag[map[string][]string]
 }
 
 type ScanOptions struct {
@@ -167,6 +173,10 @@ type ScanOptions struct {
 	Distro            ftypes.OS
 	SkipVersionCheck  bool
 	DisableTelemetry  bool
+	// MavenMirrors maps a Maven repository URL to an ordered list of mirror URLs
+	// that serve it (tried in order as fallbacks). It is applied by the pom parser
+	// as the lowest-priority mirrors, on top of the mirrors from settings.xml.
+	MavenMirrors map[string][]string
 }
 
 func NewScanFlagGroup() *ScanFlagGroup {
@@ -184,6 +194,7 @@ func NewScanFlagGroup() *ScanFlagGroup {
 		DistroFlag:        DistroFlag.Clone(),
 		SkipVersionCheck:  SkipVersionCheckFlag.Clone(),
 		DisableTelemetry:  DisableTelemetryFlag.Clone(),
+		MavenMirrors:      MavenMirrorsFlag.Clone(),
 	}
 }
 
@@ -206,6 +217,7 @@ func (f *ScanFlagGroup) Flags() []Flagger {
 		f.DistroFlag,
 		f.SkipVersionCheck,
 		f.DisableTelemetry,
+		f.MavenMirrors,
 	}
 }
 
@@ -233,6 +245,14 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 		}
 	}
 
+	var mavenMirrors map[string][]string
+	if f.MavenMirrors != nil {
+		var err error
+		if mavenMirrors, err = validateMavenMirrors(f.MavenMirrors.Value()); err != nil {
+			return err
+		}
+	}
+
 	opts.ScanOptions = ScanOptions{
 		Target:            target,
 		SkipDirs:          f.SkipDirs.Value(),
@@ -247,6 +267,28 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 		Distro:            distro,
 		SkipVersionCheck:  f.SkipVersionCheck.Value(),
 		DisableTelemetry:  f.DisableTelemetry.Value(),
+		MavenMirrors:      mavenMirrors,
 	}
 	return nil
+}
+
+// validateMavenMirrors parses and validates the Maven mirror URLs configured via
+// scan.maven.mirrors. Unlike RegistryMirrorsFlag (no validation) and the pom
+// parser's resolveMirrors (silently drops bad URLs), an unparsable URL here is a
+// configuration error the user must learn about at startup (fail-fast).
+// The returned map is the input unchanged; the function only validates.
+func validateMavenMirrors(mirrors map[string][]string) (map[string][]string, error) {
+	for src, targets := range mirrors {
+		// The key is a plain repository URL (no credentials), so it is safe to echo.
+		if _, err := url.Parse(src); err != nil {
+			return nil, xerrors.Errorf("invalid Maven repository URL %q in 'scan.maven.mirrors'", src)
+		}
+		// A mirror URL may carry userinfo, so report only which key it belongs to.
+		for _, target := range targets {
+			if _, err := url.Parse(target); err != nil {
+				return nil, xerrors.Errorf("one of the mirror URLs for repository %q in 'scan.maven.mirrors' is invalid", src)
+			}
+		}
+	}
+	return mirrors, nil
 }

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -305,9 +305,12 @@ func parseMavenMirrors(mirrors []MavenMirror) (map[string][]string, error) {
 				return nil, xerrors.Errorf("invalid Maven mirror URL in 'scan.maven.mirrors' for %s", src.Redacted())
 			}
 		}
-		// Repositories are matched ignoring the trailing slash, so entries that differ only by
-		// it are duplicates and would otherwise silently overwrite each other.
-		key := strings.TrimRight(mirror.Source, "/")
+		// The parser looks a repository up by the same key: without credentials, with a
+		// lower-cased host and without the trailing slash. Entries differing only by those
+		// collapse into one key there, so they are duplicates and are rejected here.
+		src.User = nil
+		src.Host = strings.ToLower(src.Host)
+		key := strings.TrimRight(src.String(), "/")
 		if _, ok := parsed[key]; ok {
 			return nil, xerrors.Errorf("duplicate Maven repository in 'scan.maven.mirrors': %s", src.Redacted())
 		}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -273,8 +273,8 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 }
 
 // validateMavenMirrors returns an error on the first invalid URL in the Maven mirror
-// configuration — either a repository key or a mirror value. URLs must be absolute
-// (scheme and host), so a bare repository id such as "central" is rejected.
+// configuration — either a repository key or a mirror value. URLs must be http(s) URLs
+// with a host, so a bare repository id such as "central" or a non-http scheme is rejected.
 func validateMavenMirrors(mirrors map[string][]string) error {
 	for src, targets := range mirrors {
 		// A URL may carry userinfo, so never echo it raw: redact before pointing at an entry.
@@ -291,9 +291,12 @@ func validateMavenMirrors(mirrors map[string][]string) error {
 	return nil
 }
 
-// isValidMirrorURL reports whether raw is an absolute URL usable as a Maven repository
-// or mirror: it must parse and have both a scheme and a host.
+// isValidMirrorURL reports whether raw is a usable Maven repository or mirror URL: it
+// must parse to an http/https URL with a host.
 func isValidMirrorURL(raw string) bool {
 	u, err := url.Parse(raw)
-	return err == nil && u.Scheme != "" && u.Host != ""
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -281,9 +281,12 @@ func validateMavenMirrors(mirrors map[string][]string) error {
 		if !isValidMirrorURL(src) {
 			return xerrors.New("invalid Maven repository URL in 'scan.maven.mirrors'")
 		}
+		s, _ := url.Parse(src)
+		if len(targets) == 0 {
+			return xerrors.Errorf("no mirror URLs configured in 'scan.maven.mirrors' for %s", s.Redacted())
+		}
 		for _, target := range targets {
 			if !isValidMirrorURL(target) {
-				s, _ := url.Parse(src)
 				return xerrors.Errorf("invalid Maven mirror URL in 'scan.maven.mirrors' for %s", s.Redacted())
 			}
 		}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"cmp"
 	"net/url"
 	"runtime"
 	"slices"
@@ -306,11 +307,12 @@ func parseMavenMirrors(mirrors []MavenMirror) (map[string][]string, error) {
 			}
 		}
 		// The parser looks a repository up by the same key: without credentials, with a
-		// lower-cased host and without the trailing slash. Entries differing only by those
-		// collapse into one key there, so they are duplicates and are rejected here.
+		// lower-cased host and with a cleaned path. Entries differing only by those collapse
+		// into one key there, so they are duplicates and are rejected here.
 		src.User = nil
 		src.Host = strings.ToLower(src.Host)
-		key := strings.TrimRight(src.String(), "/")
+		src.Path = cmp.Or(src.Path, "/")
+		key := src.JoinPath(".").String()
 		if _, ok := parsed[key]; ok {
 			return nil, xerrors.Errorf("duplicate Maven repository in 'scan.maven.mirrors': %s", src.Redacted())
 		}

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -136,11 +136,22 @@ var (
 		ConfigName: "scan.disable-telemetry",
 		Usage:      "disable sending anonymous usage data to Aqua",
 	}
-	MavenMirrorsFlag = Flag[map[string][]string]{
+	MavenMirrorsFlag = Flag[[]MavenMirror]{
 		ConfigName: "scan.maven.mirrors",
-		Usage:      "map of Maven repository URLs and an ordered list of mirrors that serve each of them.",
+		Usage:      "list of Maven repositories and the ordered mirrors that serve each of them.",
 	}
 )
+
+// MavenMirror maps a Maven repository to the mirrors that serve it.
+// A list is used instead of a map because viper lowercases map keys in the config
+// file, which would break the case-sensitive path of a repository URL.
+type MavenMirror struct {
+	// Source is the URL of the mirrored repository.
+	Source string `mapstructure:"source"`
+
+	// Targets are the URLs of the mirrors serving Source, tried in order.
+	Targets []string `mapstructure:"targets"`
+}
 
 type ScanFlagGroup struct {
 	SkipDirs          *Flag[[]string]
@@ -156,7 +167,7 @@ type ScanFlagGroup struct {
 	DistroFlag        *Flag[string]
 	SkipVersionCheck  *Flag[bool]
 	DisableTelemetry  *Flag[bool]
-	MavenMirrors      *Flag[map[string][]string]
+	MavenMirrors      *Flag[[]MavenMirror]
 }
 
 type ScanOptions struct {
@@ -245,12 +256,9 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 		}
 	}
 
-	var mavenMirrors map[string][]string
-	if f.MavenMirrors != nil {
-		mavenMirrors = f.MavenMirrors.Value()
-		if err := validateMavenMirrors(mavenMirrors); err != nil {
-			return err
-		}
+	mavenMirrors, err := parseMavenMirrors(f.MavenMirrors.Value())
+	if err != nil {
+		return err
 	}
 
 	opts.ScanOptions = ScanOptions{
@@ -272,26 +280,40 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 	return nil
 }
 
-// validateMavenMirrors returns an error on the first invalid URL in the Maven mirror
-// configuration — either a repository key or a mirror value. URLs must be http(s) URLs
-// with a host, so a bare repository id such as "central" or a non-http scheme is rejected.
-func validateMavenMirrors(mirrors map[string][]string) error {
-	for src, targets := range mirrors {
+// parseMavenMirrors validates the configured Maven mirrors and indexes them by source
+// repository. It returns an error on the first invalid entry — an unusable URL (either a
+// source or a target), a source without mirrors, or a source configured twice. URLs must be
+// http(s) URLs with a host, so a bare repository id such as "central" or a non-http scheme
+// is rejected.
+func parseMavenMirrors(mirrors []MavenMirror) (map[string][]string, error) {
+	if len(mirrors) == 0 {
+		return nil, nil
+	}
+
+	parsed := make(map[string][]string, len(mirrors))
+	for _, mirror := range mirrors {
 		// A URL may carry userinfo, so never echo it raw: redact before pointing at an entry.
-		if !isValidMirrorURL(src) {
-			return xerrors.New("invalid Maven repository URL in 'scan.maven.mirrors'")
+		if !isValidMirrorURL(mirror.Source) {
+			return nil, xerrors.New("invalid Maven repository URL in 'scan.maven.mirrors'")
 		}
-		s, _ := url.Parse(src)
-		if len(targets) == 0 {
-			return xerrors.Errorf("no mirror URLs configured in 'scan.maven.mirrors' for %s", s.Redacted())
+		src, _ := url.Parse(mirror.Source)
+		if len(mirror.Targets) == 0 {
+			return nil, xerrors.Errorf("no mirror URLs configured in 'scan.maven.mirrors' for %s", src.Redacted())
 		}
-		for _, target := range targets {
+		for _, target := range mirror.Targets {
 			if !isValidMirrorURL(target) {
-				return xerrors.Errorf("invalid Maven mirror URL in 'scan.maven.mirrors' for %s", s.Redacted())
+				return nil, xerrors.Errorf("invalid Maven mirror URL in 'scan.maven.mirrors' for %s", src.Redacted())
 			}
 		}
+		// Repositories are matched ignoring the trailing slash, so entries that differ only by
+		// it are duplicates and would otherwise silently overwrite each other.
+		key := strings.TrimRight(mirror.Source, "/")
+		if _, ok := parsed[key]; ok {
+			return nil, xerrors.Errorf("duplicate Maven repository in 'scan.maven.mirrors': %s", src.Redacted())
+		}
+		parsed[key] = mirror.Targets
 	}
-	return nil
+	return parsed, nil
 }
 
 // isValidMirrorURL reports whether raw is a usable Maven repository or mirror URL: it

--- a/pkg/flag/scan_flags.go
+++ b/pkg/flag/scan_flags.go
@@ -247,8 +247,8 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 
 	var mavenMirrors map[string][]string
 	if f.MavenMirrors != nil {
-		var err error
-		if mavenMirrors, err = validateMavenMirrors(f.MavenMirrors.Value()); err != nil {
+		mavenMirrors = f.MavenMirrors.Value()
+		if err := validateMavenMirrors(mavenMirrors); err != nil {
 			return err
 		}
 	}
@@ -272,23 +272,28 @@ func (f *ScanFlagGroup) ToOptions(opts *Options) error {
 	return nil
 }
 
-// validateMavenMirrors parses and validates the Maven mirror URLs configured via
-// scan.maven.mirrors. Unlike RegistryMirrorsFlag (no validation) and the pom
-// parser's resolveMirrors (silently drops bad URLs), an unparsable URL here is a
-// configuration error the user must learn about at startup (fail-fast).
-// The returned map is the input unchanged; the function only validates.
-func validateMavenMirrors(mirrors map[string][]string) (map[string][]string, error) {
+// validateMavenMirrors returns an error on the first invalid URL in the Maven mirror
+// configuration — either a repository key or a mirror value. URLs must be absolute
+// (scheme and host), so a bare repository id such as "central" is rejected.
+func validateMavenMirrors(mirrors map[string][]string) error {
 	for src, targets := range mirrors {
-		// The key is a plain repository URL (no credentials), so it is safe to echo.
-		if _, err := url.Parse(src); err != nil {
-			return nil, xerrors.Errorf("invalid Maven repository URL %q in 'scan.maven.mirrors'", src)
+		// A URL may carry userinfo, so never echo it raw: redact before pointing at an entry.
+		if !isValidMirrorURL(src) {
+			return xerrors.New("invalid Maven repository URL in 'scan.maven.mirrors'")
 		}
-		// A mirror URL may carry userinfo, so report only which key it belongs to.
 		for _, target := range targets {
-			if _, err := url.Parse(target); err != nil {
-				return nil, xerrors.Errorf("one of the mirror URLs for repository %q in 'scan.maven.mirrors' is invalid", src)
+			if !isValidMirrorURL(target) {
+				s, _ := url.Parse(src)
+				return xerrors.Errorf("invalid Maven mirror URL in 'scan.maven.mirrors' for %s", s.Redacted())
 			}
 		}
 	}
-	return mirrors, nil
+	return nil
+}
+
+// isValidMirrorURL reports whether raw is an absolute URL usable as a Maven repository
+// or mirror: it must parse and have both a scheme and a host.
+func isValidMirrorURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -20,6 +20,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		scanners         string
 		distro           string
 		skipVersionCheck bool
+		mavenMirrors     map[string][]string
 	}
 	tests := []struct {
 		name      string
@@ -138,6 +139,29 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			assertion: require.NoError,
 		},
+		{
+			name: "maven mirrors from config file reach ScanOptions",
+			fields: fields{
+				mavenMirrors: map[string][]string{
+					"https://repo.maven.apache.org/maven2/": {"https://my-internal-mirror/maven2/"},
+				},
+			},
+			want: flag.ScanOptions{
+				MavenMirrors: map[string][]string{
+					"https://repo.maven.apache.org/maven2/": {"https://my-internal-mirror/maven2/"},
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "unparsable maven mirror URL is rejected (fail-fast)",
+			fields: fields{
+				mavenMirrors: map[string][]string{
+					"https://repo.maven.apache.org/maven2/": {"http://[::1"},
+				},
+			},
+			assertion: require.Error,
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +173,9 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			setValue(flag.ScannersFlag.ConfigName, tt.fields.scanners)
 			setValue(flag.DistroFlag.ConfigName, tt.fields.distro)
 			setValue(flag.SkipVersionCheckFlag.ConfigName, tt.fields.skipVersionCheck)
+			if len(tt.fields.mavenMirrors) > 0 {
+				viper.Set(flag.MavenMirrorsFlag.ConfigName, tt.fields.mavenMirrors)
+			}
 
 			// Assert options
 			f := &flag.ScanFlagGroup{
@@ -158,6 +185,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 				Scanners:         flag.ScannersFlag.Clone(),
 				DistroFlag:       flag.DistroFlag.Clone(),
 				SkipVersionCheck: flag.SkipVersionCheckFlag.Clone(),
+				MavenMirrors:     flag.MavenMirrorsFlag.Clone(),
 			}
 
 			flags := flag.Flags{f}

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -154,10 +154,19 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
-			name: "unparsable maven mirror URL is rejected (fail-fast)",
+			name: "unparsable maven mirror URL is rejected",
 			fields: fields{
 				mavenMirrors: map[string][]string{
 					"https://repo.maven.apache.org/maven2/": {"http://[::1"},
+				},
+			},
+			assertion: require.Error,
+		},
+		{
+			name: "unparsable maven repository URL (map key) is rejected",
+			fields: fields{
+				mavenMirrors: map[string][]string{
+					"central": {"https://my-internal-mirror/maven2/"},
 				},
 			},
 			assertion: require.Error,

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -1,6 +1,7 @@
 package flag_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -20,7 +21,7 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		scanners         string
 		distro           string
 		skipVersionCheck bool
-		mavenMirrors     map[string][]string
+		mavenMirrors     []flag.MavenMirror
 	}
 	tests := []struct {
 		name      string
@@ -140,15 +141,18 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.NoError,
 		},
 		{
-			name: "maven mirrors from config file reach ScanOptions",
+			name: "maven mirrors from config file reach ScanOptions with their case preserved",
 			fields: fields{
-				mavenMirrors: map[string][]string{
-					"https://repo.maven.apache.org/maven2/": {"https://my-internal-mirror/maven2/"},
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://example.com/Repository/Maven2/",
+						Targets: []string{"https://my-internal-mirror/Maven2/"},
+					},
 				},
 			},
 			want: flag.ScanOptions{
 				MavenMirrors: map[string][]string{
-					"https://repo.maven.apache.org/maven2/": {"https://my-internal-mirror/maven2/"},
+					"https://example.com/Repository/Maven2": {"https://my-internal-mirror/Maven2/"},
 				},
 			},
 			assertion: require.NoError,
@@ -156,17 +160,23 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "unparsable maven mirror URL is rejected",
 			fields: fields{
-				mavenMirrors: map[string][]string{
-					"https://repo.maven.apache.org/maven2/": {"http://[::1"},
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://repo.maven.apache.org/maven2/",
+						Targets: []string{"http://[::1"},
+					},
 				},
 			},
 			assertion: require.Error,
 		},
 		{
-			name: "unparsable maven repository URL (map key) is rejected",
+			name: "unparsable maven repository URL is rejected",
 			fields: fields{
-				mavenMirrors: map[string][]string{
-					"central": {"https://my-internal-mirror/maven2/"},
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "central",
+						Targets: []string{"https://my-internal-mirror/maven2/"},
+					},
 				},
 			},
 			assertion: require.Error,
@@ -174,8 +184,11 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "non-http(s) maven mirror scheme is rejected",
 			fields: fields{
-				mavenMirrors: map[string][]string{
-					"https://repo.maven.apache.org/maven2/": {"ftp://my-internal-mirror/maven2/"},
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://repo.maven.apache.org/maven2/",
+						Targets: []string{"ftp://my-internal-mirror/maven2/"},
+					},
 				},
 			},
 			assertion: require.Error,
@@ -183,8 +196,26 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 		{
 			name: "empty maven mirror target list is rejected",
 			fields: fields{
-				mavenMirrors: map[string][]string{
-					"https://repo.maven.apache.org/maven2/": {},
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source: "https://repo.maven.apache.org/maven2/",
+					},
+				},
+			},
+			assertion: require.Error,
+		},
+		{
+			name: "maven repository configured twice is rejected",
+			fields: fields{
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://repo.maven.apache.org/maven2/",
+						Targets: []string{"https://my-internal-mirror/maven2/"},
+					},
+					{
+						Source:  "https://repo.maven.apache.org/maven2",
+						Targets: []string{"https://backup-mirror/maven2/"},
+					},
 				},
 			},
 			assertion: require.Error,
@@ -219,6 +250,63 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			got, err := flags.ToOptions(tt.args)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.want, got.ScanOptions)
+		})
+	}
+}
+
+// TestScanFlagGroup_ToOptions_mavenMirrorsYAML parses the Maven mirrors from a real config
+// file, since viper lowercases the keys it reads from one. A repository URL is a value here
+// rather than a key, so its case-sensitive path must survive the round trip.
+func TestScanFlagGroup_ToOptions_mavenMirrorsYAML(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    string
+		want      map[string][]string
+		assertion require.ErrorAssertionFunc
+	}{
+		{
+			name: "case-sensitive repository path is preserved",
+			config: `
+scan:
+  maven:
+    mirrors:
+      - source: https://example.com/Repository/Maven2/
+        targets:
+          - https://mirror.example.com/Maven2/
+          - https://backup.example.com/maven2/
+`,
+			want: map[string][]string{
+				"https://example.com/Repository/Maven2": {
+					"https://mirror.example.com/Maven2/",
+					"https://backup.example.com/maven2/",
+				},
+			},
+			assertion: require.NoError,
+		},
+		{
+			name: "mirrors of an unexpected type are rejected",
+			config: `
+scan:
+  maven:
+    mirrors: https://mirror.example.com/maven2/
+`,
+			assertion: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.SetConfigType("yaml")
+			require.NoError(t, viper.ReadConfig(strings.NewReader(tt.config)))
+
+			f := &flag.ScanFlagGroup{
+				MavenMirrors: flag.MavenMirrorsFlag.Clone(),
+			}
+			flags := flag.Flags{f}
+			got, err := flags.ToOptions(nil)
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got.ScanOptions.MavenMirrors)
 		})
 	}
 }

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -220,6 +220,41 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			assertion: require.Error,
 		},
+		{
+			// The parser matches repositories without their credentials, so these two
+			// would collapse into a single entry.
+			name: "maven repositories differing only by credentials are rejected",
+			fields: fields{
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://first:pass@nexus.example.com/maven2/",
+						Targets: []string{"https://my-internal-mirror/maven2/"},
+					},
+					{
+						Source:  "https://second:pass@nexus.example.com/maven2/",
+						Targets: []string{"https://backup-mirror/maven2/"},
+					},
+				},
+			},
+			assertion: require.Error,
+		},
+		{
+			// The host is case-insensitive, so these two would collapse as well.
+			name: "maven repositories differing only by host case are rejected",
+			fields: fields{
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://nexus.example.com/maven2/",
+						Targets: []string{"https://my-internal-mirror/maven2/"},
+					},
+					{
+						Source:  "https://Nexus.Example.COM/maven2/",
+						Targets: []string{"https://backup-mirror/maven2/"},
+					},
+				},
+			},
+			assertion: require.Error,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -171,6 +171,15 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			assertion: require.Error,
 		},
+		{
+			name: "non-http(s) maven mirror scheme is rejected",
+			fields: fields{
+				mavenMirrors: map[string][]string{
+					"https://repo.maven.apache.org/maven2/": {"ftp://my-internal-mirror/maven2/"},
+				},
+			},
+			assertion: require.Error,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -239,6 +239,23 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			assertion: require.Error,
 		},
 		{
+			// The path is cleaned before matching, so these two would collapse as well.
+			name: "maven repositories differing only by path segments are rejected",
+			fields: fields{
+				mavenMirrors: []flag.MavenMirror{
+					{
+						Source:  "https://nexus.example.com/nexus/maven2",
+						Targets: []string{"https://my-internal-mirror/maven2/"},
+					},
+					{
+						Source:  "https://nexus.example.com//nexus/./maven2/",
+						Targets: []string{"https://backup-mirror/maven2/"},
+					},
+				},
+			},
+			assertion: require.Error,
+		},
+		{
 			// The host is case-insensitive, so these two would collapse as well.
 			name: "maven repositories differing only by host case are rejected",
 			fields: fields{

--- a/pkg/flag/scan_flags_test.go
+++ b/pkg/flag/scan_flags_test.go
@@ -180,6 +180,15 @@ func TestScanFlagGroup_ToOptions(t *testing.T) {
 			},
 			assertion: require.Error,
 		},
+		{
+			name: "empty maven mirror target list is rejected",
+			fields: fields{
+				mavenMirrors: map[string][]string{
+					"https://repo.maven.apache.org/maven2/": {},
+				},
+			},
+			assertion: require.Error,
+		},
 	}
 
 	for _, tt := range tests {

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -808,6 +808,21 @@
         "disable-telemetry": {
           "type": "boolean",
           "description": "disable sending anonymous usage data to Aqua"
+        },
+        "maven": {
+          "type": "object",
+          "properties": {
+            "mirrors": {
+              "type": "object",
+              "description": "map of Maven repository URLs and an ordered list of mirrors that serve each of them.",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -813,14 +813,29 @@
           "type": "object",
           "properties": {
             "mirrors": {
-              "type": "object",
-              "description": "map of Maven repository URLs and an ordered list of mirrors that serve each of them.",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "description": "URL of the mirrored Maven repository"
+                  },
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "URLs of the mirrors serving the repository, tried in order",
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "source",
+                  "targets"
+                ]
+              },
+              "description": "list of Maven repositories and the ordered mirrors that serve each of them."
             }
           }
         }


### PR DESCRIPTION
## Description

This PR adds a `scan.maven.mirrors` config-file option — a list of entries, each mapping a `source` repository URL to the ordered `targets` that mirror it — so users can configure Maven repository mirrors in `trivy.yaml` without modifying the shared `settings.xml` (for example, in CI).

```yaml
scan:
  maven:
    mirrors:
      - source: https://repo.maven.apache.org/maven2/
        targets:
          - https://my-internal-mirror/maven2/
          - https://backup-mirror/maven2/
```

Behavior:

- Applied by the pom parser as the **lowest-priority** mirrors — a second pass on top of the `settings.xml` resolution.
- The two sources **chain**: `settings.xml` `repo1 -> repo2` followed by `trivy.yaml` `repo2 -> repo3` resolves `repo1` to `repo3`. On a conflict `settings.xml` wins.
- The mirrors listed for a repository are tried in order as **fallbacks**: when one does not have the artifact, or answers with `429 Too Many Requests`, Trivy tries the next.
- A `source` is matched by the repository URL, ignoring the credentials Trivy embeds from a `<server>`, the case of the host and the path segments that `path.Join` cleans.
- Repository and mirror URLs must be `http` or `https` with a host, every repository must list at least one mirror, and a repository may be configured only once — all validated at startup (fail-fast).
- There is no CLI flag or environment variable — config file only, following `RegistryMirrorsFlag`.
- Applied to filesystem and repository scans; not image or VM scans.

Credentials for config-file mirrors are supported only inline in the URL (`https://user:password@host/...`); `settings.xml` `<server>` entries are not used. For a secure setup, configure the mirror in `settings.xml` instead. This is documented in `docs/guide/coverage/language/java.md`.

### Live verification

A local proxy that logs each request and forwards it to Maven Central, with `trivy.yaml` pointing Maven Central at the proxy and an empty local repository to force remote resolution:

```yaml
scan:
  maven:
    mirrors:
      - source: https://repo.maven.apache.org/maven2/
        targets:
          - http://localhost:8099/maven2/
```

```bash
trivy fs --debug --scanners vuln ./project
```

Every POM in the transitive chain is fetched through the mirror (`localhost:8099`), nothing hits Maven Central directly:

```
[MIRROR] GET /maven2/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom -> 200
[MIRROR] GET /maven2/org/apache/commons/commons-parent/64/commons-parent-64.pom       -> 200
[MIRROR] GET /maven2/org/apache/apache/30/apache-30.pom                               -> 200
[MIRROR] GET /maven2/org/junit/junit-bom/5.10.0/junit-bom-5.10.0.pom                  -> 200
```

The artifact resolves and `CVE-2025-48924` is reported for `org.apache.commons:commons-lang3:3.14.0`.

## Related issues
- Close #11005

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
