### PR TITLE
feat(ignore): allow entries without an id in .trivyignore.yaml

### DIFF
--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -26,7 +26,9 @@ import (
 type IgnoreFinding struct {
 	// ID is the identifier of the vulnerability, misconfiguration, secret, or license.
 	// e.g. CVE-2019-8331, AVD-AWS-0175, etc.
-	// required: true
+	// If ID is not set, the ignore finding is applied to all findings that match
+	// the other fields, so at least one of ID, Paths or PURLs must be set.
+	// required: false
 	ID string `yaml:"id"`
 
 	// Paths is the list of file paths to ignore.
@@ -65,6 +67,10 @@ func (i *IgnoreFinding) UnmarshalYAML(value *yaml.Node) error {
 
 	*i = IgnoreFinding(tmp.plain)
 
+	if i.ID == "" && len(i.Paths) == 0 && len(tmp.PURLs) == 0 {
+		return xerrors.New("invalid entry in the ignore file: at least one of 'id', 'paths' or 'purls' must be set")
+	}
+
 	for _, pattern := range i.Paths {
 		if !doublestar.ValidatePattern(pattern) {
 			return xerrors.Errorf("invalid path pattern in the ignore file, id: %s, path: %s", i.ID, pattern)
@@ -87,7 +93,14 @@ type IgnoreFindings []IgnoreFinding
 
 func (f *IgnoreFindings) Match(id, path string, pkg *packageurl.PackageURL) *IgnoreFinding {
 	for _, finding := range *f {
-		if id != finding.ID {
+		// an empty ID matches any finding, so that entries can select purely by path or PURL
+		if finding.ID != "" && id != finding.ID {
+			continue
+		}
+		// an entry without an ID must still select the finding through its own criteria:
+		// a PURL selector cannot apply to findings that have no package, such as
+		// misconfigurations and secrets, otherwise it would ignore all of them
+		if finding.ID == "" && len(finding.PURLs) > 0 && pkg == nil {
 			continue
 		}
 		if !matchPath(path, finding.Paths) || !matchPURL(pkg, finding.PURLs) {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -2,10 +2,14 @@ package result
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/purl"
 )
 
 func TestParseIgnoreFile(t *testing.T) {
@@ -72,4 +76,74 @@ func TestParseIgnoreFile(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+}
+
+func TestIgnoreFindings_Match_withoutID(t *testing.T) {
+	trivyPURL, err := purl.FromString("pkg:golang/github.com/aquasecurity/trivy@0.50.0")
+	require.NoError(t, err)
+	otherPURL, err := purl.FromString("pkg:golang/github.com/other/pkg@1.0.0")
+	require.NoError(t, err)
+
+	findings := IgnoreFindings{
+		{
+			PURLs: []*purl.PackageURL{trivyPURL},
+		},
+		{
+			Paths: []string{"app/vendor/**"},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		id    string
+		path  string
+		pkg   *packageurl.PackageURL
+		match bool
+	}{
+		{
+			name:  "any ID is ignored for the selected package",
+			id:    "CVE-2019-0001",
+			pkg:   (*packageurl.PackageURL)(trivyPURL),
+			match: true,
+		},
+		{
+			name:  "another ID is ignored for the same package",
+			id:    "CVE-2021-1234",
+			pkg:   (*packageurl.PackageURL)(trivyPURL),
+			match: true,
+		},
+		{
+			name:  "another package is not ignored",
+			id:    "CVE-2019-0001",
+			pkg:   (*packageurl.PackageURL)(otherPURL),
+			match: false,
+		},
+		{
+			name:  "any ID is ignored under the selected path",
+			id:    "CVE-2022-2222",
+			path:  "app/vendor/foo/bar.go",
+			match: true,
+		},
+		{
+			name:  "another path is not ignored",
+			id:    "CVE-2022-2222",
+			path:  "app/main.go",
+			match: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findings.Match(tt.id, tt.path, tt.pkg)
+			assert.Equal(t, tt.match, got != nil)
+		})
+	}
+}
+
+func TestParseIgnoreFile_withoutSelector(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".trivyignore.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("vulnerabilities:\n  - statement: no selector at all\n"), 0o600))
+
+	_, err := ParseIgnoreFile(t.Context(), path)
+	require.ErrorContains(t, err, "at least one of 'id', 'paths' or 'purls' must be set")
 }


### PR DESCRIPTION
Closes #10583

## Summary

Makes `id` optional in `.trivyignore.yaml`, so an entry can ignore every finding for a package or a path:

```yaml
vulnerabilities:
  - purls:
      - "pkg:golang/github.com/aquasecurity/trivy"
    statement: shipped but never executed
  - paths:
      - "app/vendor/**"
```

## Details

- `IgnoreFinding.ID` is documented as optional; an empty ID matches any finding that the entry's `paths`/`purls` select.
- `UnmarshalYAML` rejects an entry that sets none of `id`, `paths` or `purls`, so a typo cannot silently turn into "ignore everything".
- A `purls` selector is not applied to findings that have no package. Without that guard an id-less entry with `purls` would also swallow misconfigurations, secrets and licenses, because `matchPURL` treats a nil package as "matches" — this is the one subtlety the new tests pin down.

Behavior for entries that do have an `id` is unchanged.

## Tests

- `TestIgnoreFindings_Match_withoutID` — an id-less entry ignores any ID for the selected package/path, and does not touch other packages, other paths, or findings without a package.
- `TestParseIgnoreFile_withoutSelector` — an entry with no selector at all is a parse error.

`go test ./pkg/result/ -run 'TestIgnoreFindings|TestParseIgnoreFile'` passes.

Note: `TestFilter/policy_file_*` and `TestFilter/ignore_file_for_licenses_and_secrets` already fail on a clean checkout of `main` in my environment (they appear to need assets I don't have locally), so they are unrelated to this change — CI should be the judge there.
