### PR TITLE
refactor(alpine): remove type assertion when reading the APKINDEX archive

### DIFF
--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -100,12 +100,12 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 	url := fmt.Sprintf(a.apkIndexArchiveURL, osVer)
 	var reader io.Reader
 	if strings.HasPrefix(url, "file://") {
-		var err error
-		reader, err = builtinos.Open(strings.TrimPrefix(url, "file://"))
+		f, err := builtinos.Open(strings.TrimPrefix(url, "file://"))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to read APKINDEX archive file: %w", err)
 		}
-		defer reader.(*builtinos.File).Close()
+		defer f.Close()
+		reader = f
 	} else {
 		// nolint
 		resp, err := http.Get(url)

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -99,8 +99,8 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 
 	url := fmt.Sprintf(a.apkIndexArchiveURL, osVer)
 	var reader io.Reader
-	if strings.HasPrefix(url, "file://") {
-		f, err := builtinos.Open(strings.TrimPrefix(url, "file://"))
+	if filePath, ok := strings.CutPrefix(url, "file://"); ok {
+		f, err := builtinos.Open(filePath)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to read APKINDEX archive file: %w", err)
 		}


### PR DESCRIPTION
## Summary

Remove an unnecessary type assertion in `pkg/fanal/analyzer/imgconf/apk/apk.go`.

## Background

In `fetchApkIndexArchive` the local-file branch assigned the result of `builtinos.Open` straight into an `io.Reader` variable, discarding the concrete `*os.File`. Closing the handle then required asserting the type back:

```go
defer reader.(*builtinos.File).Close()
```

The assertion is safe as written — `os.Open` is declared as `func Open(name string) (*File, error)`, and the error branch returns before the assignment, so the dynamic type is always `*os.File`. It is not a latent panic, just unnecessary indirection: the concrete type is thrown away on one line and recovered on the next.

It dates back to #6672, a one-line fix for a leaked descriptor. By then the `*os.File` had already been erased into `io.Reader` — a variable introduced when `file://` support was added, so that both the file and the HTTP branch could feed a single `json.NewDecoder`. Asserting the type back was the smallest way to close the file without restructuring the function.

## Change

Keep the file handle in a local variable `f`, `defer f.Close()` on the concrete type, then assign `reader = f`. This mirrors what the HTTP branch already does with `resp`, and makes ownership of the descriptor explicit.

Behaviour is unchanged: the same file is closed at the same point.
