### PR TITLE
fix(terraform): avoid panic when for_each local has unknown object values

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -680,6 +680,10 @@ func (e *evaluator) localHasDynamicValues(localVal cty.Value) bool {
 
 	// Check if the local contains DynamicVal which indicates unresolved references
 	for _, val := range valueMap {
+		if !val.IsKnown() {
+			return true
+		}
+
 		if val.Type() == cty.DynamicPseudoType {
 			return true
 		}

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -736,6 +736,52 @@ resource "aws_s3_bucket" "this" {
 	}
 }
 
+func Test_ForEachOnLocalWithUnknownObjectValues(t *testing.T) {
+	fs := testutil.CreateFS(map[string]string{
+		"main.tf": `
+variable "bucket_names" {
+  type = map(string)
+}
+
+variable "bucket_details" {
+  type = map(object({
+    bucket = string
+    tags   = optional(map(string), {})
+  }))
+}
+
+locals {
+  bucket_config = {
+    for name, _ in var.bucket_names :
+    name => var.bucket_details[name]
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  for_each = local.bucket_config
+  bucket   = each.value.bucket
+  tags     = each.value.tags
+}
+`,
+		"main.tfvars": `
+bucket_names = {
+  app-logs = "ipsos-app-logs-dev"
+  app-data = "ipsos-app-data-dev"
+}
+`,
+	})
+
+	parser := New(fs, "",
+		OptionStopOnHCLError(true),
+		OptionWithTFVarsPaths("main.tfvars"),
+	)
+	require.NoError(t, parser.ParseFS(t.Context(), "."))
+
+	modules, err := parser.EvaluateAll(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, modules, 1)
+}
+
 func Test_ForEachRefToVariableWithDefault(t *testing.T) {
 	fs := testutil.CreateFS(map[string]string{
 		"main.tf": `


### PR DESCRIPTION
## Summary
- Fix a panic (`can't use ElementIterator on unknown value`) in the Terraform parser when `for_each` references a local whose map keys are known but values are unknown objects
- Occurs when tfvars supply key maps (e.g. `bucket_names`) but omit detail maps (e.g. `bucket_details`) that locals resolve via `var.bucket_details[name]`
- `localHasDynamicValues` now treats unknown map values as unresolved and defers `for_each` expansion instead of calling `AsValueMap()` on them

## Test plan
- [x] `go test ./pkg/iac/scanners/terraform/parser/ -run Test_ForEachOnLocalWithUnknownObjectValues -v`
- [x] `go test ./pkg/iac/scanners/terraform/parser/ -run Test_ForEachRefToLocals -v`
- [x] Manual repro with `trivy config` on partial tfvars no longer panics


Made with [Cursor](https://cursor.com)