### PR TITLE
feat(ospkg): add Docker Hardened Images support

### DIFF
--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/chainguard"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/coreos"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/dhi"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/driver"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/echo"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/minimos"
@@ -51,6 +52,7 @@ var (
 		ftypes.Bottlerocket:       bottlerocket.NewScanner(),
 		ftypes.CBLMariner:         azure.NewMarinerScanner(),
 		ftypes.Debian:             debian.NewScanner(),
+		ftypes.DHI:                dhi.NewScanner(),
 		ftypes.Ubuntu:             ubuntu.NewScanner(),
 		ftypes.RedHat:             redhat.NewScanner(),
 		ftypes.CentOS:             redhat.NewScanner(),

--- a/pkg/detector/ospkg/detect.go
+++ b/pkg/detector/ospkg/detect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/chainguard"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/coreos"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/debian"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/dhi"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/driver"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/echo"
 	"github.com/aquasecurity/trivy/pkg/detector/ospkg/minimos"
@@ -52,6 +53,7 @@ var (
 		ftypes.Bottlerocket:       bottlerocket.NewScanner(),
 		ftypes.CBLMariner:         azure.NewMarinerScanner(),
 		ftypes.Debian:             debian.NewScanner(),
+		ftypes.DHI:                dhi.NewScanner(),
 		ftypes.Ubuntu:             ubuntu.NewScanner(),
 		ftypes.RedHat:             redhat.NewScanner(),
 		ftypes.CentOS:             redhat.NewScanner(),

--- a/pkg/detector/ospkg/dhi/dhi.go
+++ b/pkg/detector/ospkg/dhi/dhi.go
@@ -1,0 +1,147 @@
+package dhi
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	apkVersion "github.com/knqyf263/go-apk-version"
+	debVersion "github.com/knqyf263/go-deb-version"
+	"golang.org/x/xerrors"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/scan/utils"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+// Scanner detects vulnerabilities in Alpine- and Debian-based DHI packages.
+type Scanner struct {
+	dbc db.Operation
+}
+
+// NewScanner returns a DHI package scanner backed by the Trivy vulnerability database.
+func NewScanner() *Scanner {
+	return &Scanner{dbc: db.Config{}}
+}
+
+// Detect finds release-scoped DHI advisories and applies the package manager's version semantics.
+func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
+	log.InfoContext(ctx, "Detecting DHI vulnerabilities...", log.String("os_version", osVer), log.Int("pkg_num", len(pkgs)))
+
+	var vulns []types.DetectedVulnerability
+	for _, pkg := range pkgs {
+		pkgName := pkg.SrcName
+		if pkgName == "" {
+			pkgName = pkg.Name
+		}
+
+		lineage := packageLineage(pkg)
+		if lineage == "" {
+			log.DebugContext(ctx, "Skipping DHI package with unknown package type", log.String("package", pkg.Name))
+			continue
+		}
+		advisories, err := s.dbc.GetAdvisories(fmt.Sprintf("dhi %s %s", lineage, osVer), pkgName)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get DHI advisories: %w", err)
+		}
+
+		for _, adv := range advisories {
+			if len(adv.Arches) > 0 && !slices.Contains(adv.Arches, pkg.Arch) {
+				continue
+			}
+			if !isVulnerable(ctx, pkg, adv) {
+				continue
+			}
+
+			vulns = append(vulns, types.DetectedVulnerability{
+				VulnerabilityID:  adv.VulnerabilityID,
+				VendorIDs:        adv.VendorIDs,
+				PkgID:            pkg.ID,
+				PkgName:          pkg.Name,
+				InstalledVersion: utils.FormatVersion(pkg),
+				FixedVersion:     adv.FixedVersion,
+				PkgIdentifier:    pkg.Identifier,
+				Status:           adv.Status,
+				Layer:            pkg.Layer,
+				Custom:           adv.Custom,
+				DataSource:       adv.DataSource,
+			})
+		}
+	}
+	return vulns, nil
+}
+
+func isVulnerable(ctx context.Context, pkg ftypes.Package, adv dbTypes.Advisory) bool {
+	if adv.FixedVersion == "" {
+		return true
+	}
+
+	installed := utils.FormatSrcVersion(pkg)
+	switch packageType(pkg) {
+	case "apk":
+		installedVersion, err := apkVersion.NewVersion(installed)
+		if err != nil {
+			log.DebugContext(ctx, "Failed to parse installed APK version", log.String("version", installed), log.Err(err))
+			return false
+		}
+		fixedVersion, err := apkVersion.NewVersion(adv.FixedVersion)
+		if err != nil {
+			log.DebugContext(ctx, "Failed to parse fixed APK version", log.String("version", adv.FixedVersion), log.Err(err))
+			return false
+		}
+		return installedVersion.LessThan(fixedVersion)
+	case "deb":
+		installedVersion, err := debVersion.NewVersion(installed)
+		if err != nil {
+			log.DebugContext(ctx, "Failed to parse installed Debian version", log.String("version", installed), log.Err(err))
+			return false
+		}
+		fixedVersion, err := debVersion.NewVersion(adv.FixedVersion)
+		if err != nil {
+			log.DebugContext(ctx, "Failed to parse fixed Debian version", log.String("version", adv.FixedVersion), log.Err(err))
+			return false
+		}
+		return installedVersion.LessThan(fixedVersion)
+	default:
+		log.DebugContext(ctx, "Skipping DHI package with unknown package type", log.String("package", pkg.Name))
+		return false
+	}
+}
+
+func packageType(pkg ftypes.Package) string {
+	if pkg.Identifier.PURL != nil {
+		switch pkg.Identifier.PURL.Type {
+		case "apk":
+			return "apk"
+		case "deb":
+			return "deb"
+		}
+	}
+	switch pkg.AnalyzedBy {
+	case "apk":
+		return "apk"
+	case "dpkg":
+		return "deb"
+	default:
+		return ""
+	}
+}
+
+func packageLineage(pkg ftypes.Package) string {
+	switch packageType(pkg) {
+	case "apk":
+		return "alpine"
+	case "deb":
+		return "debian"
+	default:
+		return ""
+	}
+}
+
+// IsSupportedVersion returns true because support is determined by release-scoped DHI advisories.
+func (s *Scanner) IsSupportedVersion(_ context.Context, _ ftypes.OSType, _ string) bool {
+	return true
+}

--- a/pkg/detector/ospkg/dhi/dhi_test.go
+++ b/pkg/detector/ospkg/dhi/dhi_test.go
@@ -1,0 +1,76 @@
+package dhi_test
+
+import (
+	"testing"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy-db/pkg/db"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy/internal/dbtest"
+	"github.com/aquasecurity/trivy/pkg/detector/ospkg/dhi"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/types"
+)
+
+func TestScannerDetect(t *testing.T) {
+	tests := []struct {
+		name  string
+		osVer string
+		pkg   ftypes.Package
+		want  []types.DetectedVulnerability
+	}{
+		{
+			name:  "affected Alpine DHI package",
+			osVer: "3.24",
+			pkg: ftypes.Package{
+				Name: "coreutils", Version: "9.11-r0", SrcName: "coreutils", SrcVersion: "9.11-r0", Arch: "aarch64",
+				AnalyzedBy: analyzer.TypeApk,
+				Identifier: ftypes.PkgIdentifier{PURL: &packageurl.PackageURL{Type: packageurl.TypeApk, Namespace: "dhi", Name: "coreutils", Version: "9.11-r0"}},
+			},
+			want: []types.DetectedVulnerability{{
+				VulnerabilityID: "DHI-CVE-2016-2781-coreutils", PkgName: "coreutils", InstalledVersion: "9.11-r0", FixedVersion: "9.11-r1",
+				PkgIdentifier: ftypes.PkgIdentifier{PURL: &packageurl.PackageURL{Type: packageurl.TypeApk, Namespace: "dhi", Name: "coreutils", Version: "9.11-r0"}},
+				DataSource:    &dbTypes.DataSource{ID: "dhi", Name: "Docker Hardened Images Advisories", URL: "https://github.com/docker-hardened-images/advisories"},
+			}},
+		},
+		{
+			name:  "affected Debian DHI package",
+			osVer: "13",
+			pkg: ftypes.Package{
+				Name: "coreutils", Version: "9.7-3+dhi3", SrcName: "coreutils", SrcVersion: "9.7-3+dhi3", Arch: "arm64",
+				AnalyzedBy: analyzer.TypeDpkg,
+				Identifier: ftypes.PkgIdentifier{PURL: &packageurl.PackageURL{Type: packageurl.TypeDebian, Namespace: "dhi", Name: "coreutils", Version: "9.7-3+dhi3"}},
+			},
+			want: []types.DetectedVulnerability{{
+				VulnerabilityID: "DHI-CVE-2017-18018-coreutils", PkgName: "coreutils", InstalledVersion: "9.7-3+dhi3", FixedVersion: "9.7-3+dhi4",
+				PkgIdentifier: ftypes.PkgIdentifier{PURL: &packageurl.PackageURL{Type: packageurl.TypeDebian, Namespace: "dhi", Name: "coreutils", Version: "9.7-3+dhi3"}},
+				DataSource:    &dbTypes.DataSource{ID: "dhi", Name: "Docker Hardened Images Advisories", URL: "https://github.com/docker-hardened-images/advisories"},
+			}},
+		},
+		{
+			name:  "different architecture is isolated",
+			osVer: "3.24",
+			pkg:   ftypes.Package{Name: "coreutils", Version: "9.11-r0", SrcName: "coreutils", SrcVersion: "9.11-r0", Arch: "x86_64", AnalyzedBy: analyzer.TypeApk},
+		},
+		{
+			name:  "different release is isolated",
+			osVer: "3.25",
+			pkg:   ftypes.Package{Name: "coreutils", Version: "9.11-r0", SrcName: "coreutils", SrcVersion: "9.11-r0", Arch: "aarch64", AnalyzedBy: analyzer.TypeApk},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = dbtest.InitDB(t, []string{"testdata/fixtures/dhi.yaml", "testdata/fixtures/data-source.yaml"})
+			defer db.Close()
+
+			got, err := dhi.NewScanner().Detect(t.Context(), tt.osVer, nil, []ftypes.Package{tt.pkg})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/detector/ospkg/dhi/testdata/fixtures/data-source.yaml
+++ b/pkg/detector/ospkg/dhi/testdata/fixtures/data-source.yaml
@@ -1,0 +1,12 @@
+- bucket: data-source
+  pairs:
+    - key: dhi alpine 3.24
+      value:
+        ID: "dhi"
+        Name: "Docker Hardened Images Advisories"
+        URL: "https://github.com/docker-hardened-images/advisories"
+    - key: dhi debian 13
+      value:
+        ID: "dhi"
+        Name: "Docker Hardened Images Advisories"
+        URL: "https://github.com/docker-hardened-images/advisories"

--- a/pkg/detector/ospkg/dhi/testdata/fixtures/dhi.yaml
+++ b/pkg/detector/ospkg/dhi/testdata/fixtures/dhi.yaml
@@ -1,0 +1,15 @@
+- bucket: dhi alpine 3.24
+  pairs:
+    - bucket: coreutils
+      pairs:
+        - key: DHI-CVE-2016-2781-coreutils
+          value:
+            FixedVersion: "9.11-r1"
+            Arches: [aarch64]
+- bucket: dhi debian 13
+  pairs:
+    - bucket: coreutils
+      pairs:
+        - key: DHI-CVE-2017-18018-coreutils
+          value:
+            FixedVersion: "9.7-3+dhi4"

--- a/pkg/fanal/analyzer/os/release/release.go
+++ b/pkg/fanal/analyzer/os/release/release.go
@@ -85,6 +85,8 @@ func idToOSFamily(id string) types.OSType {
 		return types.Fedora
 	case "alpine":
 		return types.Alpine
+	case "dhi":
+		return types.DHI
 	case "bottlerocket":
 		return types.Bottlerocket
 	case "opensuse-tumbleweed":

--- a/pkg/fanal/analyzer/os/release/release_test.go
+++ b/pkg/fanal/analyzer/os/release/release_test.go
@@ -250,6 +250,16 @@ func Test_osReleaseAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			name:      "Docker Hardened Images",
+			inputFile: "testdata/dhi",
+			want: &analyzer.AnalysisResult{
+				OS: types.OS{
+					Family: types.DHI,
+					Name:   "3.24",
+				},
+			},
+		},
+		{
 			name:      "Bottlerocket",
 			inputFile: "testdata/bottlerocket",
 			want: &analyzer.AnalysisResult{

--- a/pkg/fanal/analyzer/os/release/testdata/dhi
+++ b/pkg/fanal/analyzer/os/release/testdata/dhi
@@ -1,0 +1,5 @@
+NAME="Docker Hardened Images (Alpine)"
+ID=dhi
+ID_LIKE=alpine
+VERSION_ID=3.24
+PRETTY_NAME="Docker Hardened Images (Alpine 3.24)"

--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -60,6 +60,12 @@ func (o *OS) Merge(newOS OS) {
 
 	supplier := o.Supplier
 	switch {
+	// DHI images also contain their Alpine or Debian lineage release files. The
+	// explicit ID=dhi identity from os-release must win regardless of analyzer order.
+	case newOS.Family == DHI:
+		*o = newOS
+	case o.Family == DHI:
+		// Keep the DHI identity when a lineage-specific analyzer completes later.
 	// OLE also has /etc/redhat-release and it detects OLE as RHEL by mistake.
 	// In that case, OS must be overwritten with the content of /etc/oracle-release.
 	// There is the same problem between Debian and Ubuntu.

--- a/pkg/fanal/types/artifact_test.go
+++ b/pkg/fanal/types/artifact_test.go
@@ -123,6 +123,18 @@ func TestOS_Merge(t *testing.T) {
 			want:  OS{Family: Ubuntu, Name: "24.04", Supplier: SupplierSeal},
 		},
 		{
+			name:  "DHI replaces Alpine lineage regardless of analyzer order",
+			os:    OS{Family: Alpine, Name: "3.24.0"},
+			newOS: OS{Family: DHI, Name: "3.24"},
+			want:  OS{Family: DHI, Name: "3.24"},
+		},
+		{
+			name:  "DHI is not replaced by Debian lineage",
+			os:    OS{Family: DHI, Name: "13"},
+			newOS: OS{Family: Debian, Name: "13.0"},
+			want:  OS{Family: DHI, Name: "13"},
+		},
+		{
 			// A supplier carries no family, so it must not trigger the wholesale
 			// overwrite above and wipe the detected OS.
 			name:  "supplier does not replace redhat",

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -42,6 +42,7 @@ const (
 	Chainguard         OSType = "chainguard"
 	CoreOS             OSType = "coreos"
 	Debian             OSType = "debian"
+	DHI                OSType = "dhi"
 	Echo               OSType = "echo"
 	Fedora             OSType = "fedora"
 	MinimOS            OSType = "minimos"
@@ -159,6 +160,7 @@ var (
 		Chainguard,
 		CoreOS,
 		Debian,
+		DHI,
 		Echo,
 		Fedora,
 		MinimOS,

--- a/pkg/fanal/types/const.go
+++ b/pkg/fanal/types/const.go
@@ -41,6 +41,7 @@ const (
 	Chainguard         OSType = "chainguard"
 	CoreOS             OSType = "coreos"
 	Debian             OSType = "debian"
+	DHI                OSType = "dhi"
 	Echo               OSType = "echo"
 	Fedora             OSType = "fedora"
 	MinimOS            OSType = "minimos"
@@ -158,6 +159,7 @@ var (
 		Chainguard,
 		CoreOS,
 		Debian,
+		DHI,
 		Echo,
 		Fedora,
 		MinimOS,

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -67,7 +67,7 @@ func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*Pac
 	qualifiers := parseQualifier(pkg)
 	pkg.Epoch = 0 // we moved Epoch to qualifiers so we don't need it in version
 
-	ptype := purlType(t)
+	ptype := purlType(t, pkg.AnalyzedBy)
 	name := pkg.Name
 	ver := utils.FormatVersion(pkg)
 	namespace := ""
@@ -449,8 +449,23 @@ func parseJulia(pkgName, pkgUUID string) (string, string, packageurl.Qualifiers)
 	return namespace, name, qualifiers
 }
 
+var mixedOSPackageTypes = map[ftypes.TargetType]map[ftypes.AnalyzerType]string{
+	ftypes.DHI: {
+		"apk":  packageurl.TypeApk,
+		"dpkg": packageurl.TypeDebian,
+	},
+}
+
+// purlType resolves a target's PURL type, using the package analyzer for OS
+// families that support more than one native package manager.
 // nolint: gocyclo
-func purlType(t ftypes.TargetType) string {
+func purlType(t ftypes.TargetType, analyzedBy ftypes.AnalyzerType) string {
+	if packageTypes, ok := mixedOSPackageTypes[t]; ok {
+		if ptype, ok := packageTypes[analyzedBy]; ok {
+			return ptype
+		}
+	}
+
 	switch t {
 	case ftypes.Jar, ftypes.Pom, ftypes.Gradle, ftypes.Sbt:
 		return packageurl.TypeMaven

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -541,6 +541,40 @@ func TestNewPackageURL(t *testing.T) {
 	}
 }
 
+func TestNewPackageURL_DHI(t *testing.T) {
+	tests := []struct {
+		name string
+		os   ftypes.OS
+		pkg  ftypes.Package
+		want string
+	}{
+		{
+			name: "APK package",
+			os:   ftypes.OS{Family: ftypes.DHI, Name: "3.24"},
+			pkg: ftypes.Package{
+				Name: "coreutils", Version: "9.11-r0", Arch: "aarch64", AnalyzedBy: analyzer.TypeApk,
+			},
+			want: "pkg:apk/dhi/coreutils@9.11-r0?arch=aarch64&distro=3.24",
+		},
+		{
+			name: "Debian package",
+			os:   ftypes.OS{Family: ftypes.DHI, Name: "13"},
+			pkg: ftypes.Package{
+				Name: "coreutils", Version: "9.7-3+dhi3", Arch: "arm64", AnalyzedBy: analyzer.TypeDpkg,
+			},
+			want: "pkg:deb/dhi/coreutils@9.7-3%2Bdhi3?arch=arm64&distro=dhi-13",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := purl.New(ftypes.DHI, types.Metadata{OS: &tt.os}, tt.pkg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
 func TestFromString(t *testing.T) {
 	testCases := []struct {
 		name    string


### PR DESCRIPTION
## Description

Add first-class vulnerability scanning support for Docker Hardened Images (DHI) after images begin identifying themselves with `ID=dhi`.

This change:

- detects DHI from `/etc/os-release` and keeps that identity when inherited Alpine or Debian release files are also present;
- generates `pkg:apk/dhi` or `pkg:deb/dhi` PURLs according to the native package analyzer;
- introduces a DHI OS-package detector using APK or Debian version semantics;
- queries lineage- and release-specific advisory buckets such as `dhi alpine 3.24` and `dhi debian 13`;
- filters architecture-specific advisories and does not fall back to upstream Alpine or Debian advisory feeds.

The corresponding DHI feed acquisition and database ingestion changes are being prepared separately in `aquasecurity/vuln-list-update` and `aquasecurity/trivy-db`. Those database changes must be available before this scanner support is released.

## Related issues

None yet.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

## Testing

```console
GOEXPERIMENT=jsonv2 go test ./pkg/fanal/types ./pkg/fanal/analyzer/os/release ./pkg/detector/ospkg/dhi ./pkg/detector/ospkg ./pkg/purl
```