### PR TITLE
ci(spdx): migrate to Slack notifications

### DIFF
--- a/.github/workflows/spdx-cron.yaml
+++ b/.github/workflows/spdx-cron.yaml
@@ -29,11 +29,11 @@ jobs:
             echo "send_notify=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Microsoft Teams Notification
-        uses: Skitionek/notify-microsoft-teams@b65dda7f5e6fd0960b97f923629b911890dc60b1 # main
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         if: steps.exceptions_check.outputs.send_notify == 'true'
         with:
-          webhook_url: ${{ secrets.TRIVY_MSTEAMS_WEBHOOK }}
-          needs: ${{ toJson(needs) }}
-          job: ${{ toJson(job) }}
-          steps: ${{ toJson(steps) }}
+          webhook: ${{ secrets.TRIVY_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":warning: SPDX license IDs and/or exceptions are out of date — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"


### PR DESCRIPTION
## Description

Send SPDX cron notifications to Slack via `slackapi/slack-github-action`.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
