### PR TITLE
docs: fix --exclude-namespaces example and a typo in the Terraform tutorial

### DIFF
--- a/docs/guide/target/kubernetes.md
+++ b/docs/guide/target/kubernetes.md
@@ -128,7 +128,7 @@ By default, all namespaces will be included in cluster scanning.
 Example:
 
 ```sh
-trivy k8s --report summary --exclude-namespace dev-system,staging-system
+trivy k8s --report summary --exclude-namespaces dev-system,staging-system
 ```
 
 ## Control Plane and Node Components Vulnerability Scanning

--- a/docs/tutorials/misconfiguration/terraform.md
+++ b/docs/tutorials/misconfiguration/terraform.md
@@ -94,7 +94,7 @@ We have lots of examples in the [documentation](https://trivy.dev/docs/latest/sc
 
 ## Secret and vulnerability scans
 
-The `trivy config` command does not perform secret and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan you terraform files for exposed secrets and misconfiguraction through the following flags: 
+The `trivy config` command does not perform secret and vulnerability checks out of the box. However, you can specify as part of your `trivy fs` scan that you would like to scan your Terraform files for exposed secrets and misconfiguration through the following flags: 
 
 ```
 trivy fs --scanners secret,misconfig ./


### PR DESCRIPTION
Two small docs fixes.

**`docs/guide/target/kubernetes.md`** — the example runs `--exclude-namespace` (singular), but the flag is registered as `exclude-namespaces` in `pkg/flag/kubernetes_flags.go:72` and there's no singular alias. The note directly above the example already uses `--exclude-namespaces` twice, so the snippet contradicts its own surrounding prose and would fail if copy-pasted.

**`docs/tutorials/misconfiguration/terraform.md`** — "scan you terraform files ... and misconfiguraction" → "scan your Terraform files ... and misconfiguration".

Docs only.