### PR TITLE
chore(deps): bump github.com/nikolalohinski/gonja/v2 to v2.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -441,7 +441,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
-	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
+	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
-	github.com/nikolalohinski/gonja/v2 v2.8.0
+	github.com/nikolalohinski/gonja/v2 v2.9.0
 	github.com/open-policy-agent/opa v1.18.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -441,7 +441,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
-	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
+	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nikolalohinski/gonja/v2 v2.8.0 h1:kOQv887+yMXcaSZjbfa5MMlfHVTpCIcTd8yh+liGmhQ=
-github.com/nikolalohinski/gonja/v2 v2.8.0/go.mod h1:UIzXPVuOsr5h7dZ5DUbqk3/Z7oFA/NLGQGMjqT4L2aU=
+github.com/nikolalohinski/gonja/v2 v2.9.0 h1:QICtNWj0siM3PF5xUjVod/l+C9XnGfI+wrfSIBGKQ6o=
+github.com/nikolalohinski/gonja/v2 v2.9.0/go.mod h1:UIzXPVuOsr5h7dZ5DUbqk3/Z7oFA/NLGQGMjqT4L2aU=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
@@ -1138,8 +1138,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20260603202125-055de637280b h1:v1uXiEBHo8QA0LiGCo7UgHMzHT4Kdfpl2zmtH5vaP1Q=
-golang.org/x/exp v0.0.0-20260603202125-055de637280b/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 h1:ex206bKw+v3K0dm3andkrIF+ijyQKJG1pLgwQ2PYdQM=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/go.sum
+++ b/go.sum
@@ -1138,8 +1138,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 h1:ex206bKw+v3K0dm3andkrIF+ijyQKJG1pLgwQ2PYdQM=
-golang.org/x/exp v0.0.0-20260727155853-b88d891fe743/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
+golang.org/x/exp v0.0.0-20260603202125-055de637280b h1:v1uXiEBHo8QA0LiGCo7UgHMzHT4Kdfpl2zmtH5vaP1Q=
+golang.org/x/exp v0.0.0-20260603202125-055de637280b/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/pkg/iac/scanners/ansible/parser/node.go
+++ b/pkg/iac/scanners/ansible/parser/node.go
@@ -400,7 +400,10 @@ func (n *Node) BoolValue(path string) iacTypes.BoolValue {
 	return iacTypes.Bool(val, iacTypes.Metadata{})
 }
 
-func (n *Node) AsBool() (bool, bool) {
+// AsBool interprets the node's scalar value as a boolean using Ansible's
+// conversion rules. ok is false if the value couldn't be recognized
+// (e.g. an unrecognized string, or an int other than 0/1).
+func (n *Node) AsBool() (val, ok bool) {
 	if n.IsNil() {
 		return false, false
 	}
@@ -426,8 +429,9 @@ func (n *Node) AsBool() (bool, bool) {
 	return false, false
 }
 
-// parseAnsibleBool implements Ansible's string→bool conversion.
-func parseAnsibleBool(s string) (bool, bool) {
+// parseAnsibleBool converts a string to bool per Ansible's boolean rules.
+// ok is false if s isn't a recognized boolean string.
+func parseAnsibleBool(s string) (val, ok bool) {
 	normalized := strings.ToLower(strings.TrimSpace(s))
 
 	switch normalized {

--- a/pkg/iac/scanners/ansible/parser/node_test.go
+++ b/pkg/iac/scanners/ansible/parser/node_test.go
@@ -291,3 +291,40 @@ num: 42
 		})
 	}
 }
+
+func TestNode_AsBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected bool
+		ok       bool
+	}{
+		// native YAML
+		{name: "yaml true", src: `true`, expected: true, ok: true},
+		{name: "yaml false", src: `false`, expected: false, ok: true},
+		{name: "int 1", src: `1`, expected: true, ok: true},
+		{name: "int 0", src: `0`, expected: false, ok: true},
+		{name: "int other", src: `2`, expected: false, ok: false},
+
+		// Ansible-style strings
+		{name: "string yes", src: `"yes"`, expected: true, ok: true},
+		{name: "string no", src: `"no"`, expected: false, ok: true},
+		{name: "string uppercase and whitespace", src: `"  TRUE  "`, expected: true, ok: true},
+		{name: "string invalid", src: `"bar"`, expected: false, ok: false},
+
+		// jinja
+		{name: "jinja and returns second operand", src: `"{{ 'foo' and 'bar' }}"`, expected: false, ok: false},
+		{name: "jinja explicit bool", src: `"{{ true }}"`, expected: true, ok: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := mustNodeFromYAML(t, tt.src)
+			rendered, err := node.Render(make(vars.Vars))
+			require.NoError(t, err)
+			got, ok := rendered.AsBool()
+			require.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Bumps `github.com/nikolalohinski/gonja/v2` to v2.9.0, which fixes the `or`/`and` operators (NikolaLohinski/gonja#87): they no longer coerce the result to a bool, so `{{ 'foo' and 'bar' }}` now renders as `bar` instead of `True`.

The bump was excluded from the Dependabot group update to check its effect on the Ansible parser, since it looked like the parser would need to convert scalar nodes to booleans differently: an expression like this no longer resolves to a definite boolean and makes the attribute unresolvable.

No change is needed — the parser already follows Ansible, which converts module arguments with `boolean()` and only accepts `0/1`, `y/n`, `yes/no`, `t/f`, `true/false`, `on/off`. To confirm that Ansible does not apply Python truthiness here, I ran a playbook that passes `allow_blob_public_access: "{{ 'foo' and 'bar' }}"` to `azure_rm_storageaccount`. Ansible renders the expression to `bar` and then rejects it:

    fatal: [localhost]: FAILED! => {"changed": false, "msg": "argument 'allow_blob_public_access' is of type <class 'str'> and we were unable to convert to bool: The value 'bar' is not a valid boolean.  Valid booleans include: 0, 1, 't', 'false', 'off', 'yes', '1', 'no', 'on', '0', 'y', 'true', 'f', 'n'"}

So the value has no boolean meaning for Ansible either, and marking the attribute unresolvable is the correct result. Added a test for `AsBool` covering YAML values, Ansible boolean strings and templated expressions.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
