### PR TITLE
fix(os): keep the fullest OS version when merging analyzer results

### DIFF
--- a/pkg/fanal/types/artifact.go
+++ b/pkg/fanal/types/artifact.go
@@ -3,6 +3,7 @@ package types
 import (
 	"cmp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -71,7 +72,9 @@ func (o *OS) Merge(newOS OS) {
 		if o.Family == "" {
 			o.Family = newOS.Family
 		}
-		if o.Name == "" {
+		// One of the sources may report a shortened version, e.g. 7 and 7.9.2009 for CentOS.
+		// We always take the fullest version.
+		if o.Name == "" || (o.Family == newOS.Family && strings.HasPrefix(newOS.Name, o.Name+".")) {
 			o.Name = newOS.Name
 		}
 		// Ubuntu has ESM program: https://ubuntu.com/security/esm

--- a/pkg/fanal/types/artifact_test.go
+++ b/pkg/fanal/types/artifact_test.go
@@ -98,6 +98,13 @@ func TestOS_Merge(t *testing.T) {
 			want:  OS{Family: Alpine, Name: "3.2"},
 		},
 		{
+			// Versions of different families are unrelated, so one never refines the other.
+			name:  "a longer version from another family is ignored",
+			os:    OS{Family: Alpine, Name: "3"},
+			newOS: OS{Family: Wolfi, Name: "3.20"},
+			want:  OS{Family: Alpine, Name: "3"},
+		},
+		{
 			name:  "extended is sticky",
 			os:    OS{Family: Ubuntu, Name: "18.04", Extended: true},
 			newOS: OS{Family: Ubuntu, Name: "18.04"},

--- a/pkg/fanal/types/artifact_test.go
+++ b/pkg/fanal/types/artifact_test.go
@@ -78,6 +78,26 @@ func TestOS_Merge(t *testing.T) {
 			want:  OS{Family: Alpine, Name: "3.20.3"},
 		},
 		{
+			// /etc/os-release yields 7, /etc/centos-release yields 7.9.2009.
+			// The analyzers run concurrently, so both orders must agree.
+			name:  "more specific version wins",
+			os:    OS{Family: CentOS, Name: "7"},
+			newOS: OS{Family: CentOS, Name: "7.9.2009"},
+			want:  OS{Family: CentOS, Name: "7.9.2009"},
+		},
+		{
+			name:  "less specific version loses",
+			os:    OS{Family: CentOS, Name: "7.9.2009"},
+			newOS: OS{Family: CentOS, Name: "7"},
+			want:  OS{Family: CentOS, Name: "7.9.2009"},
+		},
+		{
+			name:  "a longer version that is not a refinement is ignored",
+			os:    OS{Family: Alpine, Name: "3.2"},
+			newOS: OS{Family: Alpine, Name: "3.20"},
+			want:  OS{Family: Alpine, Name: "3.2"},
+		},
+		{
 			name:  "extended is sticky",
 			os:    OS{Family: Ubuntu, Name: "18.04", Extended: true},
 			newOS: OS{Family: Ubuntu, Name: "18.04"},


### PR DESCRIPTION
## Description

`/etc/os-release` and the distro-specific release file can describe the same OS with different granularity.
On CentOS 7 the former reports `VERSION_ID=7`, while `/etc/centos-release` reports `7.9.2009`.
Both files are analyzed concurrently, and `OS.Merge` filled `Name` only while it was still empty, so the reported version depended on which analyzer merged first.

In practice the winner is decided by the order of the entries in the layer tar, which normally puts `/etc/centos-release` first.
That order is not part of the contract though.
Rebuilding the same layer with `/etc/os-release` moved ahead of `/etc/centos-release` — with the contents of every file unchanged — flips the reported version to `7` in 100% of runs.

## Changes
`OS.Merge` now keeps the more specific version when both sources describe the same family: a new name replaces the current one when the current one is a dotted prefix of it.
CentOS is the only distribution affected in practice — Rocky, Alma, Oracle, RHEL and Fedora put the full `x.y` version into `VERSION_ID`, so their sources already agree.

## Example
Before / after, same image with `/etc/os-release` placed first in the layer tar:

Before:
```json
"OS": { "Family": "centos", "Name": "7" }
```

After:
```json
"OS": { "Family": "centos", "Name": "7.6.1810" }
```

## Related issues
- Discussion https://github.com/aquasecurity/trivy/discussions/11030

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
