### PR TITLE
test(k8s): add vuln-only and secret-only cases to Test_separateMisconfigReports

### DIFF
--- a/pkg/k8s/report/report_test.go
+++ b/pkg/k8s/report/report_test.go
@@ -822,8 +822,44 @@ func Test_separateMisconfigReports(t *testing.T) {
 			},
 		},
 
-		// TODO: add vuln only
-		// TODO: add secret only
+		{
+			name: "Vulnerability Report Only",
+			k8sReport: Report{
+				Resources: []Resource{
+					deployOrionWithVulns,
+					cronjobHelloWithVulns,
+				},
+			},
+			scanners: types.Scanners{types.VulnerabilityScanner},
+			expectedReports: []Report{
+				// the order matter for the test
+				{
+					Resources: []Resource{
+						{Kind: "Deploy"},
+						{Kind: "Cronjob"},
+					},
+				},
+				{Resources: []Resource{}},
+			},
+		},
+		{
+			name: "Secret Report Only",
+			k8sReport: Report{
+				Resources: []Resource{
+					deployLuaWithSecrets,
+				},
+			},
+			scanners: types.Scanners{types.SecretScanner},
+			expectedReports: []Report{
+				// the order matter for the test
+				{
+					Resources: []Resource{
+						{Kind: "Deploy"},
+					},
+				},
+				{Resources: []Resource{}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

`Test_separateMisconfigReports` has carried two TODOs for a while:

```go
// TODO: add vuln only
// TODO: add secret only
```

This adds both cases, reusing the existing `deployOrionWithVulns`, `cronjobHelloWithVulns` and `deployLuaWithSecrets` fixtures from the same file. Each case runs `SeparateMisconfigReports` with only the vulnerability (resp. secret) scanner enabled and pins the current routing: the workload assessment carries the resources, and the infra assessment is still emitted (empty) because `shouldAddToReport` includes both scanners. Test-only change, no behavior touched.

```
$ go test ./pkg/k8s/report/
ok  github.com/aquasecurity/trivy/pkg/k8s/report  (37 passed)
```

No linked issue: test-only addition answering an in-code TODO, per the trivial-change allowance in the contributing docs.

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#documentation) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
