### PR TITLE
docs: remove trivy-checks from AWS ECR locations

### DIFF
--- a/docs/guide/configuration/db.md
+++ b/docs/guide/configuration/db.md
@@ -31,7 +31,6 @@ Trivy's databases are published to the following locations:
 | | `aquasec/trivy-checks` | <https://hub.docker.com/r/aquasec/trivy-checks>
 | AWS ECR | `public.ecr.aws/aquasecurity/trivy-db` | <https://gallery.ecr.aws/aquasecurity/trivy-db>
 | | `public.ecr.aws/aquasecurity/trivy-java-db` | <https://gallery.ecr.aws/aquasecurity/trivy-java-db>
-| | `public.ecr.aws/aquasecurity/trivy-checks` | <https://gallery.ecr.aws/aquasecurity/trivy-checks>
 
 In addition, images are also available via pull-through cache registries like [Google Container Registry Mirror](https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images).
 


### PR DESCRIPTION
## Description

`trivy-checks` is not published to AWS ECR - the ECR registry only hosts `trivy-db` and `trivy-java-db`. The `public.ecr.aws/aquasecurity/trivy-checks` entry appears to have been added to the table by mistake along with the other artifacts, so users following the docs would try to pull a non-existent image. This PR removes that row.

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/11010

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
