### PR TITLE
ci: trigger Auto Ready for Review after Test docs

### DIFF
--- a/.github/workflows/auto-ready-for-review.yaml
+++ b/.github/workflows/auto-ready-for-review.yaml
@@ -5,7 +5,7 @@ on:
   # does not check out any PR code — it only reads PR metadata via the GitHub API and marks
   # the PR as ready for review. No code execution from forks occurs.
   workflow_run: # zizmor: ignore[dangerous-triggers]
-    workflows: ["Test", "Validate PR Title"]
+    workflows: ["Test", "Validate PR Title", "Test docs"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## Description

For docs-only PRs the `Test` workflow doesn't run (it ignores `docs/**` and`mkdocs.yml`), so `Auto Ready for Review` was triggered only by `Validate PR Title`. That check finishes in seconds, while `Test docs` is still running, so the run exited early with `[INFO] Some workflows are still running: Test docs` and never fired again - the `autoready` label had no effect.

Adding `Test docs` to the trigger list lets the last finishing workflow re-run the check.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
