### PR TITLE
refactor(ubuntu): move EOL version resolution out of loop

### DIFF
--- a/pkg/detector/ospkg/ubuntu/ubuntu.go
+++ b/pkg/detector/ospkg/ubuntu/ubuntu.go
@@ -105,9 +105,10 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
 		log.Int("pkg_num", len(pkgs)))
 
+	osVer = s.versionFromEolDates(ctx, osVer)
+
 	var vulns []types.DetectedVulnerability
 	for _, pkg := range pkgs {
-		osVer = s.versionFromEolDates(ctx, osVer)
 		advisories, err := s.vs.Get(db.GetParams{
 			Release: osVer,
 			PkgName: pkg.SrcName,


### PR DESCRIPTION
## Description

`versionFromEolDates` depends only on the OS version, so calling it for every package repeated the same work without changing the result.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
