### PR TITLE
fix(python): normalize dependency names in PEP 621 pyproject.toml

### DIFF
--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,9 +75,8 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
-			// Normalize the name (PEP 503) as the Poetry v1 branch does, so it matches
-			// the normalized names from poetry.lock/pylock.toml when identifying direct deps.
-			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true)) // Save only name
+			// Save only the name, normalized (PEP 503) to match the names from poetry.lock/pylock.toml.
+			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true))
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,7 +75,9 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
-			d.Set.Append(strings.Fields(dep)[0]) // Save only name
+			// Normalize the name (PEP 503) as the Poetry v1 branch does, so it matches
+			// the normalized names from poetry.lock/pylock.toml when identifying direct deps.
+			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true)) // Save only name
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -23,6 +23,14 @@ func TestPyProject_MainDeps(t *testing.T) {
 			file: "testdata/happy_with_optional_only.toml",
 			want: set.New[string]("pytest", "ruff"),
 		},
+		{
+			// PEP 621 `project.dependencies` may use non-normalized names
+			// (mixed case, `_` or `.`), which must be normalized (PEP 503) to
+			// match the names from poetry.lock/pylock.toml.
+			name: "PEP 621 dependencies with non-normalized names",
+			file: "testdata/normalize_v2.toml",
+			want: set.New[string]("flask", "typing-extensions", "ruamel-yaml"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -23,14 +23,6 @@ func TestPyProject_MainDeps(t *testing.T) {
 			file: "testdata/happy_with_optional_only.toml",
 			want: set.New[string]("pytest", "ruff"),
 		},
-		{
-			// PEP 621 `project.dependencies` may use non-normalized names
-			// (mixed case, `_` or `.`), which must be normalized (PEP 503) to
-			// match the names from poetry.lock/pylock.toml.
-			name: "PEP 621 dependencies with non-normalized names",
-			file: "testdata/normalize_v2.toml",
-			want: set.New[string]("flask", "typing-extensions", "ruamel-yaml"),
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -86,7 +78,9 @@ func TestParser_Parse(t *testing.T) {
 			want: pyproject.PyProject{
 				Project: pyproject.Project{
 					Dependencies: pyproject.Dependencies{
-						Set: set.New[string]("check-wheel-contents", "flask", "pluggy"),
+						// Names are normalized (PEP 503):
+						// `Flask` => `flask`, `typing_extensions` => `typing-extensions`, `ruamel.yaml` => `ruamel-yaml`
+						Set: set.New[string]("check-wheel-contents", "flask", "pluggy", "ruamel-yaml", "typing-extensions"),
 					},
 				},
 				Tool: pyproject.Tool{

--- a/pkg/dependency/parser/python/pyproject/testdata/happy_v2.toml
+++ b/pkg/dependency/parser/python/pyproject/testdata/happy_v2.toml
@@ -8,9 +8,11 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "flask(>=1.0,<2.0)",
+    "Flask(>=1.0,<2.0)",
     "check-wheel-contents==0.6.1",
     "pluggy[pre-commit,tox] (==0.13.1)",
+    "typing_extensions>=4",
+    "ruamel.yaml (>=0.18)",
 ]
 
 [tool.poetry.dependencies]

--- a/pkg/dependency/parser/python/pyproject/testdata/normalize_v2.toml
+++ b/pkg/dependency/parser/python/pyproject/testdata/normalize_v2.toml
@@ -1,8 +1,0 @@
-[project]
-name = "example"
-version = "0.1.0"
-dependencies = [
-    "Flask==1.1.4",
-    "typing_extensions>=4",
-    "ruamel.yaml (>=0.18)",
-]

--- a/pkg/dependency/parser/python/pyproject/testdata/normalize_v2.toml
+++ b/pkg/dependency/parser/python/pyproject/testdata/normalize_v2.toml
@@ -1,0 +1,8 @@
+[project]
+name = "example"
+version = "0.1.0"
+dependencies = [
+    "Flask==1.1.4",
+    "typing_extensions>=4",
+    "ruamel.yaml (>=0.18)",
+]

--- a/pkg/fanal/analyzer/language/python/poetry/testdata/happy-v2/pyproject.toml
+++ b/pkg/fanal/analyzer/language/python/poetry/testdata/happy-v2/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "flask (==1.0.3)",
+    # Non-normalized name to check that it is matched with `flask` from poetry.lock
+    "Flask (==1.0.3)",
     "pluggy (==0.13.1)"
 ]
 

--- a/pkg/fanal/analyzer/language/python/pylock/testdata/happy/pyproject.toml
+++ b/pkg/fanal/analyzer/language/python/pylock/testdata/happy/pyproject.toml
@@ -2,7 +2,8 @@
 name = "test-project"
 version = "0.1.0"
 dependencies = [
-    "requests>=2.32.0",
+    # Non-normalized name to check that it is matched with `requests` from pylock.toml
+    "Requests>=2.32.0",
     "click>=8.0.0",
 ]
 


### PR DESCRIPTION
## Description

PEP 621 dependencies (`[project].dependencies`, used by Poetry v2 and other PEP 621 backends) are stored without name normalization, while Poetry v1 dependencies (`[tool.poetry.dependencies]`) are normalized via `python.NormalizePkgName`. `poetry.lock` and `pylock.toml` store PEP 503 normalized names, so a PEP 621 dependency written in non-normalized form (canonical casing, `_`, or `.`, e.g. `Flask`, `typing_extensions`, `ruamel.yaml`) never matches its lock entry.

The consequence is in the poetry/pylock analyzers, which look up the direct dependencies by name (`dirDeps.Contains(pkg.Name)` / `prodRootDeps.Contains(pkg.Name)`) against the normalized lock names. A direct dependency that fails to match is reported as indirect, and since the production-dependency walk starts from the direct set, that package and its transitive subtree end up marked `Dev: true`. With `--include-dev-deps=false` they drop from the SBOM/scan, and the root -> dependency edge is lost from the graph.

Example: `[project]` with `dependencies = ["Flask (==1.0.3)"]` and a `poetry.lock` containing `name = "flask"`:

```
before: flask  relationship=indirect  dev=true
after:  flask  relationship=direct    dev=false
```

The fix normalizes the PEP 621 name the same way the Poetry v1 branch already does.

## How I tested

Added a `TestPyProject_MainDeps` case (`testdata/normalize_v2.toml`) with `Flask`, `typing_extensions`, and `ruamel.yaml`, asserting the normalized set `{flask, typing-extensions, ruamel-yaml}`. It fails on `main` (the set keeps the raw names) and passes with the change. `go test ./pkg/dependency/parser/python/... ./pkg/fanal/analyzer/language/python/...` stays green.

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)