### PR TITLE
fix(php): keep dependency edges to packages named like PHP extensions

### DIFF
--- a/pkg/dependency/parser/php/composer/parse.go
+++ b/pkg/dependency/parser/php/composer/parse.go
@@ -109,8 +109,8 @@ func (p *Parser) parsePackages(lockPkgs []packageInfo, isDev bool, pkgs map[stri
 		var dependsOn []string
 		for depName := range lpkg.Require {
 			// Require field includes required php version, skip this
-			// Also skip PHP extensions
-			if depName == "php" || strings.HasPrefix(depName, "ext") {
+			// Also skip PHP extensions (platform packages use the "ext-" prefix)
+			if depName == "php" || strings.HasPrefix(depName, "ext-") {
 				continue
 			}
 			dependsOn = append(dependsOn, depName) // field uses range of versions, so later we will fill in the versions from the packages

--- a/pkg/dependency/parser/php/composer/parse_test.go
+++ b/pkg/dependency/parser/php/composer/parse_test.go
@@ -203,3 +203,23 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_ExtPrefixDependency(t *testing.T) {
+	// A require key such as "extension/foo" starts with "ext" but is a regular
+	// package, not a PHP extension. Only platform extensions use the "ext-"
+	// prefix, so the dependency edge to "extension/foo" must be kept while
+	// "php" and "ext-json" are skipped.
+	f, err := os.Open("testdata/composer_ext_prefix.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	_, gotDeps, err := NewParser().Parse(t.Context(), f)
+	require.NoError(t, err)
+
+	assert.Equal(t, []ftypes.Dependency{
+		{
+			ID:        "acme/app@1.0.0",
+			DependsOn: []string{"extension/foo@1.2.0"},
+		},
+	}, gotDeps)
+}

--- a/pkg/dependency/parser/php/composer/testdata/composer_ext_prefix.lock
+++ b/pkg/dependency/parser/php/composer/testdata/composer_ext_prefix.lock
@@ -1,0 +1,20 @@
+{
+    "packages": [
+        {
+            "name": "acme/app",
+            "version": "1.0.0",
+            "require": {
+                "php": ">=7.4",
+                "ext-json": "*",
+                "extension/foo": "^1.0"
+            },
+            "license": ["MIT"]
+        },
+        {
+            "name": "extension/foo",
+            "version": "1.2.0",
+            "license": ["MIT"]
+        }
+    ],
+    "packages-dev": []
+}


### PR DESCRIPTION
## Description

The `composer.lock` parser skips every `require` key whose name starts with `ext` to keep PHP platform extensions out of the dependency graph. Platform extensions are named with an `ext-` prefix (`ext-json`, `ext-curl`, ...), so the bare `ext` prefix also matches regular packages whose name starts with `ext` and drops their `dependsOn` edges.

`pkg/dependency/parser/php/composer/parse.go`:

```go
if depName == "php" || strings.HasPrefix(depName, "ext") {
    continue
}
```

For a lock where `acme/app` requires `extension/foo`, the `acme/app -> extension/foo` edge is dropped, so the dependency graph (and the SBOM `dependsOn` / vulnerability dependency path) no longer shows how `extension/foo` was pulled in. Packagist currently lists over 180 published packages whose name starts with `ext` but not `ext-`, for example `extend/module-warranty` and `extcode/cart`.

The fix matches the `ext-` prefix only.

## Test

Added `TestParse_ExtPrefixDependency` with a small lock where `acme/app` requires `php`, `ext-json` and `extension/foo`. It checks that the edge to `extension/foo` is kept while `php` and `ext-json` are skipped. It fails before the change and passes after.

```
go test ./pkg/dependency/parser/php/composer/...
go test ./pkg/fanal/analyzer/language/php/composer/...
```