### PR TITLE
fix(conda): strip pip "~=" and "!=" operators from dependency names

### DIFF
--- a/pkg/dependency/parser/conda/environment/parse.go
+++ b/pkg/dependency/parser/conda/environment/parse.go
@@ -97,9 +97,12 @@ func (p *Parser) toPackage(dep Dependency) ftypes.Package {
 //   - numpy 1.8.1 py27_0
 //   - numpy=1.8.1=py27_0
 //
+// The `pip` subsection uses PEP 440 operators, so `~=` and `!=` are separated
+// as well to keep the name clean (e.g. `django~=5.0.6` -> "django").
+//
 // cf. https://docs.conda.io/projects/conda-build/en/latest/resources/package-spec.html#examples-of-package-specs
 func (*Parser) parseDependency(line string) (string, string) {
-	line = strings.NewReplacer(">", " >", "<", " <", "=", " ").Replace(line)
+	line = strings.NewReplacer(">", " >", "<", " <", "~", " ~", "!", " !", "=", " ").Replace(line)
 	parts := strings.Fields(line)
 	if len(parts) == 0 {
 		return "", ""

--- a/pkg/dependency/parser/conda/environment/parse_test.go
+++ b/pkg/dependency/parser/conda/environment/parse_test.go
@@ -211,6 +211,46 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			// pip dependencies use PEP 440 operators. `~=` and `!=` must be
+			// stripped from the name just like `>` and `<`, otherwise the
+			// operator character stays glued to the package name.
+			name:  "pip dependencies with PEP 440 operators",
+			input: "testdata/pip-version-operators.yaml",
+			want: environment.Packages{
+				Packages: []ftypes.Package{
+					{
+						Name: "django",
+						Locations: ftypes.Locations{
+							{
+								StartLine: 6,
+								EndLine:   6,
+							},
+						},
+					},
+					{
+						Name: "flask",
+						Locations: ftypes.Locations{
+							{
+								StartLine: 7,
+								EndLine:   7,
+							},
+						},
+					},
+					{
+						Name:    "requests",
+						Version: "2.31.0",
+						Locations: ftypes.Locations{
+							{
+								StartLine: 8,
+								EndLine:   8,
+							},
+						},
+					},
+				},
+				Prefix: "/opt/conda/envs/test-env",
+			},
+		},
+		{
 			name:    "invalid yaml file",
 			input:   "testdata/invalid.yaml",
 			wantErr: "cannot unmarshal !!str `invalid` into environment.environment",

--- a/pkg/dependency/parser/conda/environment/testdata/pip-version-operators.yaml
+++ b/pkg/dependency/parser/conda/environment/testdata/pip-version-operators.yaml
@@ -1,0 +1,10 @@
+name: test-env
+channels:
+  - defaults
+dependencies:
+  - pip:
+      - django~=5.0.6
+      - flask!=2.0
+      - requests==2.31.0
+
+prefix: /opt/conda/envs/test-env


### PR DESCRIPTION
## Description

`environment.yml` can carry a `pip:` subsection whose entries use PEP 440 version operators. `parseDependency` separates the name from the version by replacing `>`, `<` and `=` with spaces, but not `~` or `!`, so the operator character stays glued to the name:

```
django~=5.0.6  ->  name "django~"
flask!=2.0     ->  name "flask!"
```

The analyzer copies the parsed name verbatim, so the SBOM ends up with `django~`/`flask!`, and vulnerability matching (which keys on the name) finds nothing for those packages.

This adds `~` and `!` to the replacer so the name comes out clean, the same way `>` and `<` already are. Like the other range operators, `~=`/`!=` record no pinned version — they are ranges, not pins.

Tested with a new `pip:` fixture (`django~=5.0.6`, `flask!=2.0`, `requests==2.31.0`) added to the parser table test: it fails on main (names `django~`, `flask!`) and passes with the change. `go test ./pkg/dependency/parser/conda/...` and the conda analyzer tests pass.

## Related issues

None.

## Checklist
- [x] I've read the guidelines for contributing to this repository.
- [x] I've followed the conventions in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
