### PR TITLE
fix(java): don't inherit a relativePath POM that only matches the parent ArtifactID

### DIFF
--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -66,10 +66,6 @@ func (a artifact) IsEmpty() bool {
 	return false
 }
 
-func (a artifact) Equal(o artifact) bool {
-	return a.GroupID == o.GroupID || a.ArtifactID == o.ArtifactID || a.Version.String() == o.Version.String()
-}
-
 func (a artifact) ToPOMLicenses() pomLicenses {
 	return pomLicenses{
 		License: xslices.Map(a.Licenses, func(lic string) pomLicense {

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -755,7 +755,11 @@ func (p *Parser) tryRelativePath(ctx context.Context, parentArtifact artifact, c
 		return nil, xerrors.Errorf("analyze error: %w", err)
 	}
 
-	if !parentArtifact.Equal(parsedPOM.artifact()) {
+	// `resolveParent` has now filled in an inherited GroupID, so a GroupID that
+	// still differs means the local POM only shares the ArtifactID with the
+	// declared parent and is a different artifact. The declared Version can be an
+	// unevaluated property here (e.g. `${revision}`), so it is not compared.
+	if parsedPOM.artifact().GroupID != parentArtifact.GroupID {
 		return nil, xerrors.New("'parent.relativePath' points at wrong local POM")
 	}
 

--- a/pkg/dependency/parser/java/pom/parse_test.go
+++ b/pkg/dependency/parser/java/pom/parse_test.go
@@ -1998,6 +1998,22 @@ func TestPom_Parse(t *testing.T) {
 			},
 		},
 		{
+			// The relativePath POM shares only the ArtifactID with the declared
+			// parent (different GroupID), so it must not be treated as the parent
+			// and its dependencies must not be inherited.
+			name:      "relativePath points at a POM with the same ArtifactID but a different GroupID",
+			inputFile: filepath.Join("testdata", "wrong-relative-path-parent", "pom.xml"),
+			local:     true,
+			want: []ftypes.Package{
+				{
+					ID:           "com.example:child:1.0.0::739a5b0b",
+					Name:         "com.example:child",
+					Version:      "1.0.0",
+					Relationship: ftypes.RelationshipRoot,
+				},
+			},
+		},
+		{
 			name:      "dependency without version",
 			inputFile: filepath.Join("testdata", "dep-without-version", "pom.xml"),
 			local:     true,

--- a/pkg/dependency/parser/java/pom/testdata/wrong-relative-path-parent/parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/wrong-relative-path-parent/parent/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.unrelated</groupId>
+    <artifactId>parent</artifactId>
+    <version>9.9.9</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.phantom</groupId>
+            <artifactId>phantom-lib</artifactId>
+            <version>6.6.6</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pkg/dependency/parser/java/pom/testdata/wrong-relative-path-parent/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/wrong-relative-path-parent/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>child</artifactId>
+    <version>1.0.0</version>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>./parent</relativePath>
+    </parent>
+</project>


### PR DESCRIPTION
## Description

`tryRelativePath` resolves a `<parent>` declared with a `relativePath` (or the default `../pom.xml`). It first matches the local POM's ArtifactID against the declared parent, because `resolveParent` hasn't run yet and the GroupID/Version aren't available. After `resolveParent` fills those in, it re-checks the identity with `artifact.Equal`:

```go
func (a artifact) Equal(o artifact) bool {
	return a.GroupID == o.GroupID || a.ArtifactID == o.ArtifactID || a.Version.String() == o.Version.String()
}
```

The fields are combined with `||`, so `Equal` returns true whenever any single field matches. The ArtifactID is already guaranteed equal by the first check, so the second check can never reject anything. A `../pom.xml` (or relativePath target) that shares the ArtifactID but has a different GroupID is then treated as the parent, and its `dependencies`/`dependencyManagement` are inherited — dependencies that aren't really there end up in the SBOM graph.

Example: a module declares parent `com.example:parent:1.0.0`, but the sibling `./parent/pom.xml` is an unrelated `com.unrelated:parent:9.9.9` that depends on `org.phantom:phantom-lib:6.6.6`. Before this change `phantom-lib` is reported as a dependency of the module; after it isn't.

This compares the resolved GroupID at that call site instead. The declared parent Version can still be an unevaluated property (e.g. `${revision}`) there, so comparing it would reject valid parents — the `parent version in property` and `inherit parent dependencies` tests exercise exactly that — and it is left out. The now-unused `artifact.Equal` helper is removed.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
