### PR TITLE
docs: add MegaLinter to CI/CD integrations

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -81,6 +81,13 @@ It has capabilities to fail the pipeline, create issues, alert communication cha
 👉 Get it at: <https://github.com/Comcast/trivy-resource/>
 
 
+## MegaLinter (Community)
+[MegaLinter](https://megalinter.io/) is an open-source linters aggregator that runs 100+ linters and security scanners in CI workflows.
+
+Trivy is embedded out of the box to scan repositories for vulnerabilities, misconfigurations and secrets, and to generate SBOMs.
+
+👉 Get it at: <https://megalinter.io/latest/descriptors/repository_trivy/>
+
 ## SecObserve GitHub actions and GitLab templates (Community)
 [SecObserve GitHub actions and GitLab templates](https://github.com/SecObserve/secobserve_actions_templates) run various vulnerability scanners, providing uniform methods and parameters for launching the tools.
 


### PR DESCRIPTION
## Description

Small docs addition: I maintain [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI, and Trivy has been embedded in it for a while (repository scan + SBOM generation). This adds a short entry to the CI/CD ecosystem page so Trivy users can find the integration, following the format of the other community entries.

Skipping the issue as it's a trivial docs-only change, per the contributing guidelines.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.