### PR TITLE
fix(report): check the URI before converting it to a string

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -88,8 +88,8 @@ func (sw *SarifWriter) addSarifRule(data *sarifData) {
 			Level: toSarifErrorLevel(data.severity),
 		}).
 		WithProperties(toProperties(data.title, data.severity, data.cvssScore, data.cvssData))
-	if data.url != nil && data.url.String() != "" {
-		r.WithHelpURI(data.url.String())
+	if uri := uriString(data.url); uri != "" {
+		r.WithHelpURI(uri)
 	}
 }
 
@@ -100,7 +100,7 @@ func (sw *SarifWriter) addSarifResult(data *sarifData) {
 		WithRuleIndex(data.resultIndex).
 		WithMessage(sarif.NewTextMessage(data.message)).
 		WithLevel(toSarifErrorLevel(data.severity)).
-		WithLocations(toSarifLocations(data.locations, data.artifactLocation.String(), data.locationMessage))
+		WithLocations(toSarifLocations(data.locations, uriString(data.artifactLocation), data.locationMessage))
 	sw.run.AddResult(result)
 }
 
@@ -397,6 +397,17 @@ func toUri(str string) *url.URL {
 		logger.Error("Unable to parse URI", log.String("URI", str), log.Err(err))
 	}
 	return uri
+}
+
+// uriString returns the string representation of the given URI.
+// `toUri` returns nil when the input cannot be parsed (e.g. a path containing a bare `%`),
+// so the conversion has to be guarded against a nil pointer dereference.
+// cf. https://github.com/aquasecurity/trivy/issues/8154
+func uriString(uri *url.URL) string {
+	if uri == nil {
+		return ""
+	}
+	return uri.String()
 }
 
 func (sw *SarifWriter) getLocations(name, version, path string, pkgs []ftypes.Package) []location {

--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -976,3 +976,99 @@ func TestMakePropertiesMarshal(t *testing.T) {
 		})
 	}
 }
+
+// TestReportWriter_Sarif_UnparsableTarget is a regression test for
+// https://github.com/aquasecurity/trivy/issues/8154.
+// `toUri` logs and returns nil when `url.Parse` rejects its input (e.g. a path that
+// contains a bare `%`), and the returned pointer was dereferenced without a check.
+func TestReportWriter_Sarif_UnparsableTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   types.Report
+		wantURI string
+		wantMsg string
+	}{
+		{
+			name: "misconfiguration in a file whose path contains a percent sign",
+			input: types.Report{
+				ArtifactName: ".",
+				ArtifactType: ftypes.TypeFilesystem,
+				Results: types.Results{
+					{
+						Target: "terraform/main%.tf",
+						Class:  types.ClassConfig,
+						Type:   "terraform",
+						Misconfigurations: []types.DetectedMisconfiguration{
+							{
+								Type:       "Terraform Security Check",
+								ID:         "AVD-AWS-0088",
+								Title:      "Unencrypted S3 bucket",
+								Message:    "Bucket does not have encryption enabled",
+								Severity:   "HIGH",
+								PrimaryURL: "https://avd.aquasec.com/misconfig/avd-aws-0088",
+								Status:     types.MisconfStatusFailure,
+								CauseMetadata: ftypes.CauseMetadata{
+									StartLine: 1,
+									EndLine:   3,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantURI: "",
+			wantMsg: "terraform/main%.tf",
+		},
+		{
+			name: "vulnerability in a file whose path contains a percent sign",
+			input: types.Report{
+				ArtifactName: ".",
+				ArtifactType: ftypes.TypeFilesystem,
+				Results: types.Results{
+					{
+						Target: "app/50%/package-lock.json",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.NodePkg,
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2020-0001",
+								PkgName:          "foo",
+								InstalledVersion: "1.2.3",
+								FixedVersion:     "3.4.5",
+								PrimaryURL:       "https://avd.aquasec.com/nvd/cve-2020-0001",
+								Vulnerability: dbTypes.Vulnerability{
+									Title:       "foobar",
+									Description: "baz",
+									Severity:    "HIGH",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantURI: "",
+			wantMsg: "app/50%/package-lock.json: foo@1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sarifWritten := bytes.NewBuffer(nil)
+			w := report.SarifWriter{Output: sarifWritten}
+
+			require.NotPanics(t, func() {
+				require.NoError(t, w.Write(t.Context(), tt.input))
+			})
+
+			result := &sarif.Report{}
+			require.NoError(t, json.Unmarshal(sarifWritten.Bytes(), result))
+			require.Len(t, result.Runs, 1)
+			require.Len(t, result.Runs[0].Results, 1)
+
+			locs := result.Runs[0].Results[0].Locations
+			require.Len(t, locs, 1)
+			assert.Equal(t, tt.wantURI, *locs[0].PhysicalLocation.ArtifactLocation.URI)
+			assert.Equal(t, tt.wantMsg, *locs[0].Message.Text)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`toUri` logs the error and returns `nil` when `url.Parse` rejects its input, but `addSarifResult` dereferenced that pointer without a check, so writing a SARIF report panicked. `url.Parse` rejects any path that contains a bare `%` (`100%.tf` -> `invalid URL escape "%.t"`), so scanning a repository that happens to contain such a file crashes `--format sarif`.

The sibling field `data.url` was already guarded a few lines above (`sarif.go:91`); this routes both conversions through a small `uriString` helper so the two are handled the same way. Behaviour for parsable URIs is unchanged.

Both call sites of `addSarifResult` were affected, the vulnerability branch (`sarif.go:160`) and the misconfiguration branch (`sarif.go:184`); the added test covers both.

### Before

`100%.tf` containing an `aws_s3_bucket` resource, then `trivy fs --scanners misconfig --format sarif .`:

```
INFO  [terraform scanner] Scanning root module  file_path="."
ERROR [sarif] Unable to parse URI  URI="100%.tf" err="parse \"100%.tf\": invalid URL escape \"%.t\""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x2debf6c]

goroutine 1 [running]:
net/url.(*URL).String(...)
	/usr/local/go/src/net/url/url.go:800 +0x2c
github.com/aquasecurity/trivy/pkg/report.(*SarifWriter).addSarifResult(...)
	pkg/report/sarif.go:103 +0x305
github.com/aquasecurity/trivy/pkg/report.(*SarifWriter).Write(...)
	pkg/report/sarif.go:184 +0x11ce
github.com/aquasecurity/trivy/pkg/report.Write(...)
	pkg/report/writer.go:111 +0xbeb
...
exit status 2
```

### After

Same command, exit code 0, valid SARIF:

```json
"locations": [
  {
    "physicalLocation": {
      "artifactLocation": {
        "uri": "",
        "uriBaseId": "ROOTPATH"
      },
      "region": {
        "startLine": 1,
        "startColumn": 1,
        "endLine": 3,
        "endColumn": 1
      }
    },
    "message": {
      "text": "100%.tf"
    }
  }
]
```

One point I would like your opinion on: an unparsable path now produces an empty `artifactLocation.uri`, and the raw path survives only in the location `message`. The alternative is to fall back to an escaped path (`&url.URL{Path: str}`, which renders `100%.tf` as `100%25.tf`) so the location is preserved. I kept the minimal change because the issue describes "log this and return nil" as the intended contract, but I am happy to switch to the fallback if you prefer it.

## Related issues
- Close #8154

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
