### PR TITLE
fix(java): read artifact properties only from the MANIFEST.MF main section

### DIFF
--- a/docs/guide/coverage/language/java.md
+++ b/docs/guide/coverage/language/java.md
@@ -24,6 +24,7 @@ See [here](./index.md) for the detail.
 
 ## JAR/WAR/PAR/EAR
 To find information about your JAR[^2] file, Trivy parses `pom.properties` and `MANIFEST.MF` files in your JAR[^2] file and takes required properties[^3].
+Only the main section of `MANIFEST.MF` is used, because the individual sections that may follow it describe single files inside the archive rather than the archive itself.
 
 If those files don't exist or don't contain enough information - Trivy will try to find this JAR[^2] file in [trivy-java-db](https://github.com/aquasecurity/trivy-java-db).
 The Java DB will be automatically downloaded/updated when any JAR[^2] file is found.

--- a/docs/guide/coverage/language/java.md
+++ b/docs/guide/coverage/language/java.md
@@ -24,7 +24,7 @@ See [here](./index.md) for the detail.
 
 ## JAR/WAR/PAR/EAR
 To find information about your JAR[^2] file, Trivy parses `pom.properties` and `MANIFEST.MF` files in your JAR[^2] file and takes required properties[^3].
-Only the main section of `MANIFEST.MF` is used, because the individual sections that may follow it describe single files inside the archive rather than the archive itself.
+Only the main section of `MANIFEST.MF` is used for artifact properties, because the individual sections that may follow it describe packages or files inside the archive rather than the archive itself.
 
 If those files don't exist or don't contain enough information - Trivy will try to find this JAR[^2] file in [trivy-java-db](https://github.com/aquasecurity/trivy-java-db).
 The Java DB will be automatically downloaded/updated when any JAR[^2] file is found.

--- a/pkg/dependency/parser/java/jar/export_test.go
+++ b/pkg/dependency/parser/java/jar/export_test.go
@@ -1,5 +1,7 @@
 package jar
 
+import "io"
+
 // Bridge to expose jar parser internals to tests in the jar_test package.
 
 var (
@@ -8,3 +10,12 @@ var (
 	IsJarLicenseFile       = isJarLicenseFile
 	ParsePluginLicenseName = parsePluginLicenseName
 )
+
+// ManifestProperties parses a MANIFEST.MF and returns the artifact properties its main section yields.
+func ManifestProperties(r io.Reader, filePath string) (Properties, error) {
+	m, err := parseManifestMainSection(r)
+	if err != nil {
+		return Properties{}, err
+	}
+	return m.properties(filePath), nil
+}

--- a/pkg/dependency/parser/java/jar/parse.go
+++ b/pkg/dependency/parser/java/jar/parse.go
@@ -618,10 +618,21 @@ func parseManifest(f *zip.File) (manifest, error) {
 	}
 	defer file.Close()
 
+	return parseManifestMainSection(file)
+}
+
+// parseManifestMainSection reads the main section of a MANIFEST.MF, which is the one describing the archive itself.
+// It ends at the first empty line; the individual sections that may follow describe single files inside the archive,
+// so their attributes say nothing about the artifact the archive ships.
+// cf. https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html#jar-manifest
+func parseManifestMainSection(r io.Reader) (manifest, error) {
 	var m manifest
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
+		if line == "" {
+			break
+		}
 
 		// Skip variables. e.g. Bundle-Name: %bundleName
 		ss := strings.Fields(line)
@@ -657,7 +668,7 @@ func parseManifest(f *zip.File) (manifest, error) {
 		}
 	}
 
-	if err = scanner.Err(); err != nil {
+	if err := scanner.Err(); err != nil {
 		return manifest{}, xerrors.Errorf("scan error: %w", err)
 	}
 	return m, nil

--- a/pkg/dependency/parser/java/jar/parse.go
+++ b/pkg/dependency/parser/java/jar/parse.go
@@ -621,13 +621,44 @@ func parseManifest(f *zip.File) (manifest, error) {
 	return parseManifestMainSection(file)
 }
 
+// scanManifestLines is a bufio.SplitFunc that splits on the newline sequences the JAR manifest grammar allows:
+// CRLF, LF and a lone CR. bufio.ScanLines handles only the first two.
+// cf. https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html#name-value-pairs-and-sections
+func scanManifestLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	for i, b := range data {
+		switch b {
+		case '\n':
+			return i + 1, data[:i], nil
+		case '\r':
+			// The CR may be the first half of a CRLF, so wait for the next byte before deciding.
+			if i+1 == len(data) && !atEOF {
+				return 0, nil, nil
+			}
+			advance = i + 1
+			if i+1 < len(data) && data[i+1] == '\n' {
+				advance++
+			}
+			return advance, data[:i], nil
+		}
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
 // parseManifestMainSection reads the main section of a MANIFEST.MF, which is the one describing the archive itself.
-// It ends at the first empty line; the individual sections that may follow describe single files inside the archive,
-// so their attributes say nothing about the artifact the archive ships.
+// It ends at the first empty line; the individual sections that may follow describe packages or files inside the archive,
+// so their attributes must not be used as archive-level artifact properties.
 // cf. https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html#jar-manifest
 func parseManifestMainSection(r io.Reader) (manifest, error) {
 	var m manifest
 	scanner := bufio.NewScanner(r)
+	scanner.Split(scanManifestLines)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {

--- a/pkg/dependency/parser/java/jar/parse_test.go
+++ b/pkg/dependency/parser/java/jar/parse_test.go
@@ -586,3 +586,77 @@ func TestIsJarLicenseFile(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		want     jar.Properties
+	}{
+		{
+			name: "main section only",
+			manifest: `Manifest-Version: 1.0
+Implementation-Title: Apache Commons Lang
+Implementation-Version: 3.17.0
+Implementation-Vendor-Id: org.apache.commons
+`,
+			want: jar.Properties{
+				GroupID:    "org.apache.commons",
+				ArtifactID: "Apache Commons Lang",
+				Version:    "3.17.0",
+				FilePath:   "commons-lang3-3.17.0.jar",
+			},
+		},
+		{
+			name: "individual sections do not override the main section",
+			manifest: `Manifest-Version: 1.0
+Implementation-Title: xercesImpl
+Implementation-Version: 2.12.2
+Implementation-Vendor-Id: xerces
+
+Name: org/apache/xerces/xni/
+Implementation-Title: org.apache.xerces.xni
+Implementation-Version: 1.2
+Implementation-Vendor-Id: org.apache.xerces
+`,
+			want: jar.Properties{
+				GroupID:    "xerces",
+				ArtifactID: "xercesImpl",
+				Version:    "2.12.2",
+				FilePath:   "xercesImpl-2.12.2.jar",
+			},
+		},
+		{
+			// The attributes describe a package inside the archive, not the archive itself,
+			// so the artifact stays unidentified and the caller falls back to another source.
+			name: "artifact attributes only in an individual section",
+			manifest: `Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.10.14
+Created-By: 22.0.2+9-70 (Oracle Corporation)
+
+Name: org/apache/tools/ant/
+Implementation-Title: org.apache.tools.ant
+Implementation-Version: 1.10.15
+Implementation-Vendor: Apache Software Foundation
+`,
+			want: jar.Properties{},
+		},
+		{
+			name:     "CRLF line endings",
+			manifest: "Manifest-Version: 1.0\r\nImplementation-Title: xercesImpl\r\nImplementation-Version: 2.12.2\r\nImplementation-Vendor-Id: xerces\r\n\r\nName: org/apache/xerces/xni/\r\nImplementation-Version: 1.2\r\n",
+			want: jar.Properties{
+				GroupID:    "xerces",
+				ArtifactID: "xercesImpl",
+				Version:    "2.12.2",
+				FilePath:   "xercesImpl-2.12.2.jar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jar.ManifestProperties(strings.NewReader(tt.manifest), tt.want.FilePath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/dependency/parser/java/jar/parse_test.go
+++ b/pkg/dependency/parser/java/jar/parse_test.go
@@ -651,6 +651,16 @@ Implementation-Vendor: Apache Software Foundation
 				FilePath:   "xercesImpl-2.12.2.jar",
 			},
 		},
+		{
+			name:     "CR line endings",
+			manifest: "Manifest-Version: 1.0\rImplementation-Title: xercesImpl\rImplementation-Version: 2.12.2\rImplementation-Vendor-Id: xerces\r\rName: org/apache/xerces/xni/\rImplementation-Version: 1.2\r",
+			want: jar.Properties{
+				GroupID:    "xerces",
+				ArtifactID: "xercesImpl",
+				Version:    "2.12.2",
+				FilePath:   "xercesImpl-2.12.2.jar",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

A `MANIFEST.MF` starts with a main section describing the archive itself, and may continue with individual sections, each introduced by a `Name:` attribute and describing a single file or package inside the archive.
The two are separated by an empty line.

`parseManifest` read the whole file, so `Implementation-*`, `Specification-*` and `Bundle-*` attributes from individual sections overwrote the values of the main section — and since assignment is unconditional, the last section in the file won.
The artifact was then identified by attributes that describe a package shipped inside the JAR rather than the JAR itself.

This PR stops the parsing at the empty line that ends the main section, as the [JAR specification](https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html#jar-manifest) defines it.
The loop body is unchanged; it moved into `parseManifestMainSection`, which takes an `io.Reader` so the section handling can be unit-tested without building a zip.

Since the section boundary is now a line, the lines have to be split the way the [manifest grammar](https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html#name-value-pairs-and-sections) defines them: it allows CRLF, LF and a lone CR, while `bufio.ScanLines` recognises only the first two.
`scanManifestLines` covers all three and stays streaming — when a CR is the last byte of the buffer it waits for the next byte instead of guessing whether a LF follows.

## Before / after

Measured on 20 popular artifacts from Maven Central.
17 of them are unaffected: their attributes are in the main section, exactly where the parser now looks.
The three that change are the ones that keep artifact attributes in individual sections:

| JAR | mode | before | after |
|---|---|---|---|
| `xercesImpl-2.12.2.jar` | online | `xerces:xercesImpl` 2.12.2 | unchanged |
| `xercesImpl-2.12.2.jar` | offline | `Apache Software Foundation:org.apache.xerces.xni` **1.2** | not identified |
| `ant-1.10.15.jar` | online | `org.apache.ant:ant` 1.10.15 | unchanged |
| `ant-1.10.15.jar` | offline | `Apache Software Foundation:org.apache.tools.ant` 1.10.15 | not identified |
| `log4j-1.2.17.jar` | online, offline | `log4j:log4j` 1.2.17 | unchanged (`pom.properties` is preferred over the manifest) |

Nothing changes online because `resolveArtifact` only trusts manifest properties once `client.Exists(groupID, artifactID)` confirms them: neither `Apache Software Foundation:org.apache.xerces.xni` nor `Apache Software Foundation:org.apache.tools.ant` is a real Maven coordinate, so the lookup by SHA-1 already took over and returned the correct artifact.

Offline the wrong values used to be reported as they were, and such a JAR is now left unidentified instead.
That is the intended trade-off: a name that matches no artifact in any repository cannot match a vulnerability either, so what disappears from the report is a fabricated component — carrying, in the `xercesImpl` case, the version of an inner package (1.2) instead of the version of the archive (2.12.2).

Jenkins `Plugin-License-Name` attributes are main-section attributes and keep working.

## Tests

`TestManifestProperties` covers the main section alone, an individual section that must not override it, artifact attributes present only in an individual section, and CRLF and CR-only line endings.
Four of the five cases fail on current `main`.

## Related issues

Split out of #10948, where it came up in review.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

