### PR TITLE
fix(vex): avoid panic on CSAF relationships without a sub-component

### DIFF
--- a/pkg/vex/csaf.go
+++ b/pkg/vex/csaf.go
@@ -92,6 +92,13 @@ func (v *CSAF) matchProduct(productID csaf.ProductID, product *core.Component) b
 func (v *CSAF) matchRelationship(fullProductID csaf.ProductID, product, subProduct *core.Component) (
 	csaf.RelationshipCategory, bool) {
 
+	// A relationship describes a sub-component within a product, so it can only match
+	// when a sub-component is given. The leaf component is first evaluated on its own,
+	// with no sub-component.
+	if subProduct == nil {
+		return "", false
+	}
+
 	for category, relationships := range v.inspectProductRelationships(fullProductID) {
 		for _, rel := range relationships {
 			if !rel.Product.Match(product.PkgIdentifier.PURL) {

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -184,6 +184,14 @@ var (
 		InstalledVersion: goTransitivePackage.Version,
 		PkgIdentifier:    goTransitivePackage.Identifier,
 	}
+	// The same vulnerability as vuln5, but detected on go-direct1, which is the
+	// product a CSAF relationship relates to rather than its sub-component.
+	vuln6 = types.DetectedVulnerability{
+		VulnerabilityID:  "CVE-2024-0001",
+		PkgName:          goDirectPackage1.Name,
+		InstalledVersion: goDirectPackage1.Version,
+		PkgIdentifier:    goDirectPackage1.Identifier,
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -537,6 +545,31 @@ func TestFilter(t *testing.T) {
 			want: imageReport([]types.Result{
 				goMultiPathResult(types.Result{
 					Vulnerabilities: []types.DetectedVulnerability{vuln5}, // Will not be filtered because of multi paths
+				}),
+			}),
+		},
+		{
+			name: "CSAF with relationships, vulnerability on the related product",
+			args: args{
+				// The statement covers go-transitive as a component of go-direct1,
+				// while the vulnerability is detected on go-direct1 itself.
+				report: imageReport([]types.Result{
+					goSinglePathResult(types.Result{
+						Vulnerabilities: []types.DetectedVulnerability{vuln6},
+					}),
+				}),
+				opts: vex.Options{
+					Sources: []vex.Source{
+						{
+							Type:     vex.TypeFile,
+							FilePath: "testdata/csaf-relationships.json",
+						},
+					},
+				},
+			},
+			want: imageReport([]types.Result{
+				goSinglePathResult(types.Result{
+					Vulnerabilities: []types.DetectedVulnerability{vuln6}, // The statement doesn't apply to the product itself
 				}),
 			}),
 		},


### PR DESCRIPTION
## Description

Scanning with a CSAF VEX document crashes with a nil pointer panic when the document declares a relationship and the vulnerability is detected on the product that relationship relates to.

`reachRoot` evaluates the leaf component on its own before walking up to the root, and passes a nil sub-component:

```go
// pkg/vex/vex.go
if notAffected(leaf, nil) {
	return false
}
```

`matchRelationship` dereferenced that argument without a check:

```go
// pkg/vex/csaf.go
if subProductPURL.Match(subProduct.PkgIdentifier.PURL) {
```

So as soon as a relationship's `relates_to_product_reference` resolves to a PURL that matches a vulnerable component, the scan segfaults. `OpenVEX.Matches` already guards the same argument; CSAF did not.

A relationship describes a sub-component within a product, so it cannot match when no sub-component is given. This returns early in that case, which leaves the existing matching behaviour untouched.

The panic aborts the whole scan with exit code 2, and crashes programs that embed Trivy as a library.

There is no associated issue. The fix is small and self-contained, so per the contributing guide I'm including the justification here instead.

### Reproduction

A CycloneDX SBOM with `github.com/gogo/protobuf@v1.3.1` (CVE-2021-3121) and a child component, plus a CSAF document that puts the child inside protobuf:

```json
"relationships": [
  {
    "category": "default_component_of",
    "product_reference": "leaf-v0.1.0",
    "relates_to_product_reference": "protobuf-v1.3.1",
    "full_product_name": {
      "product_id": "protobuf-v1.3.1-leaf-v0.1.0",
      "name": "leaf as a component of protobuf"
    }
  }
],
"vulnerabilities": [
  {
    "cve": "CVE-2021-3121",
    "product_status": {
      "known_not_affected": ["protobuf-v1.3.1-leaf-v0.1.0"]
    }
  }
]
```

### Before

```console
$ trivy sbom sbom.json --scanners vuln --vex csaf-vex.json
2026-08-10T22:26:52+05:30	INFO	[gobinary] Detecting vulnerabilities...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb0]

goroutine 1 [running]:
github.com/aquasecurity/trivy/pkg/vex.(*CSAF).matchRelationship(...)
	pkg/vex/csaf.go:101
github.com/aquasecurity/trivy/pkg/vex.(*CSAF).match(...)
	pkg/vex/csaf.go:73
github.com/aquasecurity/trivy/pkg/vex.(*CSAF).NotAffected(...)
	pkg/vex/csaf.go:44
github.com/aquasecurity/trivy/pkg/vex.(*Client).NotAffected(...)
	pkg/vex/vex.go:141
github.com/aquasecurity/trivy/pkg/vex.reachRoot(...)
	pkg/vex/vex.go:181
github.com/aquasecurity/trivy/pkg/vex.filterVulnerabilities(...)
	pkg/vex/vex.go:153
...
$ echo $?
2
```

### After

The scan completes, and the vulnerability on protobuf is still reported, since the statement covers the child as a component of protobuf and not protobuf itself:

```console
$ trivy sbom sbom.json --scanners vuln --vex csaf-vex.json
 (gobinary)
===========
Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┐
│         Library          │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │
├──────────────────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┤
│ github.com/gogo/protobuf │ CVE-2021-3121 │ HIGH     │ fixed  │ v1.3.1            │ 1.3.2         │
└──────────────────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┘
$ echo $?
0
```

Relationship filtering itself is unchanged. With the same SBOM shape inverted, so that protobuf is the sub-component of a parent module, the statement still suppresses the finding:

```console
$ trivy sbom sbom2.json --scanners vuln --vex csaf-vex2.json
INFO	[vex] Filtered out the detected vulnerability	format="CSAF" vulnerability-id="CVE-2021-3121" product-id="parent-v0.1.0-protobuf-v1.3.1" status="not_affected" relationship="default_component_of"
```

## Related issues

N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (not needed).
- [ ] I've added usage information (no new options).
- [x] I've included a "before" and "after" example to the description (included above).
