### PR TITLE
feat(redis): allow overriding TLS server name

### DIFF
--- a/docs/guide/configuration/cache.md
+++ b/docs/guide/configuration/cache.md
@@ -96,6 +96,14 @@ $ trivy server --cache-backend redis://localhost:6379 \
   --redis-key /path/to/key.pem
 ```
 
+If the TLS certificate's server name (as verified during the TLS handshake) doesn't match the hostname you connect to,
+for example when connecting through an SSH tunnel, load balancer, or IP address, override it with `--redis-tls-server-name`.
+
+```
+$ trivy server --cache-backend redis://localhost:6379 --redis-tls \
+  --redis-tls-server-name redis.example.com
+```
+
 [trivy-db]: ./db.md
 [trivy-java-db]: ./db.md
 [misconf-checks]: ../scanner/misconfiguration/check/builtin.md

--- a/docs/guide/references/configuration/cli/trivy_config.md
+++ b/docs/guide/references/configuration/cli/trivy_config.md
@@ -60,6 +60,7 @@ trivy config [flags] DIR
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform,ansible)

--- a/docs/guide/references/configuration/cli/trivy_filesystem.md
+++ b/docs/guide/references/configuration/cli/trivy_filesystem.md
@@ -108,6 +108,7 @@ trivy filesystem [flags] PATH
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/docs/guide/references/configuration/cli/trivy_image.md
+++ b/docs/guide/references/configuration/cli/trivy_image.md
@@ -129,6 +129,7 @@ trivy image [flags] IMAGE_NAME
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/docs/guide/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/guide/references/configuration/cli/trivy_kubernetes.md
@@ -120,6 +120,7 @@ trivy kubernetes [flags] [CONTEXT]
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/docs/guide/references/configuration/cli/trivy_repository.md
+++ b/docs/guide/references/configuration/cli/trivy_repository.md
@@ -107,6 +107,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/docs/guide/references/configuration/cli/trivy_rootfs.md
+++ b/docs/guide/references/configuration/cli/trivy_rootfs.md
@@ -110,6 +110,7 @@ trivy rootfs [flags] ROOTDIR
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string             registry token
       --rego-error-limit int              maximum number of compile errors allowed during Rego policy evaluation (default 10)
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/docs/guide/references/configuration/cli/trivy_sbom.md
+++ b/docs/guide/references/configuration/cli/trivy_sbom.md
@@ -84,6 +84,7 @@ trivy sbom [flags] SBOM_PATH
       --redis-cert string              redis certificate file location, if using redis as cache backend
       --redis-key string               redis key file location, if using redis as cache backend
       --redis-tls                      enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string   redis TLS server name to verify against, if using redis as cache backend over TLS
       --registry-token string          registry token
       --rekor-url string               [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sbom-sources strings           [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)

--- a/docs/guide/references/configuration/cli/trivy_server.md
+++ b/docs/guide/references/configuration/cli/trivy_server.md
@@ -20,26 +20,27 @@ trivy server [flags]
 ### Options
 
 ```
-      --cache-backend string     [EXPERIMENTAL] cache backend (e.g. redis://localhost:6379) (default "fs")
-      --cache-ttl duration       cache TTL when using redis as cache backend
-      --db-repository strings    OCI repository(ies) to retrieve trivy-db in order of priority (default [mirror.gcr.io/aquasec/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2])
-      --download-db-only         download/update vulnerability database but don't run a scan
-      --enable-modules strings   [EXPERIMENTAL] module names to enable
-  -h, --help                     help for server
-      --listen string            listen address in server mode (default "localhost:4954")
-      --module-dir string        specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
-      --no-progress              suppress progress bar
-      --password strings         password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
-      --password-stdin           password from stdin. Comma-separated passwords are not supported.
-      --redis-ca string          redis ca file location, if using redis as cache backend
-      --redis-cert string        redis certificate file location, if using redis as cache backend
-      --redis-key string         redis key file location, if using redis as cache backend
-      --redis-tls                enable redis TLS with public certificates, if using redis as cache backend
-      --registry-token string    registry token
-      --skip-db-update           skip updating vulnerability database
-      --token string             for authentication in client/server mode
-      --token-header string      specify a header name for token in client/server mode (default "Trivy-Token")
-      --username strings         username. Comma-separated usernames allowed.
+      --cache-backend string           [EXPERIMENTAL] cache backend (e.g. redis://localhost:6379) (default "fs")
+      --cache-ttl duration             cache TTL when using redis as cache backend
+      --db-repository strings          OCI repository(ies) to retrieve trivy-db in order of priority (default [mirror.gcr.io/aquasec/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2])
+      --download-db-only               download/update vulnerability database but don't run a scan
+      --enable-modules strings         [EXPERIMENTAL] module names to enable
+  -h, --help                           help for server
+      --listen string                  listen address in server mode (default "localhost:4954")
+      --module-dir string              specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
+      --no-progress                    suppress progress bar
+      --password strings               password. Comma-separated passwords allowed. TRIVY_PASSWORD should be used for security reasons.
+      --password-stdin                 password from stdin. Comma-separated passwords are not supported.
+      --redis-ca string                redis ca file location, if using redis as cache backend
+      --redis-cert string              redis certificate file location, if using redis as cache backend
+      --redis-key string               redis key file location, if using redis as cache backend
+      --redis-tls                      enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string   redis TLS server name to verify against, if using redis as cache backend over TLS
+      --registry-token string          registry token
+      --skip-db-update                 skip updating vulnerability database
+      --token string                   for authentication in client/server mode
+      --token-header string            specify a header name for token in client/server mode (default "Trivy-Token")
+      --username strings               username. Comma-separated usernames allowed.
 ```
 
 ### Options inherited from parent commands

--- a/docs/guide/references/configuration/cli/trivy_vm.md
+++ b/docs/guide/references/configuration/cli/trivy_vm.md
@@ -100,6 +100,7 @@ trivy vm [flags] VM_IMAGE
       --redis-cert string                 redis certificate file location, if using redis as cache backend
       --redis-key string                  redis key file location, if using redis as cache backend
       --redis-tls                         enable redis TLS with public certificates, if using redis as cache backend
+      --redis-tls-server-name string      redis TLS server name to verify against, if using redis as cache backend over TLS
       --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform,ansible)
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -49,6 +49,9 @@ cache:
     # Same as '--redis-tls'
     tls: false
 
+    # Same as '--redis-tls-server-name'
+    tlsServerName: ""
+
   # Same as '--cache-ttl'
   ttl: 0s
 

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -19,13 +19,14 @@ const (
 type Type string
 
 type Options struct {
-	Backend     string
-	CacheDir    string
-	RedisCACert string
-	RedisCert   string
-	RedisKey    string
-	RedisTLS    bool
-	TTL         time.Duration
+	Backend            string
+	CacheDir           string
+	RedisCACert        string
+	RedisCert          string
+	RedisKey           string
+	RedisTLS           bool
+	RedisTLSServerName string
+	TTL                time.Duration
 }
 
 func NewType(backend string) Type {
@@ -52,7 +53,7 @@ func New(opts Options) (Cache, func(), error) {
 	log.Debug("Initializing scan cache...", log.String("type", string(t)))
 	switch t {
 	case TypeRedis:
-		redisCache, err := NewRedisCache(opts.Backend, opts.RedisCACert, opts.RedisCert, opts.RedisKey, opts.RedisTLS, opts.TTL)
+		redisCache, err := NewRedisCache(opts.Backend, opts.RedisCACert, opts.RedisCert, opts.RedisKey, opts.RedisTLSServerName, opts.RedisTLS, opts.TTL)
 		if err != nil {
 			return nil, cleanup, xerrors.Errorf("unable to initialize redis cache: %w", err)
 		}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/redis/go-redis/v9"
-	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
@@ -29,8 +28,8 @@ type RedisOptions struct {
 	TLSOptions RedisTLSOptions
 }
 
-func NewRedisOptions(backend, caCert, cert, key string, enableTLS bool) (RedisOptions, error) {
-	tlsOpts, err := NewRedisTLSOptions(caCert, cert, key)
+func NewRedisOptions(backend, caCert, cert, key, tlsServerName string, enableTLS bool) (RedisOptions, error) {
+	tlsOpts, err := NewRedisTLSOptions(caCert, cert, key, tlsServerName)
 	if err != nil {
 		return RedisOptions{}, xerrors.Errorf("redis TLS option error: %w", err)
 	}
@@ -56,20 +55,22 @@ func (o *RedisOptions) BackendMasked() string {
 
 // RedisTLSOptions holds the options for redis cache
 type RedisTLSOptions struct {
-	CACert string
-	Cert   string
-	Key    string
+	CACert     string
+	Cert       string
+	Key        string
+	ServerName string
 }
 
-func NewRedisTLSOptions(caCert, cert, key string) (RedisTLSOptions, error) {
+func NewRedisTLSOptions(caCert, cert, key, serverName string) (RedisTLSOptions, error) {
 	opts := RedisTLSOptions{
-		CACert: caCert,
-		Cert:   cert,
-		Key:    key,
+		CACert:     caCert,
+		Cert:       cert,
+		Key:        key,
+		ServerName: serverName,
 	}
 
-	// If one of redis option not nil, make sure CA, cert, and key provided
-	if !lo.IsEmpty(opts) {
+	// If one of redis CA/cert/key option not nil, make sure CA, cert, and key provided
+	if opts.CACert != "" || opts.Cert != "" || opts.Key != "" {
 		if opts.CACert == "" || opts.Cert == "" || opts.Key == "" {
 			return RedisTLSOptions{}, xerrors.Errorf("you must provide Redis CA, cert and key file path when using TLS")
 		}
@@ -82,8 +83,8 @@ type RedisCache struct {
 	expiration time.Duration
 }
 
-func NewRedisCache(backend, caCertPath, certPath, keyPath string, enableTLS bool, ttl time.Duration) (RedisCache, error) {
-	opts, err := NewRedisOptions(backend, caCertPath, certPath, keyPath, enableTLS)
+func NewRedisCache(backend, caCertPath, certPath, keyPath, tlsServerName string, enableTLS bool, ttl time.Duration) (RedisCache, error) {
+	opts, err := NewRedisOptions(backend, caCertPath, certPath, keyPath, tlsServerName, enableTLS)
 	if err != nil {
 		return RedisCache{}, xerrors.Errorf("failed to create Redis options: %w", err)
 	}
@@ -94,7 +95,8 @@ func NewRedisCache(backend, caCertPath, certPath, keyPath string, enableTLS bool
 		return RedisCache{}, xerrors.Errorf("failed to parse Redis URL: %w", err)
 	}
 
-	if tlsOpts := opts.TLSOptions; !lo.IsEmpty(tlsOpts) {
+	tlsOpts := opts.TLSOptions
+	if tlsOpts.CACert != "" || tlsOpts.Cert != "" || tlsOpts.Key != "" {
 		caCert, cert, err := GetTLSConfig(tlsOpts.CACert, tlsOpts.Cert, tlsOpts.Key)
 		if err != nil {
 			return RedisCache{}, xerrors.Errorf("failed to get TLS config: %w", err)
@@ -104,10 +106,12 @@ func NewRedisCache(backend, caCertPath, certPath, keyPath string, enableTLS bool
 			RootCAs:      caCert,
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
+			ServerName:   tlsOpts.ServerName,
 		}
 	} else if opts.TLS {
 		options.TLSConfig = &tls.Config{
 			MinVersion: tls.VersionTLS12,
+			ServerName: tlsOpts.ServerName,
 		}
 	}
 	return RedisCache{

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -66,7 +66,7 @@ func TestRedisCache_PutArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			err = c.PutArtifact(t.Context(), tt.args.artifactID, tt.args.artifactConfig)
@@ -152,7 +152,7 @@ func TestRedisCache_PutBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			err = c.PutBlob(t.Context(), tt.args.blobID, tt.args.blobConfig)
@@ -234,7 +234,7 @@ func TestRedisCache_GetArtifact(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			got, err := c.GetArtifact(t.Context(), tt.artifactID)
@@ -324,7 +324,7 @@ func TestRedisCache_GetBlob(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			got, err := c.GetBlob(t.Context(), tt.blobID)
@@ -433,7 +433,7 @@ func TestRedisCache_MissingBlobs(t *testing.T) {
 				addr = "dummy:6379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			missingArtifact, missingBlobIDs, err := c.MissingBlobs(t.Context(), tt.args.artifactID, tt.args.blobIDs)
@@ -456,7 +456,7 @@ func TestRedisCache_Close(t *testing.T) {
 	defer s.Close()
 
 	t.Run("close", func(t *testing.T) {
-		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", false, 0)
+		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", "", false, 0)
 		require.NoError(t, err)
 
 		closeErr := c.Close()
@@ -478,7 +478,7 @@ func TestRedisCache_Clear(t *testing.T) {
 	s.Set("foo", "bar")
 
 	t.Run("clear", func(t *testing.T) {
-		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", false, 0)
+		c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", s.Addr()), "", "", "", "", false, 0)
 		require.NoError(t, err)
 
 		require.NoError(t, c.Clear(t.Context()))
@@ -530,7 +530,7 @@ func TestRedisCache_DeleteBlobs(t *testing.T) {
 				addr = "dummy:16379"
 			}
 
-			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", false, 0)
+			c, err := cache.NewRedisCache(fmt.Sprintf("redis://%s", addr), "", "", "", "", false, 0)
 			require.NoError(t, err)
 
 			s.Set(tt.wantKey, "any string")

--- a/pkg/flag/cache_flags.go
+++ b/pkg/flag/cache_flags.go
@@ -54,6 +54,11 @@ var (
 		ConfigName: "cache.redis.key",
 		Usage:      "redis key file location, if using redis as cache backend",
 	}
+	RedisTLSServerNameFlag = Flag[string]{
+		Name:       "redis-tls-server-name",
+		ConfigName: "cache.redis.tlsServerName",
+		Usage:      "redis TLS server name to verify against, if using redis as cache backend over TLS",
+	}
 )
 
 // CacheFlagGroup composes common printer flag structs used for commands requiring cache logic.
@@ -62,33 +67,36 @@ type CacheFlagGroup struct {
 	CacheBackend *Flag[string]
 	CacheTTL     *Flag[time.Duration]
 
-	RedisTLS    *Flag[bool]
-	RedisCACert *Flag[string]
-	RedisCert   *Flag[string]
-	RedisKey    *Flag[string]
+	RedisTLS           *Flag[bool]
+	RedisCACert        *Flag[string]
+	RedisCert          *Flag[string]
+	RedisKey           *Flag[string]
+	RedisTLSServerName *Flag[string]
 }
 
 type CacheOptions struct {
 	ClearCache bool
 
-	CacheBackend string
-	CacheTTL     time.Duration
-	RedisTLS     bool
-	RedisCACert  string
-	RedisCert    string
-	RedisKey     string
+	CacheBackend       string
+	CacheTTL           time.Duration
+	RedisTLS           bool
+	RedisCACert        string
+	RedisCert          string
+	RedisKey           string
+	RedisTLSServerName string
 }
 
 // NewCacheFlagGroup returns a default CacheFlagGroup
 func NewCacheFlagGroup() *CacheFlagGroup {
 	return &CacheFlagGroup{
-		ClearCache:   ClearCacheFlag.Clone(),
-		CacheBackend: CacheBackendFlag.Clone(),
-		CacheTTL:     CacheTTLFlag.Clone(),
-		RedisTLS:     RedisTLSFlag.Clone(),
-		RedisCACert:  RedisCACertFlag.Clone(),
-		RedisCert:    RedisCertFlag.Clone(),
-		RedisKey:     RedisKeyFlag.Clone(),
+		ClearCache:         ClearCacheFlag.Clone(),
+		CacheBackend:       CacheBackendFlag.Clone(),
+		CacheTTL:           CacheTTLFlag.Clone(),
+		RedisTLS:           RedisTLSFlag.Clone(),
+		RedisCACert:        RedisCACertFlag.Clone(),
+		RedisCert:          RedisCertFlag.Clone(),
+		RedisKey:           RedisKeyFlag.Clone(),
+		RedisTLSServerName: RedisTLSServerNameFlag.Clone(),
 	}
 }
 
@@ -105,18 +113,20 @@ func (fg *CacheFlagGroup) Flags() []Flagger {
 		fg.RedisCACert,
 		fg.RedisCert,
 		fg.RedisKey,
+		fg.RedisTLSServerName,
 	}
 }
 
 func (fg *CacheFlagGroup) ToOptions(opts *Options) error {
 	opts.CacheOptions = CacheOptions{
-		ClearCache:   fg.ClearCache.Value(),
-		CacheBackend: fg.CacheBackend.Value(),
-		CacheTTL:     fg.CacheTTL.Value(),
-		RedisTLS:     fg.RedisTLS.Value(),
-		RedisCACert:  fg.RedisCACert.Value(),
-		RedisCert:    fg.RedisCert.Value(),
-		RedisKey:     fg.RedisKey.Value(),
+		ClearCache:         fg.ClearCache.Value(),
+		CacheBackend:       fg.CacheBackend.Value(),
+		CacheTTL:           fg.CacheTTL.Value(),
+		RedisTLS:           fg.RedisTLS.Value(),
+		RedisCACert:        fg.RedisCACert.Value(),
+		RedisCert:          fg.RedisCert.Value(),
+		RedisKey:           fg.RedisKey.Value(),
+		RedisTLSServerName: fg.RedisTLSServerName.Value(),
 	}
 	return nil
 }

--- a/pkg/flag/options.go
+++ b/pkg/flag/options.go
@@ -559,13 +559,14 @@ func (o *Options) FilterOpts() result.FilterOptions {
 // CacheOpts returns options for scan cache
 func (o *Options) CacheOpts() cache.Options {
 	return cache.Options{
-		Backend:     o.CacheBackend,
-		CacheDir:    o.CacheDir,
-		RedisCACert: o.RedisCACert,
-		RedisCert:   o.RedisCert,
-		RedisKey:    o.RedisKey,
-		RedisTLS:    o.RedisTLS,
-		TTL:         o.CacheTTL,
+		Backend:            o.CacheBackend,
+		CacheDir:           o.CacheDir,
+		RedisCACert:        o.RedisCACert,
+		RedisCert:          o.RedisCert,
+		RedisKey:           o.RedisKey,
+		RedisTLS:           o.RedisTLS,
+		RedisTLSServerName: o.RedisTLSServerName,
+		TTL:                o.CacheTTL,
 	}
 }
 

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -54,6 +54,10 @@
             "key": {
               "type": "string",
               "description": "redis key file location, if using redis as cache backend"
+            },
+            "tlsServerName": {
+              "type": "string",
+              "description": "redis TLS server name to verify against, if using redis as cache backend over TLS"
             }
           }
         }


### PR DESCRIPTION
## Description
this PR allows overriding the server name used to verify TLS connections

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
