### PR TITLE
fix(nodejs): derive Bun package name and version from the identifier

### DIFF
--- a/pkg/dependency/parser/nodejs/bun/parse.go
+++ b/pkg/dependency/parser/nodejs/bun/parse.go
@@ -101,11 +101,15 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		devDirectDeps.Append(lo.Keys(ws.DevDependencies)...)
 	}
 	for pkgName, parsed := range lockFile.Packages {
-		pkgVersion := strings.TrimPrefix(parsed.Identifier, pkgName+"@")
+		// The map key is an install path, which for deduped/nested dependencies
+		// is "parent/child" (e.g. "glob/minimatch") rather than the package name.
+		// The real name and version live in the identifier ("minimatch@9.0.5"),
+		// so derive them from there instead of trimming the key.
+		name, pkgVersion := splitIdentifier(parsed.Identifier)
 		if strings.HasPrefix(pkgVersion, "workspace") {
 			pkgVersion = lockFile.Workspaces[pkgName].Version
 		}
-		pkgId := packageID(pkgName, pkgVersion)
+		pkgId := packageID(name, pkgVersion)
 		isDirect := prodDirectDeps.Contains(pkgName) || devDirectDeps.Contains(pkgName)
 
 		relationship := ftypes.RelationshipIndirect
@@ -117,7 +121,7 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 
 		newPkg := ftypes.Package{
 			ID:           pkgId,
-			Name:         pkgName,
+			Name:         name,
 			Version:      pkgVersion,
 			Relationship: relationship,
 			Dev:          true, // Mark all dependencies as Dev. We will handle them later.
@@ -181,6 +185,21 @@ func walkProdPackages(pkgName string, pkgs map[string]ftypes.Package, deps map[s
 	for _, dep := range deps[pkgName] {
 		walkProdPackages(dep, pkgs, deps, visited)
 	}
+}
+
+// splitIdentifier splits a bun lockfile package identifier ("name@version")
+// into its name and version. The version can itself contain "@" (e.g. the git
+// dependency "adm-zip@git+ssh://git@github.com/..."), so it splits at the first
+// "@" after an optional leading "@" of a scoped name ("@types/node@22.15.18").
+func splitIdentifier(identifier string) (name, version string) {
+	start := 0
+	if strings.HasPrefix(identifier, "@") {
+		start = 1
+	}
+	if i := strings.IndexByte(identifier[start:], '@'); i >= 0 {
+		return identifier[:start+i], identifier[start+i+1:]
+	}
+	return identifier, ""
 }
 
 func packageID(name, version string) string {

--- a/pkg/dependency/parser/nodejs/bun/parse_test.go
+++ b/pkg/dependency/parser/nodejs/bun/parse_test.go
@@ -35,6 +35,11 @@ func TestParse(t *testing.T) {
 			want:     multipleWsPkgs,
 			wantDeps: multipleWsDeps,
 		},
+		{
+			name: "nested deduped package",
+			file: "testdata/bun_nested.lock",
+			want: nestedPkgs,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/bun/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/bun/parse_testcase.go
@@ -157,4 +157,45 @@ var (
 	}
 
 	multipleWsDeps = []ftypes.Dependency(nil)
+	nestedPkgs     = []ftypes.Package{
+		{
+			ID:           "adm-zip@git+ssh://git@github.com/cthackers/adm-zip.git#ff17ae85000b62b9d159e2520564902724d26c17",
+			Name:         "adm-zip",
+			Version:      "git+ssh://git@github.com/cthackers/adm-zip.git#ff17ae85000b62b9d159e2520564902724d26c17",
+			Relationship: ftypes.RelationshipDirect,
+			Dev:          false,
+			Locations: ftypes.Locations{
+				{
+					StartLine: 13,
+					EndLine:   13,
+				},
+			},
+		},
+		{
+			ID:           "glob@10.4.5",
+			Name:         "glob",
+			Version:      "10.4.5",
+			Relationship: ftypes.RelationshipDirect,
+			Dev:          false,
+			Locations: ftypes.Locations{
+				{
+					StartLine: 15,
+					EndLine:   15,
+				},
+			},
+		},
+		{
+			ID:           "minimatch@9.0.5",
+			Name:         "minimatch",
+			Version:      "9.0.5",
+			Relationship: ftypes.RelationshipIndirect,
+			Dev:          true,
+			Locations: ftypes.Locations{
+				{
+					StartLine: 17,
+					EndLine:   17,
+				},
+			},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/bun/testdata/bun_nested.lock
+++ b/pkg/dependency/parser/nodejs/bun/testdata/bun_nested.lock
@@ -1,0 +1,19 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "app",
+      "dependencies": {
+        "adm-zip": "git+ssh://git@github.com/cthackers/adm-zip.git",
+        "glob": "^10.0.0",
+      },
+    },
+  },
+  "packages": {
+    "adm-zip": ["adm-zip@git+ssh://git@github.com/cthackers/adm-zip.git#ff17ae85000b62b9d159e2520564902724d26c17", {}, "ff17ae85000b62b9d159e2520564902724d26c17"],
+
+    "glob": ["glob@10.4.5", "", {}, "sha512-6AL3ijMuTydpNW6a5kwwyR/pcHrJU9EQ5g5rAlJqjE1sJVGjNZ4nZ8Ryn/4tXBhLGr7NzZQBBAP07Xj4c1cXQ=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", {}, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+  }
+}


### PR DESCRIPTION
## Description

For deduped/nested dependencies, bun keys the `packages` map by an install path (`"parent/child"`, e.g. `"glob/minimatch"`) rather than the package name, while the entry identifier holds the real `name@version` (`"minimatch@9.0.5"`). This is bun's own dedupe format — see `oven-sh/bun`'s `test/integration/next-pages/bun.lock`, which contains entries such as `"glob/minimatch": ["minimatch@9.0.5", ...]` and `"eslint-import-resolver-node/debug": ["debug@3.2.7", ...]`.

`Parser.Parse` derived the version by trimming `<key>@` from the identifier and used the key as the name. For a nested key that prefix never matches, so the package came out as:

- Name: `glob/minimatch`
- Version: `minimatch@9.0.5`
- ID: `glob/minimatch@minimatch@9.0.5`

instead of `minimatch` / `9.0.5`. No advisory is keyed on that mangled name/version, so vulnerabilities in nested/deduped packages (there are dozens in a typical project — `minimatch`, `debug`, `semver`, `glob-parent`, ...) are silently missed.

## Fix

Derive both the name and the version from the identifier, splitting at the first `@` after an optional leading `@` of a scoped name. This keeps working for scoped names (`@types/node@22.15.18`) and for git/URL versions that themselves contain `@` (`adm-zip@git+ssh://git@github.com/...`), which a naive "last `@`" split would break.

## Tests

Added `testdata/bun_nested.lock` with a nested `glob/minimatch` entry and a `TestParse` case. Reverting only the parser change makes it fail with the mangled `glob/minimatch` / `minimatch@9.0.5` package; with the fix it reports `minimatch` / `9.0.5`. The fixture also includes a git dependency whose version contains `@` to confirm that case is unaffected. Existing fixtures only use flat, scoped, and workspace keys, so they are unaffected.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
