### PR TITLE
fix(misconf): parse Azure flexible server parameters under their own names

### DIFF
--- a/pkg/iac/adapters/terraform/azure/database/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/database/adapt_test.go
@@ -229,10 +229,16 @@ func Test_Adapt(t *testing.T) {
 				value     = "ON"
 			  }
 
-			  resource "azurerm_postgresql_flexible_server_configuration" "tls_version" {
-				name      = "tls_version"
+			  resource "azurerm_postgresql_flexible_server_configuration" "ssl_min_protocol_version" {
+				name      = "ssl_min_protocol_version"
 				server_id = azurerm_postgresql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
+			  }
+
+			  resource "azurerm_postgresql_flexible_server_configuration" "connection_throttle" {
+				name      = "connection_throttle.enable"
+				server_id = azurerm_postgresql_flexible_server.example.id
+				value     = "on"
 			  }
 
 			  resource "azurerm_postgresql_flexible_server_configuration" "log_connections" {
@@ -269,8 +275,9 @@ func Test_Adapt(t *testing.T) {
 							},
 						},
 						Config: database.PostgresSQLConfig{
-							LogConnections: iacTypes.BoolTest(true),
-							LogCheckpoints: iacTypes.BoolTest(true),
+							LogConnections:       iacTypes.BoolTest(true),
+							LogCheckpoints:       iacTypes.BoolTest(true),
+							ConnectionThrottling: iacTypes.BoolTest(true),
 						},
 						// Threat Detection is not configurable via Terraform for PostgreSQL Flexible Server
 						// It can only be configured via Azure CLI, so it's marked as unmanaged
@@ -280,7 +287,7 @@ func Test_Adapt(t *testing.T) {
 			},
 		},
 		{
-			name: "postgresql flexible server with configuration resources",
+			name: "postgresql flexible server with insecure parameters",
 			terraform: `
 			resource "azurerm_postgresql_flexible_server" "example" {
 				name                = "example-flexible"
@@ -298,13 +305,41 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_postgresql_flexible_server_configuration" "require_secure_transport" {
 				name      = "require_secure_transport"
 				server_id = azurerm_postgresql_flexible_server.example.id
-				value     = "ON"
+				value     = "OFF"
 			  }
 
-			  resource "azurerm_postgresql_flexible_server_configuration" "tls_version" {
-				name      = "tls_version"
+			  resource "azurerm_postgresql_flexible_server_configuration" "ssl_min_protocol_version" {
+				name      = "ssl_min_protocol_version"
 				server_id = azurerm_postgresql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.1"
+			  }
+			`,
+			expected: database.Database{
+				PostgreSQLServers: []database.PostgreSQLServer{
+					{
+						Server: database.Server{
+							EnableSSLEnforcement:      iacTypes.BoolTest(false),
+							MinimumTLSVersion:         iacTypes.StringTest("TLS1_1"),
+							EnablePublicNetworkAccess: iacTypes.BoolTest(true),
+							FirewallRules: []database.FirewallRule{
+								{
+									StartIP: iacTypes.StringTest("40.112.8.12"),
+									EndIP:   iacTypes.StringTest("40.112.8.12"),
+								},
+							},
+						},
+						// Threat Detection is not configurable via Terraform for PostgreSQL Flexible Server
+						// It can only be configured via Azure CLI, so it's marked as unmanaged
+						ThreatDetectionPolicy: database.ThreatDetectionPolicy{},
+					},
+				},
+			},
+		},
+		{
+			name: "postgresql flexible server without configuration resources",
+			terraform: `
+			resource "azurerm_postgresql_flexible_server" "example" {
+				name = "example-flexible"
 			  }
 			`,
 			expected: database.Database{
@@ -314,17 +349,7 @@ func Test_Adapt(t *testing.T) {
 							EnableSSLEnforcement:      iacTypes.BoolTest(true),
 							MinimumTLSVersion:         iacTypes.StringTest("TLS1_2"),
 							EnablePublicNetworkAccess: iacTypes.BoolTest(true),
-							FirewallRules: []database.FirewallRule{
-								{
-									StartIP: iacTypes.StringTest("40.112.8.12"),
-									EndIP:   iacTypes.StringTest("40.112.8.12"),
-								},
-							},
 						},
-						Config: database.PostgresSQLConfig{},
-						// Threat Detection is not configurable via Terraform for PostgreSQL Flexible Server
-						// It can only be configured via Azure CLI, so it's marked as unmanaged
-						ThreatDetectionPolicy: database.ThreatDetectionPolicy{},
 					},
 				},
 			},
@@ -354,7 +379,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_mysql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_mysql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
 			  }
 
 			  resource "azurerm_mysql_flexible_server_configuration" "interactive_timeout" {
@@ -382,7 +407,7 @@ func Test_Adapt(t *testing.T) {
 			},
 		},
 		{
-			name: "mysql flexible server with configuration resources",
+			name: "mysql flexible server with a list of TLS versions",
 			terraform: `
 			resource "azurerm_mysql_flexible_server" "example" {
 				name                = "example-flexible"
@@ -406,7 +431,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_mysql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_mysql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2,TLSv1.3"
 			  }
 			`,
 			expected: database.Database{

--- a/pkg/iac/adapters/terraform/azure/database/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/database/adapt_test.go
@@ -431,7 +431,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_mysql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_mysql_flexible_server.example.id
-				value     = "TLSv1.2,TLSv1.3"
+				value     = "TLSv1.3,TLSv1.2"
 			  }
 			`,
 			expected: database.Database{

--- a/pkg/iac/adapters/terraform/azure/database/common.go
+++ b/pkg/iac/adapters/terraform/azure/database/common.go
@@ -59,7 +59,12 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 func minimumTLSVersion(val string) string {
 	var minimum string
 	for version := range strings.SplitSeq(val, ",") {
-		normalized, ok := tlsVersions[strings.ToLower(strings.TrimSpace(version))]
+		version = strings.TrimSpace(version)
+		if version == "" {
+			continue
+		}
+
+		normalized, ok := tlsVersions[strings.ToLower(version)]
 		if !ok {
 			return val
 		}

--- a/pkg/iac/adapters/terraform/azure/database/common.go
+++ b/pkg/iac/adapters/terraform/azure/database/common.go
@@ -55,18 +55,14 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 
 // minimumTLSVersion converts an Azure TLS version to the TLS1_2 format.
 // MySQL flexible servers accept a comma-separated list of allowed versions,
-// in which case the lowest one is returned. Unknown values are left as is.
+// in which case the lowest one is returned. Unrecognized versions are skipped,
+// and the value is left as is if none of them is recognized.
 func minimumTLSVersion(val string) string {
 	var minimum string
 	for version := range strings.SplitSeq(val, ",") {
-		version = strings.TrimSpace(version)
-		if version == "" {
-			continue
-		}
-
-		normalized, ok := tlsVersions[strings.ToLower(version)]
+		normalized, ok := tlsVersions[strings.ToLower(strings.TrimSpace(version))]
 		if !ok {
-			return val
+			continue
 		}
 		if minimum == "" || normalized < minimum {
 			minimum = normalized

--- a/pkg/iac/adapters/terraform/azure/database/common.go
+++ b/pkg/iac/adapters/terraform/azure/database/common.go
@@ -1,10 +1,24 @@
 package database
 
 import (
+	"strings"
+
 	"github.com/aquasecurity/trivy/pkg/iac/providers/azure/database"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
 )
+
+const defaultTLSVersion = "TLS1_2"
+
+// Flexible servers report the minimum TLS version in the Azure parameter format,
+// e.g. TLSv1.2, while single servers and the checks use the TLS1_2 format.
+var tlsVersions = map[string]string{
+	"tlsv1":   "TLS1_0",
+	"tlsv1.0": "TLS1_0",
+	"tlsv1.1": "TLS1_1",
+	"tlsv1.2": "TLS1_2",
+	"tlsv1.3": "TLS1_3",
+}
 
 // serverParameters represents server configuration parameters that are common
 // to both MySQL and PostgreSQL flexible servers in Azure.
@@ -15,11 +29,13 @@ type serverParameters struct {
 
 // parseServerParameters parses a list of server configurations to extract
 // server parameters for MySQL and PostgreSQL flexible servers.
-func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes.Metadata) serverParameters {
+// The minimum TLS version is set by a different parameter for each engine,
+// so its name is passed by the caller.
+func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes.Metadata, tlsVersionParam string) serverParameters {
 	// https://learn.microsoft.com/en-us/azure/mysql/flexible-server/overview#enterprise-grade-security-compliance-and-privacy
 	params := serverParameters{
 		requireSecureTransport: iacTypes.BoolDefault(true, resourceMetadata),
-		tlsVersion:             iacTypes.StringDefault("TLS1.2", resourceMetadata),
+		tlsVersion:             iacTypes.StringDefault(defaultTLSVersion, resourceMetadata),
 	}
 
 	for _, config := range configs {
@@ -28,12 +44,35 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 		switch {
 		case nameAttr.Equals("require_secure_transport"):
 			params.requireSecureTransport, _ = iacTypes.BoolFromCtyValue(valAttr.Value(), valAttr.GetMetadata())
-		case nameAttr.Equals("tls_version"):
-			params.tlsVersion = valAttr.AsStringValueOrDefault("TLS1_2", config)
+		case nameAttr.Equals(tlsVersionParam):
+			val := valAttr.AsStringValueOrDefault(defaultTLSVersion, config)
+			params.tlsVersion = iacTypes.String(minimumTLSVersion(val.Value()), val.GetMetadata())
 		}
 	}
 
 	return params
+}
+
+// minimumTLSVersion converts an Azure TLS version to the TLS1_2 format.
+// MySQL flexible servers accept a comma-separated list of allowed versions,
+// in which case the lowest one is returned. Unknown values are left as is.
+func minimumTLSVersion(val string) string {
+	var minimum string
+	for version := range strings.SplitSeq(val, ",") {
+		normalized, ok := tlsVersions[strings.ToLower(strings.TrimSpace(version))]
+		if !ok {
+			return val
+		}
+		if minimum == "" || normalized < minimum {
+			minimum = normalized
+		}
+	}
+
+	if minimum == "" {
+		return val
+	}
+
+	return minimum
 }
 
 func adaptFirewallRule(resource *terraform.Block) database.FirewallRule {

--- a/pkg/iac/adapters/terraform/azure/database/common_test.go
+++ b/pkg/iac/adapters/terraform/azure/database/common_test.go
@@ -48,14 +48,14 @@ func Test_minimumTLSVersion(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "unknown version is returned as is",
-			val:      "TLSv2.0",
-			expected: "TLSv2.0",
+			name:     "unrecognized version is skipped",
+			val:      "TLSv1.2,TLSv1.4",
+			expected: "TLS1_2",
 		},
 		{
-			name:     "list with an unknown version is returned as is",
-			val:      "TLSv1.3,TLSv2.0",
-			expected: "TLSv1.3,TLSv2.0",
+			name:     "value with no recognized version is returned as is",
+			val:      "TLSv1.4",
+			expected: "TLSv1.4",
 		},
 	}
 

--- a/pkg/iac/adapters/terraform/azure/database/common_test.go
+++ b/pkg/iac/adapters/terraform/azure/database/common_test.go
@@ -1,0 +1,67 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_minimumTLSVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      string
+		expected string
+	}{
+		{
+			name:     "single version",
+			val:      "TLSv1.2",
+			expected: "TLS1_2",
+		},
+		{
+			name:     "TLSv1 without a minor version",
+			val:      "TLSv1",
+			expected: "TLS1_0",
+		},
+		{
+			name:     "mixed case",
+			val:      "tlsV1.3",
+			expected: "TLS1_3",
+		},
+		{
+			name:     "list with the lowest version last",
+			val:      "TLSv1.3,TLSv1.2",
+			expected: "TLS1_2",
+		},
+		{
+			name:     "list with spaces",
+			val:      "TLSv1.1, TLSv1.2 , TLSv1.3",
+			expected: "TLS1_1",
+		},
+		{
+			name:     "trailing comma",
+			val:      "TLSv1.2,",
+			expected: "TLS1_2",
+		},
+		{
+			name:     "empty value",
+			val:      "",
+			expected: "",
+		},
+		{
+			name:     "unknown version is returned as is",
+			val:      "TLSv2.0",
+			expected: "TLSv2.0",
+		},
+		{
+			name:     "list with an unknown version is returned as is",
+			val:      "TLSv1.3,TLSv2.0",
+			expected: "TLSv1.3,TLSv2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, minimumTLSVersion(tt.val))
+		})
+	}
+}

--- a/pkg/iac/adapters/terraform/azure/database/mysql.go
+++ b/pkg/iac/adapters/terraform/azure/database/mysql.go
@@ -56,7 +56,7 @@ func adaptMySQLFlexibleServer(resource *terraform.Block, module *terraform.Modul
 	// Each configuration resource manages a single parameter specified in the name attribute
 	// By default, the server enforces secure connections using TLS 1.2
 	configBlocks := module.GetReferencingResources(resource, "azurerm_mysql_flexible_server_configuration", "server_id")
-	params := parseServerParameters(configBlocks, resource.GetMetadata())
+	params := parseServerParameters(configBlocks, resource.GetMetadata(), "tls_version")
 
 	return database.MySQLServer{
 		Metadata: resource.GetMetadata(),

--- a/pkg/iac/adapters/terraform/azure/database/mysql.go
+++ b/pkg/iac/adapters/terraform/azure/database/mysql.go
@@ -34,7 +34,7 @@ func adaptMySQLServer(resource *terraform.Block, module *terraform.Module) datab
 			EnableSSLEnforcement: resource.GetAttribute("ssl_enforcement_enabled").
 				AsBoolValueOrDefault(false, resource),
 			MinimumTLSVersion: resource.GetAttribute("ssl_minimal_tls_version_enforced").
-				AsStringValueOrDefault("TLS1_2", resource),
+				AsStringValueOrDefault(defaultTLSVersion, resource),
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
 				AsBoolValueOrDefault(true, resource),
 			FirewallRules: firewallRules,

--- a/pkg/iac/adapters/terraform/azure/database/postgresql.go
+++ b/pkg/iac/adapters/terraform/azure/database/postgresql.go
@@ -30,7 +30,7 @@ func adaptPostgreSQLServer(resource *terraform.Block, module *terraform.Module) 
 	}
 
 	configs := module.GetReferencingResources(resource, "azurerm_postgresql_configuration", "server_name")
-	config := adaptPostgreSQLConfig(resource, configs)
+	config := adaptPostgreSQLConfig(resource, configs, "connection_throttling")
 	return database.PostgreSQLServer{
 		Metadata: resource.GetMetadata(),
 		Server: database.Server{
@@ -64,8 +64,8 @@ func adaptPostgreSQLFlexibleServer(resource *terraform.Block, module *terraform.
 	// By default, the server enforces secure connections using TLS 1.2
 	// Flexible server configurations use server_id instead of server_name
 	configBlocks := module.GetReferencingResources(resource, "azurerm_postgresql_flexible_server_configuration", "server_id")
-	config := adaptPostgreSQLConfig(resource, configBlocks)
-	params := parseServerParameters(configBlocks, resource.GetMetadata())
+	config := adaptPostgreSQLConfig(resource, configBlocks, "connection_throttle.enable")
+	params := parseServerParameters(configBlocks, resource.GetMetadata(), "ssl_min_protocol_version")
 
 	return database.PostgreSQLServer{
 		Metadata: resource.GetMetadata(),
@@ -89,7 +89,7 @@ func adaptPostgreSQLFlexibleServer(resource *terraform.Block, module *terraform.
 	}
 }
 
-func adaptPostgreSQLConfig(resource *terraform.Block, configBlocks []*terraform.Block) database.PostgresSQLConfig {
+func adaptPostgreSQLConfig(resource *terraform.Block, configBlocks []*terraform.Block, throttlingParam string) database.PostgresSQLConfig {
 	var defaultMetadata iacTypes.Metadata
 	if resource != nil {
 		defaultMetadata = resource.GetMetadata()
@@ -113,7 +113,7 @@ func adaptPostgreSQLConfig(resource *terraform.Block, configBlocks []*terraform.
 		switch {
 		case nameAttr.Equals("log_checkpoints"):
 			config.LogCheckpoints = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())
-		case nameAttr.Equals("connection_throttling"):
+		case nameAttr.Equals(throttlingParam):
 			config.ConnectionThrottling = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())
 		case nameAttr.Equals("log_connections"):
 			config.LogConnections = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())

--- a/pkg/iac/adapters/terraform/azure/database/postgresql.go
+++ b/pkg/iac/adapters/terraform/azure/database/postgresql.go
@@ -38,7 +38,7 @@ func adaptPostgreSQLServer(resource *terraform.Block, module *terraform.Module) 
 			EnableSSLEnforcement: resource.GetAttribute("ssl_enforcement_enabled").
 				AsBoolValueOrDefault(false, resource),
 			MinimumTLSVersion: resource.GetAttribute("ssl_minimal_tls_version_enforced").
-				AsStringValueOrDefault("TLS1_2", resource),
+				AsStringValueOrDefault(defaultTLSVersion, resource),
 			EnablePublicNetworkAccess: resource.GetAttribute("public_network_access_enabled").
 				AsBoolValueOrDefault(true, resource),
 			FirewallRules: firewallRules,


### PR DESCRIPTION
## Description

Flexible servers store their settings in `*_flexible_server_configuration` resources, but the adapter looked them up by the names and value format of the legacy single server model.

- the minimum TLS version is read from `ssl_min_protocol_version` for PostgreSQL and `tls_version` for MySQL, and values like `TLSv1.2` are converted to the `TLS1_2` format used by the rest of the provider. MySQL accepts a comma-separated list, in which case the lowest version is taken;
- the default is now `TLS1_2` instead of `TLS1.2`, which never matched anything;
- connection throttling is read from `connection_throttle.enable` instead of `connection_throttling`.

## Related issues
- Close #11068

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
