### PR TITLE
fix(iac): parse Azure flexible server params with flexible server names

### DIFF
--- a/pkg/iac/adapters/terraform/azure/database/adapt_test.go
+++ b/pkg/iac/adapters/terraform/azure/database/adapt_test.go
@@ -232,7 +232,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_postgresql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_postgresql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
 			  }
 
 			  resource "azurerm_postgresql_flexible_server_configuration" "log_connections" {
@@ -304,7 +304,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_postgresql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_postgresql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
 			  }
 			`,
 			expected: database.Database{
@@ -354,7 +354,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_mysql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_mysql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
 			  }
 
 			  resource "azurerm_mysql_flexible_server_configuration" "interactive_timeout" {
@@ -406,7 +406,7 @@ func Test_Adapt(t *testing.T) {
 			  resource "azurerm_mysql_flexible_server_configuration" "tls_version" {
 				name      = "tls_version"
 				server_id = azurerm_mysql_flexible_server.example.id
-				value     = "TLS1_2"
+				value     = "TLSv1.2"
 			  }
 			`,
 			expected: database.Database{
@@ -423,6 +423,64 @@ func Test_Adapt(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "postgresql flexible server with azure parameter names",
+			terraform: `
+			resource "azurerm_postgresql_flexible_server" "example" {
+				name                = "example-flexible"
+
+				public_network_access_enabled = true
+			  }
+
+			  resource "azurerm_postgresql_flexible_server_configuration" "ssl_min_protocol_version" {
+				name      = "ssl_min_protocol_version"
+				server_id = azurerm_postgresql_flexible_server.example.id
+				value     = "TLSv1.2"
+			  }
+
+			  resource "azurerm_postgresql_flexible_server_configuration" "connection_throttle_enable" {
+				name      = "connection_throttle.enable"
+				server_id = azurerm_postgresql_flexible_server.example.id
+				value     = "on"
+			  }
+			`,
+			expected: database.Database{
+				PostgreSQLServers: []database.PostgreSQLServer{
+					{
+						Server: database.Server{
+							EnableSSLEnforcement:      iacTypes.BoolTest(true),
+							MinimumTLSVersion:         iacTypes.StringTest("TLS1_2"),
+							EnablePublicNetworkAccess: iacTypes.BoolTest(true),
+						},
+						Config: database.PostgresSQLConfig{
+							ConnectionThrottling: iacTypes.BoolTest(true),
+						},
+						ThreatDetectionPolicy: database.ThreatDetectionPolicy{},
+					},
+				},
+			},
+		},
+		{
+			name: "postgresql flexible server bare",
+			terraform: `
+			resource "azurerm_postgresql_flexible_server" "example" {
+				name = "example-flexible"
+			  }
+			`,
+			expected: database.Database{
+				PostgreSQLServers: []database.PostgreSQLServer{
+					{
+						Server: database.Server{
+							EnableSSLEnforcement:      iacTypes.BoolTest(true),
+							MinimumTLSVersion:         iacTypes.StringTest("TLS1_2"),
+							EnablePublicNetworkAccess: iacTypes.BoolTest(true),
+						},
+						Config:                database.PostgresSQLConfig{},
+						ThreatDetectionPolicy: database.ThreatDetectionPolicy{},
 					},
 				},
 			},

--- a/pkg/iac/adapters/terraform/azure/database/common.go
+++ b/pkg/iac/adapters/terraform/azure/database/common.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"strings"
+
 	"github.com/aquasecurity/trivy/pkg/iac/providers/azure/database"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
@@ -19,7 +21,7 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 	// https://learn.microsoft.com/en-us/azure/mysql/flexible-server/overview#enterprise-grade-security-compliance-and-privacy
 	params := serverParameters{
 		requireSecureTransport: iacTypes.BoolDefault(true, resourceMetadata),
-		tlsVersion:             iacTypes.StringDefault("TLS1.2", resourceMetadata),
+		tlsVersion:             iacTypes.StringDefault("TLS1_2", resourceMetadata),
 	}
 
 	for _, config := range configs {
@@ -28,12 +30,21 @@ func parseServerParameters(configs []*terraform.Block, resourceMetadata iacTypes
 		switch {
 		case nameAttr.Equals("require_secure_transport"):
 			params.requireSecureTransport, _ = iacTypes.BoolFromCtyValue(valAttr.Value(), valAttr.GetMetadata())
-		case nameAttr.Equals("tls_version"):
-			params.tlsVersion = valAttr.AsStringValueOrDefault("TLS1_2", config)
+		case nameAttr.Equals("tls_version"), nameAttr.Equals("ssl_min_protocol_version"):
+			params.tlsVersion = normalizeTLSVersion(valAttr.AsStringValueOrDefault("TLS1_2", config))
 		}
 	}
 
 	return params
+}
+
+// normalizeTLSVersion converts the TLS version spelling accepted by Azure
+// ("TLSv1.2", "TLSv1.3") to the form expected by the azure-database-secure-
+// tls-policy check ("TLS1_2", "TLS1_3").
+func normalizeTLSVersion(version iacTypes.StringValue) iacTypes.StringValue {
+	normalized := strings.ReplaceAll(version.Value(), "TLSv", "TLS")
+	normalized = strings.ReplaceAll(normalized, ".", "_")
+	return iacTypes.String(normalized, version.GetMetadata())
 }
 
 func adaptFirewallRule(resource *terraform.Block) database.FirewallRule {

--- a/pkg/iac/adapters/terraform/azure/database/postgresql.go
+++ b/pkg/iac/adapters/terraform/azure/database/postgresql.go
@@ -113,7 +113,7 @@ func adaptPostgreSQLConfig(resource *terraform.Block, configBlocks []*terraform.
 		switch {
 		case nameAttr.Equals("log_checkpoints"):
 			config.LogCheckpoints = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())
-		case nameAttr.Equals("connection_throttling"):
+		case nameAttr.Equals("connection_throttling"), nameAttr.Equals("connection_throttle.enable"):
 			config.ConnectionThrottling = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())
 		case nameAttr.Equals("log_connections"):
 			config.LogConnections = iacTypes.Bool(valAttr.Equals("on"), valAttr.GetMetadata())


### PR DESCRIPTION
Fixes #11068

## Problem

Azure flexible server parameters are parsed with Single Server names. For example, `azurerm_postgresql_flexible_server` sets `ssl_min_protocol_version` (`TLSv1.2`/`TLSv1.3`), but the adapter only read the Single Server key `ssl_minimal_tls_version_enforced` (`TLS1_2`), so the value was dropped and the check falsely reported the server as missing a secure TLS config. The same applied to `tls_version` on MySQL flexible servers and `connection_throttle.enable` on PostgreSQL flexible servers.

## Changes

- `common.go` — parse flexible-server keys (`ssl_min_protocol_version`, `tls_version`) and normalize the TLS value formats between the flexible (`TLSv1.2`) and Single Server (`TLS1_2`) representations; default to `TLS1_2`.
- `postgresql.go` — match `connection_throttle.enable` for flexible server config.
- `adapt_test.go` — updated TLS values to flexible-server format and added two test cases covering flexible server parameter names.

## Verification

- `go test ./pkg/iac/adapters/terraform/azure/...` — all packages PASS
- `go vet` — clean
- `gofmt` — clean