### PR TITLE
fix(misconf): unmark cty values outside the evaluation context

### DIFF
--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -148,8 +148,14 @@ func writeBlock(tfBlock *terraform.Block, block *hclwrite.Block, causeRng types.
 			continue
 		}
 
-		value := attr.Value()
+		value := attr.MarkedValue()
 		if !value.IsWhollyKnown() {
+			continue
+		}
+
+		// The rendered cause holds resolved values, so unmarking here
+		// would expose a value hidden by sensitive().
+		if value.ContainsMarked() {
 			continue
 		}
 

--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -114,7 +114,7 @@ func (e *evaluator) exportOutputs() cty.Value {
 		if attr.IsNil() {
 			continue
 		}
-		data[block.Label()] = attr.Value()
+		data[block.Label()] = attr.MarkedValue()
 		e.logger.Debug(
 			"Added module output",
 			log.String("block", block.Label()),
@@ -525,7 +525,7 @@ func (e *evaluator) evaluateOutput(b *terraform.Block) (cty.Value, error) {
 	if attribute.IsNil() {
 		return cty.NilVal, errors.New("cannot resolve output with no attributes")
 	}
-	return attribute.Value(), nil
+	return attribute.MarkedValue(), nil
 }
 
 // returns true if all evaluations were successful

--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -669,6 +669,9 @@ func (e *evaluator) shouldDeferForEachExpansion(forEachAttr *terraform.Attribute
 }
 
 func (e *evaluator) localHasDynamicValues(localVal cty.Value) bool {
+	// Only the structure of the value matters here, so the marks are dropped.
+	localVal, _ = localVal.UnmarkDeep()
+
 	if !localVal.Type().IsObjectType() {
 		return false
 	}

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2964,6 +2964,17 @@ func Test_MarkedValues(t *testing.T) {
   test = sensitive({ id = "some_id" })
 }`,
 		},
+		{
+			name: "marked local in for_each",
+			src: `locals {
+  buckets = sensitive({ a = "bucket-a", b = "bucket-b" })
+}
+
+resource "foo" "bar" {
+  for_each = local.buckets
+  test     = each.value
+}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -2958,6 +2958,12 @@ func Test_MarkedValues(t *testing.T) {
   test = sensitive({})
 }`,
 		},
+		{
+			name: "marked non-empty object",
+			src: `resource "foo" "bar" {
+  test = sensitive({ id = "some_id" })
+}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -84,7 +84,7 @@ func (a *Attribute) GetRawValue() any {
 		default:
 			switch {
 			case typ.IsTupleType(), typ.IsListType(), typ.IsSetType():
-				values := a.Value().AsValueSlice()
+				values := v.AsValueSlice()
 				if len(values) == 0 {
 					return []string{}
 				}
@@ -198,7 +198,8 @@ func (a *Attribute) IsResolvable() bool {
 	if a == nil {
 		return false
 	}
-	return a.Value() != cty.NilVal && a.Value().IsKnown()
+	val := a.Value()
+	return val != cty.NilVal && val.IsKnown()
 }
 
 func (a *Attribute) Type() cty.Type {
@@ -277,7 +278,9 @@ func (a *Attribute) IsBool() bool {
 	})
 }
 
-func (a *Attribute) Value() (ctyVal cty.Value) {
+// value evaluates the attribute expression. If nullable is false, a null
+// result is reported as unknown instead.
+func (a *Attribute) value(nullable bool) (ctyVal cty.Value) {
 	if a == nil {
 		return cty.NilVal
 	}
@@ -287,27 +290,39 @@ func (a *Attribute) Value() (ctyVal cty.Value) {
 		}
 	}()
 	ctyVal, _ = a.hclAttribute.Expr.Value(a.ctx.Inner())
-	if ctyVal.IsNull() {
+	if nullable {
+		if !ctyVal.IsKnown() || ctyVal.IsNull() {
+			return cty.NullVal(cty.DynamicPseudoType)
+		}
+	} else if ctyVal.IsNull() {
 		return cty.DynamicVal
 	}
 	return ctyVal
 }
 
-// Allows a null value for a variable https://developer.hashicorp.com/terraform/language/expressions/types#null
-func (a *Attribute) NullableValue() (ctyVal cty.Value) {
-	if a == nil {
-		return cty.NilVal
+// MarkedValue returns the attribute value with its marks, such as the one set
+// by sensitive(). Marks are only meaningful while values are fed back into the
+// evaluation context, so use Value everywhere else.
+func (a *Attribute) MarkedValue() cty.Value {
+	return a.value(false)
+}
+
+// Value returns the attribute value with all marks removed, since go-cty
+// panics when a marked value is traversed.
+func (a *Attribute) Value() cty.Value {
+	val := a.MarkedValue()
+	if val == cty.NilVal {
+		return val
 	}
-	defer func() {
-		if err := recover(); err != nil {
-			ctyVal = cty.NilVal
-		}
-	}()
-	ctyVal, _ = a.hclAttribute.Expr.Value(a.ctx.Inner())
-	if !ctyVal.IsKnown() || ctyVal.IsNull() {
-		return cty.NullVal(cty.DynamicPseudoType)
-	}
-	return ctyVal
+	unmarked, _ := val.UnmarkDeep()
+	return unmarked
+}
+
+// NullableValue returns the attribute value with its marks. Unlike Value, a
+// null is kept as null instead of being reported as unknown.
+// See https://developer.hashicorp.com/terraform/language/expressions/types#null
+func (a *Attribute) NullableValue() cty.Value {
+	return a.value(true)
 }
 
 func (a *Attribute) Name() string {
@@ -391,6 +406,11 @@ func (a *Attribute) valueToStrings(value cty.Value) (results []iacTypes.StringVa
 			results = []iacTypes.StringValue{iacTypes.StringUnresolvable(a.metadata)}
 		}
 	}()
+
+	// The expression is evaluated directly, bypassing Value,
+	// so the marks are still in place.
+	value, _ = value.UnmarkDeep()
+
 	if value.IsNull() || !value.IsKnown() {
 		return []iacTypes.StringValue{iacTypes.StringUnresolvable(a.metadata)}
 	}
@@ -411,6 +431,8 @@ func (a *Attribute) valueToString(value cty.Value) (result iacTypes.StringValue)
 	}()
 
 	result = iacTypes.StringUnresolvable(a.metadata)
+
+	value, _ = value.UnmarkDeep()
 
 	if value.IsNull() || !value.IsKnown() {
 		return result
@@ -550,7 +572,7 @@ func (a *Attribute) Equals(checkValue any, equalityOptions ...EqualityOption) bo
 			if err != nil {
 				return false
 			}
-			return a.Value().RawEquals(checkNumber)
+			return v.RawEquals(checkNumber)
 		case cty.Bool:
 			return v.True() == checkValue
 		default:
@@ -825,9 +847,7 @@ func safeOp[T any](a *Attribute, fn func(cty.Value) T) T {
 		return res
 	}
 
-	unmarked, _ := val.UnmarkDeep()
-
-	return fn(unmarked)
+	return fn(val)
 }
 
 func isDefined(v cty.Value, t cty.Type) bool {

--- a/pkg/iac/terraform/attribute_test.go
+++ b/pkg/iac/terraform/attribute_test.go
@@ -89,6 +89,59 @@ func Test_Attribute_AsMapValue(t *testing.T) {
 	}
 }
 
+func Test_Attribute_Marks(t *testing.T) {
+	val := cty.StringVal("secret").Mark("sensitive")
+	attr := newTestAttribute(t, "val", map[string]cty.Value{"val": val})
+
+	assert.False(t, attr.Value().IsMarked())
+	assert.True(t, attr.MarkedValue().IsMarked())
+	assert.True(t, attr.NullableValue().IsMarked())
+}
+
+func Test_Attribute_AccessorsIgnoreMarks(t *testing.T) {
+	newAttr := func(t *testing.T, val cty.Value) *Attribute {
+		t.Helper()
+		return newTestAttribute(t, "val", map[string]cty.Value{"val": val.Mark("sensitive")})
+	}
+
+	t.Run("string", func(t *testing.T) {
+		attr := newAttr(t, cty.StringVal("secret"))
+		assert.Equal(t, "secret", attr.AsStringValueOrDefault("", nil).Value())
+		assert.Equal(t, []byte("secret"), attr.AsBytesValueOrDefault(nil, nil).Value())
+		assert.True(t, attr.Equals("secret"))
+		assert.False(t, attr.IsEmpty())
+		assert.True(t, attr.IsResolvable())
+		assert.Equal(t, cty.String, attr.Type())
+	})
+
+	t.Run("object", func(t *testing.T) {
+		attr := newAttr(t, cty.ObjectVal(map[string]cty.Value{"env": cty.StringVal("staging")}))
+		assert.Equal(t, map[string]string{"env": "staging"}, attr.AsMapValue().Value())
+		assert.True(t, attr.IsIterable())
+		assert.True(t, attr.Contains("env"))
+		require.NoError(t, attr.Each(func(_, _ cty.Value) {}))
+	})
+
+	t.Run("list", func(t *testing.T) {
+		attr := newAttr(t, cty.TupleVal([]cty.Value{cty.StringVal("a")}))
+		values := attr.AsStringValues()
+		require.Len(t, values, 1)
+		assert.Equal(t, "a", values[0].Value())
+		assert.Equal(t, []string{"a"}, attr.GetRawValue())
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		attr := newAttr(t, cty.True)
+		assert.True(t, attr.AsBoolValueOrDefault(false, nil).Value())
+	})
+
+	t.Run("number", func(t *testing.T) {
+		attr := newAttr(t, cty.NumberIntVal(42))
+		assert.Equal(t, 42, attr.AsIntValueOrDefault(0, nil).Value())
+		assert.True(t, attr.Equals(42))
+	})
+}
+
 func Test_AllReferences(t *testing.T) {
 	cases := []struct {
 		input string

--- a/pkg/iac/terraform/block.go
+++ b/pkg/iac/terraform/block.go
@@ -148,7 +148,7 @@ func (b *Block) GetRawValue() any {
 func (b *Block) injectBlock(block *Block) {
 	for attrName, attr := range block.Attributes() {
 		path := fmt.Sprintf("%s.%s.%s", b.reference.String(), block.hclBlock.Type, attrName)
-		b.context.Root().SetByDot(attr.Value(), path)
+		b.context.Root().SetByDot(attr.MarkedValue(), path)
 	}
 	b.childBlocks = append(b.childBlocks, block)
 }
@@ -567,7 +567,7 @@ func (b *Block) values(allowNull bool) cty.Value {
 		if allowNull {
 			values[attribute.Name()] = attribute.NullableValue()
 		} else {
-			values[attribute.Name()] = attribute.Value()
+			values[attribute.Name()] = attribute.MarkedValue()
 		}
 	}
 	return cty.ObjectVal(postProcessValues(b, values))

--- a/pkg/iac/terraform/context/context.go
+++ b/pkg/iac/terraform/context/context.go
@@ -110,8 +110,11 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 	}
 
 	data := make(map[string]cty.Value)
+	var marks cty.ValueMarks
 	if isNotEmptyObject(src) {
-		data = src.AsValueMap()
+		var unmarked cty.Value
+		unmarked, marks = src.Unmark()
+		data = unmarked.AsValueMap()
 		if attr, ok := data[parts[0]]; ok {
 			src = attr
 		} else {
@@ -121,10 +124,13 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 
 	data[parts[0]] = mergeVars(src, parts[1:], value)
 
-	return cty.ObjectVal(data)
+	return cty.ObjectVal(data).WithMarks(marks)
 }
 
 func mergeObjects(a, b cty.Value) cty.Value {
+	a, aMarks := a.Unmark()
+	b, bMarks := b.Unmark()
+
 	output := make(map[string]cty.Value)
 
 	maps.Copy(output, a.AsValueMap())
@@ -138,7 +144,7 @@ func mergeObjects(a, b cty.Value) cty.Value {
 		}
 		return false
 	})
-	return cty.ObjectVal(output)
+	return cty.ObjectVal(output).WithMarks(aMarks, bMarks)
 }
 
 func isNotEmptyObject(val cty.Value) bool {

--- a/pkg/iac/terraform/context/context.go
+++ b/pkg/iac/terraform/context/context.go
@@ -110,6 +110,8 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 	}
 
 	data := make(map[string]cty.Value)
+	// go-cty panics when a marked value is traversed, so marks are removed
+	// before the traversal and restored on the result.
 	var marks cty.ValueMarks
 	if isNotEmptyObject(src) {
 		var unmarked cty.Value
@@ -128,6 +130,8 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 }
 
 func mergeObjects(a, b cty.Value) cty.Value {
+	// go-cty panics when a marked value is traversed, so marks are removed
+	// before the traversal and restored on the result.
 	a, aMarks := a.Unmark()
 	b, bMarks := b.Unmark()
 

--- a/pkg/iac/terraform/context/context_test.go
+++ b/pkg/iac/terraform/context/context_test.go
@@ -53,7 +53,7 @@ func Test_ContextVariablesPreservation(t *testing.T) {
 }
 
 func Test_SetWithMerge(t *testing.T) {
-	hctx := hcl.EvalContext{
+	evalCtx := hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"my": cty.ObjectVal(map[string]cty.Value{
 				"someValue": cty.ObjectVal(map[string]cty.Value{
@@ -66,7 +66,7 @@ func Test_SetWithMerge(t *testing.T) {
 		},
 	}
 
-	ctx := NewContext(&hctx, nil)
+	ctx := NewContext(&evalCtx, nil)
 
 	val := cty.ObjectVal(map[string]cty.Value{
 		"foo2": cty.StringVal("test2"),
@@ -87,6 +87,33 @@ func Test_SetWithMerge(t *testing.T) {
 	})
 
 	assert.Equal(t, expected, got)
+}
+
+func Test_SetWithMergeOfMarkedValues(t *testing.T) {
+	evalCtx := hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"local": cty.ObjectVal(map[string]cty.Value{
+				"secrets": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("test"),
+				}).Mark("sensitive"),
+			}).Mark("other"),
+		},
+	}
+
+	ctx := NewContext(&evalCtx, nil)
+
+	ctx.Set(cty.ObjectVal(map[string]cty.Value{
+		"bar": cty.StringVal("test2"),
+	}), "local", "secrets")
+
+	expected := cty.ObjectVal(map[string]cty.Value{
+		"secrets": cty.ObjectVal(map[string]cty.Value{
+			"foo": cty.StringVal("test"),
+			"bar": cty.StringVal("test2"),
+		}).Mark("sensitive"),
+	}).Mark("other")
+
+	assert.Equal(t, expected, ctx.Get("local"))
 }
 
 func Test_ContextVariablesPreservationByDot(t *testing.T) {
@@ -202,6 +229,38 @@ func Test_MergeObjects(t *testing.T) {
 					"bucket": cty.StringVal("test"),
 				}),
 			}),
+		},
+		{
+			name: "marked values",
+			oldVal: cty.ObjectVal(map[string]cty.Value{
+				"this": cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("some_id"),
+				}).Mark("sensitive"),
+			}),
+			newVal: cty.ObjectVal(map[string]cty.Value{
+				"this": cty.ObjectVal(map[string]cty.Value{
+					"arn": cty.StringVal("some_arn"),
+				}).Mark("sensitive"),
+			}),
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"this": cty.ObjectVal(map[string]cty.Value{
+					"id":  cty.StringVal("some_id"),
+					"arn": cty.StringVal("some_arn"),
+				}).Mark("sensitive"),
+			}),
+		},
+		{
+			name: "marked objects",
+			oldVal: cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("some_id"),
+			}).Mark("sensitive"),
+			newVal: cty.ObjectVal(map[string]cty.Value{
+				"arn": cty.StringVal("some_arn"),
+			}).Mark("other"),
+			expected: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("some_id"),
+				"arn": cty.StringVal("some_arn"),
+			}).WithMarks(cty.NewValueMarks("sensitive", "other")),
 		},
 	}
 


### PR DESCRIPTION
## Description

Marks are now removed before accessing the object in `mergeVars`/`mergeObjects` and reapplied to the merged result, so the sensitive mark is not lost.

The same panic remained in two more places: `for_each` over a sensitive map, and any adapter that reads a sensitive attribute. `Attribute.Value()` now removes the marks, and a new `MarkedValue()` keeps them for the few places that put values back into the evaluation context.

The cause shown in the report contains resolved values, so attributes with marks are left out of it rather than unmarked, and the cause keeps the original expression instead of printing a value hidden by `sensitive()`.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/11077

## Related PRs
- [x] #9495

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
