### PR TITLE
fix(vex): only apply repository precedence when a statement exists

### DIFF
--- a/docs/guide/supply-chain/vex/repo.md
+++ b/docs/guide/supply-chain/vex/repo.md
@@ -103,19 +103,20 @@ You can add repositories with higher priority than the default or even remove th
   url: https://example.com/repo2
 ```
 
-In this configuration, when Trivy detects a vulnerability in a package, it generates a PURL for that package and searches for matching VEX documents in the configured repositories.
+In this configuration, when Trivy detects a vulnerability in a package, it generates a PURL for that package and searches for matching VEX statements in the configured repositories.
 The search process follows this order:
 
-1. Trivy first looks for a VEX document matching the package's PURL in `repo1`.
-2. If no matching VEX document is found in `repo1`, Trivy then searches in `repo2`.
-3. This process continues through all configured repositories until a match is found.
- 
-If a matching VEX document is found in any repository (e.g., `repo1`), the search stops, and Trivy uses that VEX document.
-Subsequent repositories (e.g., `repo2`) are not checked for that specific vulnerability and package combination.
+1. Trivy first looks for a VEX document matching the package's PURL in `repo1`, and for a statement about the detected vulnerability in that document.
+2. If `repo1` has no statement about that vulnerability, Trivy then searches in `repo2`.
+3. This process continues through all configured repositories until a statement is found.
 
-It's important to note that the first matching VEX document found determines the final status of the vulnerability.
+The first statement found determines the final status of the vulnerability.
 For example, if `repo1` states that a package is "Affected" by a vulnerability, this status will be used even if `repo2` states that the same package is "Not Affected" for the same vulnerability.
 The "Affected" status from the higher-priority repository (`repo1`) takes precedence, and Trivy will consider the package as affected by the vulnerability.
+Statuses that don't filter the vulnerability out, such as "Under Investigation", are statements as well and take precedence in the same way.
+
+Note that a repository takes precedence only for the vulnerabilities it has a statement about.
+A repository that merely lists the package in its index, without saying anything about the detected vulnerability, doesn't hide the statements of the repositories after it.
 
 ### Repository Updates
 

--- a/pkg/vex/csaf.go
+++ b/pkg/vex/csaf.go
@@ -34,9 +34,7 @@ func (v *CSAF) Filter(result *types.Result, bom *core.BOM) {
 }
 
 func (v *CSAF) NotAffected(vuln types.DetectedVulnerability, product, subProduct *core.Component) (types.ModifiedFinding, bool) {
-	found, ok := lo.Find(v.advisory.Vulnerabilities, func(item *csaf.Vulnerability) bool {
-		return string(*item.CVE) == vuln.VulnerabilityID
-	})
+	found, ok := v.findVulnerability(vuln.VulnerabilityID)
 	if !ok {
 		return types.ModifiedFinding{}, false
 	}
@@ -46,6 +44,50 @@ func (v *CSAF) NotAffected(vuln types.DetectedVulnerability, product, subProduct
 		return types.ModifiedFinding{}, false
 	}
 	return types.NewModifiedFinding(vuln, status, v.statement(found), v.source), true
+}
+
+// HasStatement reports whether the advisory puts the product in any of the product status
+// groups of the vulnerability, whatever the group is. Listing the product as affected or
+// under investigation is an assertion just like listing it as not affected is, even though
+// it doesn't filter the vulnerability out.
+func (v *CSAF) HasStatement(vuln types.DetectedVulnerability, product, subProduct *core.Component) bool {
+	found, ok := v.findVulnerability(vuln.VulnerabilityID)
+	if !ok || product == nil || product.PkgIdentifier.PURL == nil || found.ProductStatus == nil {
+		return false
+	}
+
+	for _, productRange := range productRanges(found.ProductStatus) {
+		for _, p := range productRange {
+			productID := lo.FromPtr(p)
+			if v.matchProduct(productID, product) {
+				return true
+			}
+			if _, match := v.matchRelationship(productID, product, subProduct); match {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (v *CSAF) findVulnerability(vulnID string) (*csaf.Vulnerability, bool) {
+	return lo.Find(v.advisory.Vulnerabilities, func(item *csaf.Vulnerability) bool {
+		return item != nil && item.CVE != nil && string(*item.CVE) == vulnID
+	})
+}
+
+// productRanges returns all the product groups of a product status.
+func productRanges(status *csaf.ProductStatus) []csaf.Products {
+	return []csaf.Products{
+		lo.FromPtr(status.FirstAffected),
+		lo.FromPtr(status.FirstFixed),
+		lo.FromPtr(status.Fixed),
+		lo.FromPtr(status.KnownAffected),
+		lo.FromPtr(status.KnownNotAffected),
+		lo.FromPtr(status.LastAffected),
+		lo.FromPtr(status.Recommended),
+		lo.FromPtr(status.UnderInvestigation),
+	}
 }
 
 func (v *CSAF) match(vuln *csaf.Vulnerability, product, subProduct *core.Component) types.FindingStatus {

--- a/pkg/vex/cyclonedx.go
+++ b/pkg/vex/cyclonedx.go
@@ -10,6 +10,9 @@ import (
 	xslices "github.com/aquasecurity/trivy/pkg/x/slices"
 )
 
+// CycloneDX doesn't implement the statementFinder interface: it is only used with
+// `--vex file`, never served from a VEX repository, so nothing needs to tell its
+// statements apart from the absence of a statement.
 type CycloneDX struct {
 	sbom       *core.BOM
 	statements map[string]Statement

--- a/pkg/vex/openvex.go
+++ b/pkg/vex/openvex.go
@@ -74,6 +74,14 @@ func (v *OpenVEX) NotAffected(vuln types.DetectedVulnerability, product, subComp
 	return types.ModifiedFinding{}, false
 }
 
+// HasStatement reports whether the document has a statement about the vulnerability and
+// product, whatever its status. A statement with the "affected" or "under_investigation"
+// status is an assertion just like "not_affected" is, even though it doesn't filter the
+// vulnerability out.
+func (v *OpenVEX) HasStatement(vuln types.DetectedVulnerability, product, subComponent *core.Component) bool {
+	return len(v.Matches(vuln, product, subComponent)) > 0
+}
+
 func (v *OpenVEX) Matches(vuln types.DetectedVulnerability, product, subComponent *core.Component) []openvex.Statement {
 	if product == nil || product.PkgIdentifier.PURL == nil {
 		return nil

--- a/pkg/vex/repo.go
+++ b/pkg/vex/repo.go
@@ -108,7 +108,19 @@ func (rs *RepositorySet) NotAffected(vuln types.DetectedVulnerability, product, 
 			return m, notAffected
 		}
 
-		break // Stop searching for the next VEX document as this repository has higher precedence.
+		// An index entry only says which document covers the package, not that the
+		// repository has anything to say about this vulnerability. Precedence applies to
+		// statements, not to silence, so this repository stops the search only when its
+		// document actually has a statement about this vulnerability and product.
+		// That keeps a deliberate "affected" from being overridden by a lower-priority
+		// "not_affected", while a repository with no statement no longer hides the
+		// statements of the repositories after it.
+		if hasStatement(doc, vuln, product, subComponent) {
+			break // Stop searching for the next VEX document as this repository has higher precedence.
+		}
+		rs.logger.Debug("No VEX statement found in the repository, continuing to the next repository",
+			log.String("vulnerability", vuln.VulnerabilityID), log.String("package", pkgID),
+			log.String("repo", index.Name))
 	}
 	return types.ModifiedFinding{}, false
 }
@@ -135,7 +147,9 @@ func (rs *RepositorySet) OpenDocument(source, dir string, entry repo.PackageEntr
 }
 
 func (rs *RepositorySet) logVEXFound(pkgID, repoName, repoURL, filePath string) {
-	once, _ := rs.logOnce.LoadOrStore(pkgID, &sync.Once{})
+	// Several repositories can be consulted for the same package, so the log is emitted
+	// once per package and repository, not once per package.
+	once, _ := rs.logOnce.LoadOrStore(pkgID+"|"+repoName, &sync.Once{})
 	once.Do(func() {
 		rs.logger.Debug("VEX found in the repository",
 			log.String("package", pkgID),

--- a/pkg/vex/repo_test.go
+++ b/pkg/vex/repo_test.go
@@ -66,6 +66,117 @@ repositories:
 			wantNotAffected: false,
 		},
 		{
+			// The higher-priority repository indexes the package, but its document has no
+			// statement about this vulnerability. An index entry only tells Trivy which
+			// document covers the package, so the repository expressed no opinion here and
+			// the lower-priority repository must still be consulted.
+			name:     "multiple repositories - high priority has no statement",
+			cacheDir: "testdata/multi-repos-no-statement",
+			configContent: `
+repositories:
+  - name: high-priority
+    url: https://example.com/vex/high-priority
+    enabled: true
+  - name: default
+    url: https://example.com/vex/default
+    enabled: true
+`,
+			vuln:    vuln3,
+			product: bashComponent,
+			wantModified: types.ModifiedFinding{
+				Type:      types.FindingTypeVulnerability,
+				Finding:   vuln3,
+				Status:    types.FindingStatusNotAffected,
+				Statement: "vulnerable_code_not_in_execute_path",
+				Source:    "VEX Repository: default (https://example.com/vex/default)",
+			},
+			wantNotAffected: true,
+		},
+		{
+			// The higher-priority repository states "not_affected", so it wins and the
+			// lower-priority repository, which states "affected", is never consulted.
+			name:     "multiple repositories - high priority not affected",
+			cacheDir: "testdata/multi-repos",
+			configContent: `
+repositories:
+  - name: default
+    url: https://example.com/vex/default
+    enabled: true
+  - name: high-priority
+    url: https://example.com/vex/high-priority
+    enabled: true
+`,
+			vuln:    vuln3,
+			product: bashComponent,
+			wantModified: types.ModifiedFinding{
+				Type:      types.FindingTypeVulnerability,
+				Finding:   vuln3,
+				Status:    types.FindingStatusNotAffected,
+				Statement: "vulnerable_code_not_in_execute_path",
+				Source:    "VEX Repository: default (https://example.com/vex/default)",
+			},
+			wantNotAffected: true,
+		},
+		{
+			// "under_investigation" is a statement, not silence. The higher-priority
+			// repository is engaged with the vulnerability, so the lower-priority
+			// "not_affected" must not suppress the finding.
+			name:     "multiple repositories - high priority under investigation",
+			cacheDir: "testdata/multi-repos-no-statement",
+			configContent: `
+repositories:
+  - name: under-investigation
+    url: https://example.com/vex/under-investigation
+    enabled: true
+  - name: default
+    url: https://example.com/vex/default
+    enabled: true
+`,
+			vuln:            vuln3,
+			product:         bashComponent,
+			wantNotAffected: false,
+		},
+		{
+			// The higher-priority repository doesn't index the package at all.
+			name:     "multiple repositories - package only in the lower priority repository",
+			cacheDir: "testdata/multi-repos-no-statement",
+			configContent: `
+repositories:
+  - name: other-package
+    url: https://example.com/vex/other-package
+    enabled: true
+  - name: default
+    url: https://example.com/vex/default
+    enabled: true
+`,
+			vuln:    vuln3,
+			product: bashComponent,
+			wantModified: types.ModifiedFinding{
+				Type:      types.FindingTypeVulnerability,
+				Finding:   vuln3,
+				Status:    types.FindingStatusNotAffected,
+				Statement: "vulnerable_code_not_in_execute_path",
+				Source:    "VEX Repository: default (https://example.com/vex/default)",
+			},
+			wantNotAffected: true,
+		},
+		{
+			name:     "multiple repositories - no statement in any repository",
+			cacheDir: "testdata/multi-repos-no-statement",
+			configContent: `
+repositories:
+  - name: high-priority
+    url: https://example.com/vex/high-priority
+    enabled: true
+  - name: other-package
+    url: https://example.com/vex/other-package
+    enabled: true
+`,
+			vuln:            vuln3,
+			product:         bashComponent,
+			wantNotAffected: false,
+		},
+		{
 			name:     "no matching VEX data",
 			cacheDir: "testdata/single-repo",
 			configContent: `

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/default/0.1/bash-vex.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/default/0.1/bash-vex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5d6e2706",
+  "author": "Example Author",
+  "role": "Document Creator",
+  "timestamp": "2023-07-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "CVE-2022-3715"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/bash@5.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/default/0.1/index.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/default/0.1/index.json
@@ -1,0 +1,10 @@
+{
+  "updated_at": "2024-07-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "pkg:deb/debian/bash",
+      "location": "bash-vex.json",
+      "format": "openvex"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/high-priority/0.1/bash-vex.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/high-priority/0.1/bash-vex.json
@@ -1,0 +1,21 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1a2b3c4d",
+  "author": "Example Author",
+  "role": "Document Creator",
+  "timestamp": "2023-07-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "CVE-2024-10000"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/bash@5.3"
+        }
+      ],
+      "status": "affected"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/high-priority/0.1/index.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/high-priority/0.1/index.json
@@ -1,0 +1,10 @@
+{
+  "updated_at": "2024-07-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "pkg:deb/debian/bash",
+      "location": "bash-vex.json",
+      "format": "openvex"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/other-package/0.1/curl-vex.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/other-package/0.1/curl-vex.json
@@ -1,0 +1,21 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-4c3b2a1d",
+  "author": "Example Author",
+  "role": "Document Creator",
+  "timestamp": "2023-07-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "CVE-2022-3715"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/curl@8.0"
+        }
+      ],
+      "status": "affected"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/other-package/0.1/index.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/other-package/0.1/index.json
@@ -1,0 +1,10 @@
+{
+  "updated_at": "2024-07-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "pkg:deb/debian/curl",
+      "location": "curl-vex.json",
+      "format": "openvex"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/under-investigation/0.1/bash-vex.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/under-investigation/0.1/bash-vex.json
@@ -1,0 +1,21 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9f8e7d6c",
+  "author": "Example Author",
+  "role": "Document Creator",
+  "timestamp": "2023-07-01T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "CVE-2022-3715"
+      },
+      "products": [
+        {
+          "@id": "pkg:deb/debian/bash@5.3"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}

--- a/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/under-investigation/0.1/index.json
+++ b/pkg/vex/testdata/multi-repos-no-statement/vex/repositories/under-investigation/0.1/index.json
@@ -1,0 +1,10 @@
+{
+  "updated_at": "2024-07-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "pkg:deb/debian/bash",
+      "location": "bash-vex.json",
+      "format": "openvex"
+    }
+  ]
+}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -29,6 +29,26 @@ type VEX interface {
 	NotAffected(vuln types.DetectedVulnerability, product, subComponent *core.Component) (types.ModifiedFinding, bool)
 }
 
+// statementFinder is implemented by VEX documents that can tell whether they contain
+// a statement about a given vulnerability and product, whatever its status.
+// NotAffected alone cannot express this: it returns false both for a document stating
+// "affected" and for a document that says nothing at all, while these are different
+// things. Absence of a statement is not a statement.
+type statementFinder interface {
+	HasStatement(vuln types.DetectedVulnerability, product, subComponent *core.Component) bool
+}
+
+// hasStatement reports whether the VEX document has a statement about the vulnerability
+// and product. Documents in a format that cannot answer honestly are assumed to have one,
+// so that the existing behavior is preserved rather than guessed.
+func hasStatement(v VEX, vuln types.DetectedVulnerability, product, subComponent *core.Component) bool {
+	f, ok := v.(statementFinder)
+	if !ok {
+		return true
+	}
+	return f.HasStatement(vuln, product, subComponent)
+}
+
 type Client struct {
 	VEXes []VEX
 }


### PR DESCRIPTION
## Description

Reported in discussion #11083.


When several VEX repositories are configured, `RepositorySet.NotAffected` iterates them in
precedence order and stops at the first one whose **index** contains the package key,
regardless of whether that repository has anything to say about the vulnerability being
evaluated:

```go
if m, notAffected := doc.NotAffected(vuln, product, subComponent); notAffected {
    return m, notAffected
}

break // Stop searching for the next VEX document as this repository has higher precedence.
```

An index entry records which document covers a package; it is not an assertion about a
vulnerability. `NotAffected` returns `false` both for a document stating `affected` and for
one that says nothing at all, so the caller cannot tell a deliberate verdict from silence
and treats both as "this repository wins".

The result is that a repository which merely mentions a package silently discards the
statements of every repository after it, for that package, with no diagnostic. In the
reported case a repository containing a version-less `pkg:deb/debian/perl-base` entry whose
newest statement is `under_investigation` shadowed a later repository's exact-version
`not_affected`, leaving 16 findings across 4 CRITICAL/HIGH CVEs unsuppressed. Reordering the
configuration changed the outcome; nothing in the output explained why.

## Approach

Precedence now applies to statements rather than to index entries:

- A higher-precedence repository with an applicable statement remains authoritative for any
  status. A deliberate `affected` still takes priority over a lower-precedence
  `not_affected` — the existing `multiple repositories - high priority affected` test is
  unchanged and still passes.
- A higher-precedence repository with no applicable statement has expressed no opinion, and
  the search continues to the next repository.

`under_investigation` is deliberately treated as an assertion that stops the search, not as
silence: a vendor stating that it is still evaluating an issue has engaged with it, and a
lower-precedence `not_affected` should not clear it. There is a test for this.

To let the caller distinguish "no statement" from "not not-affected" without changing the
exported `VEX` interface, this adds an unexported optional interface:

```go
type statementFinder interface {
	HasStatement(vuln types.DetectedVulnerability, product, subComponent *core.Component) bool
}
```

`hasStatement` type-asserts and **defaults to `true`** when a format does not implement it,
so any format that cannot answer honestly keeps today's behaviour rather than guessing.
OpenVEX and CSAF implement it; CycloneDX deliberately does not (it is never served from a
repository) and carries a comment saying so.

A `Debug` line is emitted when the search falls through, since the absence of any
diagnostic is a large part of why this was hard to isolate. `logVEXFound`'s `sync.Once` key
becomes `pkgID + "|" + repoName` so the repository that actually supplied a statement is
logged rather than only the first one consulted — happy to drop that part if you would
prefer a tighter diff.

## Impact

This is a correctness fix, not a security fix: the previous behaviour only ever left
findings **visible**, so nothing was hidden. It did, however, silently ignore VEX data the
operator had configured. Because the change increases suppression, the invariant that a
higher-precedence `affected` is never overridden is the important one, and it is covered by
the pre-existing test plus a new `under_investigation` case.

## Tests

`TestRepositorySet_NotAffected` gains 5 cases (9 total, all passing), with fixtures under
`pkg/vex/testdata/multi-repos-no-statement/`:

| Case | Expectation |
| --- | --- |
| high priority has no statement, low priority `not_affected` | suppressed (the bug) |
| high priority `affected`, low priority `not_affected` | **not** suppressed (unchanged guarantee) |
| high priority `under_investigation`, low priority `not_affected` | **not** suppressed |
| high priority `not_affected` | suppressed |
| package only in the lower-priority repository | suppressed |

Verified the fix is load-bearing: reverting only the guard makes exactly the new
`high priority has no statement` case fail and nothing else.

```
--- FAIL: TestRepositorySet_NotAffected/multiple_repositories_-_high_priority_has_no_statement
    Error: Not equal: expected: true  actual: false
```

`go test -short ./pkg/vex/...` passes; `golangci-lint run ./pkg/vex/...` reports 0 issues;
`gofmt` clean. Pre-existing unrelated failures in `pkg/result` (Rego `TestFilter`) are
identical with and without this change.

While adding `HasStatement` to the CSAF implementation I extracted `findVulnerability`,
which also removes a potential nil dereference on `item.CVE`.

## Docs

`docs/guide/supply-chain/vex/repo.md` — the "Repository Priority" section now states that
precedence is over statements rather than index entries.
