### PR TITLE
docs: update release branch ruleset instructions

### DIFF
--- a/docs/community/maintainer/release-flow.md
+++ b/docs/community/maintainer/release-flow.md
@@ -88,8 +88,9 @@ Example: https://github.com/aquasecurity/trivy/releases/tag/v0.52.0
 
 ### Adding the Release Branch to Rulesets
 For major and minor releases (e.g., v0.52.0), a `release/vX.Y` branch is automatically created.
-The release maintainer must add this branch to the repository ruleset to enable merge queue protection, unless it has already been added in advance.
-Go to the repository settings → Rules → Rulesets → "release" and add `release/vX.Y` to the branch targeting pattern.
+The `release-protection` ruleset automatically applies the standard release branch protections to branches matching `release/v*`.
+The release maintainer must add the new branch to the `release-merge-queue` ruleset to enable the merge queue, unless it has already been added in advance.
+Go to the repository settings → Rules → Rulesets → "release-merge-queue" and add `release/vX.Y` to the branch targeting pattern.
 
 ### Merging the auto-generated Helm chart update PR
 Once the release PR is merged, there will be an auto-generated PR that bumps the Trivy version for the Trivy Helm Chart. An example can be seen [here](https://github.com/aquasecurity/trivy/pull/8638).


### PR DESCRIPTION
## Description

Update the release flow documentation to match the repository's current ruleset structure.

- Explain that `release-protection` automatically applies the standard release branch protections to `release/v*`.
- Direct release maintainers to add new release branches to `release-merge-queue`.

## Related issues

- N/A

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
