### PR TITLE
fix(sbom): skip null entries in SPDX file and package arrays

### DIFF
--- a/pkg/sbom/spdx/testdata/happy/null-file-entry.json
+++ b/pkg/sbom/spdx/testdata/happy/null-file-entry.json
@@ -1,0 +1,17 @@
+{
+	"SPDXID": "SPDXRef-DOCUMENT",
+	"spdxVersion": "SPDX-2.3",
+	"creationInfo": {
+		"created": "2022-09-12T17:03:35.840861Z",
+		"creators": [
+			"Tool: trivy-dev",
+			"Organization: aquasecurity"
+		]
+	},
+	"dataLicense": "CC0-1.0",
+	"documentNamespace": "http://trivy.dev/container/null-file-entry",
+	"name": "null-file-entry",
+	"files": [
+		null
+	]
+}

--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -108,9 +108,12 @@ func (s *SPDX) unmarshal(spdxDocument *spdx.Document) error {
 
 // parseFiles parses Relationships and finds filepaths for packages
 func (s *SPDX) parseFiles(spdxDocument *spdx.Document) {
-	fileSPDXIdentifierMap := lo.SliceToMap(spdxDocument.Files, func(file *spdx.File) (common.ElementID, *spdx.File) {
-		return file.FileSPDXIdentifier, file
-	})
+	// A null element in the files array decodes to a nil pointer.
+	fileSPDXIdentifierMap := lo.SliceToMap(
+		lo.Filter(spdxDocument.Files, func(file *spdx.File, _ int) bool { return file != nil }),
+		func(file *spdx.File) (common.ElementID, *spdx.File) {
+			return file.FileSPDXIdentifier, file
+		})
 
 	for _, rel := range spdxDocument.Relationships {
 		if rel.Relationship != common.TypeRelationshipContains && rel.Relationship != "CONTAIN" {
@@ -150,6 +153,10 @@ func (s *SPDX) parsePackages(spdxDocument *spdx.Document) (map[common.ElementID]
 	// Convert packages into components
 	components := make(map[common.ElementID]*core.Component)
 	for _, pkg := range spdxDocument.Packages {
+		// A null element in the packages array decodes to a nil pointer.
+		if pkg == nil {
+			continue
+		}
 		component, err := s.parsePackage(*pkg)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to parse package: %w", err)

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -341,6 +341,12 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 			want:      types.SBOM{},
 		},
 		{
+			// a null element in an array decodes to a nil pointer
+			name:      "happy path with a null file entry",
+			inputFile: "testdata/happy/null-file-entry.json",
+			want:      types.SBOM{},
+		},
+		{
 			name:      "sad path invalid purl",
 			inputFile: "testdata/sad/invalid-purl.json",
 			wantErr:   "purl is missing type or name",


### PR DESCRIPTION
A `null` element in an SPDX JSON array decodes to a nil pointer, and both `parseFiles` and `parsePackages` dereference it immediately, so scanning an SBOM that carries one panics rather than reporting a malformed document:

```
$ trivy sbom --scanners license bad.spdx.json
INFO  Detected SBOM format  format="spdx-json"
panic: runtime error: invalid memory address or nil pointer dereference
  github.com/aquasecurity/trivy/pkg/sbom/spdx.(*SPDX).parseFiles.func1
    pkg/sbom/spdx/unmarshal.go:112
```

`"files":[null]` reaches it on SPDX 2.1, 2.2 and 2.3. `"packages":[null]` reaches the same shape in `parsePackages` on 2.1; on 2.2 and 2.3 the pinned `tools-golang` v0.5.7 fails earlier, so that half is defensive rather than currently reachable.

`parseFiles` filters nil entries before building the identifier map, and `parsePackages` skips them in the loop.

Added `testdata/happy/null-file-entry.json` and a case asserting an empty SBOM rather than a panic. It panics without the change.

Noting for the reviewer, since I saw them while checking: #10996 and #10978 are broader "guard against panics" sweeps. This one is deliberately confined to the two SPDX array walks so it does not overlap with whichever of those lands.
