### PR TITLE
fix(java): let root test/provided scopes take part in version mediation

### DIFF
--- a/pkg/dependency/parser/java/pom/artifact.go
+++ b/pkg/dependency/parser/java/pom/artifact.go
@@ -31,6 +31,14 @@ type artifact struct {
 	Module       bool
 	Relationship ftypes.Relationship
 
+	// MediationOnly marks a dependency that takes part in version mediation but
+	// is not part of the build's compile/runtime classpath (a `test` or
+	// `provided` dependency of the root POM). Maven's nearest-wins mediation
+	// ignores scope, so such a declaration still decides which version of that
+	// group:artifact is resolved. It is never reported as a package and its own
+	// dependencies are never walked.
+	MediationOnly bool
+
 	Locations ftypes.Locations
 
 	// For correctly calculation package ID (hash),

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -224,6 +224,7 @@ func (p *Parser) Parse(ctx context.Context, r xio.ReadSeekerAt) ([]ftypes.Packag
 	// Analyze root POM
 	result, err := p.analyze(ctx, root, analysisOptions{
 		rootFilePath: p.rootPath,
+		isRoot:       true,
 	})
 	if err != nil {
 		return nil, nil, xerrors.Errorf("analyze error (%s): %w", p.rootPath, err)
@@ -302,6 +303,23 @@ func (p *Parser) parseRoot(ctx context.Context, root artifact, uniqModules set.S
 			}
 		}
 
+		// A mediation-only declaration claims the group:artifact slot at its own
+		// depth so nearest-wins picks its version, but it is not on the
+		// compile/runtime classpath. Record it and stop: resolving it or walking
+		// its dependencies would cost POM lookups for a subtree that is never
+		// reported.
+		if art.MediationOnly {
+			if !art.IsEmpty() {
+				uniqArtifacts[art.Name()] = artifact{
+					Version:       art.Version,
+					Relationship:  art.Relationship,
+					Locations:     art.Locations,
+					MediationOnly: true,
+				}
+			}
+			continue
+		}
+
 		result, err := p.resolve(ctx, art, rootDepManagement)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("resolve error (%s): %w", art, err)
@@ -347,16 +365,26 @@ func (p *Parser) parseRoot(ctx context.Context, root artifact, uniqModules set.S
 			}
 
 			// save only dependency names
-			// version will be determined later
-			dependsOn := xslices.Map(result.dependencies, func(a artifact) string {
-				return a.Name()
-			})
+			// version will be determined later.
+			// Mediation-only declarations are left out: they decide a version but
+			// are not edges of the compile/runtime graph.
+			var dependsOn []string
+			for _, a := range result.dependencies {
+				if a.MediationOnly {
+					continue
+				}
+				dependsOn = append(dependsOn, a.Name())
+			}
 			uniqDeps[packageID(art.Name(), art.Version.String(), root.RootFilePath)] = dependsOn
 		}
 	}
 
 	// Convert to []ftypes.Package and []ftypes.Dependency
 	for name, art := range uniqArtifacts {
+		// Not on the compile/runtime classpath - it only decided the version.
+		if art.MediationOnly {
+			continue
+		}
 		pkg := ftypes.Package{
 			ID:           packageID(name, art.Version.String(), root.RootFilePath),
 			Name:         name,
@@ -412,6 +440,7 @@ func (p *Parser) parseModule(ctx context.Context, currentPath, relativePath stri
 	result, err := p.analyze(ctx, module, analysisOptions{
 		rootFilePath: module.filePath,
 		repositories: repos,
+		isRoot:       true,
 	})
 	if err != nil {
 		return artifact{}, xerrors.Errorf("analyze error: %w", err)
@@ -479,6 +508,10 @@ type analysisOptions struct {
 	depManagement []pomDependency // from the root POM
 	rootFilePath  string          // File path of the root POM or module POM
 	repositories  []repository    // Repositories inherited from parent
+	// isRoot marks the POM whose own `test`/`provided` dependencies still take
+	// part in version mediation. Those scopes are not transitive, so they only
+	// matter for the POM that declares them.
+	isRoot bool
 }
 
 func (p *Parser) analyze(ctx context.Context, pom *pom, opts analysisOptions) (analysisResult, error) {
@@ -594,7 +627,22 @@ func (p *Parser) parseDependencies(ctx context.Context, deps []pomDependency, pr
 		// Resolve dependencies
 		d = d.Resolve(props, depManagement, rootDepManagement)
 
-		if (d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime") || d.Optional {
+		if d.Optional {
+			continue
+		}
+
+		if d.Scope != "" && d.Scope != "compile" && d.Scope != "runtime" {
+			// `test` and `provided` are not transitive, so they only affect the
+			// POM that declares them. There they still win nearest-wins
+			// mediation, which decides the version every other path to this
+			// group:artifact resolves to. Keep the declaration for that purpose
+			// only: it is not resolved, not walked and not reported.
+			if !opts.isRoot || (d.Scope != "test" && d.Scope != "provided") {
+				continue
+			}
+			art := d.ToArtifact(opts)
+			art.MediationOnly = true
+			dependencies = append(dependencies, art)
 			continue
 		}
 

--- a/pkg/dependency/parser/java/pom/parse_scope_mediation_test.go
+++ b/pkg/dependency/parser/java/pom/parse_scope_mediation_test.go
@@ -1,0 +1,60 @@
+package pom_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/pom"
+)
+
+// A `test`-scoped dependency of the root POM is declared at depth 1, so Maven's
+// nearest-wins mediation resolves that group:artifact to its version even though
+// the scope is `test`. The single resolved copy is then test-scoped, which means
+// it is not on the compile/runtime classpath at all.
+//
+// Before this was handled, the declaration was dropped before mediation ran, so
+// the depth-2 transitive version won instead and was reported as a component
+// that the build never resolves.
+//
+// See https://github.com/aquasecurity/trivy/issues/7844
+func TestPom_Parse_TestScopeDecidesVersion(t *testing.T) {
+	inputFile := filepath.Join("testdata", "test-scope-decides-version", "pom.xml")
+
+	f, err := os.Open(inputFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	ts := httptest.NewServer(http.FileServer(http.Dir(filepath.Join("testdata", "repository"))))
+	defer ts.Close()
+
+	p := pom.NewParser(inputFile, pom.WithDefaultRepo(ts.URL, true, true))
+
+	gotPkgs, _, err := p.Parse(t.Context(), f)
+	require.NoError(t, err)
+
+	var names []string
+	versions := make(map[string]string)
+	for _, pkg := range gotPkgs {
+		names = append(names, pkg.Name)
+		versions[pkg.Name] = pkg.Version
+	}
+
+	// The test-scoped declaration wins mediation, so no copy of example-api is
+	// on the compile/runtime classpath.
+	assert.NotContains(t, names, "org.example:example-api",
+		"a test-scoped declaration at depth 1 wins mediation, so example-api must not be reported")
+
+	// In particular the transitive 2.0.0 must not be reported: it loses
+	// mediation to the depth-1 declaration and is never resolved by Maven.
+	assert.NotEqual(t, "2.0.0", versions["org.example:example-api"])
+
+	// The compile-scoped dependency that pulled it in is unaffected.
+	assert.Contains(t, names, "org.example:example-dependency")
+	assert.Equal(t, "1.2.3", versions["org.example:example-dependency"])
+}

--- a/pkg/dependency/parser/java/pom/testdata/test-scope-decides-version/pom.xml
+++ b/pkg/dependency/parser/java/pom/testdata/test-scope-decides-version/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>test-scope-decides-version</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <!-- Declared at depth 1, so nearest-wins mediation resolves
+             example-api to this version even though the scope is `test`.
+             The resolved copy is test-scoped, so it is not on the
+             compile/runtime classpath and must not be reported. -->
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>1.7.30</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Depends on org.example:example-api:2.0.0 at depth 2, which loses
+             mediation to the depth-1 declaration above. -->
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>example-dependency</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Fixes #7844.

This implements the approach I described in [my comment on the issue](https://github.com/aquasecurity/trivy/issues/7844#issuecomment-5305377112). Since the issue explicitly asks "do you have any ideas?", treat this as a concrete proposal rather than a finished decision — happy to change the semantics or close it if you want to go another way.

## What is wrong today

Maven's nearest-wins mediation **ignores scope**. A `test` or `provided` dependency declared in the POM sits at depth 1, so it decides which version of that group:artifact is resolved for everyone. The parser drops those declarations before mediation runs, so a deeper transitive version wins instead.

In the jackson example from the issue, `jackson-annotations` is declared at depth 1 with scope `test`, so Maven resolves **2.18.0, test-scoped** — meaning nothing is on the compile/runtime classpath. Trivy reports **2.18.1**, a version the build never resolves, and matches advisories against it.

So this is not only a wrong version, it is a finding for an artifact that is not in the build. The correct output for that POM is that `jackson-annotations` does not appear at all, which matches the first of the two options in the issue.

## The approach, and why it does not repeat #7414

`test` and `provided` are **not transitive** — they only apply to the POM that declares them. A `test` dependency of a *transitive* POM is already correctly ignored. So these scopes can only affect mediation in the **root POM** (and each module root).

That bounds the work. To get mediation right you only need the *declaration* to claim the slot; you never need to resolve it or walk its subtree — which is the expensive part that made the earlier attempt slow. Concretely:

- `parseDependencies` keeps root-level `test`/`provided` deps, flagged `MediationOnly`;
- the BFS records them in `uniqArtifacts` so they win nearest-wins at depth 1, then stops — no `resolve()`, no enqueueing of their dependencies;
- they are excluded from the reported packages and from the dependency edges.

**Net cost: zero additional POM lookups.**

`optional` is filtered on the same line but has different semantics (a direct optional dependency *is* on the declaring project's classpath), so I left it exactly as it was.

## Verification

- New `testdata/test-scope-decides-version/pom.xml` reproduces the issue's shape with existing repository fixtures: `example-api:1.7.30` declared `test` at depth 1, and `example-dependency:1.2.3` which pulls `example-api:2.0.0` at depth 2.
- `TestPom_Parse_TestScopeDecidesVersion` asserts `example-api` is not reported at all and that the compile-scoped dependency is unaffected. **Reverted against the old filter it fails with `[…, "org.example:example-api"] should not contain "org.example:example-api"`**, i.e. it reproduces exactly the reported bug.
- The existing `pkg/dependency/parser/java/pom` suite passes unchanged. It caught two real mistakes in my first attempt — mediation-only entries leaking into dependency edges — which is now handled explicitly.
- `go vet` clean.