### PR TITLE
docs(vm): mark monolithicSparse as a supported VMDK disk type

### DIFF
--- a/docs/guide/target/vm.md
+++ b/docs/guide/target/vm.md
@@ -211,7 +211,7 @@ More details are available in the [cache documentation](../configuration/cache.m
 | VMDK disk type              | Support |
 |-----------------------------|:-------:|
 | streamOptimized             |    ✔    |
-| monolithicSparse            |         |
+| monolithicSparse            |    ✔    |
 | vmfs                        |         |
 | vmfsSparse                  |         |
 | twoGbMaxExtentSparse        |         |


### PR DESCRIPTION
## Description

The VMDK disk type compatibility table in `docs/guide/target/vm.md` still lists `monolithicSparse` as unsupported, but support for it landed in v0.71.0.

#10575 upgraded `go-vmdk-parser` to a revision that contains [a12df68](https://github.com/masahiro331/go-vmdk-parser/commit/a12df6824e31e824cbbefd7647fa8178d2dae953) (Add MonolithicSparse support), so `vmdk.Open()` now dispatches `createType` to both `streamOptimized` and `monolithicSparse`. That PR also flipped the `testdata/monolithicSparse.vmdk` case in `pkg/fanal/artifact/vm/vm_test.go` from an expected `unsupported type error` to a happy path. Only the documentation was left behind, so the docs currently tell users the format cannot be scanned.

Verified against the revision pinned on `main` today (`go-vmdk-parser v0.0.0-20260423020818-08305fa668d2`):

```
=== RUN   TestNewArtifact/happy_path_for_monolithic_sparse_vmdk_format
--- PASS: TestNewArtifact (0.00s)
ok      github.com/aquasecurity/trivy/pkg/fanal/artifact/vm
```

Before:

| VMDK disk type   | Support |
|------------------|:-------:|
| streamOptimized  |    ✔    |
| monolithicSparse |         |

After:

| VMDK disk type   | Support |
|------------------|:-------:|
| streamOptimized  |    ✔    |
| monolithicSparse |    ✔    |

## Related issues

No associated issue. Following the [contributing guidelines](https://trivy.dev/docs/latest/community/contribute/pr/), this is a one-line documentation correction for already-shipped behaviour, so the justification is written above instead.

## Related PRs
- [x] #10575 — shipped `monolithicSparse` support in v0.71.0 (already merged; this PR only catches the docs up)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
