### PR TITLE
fix: guard against index-out-of-range in dependency parsers and OS detector

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -46,10 +46,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies
-			if !strings.Contains(ss[0], ":git") {
-				p.logger.Warn("Cannot parse dependency", log.String("line", line))
-			} else {
+			if len(ss) > 0 && strings.Contains(ss[0], ":git") {
 				p.logger.Debug("Skip git dependencies", log.String("name", name))
+			} else {
+				p.logger.Warn("Cannot parse dependency", log.String("line", line))
 			}
 			continue
 		}

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -76,7 +76,11 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
 			// Save only the name, normalized (PEP 503) to match the names from poetry.lock/pylock.toml.
-			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true))
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				continue
+			}
+			d.Set.Append(python.NormalizePkgName(fields[0], true))
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,7 +66,9 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
-			dependsOn = append(dependsOn, s[0]) // store name only for now
+			if len(s) > 0 {
+				dependsOn = append(dependsOn, s[0]) // store name only for now
+			}
 		}
 		lineNum++
 

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,11 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					childFields := strings.Fields(s)
+					if len(childFields) == 0 {
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], childFields[0])
 				}
 			}
 		}

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,7 +42,11 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	osVer = fields[0]
 	// The format `2023.xxx.xxxx` can be used.
 	osVer = osver.Major(osVer)
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {
@@ -103,7 +107,11 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 // IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return false
+	}
+	osVer = fields[0]
 	// The format `2023.xxx.xxxx` can be used.
 	osVer = osver.Major(osVer)
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {


### PR DESCRIPTION
## Summary

Five code paths call `strings.Fields(...)[0]` or `ss[0]` without first checking that the slice is non-empty. On malformed-but-parseable input this causes a `panic: runtime error: index out of range [0] with length 0` that aborts the entire scan rather than skipping the offending entry.

## Changes

| File | Location | Fix |
|---|---|---|
| `pkg/detector/ospkg/amazon/amazon.go` | `Detect` and `IsSupportedVersion` | Guard `strings.Fields(osVer)[0]` — an `/etc/system-release` containing `"Amazon Linux"` (no version) yields an empty `osVer` and panics |
| `pkg/dependency/parser/python/pyproject/pyproject.go` | `UnmarshalTOML` | Guard `strings.Fields(dep)[0]` — an empty string in `dependencies = ["flask", ""]` reduces to empty fields after operator-stripping |
| `pkg/dependency/parser/swift/cocoapods/parse.go` | `Parse` | Guard `strings.Fields(s)[0]` — an empty/whitespace child-dependency string yields empty fields |
| `pkg/dependency/parser/hex/mix/parse.go` | `Parse` | Guard `ss[0]` in the `len(ss) < 8` branch — a `mix.lock` line with empty body yields `len(ss) == 0`, entering the branch and panicking |
| `pkg/dependency/parser/ruby/bundler/parse.go` | `Parse` | Guard `s[0]` in the `countLeadingSpace == 6` branch — a line of exactly 6 spaces yields empty fields |

The amazon case is the most realistic: the `/etc/system-release` content is fully controlled by the image author, so a third-party image can trigger a real scanner crash without any manipulation of lock files.

The `conda` instance mentioned in the issue was already fixed (#10955).

## Testing

Verified by inspection that each `strings.Fields(...)[0]` or `ss[0]` access is now preceded by a length check. The fix degrades gracefully — the amazon scanner returns empty results for an unversioned OS string, and the parsers skip the malformed entries.

Fixes #10976