### PR TITLE
docs(ecosystem): add CRA Release Evidence community integration

### DIFF
--- a/docs/ecosystem/cicd.md
+++ b/docs/ecosystem/cicd.md
@@ -28,6 +28,12 @@ In this action, Trivy scans the dependency files such as package-lock.json and g
 
 👉 Get it at: <https://github.com/marketplace/actions/trivy-github-issues>
 
+### CRA Release Evidence (Community)
+
+CRA Release Evidence is an MIT-licensed GitHub Action that collects existing Trivy CycloneDX SBOM and SARIF outputs with test results and Git release changes, then creates version-specific Markdown and JSON evidence packages. It is an evidence collector, not a scanner: it does not evaluate findings or provide compliance or legal verdicts.
+
+👉 Get it at: <https://github.com/marketplace/actions/cra-release-evidence>
+
 ## Buildkite Plugin (Community)
 
 The trivy buildkite plugin provides a convenient mechanism for running the open-source trivy static analysis tool on your project. 


### PR DESCRIPTION
## Description

Adds CRA Release Evidence to the GitHub Actions section of the Trivy ecosystem documentation.

CRA Release Evidence is an MIT-licensed evidence collector that consumes existing Trivy CycloneDX SBOM and SARIF outputs, combines them with test results and Git release changes, and creates version-specific Markdown and JSON evidence packages. The entry explicitly states that it is not a scanner, does not evaluate findings, and does not provide compliance or legal verdicts.

This is a small, documentation-only ecosystem listing, so no issue was opened. It does not change Trivy code or runtime behavior.

## Before and after

- **Before:** the GitHub Actions section did not list a release-evidence collector for existing Trivy output.
- **After:** users can discover the community Action and its boundaries directly from the CI/CD ecosystem page.

## Validation

- `mike deploy test`
- `git diff --check`

## Checklist

- [x] I've read the contributing guidelines.
- [x] I've followed the PR title conventions.
- [x] I've limited this PR to one focused documentation change.
- [x] I've validated the documentation build.
