### PR TITLE
feat(python): add ZIP application support

### DIFF
--- a/docs/guide/coverage/language/python.md
+++ b/docs/guide/coverage/language/python.md
@@ -12,13 +12,14 @@ The following scanners are supported for package managers.
 | uv              |  ✓   |       ✓       |    -    |
 | pylock          |  ✓   |       ✓       |    -    |
 
-In addition, Trivy supports these formats of Python packages: `egg`, `wheel` and `conda`.
+In addition, Trivy supports these formats of Python packages: `egg`, `wheel`, `zipapp` and `conda`.
 The following scanners are supported for Python packages.
 
 | Packaging | SBOM | Vulnerability | License |
 |-----------|:----:|:-------------:|:-------:|
 | Egg       |  ✓   |       ✓       |    ✓    |
 | Wheel     |  ✓   |       ✓       |    ✓    |
+| Zipapp    |  ✓   |       ✓       |    ✓    |
 | Conda     |  ✓   |       -       |    -    |
 
 
@@ -163,6 +164,9 @@ Trivy looks for `*.egg-info`, `*.egg-info/METADATA`, `*.egg-info/PKG-INFO`, `*.e
 
 ### Wheel
 Trivy looks for `.dist-info/METADATA` to identify Python packages.
+
+### Zipapp
+Trivy looks for installed package metadata in Python zip applications with `.pyz` and `.pyzw` extensions.
 
 [^1]: Trivy checks `python`, `python3`, `python2` and `python.exe` file names.
 [^2]: Also `pylock.<identifier>.toml` per [PEP 751][pep-751].

--- a/pkg/fanal/analyzer/const.go
+++ b/pkg/fanal/analyzer/const.go
@@ -81,13 +81,14 @@ const (
 	TypeCondaEnv Type = "conda-environment"
 
 	// Python
-	TypePythonPkg    Type = "python-pkg"
-	TypePythonPkgEgg Type = "python-egg"
-	TypePip          Type = "pip"
-	TypePipenv       Type = "pipenv"
-	TypePoetry       Type = "poetry"
-	TypeUv           Type = "uv"
-	TypePyLock       Type = "pylock"
+	TypePythonPkg       Type = "python-pkg"
+	TypePythonPkgEgg    Type = "python-egg"
+	TypePythonPkgZipApp Type = "python-zipapp"
+	TypePip             Type = "pip"
+	TypePipenv          Type = "pipenv"
+	TypePoetry          Type = "poetry"
+	TypeUv              Type = "uv"
+	TypePyLock          Type = "pylock"
 
 	// Go
 	TypeGoBinary Type = "gobinary"
@@ -217,6 +218,7 @@ var (
 		TypeCondaEnv,
 		TypePythonPkg,
 		TypePythonPkgEgg,
+		TypePythonPkgZipApp,
 		TypePip,
 		TypePipenv,
 		TypePoetry,
@@ -265,6 +267,7 @@ var (
 		TypeNodePkg,
 		TypeCondaPkg,
 		TypePythonPkg,
+		TypePythonPkgZipApp,
 		TypeGoBinary,
 		TypeJar,
 		TypeRustBinary,

--- a/pkg/fanal/analyzer/language/python/packaging/zipapp.go
+++ b/pkg/fanal/analyzer/language/python/packaging/zipapp.go
@@ -1,0 +1,138 @@
+package packaging
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	pythonpackaging "github.com/aquasecurity/trivy/pkg/dependency/parser/python/packaging"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer/language"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
+	xio "github.com/aquasecurity/trivy/pkg/x/io"
+)
+
+func init() {
+	analyzer.RegisterAnalyzer(&zipAppAnalyzer{})
+}
+
+const (
+	zipAppAnalyzerVersion = 1
+	maxMetadataSize       = 10 << 20 // 10 MiB
+)
+
+type zipAppAnalyzer struct {
+	logger                           *log.Logger
+	licenseClassifierConfidenceLevel float64
+}
+
+func (a *zipAppAnalyzer) Init(opt analyzer.AnalyzerOptions) error {
+	a.logger = log.WithPrefix("python")
+	a.licenseClassifierConfidenceLevel = opt.LicenseScannerOption.ClassifierConfidenceLevel
+	return nil
+}
+
+func (a *zipAppAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	if _, err := input.Content.Seek(0, io.SeekStart); err != nil {
+		return nil, xerrors.Errorf("file seek error: %w", err)
+	}
+
+	zr, err := zip.NewReader(input.Content, input.Info.Size())
+	if err != nil {
+		return nil, xerrors.Errorf("unable to open Python zipapp: %w", err)
+	}
+
+	var metadataFiles []*zip.File
+	hasMain := false
+	for _, f := range zr.File {
+		if f.Name == "__main__.py" && !f.FileInfo().IsDir() {
+			hasMain = true
+		}
+		if !f.FileInfo().IsDir() && isZipAppMetadata(f.Name) {
+			metadataFiles = append(metadataFiles, f)
+		}
+	}
+	if !hasMain {
+		return nil, nil
+	}
+
+	var packages types.Packages
+	for _, metadataFile := range metadataFiles {
+		metadata, err := metadataFile.Open()
+		if err != nil {
+			return nil, xerrors.Errorf("unable to open Python package metadata %q: %w", metadataFile.Name, err)
+		}
+
+		rsa, err := xio.NewReadSeekerAt(xio.MaxBytesReader(metadata, maxMetadataSize))
+		_ = metadata.Close()
+		if err != nil {
+			return nil, xerrors.Errorf("unable to read Python package metadata %q: %w", metadataFile.Name, err)
+		}
+
+		// metadataFile.Name is a validated relative path and is only used for reporting, not extraction.
+		metadataPath := path.Join(input.FilePath, metadataFile.Name) // #nosec G305
+		app, err := language.ParsePackage(ctx, types.PythonPkg, metadataPath, rsa,
+			pythonpackaging.NewParser(), input.Options.FileChecksum)
+		if err != nil {
+			return nil, xerrors.Errorf("unable to parse Python package metadata %q: %w", metadataFile.Name, err)
+		} else if app == nil {
+			continue
+		}
+
+		opener := func(licensePath string) (io.ReadCloser, error) {
+			name := path.Join(path.Dir(metadataFile.Name), licensePath)
+			for _, f := range zr.File {
+				if f.Name == name && !f.FileInfo().IsDir() {
+					return f.Open()
+				}
+			}
+			return nil, nil
+		}
+		if err = fillAdditionalData(opener, app, a.licenseClassifierConfidenceLevel); err != nil {
+			a.logger.Warn("Unable to collect additional info", log.FilePath(metadataPath), log.Err(err))
+		}
+
+		packages = append(packages, app.Packages...)
+	}
+	if len(packages) == 0 {
+		return nil, nil
+	}
+
+	return &analyzer.AnalysisResult{
+		Applications: []types.Application{
+			{
+				Type:     types.PythonPkg,
+				FilePath: input.FilePath,
+				Packages: packages,
+			},
+		},
+	}, nil
+}
+
+func isZipAppMetadata(filePath string) bool {
+	if !fs.ValidPath(filePath) || strings.Contains(filePath, `\`) {
+		return false
+	}
+	return strings.HasSuffix(filePath, ".dist-info/METADATA") || isEggFile(filePath)
+}
+
+func (a *zipAppAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	ext := filepath.Ext(filePath)
+	return strings.EqualFold(ext, ".pyz") || strings.EqualFold(ext, ".pyzw")
+}
+
+func (a *zipAppAnalyzer) Type() analyzer.Type {
+	return analyzer.TypePythonPkgZipApp
+}
+
+func (a *zipAppAnalyzer) Version() int {
+	return zipAppAnalyzerVersion
+}

--- a/pkg/fanal/analyzer/language/python/packaging/zipapp_test.go
+++ b/pkg/fanal/analyzer/language/python/packaging/zipapp_test.go
@@ -1,0 +1,120 @@
+package packaging
+
+import (
+	"archive/zip"
+	"bytes"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func Test_zipAppAnalyzer_Analyze(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  *analyzer.AnalysisResult
+	}{
+		{
+			name: "zipapp with installed packages",
+			files: map[string]string{
+				"__main__.py":                                    "print('hello')",
+				"requests-2.32.4.dist-info/METADATA":             "Name: requests\nVersion: 2.32.4\n",
+				"site-packages/urllib3-2.5.0.dist-info/METADATA": "Name: urllib3\nVersion: 2.5.0\n",
+			},
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.PythonPkg,
+						FilePath: "app.pyz",
+						Packages: types.Packages{
+							{
+								Name:     "requests",
+								Version:  "2.32.4",
+								FilePath: "app.pyz/requests-2.32.4.dist-info/METADATA",
+							},
+							{
+								Name:     "urllib3",
+								Version:  "2.5.0",
+								FilePath: "app.pyz/site-packages/urllib3-2.5.0.dist-info/METADATA",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "archive without root main",
+			files: map[string]string{
+				"example-1.0.0.dist-info/METADATA": "Name: example\nVersion: 1.0.0\n",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contents := newZipApp(t, tt.files)
+			info, err := fs.Stat(fstest.MapFS{
+				"app.pyz": {Data: contents},
+			}, "app.pyz")
+			require.NoError(t, err)
+
+			a := &zipAppAnalyzer{}
+			require.NoError(t, a.Init(analyzer.AnalyzerOptions{}))
+			got, err := a.Analyze(t.Context(), analyzer.AnalysisInput{
+				Content:  bytes.NewReader(contents),
+				FilePath: "app.pyz",
+				Info:     info,
+			})
+
+			require.NoError(t, err)
+			if got != nil && tt.want != nil {
+				assert.Equal(t, tt.want.Applications[0].Type, got.Applications[0].Type)
+				assert.Equal(t, tt.want.Applications[0].FilePath, got.Applications[0].FilePath)
+				assert.ElementsMatch(t, tt.want.Applications[0].Packages, got.Applications[0].Packages)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_zipAppAnalyzer_Required(t *testing.T) {
+	tests := []struct {
+		filePath string
+		want     bool
+	}{
+		{filePath: "app.pyz", want: true},
+		{filePath: "app.PYZW", want: true},
+		{filePath: "app.zip", want: false},
+	}
+
+	a := &zipAppAnalyzer{}
+	for _, tt := range tests {
+		t.Run(tt.filePath, func(t *testing.T) {
+			assert.Equal(t, tt.want, a.Required(tt.filePath, nil))
+		})
+	}
+}
+
+func newZipApp(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	buf.WriteString("#!/usr/bin/env python3\n")
+	zw := zip.NewWriter(&buf)
+	for name, contents := range files {
+		f, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Description

Add package detection for Python ZIP applications (`.pyz` and `.pyzw`).

The analyzer verifies that the archive has a root-level `__main__.py`, then reuses Trivy's Python packaging parser for embedded `.dist-info` and egg metadata. It reports the packages under one Python application for the outer zipapp, preserves each metadata path, supports license metadata, rejects unsafe archive paths, and bounds metadata reads.

Before this change, scanning a zipapp containing `example==1.2.3` produced zero language-specific files and zero CycloneDX components. After this change, the same scan reports one language-specific file and `pkg:pypi/example@1.2.3` from `sample.pyz/site-packages/example-1.2.3.dist-info/METADATA`.

## Related issues

- Close #4240

## Validation

- `go test ./pkg/fanal/analyzer ./pkg/fanal/analyzer/language/python/packaging`
- `go test ./pkg/fanal/analyzer/language/python/... ./pkg/dependency/parser/python/...`
- `golangci-lint run --build-tags=integration`
- `mage tidy`
- `mage build`
- Built-binary rootfs scans producing CycloneDX and license results for a standards-compliant sample zipapp

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information.
- [x] I've added usage information (not applicable; this adds no options).
- [x] I've included a before and after example in the description.
