### PR TITLE
fix(go): restore stdlib version parsing for vendor-patched Go toolchains

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -56,13 +56,15 @@ func NewParser() *Parser {
 
 // parseStdlibVersion extracts the Go stdlib version from info.GoVersion,
 // which may carry trailing metadata that is not part of the version:
-//   - a GOEXPERIMENT list in both formats: " X:foo" (Go <=1.25) and "-X:foo" (Go >=1.26). 
+//   - a GOEXPERIMENT list in both formats: " X:foo" (Go <=1.25) and "-X:foo" (Go >=1.26).
 //   - a vendor build identifier, e.g. "go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1)".
 func parseStdlibVersion(goVersion string) string {
 	stdlibVersion := strings.TrimPrefix(goVersion, "go")
-	// A Go version never contains a space, so everything from the first one onward is metadata.
+	// Go itself treats whatever follows the version after a space as a custom build suffix and strips it.
+	// cf. https://github.com/golang/go/blob/c19862e5f8415b4f24b189d065ed739517c548ba/src/cmd/go/internal/gover/toolchain.go#L18-L40
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " ")
-	// Go >=1.26 may instead join the GOEXPERIMENT list with a dash.
+	// Strip the GOEXPERIMENT list, which Go >=1.26 joins with a dash instead of a space.
+	// cf. https://github.com/golang/go/blob/9daaab305c4d1dede9e4f6efdc5e1268a69327e6/src/cmd/go/internal/cache/hash.go#L48-L58
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, "-X:")
 	// Add the `v` prefix to be consistent with module and dependency versions.
 	return fmt.Sprintf("v%s", stdlibVersion)

--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -54,14 +54,15 @@ func NewParser() *Parser {
 	}
 }
 
-// parseStdlibVersion extracts the Go stdlib version from info.GoVersion.
-// It strips GOEXPERIMENT suffixes in both formats: " X:foo" (Go <=1.25) and "-X:foo" (Go >=1.26).
+// parseStdlibVersion extracts the Go stdlib version from info.GoVersion,
+// which may carry trailing metadata that is not part of the version:
+//   - a GOEXPERIMENT list in both formats: " X:foo" (Go <=1.25) and "-X:foo" (Go >=1.26). 
+//   - a vendor build identifier, e.g. "go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1)".
 func parseStdlibVersion(goVersion string) string {
-	// Ex: "go1.22.3 X:boringcrypto" (Go <=1.25) or "go1.26.0-X:nodwarf5" (Go >=1.26)
 	stdlibVersion := strings.TrimPrefix(goVersion, "go")
-	// Strip GOEXPERIMENT suffix: " X:foo" (Go <=1.25) or "-X:foo" (Go >=1.26)
-	// cf. https://github.com/golang/go/blob/9daaab305c4d1dede9e4f6efdc5e1268a69327e6/src/cmd/go/internal/cache/hash.go#L48-L58
-	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " X:")
+	// A Go version never contains a space, so everything from the first one onward is metadata.
+	stdlibVersion, _, _ = strings.Cut(stdlibVersion, " ")
+	// Go >=1.26 may instead join the GOEXPERIMENT list with a dash.
 	stdlibVersion, _, _ = strings.Cut(stdlibVersion, "-X:")
 	// Add the `v` prefix to be consistent with module and dependency versions.
 	return fmt.Sprintf("v%s", stdlibVersion)

--- a/pkg/dependency/parser/golang/binary/parse_internal_test.go
+++ b/pkg/dependency/parser/golang/binary/parse_internal_test.go
@@ -39,6 +39,18 @@ func TestParseStdlibVersion(t *testing.T) {
 			goVersion: "go1.26.0-X:nodwarf5,someother",
 			want:      "v1.26.0",
 		},
+		{
+			// Red Hat-derived toolchains (RHEL, AlmaLinux, Rocky, Fedora) append a
+			// vendor build identifier, verified on almalinux:10 golang-1.26.5-1.el10_2.alma.1.
+			name:      "vendor build identifier from a Red Hat-derived toolchain",
+			goVersion: "go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1)",
+			want:      "v1.26.5",
+		},
+		{
+			name:      "vendor build identifier followed by a GOEXPERIMENT suffix",
+			goVersion: "go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1) X:jsonv2",
+			want:      "v1.26.5",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
`parseStdlibVersion` only strips GOEXPERIMENT suffixes, so the vendor build
identifier emitted by Red Hat-derived toolchains (RHEL, AlmaLinux, Rocky, Fedora)
survives into the version, producing invalid semver and silently killing stdlib
vulnerability matching.

This is a regression from #10351, which narrowed `strings.Cut(v, " ")` (added in
#6696) to `" X:"`. This restores the broad space cut and keeps the `-X:` cut, so
#10350 remains fixed.

Verified on `almalinux:10`, `golang-1.26.5-1.el10_2.alma.1`:

| Build | Embedded `GoVersion` |
|---|---|
| plain | `go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1)` |
| `GOEXPERIMENT=jsonv2` | `go1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1) X:jsonv2` |

### Before
stdlib version: `v1.26.5 (Red Hat 1.26.5-1.el10_2.alma.1)` — malformed, no matching.

### After
stdlib version: `v1.26.5`

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
