### PR TITLE
fix(misconf): use TLS_1_2 as the default security policy for API Gateway domain names

### DIFF
--- a/pkg/iac/adapters/cloudformation/aws/apigateway/apigateway_test.go
+++ b/pkg/iac/adapters/cloudformation/aws/apigateway/apigateway_test.go
@@ -70,7 +70,7 @@ Resources:
   MyDomainName2:
     Type: 'AWS::ApiGatewayV2::DomainName'
     Properties:
-      DomainName: mydomainame.us-east-1.com
+      DomainName: mydomainame2.us-east-1.com
       DomainNameConfigurations:
         - SecurityPolicy: "TLS_1_2"
 `,
@@ -132,7 +132,7 @@ Resources:
 					},
 					DomainNames: []v2.DomainName{
 						{
-							Name:           types.StringTest("mydomainame.us-east-1.com"),
+							Name:           types.StringTest("mydomainame2.us-east-1.com"),
 							SecurityPolicy: types.StringTest("TLS_1_2"),
 						},
 					},

--- a/pkg/iac/adapters/cloudformation/aws/apigateway/apiv1.go
+++ b/pkg/iac/adapters/cloudformation/aws/apigateway/apiv1.go
@@ -1,6 +1,7 @@
 package apigateway
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway"
 	v1 "github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway/v1"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser"
 )
@@ -100,7 +101,7 @@ func adaptDomainNamesV1(fctx parser.FileContext) []v1.DomainName {
 		domainNames = append(domainNames, v1.DomainName{
 			Metadata:       domainNameResource.Metadata(),
 			Name:           domainNameResource.GetStringProperty("DomainName"),
-			SecurityPolicy: domainNameResource.GetStringProperty("SecurityPolicy"),
+			SecurityPolicy: domainNameResource.GetStringProperty("SecurityPolicy", apigateway.DefaultSecurityPolicy),
 		})
 	}
 

--- a/pkg/iac/adapters/cloudformation/aws/apigateway/apiv2.go
+++ b/pkg/iac/adapters/cloudformation/aws/apigateway/apiv2.go
@@ -1,6 +1,7 @@
 package apigateway
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway"
 	v2 "github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway/v2"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
@@ -70,17 +71,17 @@ func getAccessLogging(r *parser.Resource) v2.AccessLogging {
 func adaptDomainNamesV2(fctx parser.FileContext) []v2.DomainName {
 	var domainNames []v2.DomainName
 
-	for _, domainNameResource := range fctx.GetResourcesByType("AWS::ApiGateway::DomainName") {
+	for _, domainNameResource := range fctx.GetResourcesByType("AWS::ApiGatewayV2::DomainName") {
 
 		domainName := v2.DomainName{
 			Metadata:       domainNameResource.Metadata(),
 			Name:           domainNameResource.GetStringProperty("DomainName"),
-			SecurityPolicy: domainNameResource.GetStringProperty("SecurityPolicy"),
+			SecurityPolicy: domainNameResource.GetStringProperty("SecurityPolicy", apigateway.DefaultSecurityPolicy),
 		}
 
 		if domainNameCfgs := domainNameResource.GetProperty("DomainNameConfigurations"); domainNameCfgs.IsList() {
 			for _, domainNameCfg := range domainNameCfgs.AsList() {
-				domainName.SecurityPolicy = domainNameCfg.GetStringProperty("SecurityPolicy")
+				domainName.SecurityPolicy = domainNameCfg.GetStringProperty("SecurityPolicy", apigateway.DefaultSecurityPolicy)
 			}
 		}
 

--- a/pkg/iac/adapters/cloudformation/aws/sam/api.go
+++ b/pkg/iac/adapters/cloudformation/aws/sam/api.go
@@ -1,6 +1,7 @@
 package sam
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway"
 	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/sam"
 	"github.com/aquasecurity/trivy/pkg/iac/scanners/cloudformation/parser"
 	iacTypes "github.com/aquasecurity/trivy/pkg/iac/types"
@@ -87,7 +88,7 @@ func getDomainConfiguration(r *parser.Resource) sam.DomainConfiguration {
 		domainConfig = sam.DomainConfiguration{
 			Metadata:       domain.Metadata(),
 			Name:           domain.GetStringProperty("DomainName"),
-			SecurityPolicy: domain.GetStringProperty("SecurityPolicy"),
+			SecurityPolicy: domain.GetStringProperty("SecurityPolicy", apigateway.DefaultSecurityPolicy),
 		}
 	}
 

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv1.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv1.go
@@ -1,6 +1,7 @@
 package apigateway
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway"
 	v1 "github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway/v1"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 )
@@ -14,7 +15,7 @@ func adaptDomainNamesV1(modules terraform.Modules) []v1.DomainName {
 			domainName := v1.DomainName{
 				Metadata:       nameBlock.GetMetadata(),
 				Name:           nameBlock.GetAttribute("domain_name").AsStringValueOrDefault("", nameBlock),
-				SecurityPolicy: nameBlock.GetAttribute("security_policy").AsStringValueOrDefault("TLS_1_0", nameBlock),
+				SecurityPolicy: nameBlock.GetAttribute("security_policy").AsStringValueOrDefault(apigateway.DefaultSecurityPolicy, nameBlock),
 			}
 			domainNames = append(domainNames, domainName)
 		}

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv1_test.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv1_test.go
@@ -22,8 +22,7 @@ resource "aws_api_gateway_domain_name" "example" {
 `,
 			expected: []v1.DomainName{
 				{
-					Name:           String(""),
-					SecurityPolicy: String("TLS_1_0"),
+					SecurityPolicy: String("TLS_1_2"),
 				},
 			},
 		},

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv2.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv2.go
@@ -1,6 +1,7 @@
 package apigateway
 
 import (
+	"github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway"
 	v2 "github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway/v2"
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	"github.com/aquasecurity/trivy/pkg/iac/types"
@@ -15,10 +16,10 @@ func adaptDomainNamesV2(modules terraform.Modules) []v2.DomainName {
 			domainName := v2.DomainName{
 				Metadata:       nameBlock.GetMetadata(),
 				Name:           nameBlock.GetAttribute("domain_name").AsStringValueOrDefault("", nameBlock),
-				SecurityPolicy: types.StringDefault("TLS_1_0", nameBlock.GetMetadata()),
+				SecurityPolicy: types.StringDefault(apigateway.DefaultSecurityPolicy, nameBlock.GetMetadata()),
 			}
 			if config := nameBlock.GetBlock("domain_name_configuration"); config.IsNotNil() {
-				domainName.SecurityPolicy = config.GetAttribute("security_policy").AsStringValueOrDefault("TLS_1_0", config)
+				domainName.SecurityPolicy = config.GetAttribute("security_policy").AsStringValueOrDefault(apigateway.DefaultSecurityPolicy, config)
 			}
 			domainNames = append(domainNames, domainName)
 		}

--- a/pkg/iac/adapters/terraform/aws/apigateway/namesv2_test.go
+++ b/pkg/iac/adapters/terraform/aws/apigateway/namesv2_test.go
@@ -22,8 +22,7 @@ resource "aws_apigatewayv2_domain_name" "example" {
 `,
 			expected: []v2.DomainName{
 				{
-					Name:           String(""),
-					SecurityPolicy: String("TLS_1_0"),
+					SecurityPolicy: String("TLS_1_2"),
 				},
 			},
 		},

--- a/pkg/iac/providers/aws/apigateway/ag.go
+++ b/pkg/iac/providers/aws/apigateway/ag.go
@@ -5,6 +5,11 @@ import (
 	v2 "github.com/aquasecurity/trivy/pkg/iac/providers/aws/apigateway/v2"
 )
 
+// DefaultSecurityPolicy is assigned by API Gateway to a custom domain name
+// that has no explicit security policy:
+// https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies-list.html#apigateway-security-policies-default
+const DefaultSecurityPolicy = "TLS_1_2"
+
 type APIGateway struct {
 	V1 v1.APIGateway
 	V2 v2.APIGateway


### PR DESCRIPTION
## Description

API Gateway sets TLS_1_2 by default for a custom domain name when no security policy is specified, for regional, edge-optimized and private domains alike: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies-list.html#apigateway-security-policies-default

Terraform adapters hardcoded TLS_1_0, CloudFormation ones left the value empty when the property was missing from the template. Both made AVD-AWS-0005 report domains that are configured correctly. The default is TLS_1_2 now, including the `Domain` property of `AWS::Serverless::Api` in the SAM adapter.

The CloudFormation adapter for API Gateway V2 collected `AWS::ApiGateway::DomainName` resources, so v2 domain names were never checked and v1 ones landed in the model twice.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
