### PR TITLE
chore: bump Go to 1.27

### DIFF
--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -89,5 +89,5 @@ jobs:
       - name: Run golangci-lint for caching
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13.1
           args: --verbose

--- a/.github/workflows/cache-test-assets.yaml
+++ b/.github/workflows/cache-test-assets.yaml
@@ -91,5 +91,3 @@ jobs:
         with:
           version: v2.12
           args: --verbose
-        env:
-          GOEXPERIMENT: jsonv2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,6 @@ jobs:
           version: v2.12
           args: --verbose
           skip-save-cache: true  # Restore cache from main branch but don't save new cache
-        env:
-          GOEXPERIMENT: jsonv2
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Check if linter failed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         id: lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13.1
           args: --verbose
           skip-save-cache: true  # Restore cache from main branch but don't save new cache
         if: matrix.operating-system == 'ubuntu-latest'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -143,6 +143,10 @@ linters:
     testifylint:
       enable-all: true
 
+    modernize:
+      disable:
+        - embedlit
+
   default: none
 
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -198,7 +198,7 @@ linters:
     warn-unused: true
 
 run:
-  go: "1.26"
+  go: "1.27"
   timeout: 30m
 
 formatters:

--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -17,13 +17,11 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		var exitError *types.ExitError
-		if errors.As(err, &exitError) {
+		if exitError, ok := errors.AsType[*types.ExitError](err); ok {
 			os.Exit(exitError.Code)
 		}
 
-		var userErr *types.UserError
-		if errors.As(err, &userErr) {
+		if userErr, ok := errors.AsType[*types.UserError](err); ok {
 			log.Fatal("Error", log.Err(userErr))
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy
 
-go 1.26.3
+go 1.27.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/goreleaser-canary.yml
+++ b/goreleaser-canary.yml
@@ -11,7 +11,6 @@ builds:
       - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     goos:
       - darwin
       - linux

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -11,7 +11,6 @@ builds:
       - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     goos:
       - linux
     goarch:
@@ -32,7 +31,6 @@ builds:
       - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     goos:
       - freebsd
     goarch:
@@ -49,7 +47,6 @@ builds:
       - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     goos:
       - darwin
     goarch:
@@ -66,7 +63,6 @@ builds:
       - -X github.com/aquasecurity/trivy/pkg/version/app.ver={{.Version}}
     env:
       - CGO_ENABLED=0
-      - GOEXPERIMENT=jsonv2
     goos:
       - windows
     goarch:

--- a/integration/README.md
+++ b/integration/README.md
@@ -18,7 +18,7 @@ mage test:k8s          # Kubernetes integration tests
 
 ### Run specific test
 ```bash
-GOEXPERIMENT=jsonv2 go test -tags=integration -run TestRepository ./integration -v
+go test -tags=integration -run TestRepository ./integration -v
 ```
 
 ## Golden Files
@@ -40,7 +40,7 @@ mage test:updateModuleGolden
 mage test:updateVMGolden
 
 # Update specific golden files manually
-GOEXPERIMENT=jsonv2 go test -tags=integration -run TestRepository ./integration -v -update
+go test -tags=integration -run TestRepository ./integration -v -update
 ```
 
 **Important**:

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -28,6 +28,8 @@ var (
 	GOPATH = os.Getenv("GOPATH")
 	GOBIN  = filepath.Join(GOPATH, "bin")
 
+	golangciLint = filepath.Join(GOBIN, "golangci-lint")
+
 	ENV = map[string]string{
 		"CGO_ENABLED": "0",
 	}
@@ -74,9 +76,8 @@ func (Tool) PipTools() error {
 
 // GolangciLint installs golangci-lint
 func (t Tool) GolangciLint() error {
-	const version = "v2.12.2"
-	bin := filepath.Join(GOBIN, "golangci-lint")
-	if exists(bin) && t.matchGolangciLintVersion(bin, version) {
+	const version = "v2.13.1"
+	if exists(golangciLint) && t.matchGolangciLintVersion(golangciLint, version) {
 		return nil
 	}
 	// TODO: use `go install tool`
@@ -347,13 +348,13 @@ type Lint mg.Namespace
 // Run runs linters
 func (l Lint) Run() error {
 	mg.Deps(Tool{}.GolangciLint, Tool{}.Install)
-	return sh.RunWithV(ENV, "golangci-lint", "run", "--build-tags=integration")
+	return sh.RunWithV(ENV, golangciLint, "run", "--build-tags=integration")
 }
 
 // Fix auto fixes linters
 func (l Lint) Fix() error {
 	mg.Deps(Tool{}.GolangciLint, Tool{}.Install)
-	return sh.RunWithV(ENV, "golangci-lint", "run", "--fix", "--build-tags=integration")
+	return sh.RunWithV(ENV, golangciLint, "run", "--fix", "--build-tags=integration")
 }
 
 // Fmt formats Go code

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -29,8 +29,7 @@ var (
 	GOBIN  = filepath.Join(GOPATH, "bin")
 
 	ENV = map[string]string{
-		"CGO_ENABLED":  "0",
-		"GOEXPERIMENT": "jsonv2",
+		"CGO_ENABLED": "0",
 	}
 )
 

--- a/pkg/dependency/parser/java/pom/repository.go
+++ b/pkg/dependency/parser/java/pom/repository.go
@@ -51,8 +51,7 @@ func resolvePomRepos(servers []Server, pomRepos []pomRepository) []repository {
 
 		repoURL, err := url.Parse(rep.URL)
 		if err != nil {
-			var ue *url.Error
-			if errors.As(err, &ue) {
+			if ue, ok := errors.AsType[*url.Error](err); ok {
 				err = ue.Unwrap()
 			}
 			logger.Debug("Unable to parse remote repository url", log.String("id", rep.ID), log.Err(err))

--- a/pkg/fanal/analyzer/pkg/rpm/archive.go
+++ b/pkg/fanal/analyzer/pkg/rpm/archive.go
@@ -147,8 +147,7 @@ func (a *rpmArchiveAnalyzer) generatePURL(pkg *types.Package) *packageurl.Packag
 }
 
 func (a *rpmArchiveAnalyzer) unexpectedError(err error) error {
-	var rerr rpmutils.NoSuchTagError
-	if errors.As(err, &rerr) {
+	if rerr, ok := errors.AsType[rpmutils.NoSuchTagError](err); ok {
 		a.logger.Debug("RPM tag not found", log.Err(rerr))
 		return nil
 	}

--- a/pkg/fanal/artifact/image/image_test.go
+++ b/pkg/fanal/artifact/image/image_test.go
@@ -2182,7 +2182,7 @@ func TestArtifact_InspectWithMaxImageSize(t *testing.T) {
 			artifactOpt: artifact.Option{
 				ImageOption: types.ImageOptions{MaxImageSize: units.KB * 1},
 			},
-			wantErr: "compressed image size 2.44kB exceeds maximum allowed size 1kB",
+			wantErr: "compressed image size 2.39kB exceeds maximum allowed size 1kB",
 		},
 		{
 			name: "uncompressed layers size is larger than the maximum",

--- a/pkg/fanal/image/image_test.go
+++ b/pkg/fanal/image/image_test.go
@@ -51,6 +51,11 @@ func TestNewDockerImage(t *testing.T) {
 	}()
 	serverAddr := tr.Listener.Addr().String()
 
+	// The registry computes the manifest digest by compressing the layers of the tarball,
+	// so the value depends on the compressor of the toolchain the tests are built with.
+	imgDigest, err := localImage(t).Digest()
+	require.NoError(t, err)
+
 	type args struct {
 		imageName string
 		option    types.ImageOptions
@@ -154,7 +159,7 @@ func TestNewDockerImage(t *testing.T) {
 			wantID:       "sha256:af341ccd2df8b0e2d67cf8dd32e087bfda4e5756ebd1c76bbf3efa0dc246590e",
 			wantRepoTags: []string{serverAddr + "/library/alpine:3.10"},
 			wantRepoDigests: []string{
-				serverAddr + "/library/alpine@sha256:e10ea963554297215478627d985466ada334ed15c56d3d6bb808ceab98374d91",
+				serverAddr + "/library/alpine@" + imgDigest.String(),
 			},
 			wantConfigFile: &v1.ConfigFile{
 				Architecture:  "amd64",
@@ -213,7 +218,7 @@ func TestNewDockerImage(t *testing.T) {
 			wantID:       "sha256:af341ccd2df8b0e2d67cf8dd32e087bfda4e5756ebd1c76bbf3efa0dc246590e",
 			wantRepoTags: []string{serverAddr + "/library/alpine:3.10"},
 			wantRepoDigests: []string{
-				serverAddr + "/library/alpine@sha256:e10ea963554297215478627d985466ada334ed15c56d3d6bb808ceab98374d91",
+				serverAddr + "/library/alpine@" + imgDigest.String(),
 			},
 			wantConfigFile: &v1.ConfigFile{
 				Architecture:  "amd64",

--- a/pkg/iac/rego/convert/struct.go
+++ b/pkg/iac/rego/convert/struct.go
@@ -37,7 +37,7 @@ func StructToRego(inputValue reflect.Value) map[string]any {
 			continue
 		}
 
-		if _, ok := field.Interface().(types.Metadata); ok && name == "Metadata" {
+		if _, ok := reflect.TypeAssert[types.Metadata](field); ok && name == "Metadata" {
 			continue
 		}
 
@@ -52,13 +52,13 @@ func StructToRego(inputValue reflect.Value) map[string]any {
 
 	if inputValue.Type().Implements(metadataInterface) {
 		returns := inputValue.MethodByName("GetMetadata").Call(nil)
-		if metadata, ok := returns[0].Interface().(types.Metadata); ok {
+		if metadata, ok := reflect.TypeAssert[types.Metadata](returns[0]); ok {
 			output["__defsec_metadata"] = metadata.ToRego()
 		}
 	} else {
 		metaVal := inputValue.FieldByName("Metadata")
 		if metaVal.Kind() == reflect.Struct {
-			if meta, ok := metaVal.Interface().(types.Metadata); ok {
+			if meta, ok := reflect.TypeAssert[types.Metadata](metaVal); ok {
 				output["__defsec_metadata"] = meta.ToRego()
 			}
 		}

--- a/pkg/iac/rego/scanner.go
+++ b/pkg/iac/rego/scanner.go
@@ -207,7 +207,7 @@ func (s *Scanner) ScanInput(ctx context.Context, sourceType types.Source, inputs
 		}
 
 		namespace := getModuleNamespace(module)
-		topLevel := strings.Split(namespace, ".")[0]
+		topLevel, _, _ := strings.Cut(namespace, ".")
 		if !s.ruleNamespaces.Contains(topLevel) {
 			continue
 		}

--- a/pkg/iac/scanners/cloudformation/parser/parameter.go
+++ b/pkg/iac/scanners/cloudformation/parser/parameter.go
@@ -54,7 +54,8 @@ func unmarshalIntFirst(dec *jsontext.Decoder, v *any) error {
 		}
 		return nil
 	}
-	return json.SkipFunc
+	// Fall back to the default decoding.
+	return errors.ErrUnsupported
 }
 
 func (p *Parameter) Type() cftypes.CfType {

--- a/pkg/iac/scanners/helm/scanner.go
+++ b/pkg/iac/scanners/helm/scanner.go
@@ -169,7 +169,7 @@ func unpackedChartExists(fsys fs.FS, archivePath string) bool {
 	if path.IsAbs(name) {
 		return false
 	}
-	firstComponent := strings.SplitN(name, "/", 2)[0]
+	firstComponent, _, _ := strings.Cut(name, "/")
 	if firstComponent == "." || firstComponent == ".." {
 		return false
 	}

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -194,8 +194,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 		if p.stopOnHCLError {
 			return err
 		}
-		var diags hcl.Diagnostics
-		if errors.As(err, &diags) {
+		if diags, ok := errors.AsType[hcl.Diagnostics](err); ok {
 			errc := p.showParseErrors(p.moduleFS, path, diags)
 			if errc == nil {
 				continue

--- a/pkg/misconf/scanner.go
+++ b/pkg/misconf/scanner.go
@@ -158,8 +158,7 @@ func (s *Scanner) Scan(ctx context.Context, fsys fs.FS) ([]types.Misconfiguratio
 	log.DebugContext(ctx, "Scanning files for misconfigurations...", log.String("scanner", s.scanner.Name()))
 	results, err := s.scanner.ScanFS(ctx, newfs, ".")
 	if err != nil {
-		var invalidContentError *cfparser.InvalidContentError
-		if errors.As(err, &invalidContentError) {
+		if _, ok := errors.AsType[*cfparser.InvalidContentError](err); ok {
 			log.ErrorContext(ctx, "scan was broken with InvalidContentError", s.scanner.Name(), log.Err(err))
 			return nil, nil
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -108,8 +108,7 @@ func (p *Plugin) Run(ctx context.Context, opts Options) error {
 	// out if the error was from not being able to execute the plugin or
 	// an error set by the plugin itself.
 	if err = cmd.Run(); err != nil {
-		var execError *exec.ExitError
-		if errors.As(err, &execError) {
+		if execError, ok := errors.AsType[*exec.ExitError](err); ok {
 			return &types.ExitError{
 				Code: execError.ExitCode(),
 			}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -89,9 +89,8 @@ func tryWithMirrors[T any](ref name.Reference, option types.RegistryOptions, fn 
 	for _, r := range append(mirrors, ref) {
 		result, err := fn(r)
 		if err != nil {
-			var multiErr *multierror.Error
 			// All auth options failed, try the next mirror/host
-			if errors.As(err, &multiErr) {
+			if multiErr, ok := errors.AsType[*multierror.Error](err); ok {
 				errs = multierror.Append(errs, multiErr.Errors...)
 				continue
 			}

--- a/pkg/result/filter.go
+++ b/pkg/result/filter.go
@@ -304,7 +304,7 @@ func filterFindingsByRego[T types.Finding](
 
 func evaluate[T types.Finding](ctx context.Context, query rego.PreparedEvalQuery, finding T) (bool, error) {
 	type regoInput struct {
-		Data T      `json:",inline"`
+		Data T      `json:",embed"`
 		Type string `json:"Type"`
 	}
 

--- a/pkg/x/json/json.go
+++ b/pkg/x/json/json.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json/jsontext"
 	"encoding/json/v2"
+	"errors"
 	"io"
 
 	"golang.org/x/xerrors"
@@ -106,7 +107,8 @@ func unmarshaler[T any](r *lineReader, visited set.Set[int], hooks ...DecodeHook
 
 		// Check visited set to avoid infinity loops
 		if visited.Contains(start) {
-			return json.SkipFunc
+			// Fall back to the default decoding.
+			return errors.ErrUnsupported
 		}
 		visited.Append(start)
 


### PR DESCRIPTION
## Description

Go 1.27 removed `json.SkipFunc` from `encoding/json/v2` and expects `errors.ErrUnsupported` instead, so Trivy does not build with it. Keeping both toolchains working means hiding the sentinel behind build tags, so this PR requires Go 1.27 instead. Anyone importing Trivy as a library will need 1.27 as well. json/v2 is on by default there, so `GOEXPERIMENT=jsonv2` is no longer set anywhere.

The struct tag option that json/v2 uses for the Rego policy input was renamed from `inline` to `embed`

golangci-lint v2.12 refuses to lint a module built for a newer Go than the linter itself, so it moves to v2.13.1 and the code follows what the new version reports. Its new `embedlit` check is too noisy and stays off.

Compression changed in 1.27 as well. Test images keep their layers uncompressed, and go-containerregistry gzips them to get the digest and the size, so the values two tests expect changed.

## Related issues
- Close https://github.com/aquasecurity/trivy/discussions/11122

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
