### PR TITLE
docs: define compatibility policy

### DIFF
--- a/docs/community/contribute/pr.md
+++ b/docs/community/contribute/pr.md
@@ -202,7 +202,7 @@ The `<scope>` can be empty (e.g. if the change is a global or difficult to assig
 
 **Breaking changes**
 
-A PR, introducing a breaking API change, needs to append a `!` after the type/scope.
+A PR that introduces a breaking change to a stable interface defined in the [compatibility and stability policy](../../guide/references/compatibility.md) needs to append a `!` after the type/scope.
 
 ### Example titles
 

--- a/docs/guide/references/compatibility.md
+++ b/docs/guide/references/compatibility.md
@@ -1,0 +1,52 @@
+# Compatibility and Stability
+
+Trivy is designed, distributed, and supported primarily as a CLI application.
+
+The Trivy project strives to preserve compatibility between releases for documented user-facing interfaces, except for features explicitly marked as experimental or subject to change. Unintended compatibility issues in stable interfaces are generally treated as bugs.
+
+## Stable Interfaces
+
+The following interfaces documented in the official Trivy documentation are covered by this compatibility policy:
+
+- CLI commands, subcommands, flags, and arguments
+- Configuration file options and environment variables
+- Exit codes and the conditions under which they are returned
+- Machine-readable output formats
+- Data fields used by custom templates
+
+Adding a new command, flag, configuration option, or output field is considered compatible as long as it does not change existing usage.
+
+When the documentation and implementation disagree, neither is automatically considered authoritative. We determine the intended behavior by considering existing usage, user impact, and consistency with other features, and then correct either the implementation or the documentation.
+
+Trivy's JSON output includes a `SchemaVersion` that identifies the output structure. Within the same `SchemaVersion`, optional fields may be added or omitted, so consumers should ignore unknown fields and must not assume that optional fields are always present. Removing or renaming an existing field, changing its type, or changing its meaning incompatibly generally requires an update to `SchemaVersion` and is documented as a breaking change in the release notes.
+
+## Interfaces Outside the Compatibility Policy
+
+The following are not part of Trivy's stable user-facing interfaces:
+
+- Go packages, types, functions, methods, and other Go APIs in the Trivy repository
+- Required versions of Go, Mage, and other build tools, as well as development commands and build scripts
+- The exact formatting of terminal output, logs, warnings, error messages, and progress displays
+- Scan results, including detected vulnerabilities, misconfigurations, secrets, and licenses, as well as their content and ordering
+- Internal formats and protocols, such as caches, vulnerability databases, on-disk data, internal RPC, and Protocol Buffers definitions
+- Compatibility between different versions of the Trivy client and Trivy server
+- Experimental or preview features, canary builds, and prerelease versions
+- Changes in behavior or coverage caused by external specifications, services, platforms, or data sources
+
+Trivy is not designed or supported for use as a Go library. Interfaces outside this policy may be changed or removed without a deprecation period.
+
+Even if such a change breaks external code or a custom build procedure, it is not, by itself, considered a breaking change to the Trivy CLI. As a rule, these changes are not identified as breaking changes in the release notes or announced separately. Users should not assume that they will be announced in advance.
+
+## Trivy DB Schema
+
+Each Trivy CLI version supports a specific Trivy DB schema version. When updates for an old DB schema end, older Trivy CLI versions that depend on it can no longer receive newly published vulnerability information.
+
+Before ending updates for an old DB schema, the Trivy project announces the affected CLI versions, the end date for updates, and the minimum CLI version to which users should upgrade. A DB schema change is not considered a breaking change to the Trivy CLI. However, because users must upgrade to continue receiving current security information, it is announced separately from ordinary internal changes.
+
+## Breaking Changes
+
+A change that requires users to modify an existing valid use of a stable interface is considered a breaking change.
+
+When a breaking change is necessary, we identify it in the release notes and provide migration guidance whenever possible. We announce a deprecation before making the change when practical, but do not guarantee a fixed deprecation period for every interface.
+
+The usual deprecation process may not be possible when responding to an urgent security issue, an incompatible change in an external system, an obvious bug, or a risk of significant false positives, false negatives, data corruption, or other safety issues. Even in these cases, we describe changes with significant user impact in the release notes whenever possible.

--- a/docs/guide/references/compatibility.md
+++ b/docs/guide/references/compatibility.md
@@ -37,11 +37,19 @@ Trivy is not designed or supported for use as a Go library. Interfaces outside t
 
 Even if such a change breaks external code or a custom build procedure, it is not, by itself, considered a breaking change to the Trivy CLI. As a rule, these changes are not identified as breaking changes in the release notes or announced separately. Users should not assume that they will be announced in advance.
 
-## Trivy DB Schema
+## Scan Asset Version Support
 
-Each Trivy CLI version supports a specific Trivy DB schema version. When updates for an old DB schema end, older Trivy CLI versions that depend on it can no longer receive newly published vulnerability information.
+Some [scan assets](terminology.md#scan-assets) use versioned formats that are tied to particular Trivy CLI versions:
 
-Before ending updates for an old DB schema, the Trivy project announces the affected CLI versions, the end date for updates, and the minimum CLI version to which users should upgrade. A DB schema change is not considered a breaking change to the Trivy CLI. However, because users must upgrade to continue receiving current security information, it is announced separately from ordinary internal changes.
+- Vulnerability Database ([trivy-db](https://github.com/aquasecurity/trivy-db)): schema version
+- Java Index Database ([trivy-java-db](https://github.com/aquasecurity/trivy-java-db)): schema version
+- Checks Bundle ([trivy-checks](https://github.com/aquasecurity/trivy-checks)): major version
+
+Each Trivy CLI version is compatible with particular versions of these assets.
+
+When updates for an older scan asset version end, Trivy CLI versions that depend on it can no longer receive newly published vulnerability information, Java artifact identification data, or misconfiguration checks from that asset.
+
+Before ending updates for a scan asset version, the Trivy project announces the affected CLI versions, the end date for updates, and the minimum CLI version to which users should upgrade. A scan asset version change is not considered a breaking change to the Trivy CLI. However, because users must upgrade to continue receiving current scan asset updates, it is announced separately from ordinary internal changes.
 
 ## Breaking Changes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,6 +211,7 @@ nav:
           - Modes:
               - Standalone: guide/references/modes/standalone.md
               - Client/Server: guide/references/modes/client-server.md
+          - Compatibility and Stability: guide/references/compatibility.md
           - Troubleshooting: guide/references/troubleshooting.md
           - Terminology: guide/references/terminology.md
           - Abbreviations: guide/references/abbreviations.md


### PR DESCRIPTION
## Description

This PR defines Trivy's compatibility and stability policy for documented user-facing interfaces.

The policy:

- Identifies the CLI interfaces covered by the compatibility policy
- Clarifies that Go APIs, build toolchain requirements, human-readable output, scan results, internal formats and protocols, and experimental features are outside the policy
- Defines compatibility expectations for JSON output
- Documents how DB schema support changes are communicated when users must upgrade to continue receiving current security information
- Explains how breaking changes and exceptions are handled

It also adds the policy to the documentation navigation and links the contribution guide's breaking change rule to it.

## Checklist

- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
