### PR TITLE
perf(secret): avoid cloning the logger for every rule

### DIFF
--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -746,16 +746,15 @@ func (s *Scanner) scanChunk(filePath string, content []byte, binary bool) types.
 	contentLower := bytes.ToLower(content)
 
 	for _, rule := range s.Rules {
-		ruleLogger := logger.With("rule_id", rule.ID)
 		// Check if the file path should be scanned by this rule
 		if !rule.MatchPath(filePath) {
-			ruleLogger.Debug("Skipped secret scanning as non-compliant to the rule")
+			logger.Debug("Skipped secret scanning as non-compliant to the rule", log.String("rule_id", rule.ID))
 			continue
 		}
 
 		// Check if the file path should be allowed
 		if rule.AllowPath(filePath) {
-			ruleLogger.Debug("Skipped secret scanning as allowed")
+			logger.Debug("Skipped secret scanning as allowed", log.String("rule_id", rule.ID))
 			continue
 		}
 
@@ -769,7 +768,7 @@ func (s *Scanner) scanChunk(filePath string, content []byte, binary bool) types.
 		if len(locs) == 0 {
 			continue
 		}
-		ruleLogger.Debug("Found locations", log.Int("count", len(locs)))
+		logger.Debug("Found locations", log.String("rule_id", rule.ID), log.Int("count", len(locs)))
 
 		localExcludedBlocks := newBlocks(content, rule.ExcludeBlock.Regexes)
 

--- a/pkg/fanal/secret/scanner.go
+++ b/pkg/fanal/secret/scanner.go
@@ -746,15 +746,19 @@ func (s *Scanner) scanChunk(filePath string, content []byte, binary bool) types.
 	contentLower := bytes.ToLower(content)
 
 	for _, rule := range s.Rules {
+		// Pass the rule ID as a field instead of logger.With, which clones the
+		// logger for every rule and allocates in this hot path.
+		ruleID := log.String("rule_id", rule.ID)
+
 		// Check if the file path should be scanned by this rule
 		if !rule.MatchPath(filePath) {
-			logger.Debug("Skipped secret scanning as non-compliant to the rule", log.String("rule_id", rule.ID))
+			logger.Debug("Skipped secret scanning as non-compliant to the rule", ruleID)
 			continue
 		}
 
 		// Check if the file path should be allowed
 		if rule.AllowPath(filePath) {
-			logger.Debug("Skipped secret scanning as allowed", log.String("rule_id", rule.ID))
+			logger.Debug("Skipped secret scanning as allowed", ruleID)
 			continue
 		}
 
@@ -768,7 +772,7 @@ func (s *Scanner) scanChunk(filePath string, content []byte, binary bool) types.
 		if len(locs) == 0 {
 			continue
 		}
-		logger.Debug("Found locations", log.String("rule_id", rule.ID), log.Int("count", len(locs)))
+		logger.Debug("Found locations", ruleID, log.Int("count", len(locs)))
 
 		localExcludedBlocks := newBlocks(content, rule.ExcludeBlock.Regexes)
 
@@ -782,7 +786,7 @@ func (s *Scanner) scanChunk(filePath string, content []byte, binary bool) types.
 				Rule:     rule,
 				Location: loc,
 			})
-			logger.Debug("Found secret in chunk", log.String("rule_id", rule.ID), log.Int("start", loc.Start), log.Int("end", loc.End))
+			logger.Debug("Found secret in chunk", ruleID, log.Int("start", loc.Start), log.Int("end", loc.End))
 			copyCensored.Do(func() {
 				censored = make([]byte, len(content))
 				copy(censored, content)


### PR DESCRIPTION
## Description

The secret scanner built a per-rule logger at the very top of the rule loop, before any of the checks that decide whether the rule has anything to do. On a `--scanners` secret run over `python:3.13` that is about 530 thousand times per scan, while the three debug lines that use it sit on paths that are almost never taken.

Building it only where it is needed takes the allocations out of the hot loop.

Measured on python:3.13:

| | before | after |
|---|---|---|
| allocated, whole scan | 1497 MB | 1257 MB |
| allocated in `scanChunk` | 221 MB | 37 MB |
| CPU | 10.99 s | 10.56 s |

The share grows with the amount of text in the target, since the count scales with chunks times rules.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
