### PR TITLE
refactor: use strings.CutLast and url.URL.Clone from Go 1.27

### DIFF
--- a/pkg/dependency/parser/golang/binary/parse.go
+++ b/pkg/dependency/parser/golang/binary/parse.go
@@ -311,8 +311,8 @@ func classifyVersion(foundVersions [][]string, key, moduleName, val string) {
 func versionPrefix(s string) string {
 	// Trim module part.
 	// e.g. `github.com/aquasecurity/trivy/pkg/Version.version` => `Version.version`
-	if lastIndex := strings.LastIndex(s, "/"); lastIndex > 0 {
-		s = s[lastIndex+1:]
+	if _, base, found := strings.CutLast(s, "/"); found {
+		s = base
 	}
 
 	s, _, _ = strings.Cut(s, ".")

--- a/pkg/dependency/parser/java/jar/parse.go
+++ b/pkg/dependency/parser/java/jar/parse.go
@@ -885,9 +885,8 @@ func (m *manifest) determineGroupID() (string, error) {
 		groupID = m.bundleSymbolicName
 
 		// e.g. "com.fasterxml.jackson.core.jackson-databind" => "com.fasterxml.jackson.core"
-		idx := strings.LastIndex(m.bundleSymbolicName, ".")
-		if idx > 0 {
-			groupID = m.bundleSymbolicName[:idx]
+		if prefix, _, found := strings.CutLast(m.bundleSymbolicName, "."); found {
+			groupID = prefix
 		}
 	case m.implementationVendor != "":
 		groupID = m.implementationVendor

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -355,19 +355,19 @@ func (p *Parser) pkgNameFromPath(pkgPath string) string {
 	// we renamed to `node_modules` directory prefixes `workspace` when resolving Links
 	// node_modules/function1
 	// node_modules/nested_func/node_modules/debug
-	if index := strings.LastIndex(pkgPath, nodeModulesDir); index != -1 {
-		pkgName := pkgPath[index+len(nodeModulesDir):]
-		pkgName = strings.TrimPrefix(pkgName, "/")
-
-		if pkgName == "" {
-			p.logger.Warn("Invalid package-lock.json file. Package path doesn't have package name suffix", log.String("pkg_path", pkgPath))
-			return ""
-		}
-
-		return pkgName
+	_, pkgName, found := strings.CutLast(pkgPath, nodeModulesDir)
+	if !found {
+		p.logger.Warn("Package path doesn't have `node_modules` prefix", log.String("pkg_path", pkgPath))
+		return pkgPath
 	}
-	p.logger.Warn("Package path doesn't have `node_modules` prefix", log.String("pkg_path", pkgPath))
-	return pkgPath
+
+	pkgName = strings.TrimPrefix(pkgName, "/")
+	if pkgName == "" {
+		p.logger.Warn("Invalid package-lock.json file. Package path doesn't have package name suffix", log.String("pkg_path", pkgPath))
+		return ""
+	}
+
+	return pkgName
 }
 
 func uniqueDeps(deps []ftypes.Dependency) []ftypes.Dependency {

--- a/pkg/detector/ospkg/alpine/alpine.go
+++ b/pkg/detector/ospkg/alpine/alpine.go
@@ -170,7 +170,7 @@ func (s *Scanner) repoRelease(repo *ftypes.Repository) string {
 	}
 	release := repo.Release
 	if strings.Count(release, ".") > 1 {
-		release = release[:strings.LastIndex(release, ".")]
+		release, _, _ = strings.CutLast(release, ".")
 	}
 	return release
 }

--- a/pkg/fanal/analyzer/buildinfo/dockerfile.go
+++ b/pkg/fanal/analyzer/buildinfo/dockerfile.go
@@ -109,13 +109,12 @@ func (a dockerfileAnalyzer) Version() int {
 
 // parseVersion parses version from a file name
 func parseVersion(nvr string) string {
-	releaseIndex := strings.LastIndex(nvr, "-")
-	if releaseIndex < 0 {
+	nv, release, found := strings.CutLast(nvr, "-")
+	if !found {
 		return ""
 	}
-	versionIndex := strings.LastIndex(nvr[:releaseIndex], "-")
-	version := nvr[versionIndex+1:]
-	return version
+	_, version, _ := strings.CutLast(nv, "-")
+	return version + "-" + release
 }
 
 type envGetter struct {

--- a/pkg/fanal/analyzer/imgconf/apk/apk.go
+++ b/pkg/fanal/analyzer/imgconf/apk/apk.go
@@ -94,7 +94,7 @@ func (a alpineCmdAnalyzer) fetchApkIndexArchive(targetOS types.OS) (*apkIndex, e
 	// 3.9.3 => 3.9
 	osVer := targetOS.Name
 	if strings.Count(osVer, ".") > 1 {
-		osVer = osVer[:strings.LastIndex(osVer, ".")]
+		osVer, _, _ = strings.CutLast(osVer, ".")
 	}
 
 	url := fmt.Sprintf(a.apkIndexArchiveURL, osVer)

--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
+++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
@@ -232,24 +232,21 @@ func (a rpmPkgAnalyzer) StaticPaths() []string {
 func splitFileName(filename string) (name, ver, rel string, err error) {
 	filename = strings.TrimSuffix(filename, ".rpm")
 
-	archIndex := strings.LastIndex(filename, ".")
-	if archIndex == -1 {
+	nvr, _, found := strings.CutLast(filename, ".") // Trim arch
+	if !found {
 		return "", "", "", errUnexpectedNameFormat
 	}
 
-	relIndex := strings.LastIndex(filename[:archIndex], "-")
-	if relIndex == -1 {
+	nv, rel, found := strings.CutLast(nvr, "-")
+	if !found {
 		return "", "", "", errUnexpectedNameFormat
 	}
-	rel = filename[relIndex+1 : archIndex]
 
-	verIndex := strings.LastIndex(filename[:relIndex], "-")
-	if verIndex == -1 {
+	name, ver, found = strings.CutLast(nv, "-")
+	if !found {
 		return "", "", "", errUnexpectedNameFormat
 	}
-	ver = filename[verIndex+1 : relIndex]
 
-	name = filename[:verIndex]
 	return name, ver, rel, nil
 }
 

--- a/pkg/iac/scanners/terraform/executor/executor.go
+++ b/pkg/iac/scanners/terraform/executor/executor.go
@@ -131,9 +131,8 @@ func normalizeBlockLables(block *terraform.Block) []string {
 	labels := block.Labels()
 	if block.IsExpanded() {
 		nameLabel := labels[len(labels)-1]
-		idx := strings.LastIndex(nameLabel, "[")
-		if idx != -1 {
-			labels[len(labels)-1] = nameLabel[:idx]
+		if name, _, found := strings.CutLast(nameLabel, "["); found {
+			labels[len(labels)-1] = name
 		}
 	}
 

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -308,9 +308,8 @@ func parseOCI(metadata types.Metadata) (*packageurl.PackageURL, error) {
 	}
 
 	name := strings.ToLower(digest.RepositoryStr())
-	index := strings.LastIndex(name, "/")
-	if index != -1 {
-		name = name[index+1:]
+	if _, base, found := strings.CutLast(name, "/"); found {
+		name = base
 	}
 
 	var qualifiers packageurl.Qualifiers
@@ -518,12 +517,8 @@ func parseQualifier(pkg ftypes.Package) packageurl.Qualifiers {
 }
 
 func parsePkgName(name string) (string, string) {
-	var namespace string
-	index := strings.LastIndex(name, "/")
-	if index != -1 {
-		namespace = name[:index]
-		name = name[index+1:]
+	if namespace, base, found := strings.CutLast(name, "/"); found {
+		return namespace, base
 	}
-	return namespace, name
-
+	return "", name
 }

--- a/pkg/x/http/trace.go
+++ b/pkg/x/http/trace.go
@@ -265,8 +265,7 @@ func redactHeaders(headers http.Header) {
 // redactQueryParams redacts sensitive query parameters
 func redactQueryParams(u *url.URL) *url.URL {
 	// Clone URL to avoid modifying the original
-	cloned, _ := url.Parse(u.String())
-
+	cloned := u.Clone()
 	values := cloned.Query()
 	for _, param := range sensitiveQueryParams {
 		for k := range values {


### PR DESCRIPTION
## Description

Follow-up to #11127.

Go 1.27 added `strings.CutLast` and `url.URL.Clone`. They replace the `LastIndex` plus offset arithmetic and the `url.Parse(u.String())` trick used for cloning.

One nuance for review: in `versionPrefix` and `determineGroupID` the old guard was "separator found after the first byte", now it is simply "separator found". That differs only for input that starts with the separator, which is malformed in both cases.

## Related PRs
- [x] #11127

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
