### PR TITLE
test: use httptest.NewTestServer for shared test servers

### DIFF
--- a/internal/gittest/server.go
+++ b/internal/gittest/server.go
@@ -49,7 +49,9 @@ func setupGitServer(t *testing.T, bareDir string, opts Options) *httptest.Server
 	err := service.Setup()
 	require.NoError(t, err)
 
-	return httptest.NewServer(service)
+	ts := httptest.NewTestServer(t, service)
+	ts.Start()
+	return ts
 }
 
 func NewServer(t *testing.T, repo, dir string, opts Options) *httptest.Server {

--- a/internal/registrytest/registrytest.go
+++ b/internal/registrytest/registrytest.go
@@ -22,7 +22,10 @@ import (
 // NewServer starts a test registry server with OCI 1.1 referrers support.
 func NewServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(registry.New(registry.WithReferrersSupport(true)))
+
+	ts := httptest.NewTestServer(t, registry.New(registry.WithReferrersSupport(true)))
+	ts.Start()
+	return ts
 }
 
 // NewServerWithAuth starts a test registry server with OCI 1.1 referrers support
@@ -40,7 +43,10 @@ func NewServerWithAuth(t *testing.T, user, password string) *httptest.Server {
 		}
 		reg.ServeHTTP(w, r)
 	})
-	return httptest.NewServer(handler)
+
+	ts := httptest.NewTestServer(t, handler)
+	ts.Start()
+	return ts
 }
 
 // PushImage pushes the given image to the registry and returns its reference and descriptor.

--- a/pkg/attestation/sbom/rekor_test.go
+++ b/pkg/attestation/sbom/rekor_test.go
@@ -34,7 +34,6 @@ func TestRekor_RetrieveSBOM(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := rekortest.NewServer(t)
-			defer ts.Close()
 
 			// Set the testing URL
 			rc, err := sbom.NewRekor(ts.URL())

--- a/pkg/dependency/parser/java/jar/parse_test.go
+++ b/pkg/dependency/parser/java/jar/parse_test.go
@@ -339,7 +339,7 @@ func TestParse(t *testing.T) {
 		},
 	}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		res := apiResponse{
 			Response: response{
 				NumFound: 1,
@@ -387,6 +387,7 @@ func TestParse(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(res)
 	}))
+	ts.Start()
 
 	for _, v := range vectors {
 		t.Run(v.name, func(t *testing.T) {

--- a/pkg/fanal/artifact/image/remote_sbom_test.go
+++ b/pkg/fanal/artifact/image/remote_sbom_test.go
@@ -144,7 +144,6 @@ func TestArtifact_InspectRekorAttestation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := rekortest.NewServer(t)
-			defer ts.Close()
 
 			c := cachetest.NewCache(t, nil)
 
@@ -225,7 +224,6 @@ var wantBlobsCycloneDX = []cachetest.WantBlob{
 func TestArtifact_InspectOCIReferrerSBOM(t *testing.T) {
 	// Start a test registry with referrers support
 	ts := registrytest.NewServer(t)
-	defer ts.Close()
 
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)

--- a/pkg/fanal/artifact/repo/git_test.go
+++ b/pkg/fanal/artifact/repo/git_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestNewArtifact(t *testing.T) {
 	ts := gittest.NewTestServer(t, gittest.Options{})
-	defer ts.Close()
 
 	type args struct {
 		target     string
@@ -167,7 +166,6 @@ func TestNewArtifact(t *testing.T) {
 
 func TestArtifact_Inspect(t *testing.T) {
 	ts := gittest.NewTestServer(t, gittest.Options{})
-	defer ts.Close()
 
 	tests := []struct {
 		name         string
@@ -339,7 +337,6 @@ func setupAuthTestServer(t *testing.T, username, password string) *url.URL {
 		Username: username,
 		Password: password,
 	})
-	t.Cleanup(ts.Close)
 
 	tsURL, err := url.Parse(ts.URL)
 	require.NoError(t, err)

--- a/pkg/fanal/handler/unpackaged/unpackaged_test.go
+++ b/pkg/fanal/handler/unpackaged/unpackaged_test.go
@@ -77,7 +77,6 @@ func Test_unpackagedHook_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := rekortest.NewServer(t)
-			defer ts.Close()
 
 			// Set the testing URL
 			opt := artifact.Option{

--- a/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
+++ b/pkg/iac/scanners/terraform/parser/resolvers/cache_integration_test.go
@@ -52,7 +52,6 @@ func TestResolveModuleFromCache(t *testing.T) {
 
 	repo := "terraform-aws-s3-bucket"
 	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket", gittest.Options{})
-	defer gs.Close()
 
 	repoURL := gs.URL + "/" + repo + ".git"
 
@@ -142,7 +141,6 @@ func TestResolveModuleFromCache(t *testing.T) {
 func TestResolveModuleFromCacheWithDifferentSubdir(t *testing.T) {
 	repo := "terraform-aws-s3-bucket"
 	gs := gittest.NewServer(t, repo, "testdata/terraform-aws-s3-bucket", gittest.Options{})
-	defer gs.Close()
 
 	repoURL := gs.URL + "/" + repo + ".git"
 

--- a/pkg/oci/referrers_test.go
+++ b/pkg/oci/referrers_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestReferrers(t *testing.T) {
 	ts := registrytest.NewServer(t)
-	t.Cleanup(ts.Close)
 
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)

--- a/pkg/plugin/manager_unix_test.go
+++ b/pkg/plugin/manager_unix_test.go
@@ -63,7 +63,6 @@ func modifyManifest(t *testing.T, worktree, version string) {
 
 func TestManager_Install(t *testing.T) {
 	gs := setupGitRepository(t, "test_plugin", "testdata/test_plugin/test_plugin")
-	t.Cleanup(gs.Close)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		zr := zip.NewWriter(w)

--- a/pkg/rekortest/server.go
+++ b/pkg/rekortest/server.go
@@ -310,7 +310,7 @@ type Server struct {
 }
 
 func NewServer(t *testing.T) *Server {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/index/retrieve":
 			var params models.SearchIndex
@@ -343,16 +343,13 @@ func NewServer(t *testing.T) *Server {
 			assert.NoError(t, err)
 		}
 	}))
+	ts.Start()
 
 	return &Server{ts: ts}
 }
 
 func (s *Server) URL() string {
 	return s.ts.URL
-}
-
-func (s *Server) Close() {
-	s.ts.Close()
 }
 
 func mustMarshal(v any) []byte {

--- a/pkg/vex/oci/oci_test.go
+++ b/pkg/vex/oci/oci_test.go
@@ -138,7 +138,6 @@ func setUpReferrerRegistry(t *testing.T, user, password string) string {
 	} else {
 		ts = registrytest.NewServerWithAuth(t, user, password)
 	}
-	t.Cleanup(ts.Close)
 
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -703,7 +703,6 @@ func setUpRegistry(t *testing.T) (string, v1.Hash) {
 	t.Helper()
 
 	ts := registrytest.NewServer(t)
-	t.Cleanup(ts.Close)
 	host := strings.TrimPrefix(ts.URL, "http://")
 
 	_, subject := registrytest.PushRandomImage(t, host, "debian", "12")


### PR DESCRIPTION
## Description

Follow-up to #11127.

Test servers had to be shut down by hand, so every caller carried a `defer ts.Close()` or a `t.Cleanup`. The Sonatype stub in the jar parser test had neither and stayed alive until the whole package finished.

A panic in a handler was recovered by http.Server and written to stderr. The test then failed on a transport error somewhere else, with nothing pointing back at the handler.

Go 1.27 added `httptest.NewTestServer`, which shuts the server down at the end of the test and turns a handler panic into a failure of that test. The shared helpers in `internal/registrytest`, `internal/gittest` and `pkg/rekortest` use it now, so their callers close nothing.

The other test servers keep `httptest.NewServer`. They pass their URL to code that builds its own HTTP client, so they need a real listener and gain nothing from the switch.

## Related PRs
- [x] #11127

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
