### PR TITLE
fix(report): escape package fields in ASFF template

### DIFF
--- a/contrib/asff.tpl
+++ b/contrib/asff.tpl
@@ -33,7 +33,7 @@
             "Severity": {
                 "Label": "{{ $severity }}"
             },
-            "Title": "Trivy found a vulnerability to {{ .VulnerabilityID }} in container {{ $target }}, related to {{ .PkgName }}",
+            "Title": {{ printf "Trivy found a vulnerability to %s in container %s, related to %s" .VulnerabilityID $target .PkgName | printf "%q" }},
             "Description": {{ escapeString $description | printf "%q" }},
             {{ if not (empty .PrimaryURL) -}}
             "Remediation": {
@@ -55,9 +55,9 @@
                         "Other": {
                             "CVE ID": "{{ .VulnerabilityID }}",
                             "CVE Title": {{ .Title | printf "%q" }},
-                            "PkgName": "{{ .PkgName }}",
-                            "Installed Package": "{{ .InstalledVersion }}",
-                            "Patched Package": "{{ .FixedVersion }}",
+                            "PkgName": {{ .PkgName | printf "%q" }},
+                            "Installed Package": {{ .InstalledVersion | printf "%q" }},
+                            "Patched Package": {{ .FixedVersion | printf "%q" }},
                             "NvdCvssScoreV3": "{{ (index .CVSS (sourceID "nvd")).V3Score }}",
                             "NvdCvssVectorV3": "{{ (index .CVSS (sourceID "nvd")).V3Vector }}",
                             "NvdCvssScoreV2": "{{ (index .CVSS (sourceID "nvd")).V2Score }}",

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -211,6 +212,97 @@ func TestReportWriter_Template(t *testing.T) {
 			err = w.Write(ctx, inputReport)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, got.String())
+		})
+	}
+}
+
+// TestReportWriter_ASFFTemplate renders the ASFF template shipped in contrib/
+// and checks that the package fields arrive intact. Package names and versions
+// are taken from scanned manifests, so they may contain characters that are
+// significant inside a JSON string.
+func TestReportWriter_ASFFTemplate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		pkgName          string
+		installedVersion string
+		fixedVersion     string
+	}{
+		{
+			name:             "plain package name and versions",
+			pkgName:          "libcrypto1.1",
+			installedVersion: "1.1.1c-r0",
+			fixedVersion:     "1.1.1d-r0",
+		},
+		{
+			name:             "double quote in the installed version",
+			pkgName:          "openssl",
+			installedVersion: `1.0", "Injected": "value`,
+			fixedVersion:     "1.1.0",
+		},
+		{
+			name:             "package name ending with a backslash",
+			pkgName:          `openssl\`,
+			installedVersion: "1.0.0",
+			fixedVersion:     "1.1.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := clock.With(t.Context(), time.Date(2020, 8, 10, 7, 28, 17, 958601, time.UTC))
+
+			t.Setenv("AWS_ACCOUNT_ID", "123456789012")
+			t.Setenv("AWS_REGION", "test-region")
+
+			inputReport := types.Report{
+				Results: types.Results{
+					{
+						Target: "alpine:3.10 (alpine 3.10.2)",
+						Type:   "alpine",
+						Vulnerabilities: []types.DetectedVulnerability{
+							{
+								VulnerabilityID:  "CVE-2019-1549",
+								PkgName:          tc.pkgName,
+								InstalledVersion: tc.installedVersion,
+								FixedVersion:     tc.fixedVersion,
+								Vulnerability: dbTypes.Vulnerability{
+									Title:       "openssl: information disclosure",
+									Description: "A description.",
+									Severity:    dbTypes.SeverityMedium.String(),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			got := bytes.Buffer{}
+			w, err := report.NewTemplateWriter(&got, "@../../contrib/asff.tpl", "dev")
+			require.NoError(t, err)
+			require.NoError(t, w.Write(ctx, inputReport))
+
+			var asff struct {
+				Findings []struct {
+					Title     string `json:"Title"`
+					Resources []struct {
+						Details struct {
+							Other map[string]string `json:"Other"`
+						} `json:"Details"`
+					} `json:"Resources"`
+				} `json:"Findings"`
+			}
+			require.NoError(t, json.Unmarshal(got.Bytes(), &asff), "ASFF output must be valid JSON")
+
+			require.Len(t, asff.Findings, 1)
+			other := asff.Findings[0].Resources[0].Details.Other
+
+			assert.Equal(t, tc.pkgName, other["PkgName"])
+			assert.Equal(t, tc.installedVersion, other["Installed Package"])
+			assert.Equal(t, tc.fixedVersion, other["Patched Package"])
+			assert.Contains(t, asff.Findings[0].Title, tc.pkgName)
+
+			// A field that escapes its string would show up as an extra key.
+			assert.NotContains(t, other, "Injected")
 		})
 	}
 }


### PR DESCRIPTION
## Description

No linked issue — per the [contribution guide](https://trivy.dev/docs/latest/community/contribute/pr/), this is small and self-contained enough to justify inline instead.

`contrib/asff.tpl` interpolates `PkgName`, `InstalledVersion` and `FixedVersion` straight into the generated JSON:

```
"PkgName": "{{ .PkgName }}",
"Installed Package": "{{ .InstalledVersion }}",
"Patched Package": "{{ .FixedVersion }}",
```

The two fields directly above them in the same `Details.Other` block are already quoted:

```
"CVE Title": {{ .Title | printf "%q" }},
"Description": {{ escapeString $description | printf "%q" }},
```

So a package name or version containing a `"` or a trailing `\` escapes its JSON string. This continues the escaping work in #1914, #2004, #5351 and #7401 — those covered `Description`, misconfig `Title` and `Message`; the package fields were not included.

`.PkgName` is also interpolated unescaped into the vulnerability `Title` on line 36, so fixing only the `Other` block leaves the document corruptible through the same field. Both sites are changed here.

### Changes

- Quote `PkgName` / `InstalledVersion` / `FixedVersion` with `printf "%q"`, matching the `CVE Title` line directly above them.
- Compose the vulnerability `Title` with `printf` so `.PkgName` is quoted there too.

`printf "%q"` rather than `escapeString`, for consistency with the neighbouring `CVE Title` line and because `html.EscapeString` does not escape backslashes.

### Before / after

Rendering `contrib/asff.tpl` through `TemplateWriter` over a single-vulnerability report.

**1. Package name ending in a backslash** — `PkgName = evil\`

Before, the document does not parse:
```
"PkgName": "evil\",
```
```
document is INVALID JSON
```
The whole `BatchImportFindings` payload is rejected, so every finding in the batch is lost, not just this one.

After:
```
document parses
```

**2. Version containing a double quote** — `InstalledVersion = 1.0", "InjectedByAttacker": "yes`

Before — the document still parses, but an attacker-chosen key is now part of the finding:
```
document parses, but attacker key present: InjectedByAttacker=yes
```

After — the value stays inside its string:
```
no injected key; Installed Package="1.0\", \"InjectedByAttacker\": \"yes"
```

Caveat on this second case: #2774 reports that `Details.Other` may not be ingested by Security Hub at all, which would limit the blast radius of a key injected there. Case 1 is the one that clearly matters — a corrupt document is rejected wholesale by `BatchImportFindings`, and `.PkgName` reaches that through the `Title` field as well, which is certainly ingested. Invalid ASFF output breaking the AWS CLI import has been reported before in #2023.

**3. Normal input is unchanged** — `libcrypto1.1` / `1.1.1c-r0` / `1.1.1d-r0`

Byte-identical before and after (diffed with the timestamps from `now` normalised):
```
"Title": "Trivy found a vulnerability to CVE-2019-1549 in container test-image (alpine 3.10.2), related to libcrypto1.1",
"PkgName": "libcrypto1.1",
"Installed Package": "1.1.1c-r0",
"Patched Package": "1.1.1d-r0",
```
`printf "%q"` supplies the quotes that were previously written literally, so the existing ASFF golden files (`integration/testdata/*.asff.golden`) are unaffected and need no regeneration.

### Scope

Deliberately limited to the package fields. The same pattern still applies to `$target` / `$image` in this template, to `.Title` in the `Secrets` block, and to the equivalent fields in `contrib/gitlab.tpl` and `contrib/junit.tpl`. Happy to follow up on those separately rather than widen this PR.

I have not tried to establish how reachable a `"` or `\` in a package name is in practice — it varies by ecosystem, and several parsers validate names. This is offered as consistency with the fields already escaped alongside them, not as a reported exploit.

## Related issues

Nothing to close — this is not a reported bug.

Related but *not* fixed here: #6009 (open) covers the image name used by `asff.tpl`. It touches the same `Title` line this PR rewrites, so if it is picked up there may be a small conflict to resolve; the two changes are independent. Prior escaping work in the same file: #1914, #2004, #5351 (from #5350), #7401 (from #7400).

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

`TestReportWriter_ASFFTemplate` in `pkg/report/template_test.go` renders the real `contrib/asff.tpl` and asserts the package fields round-trip unchanged. Reverting the template change makes it fail on both hostile cases (`Injected` appears as a real key; the backslash case fails to parse as JSON) while the plain case keeps passing, so it pins the behaviour rather than just exercising it.