### PR TITLE
fix: skip empty Fields() results in parsers and Amazon detector

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -43,6 +43,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		ss := strings.FieldsFunc(body, func(r rune) bool {
 			return unicode.IsSpace(r) || r == ','
 		})
+		if len(ss) == 0 {
+			p.logger.Warn("Cannot parse dependency", log.String("line", line))
+			continue
+		}
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -3,6 +3,7 @@ package mix
 import (
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,14 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equal(t, tt.want, pkgs)
 		})
 	}
+}
+
+func TestParser_ParseSkipsEmptyDependencyBody(t *testing.T) {
+	parser := NewParser()
+
+	pkgs, deps, err := parser.Parse(t.Context(), strings.NewReader(`"x":`))
+
+	require.NoError(t, err)
+	assert.Empty(t, pkgs)
+	assert.Empty(t, deps)
 }

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -75,8 +75,12 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// There are some formats:
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				continue
+			}
 			// Save only the name, normalized (PEP 503) to match the names from poetry.lock/pylock.toml.
-			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true))
+			d.Set.Append(python.NormalizePkgName(fields[0], true))
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -3,6 +3,7 @@ package pyproject_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,4 +141,16 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "Parse(%v)", tt.file)
 		})
 	}
+}
+
+func TestParser_ParseSkipsEmptyDependency(t *testing.T) {
+	input := `[project]
+name = "test"
+version = "1.0.0"
+dependencies = ["flask>=1.0", "", "==="]
+`
+
+	got, err := pyproject.NewParser().Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, set.New[string]("flask"), got.MainDeps())
 }

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,6 +66,9 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
+			if len(s) == 0 {
+				continue
+			}
 			dependsOn = append(dependsOn, s[0]) // store name only for now
 		}
 		lineNum++

--- a/pkg/dependency/parser/ruby/bundler/parse_test.go
+++ b/pkg/dependency/parser/ruby/bundler/parse_test.go
@@ -3,6 +3,7 @@ package bundler_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,4 +278,14 @@ func TestParser_Parse(t *testing.T) {
 			assert.Equalf(t, tt.wantDeps, gotDeps, "Parse(%v)", tt.file)
 		})
 	}
+}
+
+func TestParser_ParseSkipsEmptyNestedDependency(t *testing.T) {
+	input := "GEM\n  specs:\n    parent (1.0.0)\n      \n"
+
+	pkgs, deps, err := bundler.NewParser().Parse(t.Context(), strings.NewReader(input))
+
+	require.NoError(t, err)
+	assert.Len(t, pkgs, 1)
+	assert.Empty(t, deps)
 }

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,11 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					fields := strings.Fields(s)
+					if len(fields) == 0 {
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], fields[0])
 				}
 			}
 		}

--- a/pkg/dependency/parser/swift/cocoapods/parse_test.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse_test.go
@@ -2,6 +2,7 @@ package cocoapods_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +94,16 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, tt.wantDeps, gotDeps)
 		})
 	}
+}
+
+func TestParseSkipsEmptyChildDependency(t *testing.T) {
+	input := `PODS:
+  - Parent (1.0.0):
+    - ""
+`
+
+	gotPkgs, gotDeps, err := cocoapods.NewParser().Parse(t.Context(), strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []ftypes.Package{{ID: "Parent@1.0.0", Name: "Parent", Version: "1.0.0"}}, gotPkgs)
+	assert.Empty(t, gotDeps)
 }

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,11 +42,10 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
+	var ok bool
+	osVer, ok = normalizeVersion(osVer)
+	if !ok {
+		return nil, nil
 	}
 
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
@@ -101,13 +100,26 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 	return vulns, nil
 }
 
-// IsSupportedVersion checks if the version is supported.
-func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
+func normalizeVersion(osVer string) (string, bool) {
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return "", false
+	}
+	osVer = fields[0]
 	// The format `2023.xxx.xxxx` can be used.
 	osVer = osver.Major(osVer)
 	if osVer != "2" && osVer != "2022" && osVer != "2023" {
 		osVer = "1"
+	}
+	return osVer, true
+}
+
+// IsSupportedVersion checks if the version is supported.
+func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
+	var ok bool
+	osVer, ok = normalizeVersion(osVer)
+	if !ok {
+		return false
 	}
 
 	return osver.Supported(ctx, eolDates, osFamily, osVer)

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -137,6 +137,12 @@ func TestScanner_Detect(t *testing.T) {
 			},
 		},
 		{
+			name: "empty OS version",
+			args: args{
+				osVer: "",
+			},
+		},
+		{
 			name: "empty version",
 			fixtures: []string{
 				"testdata/fixtures/amazon.yaml",
@@ -199,6 +205,15 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 		args args
 		want bool
 	}{
+		{
+			name: "empty version",
+			now:  time.Date(2020, 12, 1, 0, 0, 0, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: false,
+		},
 		{
 			name: "amazon linux 1",
 			now:  time.Date(2022, 5, 31, 23, 59, 59, 0, time.UTC),


### PR DESCRIPTION
Fixes #10976.

## What changed

`strings.Fields(...)[0]` (and the equivalent split) panicked when normalization left only whitespace or operator characters. That aborted the entire scan.

- Mix, Poetry/pyproject, Bundler, and CocoaPods parsers now skip empty field lists.
- The Amazon detector treats a version string with no fields as unsupported instead of panicking.

Poetry names still go through `python.NormalizePkgName`.

## Tests

Added regression cases for empty/operator-only inputs in each affected parser and for an Amazon release string with no version.

```
go test ./pkg/dependency/parser/hex/mix ./pkg/dependency/parser/python/pyproject ./pkg/dependency/parser/ruby/bundler ./pkg/dependency/parser/swift/cocoapods ./pkg/detector/ospkg/amazon -count=1
```

All five packages passed.

## AI assistance disclosure

OpenAI Codex / Cursor Grok assisted with applying the guards, resolving a merge against current main, and drafting tests. I reviewed the diff and ran the tests above.