### PR TITLE
fix(spdx): do not read NOASSERTION back as a license

### DIFF
--- a/pkg/sbom/spdx/unmarshal.go
+++ b/pkg/sbom/spdx/unmarshal.go
@@ -178,8 +178,13 @@ func (s *SPDX) parsePackage(spdxPkg spdx.Package) (*core.Component, error) {
 	}
 
 	// License
-	if spdxPkg.PackageLicenseDeclared != "NONE" {
-		component.Licenses = strings.Split(spdxPkg.PackageLicenseDeclared, ",")
+	// NONE and NOASSERTION are the two SPDX values that stand in for the absence of a
+	// license, not license identifiers: NONE asserts there is no license, NOASSERTION
+	// asserts nothing either way. The marshaler writes NOASSERTION for every component
+	// it has no licenses for, so reading it back as a license gives such a package one
+	// literally named "NOASSERTION".
+	if declared := spdxPkg.PackageLicenseDeclared; declared != noneField && declared != noAssertionField {
+		component.Licenses = strings.Split(declared, ",")
 	}
 
 	// Source package

--- a/pkg/sbom/spdx/unmarshal_test.go
+++ b/pkg/sbom/spdx/unmarshal_test.go
@@ -401,3 +401,46 @@ func TestUnmarshaler_Unmarshal(t *testing.T) {
 		})
 	}
 }
+
+// TestUnmarshaler_NoAssertionIsNotALicense covers the round trip a user gets from
+// `trivy convert`: the marshaler writes NOASSERTION as the declared license of every
+// component it has no licenses for, and reading that back must not turn it into a
+// license named "NOASSERTION".
+func TestUnmarshaler_NoAssertionIsNotALicense(t *testing.T) {
+	f, err := os.Open("testdata/happy/no-relationship.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	var first spdx.SPDX
+	require.NoError(t, json.NewDecoder(f).Decode(&first))
+
+	// the two apm-agent packages declare NONE, so they come back with no licenses
+	for _, c := range first.BOM.Components() {
+		if c.Name == "co.elastic.apm:apm-agent" {
+			require.Empty(t, c.Licenses)
+		}
+	}
+
+	doc, err := spdx.NewMarshaler("test").Marshal(t.Context(), first.BOM)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	var second spdx.SPDX
+	require.NoError(t, json.Unmarshal(out, &second))
+
+	for _, c := range second.BOM.Components() {
+		assert.NotContains(t, c.Licenses, "NOASSERTION", "component %q was given NOASSERTION as a license", c.Name)
+	}
+
+	// the licenses that are real still survive the round trip
+	var licensed int
+	for _, c := range second.BOM.Components() {
+		if c.Name == "Elasticsearch" {
+			assert.Equal(t, []string{"Elastic-2.0"}, c.Licenses)
+			licensed++
+		}
+	}
+	assert.Equal(t, 1, licensed)
+}


### PR DESCRIPTION
## Description

The SPDX marshaler writes `NOASSERTION` as the declared license of every component it has no licenses for, but `parsePackage` on the read side only skips `NONE`:

https://github.com/aquasecurity/trivy/blob/main/pkg/sbom/spdx/unmarshal.go#L180-L182

So a package with no license information, read back out of a document Trivy itself wrote, comes back with a license literally named `NOASSERTION`. `NONE` and `NOASSERTION` are the two SPDX values that stand in for the absence of a license, not license identifiers — `NONE` asserts there is no license, `NOASSERTION` asserts nothing either way. This skips both.

Each side looks right on its own, which is presumably why it survived the move from `NONE` to `NOASSERTION` on the write side (#7402, #10367): only the round trip shows it.

### Before and after

```console
$ trivy fs --scanners "" --format spdx-json ./demo > demo.spdx.json
```

`demo` is a `package-lock.json` with one dependency, `left-pad@1.3.0`, and Trivy writes `"licenseDeclared": "NOASSERTION"` for it.

**Before** — reading that document back invents a license, and `--scanners license` turns it into a finding:

```console
$ trivy sbom --scanners "" --format json demo.spdx.json | jq '.Results[].Packages[] | {Name, Licenses}'
{
  "Name": "left-pad",
  "Licenses": [
    "NOASSERTION"
  ]
}

$ trivy sbom --scanners license --format json demo.spdx.json | jq '.Results[] | select(.Class=="license") | .Licenses[]'
{
  "Severity": "UNKNOWN",
  "Category": "unknown",
  "PkgName": "left-pad",
  "Name": "NOASSERTION",
  ...
}
```

**After** — no license, and no finding:

```console
$ trivy sbom --scanners "" --format json demo.spdx.json | jq '.Results[].Packages[] | {Name, Licenses}'
{
  "Name": "left-pad",
  "Licenses": null
}

$ trivy sbom --scanners license --format json demo.spdx.json | jq '.Results[] | select(.Class=="license")'
(nothing)
```

Both outputs above came from two binaries built from this tree, one with the change reverted.

## Related issues

None open that I could find. Related history: #7402 and #10367 are what moved the write side to `NOASSERTION`.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the documentation with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description.

### On the test

`TestUnmarshaler_NoAssertionIsNotALicense` is a round trip rather than a fixture case, because the write side and the read side each look correct in isolation and only disagree end to end. It reuses `testdata/happy/no-relationship.json`, marshals what it decodes, decodes that again, and asserts no component came back with `NOASSERTION` as a license while `Elastic-2.0` still survives. It fails on `main` for both `co.elastic.apm` packages.

There is no fixture in `testdata/happy/` with `licenseDeclared: "NOASSERTION"` — only `NONE` — which is the gap that let this through.

`./pkg/sbom/...` and `./pkg/report/...` pass.

---

*Disclosure: I used Claude (Opus 5) while investigating and writing this. The diagnosis, the fix and every command above I ran and checked myself.*
