### PR TITLE
test(rapidfort): add integration test for the RapidFort curated image

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -84,6 +84,7 @@ const (
 	goldenOracleLinux8                = "testdata/oraclelinux-8.json.golden"
 	goldenPhoton30                    = "testdata/photon-30.json.golden"
 	goldenPom                         = "testdata/pom.json.golden"
+	goldenRapidFortUbuntu2204         = "testdata/rapidfort-ubuntu-2204.json.golden"
 	goldenRockyLinux8                 = "testdata/rockylinux-8.json.golden"
 	goldenSecrets                     = "testdata/secrets.json.golden"
 	goldenSecretsASFF                 = "testdata/secrets.asff.golden"

--- a/integration/standalone_tar_test.go
+++ b/integration/standalone_tar_test.go
@@ -372,6 +372,14 @@ func TestTar(t *testing.T) {
 			golden: goldenMariner10,
 		},
 		{
+			name: "rapidfort ubuntu 22.04",
+			args: args{
+				Format: types.FormatJSON,
+				Input:  "testdata/fixtures/images/rapidfort-ubuntu-2204.tar.gz",
+			},
+			golden: goldenRapidFortUbuntu2204,
+		},
+		{
 			name: "busybox with Cargo.lock integration",
 			args: args{
 				Format: types.FormatJSON,

--- a/integration/testdata/fixtures/db/rapidfort.yaml
+++ b/integration/testdata/fixtures/db/rapidfort.yaml
@@ -17,17 +17,6 @@
             PatchedVersions:
               - "1:10.0p1-15rfubu5.4+rf.0"
             Severity: 3
-# The image also ships stock Ubuntu packages, libpam-modules among them, and
-# this Ubuntu advisory covers the installed 1.5.3-5ubuntu5.6. It must not be
-# reported: the RapidFort driver reads the "rapidfort ubuntu*" buckets only,
-# never Ubuntu's own.
-- bucket: ubuntu 22.04
-  pairs:
-    - bucket: pam
-      pairs:
-        - key: CVE-2024-10041
-          value:
-            FixedVersion: 1.7.0-5ubuntu1
 - bucket: data-source
   pairs:
     - key: rapidfort ubuntu

--- a/integration/testdata/fixtures/db/rapidfort.yaml
+++ b/integration/testdata/fixtures/db/rapidfort.yaml
@@ -1,0 +1,44 @@
+# Fixtures for the rapidfort-ubuntu-2204 image, which carries
+# /usr/share/rapidfort/curated.json and is therefore scanned by the RapidFort
+# driver instead of the Ubuntu one.
+#
+# rf-openssh is a RapidFort rebuild ("+rf" in the version), so its advisories
+# live in the release-less "rapidfort ubuntu" bucket. CVE-2026-3497 is taken
+# from OS/ubuntu/rf-openssh_advisory.json of
+# https://github.com/rapidfort/security-advisories and must be reported.
+- bucket: rapidfort ubuntu
+  pairs:
+    - bucket: rf-openssh
+      pairs:
+        - key: CVE-2026-3497
+          value:
+            VulnerableVersions:
+              - ">=1:10.0p1-12rfubu+rf.0, <1:10.0p1-15rfubu5.4+rf.0"
+            PatchedVersions:
+              - "1:10.0p1-15rfubu5.4+rf.0"
+            Severity: 3
+# The image also ships stock Ubuntu packages, libpam-modules among them, and
+# this Ubuntu advisory covers the installed 1.5.3-5ubuntu5.6. It must not be
+# reported: the RapidFort driver reads the "rapidfort ubuntu*" buckets only,
+# never Ubuntu's own.
+- bucket: ubuntu 22.04
+  pairs:
+    - bucket: pam
+      pairs:
+        - key: CVE-2024-10041
+          value:
+            FixedVersion: 1.7.0-5ubuntu1
+- bucket: data-source
+  pairs:
+    - key: rapidfort ubuntu
+      value:
+        ID: "rapidfort"
+        BaseID: "ubuntu"
+        Name: "RapidFort Security Advisories"
+        URL: "https://github.com/rapidfort/security-advisories"
+- bucket: vulnerability
+  pairs:
+    - key: CVE-2026-3497
+      value:
+        Title: "Vulnerability in the OpenSSH GSSAPI delta included in various Lin ..."
+        Description: "Vulnerability in the OpenSSH GSSAPI delta included in various Linux distributions. This vulnerability affects the GSSAPI patches added by various Linux distributions and does not affect the OpenSSH upstream project itself. The usage of sshpkt_disconnect() on an error, which does not terminate the process, allows an attacker to send an unexpected GSSAPI message type during the GSSAPI key exchange to the server, which will call the underlying function and continue the execution of the program without setting the related connection variables. As the variables are not initialized to NULL the code later accesses those uninitialized variables, accessing random memory, which could lead to undefined behavior. The recommended workaround is to use ssh_packet_disconnect() instead, which does terminate the process. The impact of the vulnerability depends heavily on the compiler flag hardening configuration."

--- a/integration/testdata/rapidfort-ubuntu-2204.json.golden
+++ b/integration/testdata/rapidfort-ubuntu-2204.json.golden
@@ -1,0 +1,117 @@
+{
+  "SchemaVersion": 2,
+  "Trivy": {
+    "Version": "dev"
+  },
+  "ReportID": "017b7d41-e09f-7000-80ea-000000000001",
+  "CreatedAt": "2021-08-25T12:20:30.000000005Z",
+  "ArtifactID": "sha256:02fd82086a9213f63a5f97c8860ca31f870944159f07c73bda1824881a1135ac",
+  "ArtifactName": "testdata/fixtures/images/rapidfort-ubuntu-2204.tar.gz",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "Size": 179018240,
+    "OS": {
+      "Family": "ubuntu",
+      "Name": "22.04",
+      "Supplier": "rapidfort"
+    },
+    "ImageID": "sha256:99a601cf84e9b8b51bf75792c136ef5c16c5247718811cc2487a0ea7dd65d943",
+    "DiffIDs": [
+      "sha256:80b58c2eed0ce1ebd979abe62f1ae56b6625b784ae8251a89535778208a886a8"
+    ],
+    "RepoTags": [
+      "ghcr.io/aquasecurity/trivy-test-images:rapidfort-ubuntu-2204"
+    ],
+    "Reference": "ghcr.io/aquasecurity/trivy-test-images:rapidfort-ubuntu-2204",
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2026-08-19T17:53:54.171458816Z",
+      "history": [
+        {
+          "created": "2026-08-19T17:53:54.171458816Z",
+          "created_by": "LABEL maintainer=RapidFort Curation Team \u003crfcurators@rapidfort.com\u003e",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        },
+        {
+          "created": "2026-08-19T17:53:54.171458816Z",
+          "created_by": "COPY / / # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2026-08-19T17:53:54.171458816Z",
+          "created_by": "CMD [\"/bin/bash\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:80b58c2eed0ce1ebd979abe62f1ae56b6625b784ae8251a89535778208a886a8"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/bash"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Labels": {
+          "maintainer": "RapidFort Curation Team \u003crfcurators@rapidfort.com\u003e"
+        },
+        "WorkingDir": "/",
+        "ArgsEscaped": true
+      }
+    },
+    "Layers": [
+      {
+        "Size": 179018240,
+        "Digest": "sha256:c4c53eea826134daf1c57a258722b3e2a748532211abc0a23a42942fad5bb02e",
+        "DiffID": "sha256:80b58c2eed0ce1ebd979abe62f1ae56b6625b784ae8251a89535778208a886a8"
+      }
+    ]
+  },
+  "Results": [
+    {
+      "Target": "testdata/fixtures/images/rapidfort-ubuntu-2204.tar.gz (ubuntu 22.04)",
+      "Class": "os-pkgs",
+      "Type": "ubuntu",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2026-3497",
+          "PkgID": "rf-openssh-client@1:10.0p1-12rfubu+rf.0",
+          "PkgName": "rf-openssh-client",
+          "PkgIdentifier": {
+            "PURL": "pkg:deb/ubuntu/rf-openssh-client@10.0p1-12rfubu%2Brf.0?arch=amd64\u0026distro=ubuntu-22.04\u0026epoch=1",
+            "UID": "6627cc054b5d953c"
+          },
+          "InstalledVersion": "1:10.0p1-12rfubu+rf.0",
+          "FixedVersion": "1:10.0p1-15rfubu5.4+rf.0",
+          "Status": "fixed",
+          "Layer": {
+            "Digest": "sha256:c4c53eea826134daf1c57a258722b3e2a748532211abc0a23a42942fad5bb02e",
+            "DiffID": "sha256:80b58c2eed0ce1ebd979abe62f1ae56b6625b784ae8251a89535778208a886a8"
+          },
+          "SeveritySource": "rapidfort",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2026-3497",
+          "DataSource": {
+            "ID": "rapidfort",
+            "Name": "RapidFort Security Advisories",
+            "URL": "https://github.com/rapidfort/security-advisories",
+            "BaseID": "ubuntu"
+          },
+          "Fingerprint": "sha256:2d4599f8ca41303955d299e51a01de9cefb74639550360faa526f2b63762f27b",
+          "Title": "Vulnerability in the OpenSSH GSSAPI delta included in various Lin ...",
+          "Description": "Vulnerability in the OpenSSH GSSAPI delta included in various Linux distributions. This vulnerability affects the GSSAPI patches added by various Linux distributions and does not affect the OpenSSH upstream project itself. The usage of sshpkt_disconnect() on an error, which does not terminate the process, allows an attacker to send an unexpected GSSAPI message type during the GSSAPI key exchange to the server, which will call the underlying function and continue the execution of the program without setting the related connection variables. As the variables are not initialized to NULL the code later accesses those uninitialized variables, accessing random memory, which could lead to undefined behavior. The recommended workaround is to use ssh_packet_disconnect() instead, which does terminate the process. The impact of the vulnerability depends heavily on the compiler flag hardening configuration.",
+          "Severity": "HIGH",
+          "VendorSeverity": {
+            "rapidfort": 3
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

The RapidFort scanner from #10452 had unit tests only, nothing checked it on a real image.

`TestTar` now scans a curated RapidFort image based on Ubuntu 22.04. It ships RapidFort rebuilds next to stock Ubuntu packages, so one golden shows both that the RapidFort advisory is reported and that an Ubuntu advisory for the same image is not.

## Related PRs
- [x] https://github.com/aquasecurity/trivy-test-images/pull/38

Remove this section if you don't have related PRs.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
