### PR TITLE
fix(nodejs): support boolean resolved field in package-lock.json

### DIFF
--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -319,19 +319,25 @@ func (p *Parser) parseV1(dependencies map[string]Dependency, versions map[string
 	var pkgs []ftypes.Package
 	var deps []ftypes.Dependency
 	for pkgName, dep := range dependencies {
-		pkg := ftypes.Package{
-			ID:           packageID(pkgName, dep.Version),
-			Name:         pkgName,
-			Version:      dep.Version,
-			Dev:          dep.Dev,
-			Relationship: ftypes.RelationshipUnknown, // lockfile v1 schema doesn't have information about direct dependencies
-			ExternalReferences: []ftypes.ExternalRef{
+		var refs []ftypes.ExternalRef
+		// Bundled dependencies have no registry address, so the `resolved` field is empty for them.
+		if dep.Resolved != "" {
+			refs = []ftypes.ExternalRef{
 				{
 					Type: ftypes.RefOther,
 					URL:  string(dep.Resolved),
 				},
-			},
-			Locations: []ftypes.Location{ftypes.Location(dep.Location)},
+			}
+		}
+
+		pkg := ftypes.Package{
+			ID:                 packageID(pkgName, dep.Version),
+			Name:               pkgName,
+			Version:            dep.Version,
+			Dev:                dep.Dev,
+			Relationship:       ftypes.RelationshipUnknown, // lockfile v1 schema doesn't have information about direct dependencies
+			ExternalReferences: refs,
+			Locations:          []ftypes.Location{ftypes.Location(dep.Location)},
 		}
 		pkgs = append(pkgs, pkg)
 

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -2,6 +2,8 @@ package npm
 
 import (
 	"context"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"fmt"
 	"maps"
 	"path"
@@ -34,7 +36,7 @@ type Dependency struct {
 	Dev          bool                  `json:"dev"`
 	Dependencies map[string]Dependency `json:"dependencies"`
 	Requires     map[string]string     `json:"requires"`
-	Resolved     string                `json:"resolved"`
+	Resolved     resolved              `json:"resolved"`
 	xjson.Location
 }
 
@@ -48,11 +50,34 @@ type Package struct {
 	OptionalDependencies map[string]string   `json:"optionalDependencies"`
 	DevDependencies      map[string]string   `json:"devDependencies"`
 	PeerDependencies     map[string]string   `json:"peerDependencies"`
-	Resolved             string              `json:"resolved"`
+	Resolved             resolved            `json:"resolved"`
 	Dev                  bool                `json:"dev"`
 	Link                 bool                `json:"link"`
 	Workspaces           any                 `json:"workspaces"`
 	xjson.Location
+}
+
+// resolved represents the npm "resolved" field, which normally holds the tarball URL.
+// npm 6 writes `false` instead of the URL for bundled dependencies inflated from the lockfile,
+// because their metadata contains no registry address.
+type resolved string
+
+func (r *resolved) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+	switch kind := dec.PeekKind(); kind {
+	// "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+	case '"':
+		var s string
+		if err := json.UnmarshalDecode(dec, &s); err != nil {
+			return err
+		}
+		*r = resolved(s)
+		return nil
+	// `false` means the same as a missing field, so the package is left without a reference.
+	case 't', 'f':
+		return dec.SkipValue()
+	default:
+		return xerrors.Errorf("unexpected `resolved` field type: %s", kind)
+	}
 }
 
 type Parser struct {
@@ -120,7 +145,7 @@ func (p *Parser) parseV2(packages map[string]Package) ([]ftypes.Package, []ftype
 		if pkg.Resolved != "" {
 			ref = ftypes.ExternalRef{
 				Type: ftypes.RefOther,
-				URL:  pkg.Resolved,
+				URL:  string(pkg.Resolved),
 			}
 		}
 
@@ -224,7 +249,7 @@ func (p *Parser) resolveLinks(packages map[string]Package) {
 	// so we need to iterate over the cloned `packages` map, but change the original `packages` map.
 	for pkgPath, pkg := range maps.Clone(packages) {
 		for linkPath, link := range links {
-			if !strings.HasPrefix(pkgPath, link.Resolved) {
+			if !strings.HasPrefix(pkgPath, string(link.Resolved)) {
 				continue
 			}
 			// The target doesn't have the "resolved" field, so we need to copy it from the link.
@@ -233,7 +258,7 @@ func (p *Parser) resolveLinks(packages map[string]Package) {
 			}
 
 			// Resolve the link package so all packages are located under "node_modules".
-			resolvedPath := strings.ReplaceAll(pkgPath, link.Resolved, linkPath)
+			resolvedPath := strings.ReplaceAll(pkgPath, string(link.Resolved), linkPath)
 			packages[resolvedPath] = pkg
 
 			// Delete the target package
@@ -303,7 +328,7 @@ func (p *Parser) parseV1(dependencies map[string]Dependency, versions map[string
 			ExternalReferences: []ftypes.ExternalRef{
 				{
 					Type: ftypes.RefOther,
-					URL:  dep.Resolved,
+					URL:  string(dep.Resolved),
 				},
 			},
 			Locations: []ftypes.Location{ftypes.Location(dep.Location)},

--- a/pkg/dependency/parser/nodejs/npm/parse.go
+++ b/pkg/dependency/parser/nodejs/npm/parse.go
@@ -65,7 +65,7 @@ type resolved string
 func (r *resolved) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	switch kind := dec.PeekKind(); kind {
 	// "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-	case '"':
+	case jsontext.KindString:
 		var s string
 		if err := json.UnmarshalDecode(dec, &s); err != nil {
 			return err
@@ -73,7 +73,7 @@ func (r *resolved) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 		*r = resolved(s)
 		return nil
 	// `false` means the same as a missing field, so the package is left without a reference.
-	case 't', 'f':
+	case jsontext.KindTrue, jsontext.KindFalse:
 		return dec.SkipValue()
 	default:
 		return xerrors.Errorf("unexpected `resolved` field type: %s", kind)

--- a/pkg/dependency/parser/nodejs/npm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_test.go
@@ -24,6 +24,12 @@ func TestParse(t *testing.T) {
 			wantDeps: npmDeps,
 		},
 		{
+			name:     "lock version v1 with bundled dependencies",
+			file:     "testdata/package-lock_v1_with_bundled_deps.json",
+			want:     npmV1WithBundledDepsPkgs,
+			wantDeps: npmV1WithBundledDepsDeps,
+		},
+		{
 			name:     "lock version v2",
 			file:     "testdata/package-lock_v2.json",
 			want:     npmV2Pkgs,

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -692,6 +692,73 @@ var (
 		},
 	}
 
+	// docker run --name node --rm -it node:14 sh
+	//
+	// Build a package that bundles its dependency. Bundling only works for a packed package,
+	// installing a directory would give a symlink instead.
+	// mkdir bundler && cd bundler
+	// npm init --force
+	// npm install ms@2.0.0 --save-bundle
+	// npm pack && mv bundler-1.0.0.tgz ..
+	//
+	// Install it and rebuild the lockfile from `node_modules`.
+	// cd .. && npm init --force
+	// npm install ./bundler-1.0.0.tgz
+	// rm -rf node_modules && npm install
+	// rm package-lock.json && npm install
+	//
+	// The last 2 commands are what produces `"resolved": false`.
+	// npm installs the bundled `ms` from the lockfile, where the entry has no `resolved` field,
+	// saves `_resolved: false` into `node_modules/bundler/node_modules/ms/package.json`
+	// and copies that value into the lockfile when rebuilding it from `node_modules`.
+	//
+	// packages are filled manually
+	npmV1WithBundledDepsPkgs = []ftypes.Package{
+		{
+			ID:           "bundler@file:bundler-1.0.0.tgz",
+			Name:         "bundler",
+			Version:      "file:bundler-1.0.0.tgz",
+			Dev:          false,
+			Relationship: ftypes.RelationshipUnknown,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 7,
+					EndLine:   20,
+				},
+			},
+		},
+		{
+			ID:           "ms@2.0.0",
+			Name:         "ms",
+			Version:      "2.0.0",
+			Dev:          false,
+			Relationship: ftypes.RelationshipUnknown,
+			ExternalReferences: []ftypes.ExternalRef{
+				{
+					Type: ftypes.RefOther,
+				},
+			},
+			Locations: []ftypes.Location{
+				{
+					StartLine: 14,
+					EndLine:   18,
+				},
+			},
+		},
+	}
+
+	npmV1WithBundledDepsDeps = []ftypes.Dependency{
+		{
+			ID:        "bundler@file:bundler-1.0.0.tgz",
+			DependsOn: []string{"ms@2.0.0"},
+		},
+	}
+
 	// ... and
 	// npm i --lockfile-version 2
 	// same as npmV1Pkgs but change `Indirect` field to false for `body-parser@1.18.3`, `finalhandler@1.1.1`, `@babel/helper-string-parser@7.19.4`, `promise@8.3.0` and `ms@1.0.0`  packages.

--- a/pkg/dependency/parser/nodejs/npm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/npm/parse_testcase.go
@@ -720,11 +720,6 @@ var (
 			Version:      "file:bundler-1.0.0.tgz",
 			Dev:          false,
 			Relationship: ftypes.RelationshipUnknown,
-			ExternalReferences: []ftypes.ExternalRef{
-				{
-					Type: ftypes.RefOther,
-				},
-			},
 			Locations: []ftypes.Location{
 				{
 					StartLine: 7,
@@ -738,11 +733,6 @@ var (
 			Version:      "2.0.0",
 			Dev:          false,
 			Relationship: ftypes.RelationshipUnknown,
-			ExternalReferences: []ftypes.ExternalRef{
-				{
-					Type: ftypes.RefOther,
-				},
-			},
 			Locations: []ftypes.Location{
 				{
 					StartLine: 14,

--- a/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v1_with_bundled_deps.json
+++ b/pkg/dependency/parser/nodejs/npm/testdata/package-lock_v1_with_bundled_deps.json
@@ -1,0 +1,22 @@
+{
+  "name": "work",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bundler": {
+      "version": "file:bundler-1.0.0.tgz",
+      "integrity": "sha512-ccltB57BFbPgQjAG5hOvwe7LTY+57tDH4abnFLpEa9HSsYG+fK9YN8UO4eqGIKbgmW3lPGCE97wqmieCYSGTbA==",
+      "requires": {
+        "ms": "^2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": false,
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

npm writes `false` in the `resolved` field for bundled dependencies, and a string-only field turned one such entry into a decode error that dropped the entire lockfile, leaving the scan with no packages and no failure. The v1 branch also built an external reference with an empty URL whenever `resolved` was missing, now such packages are left without a reference, as in v2.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/11155

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
