### PR TITLE
refactor: use named constants for JSON token kinds

### DIFF
--- a/pkg/iac/scanners/azure/arm/parser/template.go
+++ b/pkg/iac/scanners/azure/arm/parser/template.go
@@ -40,13 +40,13 @@ type Resources []Resource
 
 func (r *Resources) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	switch dec.PeekKind() {
-	case '[':
+	case jsontext.KindBeginArray:
 		var arr []Resource
 		if err := json.UnmarshalDecode(dec, &arr); err != nil {
 			return err
 		}
 		*r = arr
-	case '{':
+	case jsontext.KindBeginObject:
 		var m map[string]Resource
 		if err := json.UnmarshalDecode(dec, &m); err != nil {
 			return err

--- a/pkg/iac/scanners/azure/value.go
+++ b/pkg/iac/scanners/azure/value.go
@@ -114,12 +114,12 @@ func (v *Value) SetMetadata(m *types.Metadata) {
 
 func (v *Value) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	switch k := dec.PeekKind(); k {
-	case 't', 'f':
+	case jsontext.KindTrue, jsontext.KindFalse:
 		v.Kind = KindBoolean
 		if err := json.UnmarshalDecode(dec, &v.rLit); err != nil {
 			return err
 		}
-	case '"':
+	case jsontext.KindString:
 		var s string
 		if err := json.UnmarshalDecode(dec, &s); err != nil {
 			return err
@@ -131,7 +131,7 @@ func (v *Value) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 			v.Kind = KindString
 			v.rLit = s
 		}
-	case '0':
+	case jsontext.KindNumber:
 		v.Kind = KindNumber
 		if err := json.UnmarshalDecode(dec, &v.rLit); err != nil {
 			return err
@@ -141,20 +141,20 @@ func (v *Value) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 				v.rLit = i
 			}
 		}
-	case '[':
+	case jsontext.KindBeginArray:
 		v.Kind = KindArray
 		if err := json.UnmarshalDecode(dec, &v.rArr); err != nil {
 			return err
 		}
-	case '{':
+	case jsontext.KindBeginObject:
 		v.Kind = KindObject
 		if err := json.UnmarshalDecode(dec, &v.rMap); err != nil {
 			return err
 		}
-	case 'n':
+	case jsontext.KindNull:
 		// TODO: UnmarshalJSONFrom is called only for the root null
 		return dec.SkipValue()
-	case 0:
+	case jsontext.KindInvalid:
 		return dec.SkipValue()
 	default:
 		return fmt.Errorf("unexpected token kind %q at %d", k.String(), dec.InputOffset())

--- a/pkg/iac/scanners/cloudformation/parser/parameter.go
+++ b/pkg/iac/scanners/cloudformation/parser/parameter.go
@@ -44,7 +44,7 @@ func (p *Parameter) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 }
 
 func unmarshalIntFirst(dec *jsontext.Decoder, v *any) error {
-	if dec.PeekKind() == '0' {
+	if dec.PeekKind() == jsontext.KindNumber {
 		if jval, err := dec.ReadValue(); err != nil {
 			return err
 		} else if v1, err := strconv.ParseInt(string(jval), 10, 64); err == nil {
@@ -100,7 +100,7 @@ func (p *Parameters) UnmarshalJSONFrom(d *jsontext.Decoder) error {
 	(*p) = make(Parameters)
 
 	switch d.PeekKind() {
-	case '{':
+	case jsontext.KindBeginObject:
 		// CodePipeline like format
 		var params struct {
 			Params map[string]any `json:"Parameters"`
@@ -111,7 +111,7 @@ func (p *Parameters) UnmarshalJSONFrom(d *jsontext.Decoder) error {
 		}
 
 		(*p) = params.Params
-	case '[':
+	case jsontext.KindBeginArray:
 		// Original format
 		var params []string
 

--- a/pkg/iac/scanners/cloudformation/parser/property.go
+++ b/pkg/iac/scanners/cloudformation/parser/property.go
@@ -134,21 +134,21 @@ func (p *Property) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var nodeType cftypes.CfType
 
 	switch k := dec.PeekKind(); k {
-	case 't', 'f':
+	case jsontext.KindTrue, jsontext.KindFalse:
 		valPtr = new(bool)
 		nodeType = cftypes.Bool
-	case '"':
+	case jsontext.KindString:
 		valPtr = new(string)
 		nodeType = cftypes.String
-	case '0':
+	case jsontext.KindNumber:
 		return p.parseNumericValue(dec)
-	case '[', 'n':
+	case jsontext.KindBeginArray, jsontext.KindNull:
 		valPtr = new([]*Property)
 		nodeType = cftypes.List
-	case '{':
+	case jsontext.KindBeginObject:
 		valPtr = new(map[string]*Property)
 		nodeType = cftypes.Map
-	case 0:
+	case jsontext.KindInvalid:
 		return dec.SkipValue()
 	default:
 		return fmt.Errorf("unexpected token kind %q at %d", k.String(), dec.InputOffset())

--- a/pkg/iac/scanners/cloudformation/parser/resource.go
+++ b/pkg/iac/scanners/cloudformation/parser/resource.go
@@ -115,14 +115,14 @@ func (r *Resource) UnmarshalYAML(node *yaml.Node) error {
 
 func (r *Resource) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	switch dec.PeekKind() {
-	case '{':
+	case jsontext.KindBeginObject:
 		var i resourceInner
 		if err := json.UnmarshalDecode(dec, &i); err != nil {
 			return err
 		}
 		r.typ = i.Type
 		r.properties = i.Properties
-	case '[':
+	case jsontext.KindBeginArray:
 		var raw Property
 		if err := json.UnmarshalDecode(dec, &raw); err != nil {
 			return err

--- a/pkg/iac/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_node.go
@@ -198,25 +198,25 @@ func (n *ManifestNode) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	var valPtr any
 	var nodeType TagType
 	switch k := dec.PeekKind(); k {
-	case 't', 'f':
+	case jsontext.KindTrue, jsontext.KindFalse:
 		valPtr = new(bool)
 		nodeType = TagBool
-	case '"':
+	case jsontext.KindString:
 		nodeType = TagStr
 		valPtr = new(string)
-	case '0':
+	case jsontext.KindNumber:
 		nodeType = TagInt
 		valPtr = new(uint64)
-	case '[':
+	case jsontext.KindBeginArray:
 		valPtr = new([]*ManifestNode)
 		nodeType = TagSlice
-	case '{':
+	case jsontext.KindBeginObject:
 		valPtr = new(map[string]*ManifestNode)
 		nodeType = TagMap
-	case 'n':
+	case jsontext.KindNull:
 		// TODO: UnmarshalJSONFrom is called only for the root null
 		return dec.SkipValue()
-	case 0:
+	case jsontext.KindInvalid:
 		return dec.SkipValue()
 	default:
 		return fmt.Errorf("unexpected token kind %q at %d", k.String(), dec.InputOffset())

--- a/pkg/x/json/json.go
+++ b/pkg/x/json/json.go
@@ -113,7 +113,7 @@ func unmarshaler[T any](r *lineReader, visited set.Set[int], hooks ...DecodeHook
 		visited.Append(start)
 
 		// Return more detailed error for cases when UnmarshalJSONFrom is not implemented for primitive type.
-		if _, ok := any(target).(json.UnmarshalerFrom); !ok && kind != '[' && kind != '{' {
+		if _, ok := any(target).(json.UnmarshalerFrom); !ok && kind != jsontext.KindBeginArray && kind != jsontext.KindBeginObject {
 			return xerrors.Errorf("structures with single primitive type should implement UnmarshalJSONFrom: %T", target)
 		}
 


### PR DESCRIPTION
## Description

Exported `Kind` constants were added in [5818c9d](https://cs.opensource.google/go/go/+/5818c9d714f1a8abeb76ec5d75ad0e0560e8d780), so the token kind checks no longer need raw character literals like `'0'` or `'t'`.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
