### PR TITLE
feat: add linux/loong64 support

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -101,6 +101,7 @@ adjust_os() {
     arm64) OS=ARM64 ;;
     ppc64le) OS=Linux ;;
     s390x) OS=Linux ;;
+    loong64) OS=Linux ;;
     darwin) OS=macOS ;;
     dragonfly) OS=DragonFlyBSD ;;
     freebsd) OS=FreeBSD ;;
@@ -120,6 +121,7 @@ adjust_arch() {
     arm64) ARCH=ARM64 ;;
     ppc64le) ARCH=PPC64LE ;;
     s390x) ARCH=s390x ;;
+    loong64) ARCH=loong64 ;;
   esac
   true
 }
@@ -203,6 +205,7 @@ uname_arch() {
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
     s390*) arch="s390x" ;;
+    loongarch64) arch="loong64" ;;
   esac
   echo ${arch}
 }
@@ -240,6 +243,7 @@ uname_arch_check() {
     mips64) return 0 ;;
     mips64le) return 0 ;;
     s390x) return 0 ;;
+    loong64) return 0 ;;
     amd64p32) return 0 ;;
   esac
   log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -20,6 +20,7 @@ builds:
       - arm64
       - s390x
       - ppc64le
+      - loong64
     goarm:
       - 7
   - id: build-bsd
@@ -149,6 +150,7 @@ dockers_v2:
       - linux/arm64
       - linux/s390x
       - linux/ppc64le
+      - linux/loong64
     extra_files:
       - contrib/
     labels:


### PR DESCRIPTION
Add loong64 to the GoReleaser Linux build architectures and the multi-arch Docker platforms, and register the architecture in install.sh.

- goreleaser.yml: add loong64 to builds[].goarch and dockers_v2 platforms (linux/loong64)
- contrib/install.sh: add loong64 to uname_arch, uname_arch_check, adjust_os and adjust_arch (uname -m reports loongarch64 on LoongArch)

## Description

This PR adds linux/loong64 (LoongArch) support to the release pipeline: GoReleaser now builds loong64 binaries/archives and publishes linux/loong64 container images, and install.sh can detect and download the loong64 asset.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
