### PR TITLE
docs: use canonical misconfiguration flags

### DIFF
--- a/docs/guide/scanner/misconfiguration/config/config.md
+++ b/docs/guide/scanner/misconfiguration/config/config.md
@@ -16,34 +16,34 @@ You can load check files or directories including your custom checks using the `
 This can be repeated for specifying multiple files or directories.
 
 ```bash
-trivy config --config-check custom-policy/policy --config-check combine/policy --config-check policy.rego --namespaces user myapp
+trivy config --config-check custom-policy/policy --config-check combine/policy --config-check policy.rego --check-namespaces user myapp
 ```
 
 You can load checks bundle as OCI Image from a Container Registry using the `--checks-bundle-repository` flag.
 
 ```bash
-trivy config --checks-bundle-repository myregistry.local/mychecks --namespaces user myapp
+trivy config --checks-bundle-repository myregistry.local/mychecks --check-namespaces user myapp
 ```
 
 
 ### Passing custom data
-You can pass directories including your custom data through `--data` option.
+You can pass directories including your custom data through `--config-data` option.
 This can be repeated for specifying multiple directories.
 
 ```bash
 cd examples/misconf/custom-data
-trivy config --config-check ./my-check --data ./data --namespaces user ./configs
+trivy config --config-check ./my-check --config-data ./data --check-namespaces user ./configs
 ```
 
 For more details, see [Custom Data](../custom/data.md).
 
 ### Passing namespaces
 By default, Trivy evaluates checks defined in `builtin.*`.
-If you want to evaluate custom checks in other packages, you have to specify package prefixes through `--namespaces` option.
+If you want to evaluate custom checks in other packages, you have to specify package prefixes through `--check-namespaces` option.
 This can be repeated for specifying multiple packages.
 
 ``` bash
-trivy config --config-check ./my-check --namespaces main --namespaces user ./configs
+trivy config --config-check ./my-check --check-namespaces main --check-namespaces user ./configs
 ```
 
 ### Limiting Rego compile errors

--- a/docs/guide/scanner/misconfiguration/custom/data.md
+++ b/docs/guide/scanner/misconfiguration/custom/data.md
@@ -29,7 +29,7 @@ ports := services.ports
 Example loading the data file:
 
 ```bash
-trivy config --config-check ./checks --config-data ./data --namespaces user ./configs
+trivy config --config-check ./checks --config-data ./data --check-namespaces user ./configs
 ```
 
 ## Customizing default checks data

--- a/docs/guide/scanner/misconfiguration/custom/index.md
+++ b/docs/guide/scanner/misconfiguration/custom/index.md
@@ -5,10 +5,10 @@ You can write custom checks in [Rego][rego].
 Once you finish writing custom checks, you can pass the check files or the directory where those checks are stored with --config-check` option.
 
 ``` bash
-trivy config --config-check /path/to/policy.rego --config-check /path/to/custom_checks --namespaces user /path/to/config_dir
+trivy config --config-check /path/to/policy.rego --config-check /path/to/custom_checks --check-namespaces user /path/to/config_dir
 ```
 
-As for `--namespaces` option, the detail is described as below.
+As for `--check-namespaces` option, the detail is described as below.
 
 ### File formats
 If a file name matches the following file patterns, Trivy will parse the file and pass it as input to your Rego policy.
@@ -90,10 +90,10 @@ A package name must be unique per policy.
     ```
 
 By default, only `builtin.*` packages will be evaluated.
-If you define custom packages, you have to specify the package prefix via `--namespaces` option. By default, Trivy only runs in its own namespace, unless specified by the user. Note that the custom namespace does not have to be `user` as in this example. It could be anything user-defined.
+If you define custom packages, you have to specify the package prefix via `--check-namespaces` option. By default, Trivy only runs in its own namespace, unless specified by the user. Note that the custom namespace does not have to be `user` as in this example. It could be anything user-defined.
 
 ``` bash
-trivy config --config-check /path/to/custom_checks --namespaces user /path/to/config_dir
+trivy config --config-check /path/to/custom_checks --check-namespaces user /path/to/config_dir
 ```
 
 In this case, `user.*` will be evaluated.

--- a/docs/tutorials/misconfiguration/custom-checks.md
+++ b/docs/tutorials/misconfiguration/custom-checks.md
@@ -93,7 +93,7 @@ Note that Rego
 Ensure that you have Trivy installed and run the following command:
 
 ```bash
-trivy fs --scanners misconf --config-check ./docker-check.rego --namespaces custom ./Dockerfile
+trivy fs --scanners misconf --config-check ./docker-check.rego --check-namespaces custom ./Dockerfile
 ```
 
 Please replace:
@@ -102,7 +102,7 @@ Please replace:
 * `custom` should be replaced with your package name if different
 * `./Dockerfile` is the path to the Dockerfile that should be scanned
 
-**Note**:  If you define custom packages, you have to specify the package prefix via `--namespaces` option. In our case, we called the custom package `custom`.
+**Note**:  If you define custom packages, you have to specify the package prefix via `--check-namespaces` option. In our case, we called the custom package `custom`.
 
 ## Resources
 


### PR DESCRIPTION
The custom-check docs use `--namespaces` and `--data`, which are hidden compatibility aliases. Trivy help and the generated flag reference use `--check-namespaces` and `--config-data` instead.

This updates the affected commands and prose to use the public flag names. Alias behavior is unchanged.

Tested with:

- `mike deploy test`
- `git diff --check`
- `trivy config --help` to confirm the canonical flags are shown and the aliases remain hidden