### PR TITLE
docs(go): explain why go.sum is not scanned for Go 1.17+ modules

### DIFF
--- a/docs/guide/coverage/language/golang.md
+++ b/docs/guide/coverage/language/golang.md
@@ -39,6 +39,7 @@ On the other hand, it uses `go.mod` for direct dependencies and `go.sum` for ind
 Go 1.17+ holds actually needed indirect dependencies in `go.mod`, and it reduces false detection.
 `go.sum` in Go 1.16 or less contains all indirect dependencies that are even not needed for compiling.
 If you want to have better detection, please consider updating the Go version in your project.
+See [go.sum](#gomod-gosum) for why `go.sum` is skipped in Go 1.17+ projects.
 
 !!! note
     The Go version doesn't mean your Go tool version, but the Go version in your go.mod.
@@ -59,6 +60,21 @@ If you want to have better detection, please consider updating the Go version in
     ```
     $ go mod tidy -go=1.18
     ```
+
+### go.sum { #gomod-gosum }
+Trivy skips `go.sum` in Go 1.17+ projects, because it lists more modules than the build uses.
+
+A common extra entry is a module that only the tests of your dependencies need. Go leaves such a module out of `go.mod` and never compiles it into your binary, so a vulnerability in it does not affect your project.
+
+To check whether a module is part of the build, list the dependencies of your packages.
+
+```
+$ go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... | grep -Fx 'golang.org/x/mod'
+```
+
+Empty output means the module is not in the build. Add the `-test` flag to also cover the tests of your own packages.
+
+To see exactly what a build linked in, scan the compiled binary instead of the source tree. See [Go Binary](#go-binary).
 
 ### Main Module { #gomod-main }
 Trivy scans only dependencies of the project, and does not detect vulnerabilities of the main module. 

--- a/docs/guide/coverage/language/golang.md
+++ b/docs/guide/coverage/language/golang.md
@@ -64,7 +64,7 @@ See [go.sum](#gomod-gosum) for why `go.sum` is skipped in Go 1.17+ projects.
 ### go.sum { #gomod-gosum }
 Trivy skips `go.sum` in Go 1.17+ projects, because it lists more modules than the build uses.
 
-A common extra entry is a module that only the tests of your dependencies need. Go leaves such a module out of `go.mod` and never compiles it into your binary, so a vulnerability in it does not affect your project.
+A common extra entry is a module that another module needs to run its own tests. Go keeps such a module out of `go.mod` and never compiles it into your binary, so a vulnerability in it does not affect your project. Your own tests are a different case. Their dependencies are listed in `go.mod`, and Trivy reports them.
 
 To check whether a module is part of the build, list the dependencies of your packages.
 

--- a/docs/guide/coverage/language/golang.md
+++ b/docs/guide/coverage/language/golang.md
@@ -68,9 +68,11 @@ A common extra entry is a module that another module needs to run its own tests.
 
 To check whether a module is part of the build, list the dependencies of your packages.
 
+{% raw %}
 ```
 $ go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... | grep -Fx 'golang.org/x/mod'
 ```
+{% endraw %}
 
 Empty output means the module is not in the build. Add the `-test` flag to also cover the tests of your own packages.
 


### PR DESCRIPTION
## Description

The Go page mentions `go.sum` only for Go 1.16 and older, so it says nothing about what `go.sum` holds in a newer project. A reader who finds a module in `go.sum` but not in the report has no way to tell whether Trivy missed it or skipped it on purpose.

The page now has a `go.sum` section that explains the skip in Go 1.17+ projects, where `go.sum` also covers modules that other modules need to run their own tests. Such a module is never compiled into your binary, so a vulnerability in it does not reach your project. The section shows how to check a single module with `go list -deps` and points to binary scanning when the report has to match what a build actually linked in.

The wording relies on the version check fixed in #11169, before which `go.sum` was still merged for Go 1.17+ projects without indirect dependencies.

## Related issues
- #11153
-  #11161

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
