### PR TITLE
fix(license): use canonical SPDX casing for license.id

### DIFF
--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -83,8 +83,9 @@ func NormalizeForSPDX(expr Expression) Expression {
 			}
 		}
 		license := b.String()
-		// SPDX license IDs are matched case-insensitively, so use the canonical
-		// casing from the SPDX license list.
+		// A license can differ from its SPDX ID by a non-canonical separator
+		// (e.g. "BSD-3-clause~Sun") or by case. Separators are replaced above and
+		// the SPDX list is matched case-insensitively, so take the canonical ID.
 		if id, ok := SPDXLicenseID(license); ok {
 			license = id
 		}

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -77,8 +77,7 @@ func NormalizeForSPDX(expr Expression) Expression {
 		}
 		license := b.String()
 		// SPDX license IDs are matched case-insensitively, so use the canonical
-		// casing from the SPDX license list. Only the license itself is looked
-		// up: String() would append "+" or the GNU "-only"/"-or-later" suffix.
+		// casing from the SPDX license list.
 		if id, ok := SPDXLicenseID(license); ok {
 			license = id
 		}

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -75,7 +75,14 @@ func NormalizeForSPDX(expr Expression) Expression {
 				_, _ = b.WriteRune('-')
 			}
 		}
-		return SimpleExpr{License: b.String(), HasPlus: e.HasPlus}
+		license := b.String()
+		// SPDX license IDs are matched case-insensitively, so use the canonical
+		// casing from the SPDX license list. Only the license itself is looked
+		// up: String() would append "+" or the GNU "-only"/"-or-later" suffix.
+		if id, ok := SPDXLicenseID(license); ok {
+			license = id
+		}
+		return SimpleExpr{License: license, HasPlus: e.HasPlus}
 	case CompoundExpr:
 		if e.Conjunction() == TokenWith {
 			initSpdxExceptions()

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -54,9 +54,6 @@ func normalize(expr Expression, fn NormalizeFunc) Expression {
 	return normalized
 }
 
-// NormalizeForSPDX replaces ' ' to '-' in license-id.
-// SPDX license MUST NOT have white space between a license-id.
-// There MUST be white space on either side of the operator "WITH".
 // NormalizeForSPDX rewrites an expression to match the SPDX license expression syntax:
 //   - in a license-id, characters outside the idstring set are replaced with '-'
 //     (a license-id MUST NOT contain white space, while the "WITH" operator MUST be

--- a/pkg/licensing/expression/expression.go
+++ b/pkg/licensing/expression/expression.go
@@ -57,6 +57,13 @@ func normalize(expr Expression, fn NormalizeFunc) Expression {
 // NormalizeForSPDX replaces ' ' to '-' in license-id.
 // SPDX license MUST NOT have white space between a license-id.
 // There MUST be white space on either side of the operator "WITH".
+// NormalizeForSPDX rewrites an expression to match the SPDX license expression syntax:
+//   - in a license-id, characters outside the idstring set are replaced with '-'
+//     (a license-id MUST NOT contain white space, while the "WITH" operator MUST be
+//     surrounded by it);
+//   - a license-id found in the SPDX license list is replaced with its canonical spelling;
+//   - the exception-id of a "WITH" expression is replaced with its canonical spelling.
+//
 // ref: https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions
 func NormalizeForSPDX(expr Expression) Expression {
 	switch e := expr.(type) {

--- a/pkg/licensing/expression/expression_test.go
+++ b/pkg/licensing/expression/expression_test.go
@@ -35,6 +35,12 @@ func TestNormalize(t *testing.T) {
 			want:    "LGPL-2.1-only OR MIT OR BSD-3-Clause",
 		},
 		{
+			name:    "SPDX, non-canonical case",
+			license: "BSD-3-clause~Sun",
+			fn:      NormalizeForSPDX,
+			want:    "BSD-3-Clause-Sun",
+		},
+		{
 			name:    "upper",
 			license: "LGPL-2.1-only OR MIT",
 			fn:      func(license Expression) Expression { return SimpleExpr{strings.ToUpper(license.String()), false} },

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -326,11 +326,9 @@ func (m *Marshaler) normalizeLicenses(licenses []string) *cdx.Licenses {
 
 	// Otherwise use individual LicenseChoice entries with license.id or license.name
 	choices := xslices.Map(expressions, func(expr expression.Expression) cdx.LicenseChoice {
-		if s, ok := expr.(expression.SimpleExpr); ok {
+		if s, ok := expr.(expression.SimpleExpr); ok && s.IsSPDXExpression() {
 			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0")
-			if id, ok := expression.SPDXLicenseID(s.String()); ok {
-				return cdx.LicenseChoice{License: &cdx.License{ID: id}}
-			}
+			return cdx.LicenseChoice{License: &cdx.License{ID: s.String()}}
 		}
 		// Use license.name for everything else (invalid SPDX ID, SPDX expression, etc.)
 		return cdx.LicenseChoice{License: &cdx.License{Name: expr.String()}}

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -326,9 +326,14 @@ func (m *Marshaler) normalizeLicenses(licenses []string) *cdx.Licenses {
 
 	// Otherwise use individual LicenseChoice entries with license.id or license.name
 	choices := xslices.Map(expressions, func(expr expression.Expression) cdx.LicenseChoice {
-		if s, ok := expr.(expression.SimpleExpr); ok && s.IsSPDXExpression() {
-			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0")
-			return cdx.LicenseChoice{License: &cdx.License{ID: s.String()}}
+		if s, ok := expr.(expression.SimpleExpr); ok {
+			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0").
+			// SPDX IDs are matched case-insensitively, so take the canonical
+			// casing from the SPDX license list: the CycloneDX schema validates
+			// license.id against a case-sensitive enumeration.
+			if id, ok := expression.SPDXLicenseID(s.String()); ok {
+				return cdx.LicenseChoice{License: &cdx.License{ID: id}}
+			}
 		}
 		// Use license.name for everything else (invalid SPDX ID, SPDX expression, etc.)
 		return cdx.LicenseChoice{License: &cdx.License{Name: expr.String()}}

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -327,12 +327,7 @@ func (m *Marshaler) normalizeLicenses(licenses []string) *cdx.Licenses {
 	// Otherwise use individual LicenseChoice entries with license.id or license.name
 	choices := xslices.Map(expressions, func(expr expression.Expression) cdx.LicenseChoice {
 		if s, ok := expr.(expression.SimpleExpr); ok {
-			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0").
-			// The lookup also canonicalizes the casing, which NormalizeForSPDX
-			// has usually done already. It is repeated here because the early
-			// returns in normalizeLicense never reach the normalizers, and the
-			// CycloneDX schema validates license.id against a case-sensitive
-			// enumeration.
+			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0")
 			if id, ok := expression.SPDXLicenseID(s.String()); ok {
 				return cdx.LicenseChoice{License: &cdx.License{ID: id}}
 			}

--- a/pkg/sbom/cyclonedx/marshal.go
+++ b/pkg/sbom/cyclonedx/marshal.go
@@ -328,9 +328,11 @@ func (m *Marshaler) normalizeLicenses(licenses []string) *cdx.Licenses {
 	choices := xslices.Map(expressions, func(expr expression.Expression) cdx.LicenseChoice {
 		if s, ok := expr.(expression.SimpleExpr); ok {
 			// Use license.id for valid SPDX ID (e.g., "MIT", "Apache-2.0").
-			// SPDX IDs are matched case-insensitively, so take the canonical
-			// casing from the SPDX license list: the CycloneDX schema validates
-			// license.id against a case-sensitive enumeration.
+			// The lookup also canonicalizes the casing, which NormalizeForSPDX
+			// has usually done already. It is repeated here because the early
+			// returns in normalizeLicense never reach the normalizers, and the
+			// CycloneDX schema validates license.id against a case-sensitive
+			// enumeration.
 			if id, ok := expression.SPDXLicenseID(s.String()); ok {
 				return cdx.LicenseChoice{License: &cdx.License{ID: id}}
 			}

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -2275,7 +2275,7 @@ func TestMarshaler_Licenses(t *testing.T) {
 		{
 			name: "SPDX ID with non-canonical case",
 			licenses: []string{
-				"BSD-3-clause-Sun",
+				"BSD-3-clause~Sun",
 			},
 			want: &cdx.Licenses{
 				cdx.LicenseChoice{

--- a/pkg/sbom/cyclonedx/marshal_test.go
+++ b/pkg/sbom/cyclonedx/marshal_test.go
@@ -2273,6 +2273,19 @@ func TestMarshaler_Licenses(t *testing.T) {
 			},
 		},
 		{
+			name: "SPDX ID with non-canonical case",
+			licenses: []string{
+				"BSD-3-clause-Sun",
+			},
+			want: &cdx.Licenses{
+				cdx.LicenseChoice{
+					License: &cdx.License{
+						ID: "BSD-3-Clause-Sun",
+					},
+				},
+			},
+		},
+		{
 			name: "Unknown SPDX ID",
 			licenses: []string{
 				"no-spdx-id-license",


### PR DESCRIPTION
## Description

`normalizeLicenses` validates a license with `SimpleExpr.IsSPDXExpression()` and then emits `s.String()` as `license.id`. `IsSPDXExpression` resolves through `spdxLicenses`, which is a `set.NewCaseInsensitive()`, so a license whose casing differs from the SPDX list is accepted, and the original spelling is written out.

The CycloneDX schema validates `license.id` against the enumeration in `spdx.schema.json`, which is **case-sensitive**. A single non-canonical id makes the whole `licenses` array fail the `oneOf`, and consumers that validate on ingest reject the entire document.

This is reachable from ordinary Debian package metadata. `nodejs`/`libnode108` declare [`License: BSD-3-clause~Sun`](https://sources.debian.org/src/nodejs/18.20.4%2Bdfsg-1~deb12u2/debian/copyright#L457); normalization rewrites the `~` to `-` but leaves the lowercase `c`, so Trivy emits `BSD-3-clause-Sun` while the SPDX id is `BSD-3-Clause-Sun`.

The fix takes the canonical spelling from `expression.SPDXLicenseID`, which is already used for this purpose in `pkg/licensing/normalize.go` and the JAR parser. It returns the value stored in the set, so it validates and canonicalises in one lookup, and the separate `IsSPDXExpression()` call is no longer needed — a license that is not in the list falls through to `license.name` exactly as before.

## Before / after

`trivy rootfs --format cyclonedx` over a Debian 12 root containing `nodejs` and `libnode108`:

```console
# before (v0.74.0)
$ jq '[.components[]|(.licenses//[])[]|.license.id]|map(select(test("sun";"i")))|unique' before.json
["BSD-3-clause-Sun"]

# after
$ jq '[.components[]|(.licenses//[])[]|.license.id]|map(select(test("sun";"i")))|unique' after.json
["BSD-3-Clause-Sun"]
```

Validated against `bom-1.7.schema.json` from `cyclonedx-core-java`:

| | result |
|---|---|
| before | `FAIL` — `$.components[1].licenses[21]: {'license': {'id': 'BSD-3-clause-Sun'}} is not valid under any of the given schemas` (and `[2]`) |
| after | `PASS` |

Nothing else in the document changes. The license entry count and the id/name split are identical before and after (54 entries, 28 `id`, 26 `name`), and the only difference in the two documents is the two rewritten values:

```console
$ diff <(jq -S '[.components[]|(.licenses//[])[]]' before.json) <(jq -S '[.components[]|(.licenses//[])[]]' after.json)
<       "id": "BSD-3-clause-Sun"
>       "id": "BSD-3-Clause-Sun"
```

## How I tested

Added a `TestMarshaler_Licenses` case, "SPDX ID with non-canonical case", asserting `BSD-3-clause-Sun` marshals to id `BSD-3-Clause-Sun`. It fails on `main` and passes with the change.

`go test ./pkg/sbom/...` is green, and `gofmt`/`go vet` are clean. No golden file in `integration/testdata` or `pkg/**/testdata` contains a `license.id` whose casing this changes, so none needed updating.

## Related issues

- Closes https://github.com/aquasecurity/trivy/issues/11177

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).