### PR TITLE
feat(cli): add --log-format flag for structured JSON logs

### DIFF
--- a/docs/guide/advanced/telemetry-flags.md
+++ b/docs/guide/advanced/telemetry-flags.md
@@ -16,6 +16,7 @@
 --insecure
 --license-full
 --list-all-pkgs
+--log-format
 --misconfig-scanners
 --offline-scan
 --parallel

--- a/docs/guide/configuration/others.md
+++ b/docs/guide/configuration/others.md
@@ -161,6 +161,31 @@ When we want to get the image `alpine` with the settings above. The logic will b
 2. Try to get the image from `mirror.without.image/library/alpine`, but we get an error because this registry doesn't have this image (but most likely it will be an error about authorization).
 3. Get the image from `index.docker.io` (the original registry).
 
+## Log Format
+
+Logs are written to stderr in a human-readable format by default.
+Use `--log-format json` to emit one JSON object per line instead, which is easier for log aggregators such as Splunk, Loki or Datadog to ingest.
+
+```shell
+$ trivy image --log-format json alpine:3.15
+```
+
+```json
+{"time":"2025-01-01T00:00:00.000000000Z","level":"INFO","msg":"Vulnerability scanning is enabled"}
+{"time":"2025-01-01T00:00:00.000000000Z","level":"INFO","prefix":"vulndb","msg":"Need to update DB"}
+```
+
+The log prefix, which is rendered as `[vulndb]` in the text output, becomes a separate `prefix` field.
+
+This is most useful for long-running processes such as the [server](../../getting-started/installation.md):
+
+```shell
+$ trivy server --log-format json --listen localhost:8080
+```
+
+!!! note
+    The flag only affects logs. It does not affect the scan report, which is controlled by `--format`.
+
 ## Check for updates
 
 Trivy periodically checks for updates and notices, and displays a message to the user with recommendations.  

--- a/docs/guide/references/configuration/cli/trivy.md
+++ b/docs/guide/references/configuration/cli/trivy.md
@@ -37,6 +37,7 @@ trivy [global flags] command [flags] target
       --generate-default-config   write the default config to trivy-default.yaml
   -h, --help                      help for trivy
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_clean.md
+++ b/docs/guide/references/configuration/cli/trivy_clean.md
@@ -41,6 +41,7 @@ trivy clean [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_config.md
+++ b/docs/guide/references/configuration/cli/trivy_config.md
@@ -93,6 +93,7 @@ trivy config [flags] DIR
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_convert.md
+++ b/docs/guide/references/configuration/cli/trivy_convert.md
@@ -64,6 +64,7 @@ trivy convert [flags] RESULT_JSON
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_filesystem.md
+++ b/docs/guide/references/configuration/cli/trivy_filesystem.md
@@ -190,6 +190,7 @@ trivy filesystem [flags] PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_image.md
+++ b/docs/guide/references/configuration/cli/trivy_image.md
@@ -211,6 +211,7 @@ trivy image [flags] IMAGE_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/guide/references/configuration/cli/trivy_kubernetes.md
@@ -199,6 +199,7 @@ trivy kubernetes [flags] [CONTEXT]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_module.md
+++ b/docs/guide/references/configuration/cli/trivy_module.md
@@ -19,6 +19,7 @@ Manage modules
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_module_install.md
+++ b/docs/guide/references/configuration/cli/trivy_module_install.md
@@ -22,6 +22,7 @@ trivy module install [flags] REPOSITORY
       --enable-modules strings    [EXPERIMENTAL] module names to enable
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
       --module-dir string         specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)

--- a/docs/guide/references/configuration/cli/trivy_module_uninstall.md
+++ b/docs/guide/references/configuration/cli/trivy_module_uninstall.md
@@ -22,6 +22,7 @@ trivy module uninstall [flags] REPOSITORY
       --enable-modules strings    [EXPERIMENTAL] module names to enable
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
       --module-dir string         specify directory to the wasm modules that will be loaded (default "$HOME/.trivy/modules")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)

--- a/docs/guide/references/configuration/cli/trivy_plugin.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin.md
@@ -17,6 +17,7 @@ Manage plugins
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_info.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_info.md
@@ -21,6 +21,7 @@ trivy plugin info PLUGIN_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_install.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_install.md
@@ -34,6 +34,7 @@ trivy plugin install NAME | URL | FILE_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_list.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_list.md
@@ -21,6 +21,7 @@ trivy plugin list
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_run.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_run.md
@@ -21,6 +21,7 @@ trivy plugin run NAME | URL | FILE_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_search.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_search.md
@@ -21,6 +21,7 @@ trivy plugin search [KEYWORD]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_uninstall.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_uninstall.md
@@ -21,6 +21,7 @@ trivy plugin uninstall PLUGIN_NAME
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_update.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_update.md
@@ -21,6 +21,7 @@ trivy plugin update
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_plugin_upgrade.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_upgrade.md
@@ -21,6 +21,7 @@ trivy plugin upgrade [PLUGIN_NAMES]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_registry.md
+++ b/docs/guide/references/configuration/cli/trivy_registry.md
@@ -17,6 +17,7 @@ Manage registry authentication
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_registry_login.md
+++ b/docs/guide/references/configuration/cli/trivy_registry_login.md
@@ -31,6 +31,7 @@ trivy registry login SERVER [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_registry_logout.md
+++ b/docs/guide/references/configuration/cli/trivy_registry_logout.md
@@ -28,6 +28,7 @@ trivy registry logout SERVER [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_repository.md
+++ b/docs/guide/references/configuration/cli/trivy_repository.md
@@ -189,6 +189,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_rootfs.md
+++ b/docs/guide/references/configuration/cli/trivy_rootfs.md
@@ -191,6 +191,7 @@ trivy rootfs [flags] ROOTDIR
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_sbom.md
+++ b/docs/guide/references/configuration/cli/trivy_sbom.md
@@ -156,6 +156,7 @@ trivy sbom [flags] SBOM_PATH
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_server.md
+++ b/docs/guide/references/configuration/cli/trivy_server.md
@@ -51,6 +51,7 @@ trivy server [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_version.md
+++ b/docs/guide/references/configuration/cli/trivy_version.md
@@ -22,6 +22,7 @@ trivy version [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vex.md
+++ b/docs/guide/references/configuration/cli/trivy_vex.md
@@ -17,6 +17,7 @@
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vex_repo.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo.md
@@ -31,6 +31,7 @@ Manage VEX repositories
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_download.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_download.md
@@ -25,6 +25,7 @@ trivy vex repo download [REPO_NAMES] [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_init.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_init.md
@@ -21,6 +21,7 @@ trivy vex repo init [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_list.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_list.md
@@ -21,6 +21,7 @@ trivy vex repo list [flags]
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/cli/trivy_vm.md
+++ b/docs/guide/references/configuration/cli/trivy_vm.md
@@ -175,6 +175,7 @@ trivy vm [flags] VM_IMAGE
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections
+      --log-format string         log output format (allowed values: text,json) (default "text")
   -q, --quiet                     suppress progress bar and log output
       --timeout duration          timeout (default 5m0s)
   -v, --version                   show version

--- a/docs/guide/references/configuration/config-file.md
+++ b/docs/guide/references/configuration/config-file.md
@@ -22,6 +22,9 @@ debug: false
 # Same as '--insecure'
 insecure: false
 
+# Same as '--log-format'
+log-format: "text"
+
 # Same as '--quiet'
 quiet: false
 

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -218,7 +218,7 @@ func NewRootCommand(globalFlags *flag.GlobalFlagGroup) *cobra.Command {
 				return err
 			}
 			// Initialize logger
-			log.InitLogger(opts.Debug, opts.Quiet)
+			log.InitLogger(opts.Debug, opts.Quiet, log.WithFormat(opts.LogFormat))
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/server/run.go
+++ b/pkg/commands/server/run.go
@@ -17,7 +17,7 @@ import (
 
 // Run runs the scan
 func Run(ctx context.Context, opts flag.Options) (err error) {
-	log.InitLogger(opts.Debug, opts.Quiet)
+	log.InitLogger(opts.Debug, opts.Quiet, log.WithFormat(opts.LogFormat))
 
 	// Set the default HTTP transport
 	xhttp.SetDefaultTransport(xhttp.NewTransport(xhttp.Options{

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/aquasecurity/trivy/pkg/log"
+	xstrings "github.com/aquasecurity/trivy/pkg/x/strings"
 )
 
 var (
@@ -41,6 +42,15 @@ var (
 		ConfigName:    "debug",
 		Shorthand:     "d",
 		Usage:         "debug mode",
+		Persistent:    true,
+		TelemetrySafe: true,
+	}
+	LogFormatFlag = Flag[string]{
+		Name:          "log-format",
+		ConfigName:    "log-format",
+		Default:       string(log.FormatText),
+		Values:        xstrings.ToStringSlice(log.Formats),
+		Usage:         "log output format",
 		Persistent:    true,
 		TelemetrySafe: true,
 	}
@@ -94,6 +104,7 @@ type GlobalFlagGroup struct {
 	ShowVersion           *Flag[bool] // spf13/cobra can't override the logic of version printing like VersionPrinter in urfave/cli. -v needs to be defined ourselves.
 	Quiet                 *Flag[bool]
 	Debug                 *Flag[bool]
+	LogFormat             *Flag[string]
 	Insecure              *Flag[bool]
 	CACert                *Flag[string]
 	Timeout               *Flag[time.Duration]
@@ -108,6 +119,7 @@ type GlobalOptions struct {
 	ShowVersion           bool
 	Quiet                 bool
 	Debug                 bool
+	LogFormat             log.Format
 	Insecure              bool
 	CACerts               *x509.CertPool
 	Timeout               time.Duration
@@ -122,6 +134,7 @@ func NewGlobalFlagGroup() *GlobalFlagGroup {
 		ShowVersion:           ShowVersionFlag.Clone(),
 		Quiet:                 QuietFlag.Clone(),
 		Debug:                 DebugFlag.Clone(),
+		LogFormat:             LogFormatFlag.Clone(),
 		Insecure:              InsecureFlag.Clone(),
 		CACert:                CACertFlag.Clone(),
 		Timeout:               TimeoutFlag.Clone(),
@@ -141,6 +154,7 @@ func (f *GlobalFlagGroup) Flags() []Flagger {
 		f.ShowVersion,
 		f.Quiet,
 		f.Debug,
+		f.LogFormat,
 		f.Insecure,
 		f.CACert,
 		f.Timeout,
@@ -180,6 +194,7 @@ func (f *GlobalFlagGroup) ToOptions(opts *Options) error {
 		ShowVersion:           f.ShowVersion.Value(),
 		Quiet:                 f.Quiet.Value(),
 		Debug:                 f.Debug.Value(),
+		LogFormat:             log.Format(f.LogFormat.Value()),
 		Insecure:              insecure,
 		CACerts:               caCerts,
 		Timeout:               f.Timeout.Value(),

--- a/pkg/flag/global_flags_test.go
+++ b/pkg/flag/global_flags_test.go
@@ -1,0 +1,81 @@
+package flag_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/flag"
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+func TestGlobalFlagGroup_LogFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		cliArgs []string
+		envs    map[string]string
+		want    log.Format
+		wantErr string
+	}{
+		{
+			name: "default",
+			want: log.FormatText,
+		},
+		{
+			name:    "text",
+			cliArgs: []string{"--log-format", "text"},
+			want:    log.FormatText,
+		},
+		{
+			name:    "json",
+			cliArgs: []string{"--log-format", "json"},
+			want:    log.FormatJSON,
+		},
+		{
+			name: "environment variable",
+			envs: map[string]string{
+				"TRIVY_LOG_FORMAT": "json",
+			},
+			want: log.FormatJSON,
+		},
+		{
+			name:    "unknown format",
+			cliArgs: []string{"--log-format", "yaml"},
+			wantErr: `invalid argument "yaml" for "--log-format" flag`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+
+			cmd := &cobra.Command{
+				Use: "test",
+				Run: func(_ *cobra.Command, _ []string) {},
+			}
+
+			// Global flags are registered on the root command, not through Flags.AddFlags.
+			globalFlags := flag.NewGlobalFlagGroup()
+			globalFlags.AddFlags(cmd)
+			require.NoError(t, cmd.ParseFlags(tt.cliArgs))
+			require.NoError(t, globalFlags.Bind(cmd))
+
+			flags := flag.Flags{globalFlags}
+			got, err := flags.ToOptions(nil)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, got.LogFormat)
+		})
+	}
+}

--- a/pkg/k8s/scanner/scanner.go
+++ b/pkg/k8s/scanner/scanner.go
@@ -54,12 +54,12 @@ func NewScanner(cluster string, runner cmd.Runner, opts flag.Options) *Scanner {
 
 func (s *Scanner) Scan(ctx context.Context, artifactsData []*artifacts.Artifact) (report.Report, error) {
 	// disable logs before scanning
-	log.InitLogger(s.opts.Debug, true)
+	log.InitLogger(s.opts.Debug, true, log.WithFormat(s.opts.LogFormat))
 
 	// enable log, this is done in a defer function,
 	// to enable logs even when the function returns earlier
 	// due to an error
-	defer log.InitLogger(s.opts.Debug, false)
+	defer log.InitLogger(s.opts.Debug, false, log.WithFormat(s.opts.LogFormat))
 
 	if s.opts.Format == types.FormatCycloneDX {
 		kbom, err := s.clusterInfoToReportResources(artifactsData)

--- a/pkg/log/json_handler.go
+++ b/pkg/log/json_handler.go
@@ -1,0 +1,178 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+
+	"github.com/aquasecurity/trivy/pkg/clock"
+)
+
+// JSONHandler emits logs as JSON objects, one per line, for consumption by log
+// aggregators such as Splunk or Loki.
+//
+// It wraps [slog.JSONHandler] rather than replacing it, and adds the parts of
+// Trivy's logging model that the standard handler knows nothing about:
+// contextual attributes and prefixes (see context.go), the custom
+// [LevelFatal] level, and errors, which are not marshalable to JSON on their own.
+type JSONHandler struct {
+	opts   Options
+	prefix string
+	inner  slog.Handler
+}
+
+func NewJSONHandler(out io.Writer, opts *Options) *JSONHandler {
+	h := &JSONHandler{}
+	if opts != nil {
+		h.opts = *opts
+	}
+	if h.opts.Level == nil {
+		h.opts.Level = slog.LevelInfo
+	}
+	h.inner = slog.NewJSONHandler(out, &slog.HandlerOptions{
+		Level:       h.opts.Level,
+		ReplaceAttr: replaceAttr,
+	})
+	return h
+}
+
+func (h *JSONHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *JSONHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	h2 := *h
+
+	// Prefixes are rendered as a dedicated field, not as an ordinary attribute.
+	rest := make([]slog.Attr, 0, len(attrs))
+	for _, a := range attrs {
+		if isLogPrefix(a) {
+			h2.prefix = cleanPrefix(string(a.Value.Any().(logPrefix)))
+			continue
+		}
+		rest = append(rest, a)
+	}
+
+	if len(rest) > 0 {
+		h2.inner = h.inner.WithAttrs(rest)
+	}
+	return &h2
+}
+
+func (h *JSONHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := *h
+	h2.inner = h.inner.WithGroup(name)
+	return &h2
+}
+
+func (h *JSONHandler) Handle(ctx context.Context, r slog.Record) error {
+	// For tests, use the fake clock's time.
+	if c, ok := clock.Clock(ctx).(*clock.FakeClock); ok {
+		r.Time = c.Now()
+	}
+
+	// The record is rebuilt so that the contextual attributes and the prefix,
+	// which [slog.JSONHandler] does not know about, are included.
+	r2 := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	if prefix := h.recordPrefix(ctx, r); prefix != "" {
+		r2.AddAttrs(String(prefixKey, prefix))
+	}
+	r2.AddAttrs(contextualAttrs(ctx)...)
+	r.Attrs(func(a slog.Attr) bool {
+		// The prefix has already been added above.
+		if !isLogPrefix(a) {
+			r2.AddAttrs(a)
+		}
+		return true
+	})
+
+	return h.inner.Handle(ctx, r2)
+}
+
+// withWriter returns a copy of the handler that writes to out.
+// It is used by [Fatal] to log to stderr even when the logger is disabled.
+func (h *JSONHandler) withWriter(out io.Writer) *JSONHandler {
+	h2 := NewJSONHandler(out, &h.opts)
+	h2.prefix = h.prefix
+	return h2
+}
+
+// recordPrefix returns the prefix from the record, the context or the handler, in that order.
+func (h *JSONHandler) recordPrefix(ctx context.Context, r slog.Record) string {
+	if p := string(findKey[logPrefix](prefixKey, r)); p != "" {
+		return cleanPrefix(p)
+	}
+	if p := contextualPrefix(ctx); p != "" {
+		return cleanPrefix(p)
+	}
+	return h.prefix
+}
+
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	// Render the custom FATAL level by name instead of as "ERROR+4".
+	if len(groups) == 0 && a.Key == slog.LevelKey {
+		if level, ok := a.Value.Any().(slog.Level); ok {
+			return slog.String(slog.LevelKey, levelString(level))
+		}
+		return a
+	}
+
+	a.Value = a.Value.Resolve()
+	if isLogPrefix(a) {
+		return slog.String(a.Key, cleanPrefix(string(a.Value.Any().(logPrefix))))
+	}
+	if a.Value.Kind() != slog.KindAny {
+		return a
+	}
+
+	v := a.Value.Any()
+	// Most error types marshal to "{}", so the message is logged instead.
+	if err, ok := v.(error); ok {
+		return slog.String(a.Key, err.Error())
+	}
+	// Interfaces and structs without exported fields also marshal to "{}".
+	// Those that define String for logging, such as table.Scanner, are rendered
+	// with it, mirroring what the text handler shows.
+	if s, ok := v.(fmt.Stringer); ok {
+		return slog.String(a.Key, s.String())
+	}
+	if ss, ok := stringSlice(v); ok {
+		return slog.Any(a.Key, ss)
+	}
+	return a
+}
+
+var stringerType = reflect.TypeFor[fmt.Stringer]()
+
+// stringSlice converts a slice of [fmt.Stringer], e.g. []table.Scanner, to a
+// slice of strings so that it is logged as ["secret"] rather than [{}].
+func stringSlice(v any) ([]string, bool) {
+	rv := reflect.ValueOf(v)
+	if k := rv.Kind(); k != reflect.Slice && k != reflect.Array {
+		return nil, false
+	}
+	if !rv.Type().Elem().Implements(stringerType) {
+		return nil, false
+	}
+
+	ss := make([]string, rv.Len())
+	for i := range ss {
+		ss[i] = rv.Index(i).Interface().(fmt.Stringer).String()
+	}
+	return ss, true
+}
+
+// cleanPrefix strips the decoration that [Prefix] and [WithContextPrefix] add
+// for the text output, e.g. "[vuln] " becomes "vuln".
+func cleanPrefix(prefix string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(prefix), "["), "]")
+}

--- a/pkg/log/json_handler_test.go
+++ b/pkg/log/json_handler_test.go
@@ -1,0 +1,259 @@
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/slogtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/log"
+)
+
+func TestJSONHandler(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+	logger.Debug("debug message", "key1", "value1", "key2", 2)
+	logger.Info("info message", "key3", true)
+	logger.Warn("warn message", slog.Group("group1", slog.Int("key4", 42)))
+	logger.Error("error message", log.Err(errors.New("something went wrong")))
+
+	want := []map[string]any{
+		{
+			"level": "DEBUG",
+			"msg":   "debug message",
+			"key1":  "value1",
+			"key2":  float64(2),
+		},
+		{
+			"level": "INFO",
+			"msg":   "info message",
+			"key3":  true,
+		},
+		{
+			"level":  "WARN",
+			"msg":    "warn message",
+			"group1": map[string]any{"key4": float64(42)},
+		},
+		{
+			// Errors are not marshalable to JSON, so the message is logged instead.
+			"level": "ERROR",
+			"msg":   "error message",
+			"err":   "something went wrong",
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}
+
+func TestJSONHandlerLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelWarn}))
+
+	logger.Debug("debug message")
+	logger.Info("info message")
+	logger.Warn("warn message")
+
+	// Only the message at or above the configured level is emitted.
+	want := []map[string]any{
+		{
+			"level": "WARN",
+			"msg":   "warn message",
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}
+
+func TestJSONHandlerFatalLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+	// Trivy's custom level would otherwise be rendered as "ERROR+4".
+	logger.Log(t.Context(), log.LevelFatal, "fatal message")
+
+	want := []map[string]any{
+		{
+			"level": "FATAL",
+			"msg":   "fatal message",
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}
+
+func TestJSONHandlerPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		log  func(logger *log.Logger)
+		want map[string]any
+	}{
+		{
+			name: "attr prefix",
+			log: func(logger *log.Logger) {
+				logger.Info("info message", log.Prefix(log.PrefixVulnerability))
+			},
+			want: map[string]any{
+				"level":  "INFO",
+				"msg":    "info message",
+				"prefix": "vuln",
+			},
+		},
+		{
+			name: "handler prefix",
+			log: func(logger *log.Logger) {
+				logger.With(log.Prefix(log.PrefixSecret)).Info("info message")
+			},
+			want: map[string]any{
+				"level":  "INFO",
+				"msg":    "info message",
+				"prefix": "secret",
+			},
+		},
+		{
+			name: "contextual prefix",
+			log: func(logger *log.Logger) {
+				ctx := log.WithContextPrefix(context.Background(), log.PrefixJavaDB)
+				logger.InfoContext(ctx, "info message")
+			},
+			want: map[string]any{
+				"level":  "INFO",
+				"msg":    "info message",
+				"prefix": "javadb",
+			},
+		},
+		{
+			name: "no prefix",
+			log: func(logger *log.Logger) {
+				logger.Info("info message")
+			},
+			want: map[string]any{
+				"level": "INFO",
+				"msg":   "info message",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+			tt.log(logger)
+
+			// The prefix is a dedicated field rather than a decoration on the message.
+			assert.Equal(t, []map[string]any{tt.want}, parseJSONLines(t, buf.String()))
+		})
+	}
+}
+
+func TestJSONHandlerContextAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+	ctx := log.WithContextAttrs(context.Background(), log.String("key1", "value1"))
+	logger.InfoContext(ctx, "info message", "key2", "value2")
+
+	want := []map[string]any{
+		{
+			"level": "INFO",
+			"msg":   "info message",
+			"key1":  "value1",
+			"key2":  "value2",
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}
+
+func TestJSONHandlerWithAttrsAndWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	baseLogger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+	logger := baseLogger.
+		With("key1", "value1").
+		WithGroup("group1").
+		With("key2", "value2")
+
+	logger.Info("info message", "key3", true)
+
+	want := []map[string]any{
+		{
+			"level": "INFO",
+			"msg":   "info message",
+			"key1":  "value1",
+			"group1": map[string]any{
+				"key2": "value2",
+				"key3": true,
+			},
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}
+
+func TestJSONSlogtest(t *testing.T) {
+	var buf bytes.Buffer
+	newHandler := func(*testing.T) slog.Handler {
+		buf.Reset()
+		return log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug})
+	}
+
+	results := func(t *testing.T) map[string]any {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+		return m
+	}
+
+	slogtest.Run(t, newHandler, results)
+}
+
+// parseJSONLines parses the emitted log lines and drops the timestamp, which is not deterministic.
+func parseJSONLines(t *testing.T, s string) []map[string]any {
+	t.Helper()
+
+	var lines []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &m), "invalid JSON log line: %s", line)
+		delete(m, slog.TimeKey)
+		lines = append(lines, m)
+	}
+	return lines
+}
+
+// stringerScanner mimics table.Scanner: an interface value with no exported
+// fields that defines String for logging.
+type stringerScanner struct{ name string }
+
+func (s stringerScanner) String() string { return s.name }
+
+func TestJSONHandlerStringer(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(log.NewJSONHandler(&buf, &log.Options{Level: slog.LevelDebug}))
+
+	logger.Info("scanner message",
+		log.Any("scanner", stringerScanner{name: "secret"}),
+		log.Any("scanners", []fmt.Stringer{
+			stringerScanner{name: "secret"},
+			stringerScanner{name: "license"},
+		}),
+	)
+
+	// Without the conversion these marshal to {} and [{},{}].
+	want := []map[string]any{
+		{
+			"level":    "INFO",
+			"msg":      "scanner message",
+			"scanner":  "secret",
+			"scanners": []any{"secret", "license"},
+		},
+	}
+	assert.Equal(t, want, parseJSONLines(t, buf.String()))
+}

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -29,6 +29,22 @@ const (
 	PrefixCycloneDX        = "cyclonedx"
 )
 
+// Format represents the output format of the logger.
+type Format string
+
+const (
+	// FormatText is the human-readable, colorized output.
+	FormatText Format = "text"
+	// FormatJSON is one JSON object per line, for machine consumption.
+	FormatJSON Format = "json"
+)
+
+// Formats is the list of supported log formats.
+var Formats = []Format{
+	FormatText,
+	FormatJSON,
+}
+
 // Logger is an alias of slog.Logger
 type Logger = slog.Logger
 
@@ -37,11 +53,36 @@ func New(h slog.Handler) *Logger {
 	return slog.New(h)
 }
 
+type initConfig struct {
+	format Format
+}
+
+// InitOption customizes the logger initialization.
+type InitOption func(*initConfig)
+
+// WithFormat sets the output format of the logger. It defaults to [FormatText].
+func WithFormat(format Format) InitOption {
+	return func(c *initConfig) {
+		c.format = format
+	}
+}
+
 // InitLogger initializes the logger variable and flushes the buffered logs if needed.
-func InitLogger(debug, disable bool) {
+func InitLogger(debug, disable bool, opts ...InitOption) {
+	conf := initConfig{format: FormatText}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
 	level := lo.Ternary(debug, slog.LevelDebug, slog.LevelInfo)
 	out := lo.Ternary(disable, io.Discard, io.Writer(os.Stderr))
-	h := NewHandler(out, &Options{Level: level})
+
+	var h slog.Handler
+	if conf.format == FormatJSON {
+		h = NewJSONHandler(out, &Options{Level: level})
+	} else {
+		h = NewHandler(out, &Options{Level: level})
+	}
 
 	// Flush the buffered logs if needed.
 	if d, ok := slog.Default().Handler().(*DeferredHandler); ok {
@@ -85,9 +126,14 @@ func Errorf(format string, args ...any) { slog.Default().Error(fmt.Sprintf(forma
 // Fatal for logging fatal errors
 func Fatal(msg string, args ...any) {
 	// Fatal errors should be logged to stderr even if the logger is disabled.
-	if h, ok := slog.Default().Handler().(*ColorHandler); ok {
+	switch h := slog.Default().Handler().(type) {
+	case *ColorHandler:
 		h.out = os.Stderr
-	} else {
+	case *JSONHandler:
+		// The writer cannot be swapped in place, so the handler is rebuilt
+		// to keep the output format the user asked for.
+		slog.SetDefault(New(h.withWriter(os.Stderr)))
+	default:
 		slog.SetDefault(New(NewHandler(os.Stderr, &Options{})))
 	}
 	slog.Default().Log(context.Background(), LevelFatal, msg, args...)

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -9,6 +9,14 @@
       "type": "boolean",
       "description": "debug mode"
     },
+    "log-format": {
+      "type": "string",
+      "description": "log output format",
+      "enum": [
+        "text",
+        "json"
+      ]
+    },
     "insecure": {
       "type": "boolean",
       "description": "allow insecure server connections"


### PR DESCRIPTION
## Description

Adds a global `--log-format` flag that switches Trivy's logs between the current human-readable text and newline-delimited JSON.

```bash
trivy image --log-format json alpine:3.15
trivy server --log-format json --listen localhost:8080
```

Allowed values are `text` (default, current behaviour) and `json`. Like every other Trivy flag it also works as `TRIVY_LOG_FORMAT=json` and as `log-format: json` in `trivy.yaml`.

This only affects the **logs** written to stderr. The scan report is untouched and still controlled by `--format`, so `--format json --log-format json` writes a JSON report to stdout and JSON logs to stderr independently.

### Motivation

Trivy already produces a machine-readable report, but its operational logs were text-only. Anyone running Trivy as infrastructure — `trivy server` as a daemon, the Kubernetes operator, or a CI pipeline — ships those logs to Splunk / Loki / Datadog / CloudWatch, which index JSON natively. Today that means regexing an unstable text format, and when a scan fails there is no report at all, so the logs are the only diagnostic available.

The log prefix is especially useful once structured. Trivy tags logs by subsystem (`[vuln]`, `[secret]`, `[vulndb]`, `[misconfig]`); in text that is decoration inside the message, but in JSON it becomes a queryable `prefix` field, so "alert me when the vulnerability DB fails to update" is `prefix:vulndb AND level:ERROR` rather than a regex.

### Implementation

`pkg/log/json_handler.go` adds a `JSONHandler` that wraps `slog.JSONHandler` rather than replacing it, and supplies the four things the standard library handler does not know about Trivy's logging model:

- **Contextual attributes and prefixes.** `WithContextAttrs` / `WithContextPrefix` store values on the `context.Context`, which a plain handler never sees, so `Handle` folds them into the record.
- **Errors.** `log.Err(err)` is a `slog.Any`, and most error types marshal to `{}` — the single most important field would silently disappear. They are rendered with `Error()` instead.
- **`LevelFatal`.** Trivy's custom `slog.Level(12)` would print as `"ERROR+4"`; it is emitted as `"FATAL"`.
- **Values that only render via `String()`.** Interfaces and structs with no exported fields also marshal to `{}`. `table.Scanner` is the live example — its interface declares `String() string // Required to show correct logs`. These use `String()`, and a slice of them becomes a JSON array of strings, so `scanners=[secret]` becomes `"scanners":["secret"]` rather than `[{}]`.

`InitLogger` takes a variadic `InitOption` so that all existing call sites compile unchanged, and `log.Fatal` gained a `*JSONHandler` case so a fatal error does not silently revert to text output on its way to stderr.

### Before / after

Before (unchanged default):

```console
$ trivy fs --scanners secret ./target
2026-09-03T14:26:13+05:30	INFO	[secret] Secret scanning is enabled
2026-09-03T14:26:13+05:30	INFO	[secret] Please see https://trivy.dev/docs/dev/guide/scanner/secret#recommendation for faster secret detection
2026-09-03T14:26:13+05:30	INFO	Number of language-specific files	num=0
2026-09-03T14:26:13+05:30	INFO	[report] No issues detected with scanner(s).	scanners=[secret]
```

After:

```console
$ trivy fs --scanners secret --log-format json ./target
{"time":"2026-09-03T14:26:13.18Z","level":"INFO","msg":"Secret scanning is enabled","prefix":"secret"}
{"time":"2026-09-03T14:26:13.18Z","level":"INFO","msg":"Please see https://trivy.dev/docs/dev/guide/scanner/secret#recommendation for faster secret detection","prefix":"secret"}
{"time":"2026-09-03T14:26:13.19Z","level":"INFO","msg":"Number of language-specific files","num":0}
{"time":"2026-09-03T14:26:13.19Z","level":"INFO","msg":"No issues detected with scanner(s).","prefix":"report","scanners":["secret"]}
```

Errors keep their message, and fatal errors keep the format:

```console
$ trivy fs --scanners secret --log-format json ./missing
{"time":"2026-09-03T14:10:44.54Z","level":"FATAL","msg":"Fatal error","err":"run error: fs scan error: ... The system cannot find the file specified."}
```

Invalid values are rejected by the existing flag validation:

```console
$ trivy fs --log-format yaml ./target
2026-09-03T14:10:44+05:30	FATAL	Fatal error	unable to parse flags: unable to parse flag: invalid argument "yaml" for "--log-format" flag: must be one of ["text" "json"]
```

### Notes for reviewers

- The default is `text`, so no existing output changes. I diffed the text output before and after and it is byte-identical.
- `--log-format` cannot apply when flag parsing itself fails, since that fatal fires before the logger is configured. It degrades to text, as shown above.
- Docs, the config-file reference, the JSON schema and `telemetry-flags.md` were regenerated with `mage docs:generate`. The flag is marked `TelemetrySafe: true`, consistent with `--debug` and `--quiet`.
- Tests include the standard library's `slogtest.Run` conformance suite for the new handler, plus coverage for prefixes, contextual attributes, errors, `FATAL`, and the `String()` conversion.

## Related issues
- Close #3300

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
