### PR TITLE
feat(ignore): make id optional in .trivyignore.yaml

### DIFF
--- a/docs/guide/configuration/filtering.md
+++ b/docs/guide/configuration/filtering.md
@@ -341,9 +341,12 @@ For the `.trivyignore.yaml` file, you can set ignored IDs separately for `vulner
 
 Available fields:
 
+!!! note
+    At least one of `id`, `purls`, or `paths` must be specified in each entry. When `id` is omitted, the entry matches any finding that satisfies the remaining filters.
+
 | Field      | Required | Type                | Description                                                                                                                                                             |
 |------------|:--------:|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id         |    ✓     | string              | The identifier of the vulnerability, misconfiguration, secret, or license[^1].                                                                                          |
+| id         |          | string              | The identifier of the vulnerability, misconfiguration, secret, or license[^1]. If not set, the entry matches any finding that satisfies the other filters.              |
 | paths[^2]  |          | string array        | The list of file paths to ignore. If `paths` is not set, the ignore finding is applied to all files.                                                                    |
 | purls      |          | string array        | The list of PURLs to ignore packages. If `purls` is not set, the ignore finding is applied to all packages. This field is currently available only for vulnerabilities. |
 | expired_at |          | date (`yyyy-mm-dd`) | The expiration date of the ignore finding. If `expired_at` is not set, the ignore finding is always valid.                                                              |
@@ -427,6 +430,15 @@ Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
 ```
 
 </details>
+
+When `id` is omitted, an entry ignores every finding that satisfies the remaining filters. For example, to ignore all vulnerabilities of a package without listing each CVE:
+
+```yaml
+vulnerabilities:
+  - purls:
+      - "pkg:deb/ubuntu/linux-libc-dev"
+    statement: Kernel headers, not exercised at runtime
+```
 
 ### By Rego
 

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -26,7 +26,8 @@ import (
 type IgnoreFinding struct {
 	// ID is the identifier of the vulnerability, misconfiguration, secret, or license.
 	// e.g. CVE-2019-8331, AVD-AWS-0175, etc.
-	// required: true
+	// If ID is not set, the entry matches any finding that satisfies the remaining filters.
+	// required: false
 	ID string `yaml:"id"`
 
 	// Paths is the list of file paths to ignore.
@@ -65,6 +66,10 @@ func (i *IgnoreFinding) UnmarshalYAML(value *yaml.Node) error {
 
 	*i = IgnoreFinding(tmp.plain)
 
+	if i.ID == "" && len(i.Paths) == 0 && len(tmp.PURLs) == 0 {
+		return xerrors.New("at least one of id, purls, or paths must be specified in the ignore file")
+	}
+
 	for _, pattern := range i.Paths {
 		if !doublestar.ValidatePattern(pattern) {
 			return xerrors.Errorf("invalid path pattern in the ignore file, id: %s, path: %s", i.ID, pattern)
@@ -87,7 +92,7 @@ type IgnoreFindings []IgnoreFinding
 
 func (f *IgnoreFindings) Match(id, path string, pkg *packageurl.PackageURL) *IgnoreFinding {
 	for _, finding := range *f {
-		if id != finding.ID {
+		if finding.ID != "" && id != finding.ID {
 			continue
 		}
 		if !matchPath(path, finding.Paths) || !matchPURL(pkg, finding.PURLs) {

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/trivy/pkg/purl"
 )
 
 func TestParseIgnoreFile(t *testing.T) {
@@ -72,4 +75,108 @@ func TestParseIgnoreFile(t *testing.T) {
 		assert.Empty(t, got)
 	})
 
+	t.Run("valid YAML config file without ids", func(t *testing.T) {
+		got, err := ParseIgnoreFile(t.Context(), "testdata/.trivyignore-no-id.yaml")
+		require.NoError(t, err)
+		assert.Len(t, got.Vulnerabilities, 2)
+		assert.Len(t, got.Misconfigurations, 1)
+		assert.Len(t, got.Secrets, 1)
+		assert.Len(t, got.Licenses, 1)
+	})
+
+	t.Run("entry without id, purls, and paths", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "TestParseIgnoreFile-*.yaml")
+		require.NoError(t, err)
+		defer f.Close()
+
+		_, err = f.WriteString(`vulnerabilities:
+  - statement: matches nothing
+`)
+		require.NoError(t, err)
+
+		_, err = ParseIgnoreFile(t.Context(), f.Name())
+		require.ErrorContains(t, err, "at least one of id, purls, or paths must be specified")
+	})
+
+}
+
+func TestIgnoreFindingsMatch(t *testing.T) {
+	linuxLibcDev, err := purl.FromString("pkg:deb/ubuntu/linux-libc-dev@5.15.0")
+	require.NoError(t, err)
+	otherPkg, err := purl.FromString("pkg:deb/ubuntu/other-pkg@1.0.0")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		findings IgnoreFindings
+		id       string
+		path     string
+		pkg      *packageurl.PackageURL
+		want     bool
+	}{
+		{
+			name: "entry without id matches a vulnerability by purl",
+			findings: IgnoreFindings{
+				{PURLs: []*purl.PackageURL{linuxLibcDev}},
+			},
+			id:   "CVE-2024-0001",
+			pkg:  linuxLibcDev.Unwrap(),
+			want: true,
+		},
+		{
+			name: "entry without id does not match other packages",
+			findings: IgnoreFindings{
+				{PURLs: []*purl.PackageURL{linuxLibcDev}},
+			},
+			id:   "CVE-2024-0001",
+			pkg:  otherPkg.Unwrap(),
+			want: false,
+		},
+		{
+			name: "entry without id matches a finding by path pattern",
+			findings: IgnoreFindings{
+				{Paths: []string{"test/fixtures/**"}},
+			},
+			id:   "AVD-AWS-0001",
+			path: "test/fixtures/main.tf",
+			want: true,
+		},
+		{
+			name: "entry without id does not match other paths",
+			findings: IgnoreFindings{
+				{Paths: []string{"test/fixtures/**"}},
+			},
+			id:   "AVD-AWS-0001",
+			path: "main.tf",
+			want: false,
+		},
+		{
+			name: "entry without id matches any finding id",
+			findings: IgnoreFindings{
+				{Paths: []string{"test/fixtures/**"}},
+			},
+			id:   "CVE-2024-0002",
+			path: "test/fixtures/Dockerfile",
+			want: true,
+		},
+		{
+			name: "entry with id still requires id equality",
+			findings: IgnoreFindings{
+				{ID: "CVE-2024-0002", PURLs: []*purl.PackageURL{linuxLibcDev}},
+			},
+			id:   "CVE-2024-0001",
+			pkg:  linuxLibcDev.Unwrap(),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.findings.Match(tt.id, tt.path, tt.pkg)
+			if tt.want {
+				assert.NotNil(t, got)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
 }

--- a/pkg/result/testdata/.trivyignore-no-id.yaml
+++ b/pkg/result/testdata/.trivyignore-no-id.yaml
@@ -1,0 +1,22 @@
+vulnerabilities:
+  - purls:
+      - "pkg:deb/ubuntu/linux-libc-dev"
+    statement: Kernel headers, not exercised at runtime
+  - paths:
+      - "**/*-lock.json"
+    statement: Lock files are not deployed
+
+misconfigurations:
+  - paths:
+      - "test/fixtures/**"
+    statement: Test fixtures, safe to ignore
+
+secrets:
+  - paths:
+      - "**/*.test.txt"
+    statement: Synthetic secrets used by tests
+
+licenses:
+  - paths:
+      - "usr/share/gcc/**"
+    statement: GCC runtime bits


### PR DESCRIPTION
## Description

Makes the `id` field optional in `.trivyignore.yaml`, as proposed in #10583.

An entry with an empty `id` now matches any finding that satisfies the remaining `purls` and/or `paths` filters, so users can ignore all findings for a package or a path without enumerating every ID. To prevent accidentally suppressing everything, entries where `id`, `purls`, and `paths` are all empty are rejected at parse time.

Before:

```yaml
vulnerabilities:
  - id: CVE-2023-2650
    purls:
      - "pkg:deb/ubuntu/linux-libc-dev"
```

After:

```yaml
vulnerabilities:
  - purls:
      - "pkg:deb/ubuntu/linux-libc-dev"
    statement: Kernel headers, not exercised at runtime
```

Existing entries that specify `id` keep working unchanged, and the legacy plain-text `.trivyignore` is unaffected. `schema/trivy-config.json` was not touched as it covers CLI flags, not the ignore file.

## Related issues
- Close #10583

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options) — no new flags; the before/after example above shows the usage.
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).

> Transparency note: this PR was prepared with AI assistance under the contributor's direction and review; all changes were verified locally (unit tests, `gofmt`, `go vet`, builds).
