### PR TITLE
fix(terraform): do not override --skip-files with --skip-dirs

### DIFF
--- a/pkg/iac/scanners/terraform/parser/option.go
+++ b/pkg/iac/scanners/terraform/parser/option.go
@@ -66,12 +66,12 @@ func OptionWithConfigsFS(fsys fs.FS) Option {
 
 func OptionWithSkipFiles(files []string) Option {
 	return func(p *Parser) {
-		p.skipPaths = files
+		p.skipFiles = files
 	}
 }
 
 func OptionWithSkipDirs(dirs []string) Option {
 	return func(p *Parser) {
-		p.skipPaths = dirs
+		p.skipDirs = dirs
 	}
 }

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -51,7 +52,8 @@ type Parser struct {
 	skipCachedModules bool
 	fsMap             map[string]fs.FS
 	configsFS         fs.FS
-	skipPaths         []string
+	skipFiles         []string
+	skipDirs          []string
 	// cwd is optional, if left to empty string, 'os.Getwd'
 	// will be used for populating 'path.cwd' in terraform.
 	cwd string
@@ -89,7 +91,8 @@ func (p *Parser) newModuleParser(moduleFS fs.FS, moduleSource, modulePath, modul
 	mp.moduleName = moduleName
 	mp.logger = p.logger
 	mp.projectRoot = p.projectRoot
-	mp.skipPaths = p.skipPaths
+	mp.skipFiles = p.skipFiles
+	mp.skipDirs = p.skipDirs
 	mp.options = p.options
 	p.children = append(p.children, mp)
 	for _, option := range p.options {
@@ -172,14 +175,16 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 		return fmt.Errorf("read dir: %w", err)
 	}
 
+	skipPaths := utils.CleanSkipPaths(slices.Concat(p.skipFiles, p.skipDirs))
+
 	var paths []string
 	for _, info := range fileInfos {
 		realPath := path.Join(dir, info.Name())
 		if info.IsDir() {
 			continue
 		}
-		if utils.SkipPath(realPath, utils.CleanSkipPaths(p.skipPaths)) {
-			p.logger.Debug("Skipping path based on input glob", log.FilePath(realPath), log.Any("glob", p.skipPaths))
+		if utils.SkipPath(realPath, skipPaths) {
+			p.logger.Debug("Skipping path based on input glob", log.FilePath(realPath), log.Any("glob", skipPaths))
 			continue
 		}
 		paths = append(paths, realPath)

--- a/pkg/iac/scanners/terraform/scanner_test.go
+++ b/pkg/iac/scanners/terraform/scanner_test.go
@@ -920,6 +920,21 @@ resource "aws_s3_bucket" "test" {}
 		assert.Empty(t, results)
 	})
 
+	t.Run("use skip-files and skip-dirs options together", func(t *testing.T) {
+		scanner := New(
+			ScannerWithSkipFiles([]string{"**/modules/*.tf"}),
+			ScannerWithSkipDirs([]string{"**/modules2/**"}),
+			ScannerWithAllDirectories(true),
+			rego.WithPolicyReader(strings.NewReader(emptyBucketCheck)),
+			rego.WithPolicyNamespaces("user"),
+		)
+
+		results, err := scanner.ScanFS(t.Context(), fsys, "deployments")
+		require.NoError(t, err)
+
+		assert.Empty(t, results)
+	})
+
 	t.Run("non existing value for skip-files option", func(t *testing.T) {
 		scanner := New(
 			ScannerWithSkipFiles([]string{"foo/bar*.tf"}),


### PR DESCRIPTION
## Description

The parser kept both skip options in one field, so skip dirs erased skip files, and an empty list erased them just as well. Now each option keeps its own value and both are applied.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/11190

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
