### PR TITLE
fix(terraform): skip .tf files shadowed by .tofu files

### DIFF
--- a/docs/guide/coverage/iac/terraform.md
+++ b/docs/guide/coverage/iac/terraform.md
@@ -46,6 +46,17 @@ If you don't want to scan them, you can use the `--tf-exclude-downloaded-modules
 trivy config --tf-exclude-downloaded-modules ./configs
 ```
 
+### OpenTofu
+Trivy scans OpenTofu files with the `.tofu` and `.tofu.json` extensions the same way it scans Terraform files.
+
+OpenTofu gives a `.tofu` file precedence over a `.tf` file with the same name, so Trivy does the same and skips the shadowed file. The pairing is per extension, which means `main.tofu` shadows `main.tf`, and `main.tofu.json` shadows `main.tf.json`. A `.tf` file without an OpenTofu counterpart is always scanned.
+
+If you keep both variants in a repository and want to scan it as Terraform, skip the OpenTofu files. Note that `.tofu` and `.tofu.json` need separate patterns:
+
+```bash
+trivy config --skip-files "**/*.tofu" --skip-files "**/*.tofu.json" ./configs
+```
+
 ## Secret
 The secret scan is performed on plain text files, with no special treatment for Terraform.
 

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/iac/terraform"
 	tfcontext "github.com/aquasecurity/trivy/pkg/iac/terraform/context"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/set"
 )
 
 type sourceFile struct {
@@ -185,6 +186,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 		paths = append(paths, realPath)
 	}
 	sort.Strings(paths)
+	paths = p.filterShadowedByTofu(paths)
 	for _, path := range paths {
 		var err error
 		if err = p.ParseFile(ctx, path); err == nil {
@@ -206,6 +208,48 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 	}
 
 	return nil
+}
+
+// tofuExtensions lists the Terraform extensions that have an OpenTofu counterpart.
+var tofuExtensions = []struct {
+	tf   string
+	tofu string
+}{
+	{tf: ".tf.json", tofu: ".tofu.json"},
+	{tf: ".tf", tofu: ".tofu"},
+}
+
+// filterShadowedByTofu drops a Terraform file if the directory also holds an
+// OpenTofu file with the same name, because OpenTofu loads that one instead.
+// The pairing is per extension, so main.tofu shadows main.tf but not main.tf.json.
+func (p *Parser) filterShadowedByTofu(paths []string) []string {
+	known := set.New(paths...)
+
+	shadowedBy := func(path string) (string, bool) {
+		for _, ext := range tofuExtensions {
+			base, ok := strings.CutSuffix(path, ext.tf)
+			if !ok {
+				continue
+			}
+			tofuPath := base + ext.tofu
+			if known.Contains(tofuPath) {
+				return tofuPath, true
+			}
+		}
+		return "", false
+	}
+
+	res := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if tofuPath, ok := shadowedBy(path); ok {
+			p.logger.Info("Skipping file shadowed by an OpenTofu file",
+				log.FilePath(path), log.String("shadowed_by", tofuPath))
+			continue
+		}
+		res = append(res, path)
+	}
+
+	return res
 }
 
 func (p *Parser) showParseErrors(fsys fs.FS, filePath string, diags hcl.Diagnostics) error {

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -181,6 +182,73 @@ language {
 
 	_, err := parser.Load(t.Context())
 	require.NoError(t, err)
+}
+
+// Regression test for https://github.com/aquasecurity/trivy/issues/11192
+func Test_OpenTofuFilePrecedence(t *testing.T) {
+	const (
+		hcl  = `resource "aws_s3_bucket" "test" {}`
+		json = `{"resource": {"aws_s3_bucket": {"test": {}}}}`
+	)
+
+	tests := []struct {
+		name     string
+		files    map[string]string
+		opts     []Option
+		expected []string
+	}{
+		{
+			name: "tofu file shadows tf file",
+			files: map[string]string{
+				"main.tf":   hcl,
+				"main.tofu": hcl,
+			},
+			expected: []string{"main.tofu"},
+		},
+		{
+			name: "tofu json file shadows tf json file",
+			files: map[string]string{
+				"main.tf.json":   json,
+				"main.tofu.json": json,
+			},
+			expected: []string{"main.tofu.json"},
+		},
+		{
+			name: "tofu file does not shadow tf json file",
+			files: map[string]string{
+				"main.tf.json": json,
+				"main.tofu":    hcl,
+			},
+			expected: []string{"main.tf.json", "main.tofu"},
+		},
+		{
+			name: "tf file without a counterpart is kept",
+			files: map[string]string{
+				"main.tf":    hcl,
+				"network.tf": hcl,
+				"main.tofu":  hcl,
+			},
+			expected: []string{"main.tofu", "network.tf"},
+		},
+		{
+			name: "skipped tofu file does not shadow tf file",
+			files: map[string]string{
+				"main.tf":   hcl,
+				"main.tofu": hcl,
+			},
+			opts:     []Option{OptionWithSkipFiles([]string{"main.tofu"})},
+			expected: []string{"main.tf"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := New(testutil.CreateFS(tt.files), "", append(tt.opts, OptionStopOnHCLError(true))...)
+			require.NoError(t, parser.ParseFS(t.Context(), "."))
+
+			assert.ElementsMatch(t, tt.expected, slices.Collect(maps.Keys(parser.Files())))
+		})
+	}
 }
 
 func Test_Modules(t *testing.T) {


### PR DESCRIPTION
## Description

Trivy read both files of a `.tf` and `.tofu` pair and merged them into one module, which matches neither Terraform nor OpenTofu. It now follows OpenTofu and skips the `.tf` file when a `.tofu` file with the same name is present, so findings no longer come from source that is not applied.

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/11192

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
