### PR TITLE
docs(java): recommend mvn install for multi-module Maven projects

### DIFF
--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -128,7 +128,7 @@ When scanning Java projects, Trivy resolves transitive dependencies by downloadi
     ```
     FATAL Error remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/.../<artifact>-<version>.pom. Retry-After: 1800.
     The repository blocks all subsequent requests from this IP until the block clears.
-    To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).
+    To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` (`mvn install` for a multi-module project) and cache ~/.m2 in CI).
     ```
 
 The block applies to *all* subsequent requests from the affected IP for the duration indicated by `Retry-After`, regardless of whether the artifact would otherwise be served from a cache layer. The wait depends on the repository's policy — for Maven Central it is typically tens of minutes on the first violation and grows on repeat — so Trivy fails fast on the first `429` rather than retrying and risking an extended block.
@@ -136,6 +136,7 @@ The block applies to *all* subsequent requests from the affected IP for the dura
 Recommended mitigations:
 
 - **Populate `~/.m2` before scanning.** Run `mvn dependency:resolve` (or any build step that resolves dependencies) so that every POM is cached locally. In CI, cache the `~/.m2` directory between runs (e.g. keyed on `pom.xml` checksums) so subsequent runs reuse the artifacts.
+    - For a multi-module project run `mvn install` instead. Goals that only resolve dependencies cache third-party artifacts, but not the artifacts of your own project — Maven takes those from the reactor, so a module that depends on a sibling module still triggers remote lookups.
 - **Configure mirrors** of the rate-limited repository, so that POM lookups go to a host that isn't blocking you. There are two ways to do it:
     - `<mirrors>` in Maven's [settings.xml][maven-mirror-settings] — the standard mechanism, honored by `mvn` itself as well. A repository is served by a single mirror, so a mirror that is rate-limited too leaves nothing to fall back on.
     - [scan.maven.mirrors][maven-mirrors] in `trivy.yaml` — Trivy-specific, and takes an ordered list of mirrors per repository. A mirror that returns `429` is skipped in favor of the next one, and if the remaining mirrors do not return the artifact, the scan stops and reports the `429`.

--- a/docs/guide/references/troubleshooting.md
+++ b/docs/guide/references/troubleshooting.md
@@ -128,7 +128,7 @@ When scanning Java projects, Trivy resolves transitive dependencies by downloadi
     ```
     FATAL Error remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/.../<artifact>-<version>.pom. Retry-After: 1800.
     The repository blocks all subsequent requests from this IP until the block clears.
-    To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` (`mvn install` for a multi-module project) and cache ~/.m2 in CI).
+    To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve`, or `mvn install` for a multi-module project, and cache ~/.m2 in CI).
     ```
 
 The block applies to *all* subsequent requests from the affected IP for the duration indicated by `Retry-After`, regardless of whether the artifact would otherwise be served from a cache layer. The wait depends on the repository's policy — for Maven Central it is typically tens of minutes on the first violation and grows on repeat — so Trivy fails fast on the first `429` rather than retrying and risking an extended block.
@@ -136,7 +136,7 @@ The block applies to *all* subsequent requests from the affected IP for the dura
 Recommended mitigations:
 
 - **Populate `~/.m2` before scanning.** Run `mvn dependency:resolve` (or any build step that resolves dependencies) so that every POM is cached locally. In CI, cache the `~/.m2` directory between runs (e.g. keyed on `pom.xml` checksums) so subsequent runs reuse the artifacts.
-    - For a multi-module project run `mvn install` instead. Goals that only resolve dependencies cache third-party artifacts, but not the artifacts of your own project — Maven takes those from the reactor, so a module that depends on a sibling module still triggers remote lookups.
+    - For a multi-module project run `mvn install -DskipTests` instead. Goals that only resolve dependencies cache third-party artifacts, but not the artifacts of your own project — Maven takes those from the reactor, so a module that depends on a sibling module still triggers remote lookups.
 - **Configure mirrors** of the rate-limited repository, so that POM lookups go to a host that isn't blocking you. There are two ways to do it:
     - `<mirrors>` in Maven's [settings.xml][maven-mirror-settings] — the standard mechanism, honored by `mvn` itself as well. A repository is served by a single mirror, so a mirror that is rate-limited too leaves nothing to fall back on.
     - [scan.maven.mirrors][maven-mirrors] in `trivy.yaml` — Trivy-specific, and takes an ordered list of mirrors per repository. A mirror that returns `429` is skipped in favor of the next one, and if the remaining mirrors do not return the artifact, the scan stops and reports the `429`.

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -1087,13 +1087,15 @@ func newRateLimitError(req *http.Request, resp *http.Response) *rateLimitError {
 	if v := resp.Header.Get("Retry-After"); v != "" {
 		ra = fmt.Sprintf(" Retry-After: %s.", v)
 	}
-	return &rateLimitError{err: &types.UserError{
-		Message: fmt.Sprintf(
-			"remote Maven repository returned 429 Too Many Requests for %s.%s\n"+
-				"The repository blocks all subsequent requests from this IP until the block clears.\n"+
-				"To avoid this, populate the local Maven cache before scanning "+
-				"(e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).",
-			req.URL.Redacted(), ra,
-		),
-	}}
+	return &rateLimitError{
+		err: &types.UserError{
+			Message: fmt.Sprintf(
+				"remote Maven repository returned 429 Too Many Requests for %s.%s\n"+
+					"The repository blocks all subsequent requests from this IP until the block clears.\n"+
+					"To avoid this, populate the local Maven cache before scanning "+
+					"(e.g. run `mvn dependency:resolve` (`mvn install` for a multi-module project) and cache ~/.m2 in CI).",
+				req.URL.Redacted(), ra,
+			),
+		},
+	}
 }

--- a/pkg/dependency/parser/java/pom/parse.go
+++ b/pkg/dependency/parser/java/pom/parse.go
@@ -1093,7 +1093,7 @@ func newRateLimitError(req *http.Request, resp *http.Response) *rateLimitError {
 				"remote Maven repository returned 429 Too Many Requests for %s.%s\n"+
 					"The repository blocks all subsequent requests from this IP until the block clears.\n"+
 					"To avoid this, populate the local Maven cache before scanning "+
-					"(e.g. run `mvn dependency:resolve` (`mvn install` for a multi-module project) and cache ~/.m2 in CI).",
+					"(e.g. run `mvn dependency:resolve`, or `mvn install` for a multi-module project, and cache ~/.m2 in CI).",
 				req.URL.Redacted(), ra,
 			),
 		},


### PR DESCRIPTION
## Description

`mvn dependency:resolve` populates `~/.m2` with third-party artifacts only.
A project's own parent POMs, internal BOMs and module artifacts are taken from the reactor and never written to the local repository.
For a multi-module project this means Trivy has to look up every one of them remotely, and with `--offline-scan` it silently drops the entire dependency subtree behind each of them.

The `429` troubleshooting section and the error message itself recommended `mvn dependency:resolve` without that caveat, so both now point at `mvn install` for multi-module projects.

This came up in #11061, where a multi-module Maven project reports 696 vulnerabilities from a local scan and 16 from the same scan in CI.

### Before

```
To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).
```

### After

```
To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve`, or `mvn install` for a multi-module project, and cache ~/.m2 in CI).
```

## Related issues
- https://github.com/aquasecurity/trivy/discussions/11061

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
