### PR TITLE
docs(server): clarify client/server security considerations

### DIFF
--- a/docs/guide/references/modes/client-server.md
+++ b/docs/guide/references/modes/client-server.md
@@ -305,6 +305,14 @@ $ trivy server --listen localhost:8080 --token dummy
 $ trivy image --server http://localhost:8080 --token dummy alpine:3.10
 ```
 
+## Security considerations
+
+Clients analyze artifacts locally and upload analysis results, such as package lists, to the server's shared cache. The server uses these results for vulnerability scanning without receiving the original artifact contents. All clients with access to the server must therefore be trusted to submit accurate analysis results.
+
+The server token controls access to both the scanning and cache APIs. It does not provide per-client permissions or tenant isolation: clients with access can write and delete shared cache entries, affecting scans performed by other clients. Use separate server instances and separate cache storage for mutually untrusted clients, including when using a Redis cache backend.
+
+The server listens on `localhost:4954` by default. When exposing it to other hosts, configure `--token` and restrict network access to trusted clients. Protect connections with HTTPS through a TLS-terminating reverse proxy or an equivalent secure transport, since the server itself serves HTTP.
+
 ## Endpoints
 
 ### Health


### PR DESCRIPTION
## Description

Clarify the trust model for client/server deployments: clients submit analysis results to a shared cache, and the server token grants access to that shared service without providing per-client permissions or tenant isolation. Explain that mutually untrusted clients need separate servers and cache storage, including when Redis is used.

Document the loopback default and recommend token authentication, restricted network access, and secure transport when exposing the server to other hosts. The guidance is placed alongside the existing authentication examples.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information.
