### PR TITLE
docs(terraform): clarify remote module downloads and network access

### DIFF
--- a/docs/guide/advanced/air-gap.md
+++ b/docs/guide/advanced/air-gap.md
@@ -12,7 +12,7 @@ Java Vulnerability Database | Java vulnerability scanning | [Trivy Java DB](../c
 Checks Bundle | Misconfigurations scanning | [Trivy Checks](../scanner/misconfiguration/check/builtin.md)
 VEX Hub | VEX Hub | [VEX Hub](../supply-chain/vex/repo.md)
 Maven Central / Remote Repositories | Java vulnerability scanning | [Java Scanner/Remote Repositories](../coverage/language/java.md#remote-repositories)
-Terraform modules | Terraform misconfiguration scanning | [Remote modules](../coverage/iac/terraform.md#remote-modules)
+Remote Terraform modules | Terraform misconfiguration scanning | [Remote modules](../coverage/iac/terraform.md#remote-modules)
 
 !!! note
     Trivy is an open source project that relies on public free infrastructure. In case of extreme load, you may encounter rate limiting when Trivy attempts to connect to external resources.

--- a/docs/guide/advanced/air-gap.md
+++ b/docs/guide/advanced/air-gap.md
@@ -12,6 +12,7 @@ Java Vulnerability Database | Java vulnerability scanning | [Trivy Java DB](../c
 Checks Bundle | Misconfigurations scanning | [Trivy Checks](../scanner/misconfiguration/check/builtin.md)
 VEX Hub | VEX Hub | [VEX Hub](../supply-chain/vex/repo.md)
 Maven Central / Remote Repositories | Java vulnerability scanning | [Java Scanner/Remote Repositories](../coverage/language/java.md#remote-repositories)
+Terraform modules | Terraform misconfiguration scanning | [Remote modules](../coverage/iac/terraform.md#remote-modules)
 
 !!! note
     Trivy is an open source project that relies on public free infrastructure. In case of extreme load, you may encounter rate limiting when Trivy attempts to connect to external resources.

--- a/docs/guide/coverage/iac/terraform.md
+++ b/docs/guide/coverage/iac/terraform.md
@@ -38,9 +38,16 @@ You can provide `tf-vars` files to Trivy to override default values specified in
 trivy config --tf-vars dev.terraform.tfvars ./infrastructure/tf
 ```
 
-### Exclude Downloaded Terraform Modules
+### Remote modules
+
+When scanning Terraform configurations for misconfigurations, Trivy resolves module references and downloads remote modules as needed. Remote module downloads are enabled by default, and their destinations are determined by the module sources specified in the Terraform configuration.
+
+Scanning an untrusted configuration can therefore cause network requests to destinations chosen by its author, including services reachable from the scanning environment. When scanning untrusted configurations, restrict outbound network access to approved module sources and prevent access to sensitive internal services, such as cloud instance metadata endpoints.
+
+#### Exclude Downloaded Terraform Modules
+
 By default, downloaded modules are also scanned.
-If you don't want to scan them, you can use the `--tf-exclude-downloaded-modules` flag.
+If you don't want to scan them, you can use the `--tf-exclude-downloaded-modules` flag. This flag excludes downloaded modules from misconfiguration checks; it does not disable module downloads.
 
 ```bash
 trivy config --tf-exclude-downloaded-modules ./configs

--- a/docs/guide/coverage/iac/terraform.md
+++ b/docs/guide/coverage/iac/terraform.md
@@ -40,14 +40,16 @@ trivy config --tf-vars dev.terraform.tfvars ./infrastructure/tf
 
 ### Remote modules
 
-When scanning Terraform configurations for misconfigurations, Trivy resolves module references and downloads remote modules as needed. Remote module downloads are enabled by default, and their destinations are determined by the module sources specified in the Terraform configuration.
+When scanning Terraform configurations for misconfigurations, Trivy downloads the modules whose source is remote. Downloads are enabled by default and cannot be turned off from the CLI.
 
-Scanning an untrusted configuration can therefore cause network requests to destinations chosen by its author, including services reachable from the scanning environment. When scanning untrusted configurations, restrict outbound network access to approved module sources and prevent access to sensitive internal services, such as cloud instance metadata endpoints.
+Scanning an untrusted configuration can therefore cause network requests to hosts chosen by its author, including services reachable from the scanning environment. When scanning untrusted configurations, allow outbound traffic only to the module registries and repositories you trust, and block access to sensitive internal services, such as cloud instance metadata endpoints.
+
+To avoid downloading modules during the scan, run `terraform init` first in an environment you control and include the resulting `.terraform/modules` directory with the configuration. Trivy reuses modules from that cache, but may still attempt downloads if a required module cannot be loaded.
 
 #### Exclude Downloaded Terraform Modules
 
 By default, downloaded modules are also scanned.
-If you don't want to scan them, you can use the `--tf-exclude-downloaded-modules` flag. This flag excludes downloaded modules from misconfiguration checks; it does not disable module downloads.
+If you don't want their findings in the report, you can use the `--tf-exclude-downloaded-modules` flag. The modules are still downloaded and evaluated, but the findings from them are marked as ignored.
 
 ```bash
 trivy config --tf-exclude-downloaded-modules ./configs


### PR DESCRIPTION
## Description

Explain that Terraform misconfiguration scanning downloads remote modules by default and that module sources in the scanned configuration determine the download destinations. Document network restrictions for scanning untrusted configurations and clarify that `--tf-exclude-downloaded-modules` suppresses findings without disabling downloads or evaluation.

Keep the explanation in the Terraform guide by expanding the existing downloaded-modules section. Add a link from the network connectivity table so the guidance is discoverable without duplicating it.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information.

