### PR TITLE
docs(plugin): clarify plugin permissions and security considerations

### DIFF
--- a/docs/guide/plugin/index.md
+++ b/docs/guide/plugin/index.md
@@ -11,8 +11,13 @@ They provide a way to extend the core feature set of Trivy, but without requirin
 - They integrate with Trivy, and will show up in Trivy help and subcommands.
 
 !!! warning
-    Trivy plugins available in public are not audited for security.
-    You should install and run third-party plugins at your own risk, since they are arbitrary programs running on your machine.
+    Only install and run plugins from sources you trust. Plugins execute with your permissions and are not sandboxed; see [Security considerations](#security-considerations).
+
+## Security considerations
+
+Trivy plugins are external programs executed with the privileges of the user running Trivy. They inherit the Trivy process's environment variables, which may include credentials, and can access files and network services permitted by the execution environment. Trivy does not sandbox plugins or isolate them from these resources.
+
+Publicly available plugins are not audited for security. Choose plugin sources you trust before installing or running them. In CI, provide only the credentials and permissions required by the plugin, and use an isolated execution environment when additional restrictions are needed.
 
 ## Quickstart
 Trivy helps you discover and install plugins on your machine.

--- a/docs/guide/plugin/user-guide.md
+++ b/docs/guide/plugin/user-guide.md
@@ -187,6 +187,8 @@ $ trivy image --format json --output plugin=<plugin_name> [--output-plugin-arg <
 
 Since scan results are passed to the plugin via standard input, plugins must be capable of handling standard input.
 
+Output plugins execute with the same permissions as other plugins and receive the scan results. See [Security considerations](./index.md#security-considerations) before enabling an output plugin.
+
 !!! warning
     To avoid Trivy hanging, you need to read all data from `Stdin` before the plugin exits successfully or stops with an error.
 


### PR DESCRIPTION
## Description

Document that plugins run with the invoking user's privileges, inherit environment variables, and can access files and network services allowed by the execution environment. Explain that Trivy does not sandbox plugins and provide guidance for choosing trusted sources and limiting permissions in CI.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
