### PR TITLE
fix(java): mark dependencies of an embedded pom.xml as dev

### DIFF
--- a/pkg/fanal/analyzer/language/java/pom/pom.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom.go
@@ -18,7 +18,7 @@ func init() {
 	analyzer.RegisterAnalyzer(&pomAnalyzer{})
 }
 
-const version = 1
+const version = 2
 
 // pomAnalyzer analyzes pom.xml
 type pomAnalyzer struct{}
@@ -43,6 +43,26 @@ func (a pomAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) 
 		}
 	}
 
+	// A pom.xml under META-INF/maven/<groupId>/<artifactId>/ is the copy that maven-archiver
+	// embeds into a built artifact. It describes what the artifact was compiled against, not
+	// what ships next to it: test, provided and optional dependencies are listed just the same,
+	// and none of them is necessarily present. When such an artifact is scanned in exploded form
+	// (an unpacked fat JAR, an exploded WAR, a JAR unzipped in a Dockerfile) the file is visible
+	// to this analyzer, and treating it as a project manifest reports every declared dependency
+	// as installed. Keep the artifact itself -- it is what was unpacked -- and mark the declared
+	// dependencies as Dev so they are skipped by default but still reachable with
+	// --include-dev-deps.
+	if isEmbeddedArchivePom(filePath) && res != nil {
+		for i := range res.Applications {
+			for j := range res.Applications[i].Packages {
+				if res.Applications[i].Packages[j].Relationship == types.RelationshipRoot {
+					continue
+				}
+				res.Applications[i].Packages[j].Dev = true
+			}
+		}
+	}
+
 	return res, nil
 }
 
@@ -56,6 +76,17 @@ func (a pomAnalyzer) Type() analyzer.Type {
 
 func (a pomAnalyzer) Version() int {
 	return version
+}
+
+// isEmbeddedArchivePom checks that the pom file is the copy maven-archiver embeds into a built artifact.
+// https://maven.apache.org/shared/maven-archiver/#pom-properties-content
+func isEmbeddedArchivePom(filePath string) bool {
+	dirs := strings.Split(filepath.ToSlash(filePath), "/")
+	// filepath pattern: `**/META-INF/maven/<groupId>/<artifactId>/pom.xml`
+	if len(dirs) < 5 {
+		return false
+	}
+	return dirs[len(dirs)-5] == "META-INF" && dirs[len(dirs)-4] == "maven"
 }
 
 // isIntegrationTestDir checks that pom file is in directory with integration tests of `maven-invoker-plugin`

--- a/pkg/fanal/analyzer/language/java/pom/pom_test.go
+++ b/pkg/fanal/analyzer/language/java/pom/pom_test.go
@@ -132,6 +132,45 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 			},
 		},
 		{
+			// The pom that maven-archiver embeds into a built artifact: keep the artifact
+			// itself, mark what it merely declares as Dev.
+			name:      "embedded archive pom",
+			inputFile: "testdata/embedded/META-INF/maven/com.example/example/pom.xml",
+			want: &analyzer.AnalysisResult{
+				Applications: []types.Application{
+					{
+						Type:     types.Pom,
+						FilePath: "testdata/embedded/META-INF/maven/com.example/example/pom.xml",
+						Packages: types.Packages{
+							{
+								ID:           "com.example:example:1.0.0::645aa3e2",
+								Name:         "com.example:example",
+								Version:      "1.0.0",
+								Licenses:     []string{"Apache 2.0"},
+								Relationship: types.RelationshipRoot,
+								DependsOn: []string{
+									"com.example:example-api:2.0.0::9f276521",
+								},
+							},
+							{
+								ID:           "com.example:example-api:2.0.0::9f276521",
+								Name:         "com.example:example-api",
+								Version:      "2.0.0",
+								Relationship: types.RelationshipDirect,
+								Locations: []types.Location{
+									{
+										StartLine: 28,
+										EndLine:   32,
+									},
+								},
+								Dev: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:      "unsupported requirement",
 			inputFile: "testdata/requirements/pom.xml",
 			want: &analyzer.AnalysisResult{
@@ -212,6 +251,11 @@ func Test_pomAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "embedded archive pom is still analyzed",
+			filePath: "app/META-INF/maven/com.example/example/pom.xml",
+			want:     true,
+		},
+		{
 			name:     "no extension",
 			filePath: "test/pom",
 			want:     false,
@@ -227,6 +271,27 @@ func Test_pomAnalyzer_Required(t *testing.T) {
 			a := pomAnalyzer{}
 			got := a.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_isEmbeddedArchivePom(t *testing.T) {
+	tests := []struct {
+		filePath string
+		want     bool
+	}{
+		{"META-INF/maven/com.example/example/pom.xml", true},
+		{"app/BOOT-INF/classes/META-INF/maven/com.example/app/pom.xml", true},
+		{"webapp/WEB-INF/classes/META-INF/maven/com.example/webapp/pom.xml", true},
+		{"pom.xml", false},
+		{"project/pom.xml", false},
+		{"maven/com.example/example/pom.xml", false},
+		{"META-INF/maven/pom.xml", false},
+		{"X-META-INF/maven/com.example/example/pom.xml", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filePath, func(t *testing.T) {
+			assert.Equal(t, tt.want, isEmbeddedArchivePom(tt.filePath))
 		})
 	}
 }

--- a/pkg/fanal/analyzer/language/java/pom/testdata/embedded/META-INF/maven/com.example/example/pom.xml
+++ b/pkg/fanal/analyzer/language/java/pom/testdata/embedded/META-INF/maven/com.example/example/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0.0</version>
+
+    <name>example</name>
+    <description>Example</description>
+
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>knqyf263</id>
+            <url>https://github.com/knqyf263</url>
+        </developer>
+    </developers>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>example-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description

A `pom.xml` under `META-INF/maven/<groupId>/<artifactId>/` is the copy of the *build* descriptor that maven-archiver embeds into every artifact. It describes what the artifact was compiled against, not what ships next to it: test, provided and optional dependencies are listed just the same, and none of them is necessarily present. When such an artifact is scanned in exploded form (a JAR unzipped in a Dockerfile layer, an exploded WAR, an unpacked delivery) the file is visible to the `pom` analyzer, which treats it as a project manifest and reports **every declared dependency as an installed package**. The `jar` analyzer never does this for the same jar — it reads the embedded pom for identity only — so the same artifact gets two different answers depending on whether it is a file or a directory.

In the scan that surfaced this (an unpacked Java delivery), every CRITICAL finding was attached to such a package: `bcprov-jdk18on` and `woodstox-core` were "found" through the embedded pom of `xmlsec-2.3.4.jar`, which ships neither.

**Fix:** keep the root package — it is the artifact that was unpacked — and mark the declared dependencies as `Dev`, so they are skipped by default but still reachable with `--include-dev-deps`. This mirrors how integration-test poms of `maven-invoker-plugin` are already handled in this analyzer (`isIntegrationTestDir`). The analyzer `version` is bumped so cached results are refreshed.

Why `Dev` rather than dropping the file: skipping `META-INF/maven/**/pom.xml` entirely (the `--skip-files` workaround) also removes the artifact itself whenever the jar is not present as a file — exactly the case in which the pom analyzer is the only thing that sees it.

### Before / after

`trivy fs --format cyclonedx --offline-scan <dir with xmlsec-2.3.4 unzipped>` (0.73.0, library components):

```
before:  bcprov-jdk18on@1.76  woodstox-core@6.5.0  xmlsec@2.3.4
after:   xmlsec@2.3.4                                     (bcprov-jdk18on, woodstox-core: Dev, hidden unless --include-dev-deps)
```

Unit test: the happy-path pom placed at `testdata/embedded/META-INF/maven/com.example/example/pom.xml` yields the root `com.example:example:1.0.0` as before and its dependency `com.example:example-api:2.0.0` with `Dev: true` (`Dev: false` on `main`). `isEmbeddedArchivePom` is covered for the positive path, a too-shallow path and a project pom that merely mentions `META-INF` elsewhere.

## Related issues

- Discussion: #11204
- #3197 (closed as stale; a different mechanism — shaded jar — but the same confusion between what a pom declares and what is shipped)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed). — no new options; happy to add a note under the Java coverage page if wanted.
- [x] I've included a "before" and "after" example to the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CsUTRwsaFCwavDJTPwEpW