### PR TITLE
fix(report)!: remove getHostByName from templates

### DIFF
--- a/docs/guide/configuration/reporting.md
+++ b/docs/guide/configuration/reporting.md
@@ -533,6 +533,7 @@ Critical: 0, High: 2
 </details>
 
 For other features of sprig, see the official [sprig][sprig] documentation.
+
 The `getHostByName` function is not available in Trivy templates.
 
 #### Load templates from a file

--- a/docs/guide/configuration/reporting.md
+++ b/docs/guide/configuration/reporting.md
@@ -496,6 +496,9 @@ This snapshot file can be [submitted][github-sbom-submit] to your GitHub reposit
 
 #### Custom Template
 
+!!! warning "Trusted templates"
+    Only use templates from trusted sources. Templates can read environment variables and include sensitive values in report output.
+
 {% raw %}
 ```
 $ trivy image --format template --template "{{ range . }} {{ .Target }} {{ end }}" golang:1.12-alpine
@@ -530,6 +533,7 @@ Critical: 0, High: 2
 </details>
 
 For other features of sprig, see the official [sprig][sprig] documentation.
+The `getHostByName` function is not available in Trivy templates.
 
 #### Load templates from a file
 You can load templates from a file prefixing the template path with an `@`.

--- a/pkg/report/template.go
+++ b/pkg/report/template.go
@@ -63,6 +63,9 @@ func NewTemplateWriter(output io.Writer, outputTemplate, appVersion string) (*Te
 	// Overwrite functions
 	maps.Copy(templateFuncMap, CustomTemplateFuncMap)
 
+	// Network access is not an intended use of report templates.
+	delete(templateFuncMap, "getHostByName")
+
 	tmpl, err := template.New("output template").Funcs(templateFuncMap).Parse(outputTemplate)
 	if err != nil {
 		return nil, xerrors.Errorf("error parsing template: %w", err)

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -22,6 +22,7 @@ func TestReportWriter_Template(t *testing.T) {
 		detectedVulns []types.DetectedVulnerability
 		template      string
 		expected      string
+		wantErr       bool
 	}{
 		{
 			name: "happy path",
@@ -189,6 +190,11 @@ func TestReportWriter_Template(t *testing.T) {
 			template:      `{{ lower (env "AWS_ACCOUNT_ID") }}`,
 			expected:      `123456789012`,
 		},
+		{
+			name:     "DNS lookup is unavailable",
+			template: `{{ getHostByName "example.com" }}`,
+			wantErr:  true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -207,6 +213,10 @@ func TestReportWriter_Template(t *testing.T) {
 			}
 
 			w, err := report.NewTemplateWriter(&got, tc.template, "dev")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			err = w.Write(ctx, inputReport)
 			require.NoError(t, err)

--- a/pkg/report/template_test.go
+++ b/pkg/report/template_test.go
@@ -22,7 +22,7 @@ func TestReportWriter_Template(t *testing.T) {
 		detectedVulns []types.DetectedVulnerability
 		template      string
 		expected      string
-		wantErr       bool
+		wantErr       string
 	}{
 		{
 			name: "happy path",
@@ -193,7 +193,7 @@ func TestReportWriter_Template(t *testing.T) {
 		{
 			name:     "DNS lookup is unavailable",
 			template: `{{ getHostByName "example.com" }}`,
-			wantErr:  true,
+			wantErr:  `function "getHostByName" not defined`,
 		},
 	}
 	for _, tc := range testCases {
@@ -213,8 +213,8 @@ func TestReportWriter_Template(t *testing.T) {
 			}
 
 			w, err := report.NewTemplateWriter(&got, tc.template, "dev")
-			if tc.wantErr {
-				require.Error(t, err)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

Remove Sprig's `getHostByName` function from report templates. Network access is not an intended use of report templates, so this small change removes DNS lookup support as defense in depth.

Templates must still come from trusted sources. Functions such as `env` can read environment variables and include sensitive values in report output.

This is a breaking change: previously, `{{ getHostByName "example.com" }}` performed a DNS lookup during rendering. It now fails during template parsing because the function is not defined. Existing templates using this function must remove those calls.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
