### PR TITLE
fix(misconf): report correct line numbers in multi-document manifests

### DIFF
--- a/pkg/iac/rego/result.go
+++ b/pkg/iac/rego/result.go
@@ -124,18 +124,6 @@ func parseLineNumber(raw any) int {
 func (s *Scanner) convertResults(resultSet rego.ResultSet, input Input, namespace, rule string, traces []string) scan.Results {
 	var results scan.Results
 
-	offset := 0
-	if input.Contents != nil {
-		if xx, ok := input.Contents.(map[string]any); ok {
-			if md, ok := xx["__defsec_metadata"]; ok {
-				if md2, ok := md.(map[string]any); ok {
-					if sl, ok := md2["offset"]; ok {
-						offset, _ = sl.(int)
-					}
-				}
-			}
-		}
-	}
 	for _, result := range resultSet {
 		for _, expression := range result.Expressions {
 			values, ok := expression.Value.([]any)
@@ -152,8 +140,6 @@ func (s *Scanner) convertResults(resultSet rego.ResultSet, input Input, namespac
 				if regoResult.Message == "" {
 					regoResult.Message = fmt.Sprintf("Rego check rule: %s.%s", namespace, rule)
 				}
-				regoResult.StartLine += offset
-				regoResult.EndLine += offset
 				results.AddRego(regoResult.Message, namespace, rule, traces, regoResult)
 			}
 		}

--- a/pkg/iac/scanners/kubernetes/parser/manifest_node.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_node.go
@@ -31,7 +31,6 @@ const (
 
 type ManifestNode struct {
 	xjson.Location
-	Offset   int
 	Value    any
 	Type     TagType
 	FilePath string
@@ -73,7 +72,6 @@ func (n *ManifestNode) metadata() map[string]any {
 		"startline": n.StartLine,
 		"endline":   n.EndLine,
 		"filepath":  n.FilePath,
-		"offset":    n.Offset,
 	}
 }
 

--- a/pkg/iac/scanners/kubernetes/parser/manifest_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/manifest_test.go
@@ -40,7 +40,6 @@ func TestJsonManifestToRego(t *testing.T) {
 	expected := map[string]any{
 		"__defsec_metadata": map[string]any{
 			"filepath":  filePath,
-			"offset":    0,
 			"startline": 1,
 			"endline":   22,
 		},
@@ -49,7 +48,6 @@ func TestJsonManifestToRego(t *testing.T) {
 		"metadata": map[string]any{
 			"__defsec_metadata": map[string]any{
 				"filepath":  filePath,
-				"offset":    0,
 				"startline": 4,
 				"endline":   7,
 			},
@@ -58,7 +56,6 @@ func TestJsonManifestToRego(t *testing.T) {
 		"spec": map[string]any{
 			"__defsec_metadata": map[string]any{
 				"filepath":  filePath,
-				"offset":    0,
 				"startline": 8,
 				"endline":   21,
 			},
@@ -66,7 +63,6 @@ func TestJsonManifestToRego(t *testing.T) {
 				map[string]any{
 					"__defsec_metadata": map[string]any{
 						"filepath":  filePath,
-						"offset":    0,
 						"startline": 10,
 						"endline":   19,
 					},
@@ -108,7 +104,6 @@ spec:
 	expected := map[string]any{
 		"__defsec_metadata": map[string]any{
 			"filepath":  filePath,
-			"offset":    0,
 			"startline": 1,
 			"endline":   14,
 		},
@@ -117,7 +112,6 @@ spec:
 		"metadata": map[string]any{
 			"__defsec_metadata": map[string]any{
 				"filepath":  filePath,
-				"offset":    0,
 				"startline": 3,
 				"endline":   5,
 			},
@@ -127,7 +121,6 @@ spec:
 		"spec": map[string]any{
 			"__defsec_metadata": map[string]any{
 				"filepath":  filePath,
-				"offset":    0,
 				"startline": 6,
 				"endline":   14,
 			},
@@ -135,7 +128,6 @@ spec:
 				map[string]any{
 					"__defsec_metadata": map[string]any{
 						"filepath":  filePath,
-						"offset":    0,
 						"startline": 8,
 						"endline":   14,
 					},
@@ -167,7 +159,6 @@ func TestManifestToRego(t *testing.T) {
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
 					"filepath":  filePath,
-					"offset":    0,
 					"startline": 1,
 					"endline":   1,
 				},
@@ -180,7 +171,6 @@ func TestManifestToRego(t *testing.T) {
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
 					"filepath":  filePath,
-					"offset":    0,
 					"startline": 1,
 					"endline":   1,
 				},
@@ -193,7 +183,6 @@ func TestManifestToRego(t *testing.T) {
 			expected: map[string]any{
 				"__defsec_metadata": map[string]any{
 					"filepath":  filePath,
-					"offset":    0,
 					"startline": 1,
 					"endline":   1,
 				},

--- a/pkg/iac/scanners/kubernetes/parser/parser.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+var separatorRegex = regexp.MustCompile(`(?m:^---\r?\n)`)
+
 func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 	contents, err := io.ReadAll(r)
 	if err != nil {
@@ -28,15 +30,24 @@ func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 
 	var manifests []*Manifest
 
-	re := regexp.MustCompile(`(?m:^---\r?\n)`)
 	offset := 0
-	for _, partial := range re.Split(string(contents), -1) {
+	for i, partial := range separatorRegex.Split(string(contents), -1) {
+		if i > 0 {
+			// The separator line is dropped by the split.
+			offset++
+		}
+
 		manifest, err := ManifestFromYAML(path, []byte(partial))
 		if err != nil {
 			return nil, err
 		}
 		if manifest.Content != nil {
-			manifest.Content.Offset = offset
+			// Each document is parsed on its own, so its lines are counted from the
+			// start of the document. Shift them to point at the place in the file.
+			manifest.Content.Walk(func(n *ManifestNode) {
+				n.StartLine += offset
+				n.EndLine += offset
+			})
 			manifests = append(manifests, manifest)
 		}
 
@@ -48,7 +59,7 @@ func Parse(_ context.Context, r io.Reader, path string) ([]*Manifest, error) {
 
 func countLines(s string) int {
 	if s == "" {
-		return 1
+		return 0
 	}
 
 	count := strings.Count(s, "\n")

--- a/pkg/iac/scanners/kubernetes/parser/parser_test.go
+++ b/pkg/iac/scanners/kubernetes/parser/parser_test.go
@@ -12,15 +12,20 @@ import (
 func TestParse(t *testing.T) {
 	const filePath = "test.yaml"
 
+	type lines struct {
+		start int
+		end   int
+	}
+
 	tests := []struct {
-		name            string
-		src             string
-		expectedOffsets []int
+		name          string
+		src           string
+		expectedLines []lines
 	}{
 		{
-			name:            "empty file",
-			src:             "",
-			expectedOffsets: nil,
+			name:          "empty file",
+			src:           "",
+			expectedLines: nil,
 		},
 		{
 			name: "single YAML without separator",
@@ -28,7 +33,7 @@ func TestParse(t *testing.T) {
 apiVersion: v1
 kind: Pod
 `,
-			expectedOffsets: []int{0},
+			expectedLines: []lines{{start: 2, end: 3}},
 		},
 		{
 			name: "multiple YAML documents",
@@ -39,7 +44,7 @@ kind: Pod
 apiVersion: v1
 kind: Service
 `,
-			expectedOffsets: []int{1, 3},
+			expectedLines: []lines{{start: 2, end: 3}, {start: 5, end: 6}},
 		},
 		{
 			name: "YAML with multiple empty blocks",
@@ -50,12 +55,12 @@ kind: Service
 apiVersion: v1
 kind: Pod
 `,
-			expectedOffsets: []int{3},
+			expectedLines: []lines{{start: 5, end: 6}},
 		},
 		{
-			name:            "Windows line endings",
-			src:             "---\r\napiVersion: v1\r\nkind: Pod\r\n",
-			expectedOffsets: []int{1},
+			name:          "Windows line endings",
+			src:           "---\r\napiVersion: v1\r\nkind: Pod\r\n",
+			expectedLines: []lines{{start: 2, end: 3}},
 		},
 	}
 
@@ -63,11 +68,12 @@ kind: Pod
 		t.Run(tt.name, func(t *testing.T) {
 			manifests, err := parser.Parse(t.Context(), strings.NewReader(tt.src), filePath)
 			require.NoError(t, err)
-			require.Len(t, manifests, len(tt.expectedOffsets))
+			require.Len(t, manifests, len(tt.expectedLines))
 
 			for i, manifest := range manifests {
 				require.NotNil(t, manifest.Content)
-				require.Equal(t, tt.expectedOffsets[i], manifest.Content.Offset)
+				require.Equal(t, tt.expectedLines[i].start, manifest.Content.StartLine)
+				require.Equal(t, tt.expectedLines[i].end, manifest.Content.EndLine)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Every YAML document in a manifest is parsed on its own, so its lines are counted from the start of the document and not from the start of the file. Trivy carried the document position as an `offset` field inside the Rego input and added it back to the reported lines, but the count skipped the `---` line, so every document after the first was reported one line above its real place. Now the position is applied to the line numbers right after the document is parsed, and nothing after the parser needs to know about it.

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: first
spec:
  containers:
    - name: app
      image: nginx
---
apiVersion: v1
kind: Pod
metadata:
  name: second
spec:
  containers:
    - name: app
      image: nginx
```

The first pod is reported at `test.yaml:6-9` in both cases. The second one moves, and before the fix the snippet started at the wrong key.

Before:

```
 test.yaml:14-17
  14 ┌   name: second
  15 │ spec:
  16 │   containers:
  17 └     - name: app
```

After:

```
 test.yaml:15-18
  15 ┌ spec:
  16 │   containers:
  17 │     - name: app
  18 └       image: nginx
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
