### PR TITLE
fix: prevent panics from unchecked slice indexing in dependency parsers and OS detector

### DIFF
--- a/pkg/dependency/parser/hex/mix/parse.go
+++ b/pkg/dependency/parser/hex/mix/parse.go
@@ -46,7 +46,8 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if len(ss) < 8 { // In the case where <required deps> array is empty: s == 8, in other cases s > 8
 			// git repository doesn't have dependency version
 			// skip these dependencies
-			if !strings.Contains(ss[0], ":git") {
+			// cf. #10976: an empty body (e.g. `"x":`) produces len(ss)==0; skip it safely.
+			if len(ss) == 0 || !strings.Contains(ss[0], ":git") {
 				p.logger.Warn("Cannot parse dependency", log.String("line", line))
 			} else {
 				p.logger.Debug("Skip git dependencies", log.String("name", name))

--- a/pkg/dependency/parser/hex/mix/parse_test.go
+++ b/pkg/dependency/parser/hex/mix/parse_test.go
@@ -72,6 +72,24 @@ func TestParser_Parse(t *testing.T) {
 			inputFile: "testdata/empty.mix.lock",
 			want:      nil,
 		},
+		// cf. #10976: a line like `"x":` with an empty body must not panic
+		{
+			name:      "malformed empty body",
+			inputFile: "testdata/malformed_empty_body.mix.lock",
+			want: []ftypes.Package{
+				{
+					ID:      "bunt@0.2.0",
+					Name:    "bunt",
+					Version: "0.2.0",
+					Locations: []ftypes.Location{
+						{
+							StartLine: 3,
+							EndLine:   3,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/hex/mix/testdata/malformed_empty_body.mix.lock
+++ b/pkg/dependency/parser/hex/mix/testdata/malformed_empty_body.mix.lock
@@ -1,0 +1,4 @@
+%{
+  "x":
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+}

--- a/pkg/dependency/parser/python/pyproject/pyproject.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject.go
@@ -76,7 +76,13 @@ func (d *Dependencies) UnmarshalTOML(data any) error {
 			// e.g. `Flask == 1.1.4`, `Flask==1.1.4`, `Flask(>= 1.0.0)`, `pluggy[pre-commit,tox] (==0.13.1)`, etc.
 			dep = strings.NewReplacer(">", " ", "<", " ", "=", " ", "(", " ", "[", " ").Replace(dep)
 			// Save only the name, normalized (PEP 503) to match the names from poetry.lock/pylock.toml.
-			d.Set.Append(python.NormalizePkgName(strings.Fields(dep)[0], true))
+			// cf. #10976: a dep string that is empty, whitespace-only, or contains only operators has no
+			// name after replacement; skip it rather than panic.
+			fields := strings.Fields(dep)
+			if len(fields) == 0 {
+				continue
+			}
+			d.Set.Append(python.NormalizePkgName(fields[0], true))
 		}
 	default:
 		return xerrors.Errorf("dependencies must be map, but got: %T", data)

--- a/pkg/dependency/parser/python/pyproject/pyproject_test.go
+++ b/pkg/dependency/parser/python/pyproject/pyproject_test.go
@@ -125,6 +125,19 @@ func TestParser_Parse(t *testing.T) {
 			file:    "testdata/sad.toml",
 			wantErr: assert.Error,
 		},
+		// cf. #10976: empty, whitespace-only, and operators-only entries must be silently skipped
+		{
+			name: "empty dep entries",
+			file: "testdata/empty_dep_entry.toml",
+			want: pyproject.PyProject{
+				Project: pyproject.Project{
+					Dependencies: pyproject.Dependencies{
+						Set: set.New[string]("flask", "requests"),
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/python/pyproject/testdata/empty_dep_entry.toml
+++ b/pkg/dependency/parser/python/pyproject/testdata/empty_dep_entry.toml
@@ -1,0 +1,4 @@
+[project]
+name = "test"
+version = "1.0.0"
+dependencies = ["flask>=1.0", "", " ", "===", "requests>=2.0"]

--- a/pkg/dependency/parser/ruby/bundler/parse.go
+++ b/pkg/dependency/parser/ruby/bundler/parse.go
@@ -66,7 +66,10 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 		if countLeadingSpace(line) == 6 {
 			line = strings.TrimSpace(line)
 			s := strings.Fields(line)
-			dependsOn = append(dependsOn, s[0]) // store name only for now
+			// cf. #10976: a line of exactly 6 spaces has no name after trimming; keep lineNum++ below.
+			if len(s) > 0 {
+				dependsOn = append(dependsOn, s[0]) // store name only for now
+			}
 		}
 		lineNum++
 

--- a/pkg/dependency/parser/ruby/bundler/parse_test.go
+++ b/pkg/dependency/parser/ruby/bundler/parse_test.go
@@ -261,6 +261,34 @@ func TestParser_Parse(t *testing.T) {
 			wantPkgs: []ftypes.Package{},
 			wantErr:  assert.NoError,
 		},
+		// cf. #10976: a line of exactly 6 spaces in the dep graph section must be skipped without panicking
+		{
+			name: "empty dep graph line",
+			file: "testdata/Gemfile_empty_dep_graph.lock",
+			wantPkgs: []ftypes.Package{
+				{
+					ID:           "pry@0.12.2",
+					Name:         "pry",
+					Version:      "0.12.2",
+					Relationship: ftypes.RelationshipDirect,
+					Locations:    []ftypes.Location{{StartLine: 5, EndLine: 5}},
+				},
+				{
+					ID:           "coderay@1.1.2",
+					Name:         "coderay",
+					Version:      "1.1.2",
+					Relationship: ftypes.RelationshipIndirect,
+					Locations:    []ftypes.Location{{StartLine: 4, EndLine: 4}},
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID:        "pry@0.12.2",
+					DependsOn: []string{"coderay@1.1.2"},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/dependency/parser/ruby/bundler/testdata/Gemfile_empty_dep_graph.lock
+++ b/pkg/dependency/parser/ruby/bundler/testdata/Gemfile_empty_dep_graph.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+
+BUNDLED WITH
+   2.1.4

--- a/pkg/dependency/parser/swift/cocoapods/parse.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse.go
@@ -67,7 +67,12 @@ func (p *Parser) Parse(_ context.Context, r xio.ReadSeekerAt) ([]ftypes.Package,
 					if !ok {
 						return nil, nil, xerrors.Errorf("must be string: %q", childDep)
 					}
-					directDeps[pkg.Name] = append(directDeps[pkg.Name], strings.Fields(s)[0])
+					// cf. #10976: a child dependency without a name carries no information; skip it.
+					fields := strings.Fields(s)
+					if len(fields) == 0 {
+						continue
+					}
+					directDeps[pkg.Name] = append(directDeps[pkg.Name], fields[0])
 				}
 			}
 		}

--- a/pkg/dependency/parser/swift/cocoapods/parse_test.go
+++ b/pkg/dependency/parser/swift/cocoapods/parse_test.go
@@ -78,6 +78,29 @@ func TestParse(t *testing.T) {
 			name:      "sad path. wrong dep format",
 			inputFile: "testdata/sad.lock",
 		},
+		// cf. #10976: a child dependency with an empty/whitespace name must be skipped without panicking
+		{
+			name:      "malformed empty child dependency",
+			inputFile: "testdata/malformed_empty_child.lock",
+			wantPkgs: []ftypes.Package{
+				{
+					ID:      "AppCenter@4.2.0",
+					Name:    "AppCenter",
+					Version: "4.2.0",
+				},
+				{
+					ID:      "AppCenter/Core@4.2.0",
+					Name:    "AppCenter/Core",
+					Version: "4.2.0",
+				},
+			},
+			wantDeps: []ftypes.Dependency{
+				{
+					ID:        "AppCenter@4.2.0",
+					DependsOn: []string{"AppCenter/Core@4.2.0"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/swift/cocoapods/testdata/malformed_empty_child.lock
+++ b/pkg/dependency/parser/swift/cocoapods/testdata/malformed_empty_child.lock
@@ -1,0 +1,7 @@
+PODS:
+  - AppCenter (4.2.0):
+    - ""
+    - AppCenter/Core (= 4.2.0)
+  - AppCenter/Core (4.2.0)
+
+COCOAPODS: 1.11.2

--- a/pkg/detector/ospkg/amazon/amazon.go
+++ b/pkg/detector/ospkg/amazon/amazon.go
@@ -42,12 +42,7 @@ func NewScanner() *Scanner {
 
 // Detect scans the packages using amazon scanner
 func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository, pkgs []ftypes.Package) ([]types.DetectedVulnerability, error) {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
-	}
+	osVer = majorVersion(osVer)
 
 	log.InfoContext(ctx, "Detecting vulnerabilities...", log.String("os_version", osVer),
 		log.Int("pkg_num", len(pkgs)))
@@ -103,12 +98,20 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
 
 // IsSupportedVersion checks if the version is supported.
 func (s *Scanner) IsSupportedVersion(ctx context.Context, osFamily ftypes.OSType, osVer string) bool {
-	osVer = strings.Fields(osVer)[0]
-	// The format `2023.xxx.xxxx` can be used.
-	osVer = osver.Major(osVer)
-	if osVer != "2" && osVer != "2022" && osVer != "2023" {
-		osVer = "1"
-	}
+	osVer = majorVersion(osVer)
 
 	return osver.Supported(ctx, eolDates, osFamily, osVer)
+}
+
+func majorVersion(osVer string) string {
+	fields := strings.Fields(osVer)
+	if len(fields) == 0 {
+		return "1"
+	}
+	// The format `2023.xxx.xxxx` can be used.
+	ver := osver.Major(fields[0])
+	if ver != "2" && ver != "2022" && ver != "2023" {
+		return "1"
+	}
+	return ver
 }

--- a/pkg/detector/ospkg/amazon/amazon_test.go
+++ b/pkg/detector/ospkg/amazon/amazon_test.go
@@ -170,6 +170,18 @@ func TestScanner_Detect(t *testing.T) {
 			},
 			wantErr: "failed to get amazon advisories",
 		},
+		// cf. #10976: an empty osVer (e.g. /etc/system-release with no version number) must not panic
+		{
+			name: "empty osVer falls back to AL1",
+			fixtures: []string{
+				"testdata/fixtures/amazon.yaml",
+				"testdata/fixtures/data-source.yaml",
+			},
+			args: args{
+				osVer: "",
+				pkgs:  []ftypes.Package{},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -243,6 +255,25 @@ func TestScanner_IsSupportedVersion(t *testing.T) {
 				osVer:    "2023",
 			},
 			want: true,
+		},
+		// cf. #10976: an empty osVer (no version in /etc/system-release) falls back to AL1 and must not panic
+		{
+			name: "empty osVer falls back to AL1 (within support)",
+			now:  time.Date(2020, 5, 31, 23, 59, 59, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: true,
+		},
+		{
+			name: "empty osVer falls back to AL1 (past EOL)",
+			now:  time.Date(2024, 5, 31, 23, 59, 59, 0, time.UTC),
+			args: args{
+				osFamily: "amazon",
+				osVer:    "",
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the changes in this PR.
Explain the problem the PR is trying to solve and how it solves it.
-->

This PR addresses multiple `index out of range [0] with length 0` panics that occur across various dependency parsers and the Amazon OS detector when `strings.Fields()` or similar tokenization returns an empty slice. When the scanner encounters malformed package files or an empty `/etc/system-release`, it panics and aborts the entire scan.

The fix adds proper length checks before slice indexing:
- **`pkg/detector/ospkg/amazon/amazon.go`**: Extracted a `majorVersion()` helper to centralize the AL1 fallback when `osVer` is empty.
- **`pkg/dependency/parser/python/pyproject/pyproject.go`**: Skips empty dependency entries gracefully.
- **`pkg/dependency/parser/swift/cocoapods/parse.go`**: Skips empty child dependencies.
- **`pkg/dependency/parser/hex/mix/parse.go`**: Handles `len(ss) == 0` within the short line loop logic.
- **`pkg/dependency/parser/ruby/bundler/parse.go`**: Wraps the graph parsing section in `if len(s) > 0` to preserve the `lineNum` increment without panicking.

Regression tests and malformed fixtures have been added for all affected locations to prevent future regressions.

## Related issues
- Close #10976

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/trivy/blob/main/CONTRIBUTING.md#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
