### PR TITLE
feat(cli): allow disabling configuration files with empty paths

### DIFF
--- a/docs/guide/configuration/index.md
+++ b/docs/guide/configuration/index.md
@@ -38,3 +38,5 @@ trivy --config="" fs --ignorefile="" --secret-config="" /workspace/project
 ```
 
 CLI flags and environment variables still apply. Secret scanning continues to use its built-in rules and allow rules. Omitting these flags preserves the default file-loading behavior.
+
+Empty environment variables such as `TRIVY_CONFIG=""`, `TRIVY_IGNOREFILE=""`, and `TRIVY_SECRET_CONFIG=""` are treated as unset and do not disable file loading. Use the CLI flags shown above to disable these files.

--- a/docs/guide/configuration/index.md
+++ b/docs/guide/configuration/index.md
@@ -28,3 +28,13 @@ $ TRIVY_DEBUG=true TRIVY_SEVERITY=CRITICAL trivy image alpine:3.15
 Any setting can be set in a YAML file. By default, config file named `trivy.yaml` is read from the current directory where Trivy is run. To load configuration from a different file, use the `--config` flag and specify the config path to load: `trivy --config /etc/trivy/myconfig.yaml`.
 
 The structure and settings of the YAML config file is documented in the [Config file](../references/configuration/config-file.md) document.
+
+### Disabling configuration files
+
+Pass an empty string to `--config` to skip loading `trivy.yaml`. To also skip the default `.trivyignore` and `trivy-secret.yaml` files, pass empty strings to `--ignorefile` and `--secret-config`:
+
+```shell
+trivy --config="" fs --ignorefile="" --secret-config="" /workspace/project
+```
+
+CLI flags and environment variables still apply. Secret scanning continues to use its built-in rules and allow rules. Omitting these flags preserves the default file-loading behavior.

--- a/docs/guide/references/configuration/cli/trivy.md
+++ b/docs/guide/references/configuration/cli/trivy.md
@@ -31,7 +31,7 @@ trivy [global flags] command [flags] target
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
   -f, --format string             version format (json)
       --generate-default-config   write the default config to trivy-default.yaml

--- a/docs/guide/references/configuration/cli/trivy_clean.md
+++ b/docs/guide/references/configuration/cli/trivy_clean.md
@@ -37,7 +37,7 @@ trivy clean [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_config.md
+++ b/docs/guide/references/configuration/cli/trivy_config.md
@@ -45,7 +45,7 @@ trivy config [flags] DIR
       --helm-values strings               specify paths to override the Helm values.yaml files
   -h, --help                              help for config
       --ignore-policy string              specify the Rego file path to evaluate each vulnerability
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
       --include-non-failures              include successes, available with '--scanners misconfig'
       --k8s-version string                specify k8s version to validate outdated api by it (example: 1.21.0)
@@ -89,7 +89,7 @@ trivy config [flags] DIR
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_convert.md
+++ b/docs/guide/references/configuration/cli/trivy_convert.md
@@ -36,7 +36,7 @@ trivy convert [flags] RESULT_JSON
                                     (default "table")
   -h, --help                       help for convert
       --ignore-policy string       specify the Rego file path to evaluate each vulnerability
-      --ignorefile string          specify .trivyignore file (default ".trivyignore")
+      --ignorefile string          specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --list-all-pkgs              output all packages in the JSON report regardless of vulnerability (default true)
   -o, --output string              output file name
       --output-plugin-arg string   [EXPERIMENTAL] output plugin arguments
@@ -60,7 +60,7 @@ trivy convert [flags] RESULT_JSON
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_filesystem.md
+++ b/docs/guide/references/configuration/cli/trivy_filesystem.md
@@ -77,7 +77,7 @@ trivy filesystem [flags] PATH
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn, gradle)
       --include-non-failures              include successes, available with '--scanners misconfig'
@@ -115,7 +115,7 @@ trivy filesystem [flags] PATH
       --report string                     specify a compliance report format for the output (allowed values: all,summary) (default "all")
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
@@ -186,7 +186,7 @@ trivy filesystem [flags] PATH
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_image.md
+++ b/docs/guide/references/configuration/cli/trivy_image.md
@@ -93,7 +93,7 @@ trivy image [flags] IMAGE_NAME
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --image-config-scanners strings     comma-separated list of what security issues to detect on container image configurations (allowed values: misconfig,secret)
       --image-src strings                 image source(s) to use, in priority order (allowed values: docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-deprecated-checks         include deprecated checks
@@ -137,7 +137,7 @@ trivy image [flags] IMAGE_NAME
       --report string                     specify a format for the compliance report. (allowed values: all,summary) (default "summary")
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
@@ -207,7 +207,7 @@ trivy image [flags] IMAGE_NAME
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_kubernetes.md
+++ b/docs/guide/references/configuration/cli/trivy_kubernetes.md
@@ -85,7 +85,7 @@ trivy kubernetes [flags] [CONTEXT]
                                             - fix_deferred
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --image-src strings                 image source(s) to use, in priority order (allowed values: docker,containerd,podman,remote) (default [docker,containerd,podman,remote])
       --include-deprecated-checks         include deprecated checks
       --include-kinds strings             indicate the kinds included in scanning (example: node)
@@ -127,7 +127,7 @@ trivy kubernetes [flags] [CONTEXT]
       --report string                     specify a report format for the output (allowed values: all,summary) (default "all")
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,rbac) (default [vuln,misconfig,secret,rbac])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
                                             - UNKNOWN
@@ -195,7 +195,7 @@ trivy kubernetes [flags] [CONTEXT]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_module.md
+++ b/docs/guide/references/configuration/cli/trivy_module.md
@@ -15,7 +15,7 @@ Manage modules
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_module_install.md
+++ b/docs/guide/references/configuration/cli/trivy_module_install.md
@@ -17,7 +17,7 @@ trivy module install [flags] REPOSITORY
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --enable-modules strings    [EXPERIMENTAL] module names to enable
       --generate-default-config   write the default config to trivy-default.yaml

--- a/docs/guide/references/configuration/cli/trivy_module_uninstall.md
+++ b/docs/guide/references/configuration/cli/trivy_module_uninstall.md
@@ -17,7 +17,7 @@ trivy module uninstall [flags] REPOSITORY
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --enable-modules strings    [EXPERIMENTAL] module names to enable
       --generate-default-config   write the default config to trivy-default.yaml

--- a/docs/guide/references/configuration/cli/trivy_plugin.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin.md
@@ -13,7 +13,7 @@ Manage plugins
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_info.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_info.md
@@ -17,7 +17,7 @@ trivy plugin info PLUGIN_NAME
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_install.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_install.md
@@ -30,7 +30,7 @@ trivy plugin install NAME | URL | FILE_PATH
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_list.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_list.md
@@ -17,7 +17,7 @@ trivy plugin list
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_run.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_run.md
@@ -17,7 +17,7 @@ trivy plugin run NAME | URL | FILE_PATH
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_search.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_search.md
@@ -17,7 +17,7 @@ trivy plugin search [KEYWORD]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_uninstall.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_uninstall.md
@@ -17,7 +17,7 @@ trivy plugin uninstall PLUGIN_NAME
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_update.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_update.md
@@ -17,7 +17,7 @@ trivy plugin update
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_plugin_upgrade.md
+++ b/docs/guide/references/configuration/cli/trivy_plugin_upgrade.md
@@ -17,7 +17,7 @@ trivy plugin upgrade [PLUGIN_NAMES]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_registry.md
+++ b/docs/guide/references/configuration/cli/trivy_registry.md
@@ -13,7 +13,7 @@ Manage registry authentication
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_registry_login.md
+++ b/docs/guide/references/configuration/cli/trivy_registry_login.md
@@ -27,7 +27,7 @@ trivy registry login SERVER [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_registry_logout.md
+++ b/docs/guide/references/configuration/cli/trivy_registry_logout.md
@@ -24,7 +24,7 @@ trivy registry logout SERVER [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_repository.md
+++ b/docs/guide/references/configuration/cli/trivy_repository.md
@@ -76,7 +76,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
       --include-dev-deps                  include development dependencies in the report (supported: npm, yarn, gradle)
       --include-non-failures              include successes, available with '--scanners misconfig'
@@ -113,7 +113,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
       --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform,ansible)
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
@@ -185,7 +185,7 @@ trivy repository [flags] (REPO_PATH | REPO_URL)
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_rootfs.md
+++ b/docs/guide/references/configuration/cli/trivy_rootfs.md
@@ -80,7 +80,7 @@ trivy rootfs [flags] ROOTDIR
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
       --ignored-licenses strings          specify a list of license to ignore
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --include-deprecated-checks         include deprecated checks
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
@@ -116,7 +116,7 @@ trivy rootfs [flags] ROOTDIR
       --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform,ansible)
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
@@ -187,7 +187,7 @@ trivy rootfs [flags] ROOTDIR
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_sbom.md
+++ b/docs/guide/references/configuration/cli/trivy_sbom.md
@@ -62,7 +62,7 @@ trivy sbom [flags] SBOM_PATH
                                          - end_of_life
       --ignore-unfixed                 display only fixed vulnerabilities
       --ignored-licenses strings       specify a list of license to ignore
-      --ignorefile string              specify .trivyignore file (default ".trivyignore")
+      --ignorefile string              specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --java-db-repository strings     OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
       --list-all-pkgs                  output all packages in the JSON report regardless of vulnerability (default true)
       --no-progress                    suppress progress bar
@@ -152,7 +152,7 @@ trivy sbom [flags] SBOM_PATH
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_server.md
+++ b/docs/guide/references/configuration/cli/trivy_server.md
@@ -47,7 +47,7 @@ trivy server [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_version.md
+++ b/docs/guide/references/configuration/cli/trivy_version.md
@@ -18,7 +18,7 @@ trivy version [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vex.md
+++ b/docs/guide/references/configuration/cli/trivy_vex.md
@@ -13,7 +13,7 @@
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vex_repo.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo.md
@@ -27,7 +27,7 @@ Manage VEX repositories
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_download.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_download.md
@@ -21,7 +21,7 @@ trivy vex repo download [REPO_NAMES] [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_init.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_init.md
@@ -17,7 +17,7 @@ trivy vex repo init [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vex_repo_list.md
+++ b/docs/guide/references/configuration/cli/trivy_vex_repo_list.md
@@ -17,7 +17,7 @@ trivy vex repo list [flags]
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/docs/guide/references/configuration/cli/trivy_vm.md
+++ b/docs/guide/references/configuration/cli/trivy_vm.md
@@ -75,7 +75,7 @@ trivy vm [flags] VM_IMAGE
                                             - fix_deferred
                                             - end_of_life
       --ignore-unfixed                    display only fixed vulnerabilities
-      --ignorefile string                 specify .trivyignore file (default ".trivyignore")
+      --ignorefile string                 specify .trivyignore file (empty string disables loading) (default ".trivyignore")
       --include-non-failures              include successes, available with '--scanners misconfig'
       --java-db-repository strings        OCI repository(ies) to retrieve trivy-java-db in order of priority (default [mirror.gcr.io/aquasec/trivy-java-db:1,ghcr.io/aquasecurity/trivy-java-db:1])
       --list-all-pkgs                     output all packages in the JSON report regardless of vulnerability (default true)
@@ -104,7 +104,7 @@ trivy vm [flags] VM_IMAGE
       --render-cause strings              specify configuration types for which the rendered causes will be shown in the table report (allowed values: terraform,ansible)
       --sbom-sources strings              [EXPERIMENTAL] try to retrieve SBOM from the specified sources (allowed values: oci,rekor)
       --scanners strings                  comma-separated list of what security issues to detect (allowed values: vuln,misconfig,secret,license) (default [vuln,secret])
-      --secret-config string              specify a path to config file for secret scanning (default "trivy-secret.yaml")
+      --secret-config string              specify a path to config file for secret scanning (empty string disables loading) (default "trivy-secret.yaml")
       --server string                     server address in client mode
   -s, --severity strings                  severities of security issues to be displayed
                                           Allowed values:
@@ -171,7 +171,7 @@ trivy vm [flags] VM_IMAGE
 ```
       --cacert string             Path to PEM-encoded CA certificate file
       --cache-dir string          cache directory (default "/path/to/cache")
-  -c, --config string             config path (default "trivy.yaml")
+  -c, --config string             config path (empty string disables loading) (default "trivy.yaml")
   -d, --debug                     debug mode
       --generate-default-config   write the default config to trivy-default.yaml
       --insecure                  allow insecure server connections

--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -157,6 +157,10 @@ func loadPluginCommands() []*cobra.Command {
 }
 
 func initConfig(configFile string, pathChanged bool) error {
+	if configFile == "" {
+		return nil
+	}
+
 	// Read from config
 	viper.SetConfigFile(configFile)
 	viper.SetConfigType("yaml")

--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -3,9 +3,11 @@ package commands
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -169,6 +171,12 @@ Check Bundle:
 }
 
 func TestFlags(t *testing.T) {
+	const customConfig = `format: json
+severity: [HIGH]
+scan:
+  scanners: [secret]
+`
+
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity
@@ -177,6 +185,7 @@ func TestFlags(t *testing.T) {
 	tests := []struct {
 		name      string
 		arguments []string // 1st argument is path to trivy binaries
+		config    string
 		want      want
 		wantErr   string
 	}{
@@ -288,6 +297,37 @@ func TestFlags(t *testing.T) {
 			},
 		},
 		{
+			name:      "default configuration file",
+			arguments: []string{"test"},
+			config:    customConfig,
+			want: want{
+				format:     types.FormatJSON,
+				severities: []dbTypes.Severity{dbTypes.SeverityHigh},
+				scanners:   types.Scanners{types.SecretScanner, types.SBOMScanner},
+			},
+		},
+		{
+			name: "empty configuration paths",
+			arguments: []string{
+				"test",
+				"--config=",
+				"--ignorefile=",
+				"--secret-config=",
+			},
+			config: customConfig,
+			want: want{
+				format: types.FormatTable,
+				severities: []dbTypes.Severity{
+					dbTypes.SeverityUnknown,
+					dbTypes.SeverityLow,
+					dbTypes.SeverityMedium,
+					dbTypes.SeverityHigh,
+					dbTypes.SeverityCritical,
+				},
+				scanners: types.Scanners{types.VulnerabilityScanner, types.SecretScanner, types.SBOMScanner},
+			},
+		},
+		{
 			name: "invalid format",
 			arguments: []string{
 				"test",
@@ -309,6 +349,12 @@ func TestFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			if tt.config != "" {
+				t.Chdir(t.TempDir())
+				require.NoError(t, os.WriteFile("trivy.yaml", []byte(tt.config), 0o600))
+			}
+
 			globalFlags := flag.NewGlobalFlagGroup()
 			rootCmd := NewRootCommand(globalFlags)
 			rootCmd.SetErr(io.Discard)
@@ -318,6 +364,7 @@ func TestFlags(t *testing.T) {
 				globalFlags,
 				flag.NewReportFlagGroup(),
 				flag.NewScanFlagGroup(),
+				flag.NewSecretFlagGroup(),
 			}
 			cmd := &cobra.Command{
 				Use: "test",

--- a/pkg/flag/global_flags.go
+++ b/pkg/flag/global_flags.go
@@ -18,7 +18,7 @@ var (
 		ConfigName: "config",
 		Shorthand:  "c",
 		Default:    "trivy.yaml",
-		Usage:      "config path",
+		Usage:      "config path (empty string disables loading)",
 		Persistent: true,
 	}
 	ShowVersionFlag = Flag[bool]{

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -69,7 +69,7 @@ var (
 		Name:       "ignorefile",
 		ConfigName: "ignorefile",
 		Default:    result.DefaultIgnoreFile,
-		Usage:      "specify .trivyignore file",
+		Usage:      "specify .trivyignore file (empty string disables loading)",
 	}
 	IgnorePolicyFlag = Flag[string]{
 		Name:       "ignore-policy",

--- a/pkg/flag/report_flags.go
+++ b/pkg/flag/report_flags.go
@@ -270,7 +270,7 @@ func (f *ReportFlagGroup) ToOptions(opts *Options) error {
 		}
 	}
 
-	if viper.IsSet(f.IgnoreFile.ConfigName) && !fsutils.FileExists(f.IgnoreFile.Value()) {
+	if f.IgnoreFile.Value() != "" && viper.IsSet(f.IgnoreFile.ConfigName) && !fsutils.FileExists(f.IgnoreFile.Value()) {
 		return xerrors.Errorf("ignore file not found: %s", f.IgnoreFile.Value())
 	}
 

--- a/pkg/flag/secret_flags.go
+++ b/pkg/flag/secret_flags.go
@@ -5,7 +5,7 @@ var (
 		Name:       "secret-config",
 		ConfigName: "secret.config",
 		Default:    "trivy-secret.yaml",
-		Usage:      "specify a path to config file for secret scanning",
+		Usage:      "specify a path to config file for secret scanning (empty string disables loading)",
 	}
 )
 

--- a/pkg/result/ignore.go
+++ b/pkg/result/ignore.go
@@ -215,6 +215,11 @@ func (c *IgnoreConfig) MatchLicense(licenseID, filePath string) *IgnoreFinding {
 }
 
 func ParseIgnoreFile(ctx context.Context, ignoreFile string) (IgnoreConfig, error) {
+	// An empty path explicitly disables the ignore file.
+	if ignoreFile == "" {
+		return IgnoreConfig{}, nil
+	}
+
 	var conf IgnoreConfig
 	if _, err := os.Stat(ignoreFile); errors.Is(err, fs.ErrNotExist) {
 		// .trivyignore doesn't necessarily exist

--- a/pkg/result/ignore_test.go
+++ b/pkg/result/ignore_test.go
@@ -9,6 +9,19 @@ import (
 )
 
 func TestParseIgnoreFile(t *testing.T) {
+	t.Run("empty path disables the default ignore file", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile(".trivyignore", []byte("CVE-2024-1234\n"), 0o600))
+
+		got, err := ParseIgnoreFile(t.Context(), ".trivyignore")
+		require.NoError(t, err)
+		assert.Len(t, got.Vulnerabilities, 1)
+
+		got, err = ParseIgnoreFile(t.Context(), "")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
 	t.Run("happy path valid config file", func(t *testing.T) {
 		got, err := ParseIgnoreFile(t.Context(), "testdata/.trivyignore")
 		require.NoError(t, err)

--- a/schema/trivy-config.json
+++ b/schema/trivy-config.json
@@ -685,7 +685,7 @@
     },
     "ignorefile": {
       "type": "string",
-      "description": "specify .trivyignore file"
+      "description": "specify .trivyignore file (empty string disables loading)"
     },
     "ignore-policy": {
       "type": "string",
@@ -874,7 +874,7 @@
       "properties": {
         "config": {
           "type": "string",
-          "description": "specify a path to config file for secret scanning"
+          "description": "specify a path to config file for secret scanning (empty string disables loading)"
         }
       }
     },


### PR DESCRIPTION
## Description

Allow explicitly empty `--config` and `--ignorefile` values to disable loading their respective files, matching the existing behavior of `--secret-config`.

Previously, empty values for `--config` and `--ignorefile` caused errors. Users can now skip all three configuration files without creating empty files or using platform-specific null devices:

```shell
trivy --config="" fs --ignorefile="" --secret-config="" /workspace/project
```

Omitting these flags preserves the default file-loading behavior. CLI flags and environment variables still apply, and secret scanning continues to use its built-in rules and allow rules.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
