### PR TITLE
fix: correct grammar and typos in user-facing error messages

### DIFF
--- a/pkg/dependency/parser/java/pom/var.go
+++ b/pkg/dependency/parser/java/pom/var.go
@@ -57,5 +57,5 @@ func printLoopedPropertiesStack(env string, usedProps []string) {
 	for _, prop := range usedProps {
 		fmt.Fprintf(&sb, "%s -> ", prop)
 	}
-	log.Warn("Lopped properties were detected", log.String("prop", sb.String()+env))
+	log.Warn("Looped properties were detected", log.String("prop", sb.String()+env))
 }

--- a/pkg/fanal/analyzer/language/python/pip/pip.go
+++ b/pkg/fanal/analyzer/language/python/pip/pip.go
@@ -87,7 +87,7 @@ func (a pipLibraryAnalyzer) PostAnalyze(ctx context.Context, input analyzer.Post
 		apps = append(apps, *app)
 		return nil
 	}); err != nil {
-		return nil, xerrors.Errorf("pip walt error: %w", err)
+		return nil, xerrors.Errorf("pip walk error: %w", err)
 	}
 
 	return &analyzer.AnalysisResult{

--- a/pkg/fanal/vm/disk/disk.go
+++ b/pkg/fanal/vm/disk/disk.go
@@ -33,5 +33,5 @@ func New(rs io.ReadSeeker, cache vm.Cache[string, []byte]) (*io.SectionReader, e
 
 		return vreader, nil
 	}
-	return nil, xerrors.New("virtual machine can not be detected")
+	return nil, xerrors.New("virtual machine disk format cannot be detected")
 }

--- a/pkg/fanal/vm/disk/disk_test.go
+++ b/pkg/fanal/vm/disk/disk_test.go
@@ -25,7 +25,7 @@ func TestNew(t *testing.T) {
 		{
 			name:     "invalid vm file",
 			fileName: "testdata/invalid.vmdk",
-			wantErr:  "virtual machine can not be detected",
+			wantErr:  "virtual machine disk format cannot be detected",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/flag/db_flags.go
+++ b/pkg/flag/db_flags.go
@@ -134,13 +134,13 @@ func (f *DBFlagGroup) ToOptions(opts *Options) error {
 	downloadJavaDBOnly := f.DownloadJavaDBOnly.Value()
 
 	if downloadDBOnly && downloadJavaDBOnly {
-		return xerrors.New("--download-db-only and --download-java-db-only options can not be specified both")
+		return xerrors.New("--download-db-only and --download-java-db-only cannot be specified together")
 	}
 	if downloadDBOnly && skipDBUpdate {
-		return xerrors.New("--skip-db-update and --download-db-only options can not be specified both")
+		return xerrors.New("--skip-db-update and --download-db-only cannot be specified together")
 	}
 	if downloadJavaDBOnly && skipJavaDBUpdate {
-		return xerrors.New("--skip-java-db-update and --download-java-db-only options can not be specified both")
+		return xerrors.New("--skip-java-db-update and --download-java-db-only cannot be specified together")
 	}
 
 	var dbRepositories, javaDBRepositories []name.Reference

--- a/pkg/flag/db_flags_test.go
+++ b/pkg/flag/db_flags_test.go
@@ -52,7 +52,7 @@ func TestDBFlagGroup_ToOptions(t *testing.T) {
 				SkipDBUpdate:   true,
 				DownloadDBOnly: true,
 			},
-			wantErr: "--skip-db-update and --download-db-only options can not be specified both",
+			wantErr: "--skip-db-update and --download-db-only cannot be specified together",
 		},
 		{
 			name: "invalid repo",


### PR DESCRIPTION
Addresses grammar and spelling findings from the error-message audit across CLI flags, VM disk detection, pip analyzer and POM parser.

## Description

## Related issues
- Close #XXX

## Related PRs
- [ ] #XXX
- [ ] #YYY

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
