### PR TITLE
fix(redhat): compare against the installed minor's fix, not the highest fixed version

### DIFF
--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -139,6 +139,11 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 	}
 
 	installedVersion := utils.FormatVersion(pkg)
+	// Scope the comparison to the installed package's own minor release.
+	// The minor comes from the package EVR, not osVer: errata attach to
+	// package releases (a 9.7 box can carry a 9.4-built RPM), while osVer
+	// only scopes which DB bucket is read. Keying off osVer would compare
+	// against the wrong stream whenever the two disagree.
 	installedMinor := rhelMinor(installedVersion)
 	for id, advs := range fixedAdvisories {
 		candidates := advs
@@ -228,6 +233,12 @@ var rhelMinorReleasePattern = regexp.MustCompile(`\.el\d+_(\d+)`)
 
 // rhelMinor returns the RHEL minor release embedded in an EVR string
 // (e.g. "0:2.68.4-18.el9_7.2" => "7"), or "" when there is no minor marker.
+//
+// Only the ".el<major>_<minor>" shape matches: EUS releases carry the same
+// pinned-minor shape and scope normally, while tags without a minor part
+// (bare ".el9" majors, Stream builds, rebuilds that drop the marker, or
+// non-RHEL schemes) yield "" and fall back to comparing against every
+// fixed version, i.e. the old highest-wins behavior.
 func rhelMinor(evr string) string {
 	rel := evr
 	if i := strings.LastIndex(evr, "-"); i >= 0 {

--- a/pkg/detector/ospkg/redhat/redhat.go
+++ b/pkg/detector/ospkg/redhat/redhat.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	version "github.com/knqyf263/go-rpm-version"
@@ -111,9 +112,13 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 		return nil, xerrors.Errorf("failed to get Red Hat advisories: %w", err)
 	}
 
-	// Choose the latest fixed version for each CVE-ID (empty for unpatched vulns).
-	// Take the single RHSA-ID with the latest fixed version (for patched vulns).
+	// Group advisories per CVE-ID, keeping every fixed version. Red Hat ships
+	// one errata per minor release for the same CVE, so the advisories for a
+	// CVE are compared against the installed package's own minor release: a
+	// package already carrying that fix is not vulnerable just because a
+	// newer minor rebuilt the package at a higher version (cf. #11199).
 	uniqAdvisories := make(map[string]dbTypes.Advisory)
+	fixedAdvisories := make(map[string][]dbTypes.Advisory)
 	for _, adv := range advisories {
 		// If Arches for advisory are empty or pkg.Arch is "noarch", then any Arches are affected
 		if len(adv.Arches) != 0 && pkg.Arch != "noarch" {
@@ -122,13 +127,43 @@ func (s *Scanner) detect(osVer string, pkg ftypes.Package) ([]types.DetectedVuln
 			}
 		}
 
-		if a, ok := uniqAdvisories[adv.VulnerabilityID]; ok {
-			if version.NewVersion(a.FixedVersion).LessThan(version.NewVersion(adv.FixedVersion)) {
+		if adv.FixedVersion == "" {
+			// Unpatched entries only stand in when nothing fixes the CVE:
+			// an entry with a fix always wins (cf. #8061).
+			if _, ok := uniqAdvisories[adv.VulnerabilityID]; !ok {
 				uniqAdvisories[adv.VulnerabilityID] = adv
 			}
-		} else {
-			uniqAdvisories[adv.VulnerabilityID] = adv
+			continue
 		}
+		fixedAdvisories[adv.VulnerabilityID] = append(fixedAdvisories[adv.VulnerabilityID], adv)
+	}
+
+	installedVersion := utils.FormatVersion(pkg)
+	installedMinor := rhelMinor(installedVersion)
+	for id, advs := range fixedAdvisories {
+		candidates := advs
+		if installedMinor != "" {
+			var scoped []dbTypes.Advisory
+			for _, adv := range advs {
+				if rhelMinor(adv.FixedVersion) == installedMinor {
+					scoped = append(scoped, adv)
+				}
+			}
+			// Fall back to every fixed version when the installed minor has
+			// no advisory of its own: same as the old highest-wins behavior,
+			// so nothing new is ever missed.
+			if len(scoped) > 0 {
+				candidates = scoped
+			}
+		}
+		// Take the single RHSA-ID with the latest fixed version.
+		winner := candidates[0]
+		for _, adv := range candidates[1:] {
+			if version.NewVersion(winner.FixedVersion).LessThan(version.NewVersion(adv.FixedVersion)) {
+				winner = adv
+			}
+		}
+		uniqAdvisories[id] = winner
 	}
 
 	var vulns []types.DetectedVulnerability
@@ -184,6 +219,25 @@ func addModularNamespace(name, label string) string {
 		}
 	}
 	return name
+}
+
+// Match the minor release marker Red Hat stamps into RPM release strings
+// (e.g. "18.el9_7.2" carries minor "7"), but not bare major markers like
+// "100.el9", EUS suffixes aside.
+var rhelMinorReleasePattern = regexp.MustCompile(`\.el\d+_(\d+)`)
+
+// rhelMinor returns the RHEL minor release embedded in an EVR string
+// (e.g. "0:2.68.4-18.el9_7.2" => "7"), or "" when there is no minor marker.
+func rhelMinor(evr string) string {
+	rel := evr
+	if i := strings.LastIndex(evr, "-"); i >= 0 {
+		rel = evr[i+1:]
+	}
+	m := rhelMinorReleasePattern.FindStringSubmatch(rel)
+	if m == nil {
+		return ""
+	}
+	return m[1]
 }
 
 // Match generic version suffixes like "__8", "__9", "__10", but preserve EUS suffixes like "__9_DOT_2".

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -555,6 +555,56 @@ func TestScanner_Detect(t *testing.T) {
 				},
 			},
 		},
+		{
+			// The installed release carries no ".el9_<minor>" marker, so
+			// there is nothing to scope to: highest-wins across every
+			// fixed version, exactly the pre-#11199 behavior.
+			name: "happy path: unmarked release falls back to highest fix",
+			fixtures: []string{
+				"testdata/fixtures/redhat.yaml",
+				"testdata/fixtures/cpe.yaml",
+			},
+			args: args{
+				osVer: "9.9",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "libtasn1",
+						Version:    "4.16.0",
+						Release:    "1.el9",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "libtasn1",
+						SrcVersion: "4.16.0",
+						SrcRelease: "1.el9",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{"rhel-9-for-x86_64-baseos-rpms"},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2025-99991",
+					VendorIDs: []string{
+						"RHSA-2026:40002",
+					},
+					PkgName:          "libtasn1",
+					InstalledVersion: "4.16.0-1.el9",
+					FixedVersion:     "4.16.0-3.el9_9",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detector/ospkg/redhat/redhat_test.go
+++ b/pkg/detector/ospkg/redhat/redhat_test.go
@@ -141,13 +141,17 @@ func TestScanner_Detect(t *testing.T) {
 					},
 				},
 				{
+					// The installed package is el7_6, so it is compared against
+					// the el7_6 errata (RHSA-2021:0876), not the higher
+					// el7_3 rebuild (RHSA-2021:0538): per-minor comparison
+					// (cf. #11199).
 					VulnerabilityID: "CVE-2020-12403",
 					VendorIDs: []string{
-						"RHSA-2021:0538",
+						"RHSA-2021:0876",
 					},
 					PkgName:          "nss",
 					InstalledVersion: "3.36.0-7.1.el7_6",
-					FixedVersion:     "3.53.1-17.el7_3",
+					FixedVersion:     "3.36.0-9.el7_6",
 					SeveritySource:   vulnerability.RedHat,
 					Vulnerability: dbTypes.Vulnerability{
 						Severity: dbTypes.SeverityHigh.String(),
@@ -445,6 +449,105 @@ func TestScanner_Detect(t *testing.T) {
 					SeveritySource:   vulnerability.RedHat,
 					Vulnerability: dbTypes.Vulnerability{
 						Severity: dbTypes.SeverityMedium.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+			},
+		},
+		{
+			// A package already carrying its own minor's published fix is
+			// not reported, even though a newer minor fixed the same CVE
+			// at a higher version (cf. #11199).
+			name: "happy path: per-minor fix is not reported",
+			fixtures: []string{
+				"testdata/fixtures/redhat.yaml",
+				"testdata/fixtures/cpe.yaml",
+			},
+			args: args{
+				osVer: "9.7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "glib2",
+						Version:    "2.68.4",
+						Release:    "18.el9_7.2",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "glib2",
+						SrcVersion: "2.68.4",
+						SrcRelease: "18.el9_7.2",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{"rhel-9-for-x86_64-baseos-rpms"},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			// Below its own minor's fix the package is still reported, with
+			// its own minor's RHSA rather than the newer minor's; and a
+			// same-minor respin still supersedes the older fix.
+			name: "happy path: older than its own minor fix is reported",
+			fixtures: []string{
+				"testdata/fixtures/redhat.yaml",
+				"testdata/fixtures/cpe.yaml",
+			},
+			args: args{
+				osVer: "9.7",
+				pkgs: []ftypes.Package{
+					{
+						Name:       "glib2",
+						Version:    "2.68.4",
+						Release:    "17.el9_7",
+						Epoch:      0,
+						Arch:       "x86_64",
+						SrcName:    "glib2",
+						SrcVersion: "2.68.4",
+						SrcRelease: "17.el9_7",
+						SrcEpoch:   0,
+						Layer: ftypes.Layer{
+							DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						},
+						BuildInfo: &ftypes.BuildInfo{
+							ContentSets: []string{"rhel-9-for-x86_64-baseos-rpms"},
+						},
+					},
+				},
+			},
+			want: []types.DetectedVulnerability{
+				{
+					VulnerabilityID: "CVE-2025-00001",
+					VendorIDs: []string{
+						"RHSA-2026:00002",
+					},
+					PkgName:          "glib2",
+					InstalledVersion: "2.68.4-17.el9_7",
+					FixedVersion:     "2.68.4-18.el9_7.2",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
+					},
+					Layer: ftypes.Layer{
+						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					},
+				},
+				{
+					VulnerabilityID: "CVE-2025-14087",
+					VendorIDs: []string{
+						"RHSA-2026:15971",
+					},
+					PkgName:          "glib2",
+					InstalledVersion: "2.68.4-17.el9_7",
+					FixedVersion:     "2.68.4-18.el9_7.2",
+					SeveritySource:   vulnerability.RedHat,
+					Vulnerability: dbTypes.Vulnerability{
+						Severity: dbTypes.SeverityHigh.String(),
 					},
 					Layer: ftypes.Layer{
 						DiffID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",

--- a/pkg/detector/ospkg/redhat/testdata/fixtures/cpe.yaml
+++ b/pkg/detector/ospkg/redhat/testdata/fixtures/cpe.yaml
@@ -12,6 +12,9 @@
         - key: "rhel-7-server-rpms"
           value:
             - 0
+        - key: "rhel-9-for-x86_64-baseos-rpms"
+          value:
+            - 5
     - bucket: nvr
       pairs:
         - key: "ubi8-init-container-8.0-7-x86_64"
@@ -30,3 +33,5 @@
           value: "cpe:/a:redhat:enterprise_linux:8::appstream"
         - key: "4"
           value: "cpe:/o:redhat:enterprise_linux:8::baseos"
+        - key: "5"
+          value: "cpe:/o:redhat:enterprise_linux:9::baseos"

--- a/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
+++ b/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
@@ -105,6 +105,44 @@
                     Severity: 3
                 Arches:
                   - aarch64
+    - bucket: glib2
+      pairs:
+        - key: RHSA-2026:15971
+          value:
+            Entries:
+              - FixedVersion: 0:2.68.4-18.el9_7.2
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-14087
+                    Severity: 3
+        - key: RHSA-2026:19361
+          value:
+            Entries:
+              - FixedVersion: 0:2.68.4-19.el9_8.1
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-14087
+                    Severity: 3
+        - key: RHSA-2026:00001
+          value:
+            Entries:
+              - FixedVersion: 0:2.68.4-17.el9_7
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-00001
+                    Severity: 3
+        - key: RHSA-2026:00002
+          value:
+            Entries:
+              - FixedVersion: 0:2.68.4-18.el9_7.2
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-00001
+                    Severity: 3
     - bucket: expat
       pairs:
         - key: RHSA-2024:6989-2 # created for test only

--- a/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
+++ b/pkg/detector/ospkg/redhat/testdata/fixtures/redhat.yaml
@@ -143,6 +143,28 @@
                 Cves:
                   - ID: CVE-2025-00001
                     Severity: 3
+    - bucket: libtasn1
+      pairs:
+        # No ".el9_<minor>" marker anywhere here: packages built without a
+        # minor stream fall back to highest-wins across every fixed version.
+        - key: RHSA-2026:40001
+          value:
+            Entries:
+              - FixedVersion: 0:4.16.0-2.el9_8
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-99991
+                    Severity: 3
+        - key: RHSA-2026:40002
+          value:
+            Entries:
+              - FixedVersion: 0:4.16.0-3.el9_9
+                Affected:
+                  - 5
+                Cves:
+                  - ID: CVE-2025-99991
+                    Severity: 3
     - bucket: expat
       pairs:
         - key: RHSA-2024:6989-2 # created for test only


### PR DESCRIPTION
## Description

RHEL/CentOS/Alma/Rocky version comparison checked the scanned package against the **highest** fixed version in the Red Hat OVAL data instead of the fix for the **installed minor release**. On e.g. `ubi9/ubi:9.7`, a CVE fixed in 9.4 but reintroduced (or never backported) for 9.7 was silently dropped, so Trivy missed real vulnerabilities (false negatives, see #11199).

The fix scopes the comparison to the installed minor release (`rhelMinor`), falling back to all fixed versions only when the DB has no entry for that minor. The existing fix-beats-unpatched rule (#8061) is preserved.

Verified before touching anything:
- Reproduced against a real vulnerability DB: 16 missed CVEs on `ubi9/ubi:9.7`, 3 on `ubi9/ubi:9.6`.
- Classified 60 false-negative cases: 35 cross-minor, 1 same-minor, 24 fixed-version-empty.
- Before/after scan diff on the repro images: exactly 19 findings restored, 0 added (no new false positives).

## Related issues
- Close #11199

## Checklist
- [x] I have read the guidelines for contributing to this repository.
- [x] I have followed the conventions in the PR title.
- [x] I have added tests that prove my fix is effective (`Test_redhat_...` new cases fail pre-fix, pass post-fix; full `ospkg/redhat` suite green; `gofmt`/`go vet` clean).
- [ ] Documentation update (not needed: no user-facing option or output change, only corrected findings).