### PR TITLE
feat(helm): make livenessProbe and readinessProbe configurable

### DIFF
--- a/helm/trivy/README.md
+++ b/helm/trivy/README.md
@@ -90,6 +90,8 @@ The following table lists the configurable parameters of the Trivy chart and the
 | `affinity`                            | Affinity settings for pod assignment                                              |     |
 | `tolerations`                         | Tolerations for pod assignment                                              |     |
 | `podAnnotations`                      | Annotations for pods created by statefulset                             | `{}` |
+| `livenessProbe`                       | Liveness probe for the main container                                   | See `values.yaml` |
+| `readinessProbe`                      | Readiness probe for the main container                                  | See `values.yaml` |
 
 The above parameters map to the env variables defined in [trivy](https://trivy.dev/docs/latest/configuration/#configuration).
 

--- a/helm/trivy/templates/statefulset.yaml
+++ b/helm/trivy/templates/statefulset.yaml
@@ -101,23 +101,9 @@ spec:
             - name: trivy-http
               containerPort: {{ .Values.service.port }}
           livenessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /healthz
-              port: trivy-http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /healthz
-              port: trivy-http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           volumeMounts:
             - mountPath: /tmp
               name: tmp-data

--- a/helm/trivy/values.yaml
+++ b/helm/trivy/values.yaml
@@ -56,6 +56,30 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
 
+## Liveness probe for the main container
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    scheme: HTTP
+    path: /healthz
+    port: trivy-http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
+## Readiness probe for the main container
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbe:
+  httpGet:
+    scheme: HTTP
+    path: /healthz
+    port: trivy-http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 3
+
 trivy:
   # debugMode the flag to enable Trivy debug mode
   debugMode: false


### PR DESCRIPTION
Addresses #11219: the Trivy Helm chart hardcodes `livenessProbe`/`readinessProbe` in `templates/statefulset.yaml`, so users can't tune health-check behavior (path, timing, thresholds) without patching the chart.

This exposes both probes as `values.yaml` entries, defaulted to the previously hardcoded values (no behavior change), and renders them in the StatefulSet via `toYaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)