### PR TITLE
fix(terraform): convert primitives to string in list attributes

### DIFF
--- a/pkg/iac/adapters/terraform/google/compute/networks_test.go
+++ b/pkg/iac/adapters/terraform/google/compute/networks_test.go
@@ -169,6 +169,46 @@ func Test_adaptNetworks(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "firewall with ports as numbers",
+			terraform: `resource "google_compute_firewall" "example" {
+  network       = "test"
+  source_ranges = ["1.2.3.4/32"]
+  allow {
+    protocol = "tcp"
+    ports    = [111, 343]
+  }
+}
+`,
+			expected: []compute.Network{
+				{
+					Firewall: &compute.Firewall{
+						IngressRules: []compute.IngressRule{
+							{
+								FirewallRule: compute.FirewallRule{
+									Enforced: iacTypes.BoolTest(true),
+									IsAllow:  iacTypes.BoolTest(true),
+									Protocol: iacTypes.StringTest("tcp"),
+									Ports: []common.PortRange{
+										{
+											Start: iacTypes.IntTest(111),
+											End:   iacTypes.IntTest(111),
+										},
+										{
+											Start: iacTypes.IntTest(343),
+											End:   iacTypes.IntTest(343),
+										},
+									},
+								},
+								SourceRanges: []iacTypes.StringValue{
+									iacTypes.StringTest("1.2.3.4/32"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/iac/terraform/attribute.go
+++ b/pkg/iac/terraform/attribute.go
@@ -441,6 +441,12 @@ func (a *Attribute) valueToString(value cty.Value) (result iacTypes.StringValue)
 	switch value.Type() {
 	case cty.String:
 		return iacTypes.String(value.AsString(), a.metadata)
+	case cty.Number, cty.Bool:
+		converted, err := convert.Convert(value, cty.String)
+		if err != nil {
+			return result
+		}
+		return iacTypes.String(converted.AsString(), a.metadata)
 	default:
 		return result
 	}

--- a/pkg/iac/terraform/attribute_test.go
+++ b/pkg/iac/terraform/attribute_test.go
@@ -89,6 +89,52 @@ func Test_Attribute_AsMapValue(t *testing.T) {
 	}
 }
 
+func Test_Attribute_AsStringValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected []string
+	}{
+		{
+			name:     "strings",
+			expr:     `["80", "9090-9095"]`,
+			expected: []string{"80", "9090-9095"},
+		},
+		{
+			name:     "numbers",
+			expr:     `[80, 8080]`,
+			expected: []string{"80", "8080"},
+		},
+		{
+			name:     "number in exponent notation",
+			expr:     `[1e3]`,
+			expected: []string{"1000"},
+		},
+		{
+			name:     "numbers mixed with strings",
+			expr:     `[80, "9090-9095"]`,
+			expected: []string{"80", "9090-9095"},
+		},
+		{
+			name:     "bools",
+			expr:     `[true, false]`,
+			expected: []string{"true", "false"},
+		},
+		{
+			name:     "value that has no string representation",
+			expr:     `[["80"]]`,
+			expected: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := newTestAttribute(t, tt.expr, nil)
+			assert.Equal(t, tt.expected, attr.AsStringValues().AsStrings())
+		})
+	}
+}
+
 func Test_Attribute_Marks(t *testing.T) {
 	val := cty.StringVal("secret").Mark("sensitive")
 	attr := newTestAttribute(t, "val", map[string]cty.Value{"val": val})


### PR DESCRIPTION
## Description

Numbers and bools are now converted with the same go-cty call that Terraform uses while decoding.

Before:
```console
trivy conf main.tf -q              

Report Summary

┌─────────┬───────────┬───────────────────┐
│ Target  │   Type    │ Misconfigurations │
├─────────┼───────────┼───────────────────┤
│ .       │ terraform │         0         │
├─────────┼───────────┼───────────────────┤
│ main.tf │ terraform │         1         │
└─────────┴───────────┴───────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


main.tf (terraform)

Tests: 1 (SUCCESSES: 0, FAILURES: 1)
Failures: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

GCP-0072 (MEDIUM): Firewall rule allows access to all ports.
══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Firewall rules should not be wide open to all ports. Lock down rules to only required ports.


See https://avd.aquasec.com/misconfig/gcp-0072
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 main.tf:3-10
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   3 ┌ resource "google_compute_firewall" "example" {
   4 │   network       = "test"
   5 │   source_ranges = ["1.2.3.4/32"]
   6 │   allow {
   7 │     protocol = "tcp"
   8 │     ports    = [111, 343]
   9 │   }
  10 └ }
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

After:
```console
./trivy conf main.tf -q              

Report Summary

┌────────┬───────────┬───────────────────┐
│ Target │   Type    │ Misconfigurations │
├────────┼───────────┼───────────────────┤
│ .      │ terraform │         0         │
└────────┴───────────┴───────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

## Related issues
- Close https://github.com/aquasecurity/trivy/issues/11222

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
