### PR TITLE
fix(terraform): drop .tf files shadowed by same-name .tofu files

### DIFF
--- a/pkg/iac/scanners/terraform/parser/dropshadow_test.go
+++ b/pkg/iac/scanners/terraform/parser/dropshadow_test.go
@@ -1,0 +1,26 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDropShadowedTerraformFiles(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    []string
+		want  []string
+	}{
+		{"tofu shadows tf", []string{"dir/main.tf", "dir/main.tofu"}, []string{"dir/main.tofu"}},
+		{"tofu.json shadows tf.json", []string{"dir/main.tf.json", "dir/main.tofu.json"}, []string{"dir/main.tofu.json"}},
+		{"no cross-extension shadow", []string{"dir/main.tofu", "dir/main.tf.json"}, []string{"dir/main.tofu", "dir/main.tf.json"}},
+		{"tf alone kept", []string{"dir/main.tf"}, []string{"dir/main.tf"}},
+		{"unrelated files kept", []string{"dir/a.tf", "dir/b.tofu", "dir/c.txt"}, []string{"dir/a.tf", "dir/b.tofu", "dir/c.txt"}},
+	}
+	for _, c := range cases {
+		got := dropShadowedTerraformFiles(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/pkg/iac/scanners/terraform/parser/parser.go
+++ b/pkg/iac/scanners/terraform/parser/parser.go
@@ -189,6 +189,7 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 		}
 		paths = append(paths, realPath)
 	}
+	paths = dropShadowedTerraformFiles(paths)
 	sort.Strings(paths)
 	for _, path := range paths {
 		var err error
@@ -211,6 +212,44 @@ func (p *Parser) ParseFS(ctx context.Context, dir string) error {
 	}
 
 	return nil
+}
+
+// dropShadowedTerraformFiles mirrors the loading rule OpenTofu applies when
+// both language variants of a file exist: main.tofu shadows main.tf, and
+// main.tofu.json shadows main.tf.json. The shadowed file is never loaded by
+// OpenTofu, so scanning it reports findings for a configuration that is not
+// applied. The pairing is per extension family; main.tofu does not shadow
+// main.tf.json.
+func dropShadowedTerraformFiles(paths []string) []string {
+	shadowed := make(map[string]struct{})
+	for _, f := range paths {
+		var twin string
+		switch {
+		case strings.HasSuffix(f, ".tofu"):
+			twin = strings.TrimSuffix(f, ".tofu") + ".tf"
+		case strings.HasSuffix(f, ".tofu.json"):
+			twin = strings.TrimSuffix(f, ".tofu.json") + ".tf.json"
+		default:
+			continue
+		}
+		for _, other := range paths {
+			if other == twin {
+				shadowed[twin] = struct{}{}
+				break
+			}
+		}
+	}
+	if len(shadowed) == 0 {
+		return paths
+	}
+	kept := paths[:0]
+	for _, f := range paths {
+		if _, drop := shadowed[f]; drop {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept
 }
 
 func (p *Parser) showParseErrors(fsys fs.FS, filePath string, diags hcl.Diagnostics) error {


### PR DESCRIPTION
Closes #11192.

OpenTofu skips a `.tf` file when a `.tofu` file with the same base name exists in the same directory, and `.tofu.json` shadows `.tf.json` the same way. Trivy parsed both, so a scan reported findings from a file the applied configuration never loads (the #11181 discussion case), and a same-address resource pair produced duplicate module blocks with undefined evaluation.

This follows the OpenTofu pairing per extension family when collecting files for a module:
- `main.tofu` shadows `main.tf`
- `main.tofu.json` shadows `main.tf.json`
- no shadowing across the HCL/JSON families (`main.tofu` does not shadow `main.tf.json`)

Published modules shipping both variants can restore the Terraform reading with `--skip-files`, as noted in the issue.

```
$ go test ./pkg/iac/scanners/terraform/... -count=1
ok  github.com/aquasecurity/trivy/pkg/iac/scanners/terraform   18.461s
ok  github.com/aquasecurity/trivy/pkg/iac/scanners/terraform/parser   0.617s
(unit table covers shadowing, cross-family non-shadowing, single-file, and mixed unrelated cases)
```