### PR TITLE
fix: set locations for JSON values sharing a line

### DIFF
--- a/pkg/x/json/json.go
+++ b/pkg/x/json/json.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/set"
 )
 
 // lineReader is a custom reader that tracks line numbers.
@@ -84,15 +83,21 @@ var SetLocationHook = DecodeHook{
 // To use UnmarshalerWithLocation for primitive types, you must implement the [json.UnmarshalerFrom] interface for those objects.
 // cf. https://pkg.go.dev/github.com/go-json-experiment/json#UnmarshalerFrom
 func UnmarshalerWithLocation[T any](r *lineReader, hooks ...DecodeHook) *json.Unmarshalers {
-	visited := set.New[int]()
 	if len(hooks) == 0 {
 		hooks = []DecodeHook{SetLocationHook}
 	}
-	return unmarshaler[T](r, visited, hooks...)
+	return unmarshaler[T](r, false, hooks...)
 }
 
-func unmarshaler[T any](r *lineReader, visited set.Set[int], hooks ...DecodeHook) *json.Unmarshalers {
+func unmarshaler[T any](r *lineReader, skip bool, hooks ...DecodeHook) *json.Unmarshalers {
 	return json.UnmarshalFromFunc(func(dec *jsontext.Decoder, target T) error {
+		// json.UnmarshalDecode below passes the same value to this function again.
+		// ErrUnsupported leaves that repeated call to the default decoding and breaks the recursion.
+		if skip {
+			skip = false
+			return errors.ErrUnsupported
+		}
+
 		// Decoder.InputOffset reports the offset after the last token,
 		// but we want to record the offset before the next token.
 		//
@@ -105,19 +110,12 @@ func unmarshaler[T any](r *lineReader, visited set.Set[int], hooks ...DecodeHook
 		unread := bytes.TrimLeft(dec.UnreadBuffer(), " \n\r\t,:")
 		start := r.Line() - bytes.Count(unread, []byte("\n")) // The decoder buffer may have read more lines.
 
-		// Check visited set to avoid infinity loops
-		if visited.Contains(start) {
-			// Fall back to the default decoding.
-			return errors.ErrUnsupported
-		}
-		visited.Append(start)
-
 		// Return more detailed error for cases when UnmarshalJSONFrom is not implemented for primitive type.
 		if _, ok := any(target).(json.UnmarshalerFrom); !ok && kind != jsontext.KindBeginArray && kind != jsontext.KindBeginObject {
 			return xerrors.Errorf("structures with single primitive type should implement UnmarshalJSONFrom: %T", target)
 		}
 
-		if err := json.UnmarshalDecode(dec, target, json.WithUnmarshalers(unmarshaler[T](r, visited, hooks...))); err != nil {
+		if err := json.UnmarshalDecode(dec, target, json.WithUnmarshalers(unmarshaler[T](r, true, hooks...))); err != nil {
 			return err
 		}
 

--- a/pkg/x/json/json_test.go
+++ b/pkg/x/json/json_test.go
@@ -77,12 +77,36 @@ func TestUnmarshal(t *testing.T) {
 							EndLine:   10,
 						},
 						Dependencies: map[string]Dependency{
-							// UnmarshalerWithObjectLocation doesn't support Location for nested objects
 							"debug": {
 								Version: "2.6.9",
 								Location: xjson.Location{
 									StartLine: 6,
 									EndLine:   8,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "objects on the same line",
+			in:   []byte(`{"dependencies": {"body-parser": {"version": "1.18.3", "dependencies": {"debug": {"version": "2.6.9"}}}}}`),
+			out:  nestedStruct{},
+			want: nestedStruct{
+				Dependencies: map[string]Dependency{
+					"body-parser": {
+						Version: "1.18.3",
+						Location: xjson.Location{
+							StartLine: 1,
+							EndLine:   1,
+						},
+						Dependencies: map[string]Dependency{
+							"debug": {
+								Version: "2.6.9",
+								Location: xjson.Location{
+									StartLine: 1,
+									EndLine:   1,
 								},
 							},
 						},


### PR DESCRIPTION
## Description

Re-entry into the unmarshaler was recognized by the start line of the value, so a value that began on a line already seen was taken for a repeat, went to the default decoding and got no location. In a minified lock file every package sits on the first line, so almost all locations stayed empty. Now the repeat is recognized by the order of calls, so the result does not depend on formatting.

Example `package-lock.json` with every package on one line:

```json
{"name":"demo","lockfileVersion":3,"requires":true,"packages":{"":{"name":"demo","version":"1.0.0","dependencies":{"debug":"2.6.9"}},"node_modules/debug":{"version":"2.6.9","resolved":"https://registry.npmjs.org/debug/-/debug-2.6.9.tgz","dependencies":{"ms":"2.0.0"}},"node_modules/ms":{"version":"2.0.0","resolved":"https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"}}}
```

Before:
```console
trivy fs --scanners vuln --skip-db-update -q --list-all-pkgs -f json ./package-lock.json | jq -c '.Results[].Packages[] | {Name, Locations}'
{"Name":"debug","Locations":[{}]}
{"Name":"ms","Locations":[{}]}
```

After:
```console
./trivy fs --scanners vuln --skip-db-update -q --list-all-pkgs -f json ./package-lock.json | jq -c '.Results[].Packages[] | {Name, Locations}'
{"Name":"debug","Locations":[{"StartLine":1,"EndLine":1}]}
{"Name":"ms","Locations":[{"StartLine":1,"EndLine":1}]}
```

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
