### PR TITLE
docs: link security reporting guidance to relevant documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,17 @@ As such, there is no supportability commitment. The maintainers will do the best
 
 ## Reporting a Vulnerability
 
+Before submitting a report, please review the [project scope and principles](docs/community/principles.md#intentional-attacks) and the relevant security considerations:
+
+- [Configuration files](docs/guide/configuration/index.md#security-considerations)
+- [Report templates](docs/guide/configuration/reporting.md#custom-template)
+- [Client/server deployments](docs/guide/references/modes/client-server.md#security-considerations)
+- [Plugins](docs/guide/plugin/index.md#security-considerations) and [modules](docs/guide/advanced/modules.md#overview)
+- [Terraform remote modules](docs/guide/coverage/iac/terraform.md#remote-modules) and [filesystem functions](docs/guide/coverage/iac/terraform.md#filesystem-functions)
+- [Registry credentials](docs/guide/advanced/private-registries/index.md#passing-credentials) and [Maven mirror credentials](docs/guide/coverage/language/java.md#config-file-mirrors)
+- [VEX attestations](docs/guide/supply-chain/vex/oci.md#step-3-use-vex-attestation-with-trivy)
+- [HTTP request/response tracing](docs/guide/references/troubleshooting.md#http-requestresponse-tracing)
+
 Please use the "Private vulnerability reporting" feature in the GitHub repository (under the "Security" tab).  
 
 ⚠️ **Important:**  


### PR DESCRIPTION
## Description

Help reporters review Trivy's scope and relevant security considerations before submitting a vulnerability report. Add links to the existing documentation from SECURITY.md without duplicating the guidance.

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
