### PR TITLE
docs: fix 'allows to load' grammar in ecosystem explorer notes

### DIFF
--- a/docs/ecosystem/ide.md
+++ b/docs/ecosystem/ide.md
@@ -52,7 +52,7 @@ A terminal native UI for Trivy
 
 ## Trivy Vulnerability explorer (Community)
 
-Web application that allows to load a Trivy report in json format and displays the vulnerabilities of a single target in an interactive data table
+Web application that allows loading a Trivy report in json format and displays the vulnerabilities of a single target in an interactive data table
 
 👉 Get it at: <https://github.com/dbsystel/trivy-vulnerability-explorer>
 

--- a/docs/ecosystem/reporting.md
+++ b/docs/ecosystem/reporting.md
@@ -27,7 +27,7 @@ Trivy-Streamlit is a Streamlit application that allows you to quickly parse the 
 
 ## Trivy-Vulnerability-Explorer (Community)
 
-This project is a web application that allows to load a Trivy report in json format and displays the vulnerabilities of a single target in an interactive data table.
+This project is a web application that allows loading a Trivy report in json format and displays the vulnerabilities of a single target in an interactive data table.
 
 👉 Get it at: <https://github.com/dbsystel/trivy-vulnerability-explorer>
 


### PR DESCRIPTION
## Description

Fixes non-idiomatic "allows to load" wording in the Trivy Vulnerability Explorer ecosystem notes:

- `docs/ecosystem/ide.md`
- `docs/ecosystem/reporting.md`

`allows to load` → `allows loading`

## Related issues
- Close #11241

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).